### PR TITLE
GTM fix Setup new container feature

### DIFF
--- a/assets/js/modules/tagmanager/setup.js
+++ b/assets/js/modules/tagmanager/setup.js
@@ -211,31 +211,28 @@ class TagmanagerSetup extends Component {
 				containerId: selectedContainer,
 			};
 
-			return await data.set( 'modules', 'tagmanager', 'save', optionData )
-				.then( ( responseData ) => {
+			const responseData = await data.set( 'modules', 'tagmanager', 'save', optionData );
+			if ( finishSetup ) {
+				finishSetup();
+			}
 
-					if ( finishSetup ) {
-						finishSetup();
-					}
+			googlesitekit.modules.tagmanager.settings = {
+				accountId: responseData.accountId,
+				containerId: responseData.containerId,
+			};
 
-					googlesitekit.modules.tagmanager.settings = {
-						accountId: responseData.accountId,
-						containerId: responseData.containerId,
-					};
-					if ( this._isMounted ) {
-						this.setState( {
-							isSaving: false
-						} );
-					}
-				} );
-		} catch ( err ) {
 			if ( this._isMounted ) {
 				this.setState( {
-					isLoading: false,
-					error: true,
-					message: err.message
+					isSaving: false
 				} );
 			}
+
+		} catch ( err ) {
+
+			// Catches error in handleButtonAction from <SettingsModules> component.
+			return new Promise( ( resolve, reject ) => {
+				reject( err );
+			} );
 		}
 	}
 

--- a/includes/Modules/TagManager.php
+++ b/includes/Modules/TagManager.php
@@ -451,7 +451,7 @@ final class TagManager extends Module implements Module_With_Scopes {
 		} catch ( Google_Service_Exception $e ) {
 			$client->setDefer( $orig_defer );
 			$message = $e->getErrors();
-			if ( isset( $message[0] ) && isset( $message[0]['message'] ) ) {
+			if ( isset( $message[0]['message'] ) ) {
 				$message = $message[0]['message'];
 			}
 			return new WP_Error( $e->getCode(), $message );

--- a/includes/Modules/TagManager.php
+++ b/includes/Modules/TagManager.php
@@ -400,7 +400,7 @@ final class TagManager extends Module implements Module_With_Scopes {
 							$orig_defer = $client->shouldDefer();
 							$client->setDefer( false );
 							$container = new \Google_Service_TagManager_Container();
-							$container->setName( get_bloginfo( 'name' ) );
+							$container->setName( remove_accents( get_bloginfo( 'name' ) ) );
 							$container->setUsageContext( array( 'web' ) );
 							try {
 								$container = $this->get_service( 'tagmanager' )->accounts_containers->create( "accounts/{$data['accountId']}", $container );

--- a/includes/Modules/TagManager.php
+++ b/includes/Modules/TagManager.php
@@ -501,13 +501,19 @@ final class TagManager extends Module implements Module_With_Scopes {
 
 					return array_merge( $response, $containers );
 				case 'list-containers':
-					$account_id = $this->_containers_account_id;
-					$response   = array(
+					$account_id = null;
+					if ( ! empty( $this->_containers_account_id ) ) {
+						$account_id = $this->_containers_account_id;
+
+						$this->_containers_account_id = null;
+					}
+
+					$response = array(
 						// TODO: Parse this response to a regular array.
 						'containers' => $response->getContainer(),
 					);
 
-					if ( 0 === count( $response['containers'] ) ) {
+					if ( 0 === count( $response['containers'] ) && ! empty( $account_id ) ) {
 						// If empty containers, attempt to create a new container.
 						$new_container = $this->create_container( $account_id );
 						if ( is_wp_error( $new_container ) ) {


### PR DESCRIPTION
## Summary
Creates a new container while setting up TagManager if there are no containers for the account.
Fixes error rendering on TagManager settings page when attempting to create a new container when there is an existing one with the same name.

<!-- Please reference the issue this PR addresses. -->
Addresses issue https://github.com/google/site-kit-wp/issues/66

## Relevant technical choices

<!-- Please describe your changes. -->

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
