### PR TITLE
Update adsenseURL to use siteURL hostname

### DIFF
--- a/assets/js/modules/adsense/dashboard/adsense-in-process-status.js
+++ b/assets/js/modules/adsense/dashboard/adsense-in-process-status.js
@@ -29,6 +29,7 @@ class AdSenseInProcessStatus extends Component {
 		const { status } = this.props;
 		const { siteURL } = googlesitekit.admin;
 		const siteURLURL = new URL( siteURL );
+		const adsenseURL = `https://www.google.com/adsense/new/sites?url=${ siteURLURL.hostname }&source=site-kit`;
 		const actionableItems = [
 			{
 				id: 1,
@@ -36,7 +37,7 @@ class AdSenseInProcessStatus extends Component {
 				/* translators: %s: Site URL */
 				text: sprintf( __( 'Added your site %s in ', 'google-site-kit' ), siteURLURL.hostname ),
 				linkText: __( 'Sites', 'google-site-kit' ),
-				linkURL: `https://www.google.com/adsense/new/sites?url=${ siteURL }&source=site-kit`,
+				linkURL: adsenseURL,
 			},
 			{
 				id: 2,
@@ -99,7 +100,6 @@ class AdSenseInProcessStatus extends Component {
 			</div>
 		);
 
-		const adsenseURL = `https://www.google.com/adsense/new/sites?url=${ siteURL }&source=site-kit`;
 		const ctaList = {
 			incomplete: null,
 


### PR DESCRIPTION
## Summary

This PR updates the URL that links out to adsense for your site to use the local site's hostname for the `url` parameter, rather than a fully formed URL, including the scheme.

Addresses issue #94 

## Relevant technical choices

* This same URL was used in multiple places in the same component, not just the one case described in the issue, so I updated it to update them all. 

I noticed this when setting up my Adsense account and seeing this alternate state

![image](https://user-images.githubusercontent.com/1621608/61047990-5927d180-a3e9-11e9-8cd5-0b019819de2f.png)

## Checklist

- [ ] My code is tested and passes existing unit tests. n/a
- [ ] My code has an appropriate set of unit tests which all pass. n/a
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
