### PR TITLE
Updating URL escaping function.

### DIFF
--- a/includes/Core/Modules/Modules.php
+++ b/includes/Core/Modules/Modules.php
@@ -167,7 +167,7 @@ final class Modules {
 
 					$src = add_query_arg( 'tagverify', '1', home_url() );
 
-					echo '<iframe style="display:none;" data-modules="' . esc_attr( join( '_', $modules ) ) . '" id="sitekit_fe_load_check" src="' . esc_attr( $src ) . '" sandbox="allow-same-origin"></iframe>';
+					echo '<iframe style="display:none;" data-modules="' . esc_attr( join( '_', $modules ) ) . '" id="sitekit_fe_load_check" src="' . esc_url( $src ) . '" sandbox="allow-same-origin"></iframe>';
 
 					$iframe_loaded = true;
 				}


### PR DESCRIPTION
`esc_url()` should be used for `src` attributes instead of `esc_attr()`

## Summary

<!-- Please provide one sentence summarizing the PR, to be used in the changelog. -->
This PR can be summarized in the following changelog entry:

*

<!-- Please reference the issue this PR addresses. -->
Addresses issue #

## Relevant technical choices
<!-- Please describe your changes. -->

## Checklist:
- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.4.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
