### PR TITLE
add canPublishPosts permission for contributor messages

### DIFF
--- a/assets/js/components/dashboard-splash/dashboard-splash-app.js
+++ b/assets/js/components/dashboard-splash/dashboard-splash-app.js
@@ -48,12 +48,14 @@ class DashboardSplashApp extends Component {
 			canAuthenticate,
 			canSetup,
 			canViewDashboard,
+			canPublishPosts,
 		} = googlesitekit.permissions;
 
 		this.state = {
 			showAuthenticationSetupWizard: canSetup && ( ! isAuthenticated || ! isVerified || ! hasSearchConsoleProperty ),
-			showModuleSetupWizard: showModuleSetupWizard,
-			canViewDashboard: canViewDashboard,
+			showModuleSetupWizard,
+			canViewDashboard,
+			canPublishPosts,
 			buttonMode: 0,
 			connectUrl,
 		};
@@ -116,7 +118,11 @@ class DashboardSplashApp extends Component {
 						if ( this.state.canViewDashboard ) {
 							introDescription = __( 'Start gaining insights on how your site is performing in search by visiting the dashboard.', 'google-site-kit' );
 						} else {
-							introDescription = __( 'Start gaining insights on how your site is performing in search by editing one of your posts.', 'google-site-kit' );
+							if ( this.state.canPublishPosts ) {
+								introDescription = __( 'Start gaining insights on how your site is performing in search by editing one of your posts.', 'google-site-kit' );
+							} else {
+								introDescription = __( 'Start gaining insights on how your site is performing in search by viewing one of your published posts.', 'google-site-kit' );
+							}
 						}
 			}
 

--- a/includes/Core/Assets/Assets.php
+++ b/includes/Core/Assets/Assets.php
@@ -517,6 +517,7 @@ final class Assets {
 				'canViewDashboard'     => current_user_can( Permissions::VIEW_DASHBOARD ),
 				'canViewModuleDetails' => current_user_can( Permissions::VIEW_MODULE_DETAILS ),
 				'canManageOptions'     => current_user_can( Permissions::MANAGE_OPTIONS ),
+				'canPublishPosts'      => current_user_can( Permissions::PUBLISH_POSTS ),
 			),
 
 			/**

--- a/includes/Core/Permissions/Permissions.php
+++ b/includes/Core/Permissions/Permissions.php
@@ -30,6 +30,7 @@ final class Permissions {
 	const VIEW_DASHBOARD      = 'googlesitekit_view_dashboard';
 	const VIEW_MODULE_DETAILS = 'googlesitekit_view_module_details';
 	const MANAGE_OPTIONS      = 'googlesitekit_manage_options';
+	const PUBLISH_POSTS       = 'googlesitekit_publish_posts';
 
 	/*
 	 * Custom meta capabilities.
@@ -116,6 +117,9 @@ final class Permissions {
 			// Allow administrators and up to manage options and set up the plugin.
 			self::MANAGE_OPTIONS      => 'manage_options',
 			self::SETUP               => 'manage_options',
+
+			// Allow to differentiate between authors and contributors.
+			self::PUBLISH_POSTS       => 'publish_posts',
 		);
 
 		$this->meta_to_core = array(


### PR DESCRIPTION
## Summary
Adds canPublishPosts to the global googlesitekit.permissions in order to differentiate between contributor and author permissions so we can render different message on splash page.

<!-- Please reference the issue this PR addresses. -->
Addresses issue https://github.com/google/site-kit-wp/issues/298

## Relevant technical choices

<!-- Please describe your changes. -->

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
