### PR TITLE
Allow to show admin bar on front page

### DIFF
--- a/includes/Core/Admin_Bar/Admin_Bar.php
+++ b/includes/Core/Admin_Bar/Admin_Bar.php
@@ -163,6 +163,20 @@ final class Admin_Bar {
 		}
 
 		/**
+		 * Allows admin bar on front page.
+		 */
+		if ( is_front_page() ) {
+			/**
+			 * Filters whether the Site Kit admin bar menu should be displayed on front page.
+			 *
+			 * @since 1.0.0
+			 *
+			 * @param bool $display Whether to display the admin bar menu.
+			 */
+			return apply_filters( 'googlesitekit_show_admin_bar_menu_front_page', true );
+		}
+
+		/**
 		 * Filters whether the Site Kit admin bar menu should be displayed.
 		 *
 		 * The admin bar menu is only intended for when a single published post is being visited, hence this filter is fired only


### PR DESCRIPTION
## Summary

<!-- Please provide one sentence summarizing the PR, to be used in the changelog. -->
This PR can be summarized in the following changelog entry:

* Add Site Kit component in admin bar on front page.

<!-- Please reference the issue this PR addresses. -->
Fixes #61 

## Relevant technical choices
<!-- Please describe your changes. -->
Show Site Kit component in admin bar on homepage, also provided a new filter `googlesitekit_show_admin_bar_menu_front_page` to allow developer to disable it.

## Checklist:
- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
