### PR TITLE
Composer: Require `wordpress/core-implementation` and put `johnpbloch/wordpress-core` into `require-dev`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,13 +10,13 @@
     "squizlabs/php_codesniffer": "^3.3",
     "wp-coding-standards/wpcs": "^1",
     "phpcompatibility/php-compatibility": "^9",
-    "dealerdirect/phpcodesniffer-composer-installer": "0.4.4"
+    "dealerdirect/phpcodesniffer-composer-installer": "0.4.4",
+    "johnpbloch/wordpress-core": "^5.2"
   },
   "require": {
     "php": ">=5.4",
     "google/apiclient": "^2.0",
-    "guzzlehttp/guzzle": "~5.3.3",
-    "johnpbloch/wordpress-core": "^5.1"
+    "guzzlehttp/guzzle": "~5.3.3"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
## Summary

<!-- Please provide one sentence summarizing the PR, to be used in the changelog. -->
This PR can be summarized in the following changelog entry:

* Move `johnpbloch/wordpress-core` dependency to `require-dev`.

Fixes #38.

## Relevant technical choices

Require `wordpress/core-implementation` so that user can install wordpress from one of these [packages](https://packagist.org/providers/wordpress/core-implementation) or make their own [like so](https://github.com/ItinerisLtd/wordpress-packager/blob/fee2da2b57df72a2193e904de292c737d40443ad/src/Release.php#L33).

Moving `johnpbloch/wordpress-core` into `require-dev` to [keep visual regression tests working](https://github.com/google/site-kit-wp/issues/38#issuecomment-504757621).

## Checklist:
- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.4.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
