### PR TITLE
Test oldest supported WP version, automate latest WP version, include…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,11 +30,6 @@ cache:
     - $HOME/.phpbrew
     - $HOME/.npm
 
-before_script:
-  - npm install -g gulp-cli
-  - composer install
-  - bash tests/bin/install-wp-tests.sh wordpress_test root '' localhost $WP_VERSION
-
 branches:
   only:
     - master
@@ -42,12 +37,22 @@ branches:
 
 # Before install, failures in this section will result in build status 'errored'
 before_install:
-    # setup WP_DEVELOP_DIR (needed for bbPress to bootstrap WP PHPUnit tests)
-    - WP_DEVELOP_DIR=/tmp/wordpress
-    # clone the WordPress develop repo
-    - git clone --depth=1 --branch="$WP_VERSION" git://develop.git.wordpress.org/ $WP_DEVELOP_DIR
-    - WP_DEVELOP_DIR=/tmp/wordpress/src
-    - WP_TESTS_DIR=/tmp/wordpress/tests/phpunit
+  # setup WP_DEVELOP_DIR (needed for bbPress to bootstrap WP PHPUnit tests)
+  - WP_DEVELOP_DIR=/tmp/wordpress
+  # clone the WordPress develop repo
+  - |
+    if [[ "$WP_VERSION" == "latest" ]]; then
+      curl -s http://api.wordpress.org/core/version-check/1.7/ > /tmp/wp-latest.json
+      WP_VERSION=$(grep -o '"version":"[^"]*' /tmp/wp-latest.json | sed 's/"version":"//')
+    fi
+  - git clone --depth=1 --branch="$WP_VERSION" git://develop.git.wordpress.org/ $WP_DEVELOP_DIR
+  - WP_DEVELOP_DIR=/tmp/wordpress/src
+  - WP_TESTS_DIR=/tmp/wordpress/tests/phpunit
+
+before_script:
+  - npm install -g gulp-cli
+  - composer install
+  - bash tests/bin/install-wp-tests.sh wordpress_test root '' localhost $WP_VERSION
 
 jobs:
   include:
@@ -55,7 +60,7 @@ jobs:
     - stage: test
       php: 5.4
       env:
-        - WP_VERSION=5.1
+        - WP_VERSION=4.7
         - PHPCS_PHP_VERSION='5.4'
       script:
         - npm install || exit 1
@@ -64,14 +69,14 @@ jobs:
 
     - stage: test
       php: 5.6
-      env: WP_VERSION=master
+      env: WP_VERSION=latest
       script:
         - npm install || exit 1
         - gulp phpunit || exit 1
 
     - stage: test
-      php: 7.2
-      env: WP_VERSION=master
+      php: 7.3
+      env: WP_VERSION=latest
       script:
         - npm install || exit 1
         - gulp phpunit || exit 1
@@ -83,6 +88,15 @@ jobs:
         - npm install || exit 1
         - npm run test || exit 1 # Bundle size test.
         - travis_retry npm run travis:test || exit 1 # Runs QUnit, PHPUnit and BackstopJS visual regression tests.
+
+  allow_failures:
+
+    - stage: test
+      php: 'nightly'
+      env: WP_VERSION=master
+      script:
+        - npm install || exit 1
+        - gulp phpunit || exit 1
 
 services:
   - docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,22 +37,19 @@ branches:
 
 # Before install, failures in this section will result in build status 'errored'
 before_install:
-  # setup WP_DEVELOP_DIR (needed for bbPress to bootstrap WP PHPUnit tests)
-  - WP_DEVELOP_DIR=/tmp/wordpress
-  # clone the WordPress develop repo
   - |
     if [[ "$WP_VERSION" == "latest" ]]; then
       curl -s http://api.wordpress.org/core/version-check/1.7/ > /tmp/wp-latest.json
       WP_VERSION=$(grep -o '"version":"[^"]*' /tmp/wp-latest.json | sed 's/"version":"//')
     fi
