### PR TITLE
Remove johnpbloch/wordpress-core from Composer require

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,7 @@
   "require": {
     "php": ">=5.4",
     "google/apiclient": "^2.0",
-    "guzzlehttp/guzzle": "~5.3.3",
-    "johnpbloch/wordpress-core": "^5.1"
+    "guzzlehttp/guzzle": "~5.3.3"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
## Summary

Remove `johnpbloch/wordpress-core` from the `require` section of `composer.json` to avoid forcing a duplicate/specific version of WordPress core on Composer based projects that require this project as a dependency.

<!-- Please provide one sentence summarizing the PR, to be used in the changelog. -->
This PR can be summarized in the following changelog entry:

* Remove `johnpbloch/wordpress-core` from the `require` section of `composer.json`

<!-- Please reference the issue this PR addresses. -->
Addresses issue #38

## Relevant technical choices
<!-- Please describe your changes. -->

## Checklist:
- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.4.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
