### PR TITLE
Reset: Update User Query to match with or without prefix

### DIFF
--- a/includes/Core/Util/Reset.php
+++ b/includes/Core/Util/Reset.php
@@ -140,22 +140,13 @@ final class Reset {
 	private function delete_all_user_metas() {
 		global $wpdb;
 
+		// User option keys are prefixed in single site and multisite when not in network mode.
+		$key_prefix = $this->context->is_network_mode() ? '' : $wpdb->get_blog_prefix();
 		$user_query = new \WP_User_Query(
 			array(
-				'fields'     => 'id',
-				'meta_query' => array(
-					'relation' => 'OR',
-					// Keys are un-prefixed in network mode.
-					array(
-						'key'     => OAuth_Client::OPTION_ACCESS_TOKEN,
-						'compare' => 'EXISTS',
-					),
-					// Keys are prefixed in single site and multisite when not in network mode.
-					array(
-						'key'     => $wpdb->get_blog_prefix() . OAuth_Client::OPTION_ACCESS_TOKEN,
-						'compare' => 'EXISTS',
-					),
-				),
+				'fields'   => 'id',
+				'meta_key' => $key_prefix . OAuth_Client::OPTION_ACCESS_TOKEN,
+				'compare'  => 'EXISTS',
 			)
 		);
 

--- a/includes/Core/Util/Reset.php
+++ b/includes/Core/Util/Reset.php
@@ -145,17 +145,17 @@ final class Reset {
 				'fields'     => 'id',
 				'meta_query' => array(
 					'relation' => 'OR',
-					// Keys are un-prefixed in network mode
+					// Keys are un-prefixed in network mode.
 					array(
 						'key'     => OAuth_Client::OPTION_ACCESS_TOKEN,
 						'compare' => 'EXISTS',
 					),
-					// Keys are prefixed in single site and multisite when not in network mode
+					// Keys are prefixed in single site and multisite when not in network mode.
 					array(
 						'key'     => $wpdb->get_blog_prefix() . OAuth_Client::OPTION_ACCESS_TOKEN,
 						'compare' => 'EXISTS',
 					),
-				)
+				),
 			)
 		);
 

--- a/includes/Core/Util/Reset.php
+++ b/includes/Core/Util/Reset.php
@@ -139,11 +139,23 @@ final class Reset {
 	 */
 	private function delete_all_user_metas() {
 		global $wpdb;
+
 		$user_query = new \WP_User_Query(
 			array(
-				'fields'   => 'id',
-				'meta_key' => $wpdb->prefix . OAuth_Client::OPTION_ACCESS_TOKEN,
-				'compare'  => 'EXISTS',
+				'fields'     => 'id',
+				'meta_query' => array(
+					'relation' => 'OR',
+					// Keys are un-prefixed in network mode
+					array(
+						'key'     => OAuth_Client::OPTION_ACCESS_TOKEN,
+						'compare' => 'EXISTS',
+					),
+					// Keys are prefixed in single site and multisite when not in network mode
+					array(
+						'key'     => $wpdb->get_blog_prefix() . OAuth_Client::OPTION_ACCESS_TOKEN,
+						'compare' => 'EXISTS',
+					),
+				)
 			)
 		);
 


### PR DESCRIPTION
## Summary

This PR fixes a problem where user meta is not deleted during a reset when the plugin is in a network mode context. This is because the User Query used in the `delete_all_user_metas` method used a prefixed meta key. This will not match user options set in a network mode context as these are saved without a prefix and user meta will not be deleted. This change extends the query to match meta keys both with and without a prefix which also ensures that everything is cleaned up should the site convert to (or from) a multisite install after the plugin is installed.

Addresses issue #101

## Relevant technical choices

- Changes the meta query from a single key to check for either a prefixed key OR an unprefixed key.
- This bug was found during the work for #102 which fails without this change when running in a multisite context

## Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
