### PR TITLE
Fix search console data for filtered site url

### DIFF
--- a/includes/Context.php
+++ b/includes/Context.php
@@ -151,15 +151,19 @@ final class Context {
 	 */
 	public function get_reference_permalink( $post = 0 ) {
 		$reference_site_url = untrailingslashit( $this->get_reference_site_url() );
+		$orig_site_url      = untrailingslashit( home_url() );
 
-		// Returns home page url when front page mode is latest blog posts.
-		if ( ! $post && 'posts' === get_option( 'show_on_front' ) && is_home() ) {
-			return trailingslashit( $reference_site_url );
+		// Gets post object. On front area we need to use get_queried_object to get the current post object.
+		if ( ! $post && ! is_admin() ) {
+			$post = get_queried_object();
+
+			// Fallbacks to default if $post is not a WP_Post object.
+			if ( ! $post instanceof \WP_Post ) {
+				$post = 0;
+			}
 		}
 
-		$orig_site_url = untrailingslashit( home_url() );
-		$permalink     = get_permalink( $post );
-
+		$permalink = get_permalink( $post );
 		if ( false === $permalink ) {
 			return $permalink;
 		}

--- a/includes/Context.php
+++ b/includes/Context.php
@@ -154,12 +154,15 @@ final class Context {
 		$orig_site_url      = untrailingslashit( home_url() );
 
 		// Gets post object. On front area we need to use get_queried_object to get the current post object.
-		if ( ! $post && ! is_admin() ) {
-			$post = get_queried_object();
+		if ( ! $post ) {
+			if ( is_admin() ) {
+				$post = get_post();
+			} else {
+				$post = get_queried_object();
+			}
 
-			// Fallbacks to default if $post is not a WP_Post object.
 			if ( ! $post instanceof \WP_Post ) {
-				$post = 0;
+				return false;
 			}
 		}
 

--- a/includes/Context.php
+++ b/includes/Context.php
@@ -140,6 +140,29 @@ final class Context {
 		return $site_url;
 	}
 
+
+	/**
+	 * Gets the permalink of the reference site to use for stats.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param int|\WP_Post $post  Optional. Post ID or post object. Default is the global `$post`.
+	 *
+	 * @return string Reference permalink.
+	 */
+	public function get_reference_permalink( $post = 0 ) {
+		$orig_site_url      = untrailingslashit( home_url() );
+		$reference_site_url = untrailingslashit( $this->get_reference_site_url() );
+
+		$permalink = get_permalink( $post );
+
+		if ( $orig_site_url !== $reference_site_url ) {
+			$permalink = str_replace( $orig_site_url, $reference_site_url, $permalink );
+		}
+
+		return $permalink;
+	}
+
 	/**
 	 * Gets the current version is beta released.
 	 *

--- a/includes/Context.php
+++ b/includes/Context.php
@@ -152,7 +152,7 @@ final class Context {
 	public function get_reference_permalink( $post = 0 ) {
 		$reference_site_url = untrailingslashit( $this->get_reference_site_url() );
 
-		// Returns home page url when homepage mode is latest blog posts.
+		// Returns home page url when front page mode is latest blog posts.
 		if ( 'posts' === get_option( 'show_on_front' ) && is_home() ) {
 			return trailingslashit( $reference_site_url );
 		}

--- a/includes/Context.php
+++ b/includes/Context.php
@@ -147,17 +147,16 @@ final class Context {
 	 *
 	 * @param int|\WP_Post $post  Optional. Post ID or post object. Default is the global `$post`.
 	 *
-	 * @return string Reference permalink.
+	 * @return string|false The  Reference permalink URL or false if post does not exist.
 	 */
 	public function get_reference_permalink( $post = 0 ) {
 		$orig_site_url      = untrailingslashit( home_url() );
 		$reference_site_url = untrailingslashit( $this->get_reference_site_url() );
 
-		// Specific on homepage get_permalink either return the global posts or false.
-		if ( is_home() ) {
-			$permalink = $this->get_reference_site_url();
-		} else {
-			$permalink = get_permalink( $post );
+		$permalink = get_permalink( $post );
+
+		if ( false === $permalink ) {
+			return $permalink;
 		}
 
 		if ( $orig_site_url !== $reference_site_url ) {

--- a/includes/Context.php
+++ b/includes/Context.php
@@ -150,10 +150,15 @@ final class Context {
 	 * @return string|false The  Reference permalink URL or false if post does not exist.
 	 */
 	public function get_reference_permalink( $post = 0 ) {
-		$orig_site_url      = untrailingslashit( home_url() );
 		$reference_site_url = untrailingslashit( $this->get_reference_site_url() );
 
-		$permalink = get_permalink( $post );
+		// Returns home page url when homepage mode is latest blog posts.
+		if ( 'posts' === get_option( 'show_on_front' ) && is_home() ) {
+			return trailingslashit( $reference_site_url );
+		}
+
+		$orig_site_url = untrailingslashit( home_url() );
+		$permalink     = get_permalink( $post );
 
 		if ( false === $permalink ) {
 			return $permalink;

--- a/includes/Context.php
+++ b/includes/Context.php
@@ -140,7 +140,6 @@ final class Context {
 		return $site_url;
 	}
 
-
 	/**
 	 * Gets the permalink of the reference site to use for stats.
 	 *
@@ -154,7 +153,12 @@ final class Context {
 		$orig_site_url      = untrailingslashit( home_url() );
 		$reference_site_url = untrailingslashit( $this->get_reference_site_url() );
 
-		$permalink = get_permalink( $post );
+		// Specific on homepage get_permalink either return the global posts or false.
+		if ( is_home() ) {
+			$permalink = $this->get_reference_site_url();
+		} else {
+			$permalink = get_permalink( $post );
+		}
 
 		if ( $orig_site_url !== $reference_site_url ) {
 			$permalink = str_replace( $orig_site_url, $reference_site_url, $permalink );

--- a/includes/Context.php
+++ b/includes/Context.php
@@ -153,7 +153,7 @@ final class Context {
 		$reference_site_url = untrailingslashit( $this->get_reference_site_url() );
 
 		// Returns home page url when front page mode is latest blog posts.
-		if ( 'posts' === get_option( 'show_on_front' ) && is_home() ) {
+		if ( ! $post && 'posts' === get_option( 'show_on_front' ) && is_home() ) {
 			return trailingslashit( $reference_site_url );
 		}
 

--- a/includes/Core/Admin_Bar/Admin_Bar.php
+++ b/includes/Core/Admin_Bar/Admin_Bar.php
@@ -149,6 +149,13 @@ final class Admin_Bar {
 			return false;
 		}
 
+		// Always show admin bar on front page if user has capability.
+		// We need to shortcut this here, since this method run in 2 different hooks. In *_enqueue_scripts and admin_bar_menu.
+		// Since admin_bar_menu is called very late, the get_post below return different post object.
+		if ( is_front_page() && current_user_can( Permissions::VIEW_DASHBOARD ) ) {
+			return true;
+		}
+
 		$post = get_post();
 		if ( ! $post ) {
 			return false;

--- a/includes/Core/Admin_Bar/Admin_Bar.php
+++ b/includes/Core/Admin_Bar/Admin_Bar.php
@@ -149,13 +149,6 @@ final class Admin_Bar {
 			return false;
 		}
 
-		// Shows admin bar on homepage when front page mode is latest blog posts.
-		if ( 'posts' === get_option( 'show_on_front' ) &&
-			is_home() &&
-			current_user_can( Permissions::VIEW_DASHBOARD ) ) {
-			return true;
-		}
-
 		// Gets post object. On front area we need to use get_queried_object to get the current post object.
 		if ( is_admin() ) {
 			$post = get_post();

--- a/includes/Core/Admin_Bar/Admin_Bar.php
+++ b/includes/Core/Admin_Bar/Admin_Bar.php
@@ -149,15 +149,14 @@ final class Admin_Bar {
 			return false;
 		}
 
-		// Always show admin bar on front page if user has capability.
-		// We need to shortcut this here, since this method run in 2 different hooks. In *_enqueue_scripts and admin_bar_menu.
-		// Since admin_bar_menu is called very late, the get_post below return different post object.
-		if ( is_front_page() && current_user_can( Permissions::VIEW_DASHBOARD ) ) {
-			return true;
+		// Gets post object. On front area we need to use get_queried_object to get the current post object.
+		if ( is_admin() ) {
+			$post = get_post();
+		} else {
+			$post = get_queried_object();
 		}
 
-		$post = get_post();
-		if ( ! $post ) {
+		if ( ! $post || ! $post instanceof \WP_Post ) {
 			return false;
 		}
 

--- a/includes/Core/Admin_Bar/Admin_Bar.php
+++ b/includes/Core/Admin_Bar/Admin_Bar.php
@@ -149,7 +149,7 @@ final class Admin_Bar {
 			return false;
 		}
 
-		// Shows admin bar on homepage homepage mode is latest blog posts.
+		// Shows admin bar on homepage when front page mode is latest blog posts.
 		if ( 'posts' === get_option( 'show_on_front' ) &&
 			is_home() &&
 			current_user_can( Permissions::VIEW_DASHBOARD ) ) {

--- a/includes/Core/Admin_Bar/Admin_Bar.php
+++ b/includes/Core/Admin_Bar/Admin_Bar.php
@@ -149,6 +149,13 @@ final class Admin_Bar {
 			return false;
 		}
 
+		// Shows admin bar on homepage homepage mode is latest blog posts.
+		if ( 'posts' === get_option( 'show_on_front' ) &&
+			is_home() &&
+			current_user_can( Permissions::VIEW_DASHBOARD ) ) {
+			return true;
+		}
+
 		// Gets post object. On front area we need to use get_queried_object to get the current post object.
 		if ( is_admin() ) {
 			$post = get_post();

--- a/includes/Core/Assets/Assets.php
+++ b/includes/Core/Assets/Assets.php
@@ -479,15 +479,6 @@ final class Assets {
 			$permalink = esc_url_raw( $this->context->get_reference_permalink() );
 		}
 
-		/**
-		 * Filter the permalink.
-		 *
-		 * Enables modules to overwrite how the page permalink is retrieved.
-		 *
-		 * @param array $permalink The page permalink.
-		 */
-		$permalink = esc_url_raw( apply_filters( 'googlesitekit_permalink', $permalink ) );
-
 		if ( isset( $_GET['pageTitle'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.NoNonceVerification
 			$page_title = sanitize_text_field( $_GET['pageTitle'] );
 		} else {

--- a/includes/Core/Assets/Assets.php
+++ b/includes/Core/Assets/Assets.php
@@ -475,6 +475,8 @@ final class Assets {
 
 		if ( isset( $_GET['permaLink'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.NoNonceVerification
 			$permalink = esc_url_raw( $_GET['permaLink'] );
+		} elseif ( is_front_page() ) {
+			$permalink = esc_url_raw( $site_url );
 		} else {
 			$permalink = esc_url_raw( $this->context->get_reference_permalink() );
 		}

--- a/includes/Core/Assets/Assets.php
+++ b/includes/Core/Assets/Assets.php
@@ -476,12 +476,9 @@ final class Assets {
 		if ( isset( $_GET['permaLink'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.NoNonceVerification
 			$permalink = esc_url_raw( $_GET['permaLink'] );
 		} else {
-			if ( is_home() ) {
-				$permalink = esc_url_raw( $this->context->get_reference_site_url() );
-			} else {
-				$permalink = get_permalink();
-			}
+			$permalink = esc_url_raw( $this->context->get_reference_permalink() );
 		}
+
 		/**
 		 * Filter the permalink.
 		 *

--- a/includes/Core/Assets/Assets.php
+++ b/includes/Core/Assets/Assets.php
@@ -475,8 +475,6 @@ final class Assets {
 
 		if ( isset( $_GET['permaLink'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.NoNonceVerification
 			$permalink = esc_url_raw( $_GET['permaLink'] );
-		} elseif ( is_front_page() ) {
-			$permalink = esc_url_raw( $site_url );
 		} else {
 			$permalink = esc_url_raw( $this->context->get_reference_permalink() );
 		}

--- a/includes/Modules/Search_Console.php
+++ b/includes/Modules/Search_Console.php
@@ -586,10 +586,11 @@ final class Search_Console extends Module implements Module_With_Screen, Module_
 			$post_url = get_permalink( $post_id );
 
 			// Checks if googlesitekit_site_url has been filtered.
-			$filtered_site_url = esc_url_raw( apply_filters( 'googlesitekit_site_url', '' ) );
-			if ( ! empty( $filtered_site_url ) ) {
+			$reference_site_url = untrailingslashit( $this->context->get_reference_site_url() );
+			$home_url           = untrailingslashit( home_url() );
+			if ( $reference_site_url !== $home_url ) {
 				// Replaces post_url with production domain to get real data.
-				$post_url = trailingslashit( str_replace( home_url(), $filtered_site_url, $post_url ) );
+				$post_url = str_replace( $home_url, $reference_site_url, $post_url );
 			}
 
 			$datasets = array(

--- a/includes/Modules/Search_Console.php
+++ b/includes/Modules/Search_Console.php
@@ -585,6 +585,10 @@ final class Search_Console extends Module implements Module_With_Screen, Module_
 		if ( false === $has_data ) {
 			$post_url = esc_url_raw( $this->context->get_reference_permalink( $post_id ) );
 
+			if ( false === $post_url ) {
+				return false;
+			}
+
 			$datasets = array(
 				array(
 					'identifier' => $this->slug,

--- a/includes/Modules/Search_Console.php
+++ b/includes/Modules/Search_Console.php
@@ -585,6 +585,13 @@ final class Search_Console extends Module implements Module_With_Screen, Module_
 		if ( false === $has_data ) {
 			$post_url = get_permalink( $post_id );
 
+			// Checks if googlesitekit_site_url has been filtered.
+			$filtered_site_url = esc_url_raw( apply_filters( 'googlesitekit_site_url', '' ) );
+			if ( ! empty( $filtered_site_url ) ) {
+				// Replaces post_url with production domain to get real data.
+				$post_url = trailingslashit( str_replace( home_url(), $filtered_site_url, $post_url ) );
+			}
+
 			$datasets = array(
 				array(
 					'identifier' => $this->slug,

--- a/includes/Modules/Search_Console.php
+++ b/includes/Modules/Search_Console.php
@@ -583,15 +583,7 @@ final class Search_Console extends Module implements Module_With_Screen, Module_
 		$transient_key = 'googlesitekit_sc_has_data_for_post_' . $post_id;
 		$has_data      = get_transient( $transient_key );
 		if ( false === $has_data ) {
-			$post_url = get_permalink( $post_id );
-
-			// Checks if googlesitekit_site_url has been filtered.
-			$reference_site_url = untrailingslashit( $this->context->get_reference_site_url() );
-			$home_url           = untrailingslashit( home_url() );
-			if ( $reference_site_url !== $home_url ) {
-				// Replaces post_url with production domain to get real data.
-				$post_url = str_replace( $home_url, $reference_site_url, $post_url );
-			}
+			$post_url = esc_url_raw( $this->context->get_reference_permalink( $post_id ) );
 
 			$datasets = array(
 				array(

--- a/tests/phpunit/integration/ContextTest.php
+++ b/tests/phpunit/integration/ContextTest.php
@@ -132,6 +132,10 @@ class ContextTest extends TestCase {
 		// If the filtered value returns a non-empty value, it takes precedence.
 		add_filter( 'googlesitekit_site_url', $other_url_filter );
 		$this->assertEquals( 'https://test.com/hello-world/', $context->get_reference_permalink( $post_id ) );
+
+		update_option( 'show_on_front', 'posts' );
+		$this->go_to( '/' );
+		$this->assertEquals( 'https://test.com/', $context->get_reference_permalink() );
 	}
 
 	public function test_is_beta() {

--- a/tests/phpunit/integration/ContextTest.php
+++ b/tests/phpunit/integration/ContextTest.php
@@ -122,12 +122,15 @@ class ContextTest extends TestCase {
 
 		$post_id = self::factory()->post->create( array( 'post_title' => 'hello-world' ) );
 		$page_id = self::factory()->post->create( array( 'post_title' => 'homepage', 'post_type' => 'page' ) );
+		self::factory()->category->create( array( 'slug' => 'postcategory' ) );
+
+		$this->go_to( '/category/postcategory' );
+		$this->assertFalse( $context->get_reference_permalink() );
 
 		update_option( 'show_on_front', 'page' );
 		update_option( 'page_on_front', $page_id );
 
 		$this->go_to( '/hello-world' );
-
 		$this->assertEquals( get_permalink(), $context->get_reference_permalink() );
 
 		$other_url_filter = function () {
@@ -139,7 +142,6 @@ class ContextTest extends TestCase {
 
 		$this->go_to( '/' );
 		$this->assertEquals( 'https://test.com/', $context->get_reference_permalink() );
-
 		$this->assertEquals( 'https://test.com/hello-world/', $context->get_reference_permalink( $post_id ) );
 	}
 

--- a/tests/phpunit/integration/ContextTest.php
+++ b/tests/phpunit/integration/ContextTest.php
@@ -121,6 +121,11 @@ class ContextTest extends TestCase {
 		$context = new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE );
 
 		$post_id = self::factory()->post->create( array( 'post_title' => 'hello-world' ) );
+		$page_id = self::factory()->post->create( array( 'post_title' => 'homepage', 'post_type' => 'page' ) );
+
+		update_option( 'show_on_front', 'page' );
+		update_option( 'page_on_front', $page_id );
+
 		$this->go_to( '/hello-world' );
 
 		$this->assertEquals( get_permalink(), $context->get_reference_permalink() );
@@ -132,7 +137,6 @@ class ContextTest extends TestCase {
 		// If the filtered value returns a non-empty value, it takes precedence.
 		add_filter( 'googlesitekit_site_url', $other_url_filter );
 
-		update_option( 'show_on_front', 'posts' );
 		$this->go_to( '/' );
 		$this->assertEquals( 'https://test.com/', $context->get_reference_permalink() );
 

--- a/tests/phpunit/integration/ContextTest.php
+++ b/tests/phpunit/integration/ContextTest.php
@@ -131,11 +131,12 @@ class ContextTest extends TestCase {
 
 		// If the filtered value returns a non-empty value, it takes precedence.
 		add_filter( 'googlesitekit_site_url', $other_url_filter );
-		$this->assertEquals( 'https://test.com/hello-world/', $context->get_reference_permalink( $post_id ) );
 
 		update_option( 'show_on_front', 'posts' );
 		$this->go_to( '/' );
 		$this->assertEquals( 'https://test.com/', $context->get_reference_permalink() );
+
+		$this->assertEquals( 'https://test.com/hello-world/', $context->get_reference_permalink( $post_id ) );
 	}
 
 	public function test_is_beta() {

--- a/tests/phpunit/integration/ContextTest.php
+++ b/tests/phpunit/integration/ContextTest.php
@@ -118,14 +118,12 @@ class ContextTest extends TestCase {
 		$this->set_permalink_structure( '/%postname%/' );
 		flush_rewrite_rules();
 
-		update_option( 'show_on_front', 'posts' );
-
 		$context = new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE );
-		$reference_site_url  = $context->get_reference_site_url();
 
-		// By default, the reference site_url is the same with reference_permalink if post is 0.
-		$this->go_to( '/' );
-		$this->assertEquals( $reference_site_url, $context->get_reference_permalink() );
+		$post_id = self::factory()->post->create( array( 'post_title' => 'hello-world' ) );
+		$this->go_to( '/hello-world' );
+
+		$this->assertEquals( get_permalink(), $context->get_reference_permalink() );
 
 		$other_url_filter = function () {
 			return 'https://test.com/';
@@ -133,10 +131,6 @@ class ContextTest extends TestCase {
 
 		// If the filtered value returns a non-empty value, it takes precedence.
 		add_filter( 'googlesitekit_site_url', $other_url_filter );
-		$this->assertEquals( 'https://test.com/', $context->get_reference_permalink() );
-
-		$post_id = self::factory()->post->create( array( 'post_title' => 'hello-world' ) );
-		$this->go_to( '/hello-world' );
 		$this->assertEquals( 'https://test.com/hello-world/', $context->get_reference_permalink( $post_id ) );
 	}
 

--- a/tests/phpunit/integration/ContextTest.php
+++ b/tests/phpunit/integration/ContextTest.php
@@ -113,6 +113,33 @@ class ContextTest extends TestCase {
 		$this->assertEquals( $home_url, $context->get_reference_site_url() );
 	}
 
+	public function test_get_reference_permalink() {
+		remove_all_filters( 'googlesitekit_site_url' );
+		$this->set_permalink_structure( '/%postname%/' );
+		flush_rewrite_rules();
+
+		update_option( 'show_on_front', 'posts' );
+
+		$context = new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE );
+		$reference_site_url  = $context->get_reference_site_url();
+
+		// By default, the reference site_url is the same with reference_permalink if post is 0.
+		$this->go_to( '/' );
+		$this->assertEquals( $reference_site_url, $context->get_reference_permalink() );
+
+		$other_url_filter = function () {
+			return 'https://test.com/';
+		};
+
+		// If the filtered value returns a non-empty value, it takes precedence.
+		add_filter( 'googlesitekit_site_url', $other_url_filter );
+		$this->assertEquals( 'https://test.com/', $context->get_reference_permalink() );
+
+		$post_id = self::factory()->post->create( array( 'post_title' => 'hello-world' ) );
+		$this->go_to( '/hello-world' );
+		$this->assertEquals( 'https://test.com/hello-world/', $context->get_reference_permalink( $post_id ) );
+	}
+
 	public function test_is_beta() {
 		$context = new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE );
 


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #61 

## Relevant technical choices
Replace the permalink with filtered site url when query to Search Console. So we can get the production data.

## Checklist:
- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
