### PR TITLE
Fix analytics setup flow not rendering for accounts that only share views and have no associated analytics account.

### DIFF
--- a/assets/js/modules/analytics/setup.js
+++ b/assets/js/modules/analytics/setup.js
@@ -787,15 +787,11 @@ class AnalyticsSetup extends Component {
 			return <ProgressBar/>;
 		}
 
-		// Accounts will always include Set up New Account option unless existing tag matches property.
-		if ( ( 1 >= accounts.length && ! existingTag ) || ( 0 >= accounts.length && existingTag ) || setupNewAccount ) {
+		if ( 0 >= accounts.length ) {
 			if ( ! isEditing ) {
 				return __( 'No account found.', 'google-site-kit' );
 			}
 			if ( ! setupComplete || isEditing ) {
-				if ( ! this.hasAccessToExistingTagProperty() && 0 < accounts.length ) {
-					return null;
-				}
 				return (
 					<Fragment>
 						{ ( setupNewAccount && 1 < accounts.length ) &&

--- a/assets/js/modules/analytics/setup.js
+++ b/assets/js/modules/analytics/setup.js
@@ -53,7 +53,6 @@ class AnalyticsSetup extends Component {
 		} = googlesitekit.modules.analytics.settings;
 
 		this.state = {
-			setupNewAccount: false,
 			isLoading: true,
 			isSaving: false,
 			propertiesLoading: false,
@@ -148,20 +147,11 @@ class AnalyticsSetup extends Component {
 		}
 
 		// The selected value is string.
-		if ( '-1' === selectValue ) {
-			this.setState( {
-				selectedAccount: selectValue,
-				setupNewAccount: true,
-			} );
-			return;
-		}
-
 		if ( '0' === selectValue ) {
 			this.setState( {
 				selectedAccount: selectValue,
 				selectedProperty: '-1',
 				selectedProfile: '-1',
-				setupNewAccount: false,
 				properties: [ {
 					id: '-1',
 					name: __( 'Select an account', 'google-site-kit' )
@@ -178,7 +168,6 @@ class AnalyticsSetup extends Component {
 			propertiesLoading: true,
 			profilesLoading: true,
 			selectedAccount: selectValue,
-			setupNewAccount: false,
 		} );
 
 		// Track selection.
@@ -766,7 +755,6 @@ class AnalyticsSetup extends Component {
 			selectedProperty,
 			selectedProfile,
 			useSnippet,
-			setupNewAccount,
 			existingTag,
 		} = this.state;
 
@@ -794,9 +782,6 @@ class AnalyticsSetup extends Component {
 			if ( ! setupComplete || isEditing ) {
 				return (
 					<Fragment>
-						{ ( setupNewAccount && 1 < accounts.length ) &&
-							<div className="googlesitekit-setup-module__inputs">{ this.accountsDropdown() }</div>
-						}
 						<div className="googlesitekit-setup-module__action">
 							<Button onClick={ AnalyticsSetup.createNewAccount }>{ __( 'Create an account', 'google-site-kit' ) }</Button>
 


### PR DESCRIPTION
## Summary

<!-- Please provide one sentence summarizing the PR, to be used in the changelog. -->
This PR can be summarized in the following changelog entry:

* Fix analytics setup flow empty render for accounts with only shared properties or views.

<!-- Please reference the issue this PR addresses. -->
Fixes https://github.com/google/site-kit-wp/issues/11

## Relevant technical choices
<!-- Please describe your changes. -->

## Checklist:
- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.4.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
