### PR TITLE
Add phpseclib as a replace entry in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,5 +36,8 @@
   "scripts": {
     "lint": "vendor/bin/phpcs",
     "lint-fix": "vendor/bin/phpcbf"
+  },
+  "replace": {
+    "phpseclib/phpseclib": "*"
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,9 @@
     "google/apiclient": "^2.0",
     "guzzlehttp/guzzle": "~5.3.3"
   },
+  "replace": {
+    "phpseclib/phpseclib": "*"
+  },
   "autoload": {
     "psr-4": {
       "Google\\Site_Kit\\": "includes"
@@ -36,8 +39,5 @@
   "scripts": {
     "lint": "vendor/bin/phpcs",
     "lint-fix": "vendor/bin/phpcbf"
-  },
-  "replace": {
-    "phpseclib/phpseclib": "*"
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,7 @@
   "require": {
     "php": ">=5.4",
     "google/apiclient": "^2.0",
-    "guzzlehttp/guzzle": "~5.3.3",
-    "johnpbloch/wordpress-core": "^5.1"
+    "guzzlehttp/guzzle": "~5.3.3"
   },
   "autoload": {
     "psr-4": {

--- a/gulp-tasks/copy.js
+++ b/gulp-tasks/copy.js
@@ -32,7 +32,6 @@ gulp.task( 'copy', () => {
 			'vendor/google/apiclient-services/src/Google/Service/PeopleService.php',
 			'vendor/google/apiclient-services/src/Google/Service/PeopleService/**/*',
 			'vendor/firebase/**/*',
-			'vendor/phpseclib/**/*',
 			'vendor/guzzlehttp/**/*',
 			'vendor/psr/**/*',
 			'vendor/monolog/**/*',


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #21

## Relevant technical choices
Inspired by #43 but removing the unwanted dependency via Composer so that the autoloader is not problematic.

The `phpseclib/phpseclib` dependency of `google/apiclient` is not PHP 7+ compatible and not used by Site Kit, so it should be removed. Since it is an inherited dependency the removal needs to be done via Composer.

The `composer.json` can have `replace` entries to specify dependencies fulfilled by the current project, which will not be installed by Composer. The intention is to use forked or self-maintained versions of a dependency but, in this case, can be used to skip the dependency entirely. See [the `composer.json` replace doc](https://getcomposer.org/doc/04-schema.md#replace) for details.

## Checklist:
- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.4.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
