### PR TITLE
PHPUnit: add OptionsTest

### DIFF
--- a/tests/phpunit/includes/TestCase.php
+++ b/tests/phpunit/includes/TestCase.php
@@ -78,4 +78,37 @@ class TestCase extends \WP_UnitTestCase {
 	protected function get_testcase() {
 		return $this;
 	}
+
+	protected function checkRequirements() {
+		parent::checkRequirements();
+
+		/**
+		 * Proper handling for MS group annotation handling was fixed in 5.1
+		 * @see https://core.trac.wordpress.org/ticket/43863
+		 */
+		if ( version_compare( $GLOBALS['wp_version'], '5.1', '<' ) ) {
+			$annotations = $this->getAnnotations();
+			$groups      = array();
+
+			if ( ! empty( $annotations['class']['group'] ) ) {
+				$groups = array_merge( $groups, $annotations['class']['group'] );
+			}
+			if ( ! empty( $annotations['method']['group'] ) ) {
+				$groups = array_merge( $groups, $annotations['method']['group'] );
+			}
+
+			if ( ! empty( $groups ) ) {
+				if ( in_array( 'ms-required', $groups, true ) ) {
+					if ( ! is_multisite() ) {
+						$this->markTestSkipped( 'Test only runs on Multisite' );
+					}
+				}
+				if ( in_array( 'ms-excluded', $groups, true ) ) {
+					if ( is_multisite() ) {
+						$this->markTestSkipped( 'Test does not run on Multisite' );
+					}
+				}
+			}
+		}
+	}
 }

--- a/tests/phpunit/integration/Core/Storage/Google/OptionsTest.php
+++ b/tests/phpunit/integration/Core/Storage/Google/OptionsTest.php
@@ -1,0 +1,107 @@
+<?php
+/**
+ * OptionsTest
+ *
+ * @package   Google
+ * @copyright 2019 Google LLC
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
+ * @link      https://sitekit.withgoogle.com
+ */
+
+namespace Google\Site_Kit\Tests\Core\Storage;
+
+use Google\Site_Kit\Context;
+use Google\Site_Kit\Core\Storage\Options;
+use Google\Site_Kit\Tests\TestCase;
+
+/**
+ * @group Storage
+ */
+class OptionsTest extends TestCase {
+
+	public function test_get() {
+		$options = new Options( new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE ) );
+		delete_option( 'test_option' );
+
+		$this->assertFalse( $options->get( 'test_option' ) );
+		update_option( 'test_option', 'test-value' );
+
+		$this->assertEquals( 'test-value', $options->get( 'test_option' ) );
+	}
+
+	/**
+	 * @group ms-required
+	 */
+	public function test_network_mode_get() {
+		$context = new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE );
+		$options = new Options( $context );
+		delete_network_option( null, 'test_option' );
+		$this->network_activate_site_kit();
+		$this->assertTrue( $context->is_network_mode() );
+
+		$this->assertFalse( $options->get( 'test_option' ) );
+		update_network_option( null, 'test_option', 'test-value' );
+
+		$this->assertEquals( 'test-value', $options->get( 'test_option' ) );
+	}
+
+	public function test_set() {
+		$options = new Options( new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE ) );
+		$this->assertFalse( get_option( 'test_option' ) );
+
+		$options->set( 'test_option', 'test-value' );
+
+		$this->assertEquals( 'test-value', get_option( 'test_option' ) );
+	}
+
+	/**
+	 * @group ms-required
+	 */
+	public function test_network_mode_set() {
+		$context = new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE );
+		$options = new Options( $context );
+		$this->network_activate_site_kit();
+		$this->assertTrue( $context->is_network_mode() );
+
+		$this->assertFalse( get_network_option( null, 'test_option' ) );
+		$options->set( 'test_option', 'test-value' );
+
+		$this->assertEquals( 'test-value', get_network_option( null, 'test_option' ) );
+	}
+
+	public function test_delete() {
+		$options = new Options( new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE ) );
+		update_option( 'test_option', 'test-value' );
+		$this->assertEquals( 'test-value', get_option( 'test_option' ) );
+
+		$options->delete( 'test_option' );
+
+		$this->assertFalse( get_option( 'test_option' ) );
+	}
+
+	/**
+	 * @group ms-required
+	 */
+	public function test_network_mode_delete() {
+		$context = new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE );
+		$options = new Options( $context );
+		$this->network_activate_site_kit();
+		$this->assertTrue( $context->is_network_mode() );
+
+		update_network_option( null, 'test_option', 'test-value' );
+		$this->assertEquals( 'test-value', get_network_option( null, 'test_option' ) );
+
+		$options->delete( 'test_option' );
+
+		$this->assertFalse( get_network_option( null, 'test_option' ) );
+	}
+
+	protected function network_activate_site_kit() {
+		add_filter(
+			'pre_site_option_active_sitewide_plugins',
+			function () {
+				return array( GOOGLESITEKIT_PLUGIN_BASENAME => true );
+			}
+		);
+	}
+}


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* PHPUnit: add OptionsTest

## Relevant technical choices

* `test_*` methods apply to both MS and single site contexts
* `test_network_mode_*` are MS-specific with the plugin in a network mode context

## Checklist:
- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
