### PR TITLE
PHPUnit: add Encrypted_OptionsTest

### DIFF
--- a/tests/phpunit/includes/Core/Storage/Base64_Encryption.php
+++ b/tests/phpunit/includes/Core/Storage/Base64_Encryption.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Base64_Encryption
+ *
+ * @package   Google\Site_Kit\Tests\Core\Storage
+ * @copyright 2019 Google LLC
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
+ * @link      https://sitekit.withgoogle.com
+ */
+
+namespace Google\Site_Kit\Tests\Core\Storage;
+
+/**
+ * Class Base64_Encryption
+ *
+ * A dummy encryption implementation for use in testing only.
+ *
+ * @package Google\Site_Kit\Tests\Core\Storage
+ */
+class Base64_Encryption {
+	/**
+	 * Encrypt the given value.
+	 *
+	 * @param mixed $value
+	 *
+	 * @return string
+	 */
+	public function encrypt( $value ) {
+		return base64_encode( $value );
+	}
+
+	/**
+	 * Decrypt the given value.
+	 *
+	 * @param mixed $value
+	 *
+	 * @return bool|string
+	 */
+	public function decrypt( $value ) {
+		return base64_decode( $value );
+	}
+}

--- a/tests/phpunit/integration/Core/Storage/Encrypted_OptionsTest.php
+++ b/tests/phpunit/integration/Core/Storage/Encrypted_OptionsTest.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * Encrypted_OptionsTest
+ *
+ * @package   Google\Site_Kit\Tests\Core\Storage
+ * @copyright 2019 Google LLC
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
+ * @link      https://sitekit.withgoogle.com
+ */
+
+namespace Google\Site_Kit\Tests\Core\Storage;
+
+use Google\Site_Kit\Context;
+use Google\Site_Kit\Core\Storage\Encrypted_Options;
+use Google\Site_Kit\Core\Storage\Options;
+use Google\Site_Kit\Tests\TestCase;
+
+/**
+ * @group Storage
+ */
+class Encrypted_OptionsTest extends TestCase {
+
+	public function test_get() {
+		$encrypted_options = $this->new_encrypted_options();
+
+		update_option( 'test-option', base64_encode( 'test-value' ) );
+		$this->assertEquals( 'test-value', $encrypted_options->get( 'test-option' ) );
+
+		update_option( 'test-serialized-option', base64_encode( serialize( array( 'test-value' ) ) ) );
+		$this->assertEquals( array( 'test-value' ), $encrypted_options->get( 'test-serialized-option' ) );
+	}
+
+	public function test_set() {
+		$encrypted_options = $this->new_encrypted_options();
+		$this->assertFalse( get_option( 'test-option' ) );
+		$this->assertFalse( get_option( 'test-serialized-option' ) );
+
+		$encrypted_options->set( 'test-option', 'test-value' );
+		$this->assertEquals( base64_encode( 'test-value' ), get_option( 'test-option' ) );
+
+		$encrypted_options->set( 'test-serialized-option', array( 'test-value' ) );
+		$this->assertEquals( base64_encode( serialize( array( 'test-value' ) ) ), get_option( 'test-serialized-option' ) );
+	}
+
+	public function test_delete() {
+		$encrypted_options = $this->new_encrypted_options();
+
+		// Use add_option to assert that the option was in fact deleted. (true means option did not exist before)
+		update_option( 'test-option', 'test-value' );
+		$this->assertFalse( add_option( 'test-option', 'irrelevant-value' ) );
+		$this->assertTrue( $encrypted_options->delete( 'test-option' ) );
+		$this->assertTrue( add_option( 'test-option', 'irrelevant-value' ) );
+
+		update_option( 'test-serialized-option', 'test-serialized-value' );
+		$this->assertFalse( add_option( 'test-serialized-option', 'irrelevant-value' ) );
+		$this->assertTrue( $encrypted_options->delete( 'test-serialized-option' ) );
+		$this->assertTrue( add_option( 'test-serialized-option', 'irrelevant-value' ) );
+	}
+
+	/**
+	 * Get a new instance of Encrypted_Options for testing.
+	 *
+	 * Replaces the normal secure encryption class with a predictable base64-based encryption mechanism for assertions.
+	 *
+	 * @return Encrypted_Options
+	 * @throws \ReflectionException
+	 */
+	protected function new_encrypted_options() {
+		$instance = new Encrypted_Options( new Options( new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE ) ) );
+
+		$this->force_set_property( $instance, 'encryption', new Base64_Encryption() );
+
+		return $instance;
+	}
+}


### PR DESCRIPTION
## Summary

Adds PHPUnit test coverage for the `Core\Storage\Encrypted_Options` class.

Addresses #141 

## Relevant technical choices

- Adds a simple encryption mechanism for use with tests
- Tests primitive and serialized values

## Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
