### PR TITLE
fix duplicated word in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Build Status](https://travis-ci.com/google/site-kit-wp.svg?token=smY3Y9yhMfh6hWnXQ2te&branch=master)](https://travis-ci.com/google/site-kit-wp/)
 # Site Kit by Google
 
-Site Kit is is a one-stop solution for WordPress users to use everything Google has to offer to make them successful on the web.
+Site Kit is a one-stop solution for WordPress users to use everything Google has to offer to make them successful on the web.
 
 Learn more: [https://sitekit.withgoogle.com](https://sitekit.withgoogle.com)
 


### PR DESCRIPTION
## Summary
* duplicated word in readme

## Relevant technical choices
Duplicated word in readme: is is

## Checklist:
- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
