### PR TITLE
fix error state tagmanager

### DIFF
--- a/assets/js/modules/tagmanager/setup.js
+++ b/assets/js/modules/tagmanager/setup.js
@@ -241,8 +241,8 @@ class TagmanagerSetup extends Component {
 			if ( this._isMounted ) {
 				this.setState( {
 					isLoading: false,
-					error: true,
-					message: err.message
+					errorCode: true,
+					errorMsg: err.message
 				} );
 			}
 

--- a/assets/js/modules/tagmanager/setup.js
+++ b/assets/js/modules/tagmanager/setup.js
@@ -241,7 +241,7 @@ class TagmanagerSetup extends Component {
 			if ( this._isMounted ) {
 				this.setState( {
 					isLoading: false,
-					errorCode: true,
+					errorCode: err.code,
 					errorMsg: err.message
 				} );
 			}


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Fixes tagmanager error state merged in this PR https://github.com/google/site-kit-wp/pull/354/files

## Relevant technical choices

<!-- Please describe your changes. -->

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
