### PR TITLE
fix  node-qunit-phantomjs: command not found

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -89,7 +89,7 @@ gulp.task( 'default', () => {
 } );
 
 gulp.task( 'qunit', function() {
-	execSync( 'node-qunit-phantomjs ./tests/qunit/index.html', { stdio: [ 0, 1, 2 ] } );
+	execSync( './node_modules/.bin/node-qunit-phantomjs ./tests/qunit/index.html', { stdio: [ 0, 1, 2 ] } );
 } );
 
 gulp.task( 'phpunit', function() {


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #111 #112 

When `gulp qunit` is executed, `/bin/sh: node-qunit-phantomjs: command not found` error occurs.
Fix the issue.

## Relevant technical choices

use `node-qunit-phantomjs` in node_modules.

<!-- Please describe your changes. -->

## Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
