### PR TITLE
PHPUnit: add StylesheetTest

### DIFF
--- a/tests/phpunit/integration/Core/Assets/StylesheetTest.php
+++ b/tests/phpunit/integration/Core/Assets/StylesheetTest.php
@@ -1,0 +1,136 @@
+<?php
+/**
+ * StylesheetTest
+ *
+ * @package   Google\Site_Kit\Tests\Core\Assets
+ * @copyright 2019 Google LLC
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
+ * @link      https://sitekit.withgoogle.com
+ */
+
+namespace Google\Site_Kit\Tests\Core\Assets;
+
+use Google\Site_Kit\Core\Assets\Stylesheet;
+use Google\Site_Kit\Tests\TestCase;
+
+/**
+ * @group Assets
+ */
+class StylesheetTest extends TestCase {
+
+	public function setUp() {
+		parent::setUp();
+
+		wp_styles()->registered = array();
+		wp_styles()->queue      = array();
+	}
+
+	public function test_get_handle() {
+		$style = new Stylesheet( 'test-handle', array() );
+
+		$this->assertEquals( 'test-handle', $style->get_handle() );
+	}
+
+	public function test_register() {
+		$style = new Stylesheet( 'test-handle', array() );
+
+		$this->assertFalse( wp_style_is( 'test-handle', 'registered' ) );
+
+		$style->register();
+
+		$this->assertTrue( wp_style_is( 'test-handle', 'registered' ) );
+	}
+
+	public function test_register_with_post_register_callback() {
+		$invocations = array();
+		$callback    = function () use ( &$invocations ) {
+			$invocations[] = func_get_args();
+		};
+		$style       = new Stylesheet( 'test-handle', array(
+			'post_register' => $callback,
+		) );
+
+		$style->register();
+
+		$this->assertCount( 1, $invocations );
+		// Callback is only invoked once when style is registered.
+		$style->register();
+		$style->register();
+
+		$this->assertCount( 1, $invocations );
+	}
+
+	public function test_registered_src() {
+		$src   = home_url( 'test.css' );
+		$style = new Stylesheet( 'test-handle', array(
+			'src' => $src,
+		) );
+
+		$style->register();
+
+		$expected_src = add_query_arg( 'ver', GOOGLESITEKIT_VERSION, $src );
+		$mock         = $this->getMock( 'MockClass', array( 'callback' ) );
+		$mock->expects( $this->once() )
+		     ->method( 'callback' )
+		     ->with( $expected_src, 'test-handle' );
+
+		add_filter( 'style_loader_src', array( $mock, 'callback' ), 10, 2 );
+
+		wp_styles()->do_item( 'test-handle' );
+	}
+
+	public function test_registered_media() {
+		$style = new Stylesheet( 'test-handle', array(
+			'src'   => home_url( 'test.css' ),
+			'media' => 'test-media',
+		) );
+
+		$style->register();
+
+		$mock = $this->getMock( 'MockClass', array( 'callback' ) );
+		$mock->expects( $this->once() )
+		     ->method( 'callback' )
+		     ->with( $this->isType( 'string' ), 'test-handle', $this->isType( 'string' ), 'test-media' );
+
+		add_filter( 'style_loader_tag', array( $mock, 'callback' ), 10, 4 );
+
+		wp_styles()->do_item( 'test-handle' );
+	}
+
+	public function test_enqueue() {
+		$style = new Stylesheet( 'test-handle', array() );
+		$this->assertFalse( wp_style_is( 'test-handle', 'enqueued' ) );
+
+		$style->enqueue();
+
+		// Must be registered first
+		$this->assertFalse( wp_style_is( 'test-handle', 'enqueued' ) );
+
+		$style->register();
+		$style->enqueue();
+
+		$this->assertTrue( wp_style_is( 'test-handle', 'enqueued' ) );
+	}
+
+	public function test_register_with_post_enqueue_callback() {
+		$invocations = array();
+		$callback    = function () use ( &$invocations ) {
+			$invocations[] = func_get_args();
+		};
+		$style       = new Stylesheet( 'test-handle', array(
+			'post_enqueue' => $callback,
+		) );
+
+		$style->register();
+		$this->assertCount( 0, $invocations );
+
+		$style->enqueue();
+
+		$this->assertCount( 1, $invocations );
+		// Callback is only invoked once when style is enqueued.
+		$style->enqueue();
+		$style->enqueue();
+
+		$this->assertCount( 1, $invocations );
+	}
+}


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* PHPUnit: add StylesheetTest

## Checklist:
- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
