### PR TITLE
E2E Reset site kit

### DIFF
--- a/tests/e2e/specs/plugin-reset.test.js
+++ b/tests/e2e/specs/plugin-reset.test.js
@@ -1,0 +1,65 @@
+/**
+ * WordPress dependencies
+ */
+import { deactivatePlugin, activatePlugin, visitAdminPage } from '@wordpress/e2e-test-utils';
+
+describe( 'Reset plugin', () => {
+	beforeAll( async() => {
+		await activatePlugin( 'e2e-tests-auth-plugin' );
+		await activatePlugin( 'google-site-kit' );
+	} );
+
+	afterAll( async() => {
+		await deactivatePlugin( 'e2e-tests-auth-plugin' );
+		await deactivatePlugin( 'google-site-kit' );
+	} );
+
+	beforeEach( async() => {
+		await visitAdminPage( 'admin.php', 'page=googlesitekit-settings' );
+		await page.waitForSelector( '.mdc-tab-scroller__scroll-content' );
+
+		// Click on Admin Settings Tab.
+		await page.evaluate( () => {
+			Array.apply( null, document.querySelectorAll( '.mdc-tab-scroller__scroll-content button' ) )
+				.find( element => 'Admin Settings' === element.textContent )
+				.click();
+		} );
+
+		// Click on Reset Site Kit.
+		await page.evaluate( () => {
+			document.evaluate(
+				'//button[contains(text(), "Reset Site Kit")]', document, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null
+			).singleNodeValue.click();
+		} );
+
+		await page.waitFor( 1000 );
+	} );
+
+	it( 'On Reset Site Kit click, confirm dialog displays', async() => {
+		const hidden = await page.evaluate( () => {
+			return Array.apply( null, document.querySelectorAll( '.mdc-button__label' ) )
+				.find( element => 'Reset' === element.textContent )
+				.closest( 'div.mdc-dialog' )
+				.getAttribute( 'aria-hidden' );
+		} );
+
+		expect( hidden ).toBe( true );
+	} );
+
+	it( 'Reset dialog button disconnects site kit', async() => {
+		await page.waitForSelector( '.mdc-dialog__actions' );
+		await page.evaluate( () => {
+			Array.apply( null, document.querySelectorAll( '.mdc-dialog__actions button .mdc-button__label' ) )
+				.find( element => 'Reset' === element.textContent )
+				.click();
+		} );
+
+		await visitAdminPage( 'admin.php', 'page=googlesitekit-dashboard' );
+
+		const setupFlow = await page.$x(
+			'//div[contains(@class,"googlesitekit-wizard")]'
+		);
+
+		expect( setupFlow.length ).not.toEqual( 0 );
+	} );
+} );

--- a/tests/e2e/specs/plugin-reset.test.js
+++ b/tests/e2e/specs/plugin-reset.test.js
@@ -3,7 +3,7 @@
  */
 import { deactivatePlugin, activatePlugin, visitAdminPage } from '@wordpress/e2e-test-utils';
 
