### PR TITLE
Removes babel-plugin-makepot package from the build process

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -8,12 +8,6 @@
 	],
 	"plugins": [
 		"@babel/plugin-syntax-dynamic-import",
-		"@babel/plugin-transform-runtime",
-		[
-			"@wordpress/babel-plugin-makepot",
-			{
-				"output": "languages/translation.pot"
-			}
-		]
+		"@babel/plugin-transform-runtime"
 	]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5926,17 +5926,6 @@
         "@wordpress/url": "^2.3.3"
       }
     },
-    "@wordpress/babel-plugin-makepot": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@wordpress/babel-plugin-makepot/-/babel-plugin-makepot-2.1.3.tgz",
-      "integrity": "sha512-8ijU4bYUmJuXPnHS47X9Y5OrESLmgx3VVGb+9tNO5hyPoXnZj+ELw9+SB4fJtg0Ur1MDNKRLz4ruJS4Y0tRnNQ==",
-      "dev": true,
-      "requires": {
-        "@babel/runtime": "^7.0.0",
-        "gettext-parser": "^1.3.1",
-        "lodash": "^4.17.10"
-      }
-    },
     "@wordpress/browserslist-config": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-2.3.0.tgz",

--- a/package.json
+++ b/package.json
@@ -108,7 +108,6 @@
     "@storybook/addon-viewport": "^5.0.11",
     "@storybook/react": "^5.0.11",
     "@wordpress/api-fetch": "^2.2.8",
-    "@wordpress/babel-plugin-makepot": "^2.1.3",
     "@wordpress/browserslist-config": "^2.3.0",
     "@wordpress/components": "^7.2.0",
     "@wordpress/dom-ready": "^2.2.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -143,14 +143,6 @@ module.exports = ( env, argv ) => {
 										'useBuiltIns': 'entry',
 										'corejs': 2
 									} ], '@babel/preset-react' ],
-									plugins: [
-										[
-											'@wordpress/babel-plugin-makepot',
-											{
-												'output': 'languages/translation.pot',
-											}
-										]
-									]
 								}
 							},
 							{
@@ -230,14 +222,6 @@ module.exports = ( env, argv ) => {
 										'useBuiltIns': 'entry',
 										'corejs': 2
 									} ], '@babel/preset-react' ],
-									plugins: [
-										[
-											'@wordpress/babel-plugin-makepot',
-											{
-												'output': 'languages/translation.pot',
-											}
-										]
-									]
 								}
 							},
 							{


### PR DESCRIPTION
## Summary

Currently we have an error with the build process because of the translation.pot not exist anymore.

This PR can be summarized in the following changelog entry:

* Remove translation file generator from build process and the `@wordpress/babel-plugin-makepot` package.

Fixes #17 

## Relevant technical choices
Translation will be handled by polyglots.

## Checklist:
- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
