### PR TITLE
Update plugin version to 1.0.0-beta.1.0.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "google/google-site-kit",
   "description": "Site Kit is a one-stop solution for WordPress users to use everything Google has to offer to make them successful on the web.",
-  "version": "1.0.0-beta.1",
+  "version": "1.0.0-beta.1.0.1",
   "license": "Apache-2.0",
   "type": "wordpress-plugin",
   "homepage": "https://sitekit.withgoogle.com",

--- a/google-site-kit.php
+++ b/google-site-kit.php
@@ -11,7 +11,7 @@
  * Plugin Name: Site Kit by Google
  * Plugin URI:  https://sitekit.withgoogle.com
  * Description: Site Kit is a one-stop solution for WordPress users to use everything Google has to offer to make them successful on the web.
- * Version:     1.0.0-beta.1
+ * Version:     1.0.0-beta.1.0.1
  * Author:      Google
  * Author URI:  https://opensource.google.com
  * License:     Apache License 2.0
@@ -24,7 +24,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 // Define most essential constants.
-define( 'GOOGLESITEKIT_VERSION', '1.0.0-beta.1' );
+define( 'GOOGLESITEKIT_VERSION', '1.0.0-beta.1.0.1' );
 define( 'GOOGLESITEKIT_PLUGIN_MAIN_FILE', __FILE__ );
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "googlesitekit",
-  "version": "1.0.0-beta.1",
+  "version": "1.0.0-beta.1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "googlesitekit",
-  "version": "1.0.0-beta.1",
+  "version": "1.0.0-beta.1.0.1",
   "description": "Site Kit is a one-stop solution for WordPress users to use everything Google has to offer to make them successful on the web.",
   "main": "index.js",
   "scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Contributors:      google
 Requires at least: 4.7
 Tested up to:      5.2
 Requires PHP:      5.4
-Stable tag:        1.0.0-beta.1
+Stable tag:        1.0.0-beta.1.0.1
 License:           Apache License 2.0
 License URI:       https://www.apache.org/licenses/LICENSE-2.0
 Tags:              google, search-console, analytics, adsense, pagespeed-insights, optimize, tag-manager


### PR DESCRIPTION
## Summary
Bump plugin version to 1.0.0-beta.1.0.1.
Also tested with php version_compare:
```
version_compare("1.0.0-beta.1", "1.0.0-beta.1.0.1", "<")
=> true
```

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.4.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
