### PR TITLE
fix error message while setting up new container in setup flow

### DIFF
--- a/assets/js/modules/tagmanager/setup.js
+++ b/assets/js/modules/tagmanager/setup.js
@@ -228,6 +228,13 @@ class TagmanagerSetup extends Component {
 			}
 
 		} catch ( err ) {
+			if ( this._isMounted ) {
+				this.setState( {
+					isLoading: false,
+					error: true,
+					message: err.message
+				} );
+			}
 
 			// Catches error in handleButtonAction from <SettingsModules> component.
 			return new Promise( ( resolve, reject ) => {


### PR DESCRIPTION
## Summary
Fixes showing same name container on GTM setup flow.

<!-- Please reference the issue this PR addresses. -->
Addresses issue https://github.com/google/site-kit-wp/issues/66

## Relevant technical choices

<!-- Please describe your changes. -->

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
