### PR TITLE
Fix JavaScript errors when missing admin bar

### DIFF
--- a/assets/js/googlesitekit-admin.js
+++ b/assets/js/googlesitekit-admin.js
@@ -29,6 +29,8 @@ if ( 'toplevel_page_googlesitekit-dashboard' !== window.pagenow && 'site-kit_pag
 }
 
 const wpLogout = document.querySelector( '#wp-admin-bar-logout a' );
-wpLogout.addEventListener( 'click', () => {
-	clearAppLocalStorage();
-} );
+if ( wpLogout ) {
+	wpLogout.addEventListener( 'click', () => {
+		clearAppLocalStorage();
+	} );
+}

--- a/assets/js/googlesitekit-admin.js
+++ b/assets/js/googlesitekit-admin.js
@@ -28,7 +28,13 @@ if ( 'toplevel_page_googlesitekit-dashboard' !== window.pagenow && 'site-kit_pag
 	appendNotificationsCount( count );
 }
 
-const wpLogout = document.querySelector( '#wp-admin-bar-logout a' );
+let wpLogout = document.querySelector( '#wp-admin-bar-logout a' );
+
+// Support for WordPress.com signout button.
+if ( ! wpLogout ) {
+	wpLogout = document.querySelector( '.sidebar__me-signout button' );
+}
+
 if ( wpLogout ) {
 	wpLogout.addEventListener( 'click', () => {
 		clearAppLocalStorage();


### PR DESCRIPTION
## Summary

<!-- Please provide one sentence summarizing the PR, to be used in the changelog. -->
This PR can be summarized in the following changelog entry:

* Fix JavaScript error when admin bar is missing and add partial support for WordPress.com toolbar.

<!-- Please reference the issue this PR addresses. -->
Fixes https://github.com/google/site-kit-wp/issues/49

## Relevant technical choices
<!-- Please describe your changes. -->

## Checklist:
- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.4.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
