### PR TITLE
Update URL attributes to escape the full URL

### DIFF
--- a/includes/Core/Util/Tracking.php
+++ b/includes/Core/Util/Tracking.php
@@ -156,7 +156,7 @@ final class Tracking {
 		}
 		?>
 		<!-- Global site tag (gtag.js) - Google Analytics -->
-		<script async src="https://www.googletagmanager.com/gtag/js?id=<?php echo esc_attr( self::TRACKING_ID ); ?>"></script><?php // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript ?>
+		<script async src="<?php echo esc_url( 'https://www.googletagmanager.com/gtag/js?id=' . self::TRACKING_ID ); ?>"></script><?php // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript ?>
 		<script>
 			window.dataLayer = window.dataLayer || [];
 			function gtag(){dataLayer.push(arguments);}

--- a/includes/Modules/TagManager.php
+++ b/includes/Modules/TagManager.php
@@ -192,7 +192,7 @@ final class TagManager extends Module implements Module_With_Scopes {
 		?>
 		<!-- Google Tag Manager (noscript) added by Site Kit -->
 		<noscript>
-			<iframe src="https://www.googletagmanager.com/ns.html?id=<?php echo esc_attr( $container_id ); ?>" height="0" width="0" style="display:none;visibility:hidden"></iframe>
+			<iframe src="<?php echo esc_url( "https://www.googletagmanager.com/ns.html?id=$container_id" ); ?>" height="0" width="0" style="display:none;visibility:hidden"></iframe>
 		</noscript>
 		<!-- End Google Tag Manager (noscript) -->
 		<?php
@@ -215,7 +215,7 @@ final class TagManager extends Module implements Module_With_Scopes {
 
 		?>
 		<!-- Google Tag Manager added by Site Kit -->
-		<amp-analytics config="https://www.googletagmanager.com/amp.json?id=<?php echo esc_attr( $container_id ); ?>" data-credentials="include"></amp-analytics>
+		<amp-analytics config="<?php echo esc_url( "https://www.googletagmanager.com/amp.json?id=$container_id" ); ?>" data-credentials="include"></amp-analytics>
 		<!-- End Google Tag Manager -->
 		<?php
 	}


### PR DESCRIPTION
## Summary

Addresses issue #16 

## Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.  
`TagManager` relies on `get_data` to output affected `iframe` or `amp-analytics` tags  
`TrackingTest` is not yet merged, but does cover testing for the presence of the URL
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation. n/a
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
