### PR TITLE
PHPUnit: add PluginTest

### DIFF
--- a/tests/phpunit/includes/TestCase.php
+++ b/tests/phpunit/includes/TestCase.php
@@ -111,4 +111,13 @@ class TestCase extends \WP_UnitTestCase {
 			}
 		}
 	}
+
+	protected function network_activate_site_kit() {
+		add_filter(
+			'pre_site_option_active_sitewide_plugins',
+			function () {
+				return array( GOOGLESITEKIT_PLUGIN_BASENAME => true );
+			}
+		);
+	}
 }

--- a/tests/phpunit/includes/TestCase.php
+++ b/tests/phpunit/includes/TestCase.php
@@ -40,32 +40,32 @@ class TestCase extends \WP_UnitTestCase {
 	/**
 	 * Forcibly set a property of an object that would otherwise not be possible.
 	 *
-	 * @param object $instance Class instance to set the property on
+	 * @param object|string $class Class instance to set the property on, or class name containing the property.
 	 * @param string $property Property name
-	 * @param mixed  $value    New value to assign the property
+	 * @param mixed $value New value to assign the property
 	 *
 	 * @throws \ReflectionException
 	 */
-	protected function force_set_property( $instance, $property, $value ) {
-		$reflection_property = new \ReflectionProperty( $instance, $property );
+	protected function force_set_property( $class, $property, $value ) {
+		$reflection_property = new \ReflectionProperty( $class, $property );
 		$reflection_property->setAccessible( true );
-		$reflection_property->setValue( $instance, $value );
+		$reflection_property->setValue( $class, $value );
 	}
 
 	/**
 	 * Forcibly get a property's value from an object that would otherwise not be possible.
 	 *
-	 * @param object $instance Class instance to get the property from
+	 * @param object|string $class Class instance to get the property from, or class name containing the property.
 	 * @param string $property Property name
 	 *
 	 * @return mixed
 	 * @throws \ReflectionException
 	 */
-	protected function force_get_property( $instance, $property ) {
-		$reflection_property = new \ReflectionProperty( $instance, $property );
+	protected function force_get_property( $class, $property ) {
+		$reflection_property = new \ReflectionProperty( $class, $property );
 		$reflection_property->setAccessible( true );
 
-		return $reflection_property->getValue( $instance );
+		return $reflection_property->getValue( $class );
 	}
 
 	/**

--- a/tests/phpunit/integration/ContextTest.php
+++ b/tests/phpunit/integration/ContextTest.php
@@ -14,7 +14,7 @@ use Google\Site_Kit\Context;
 use Google\Site_Kit\Core\Admin\Screens;
 
 /**
- * @group context
+ * @group Root
  */
 class ContextTest extends TestCase {
 

--- a/tests/phpunit/integration/Core/Storage/Google/OptionsTest.php
+++ b/tests/phpunit/integration/Core/Storage/Google/OptionsTest.php
@@ -95,13 +95,4 @@ class OptionsTest extends TestCase {
 
 		$this->assertFalse( get_network_option( null, 'test_option' ) );
 	}
-
-	protected function network_activate_site_kit() {
-		add_filter(
-			'pre_site_option_active_sitewide_plugins',
-			function () {
-				return array( GOOGLESITEKIT_PLUGIN_BASENAME => true );
-			}
-		);
-	}
 }

--- a/tests/phpunit/integration/Core/Storage/Google/OptionsTest.php
+++ b/tests/phpunit/integration/Core/Storage/Google/OptionsTest.php
@@ -95,4 +95,13 @@ class OptionsTest extends TestCase {
 
 		$this->assertFalse( get_network_option( null, 'test_option' ) );
 	}
+
+	protected function network_activate_site_kit() {
+		add_filter(
+			'pre_site_option_active_sitewide_plugins',
+			function () {
+				return array( GOOGLESITEKIT_PLUGIN_BASENAME => true );
+			}
+		);
+	}
 }

--- a/tests/phpunit/integration/PluginTest.php
+++ b/tests/phpunit/integration/PluginTest.php
@@ -1,0 +1,109 @@
+<?php
+/**
+ * PluginTest
+ *
+ * @package   Google\Site_Kit\Tests
+ * @copyright 2019 Google LLC
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
+ * @link      https://sitekit.withgoogle.com
+ */
+
+namespace Google\Site_Kit\Tests;
+
+use Google\Site_Kit\Plugin;
+
+class PluginTest extends TestCase {
+
+	/**
+	 * Plugin instance backup.
+	 *
+	 * @var Plugin
+	 */
+	protected static $backup_instance;
+
+	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
+		self::$backup_instance = Plugin::instance();
+	}
+
+	public function tearDown() {
+		parent::tearDown();
+		// Restore the main instance after each test.
+		$this->force_set_property( 'Google\Site_Kit\Plugin', 'instance', self::$backup_instance );
+	}
+
+	public function test_context() {
+		$plugin = new Plugin( GOOGLESITEKIT_PLUGIN_MAIN_FILE );
+
+		$this->assertInstanceOf( 'Google\Site_Kit\Context', $plugin->context() );
+		// Test that the context provided is using the same file.
+		$this->assertEquals( plugin_dir_path( GOOGLESITEKIT_PLUGIN_MAIN_FILE ), $plugin->context()->path() );
+	}
+
+	public function test_register() {
+		$plugin = new Plugin( GOOGLESITEKIT_PLUGIN_MAIN_FILE );
+		remove_all_actions( 'init' );
+		remove_all_actions( 'googlesitekit_init' );
+		remove_all_actions( 'wp_head' );
+		remove_all_actions( 'login_head' );
+		$GLOBALS['wp_actions'] = [];
+
+		$plugin->register();
+
+		$this->assertActionRendersGeneratorTag( 'wp_head' );
+		$this->assertActionRendersGeneratorTag( 'login_head' );
+
+		// Ensure the googlesitekit_init action is fired.
+		$mock_callback = $this->getMock( 'MockClass', array( 'callback' ) );
+		$mock_callback->expects( $this->once() )->method( 'callback' );
+		add_action( 'googlesitekit_init', array( $mock_callback, 'callback' ) );
+
+		$this->assertEquals( 0, did_action( 'googlesitekit_init' ) );
+		do_action( 'init' );
+		$this->assertEquals( 1, did_action( 'googlesitekit_init' ) );
+	}
+
+	protected function assertActionRendersGeneratorTag( $action ) {
+		ob_start();
+		do_action( $action );
+		$output = ob_get_clean();
+
+		$this->assertContains(
+			'<meta name="generator" content="Site Kit by Google ' . GOOGLESITEKIT_VERSION . '"',
+			$output
+		);
+	}
+
+	/**
+	 * @group ms-required
+	 */
+	public function test_network_mode_register() {
+		$this->network_activate_site_kit();
+		$plugin = new Plugin( GOOGLESITEKIT_PLUGIN_MAIN_FILE );
+		$this->assertTrue( $plugin->context()->is_network_mode() );
+		remove_all_actions( 'network_admin_notices' );
+
+		$plugin->register();
+
+		ob_start();
+		do_action( 'network_admin_notices' );
+		$network_admin_notices = ob_get_clean();
+
+		// Regex is case-insensitive and dotall (s) to match over multiple lines.
+		$this->assertRegExp( '#<div class="notice notice-warning.*?not yet compatible.*?</div>#is', $network_admin_notices );
+	}
+
+	public function test_load_and_instance() {
+		// Clear out the plugin instance instantiated during bootstrap.
+		$this->force_set_property( 'Google\Site_Kit\Plugin', 'instance', null );
+		$this->assertNull( Plugin::instance() );
+
+		$this->assertTrue( Plugin::load( GOOGLESITEKIT_PLUGIN_MAIN_FILE ) );
+		$plugin = Plugin::instance();
+
+		// Subsequent calls return false after the instance is loaded.
+		$this->assertFalse( Plugin::load( GOOGLESITEKIT_PLUGIN_MAIN_FILE ) );
+		// Instance returns the same instance every time.
+		$this->assertSame( $plugin, Plugin::instance() );
+	}
+}

--- a/tests/phpunit/integration/PluginTest.php
+++ b/tests/phpunit/integration/PluginTest.php
@@ -12,6 +12,9 @@ namespace Google\Site_Kit\Tests;
 
 use Google\Site_Kit\Plugin;
 
+/**
+ * @group Root
+ */
 class PluginTest extends TestCase {
 
 	/**


### PR DESCRIPTION
## Summary

Addresses issue #147 

## Relevant technical choices

- Updates the definition of force set/get property methods to be more clear that it does not require an instance, but also accepts a class name (if setting a static property for example)
- Pulls the `network_activate_site_kit` helper method into the base `TestCase`  
_This can be removed from child test cases in a future PR, once all others are merged_
- Adds a top-level "Root" group for top-level test cases

## Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
