### PR TITLE
Fix PHP notice being thrown on AMP reader mode when Analytics or Tag Manager snippet is not inserted

### DIFF
--- a/includes/Modules/Analytics.php
+++ b/includes/Modules/Analytics.php
@@ -384,12 +384,12 @@ final class Analytics extends Module implements Module_With_Screen, Module_With_
 
 		$use_snippet = $this->get_data( 'use-snippet' );
 		if ( is_wp_error( $use_snippet ) || ! $use_snippet ) {
-			return;
+			return $data;
 		}
 
 		$tracking_id = $this->get_data( 'property-id' );
 		if ( is_wp_error( $tracking_id ) ) {
-			return;
+			return $data;
 		}
 
 		$data['amp_component_scripts']['amp-analytics'] = 'https://cdn.ampproject.org/v0/amp-analytics-0.1.js';

--- a/includes/Modules/Optimize.php
+++ b/includes/Modules/Optimize.php
@@ -181,7 +181,6 @@ final class Optimize extends Module {
 		}
 
 		$data['amp_component_scripts']['amp-experiment'] = 'https://cdn.ampproject.org/v0/amp-experiment-0.1.js';
-
 		return $data;
 	}
 

--- a/includes/Modules/TagManager.php
+++ b/includes/Modules/TagManager.php
@@ -237,7 +237,7 @@ final class TagManager extends Module implements Module_With_Scopes {
 
 		$container_id = $this->get_data( 'container-id' );
 		if ( is_wp_error( $container_id ) || ! $container_id ) {
-			return;
+			return $data;
 		}
 
 		$data['amp_component_scripts']['amp-analytics'] = 'https://cdn.ampproject.org/v0/amp-analytics-0.1.js';

--- a/tests/phpunit/integration/Modules/AnalyticsTest.php
+++ b/tests/phpunit/integration/Modules/AnalyticsTest.php
@@ -200,6 +200,22 @@ class AnalyticsTest extends TestCase {
 		);
 	}
 
+	public function test_amp_data_load_analytics_component() {
+		$analytics = new Analytics( new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE ) );
+		$analytics->register();
+
+		$data = array( 'amp_component_scripts' => array() );
+
+		$result = apply_filters( 'amp_post_template_data', $data );
+		$this->assertSame( $data, $result );
+
+		$analytics->set_data( 'use-snippet', array( 'useSnippet' => true ) );
+		$analytics->set_data( 'property-id', array( 'propertyId' => '12345678' ) );
+
+		$result = apply_filters( 'amp_post_template_data', $data );
+		$this->assertArrayHasKey( 'amp-analytics', $result['amp_component_scripts'] );
+	}
+
 	/**
 	 * @return Module_With_Scopes
 	 */

--- a/tests/phpunit/integration/Modules/TagManagerTest.php
+++ b/tests/phpunit/integration/Modules/TagManagerTest.php
@@ -114,6 +114,21 @@ class TagManagerTest extends TestCase {
 		);
 	}
 
+	public function test_amp_data_load_analytics_component() {
+		$tagmanager = new TagManager( new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE ) );
+		$tagmanager->register();
+
+		$data = array( 'amp_component_scripts' => array() );
+
+		$result = apply_filters( 'amp_post_template_data', $data );
+		$this->assertSame( $data, $result );
+
+		$tagmanager->set_data( 'container-id', array( 'containerId' => '12345678' ) );
+
+		$result = apply_filters( 'amp_post_template_data', $data );
+		$this->assertArrayHasKey( 'amp-analytics', $result['amp_component_scripts'] );
+	}
+
 	/**
 	 * @return Module_With_Scopes
 	 */


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #5

## Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
