### PR TITLE
Remove phpseclib from plugin build.

### DIFF
--- a/gulp-tasks/copy.js
+++ b/gulp-tasks/copy.js
@@ -32,7 +32,6 @@ gulp.task( 'copy', () => {
 			'vendor/google/apiclient-services/src/Google/Service/PeopleService.php',
 			'vendor/google/apiclient-services/src/Google/Service/PeopleService/**/*',
 			'vendor/firebase/**/*',
-			'vendor/phpseclib/**/*',
 			'vendor/guzzlehttp/**/*',
 			'vendor/psr/**/*',
 			'vendor/monolog/**/*',


### PR DESCRIPTION
## Summary

<!-- Please provide one sentence summarizing the PR, to be used in the changelog. -->
This PR can be summarized in the following changelog entry:

* Remove `phpseclib/phpseclib` from plugin build as it contains problematic code for PHP7+ and is only a conditional requirement for `google/apiclient` and not actually used by the plugin.

<!-- Please reference the issue this PR addresses. -->
Fixes #21

## Relevant technical choices
The library is only used conditionally in a single class of the `google/apiclient` package, by a method that we don't actually use. For testing, please just remove the folder from your vendor directory, to verify that authenticating with OAuth still works as expected.

A nice side effect of this is that we reduce the build size yet a bit more.

## Checklist:
- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.4.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
