### PR TITLE
Fix TypeError in readableLargeNumber for currency using only integers

### DIFF
--- a/assets/js/util/index.js
+++ b/assets/js/util/index.js
@@ -105,14 +105,12 @@ export const readableLargeNumber = ( number, currencyCode = false ) =>  {
 	if ( isUndefined( number ) ) {
 		readableNumber = 0;
 	} else if ( 1000000 < number ) {
-		number = number / 1000000;
-		readableNumber = number.toFixed( 1 ) + 'M';
+		readableNumber = ( number / 1000000 ).toFixed( 1 ) + 'M';
 	} else if ( 1000 < number ) {
-		number = number / 1000;
-		if ( 99 < number ) {
-			readableNumber = Math.round( number ) + 'K';
+		if ( 99 < ( number / 1000 ) ) {
+			readableNumber = Math.round( number / 1000 ) + 'K';
 		} else {
-			readableNumber = number.toFixed( 1 ) + 'K';
+			readableNumber = ( number / 1000 ).toFixed( 1 ) + 'K';
 		}
 	} else {
 		readableNumber = number;
@@ -134,12 +132,10 @@ export const readableLargeNumber = ( number, currencyCode = false ) =>  {
 	// Format as amount if currencyCode is passed.
 	if ( false !== currencyCode && '' !== readableNumber ) {
 		const formatedParts = new Intl.NumberFormat( navigator.language, { style: 'currency', currency: currencyCode } ).formatToParts( number );
-
-		const decimal = formatedParts.find( part => 'decimal' === part.type ).value;
+		const decimal = ( formatedParts.find( part => 'decimal' === part.type ) || {} ).value || '.';
 		const currency = formatedParts.find( part => 'currency' === part.type ).value;
-
 		if ( 1000 > number ) {
-			readableNumber = Number.isInteger( number ) ? number : number.replace( '.', decimal );
+			readableNumber = Number.isInteger( number ) ? number : String( number ).replace( '.', decimal );
 		}
 
 		return `${currency}${readableNumber}`;

--- a/tests/qunit/assets/js/util/index.js
+++ b/tests/qunit/assets/js/util/index.js
@@ -716,38 +716,66 @@ valuesToTest.forEach( function( itemToTest ) {
 valuesToTest = [
 	{
 		in: 123,
-		expected: '123'
+		expected: '123',
+		currencyCode: false
 	},
 	{
 		in: 1234,
-		expected: '1.2K'
+		expected: '1.2K',
+		currencyCode: false
 	},
 	{
 		in: 12345,
-		expected: '12.3K'
+		expected: '12.3K',
+		currencyCode: false
 	},
 	{
 		in: 123456,
-		expected: '123K'
+		expected: '123K',
+		currencyCode: false
 	},
 	{
 		in: 1234567,
-		expected: '1.2M'
+		expected: '1.2M',
+		currencyCode: false
 	},
 	{
 		in: 12345678,
-		expected: '12.3M'
+		expected: '12.3M',
+		currencyCode: false
 	},
 	{
 		in: 123456789,
-		expected: '123.5M'
+		expected: '123.5M',
+		currencyCode: false
 	},
+	{
+		in: 123,
+		expected: '$123',
+		currencyCode: 'USD'
+	},
+	{
+		in: 123,
+		expected: '¥123',
+		currencyCode: 'JPY'
+	},
+	{
+		in: 123456789,
+		expected: '$123.5M',
+		currencyCode: 'USD'
+	},
+	{
+		in: 123456789,
+		expected: '¥123.5M',
+		currencyCode: 'JPY'
+	},
+
 ];
 
 valuesToTest.forEach( function( itemToTest ) {
 	QUnit.test( 'readableLargeNumber::' + itemToTest.in, function ( assert ) {
-		var value = testFunctions.readableLargeNumber( itemToTest.in );
-		assert.equal( value, itemToTest.expected, 'Expect readableLargeNumber( \'' + itemToTest.in + '\' ) to return ' + itemToTest.expected );
+		var value = testFunctions.readableLargeNumber( itemToTest.in, itemToTest.currencyCode );
+		assert.equal( value, itemToTest.expected, 'Expect readableLargeNumber( \'' + itemToTest.in + ', ' + itemToTest.currencyCode + '\' ) to return ' + itemToTest.expected );
 	} );
 } );
 


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #114 

This fix for currency using only integers. (ex. JPY)

## Relevant technical choices

Fix `readableLargeNumber` . 
* removed reassignment to `number`.
* when not found `type: decimal`, use '.' .
* Add test `currencyCode` passed.

## Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
