### PR TITLE
fix console error innerHTML of null on iframe existing tag check

### DIFF
--- a/assets/js/util/index.js
+++ b/assets/js/util/index.js
@@ -723,12 +723,16 @@ export const findTagInIframeContent = ( iframe, module ) => {
 
 	// Check if tag present in <head>.
 	const head = iframe.contentWindow.document.querySelector( 'head' );
-	existingTag = extractTag( head.innerHTML, module );
+	if ( head ) {
+		existingTag = extractTag( head.innerHTML, module );
+	}
 
 	// If not in <head> check if tag present in <body>.
 	if ( false === existingTag ) {
 		const body = iframe.contentWindow.document.querySelector( 'body' );
-		existingTag = extractTag( body.innerHTML, module );
+		if ( body ) {
+			existingTag = extractTag( body.innerHTML, module );
+		}
 	}
 
 	return existingTag;


### PR DESCRIPTION
## Summary

<!-- Please provide one sentence summarizing the PR, to be used in the changelog. -->
This PR can be summarized in the following changelog entry:

* Fix console error on settings page while checking for existing analytics tag

<!-- Please reference the issue this PR addresses. -->
Fixes https://github.com/google/site-kit-wp/issues/59

## Relevant technical choices
<!-- Please describe your changes. -->

## Checklist:
- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.4.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