-describe( 'Reset plugin', () => {
+describe( 'Plugin Reset', () => {
 	beforeAll( async() => {
 		await activatePlugin( 'e2e-tests-auth-plugin' );
 	} );
@@ -23,7 +23,7 @@ describe( 'Reset plugin', () => {
 		await page.waitForSelector( '.googlesitekit-settings-module__footer' );
 	} );
 
-	it( 'On Reset Site Kit click, confirm dialog displays.', async() => {
+	it( 'displays a confirmation dialog when clicking the "Reset Site Kit" link', async() => {
 
 		await expect( page ).toClick( 'button.googlesitekit-cta-link', { text: 'Reset Site Kit' } );
 		await page.waitForSelector( '.mdc-dialog--open' );
@@ -31,14 +31,14 @@ describe( 'Reset plugin', () => {
 		await expect( page ).toMatchElement( '.mdc-dialog.mdc-dialog--open .mdc-button', { text: 'Reset' } );
 	} );
 
-	it( 'On Reset Site Kit click, confirm dialog hides when cancel', async() => {
+	it( 'dismisses the reset confirmation dialog when clicking "Cancel"', async() => {
 		await expect( page ).toClick( 'button.googlesitekit-cta-link', { text: 'Reset Site Kit' } );
 		await page.waitForSelector( '.mdc-dialog--open' );
 
 		await expect( page ).toClick( '.mdc-dialog.mdc-dialog--open button', { text: 'Cancel' } );
 	} );
 
-	it( 'Reset dialog button disconnects site kit', async() => {
+	it( 'disconnects Site Kit by clicking the "Reset" button in the confirmation dialog', async() => {
 		await expect( page ).toClick( 'button.googlesitekit-cta-link', { text: 'Reset Site Kit' } );
 		await page.waitForSelector( '.mdc-dialog--open' );
 		await expect( page ).toClick( '.mdc-dialog.mdc-dialog--open .mdc-button', { text: 'Reset' } );

--- a/tests/e2e/specs/plugin-reset.test.js
+++ b/tests/e2e/specs/plugin-reset.test.js
@@ -6,88 +6,42 @@ import { deactivatePlugin, activatePlugin, visitAdminPage } from '@wordpress/e2e
 describe( 'Reset plugin', () => {
 	beforeAll( async() => {
 		await activatePlugin( 'e2e-tests-auth-plugin' );
-		await activatePlugin( 'google-site-kit' );
 	} );
 
 	afterAll( async() => {
 		await deactivatePlugin( 'e2e-tests-auth-plugin' );
-		await deactivatePlugin( 'google-site-kit' );
 	} );
 
 	beforeEach( async() => {
 		await visitAdminPage( 'admin.php', 'page=googlesitekit-settings' );
-		await page.waitForSelector( '.mdc-tab-scroller__scroll-content' );
+		await expect( page ).toMatchElement( '.googlesitekit-page-header__title', { text: 'Settings' } );
+
+		await page.waitForSelector( 'button.mdc-tab' );
 
 		// Click on Admin Settings Tab.
-		await page.$$eval( '.mdc-tab-scroller__scroll-content button', tabs => {
-			Array.apply( null, tabs )
-				.find( element => 'Admin Settings' === element.textContent )
-				.click();
-		} );
-
-		// Click on Reset Site Kit.
-		await page.evaluate( () => {
-			document.evaluate(
-				'//button[contains(text(), "Reset Site Kit")]', document, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null
-			).singleNodeValue.click();
-		} );
+		await expect( page ).toClick( 'button.mdc-tab', { text: 'Admin Settings' } );
+		await page.waitForSelector( '.googlesitekit-settings-module__footer' );
 	} );
 
-	it( 'On Reset Site Kit click, confirm dialog displays', async() => {
-		await page.waitForSelector( '.mdc-dialog[aria-hidden="false"]' );
+	it( 'On Reset Site Kit click, confirm dialog displays.', async() => {
 
-		const isHidden = await page.$eval( '.mdc-dialog[aria-hidden="false"]', dialog => {
-			if ( dialog && 'Reset' === dialog.querySelector( '.mdc-button__label' ).textContent ) {
-				return false;
-			}
+		await expect( page ).toClick( 'button.googlesitekit-cta-link', { text: 'Reset Site Kit' } );
+		await page.waitForSelector( '.mdc-dialog--open' );
 
-			return true;
-		} );
-
-		expect( isHidden ).toBe( false );
+		await expect( page ).toMatchElement( '.mdc-dialog.mdc-dialog--open .mdc-button', { text: 'Reset' } );
 	} );
 
 	it( 'On Reset Site Kit click, confirm dialog hides when cancel', async() => {
-		await page.waitForSelector( '.mdc-dialog[aria-hidden="false"]' );
+		await expect( page ).toClick( 'button.googlesitekit-cta-link', { text: 'Reset Site Kit' } );
+		await page.waitForSelector( '.mdc-dialog--open' );
 
-		const resetDialogFound = await page.$eval( '.mdc-dialog[aria-hidden="false"]', dialog => {
-			if ( dialog && 'Reset' === dialog.querySelector( '.mdc-button__label' ).textContent ) {
-				dialog.querySelector( '.mdc-dialog__cancel-button' ).click();
-			}
-
-			return dialog;
-		} );
-
-		expect( resetDialogFound ).not.toEqual( null );
-
-		const isHidden = await page.$$eval( '.mdc-dialog[aria-hidden="true"]', dialogs => {
-
-			// Check reset dialog is hidden.
-			const dialog = Array.apply( dialogs ).filter( dialog => {
-				const button = dialog.querySelector( '.mdc-button__label' );
-				return button && 'Reset' === button.textContent;
-			} );
-			if ( dialog ) {
-				return true;
-			}
-
-			return false;
-		} );
-
-		expect( isHidden ).toBe( true );
+		await expect( page ).toClick( '.mdc-dialog.mdc-dialog--open button', { text: 'Cancel' } );
 	} );
 
 	it( 'Reset dialog button disconnects site kit', async() => {
-
-		// Click Reset button.
-		await page.$$eval( '.mdc-dialog__actions button', buttons => {
-			Array.apply( null, buttons ).map( button => {
-				const label = button.querySelector( '.mdc-button__label' );
-				if ( label && 'Reset' === label.textContent  ) {
-					button.click();
-				}
-			} );
-		} );
+		await expect( page ).toClick( 'button.googlesitekit-cta-link', { text: 'Reset Site Kit' } );
+		await page.waitForSelector( '.mdc-dialog--open' );
+		await expect( page ).toClick( '.mdc-dialog.mdc-dialog--open .mdc-button', { text: 'Reset' } );
 
 		await visitAdminPage( 'admin.php', 'page=googlesitekit-dashboard' );
 

--- a/tests/e2e/specs/plugin-reset.test.js
+++ b/tests/e2e/specs/plugin-reset.test.js
@@ -45,10 +45,6 @@ describe( 'Reset plugin', () => {
 
 		await visitAdminPage( 'admin.php', 'page=googlesitekit-dashboard' );
 
-		const setupFlow = await page.$x(
-			'//div[contains(@class,"googlesitekit-wizard")]'
-		);
-
-		expect( setupFlow.length ).not.toEqual( 0 );
+		await expect( page ).toMatchElement( '.googlesitekit-wizard' );
 	} );
 } );


### PR DESCRIPTION
## Summary
E2E Reset site kit
<!-- Please reference the issue this PR addresses. -->
Addresses issue https://github.com/google/site-kit-wp/issues/275

## Relevant technical choices

<!-- Please describe your changes. -->

## Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
