### PR TITLE
fix standalone sendAnalyticsTrackingEvent not being defined

### DIFF
--- a/includes/Core/Util/Activation.php
+++ b/includes/Core/Util/Activation.php
@@ -155,7 +155,9 @@ final class Activation {
 					ob_start();
 					?>
 					<script type="text/javascript">
-					sendAnalyticsTrackingEvent( 'plugin_setup', 'plugin_activated' );
+					if( 'undefined' !== typeof sendAnalyticsTrackingEvent ) {
+						sendAnalyticsTrackingEvent( 'plugin_setup', 'plugin_activated' );
+					}
 					</script>
 					<div class="googlesitekit-plugin">
 						<div class="googlesitekit-activation">
@@ -194,7 +196,7 @@ final class Activation {
 										mdc-layout-grid__cell--offset-1-desktop
 										mdc-layout-grid__cell--align-middle
 									">
-										<a href="#" onClick="javascript:sendAnalyticsTrackingEvent( 'plugin_setup', 'goto_sitekit' );document.location='<?php echo esc_url( $sitekit_splash_url ); ?>';"
+										<a href="#" onClick="javascript:if( 'undefined' !== typeof sendAnalyticsTrackingEvent ) { sendAnalyticsTrackingEvent( 'plugin_setup', 'goto_sitekit' ) };document.location='<?php echo esc_url( $sitekit_splash_url ); ?>';"
 											class="googlesitekit-activation__button mdc-button mdc-button--raised">
 											<?php esc_html_e( 'Start Setup', 'google-site-kit' ); ?>
 										</a>

--- a/includes/Core/Util/Tracking.php
+++ b/includes/Core/Util/Tracking.php
@@ -182,14 +182,12 @@ final class Tracking {
 				return;
 			}
 
-			<?php if ( ! empty( $track_id ) ) { ?>
-				if ( window.googlesitekitTrackingEnabled ) {
-					gtag( 'event', eventName, {
-						send_to: '<?php echo esc_attr( self::TRACKING_ID ); ?>', /*eslint camelcase: 0*/
-						event_category: eventCategory, /*eslint camelcase: 0*/
-					} );
-				}
-			<?php } ?>
+			if ( window.googlesitekitTrackingEnabled ) {
+				gtag( 'event', eventName, {
+					send_to: '<?php echo esc_attr( self::TRACKING_ID ); ?>', /*eslint camelcase: 0*/
+					event_category: eventCategory, /*eslint camelcase: 0*/
+				} );
+			}
 		};
 		</script>
 		<?php


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue https://github.com/google/site-kit-wp/issues/126

## Relevant technical choices

<!-- Please describe your changes. -->
Fix printing the standalone sendAnalyticsTrackingEvent function.
Check if sendAnalyticsTrackingEvent defined before calling on plugin activation to prevent console errors.

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