-  - git clone --depth=1 --branch="$WP_VERSION" git://develop.git.wordpress.org/ $WP_DEVELOP_DIR
-  - WP_DEVELOP_DIR=/tmp/wordpress/src
-  - WP_TESTS_DIR=/tmp/wordpress/tests/phpunit
+  - git clone --depth=1 --branch="$WP_VERSION" git://develop.git.wordpress.org/ /tmp/wordpress
 
 before_script:
+  - WP_DEVELOP_DIR=/tmp/wordpress/src
+  - WP_TESTS_DIR=/tmp/wordpress/tests/phpunit
   - npm install -g gulp-cli
   - composer install
-  - bash tests/bin/install-wp-tests.sh wordpress_test root '' localhost $WP_VERSION
+  - bash tests/bin/install-wp-tests.sh wordpress_test root '' localhost
 
 jobs:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,7 @@ before_install:
       WP_VERSION=$(grep -o '"version":"[^"]*' /tmp/wp-latest.json | sed 's/"version":"//')
     fi
   - git clone --depth=1 --branch="$WP_VERSION" git://develop.git.wordpress.org/ /tmp/wordpress
+  - mv /tmp/wordpress/wp-tests-config-sample.php /tmp/wordpress/tests/phpunit/wp-tests-config.php
 
 before_script:
   - WP_DEVELOP_DIR=/tmp/wordpress/src

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,11 +43,11 @@ before_install:
       WP_VERSION=$(grep -o '"version":"[^"]*' /tmp/wp-latest.json | sed 's/"version":"//')
     fi
   - git clone --depth=1 --branch="$WP_VERSION" git://develop.git.wordpress.org/ /tmp/wordpress
-  - mv /tmp/wordpress/wp-tests-config-sample.php /tmp/wordpress/tests/phpunit/wp-tests-config.php
+  - cp /tmp/wordpress/wp-tests-config-sample.php /tmp/wordpress/tests/phpunit/wp-tests-config.php
 
 before_script:
-  - WP_DEVELOP_DIR=/tmp/wordpress/src
-  - WP_TESTS_DIR=/tmp/wordpress/tests/phpunit
+  - export WP_DEVELOP_DIR=/tmp/wordpress
+  - export WP_TESTS_DIR=/tmp/wordpress/tests/phpunit
   - npm install -g gulp-cli
   - composer install
   - bash tests/bin/install-wp-tests.sh wordpress_test root '' localhost

--- a/tests/bin/install-wp-tests.sh
+++ b/tests/bin/install-wp-tests.sh
@@ -11,7 +11,7 @@ DB_PASS=$3
 DB_HOST=${4-localhost}
 
 WP_TESTS_DIR=${WP_TESTS_DIR-/tmp/wordpress/tests/phpunit}
-WP_DEVELOP_DIR=${WP_DEVELOP_DIR-/tmp/wordpress/src}
+WP_DEVELOP_DIR=${WP_DEVELOP_DIR-/tmp/wordpress}
 
 set -ex
 
