### PR TITLE
PHPUnit: add TransientsTest

### DIFF
--- a/tests/phpunit/integration/Core/Storage/TransientsTest.php
+++ b/tests/phpunit/integration/Core/Storage/TransientsTest.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * TransientsTest
+ *
+ * @package   Google\Site_Kit\Tests\Core\Storage
+ * @copyright 2019 Google LLC
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
+ * @link      https://sitekit.withgoogle.com
+ */
+
+namespace Google\Site_Kit\Tests\Core\Storage;
+
+use Google\Site_Kit\Context;
+use Google\Site_Kit\Core\Storage\Transients;
+use Google\Site_Kit\Tests\TestCase;
+
+/**
+ * @group Storage
+ */
+class TransientsTest extends TestCase {
+
+	public function test_get() {
+		$context    = new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE );
+		$transients = new Transients( $context );
+		$this->assertFalse( $context->is_network_mode() );
+		set_transient( 'test-transient', 'test-value' );
+
+		$this->assertEquals( 'test-value', $transients->get( 'test-transient' ) );
+	}
+
+	/**
+	 * @group ms-required
+	 */
+	public function test_network_mode_get() {
+		$this->network_activate_site_kit();
+		$context    = new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE );
+		$transients = new Transients( $context );
+		$this->assertTrue( $context->is_network_mode() );
+		set_site_transient( 'test-transient', 'test-value' );
+
+		$this->assertEquals( 'test-value', $transients->get( 'test-transient' ) );
+	}
+
+	public function test_set() {
+		$context    = new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE );
+		$transients = new Transients( $context );
+		$this->assertFalse( $context->is_network_mode() );
+		$this->assertFalse( get_transient( 'test-transient' ) );
+
+		$transients->set( 'test-transient', 'test-value' );
+
+		$this->assertEquals( 'test-value', get_transient( 'test-transient' ) );
+	}
+
+	/**
+	 * @group ms-required
+	 */
+	public function test_network_mode_set() {
+		$this->network_activate_site_kit();
+		$context    = new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE );
+		$transients = new Transients( $context );
+		$this->assertTrue( $context->is_network_mode() );
+		$this->assertFalse( get_site_transient( 'test-transient' ) );
+
+		$transients->set( 'test-transient', 'test-value' );
+
+		$this->assertEquals( 'test-value', get_site_transient( 'test-transient' ) );
+	}
+
+	public function test_delete() {
+		$context    = new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE );
+		$transients = new Transients( $context );
+		$this->assertFalse( $context->is_network_mode() );
+		set_transient( 'test-transient', 'test-value' );
+		$this->assertEquals( 'test-value', get_transient( 'test-transient' ) );
+
+		$transients->delete( 'test-transient' );
+
+		$this->assertFalse( get_transient( 'test-transient' ) );
+	}
+
+	/**
+	 * @group ms-required
+	 */
+	public function test_network_mode_delete() {
+		$this->network_activate_site_kit();
+		$context    = new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE );
+		$transients = new Transients( $context );
+		$this->assertTrue( $context->is_network_mode() );
+		set_site_transient( 'test-transient', 'test-value' );
+		$this->assertEquals( 'test-value', get_site_transient( 'test-transient' ) );
+
+		$transients->delete( 'test-transient' );
+
+		$this->assertFalse( get_site_transient( 'test-transient' ) );
+	}
+
+	protected function network_activate_site_kit() {
+		add_filter(
+			'pre_site_option_active_sitewide_plugins',
+			function () {
+				return array( GOOGLESITEKIT_PLUGIN_BASENAME => true );
+			}
+		);
+	}
+}


### PR DESCRIPTION
## Summary

Adds test coverage for the `Core\Storage\Transients` class.

## Relevant technical choices

Tests in single site, multisite, and network activated contexts.

## Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
