### PR TITLE
Add e2e tests for client configuration

### DIFF
--- a/tests/e2e/jest.config.js
+++ b/tests/e2e/jest.config.js
@@ -4,6 +4,7 @@ module.exports = {
 	preset: 'jest-puppeteer',
 	setupFilesAfterEnv: [
 		'<rootDir>/config/bootstrap.js',
+		'expect-puppeteer',
 	],
 	testMatch: [
 		'<rootDir>/specs/**/__tests__/**/*.js',

--- a/tests/e2e/specs/auth-client-configuration.test.js
+++ b/tests/e2e/specs/auth-client-configuration.test.js
@@ -39,7 +39,7 @@ describe( 'Providing client configuration', () => {
 
 	} );
 
-	it( 'Should have enabled button valid value', async() => {
+	it( 'Should have enabled button with valid value', async() => {
 
 		await page.waitForSelector( '#client-configuration' );
 		page.click( '#client-configuration' );
@@ -58,10 +58,7 @@ describe( 'Providing client configuration', () => {
 		}`;
 		await page.keyboard.type( configJSON );
 
-		const errorMessage = await page.$x(
-			'//p[contains(@class,"googlesitekit-error-text") and contains(text(), "Unable to parse client configuration values.")]'
-		);
-		expect( errorMessage.length ).toEqual( 0 );
+		await expect( page ).not.toMatchElement( '.googlesitekit-error-text', { text: 'Unable to parse client configuration values' } );
 
 		expect( await page.$eval( '#wizard-step-one-proceed', ( el ) => el.matches( '[disabled]' ) ) ).toBe( false );
 
@@ -69,11 +66,7 @@ describe( 'Providing client configuration', () => {
 
 		await page.waitForSelector( '.googlesitekit-wizard-step--two' );
 
-		const stepTwoTitle = await page.$x(
-			'//h2[contains(@class,"googlesitekit-wizard-step__title") and contains(text(), "Authenticate with Google")]'
-		);
-
-		expect( stepTwoTitle.length ).not.toEqual( 0 );
+		await expect( page ).toMatchElement( '.googlesitekit-wizard-step__title', { text: 'Authenticate with Google' } );
 
 	} );
 

--- a/tests/e2e/specs/auth-client-configuration.test.js
+++ b/tests/e2e/specs/auth-client-configuration.test.js
@@ -1,13 +1,20 @@
 /**
  * WordPress dependencies
  */
-import { activatePlugin, visitAdminPage } from '@wordpress/e2e-test-utils';
+import { activatePlugin, deactivatePlugin, visitAdminPage } from '@wordpress/e2e-test-utils';
 
 describe( 'Providing client configuration', () => {
 
-	beforeEach( async() => {
+	beforeAll( async() => {
 		await activatePlugin( 'google-site-kit' );
+	} );
+
+	beforeEach( async() => {
 		await visitAdminPage( 'admin.php', 'page=googlesitekit-splash' );
+	} );
+
+	afterAll( async() => {
+		await deactivatePlugin( 'google-site-kit' );
 	} );
 
 	it( 'Should have disabled button on load', async() => {

--- a/tests/e2e/specs/auth-client-configuration.test.js
+++ b/tests/e2e/specs/auth-client-configuration.test.js
@@ -21,9 +21,8 @@ describe( 'Providing client configuration', () => {
 
 		await page.waitForSelector( '#wizard-step-one-proceed' );
 
-		const proceedButton = await page.$$eval( '#wizard-step-one-proceed', el => el.map( x => x.hasAttribute( 'disabled' ) ) );
+		expect( await page.$eval( '#wizard-step-one-proceed', ( el ) => el.matches( '[disabled]' ) ) ).toBe( true );
 
-		expect( proceedButton.length ).not.toEqual( 0 );
 	} );
 
 
@@ -38,9 +37,8 @@ describe( 'Providing client configuration', () => {
 			'//p[contains(@class,"googlesitekit-error-text") and contains(text(), "Unable to parse client configuration values.")]'
 		);
 		expect( errorMessage.length ).not.toEqual( 0 );
+		expect( await page.$eval( '#wizard-step-one-proceed', ( el ) => el.matches( '[disabled]' ) ) ).toBe( true );
 
-		const proceedButton = await page.$$eval( '#wizard-step-one-proceed', el => el.map( x => x.hasAttribute( 'disabled' ) ) );
-		expect( proceedButton.length ).not.toEqual( 0 );
 	} );
 
 	it( 'Should have enabled button valid value', async() => {
@@ -67,10 +65,7 @@ describe( 'Providing client configuration', () => {
 		);
 		expect( errorMessage.length ).toEqual( 0 );
 
-		const proceedButton = await page.$x(
-			'//button[not(@disabled)][contains(@id,"wizard-step-one-proceed")]'
-		);
-		expect( proceedButton.length ).not.toEqual( 0 );
+		expect( await page.$eval( '#wizard-step-one-proceed', ( el ) => el.matches( '[disabled]' ) ) ).toBe( false );
 
 		page.click( '#wizard-step-one-proceed' );
 

--- a/tests/e2e/specs/auth-client-configuration.test.js
+++ b/tests/e2e/specs/auth-client-configuration.test.js
@@ -44,7 +44,7 @@ describe( 'Providing client configuration', () => {
 		await page.waitForSelector( '#client-configuration' );
 		page.click( '#client-configuration' );
 
-		await page.waitFor( 1000 );
+		await page.waitForSelector( '.mdc-text-field--focused' );
 
 		const configJSON = `{
 			"web": {

--- a/tests/e2e/specs/auth-client-configuration.test.js
+++ b/tests/e2e/specs/auth-client-configuration.test.js
@@ -4,14 +4,78 @@
 import { activatePlugin, visitAdminPage } from '@wordpress/e2e-test-utils';
 
 describe( 'Providing client configuration', () => {
-	it( 'accepts the client and secret as a json blob', async() => {
+
+	beforeEach( async() => {
 		await activatePlugin( 'google-site-kit' );
 		await visitAdminPage( 'admin.php', 'page=googlesitekit-splash' );
+	} );
+
+	it( 'Should have disabled button on load', async() => {
 
 		await page.waitForSelector( '#wizard-step-one-proceed' );
 
-		const proceedButton = await page.$( '#wizard-step-one-proceed' );
+		const proceedButton = await page.$$eval( '#wizard-step-one-proceed', el => el.map( x => x.hasAttribute( 'disabled' ) ) );
 
-		expect( await proceedButton.getProperty( 'disabled' ) ).toBe( true );
+		// const proceedButton = await page.$x(
+		// 	'//button[@disabled][contains(@id,"wizard-step-one-proceed")]'
+		// );
+
+		expect( proceedButton.length ).not.toEqual( 0 );
 	} );
+
+
+	it( 'Should have disabled button and display error when input is invalid', async() => {
+
+		await page.waitForSelector( '#client-configuration' );
+		page.click( '#client-configuration' );
+		await page.keyboard.type( 'This is not valid JSON' );
+
+		//error
+		await page.waitForSelector( '.googlesitekit-error-text' );
+		const errorMessage = await page.$x(
+			'//p[contains(@class,"googlesitekit-error-text") and contains(text(), "Unable to parse client configuration values.")]'
+		);
+		expect( errorMessage.length ).not.toEqual( 0 );
+
+		// button
+		const proceedButton = await page.$$eval( '#wizard-step-one-proceed', el => el.map( x => x.hasAttribute( 'disabled' ) ) );
+		expect( proceedButton.length ).not.toEqual( 0 );
+	} );
+
+	it( 'Should have enabled button valid value', async() => {
+
+		await page.waitForSelector( '#client-configuration' );
+		page.click( '#client-configuration' );
+
+		await page.waitFor( 1000 );
+
+		const configJSON = `{
+			"web": {
+				"client_id": "123-456.apps.googleusercontent.com",
+				"project_id": "lorem-ipsum-123456",
+				"auth_uri": "https://accounts.google.com/o/oauth2/auth",
+				"token_uri": "https://accounts.google.com/o/oauth2/token",
+				"auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+				"client_secret": "this_is_not_real"
+			}
+		}`;
+		await page.keyboard.type( configJSON );
+
+		const proceedButton = await page.$x(
+			'//button[not(@disabled)][contains(@id,"wizard-step-one-proceed")]'
+		);
+		expect( proceedButton.length ).not.toEqual( 0 );
+
+		page.click( '#wizard-step-one-proceed' );
+
+		await page.waitForSelector( '.googlesitekit-wizard-step--two' );
+
+		const stepTwoTitle = await page.$x(
+			'//h2[contains(@class,"googlesitekit-wizard-step__title") and contains(text(), "Authenticate with Google")]'
+		);
+
+		expect( stepTwoTitle.length ).not.toEqual( 0 );
+
+	} );
+
 } );

--- a/tests/e2e/specs/auth-client-configuration.test.js
+++ b/tests/e2e/specs/auth-client-configuration.test.js
@@ -16,10 +16,6 @@ describe( 'Providing client configuration', () => {
 
 		const proceedButton = await page.$$eval( '#wizard-step-one-proceed', el => el.map( x => x.hasAttribute( 'disabled' ) ) );
 
-		// const proceedButton = await page.$x(
-		// 	'//button[@disabled][contains(@id,"wizard-step-one-proceed")]'
-		// );
-
 		expect( proceedButton.length ).not.toEqual( 0 );
 	} );
 
@@ -30,14 +26,12 @@ describe( 'Providing client configuration', () => {
 		page.click( '#client-configuration' );
 		await page.keyboard.type( 'This is not valid JSON' );
 
-		//error
 		await page.waitForSelector( '.googlesitekit-error-text' );
 		const errorMessage = await page.$x(
 			'//p[contains(@class,"googlesitekit-error-text") and contains(text(), "Unable to parse client configuration values.")]'
 		);
 		expect( errorMessage.length ).not.toEqual( 0 );
 
-		// button
 		const proceedButton = await page.$$eval( '#wizard-step-one-proceed', el => el.map( x => x.hasAttribute( 'disabled' ) ) );
 		expect( proceedButton.length ).not.toEqual( 0 );
 	} );
@@ -60,6 +54,11 @@ describe( 'Providing client configuration', () => {
 			}
 		}`;
 		await page.keyboard.type( configJSON );
+
+		const errorMessage = await page.$x(
+			'//p[contains(@class,"googlesitekit-error-text") and contains(text(), "Unable to parse client configuration values.")]'
+		);
+		expect( errorMessage.length ).toEqual( 0 );
 
 		const proceedButton = await page.$x(
 			'//button[not(@disabled)][contains(@id,"wizard-step-one-proceed")]'

--- a/tests/e2e/specs/auth-client-configuration.test.js
+++ b/tests/e2e/specs/auth-client-configuration.test.js
@@ -1,0 +1,17 @@
+/**
+ * WordPress dependencies
+ */
+import { activatePlugin, visitAdminPage } from '@wordpress/e2e-test-utils';
+
+describe( 'Providing client configuration', () => {
+	it( 'accepts the client and secret as a json blob', async() => {
+		await activatePlugin( 'google-site-kit' );
+		await visitAdminPage( 'admin.php', 'page=googlesitekit-splash' );
+
+		await page.waitForSelector( '#wizard-step-one-proceed' );
+
+		const proceedButton = await page.$( '#wizard-step-one-proceed' );
+
+		expect( await proceedButton.getProperty( 'disabled' ) ).toBe( true );
+	} );
+} );

--- a/tests/e2e/specs/auth-client-configuration.test.js
+++ b/tests/e2e/specs/auth-client-configuration.test.js
@@ -33,10 +33,8 @@ describe( 'Providing client configuration', () => {
 		await page.keyboard.type( 'This is not valid JSON' );
 
 		await page.waitForSelector( '.googlesitekit-error-text' );
-		const errorMessage = await page.$x(
-			'//p[contains(@class,"googlesitekit-error-text") and contains(text(), "Unable to parse client configuration values.")]'
-		);
-		expect( errorMessage.length ).not.toEqual( 0 );
+		await expect( page ).toMatchElement( '.googlesitekit-error-text', { text: 'Unable to parse client configuration values' } );
+
 		expect( await page.$eval( '#wizard-step-one-proceed', ( el ) => el.matches( '[disabled]' ) ) ).toBe( true );
 
 	} );


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #249 

## Relevant technical choices

<!-- Please describe your changes. -->
Add e2e tests for client configuration, the first step in setup. 

Includes checks that button is disabled on load, still disabled when invalid json entered and an error message displays, the error message is not present with valid data input and button is enabled and takes user to step two on click.

## Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
