### PR TITLE
Check for encryption constant before use it

### DIFF
--- a/includes/Core/Storage/Data_Encryption.php
+++ b/includes/Core/Storage/Data_Encryption.php
@@ -115,7 +115,7 @@ final class Data_Encryption {
 			return GOOGLESITEKIT_ENCRYPTION_KEY;
 		}
 
-		if ( '' !== LOGGED_IN_KEY ) {
+		if ( defined( 'LOGGED_IN_KEY' ) && '' !== LOGGED_IN_KEY ) {
 			return LOGGED_IN_KEY;
 		}
 
@@ -135,7 +135,7 @@ final class Data_Encryption {
 			return GOOGLESITEKIT_ENCRYPTION_SALT;
 		}
 
-		if ( '' !== LOGGED_IN_SALT ) {
+		if ( defined( 'LOGGED_IN_SALT' ) && '' !== LOGGED_IN_SALT ) {
 			return LOGGED_IN_SALT;
 		}
 


### PR DESCRIPTION
## Summary

<!-- Please provide one sentence summarizing the PR, to be used in the changelog. -->
This PR can be summarized in the following changelog entry:

* Check if `LOGGED_IN_KEY` and `LOGGED_IN_SALT` are defined before using it, to account for some environments such as local ones.

<!-- Please reference the issue this PR addresses. -->
Fixes #7 

## Checklist:
- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