@@ -25,7 +25,7 @@ install_test_suite() {
 
 	# set up testing suite
 	cd $WP_TESTS_DIR
-	sed $ioption "s:dirname( __FILE__ ) . '/src/':'$WP_DEVELOP_DIR/':" wp-tests-config.php
+	sed $ioption "s:dirname( __FILE__ ) . '/src/':'$WP_DEVELOP_DIR/src/':" wp-tests-config.php
 	sed $ioption "s/youremptytestdbnamehere/$DB_NAME/" wp-tests-config.php
 	sed $ioption "s/yourusernamehere/$DB_USER/" wp-tests-config.php
 	sed $ioption "s/yourpasswordhere/$DB_PASS/" wp-tests-config.php

--- a/tests/bin/install-wp-tests.sh
+++ b/tests/bin/install-wp-tests.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 if [ $# -lt 3 ]; then
-	echo "usage: $0 <db-name> <db-user> <db-pass> [db-host] [wp-version]"
+	echo "usage: $0 <db-name> <db-user> <db-pass> [db-host]"
 	exit 1
 fi
 
@@ -9,27 +9,11 @@ DB_NAME=$1
 DB_USER=$2
 DB_PASS=$3
 DB_HOST=${4-localhost}
-WP_VERSION=${5-latest}
 
-WP_TESTS_DIR=${WP_TESTS_DIR-/tmp/wordpress-tests-lib}
-WP_CORE_DIR=/tmp/wordpress/src/
+WP_TESTS_DIR=${WP_TESTS_DIR-/tmp/wordpress/tests/phpunit}
+WP_DEVELOP_DIR=${WP_DEVELOP_DIR-/tmp/wordpress/src}
 
 set -ex
-
-install_wp() {
-	mkdir -p $WP_CORE_DIR
-
-	if [ $WP_VERSION == 'latest' ]; then
-		local ARCHIVE_NAME='latest'
-	else
-		local ARCHIVE_NAME="wordpress-$WP_VERSION"
-	fi
-
-	wget -nv -O /tmp/wordpress.tar.gz http://wordpress.org/${ARCHIVE_NAME}.tar.gz
-	tar --strip-components=1 -zxmf /tmp/wordpress.tar.gz -C $WP_CORE_DIR
-
-	wget -nv -O $WP_CORE_DIR/wp-content/db.php https://raw.github.com/markoheijnen/wp-mysqli/master/db.php
-}
 
 install_test_suite() {
 	# portable in-place argument for both GNU sed and Mac OSX sed
@@ -45,7 +29,7 @@ install_test_suite() {
 	svn co --quiet http://develop.svn.wordpress.org/trunk/tests/phpunit/includes/
 
 	wget -nv -O wp-tests-config.php http://develop.svn.wordpress.org/trunk/wp-tests-config-sample.php
-	sed $ioption "s:dirname( __FILE__ ) . '/src/':'$WP_CORE_DIR':" wp-tests-config.php
+	sed $ioption "s:dirname( __FILE__ ) . '/src/':'$WP_DEVELOP_DIR/':" wp-tests-config.php
 	sed $ioption "s/youremptytestdbnamehere/$DB_NAME/" wp-tests-config.php
 	sed $ioption "s/yourusernamehere/$DB_USER/" wp-tests-config.php
 	sed $ioption "s/yourpasswordhere/$DB_PASS/" wp-tests-config.php
@@ -73,6 +57,5 @@ install_db() {
 	mysqladmin create $DB_NAME --user="$DB_USER" --password="$DB_PASS"$EXTRA
 }
 
-#install_wp
 install_test_suite
 install_db

--- a/tests/bin/install-wp-tests.sh
+++ b/tests/bin/install-wp-tests.sh
@@ -24,11 +24,7 @@ install_test_suite() {
 	fi
 
 	# set up testing suite
-	mkdir -p $WP_TESTS_DIR
 	cd $WP_TESTS_DIR
-	svn co --quiet http://develop.svn.wordpress.org/trunk/tests/phpunit/includes/
-
-	wget -nv -O wp-tests-config.php http://develop.svn.wordpress.org/trunk/wp-tests-config-sample.php
 	sed $ioption "s:dirname( __FILE__ ) . '/src/':'$WP_DEVELOP_DIR/':" wp-tests-config.php
 	sed $ioption "s/youremptytestdbnamehere/$DB_NAME/" wp-tests-config.php
 	sed $ioption "s/yourusernamehere/$DB_USER/" wp-tests-config.php


### PR DESCRIPTION
… PHP and WP nightly test in allow_failures.

## Summary

<!-- Please provide one sentence summarizing the PR, to be used in the changelog. -->
This PR can be summarized in the following changelog entry:

* Enhance Travis-CI build matrix to test against oldest and newest supported WordPress versions.

<!-- Please reference the issue this PR addresses. -->
Addresses issue #45 

## Relevant technical choices
* We should always have a job running against WP 4.7 (oldest supported version).
* Generally, other jobs should run against the latest stable WP version, which this PR automates.
* We should be testing against PHP and WP nightly builds (in `allow_failures`), so that we can spot potential future problems easily.

## Checklist:
- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.4.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
