### PR TITLE
PHPUnit: add UninstallationTest

### DIFF
--- a/tests/phpunit/includes/MethodSpy.php
+++ b/tests/phpunit/includes/MethodSpy.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * MethodSpy
+ *
+ * @package   Google\Site_Kit\Tests
+ * @copyright 2019 Google LLC
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
+ * @link      https://sitekit.withgoogle.com
+ */
+
+namespace Google\Site_Kit\Tests;
+
+class MethodSpy {
+	/**
+	 * Associative array of method invocations.
+	 *
+	 * @var array
+	 */
+	public $invocations = array();
+
+	/**
+	 * Record all method calls.
+	 *
+	 * @param string $method Method invoked
+	 * @param array $arguments Arguments invoked with
+	 */
+	public function __call( $method, $arguments ) {
+		$this->invocations[ $method ][] = $arguments;
+	}
+}

--- a/tests/phpunit/integration/Core/Util/Google/Site_Kit/Tests/Core/Util/UninstallationTest.php
+++ b/tests/phpunit/integration/Core/Util/Google/Site_Kit/Tests/Core/Util/UninstallationTest.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * UninstallationTest
+ *
+ * @package   Google\Site_Kit\Tests\Core\Util
+ * @copyright 2019 Google LLC
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
+ * @link      https://sitekit.withgoogle.com
+ */
+
+namespace Google\Site_Kit\Tests\Core\Util;
+
+use Google\Site_Kit\Core\Util\Uninstallation;
+use Google\Site_Kit\Tests\MethodSpy;
+use Google\Site_Kit\Tests\TestCase;
+
+/**
+ * @group Util
+ */
+class UninstallationTest extends TestCase {
+
+	public function test_register() {
+		$uninstall = new Uninstallation();
+		remove_all_actions( 'googlesitekit_uninstall' );
+
+		$spy = new MethodSpy();
+		$this->assertCount( 0, $spy->invocations );
+		$this->force_set_property( $uninstall, 'reset', $spy );
+
+		do_action( 'googlesitekit_uninstall' );
+		$this->assertCount( 0, $spy->invocations );
+
+		$uninstall->register();
+
+		do_action( 'googlesitekit_uninstall' );
+		$this->assertCount( 1, $spy->invocations );
+		$this->assertCount( 1, $spy->invocations['all'] );
+	}
+}


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* PHPUnit: add UninstallationTest

## Relevant technical choices

* Adds a `MethodSpy` helper for making assertions about method calls which will be useful in other tests as well.

## Checklist:
- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
