### PR TITLE
Add link to start setup button

### DIFF
--- a/includes/Core/Util/Activation.php
+++ b/includes/Core/Util/Activation.php
@@ -194,7 +194,7 @@ final class Activation {
 										mdc-layout-grid__cell--offset-1-desktop
 										mdc-layout-grid__cell--align-middle
 									">
-										<a href="#" onClick="javascript:sendAnalyticsTrackingEvent( 'plugin_setup', 'goto_sitekit' );document.location='<?php echo esc_url( $sitekit_splash_url ); ?>';"
+										<a href="<?php echo admin_url( 'admin.php?page=googlesitekit-splash'); ?>" onClick="javascript:sendAnalyticsTrackingEvent( 'plugin_setup', 'goto_sitekit' );document.location='<?php echo esc_url( $sitekit_splash_url ); ?>';"
 											class="googlesitekit-activation__button mdc-button mdc-button--raised">
 											<?php esc_html_e( 'Start Setup', 'google-site-kit' ); ?>
 										</a>


### PR DESCRIPTION
fixes #75

## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #75 

## Relevant technical choices

Added proper setup link to setup button.

## Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
