### PR TITLE
Add E2E test for tracking opt-in toggle

### DIFF
--- a/bin/local-env/install-wordpress.sh
+++ b/bin/local-env/install-wordpress.sh
@@ -94,6 +94,10 @@ docker-compose $DOCKER_COMPOSE_FILE_OPTIONS run --rm $CONTAINER touch /var/www/h
 echo -e $(status_message "Activating Google Site Kit plugin...")
 docker-compose $DOCKER_COMPOSE_FILE_OPTIONS run --rm -u 33 $CLI plugin activate google-site-kit --quiet
 
+# Set pretty permalinks.
+echo -e $(status_message "Setting permalink structure...")
+docker-compose $DOCKER_COMPOSE_FILE_OPTIONS run --rm -u 33 $CLI rewrite structure '%postname%' --hard
+
 # Configure site constants.
 echo -e $(status_message "Configuring site constants...")
 WP_DEBUG_CURRENT=$(docker-compose $DOCKER_COMPOSE_FILE_OPTIONS run -T --rm -u 33 $CLI config get --type=constant --format=json WP_DEBUG)

--- a/tests/e2e/jest.config.js
+++ b/tests/e2e/jest.config.js
@@ -4,6 +4,7 @@ module.exports = {
 	preset: 'jest-puppeteer',
 	setupFilesAfterEnv: [
 		'<rootDir>/config/bootstrap.js',
+		'expect-puppeteer',
 	],
 	testMatch: [
 		'<rootDir>/specs/**/__tests__/**/*.js',

--- a/tests/e2e/plugins/auth.php
+++ b/tests/e2e/plugins/auth.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Plugin Name: E2E Tests Auth Plugin
+ * Plugin URI:  https://github.com/google/site-kit-wp
+ * Description: Utility plugin for bypassing set up and authentication during E2E tests.
+ * Author:      Google
+ * Author URI:  https://opensource.google.com
+ */
+
+use Google\Site_Kit\Core\Authentication\Clients\OAuth_Client;
+use Google\Site_Kit\Core\Storage\Data_Encryption;
+use Google\Site_Kit\Plugin;
+
+/**
+ * Provide dummy client configuration, normally provided in step 1 of the set up.
+ */
+add_filter( 'pre_option_googlesitekit_credentials', function () {
+	return ( new Data_Encryption() )->encrypt(
+		serialize(
+			array(
+				'oauth2_client_id'     => '1234567890-asdfasdfasdfasdfzxcvzxcvzxcvzxcv.apps.googleusercontent.com',
+				'oauth2_client_secret' => 'x_xxxxxxxxxxxxxxxxxxxxxx',
+			)
+		)
+	);
+} );
+
+/**
+ * Provide a dummy access token to fake an authenticated state.
+ */
+add_filter( 'get_user_option_googlesitekit_access_token', function () {
+	return ( new Data_Encryption() )->encrypt(
+		serialize( array( 'access_token' => 'test-access-token' ) )
+	);
+} );
+
+/**
+ * Fake a verified site state.
+ */
+add_filter( 'get_user_option_googlesitekit_site_verified_meta', function () {
+	return 'verified';
+} );
+
+/**
+ * Fake all required scopes have been granted.
+ */
+add_filter( 'get_user_option_googlesitekit_auth_scopes', function () {
+	return ( new OAuth_Client( Plugin::instance()->context() ) )->get_required_scopes();
+} );

--- a/tests/e2e/plugins/reset.php
+++ b/tests/e2e/plugins/reset.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Plugin Name: E2E Tests Reset Plugin
+ * Plugin URI:  https://github.com/google/site-kit-wp
+ * Description: Utility plugin for resetting Site Kit during E2E tests.
+ * Author:      Google
+ * Author URI:  https://opensource.google.com
+ */
+
+use Google\Site_Kit\Context;
+use Google\Site_Kit\Core\Util\Reset;
+
+/**
+ * Trigger a full reset on Site Kit init and self-deactivate.
+ */
+add_action( 'googlesitekit_init', function () {
+	( new Reset( new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE ) ) )->all();
+
+	require_once( ABSPATH . 'wp-admin/includes/plugin.php' );
+
+	deactivate_plugins( plugin_basename( __FILE__ ), true );
+} );

--- a/tests/e2e/specs/admin-tracking.test.js
+++ b/tests/e2e/specs/admin-tracking.test.js
@@ -8,35 +8,36 @@ import { resetSiteKit } from '../utils';
 describe( 'Providing client configuration', () => {
 
 	beforeAll( async() => {
-		await activatePlugin( 'google-site-kit' );
 		await activatePlugin( 'e2e-tests-auth-plugin' );
 		await resetSiteKit();
 	} );
 
 	beforeEach( async() => {
 		await visitAdminPage( 'admin.php', 'page=googlesitekit-settings' );
-		await page.waitForSelector( '.mdc-tab-scroller__scroll-content' );
-		page.click( '.mdc-tab-scroller__scroll-content button:last-child' );
+		await page.waitForSelector( '.mdc-tab-bar' );
+
+		// Click on Admin Settings Tab.
+		await expect( page ).toClick( 'button.mdc-tab', { text: 'Admin Settings' } );
 	} );
 
 	afterAll( async() => {
 		await resetSiteKit();
-		await deactivatePlugin( 'google-site-kit' );
 		await deactivatePlugin( 'e2e-tests-auth-plugin' );
 	} );
 
-	it( 'Should select opt-in by default', async() => {
+	it( 'should select opt-in by default', async() => {
 
 		await page.waitForSelector( '#opt-in' );
 
-		expect( await page.$eval( '#opt-in', el => el.checked ) ).toBe( true );
+		await expect( page ).toMatchElement( '#opt-in[checked]' );
 
 	} );
-	it( 'Should have tracking code when opted in', async() => {
+
+	it( 'should have tracking code when opted in', async() => {
 
 		await page.waitForSelector( '#opt-in' );
 
-		expect( await page.$eval( '#opt-in', el => el.checked ) ).toBe( true );
+		await expect( page ).toMatchElement( '#opt-in[checked]' );
 
 		const analyticsScriptTag = await page.$x(
 			'//script[contains(@src,"https://www.google-analytics.com/analytics.js")]'
@@ -50,11 +51,12 @@ describe( 'Providing client configuration', () => {
 
 	} );
 
-	it( 'Should uncheck opt-in box when clicked', async() => {
+	it( 'should uncheck opt-in box when clicked', async() => {
 
 		await page.waitForSelector( '#opt-in' );
 
-		await page.$eval( '#opt-in', elem => elem.click() );
+		// await page.$eval( '#opt-in', elem => elem.click() );
+		await expect( page ).toClick( '#opt-in' );
 
 		await page.waitForResponse( res => {
 			const reqURL = new URL( res.url() );
@@ -63,15 +65,13 @@ describe( 'Providing client configuration', () => {
 		} );
 
 		await page.waitForSelector( '.mdc-checkbox:not(.mdc-checkbox--selected) #opt-in' );
-
 		const optinChecked = await page.$( '.mdc-checkbox--selected #opt-in' );
 		expect( optinChecked ).toBeNull();
-
 		const optinUnChecked = await page.$( '.mdc-checkbox:not(.mdc-checkbox--selected) #opt-in' );
 		expect( optinUnChecked.length ).not.toEqual( 0 );
 	} );
 
-	it( 'Should not have tracking code when not opted in', async() => {
+	it( 'should not have tracking code when not opted in', async() => {
 
 		await page.waitForSelector( '#opt-in' );
 

--- a/tests/e2e/specs/admin-tracking.test.js
+++ b/tests/e2e/specs/admin-tracking.test.js
@@ -28,14 +28,14 @@ describe( 'Providing client configuration', () => {
 
 		await page.waitForSelector( '#opt-in' );
 
-		expect( await page.$eval( '#opt-in', ( el ) => el.matches( '[checked]' ) ) ).toBe( true );
+		expect( await page.$eval( '#opt-in', el => el.checked ) ).toBe( true );
 
 	} );
 	it( 'Should have tracking code when opted in', async() => {
 
 		await page.waitForSelector( '#opt-in' );
 
-		expect( await page.$eval( '#opt-in', ( el ) => el.matches( '[checked]' ) ) ).toBe( true );
+		expect( await page.$eval( '#opt-in', el => el.checked ) ).toBe( true );
 
 		const analyticsScriptTag = await page.$x(
 			'//script[contains(@src,"https://www.google-analytics.com/analytics.js")]'

--- a/tests/e2e/specs/admin-tracking.test.js
+++ b/tests/e2e/specs/admin-tracking.test.js
@@ -1,0 +1,87 @@
+/**
+ * WordPress dependencies
+ */
+import { activatePlugin, deactivatePlugin, visitAdminPage } from '@wordpress/e2e-test-utils';
+import { resetSiteKit } from '../utils';
+
+describe( 'Providing client configuration', () => {
+
+	beforeAll( async() => {
+		await activatePlugin( 'google-site-kit' );
+		await activatePlugin( 'e2e-tests-auth-plugin' );
+		await resetSiteKit();
+	} );
+
+	beforeEach( async() => {
+		await visitAdminPage( 'admin.php', 'page=googlesitekit-settings' );
+		await page.waitForSelector( '.mdc-tab-scroller__scroll-content' );
+		page.click( '.mdc-tab-scroller__scroll-content button:last-child' );
+	} );
+
+	afterAll( async() => {
+
+		await resetSiteKit();
+		await deactivatePlugin( 'google-site-kit' );
+		await deactivatePlugin( 'e2e-tests-auth-plugin' );
+	} );
+
+	it( 'Should select opt-in by default', async() => {
+
+		await page.waitForSelector( '#opt-in' );
+
+		expect( await page.$eval( '#opt-in', ( el ) => el.matches( '[checked]' ) ) ).toBe( true );
+
+	} );
+	it( 'Should have tracking code when opted in', async() => {
+
+		await page.waitForSelector( '#opt-in' );
+
+		expect( await page.$eval( '#opt-in', ( el ) => el.matches( '[checked]' ) ) ).toBe( true );
+
+		const analyticsScriptTag = await page.$x(
+			'//script[contains(@src,"https://www.google-analytics.com/analytics.js")]'
+		);
+		expect( analyticsScriptTag.length ).not.toEqual( 0 );
+
+		const tagManagerScriptTag = await page.$x(
+			'//script[contains(@src,"https://www.googletagmanager.com/gtag/js?id=UA-130569087-3")]'
+		);
+		expect( tagManagerScriptTag.length ).not.toEqual( 0 );
+
+	} );
+
+	it( 'Should uncheck opt-in box when clicked', async() => {
+
+		await page.waitForSelector( '#opt-in' );
+
+		await page.$eval( '#opt-in', elem => elem.click() );
+
+		// page.click( '#opt-in', {
+		// 	delay: 10,
+		// 	clickCount: 1,
+		// } );
+
+		// page.waitForSelector( '.mdc-ripple-upgraded--background-focused' );
+		page.waitFor( 1000 );
+
+		expect( await page.$eval( '#opt-in', ( el ) => el.matches( '[checked]' ) ) ).not.toBe( true );
+	} );
+
+	it( 'Should not have tracking code when not opted in', async() => {
+
+		await page.waitForSelector( '#opt-in' );
+
+		expect( await page.$eval( '#opt-in', ( el ) => el.matches( '[checked]' ) ) ).not.toBe( true );
+
+		const analyticsScriptTag = await page.$x(
+			'//script[contains(@src,"https://www.google-analytics.com/analytics.js")]'
+		);
+		expect( analyticsScriptTag.length ).toEqual( 0 );
+
+		const tagManagerScriptTag = await page.$x(
+			'//script[contains(@src,"https://www.googletagmanager.com/gtag/js?id=UA-130569087-3")]'
+		);
+		expect( tagManagerScriptTag.length ).toEqual( 0 );
+	} );
+
+} );

--- a/tests/e2e/specs/admin-tracking.test.js
+++ b/tests/e2e/specs/admin-tracking.test.js
@@ -19,7 +19,6 @@ describe( 'Providing client configuration', () => {
 	} );
 
 	afterAll( async() => {
-
 		await resetSiteKit();
 		await deactivatePlugin( 'google-site-kit' );
 		await deactivatePlugin( 'e2e-tests-auth-plugin' );
@@ -56,22 +55,26 @@ describe( 'Providing client configuration', () => {
 
 		await page.$eval( '#opt-in', elem => elem.click() );
 
-		// page.click( '#opt-in', {
-		// 	delay: 10,
-		// 	clickCount: 1,
-		// } );
+		await page.waitFor( 3000 );
 
-		// page.waitForSelector( '.mdc-ripple-upgraded--background-focused' );
-		page.waitFor( 1000 );
+		await page.waitForSelector( '.mdc-checkbox:not(.mdc-checkbox--selected) #opt-in' );
 
-		expect( await page.$eval( '#opt-in', ( el ) => el.matches( '[checked]' ) ) ).not.toBe( true );
+		const optinChecked = await page.$( '.mdc-checkbox--selected #opt-in' );
+		expect( optinChecked ).toBeNull();
+
+		const optinUnChecked = await page.$( '.mdc-checkbox:not(.mdc-checkbox--selected) #opt-in' );
+		expect( optinUnChecked.length ).not.toEqual( 0 );
 	} );
 
 	it( 'Should not have tracking code when not opted in', async() => {
 
 		await page.waitForSelector( '#opt-in' );
 
-		expect( await page.$eval( '#opt-in', ( el ) => el.matches( '[checked]' ) ) ).not.toBe( true );
+		const optinChecked = await page.$( '.mdc-checkbox--selected #opt-in' );
+		expect( optinChecked ).toBeNull();
+
+		const optinUnChecked = await page.$( '.mdc-checkbox:not(.mdc-checkbox--selected) #opt-in' );
+		expect( optinUnChecked.length ).not.toEqual( 0 );
 
 		const analyticsScriptTag = await page.$x(
 			'//script[contains(@src,"https://www.google-analytics.com/analytics.js")]'

--- a/tests/e2e/specs/admin-tracking.test.js
+++ b/tests/e2e/specs/admin-tracking.test.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { activatePlugin, deactivatePlugin, visitAdminPage } from '@wordpress/e2e-test-utils';
+import { URL } from 'url';
 import { resetSiteKit } from '../utils';
 
 describe( 'Providing client configuration', () => {
@@ -55,7 +56,11 @@ describe( 'Providing client configuration', () => {
 
 		await page.$eval( '#opt-in', elem => elem.click() );
 
-		await page.waitFor( 3000 );
+		await page.waitForResponse( res => {
+			const reqURL = new URL( res.url() );
+
+			return '/wp-json/wp/v2/settings' === reqURL.pathname;
+		} );
 
 		await page.waitForSelector( '.mdc-checkbox:not(.mdc-checkbox--selected) #opt-in' );
 

--- a/tests/e2e/specs/admin-tracking.test.js
+++ b/tests/e2e/specs/admin-tracking.test.js
@@ -39,11 +39,13 @@ describe( 'Providing client configuration', () => {
 
 		await expect( page ).toMatchElement( '#opt-in[checked]' );
 
+		// Ensure analytics script tag exists.
 		const analyticsScriptTag = await page.$x(
 			'//script[contains(@src,"https://www.google-analytics.com/analytics.js")]'
 		);
 		expect( analyticsScriptTag.length ).not.toEqual( 0 );
 
+		// Ensure tag manager script tag exists.
 		const tagManagerScriptTag = await page.$x(
 			'//script[contains(@src,"https://www.googletagmanager.com/gtag/js?id=UA-130569087-3")]'
 		);
@@ -65,31 +67,41 @@ describe( 'Providing client configuration', () => {
 		} );
 
 		await page.waitForSelector( '.mdc-checkbox:not(.mdc-checkbox--selected) #opt-in' );
+
+		// Ensure no checked checkbox exists.
 		const optinChecked = await page.$( '.mdc-checkbox--selected #opt-in' );
 		expect( optinChecked ).toBeNull();
+
+		// Ensure unchecked checkbox exists.
 		const optinUnChecked = await page.$( '.mdc-checkbox:not(.mdc-checkbox--selected) #opt-in' );
 		expect( optinUnChecked.length ).not.toEqual( 0 );
+
 	} );
 
 	it( 'should not have tracking code when not opted in', async() => {
 
 		await page.waitForSelector( '#opt-in' );
 
+		// Ensure no checked checkbox exists.
 		const optinChecked = await page.$( '.mdc-checkbox--selected #opt-in' );
 		expect( optinChecked ).toBeNull();
 
+		// Ensure unchecked checkbox exists.
 		const optinUnChecked = await page.$( '.mdc-checkbox:not(.mdc-checkbox--selected) #opt-in' );
 		expect( optinUnChecked.length ).not.toEqual( 0 );
 
+		// Ensure no analytics script tag exists.
 		const analyticsScriptTag = await page.$x(
 			'//script[contains(@src,"https://www.google-analytics.com/analytics.js")]'
 		);
 		expect( analyticsScriptTag.length ).toEqual( 0 );
 
+		// Ensure no tag manager script exists.
 		const tagManagerScriptTag = await page.$x(
 			'//script[contains(@src,"https://www.googletagmanager.com/gtag/js?id=UA-130569087-3")]'
 		);
 		expect( tagManagerScriptTag.length ).toEqual( 0 );
+
 	} );
 
 } );

--- a/tests/e2e/specs/psi-activation.test.js
+++ b/tests/e2e/specs/psi-activation.test.js
@@ -1,0 +1,55 @@
+/**
+ * WordPress dependencies
+ */
+import { visitAdminPage, activatePlugin, deactivatePlugin } from '@wordpress/e2e-test-utils';
+
+/**
+ * Internal dependencies
+ */
+import { resetSiteKit } from '../utils';
+
+describe( 'PageSpeed Insights Activation', () => {
+	beforeEach( async() => {
+		await resetSiteKit();
+		await activatePlugin( 'e2e-tests-auth-plugin' );
+	} );
+
+	afterEach( async() => {
+		await deactivatePlugin( 'e2e-tests-auth-plugin' );
+	} );
+
+	it( 'should lead you to the activation page', async() => {
+		await visitAdminPage( 'admin.php', 'page=googlesitekit-dashboard' );
+
+		await expect( page ).toMatchElement( 'h3.googlesitekit-cta__title', { text: 'Activate PageSpeed Insights.' } );
+
+		await expect( page ).toClick( '.googlesitekit-cta-link', { text: 'Activate PageSpeed Insights' } );
+		await page.waitForSelector( 'h2.googlesitekit-setup-module__title' );
+
+		await expect( page ).toMatchElement( 'h2.googlesitekit-setup-module__title', { text: 'PageSpeed Insights' } );
+	} );
+
+	it ( 'should submit and save the entered key', async() => {
+		await visitAdminPage( 'admin.php', 'page=googlesitekit-dashboard' );
+
+		await expect( page ).toClick( '.googlesitekit-cta-link', { text: 'Activate PageSpeed Insights' } );
+		await page.waitForSelector( 'h2.googlesitekit-setup-module__title' );
+
+		await expect( page ).toMatchElement( 'h2.googlesitekit-setup-module__title', { text: 'PageSpeed Insights' } );
+
+		await page.type( 'input.mdc-text-field__input', 'PSIKEYTOSUBMITANDTEST' );
+
+		await expect( page ).toClick( 'button.mdc-button', { text: 'Proceed' } );
+
+		await page.waitForSelector( 'h3.googlesitekit-heading-3' );
+
+		// Check that the correct key is saved on the settings page.
+		await visitAdminPage( 'admin.php', 'page=googlesitekit-settings' );
+
+		await expect( page ).toClick( 'button.mdc-tab', { text: 'Admin Settings' } );
+
+		// Check the API Key text, verifying the submitted value has been stored.
+		await expect( page ).toMatchElement( '.googlesitekit-settings-module__meta-item-type', { text: 'API Key' } );
+		await expect( page ).toMatchElement( 'h5.googlesitekit-settings-module__meta-item-data', { text: 'PSIKEYTOSUBMITANDTEST' } );
+	} );
+} );

--- a/tests/e2e/utils/index.js
+++ b/tests/e2e/utils/index.js
@@ -1,0 +1,1 @@
+export { resetSiteKit } from './reset';

--- a/tests/e2e/utils/reset.js
+++ b/tests/e2e/utils/reset.js
@@ -1,0 +1,17 @@
+/**
+ * Internal dependencies
+ */
+import { switchUserToAdmin, switchUserToTest, visitAdminPage } from '@wordpress/e2e-test-utils';
+
+const PLUGIN_SLUG = 'e2e-tests-reset-plugin';
+
+/**
+ * Reset Site Kit using utility plugin.
+ */
+export async function resetSiteKit() {
+	await switchUserToAdmin();
+	await visitAdminPage( 'plugins.php' );
+	await page.click( `tr[data-slug="${ PLUGIN_SLUG }"] .activate a` );
+	await page.waitForSelector( `tr[data-slug="${ PLUGIN_SLUG }"]` );
+	await switchUserToTest();
+}


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #274 

## Relevant technical choices

Adds tests to verify default opt-in value and tracking is in place as well as verify toggling opt-in setting removes tracking. 

## Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
