### PR TITLE
Fix Analytics set up regression 

### DIFF
--- a/assets/js/modules/analytics/setup.js
+++ b/assets/js/modules/analytics/setup.js
@@ -260,7 +260,7 @@ class AnalyticsSetup extends Component {
 			} else {
 
 				if ( ! selectedAccount ) {
-					let matchedProperty = null;
+					let matchedProperty = [];
 
 					if ( responseData.existingTag ) {
 


### PR DESCRIPTION
## Summary

Fixes a regression in Analytics set up introduced in 4e6896bef32bb1ce0e6010354b8cc4ff067ed4ee

## To Test

- Set up analytics using a URL that does not match any properties in Analytics
- Ensure that dropdowns are presented for selecting Account, Property, and View

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation. n/a
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
