### PR TITLE
Don't allow any whitespace characters in API key

### DIFF
--- a/assets/js/modules/pagespeed-insights/setup.js
+++ b/assets/js/modules/pagespeed-insights/setup.js
@@ -88,7 +88,7 @@ class PageSpeedInsightsSetup extends Component {
 
 	handleAPIKeyChange( e ) {
 		this.setState( {
-			apikey: e.currentTarget.value,
+			apikey: e.currentTarget.value.replace( /\s/g, '' ),
 			disabled: 0 === e.currentTarget.value.length,
 		} );
 	}

--- a/assets/js/modules/pagespeed-insights/setup.js
+++ b/assets/js/modules/pagespeed-insights/setup.js
@@ -88,7 +88,7 @@ class PageSpeedInsightsSetup extends Component {
 
 	handleAPIKeyChange( e ) {
 		this.setState( {
-			apikey: e.currentTarget.value.replace( /\s/g, '' ),
+			apikey: e.currentTarget.value.trim(),
 			disabled: 0 === e.currentTarget.value.length,
 		} );
 	}


### PR DESCRIPTION
## Summary

Addresses issue #81 

## Relevant technical choices

- Filters out any whitespace characters in the API key input on entry
- Tested manual entry as well as pasting an API key containing spaces
- Tested with Chrome & Firefox (shouldn't be browser dependent though)

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.  
No tooling set up for testing React components yet
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation. (n/a)
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
