### PR TITLE
Fix undefined variable access preventing completion of Analytics setup when there is no matching property

### DIFF
--- a/assets/js/modules/analytics/setup.js
+++ b/assets/js/modules/analytics/setup.js
@@ -277,7 +277,7 @@ class AnalyticsSetup extends Component {
 						}
 					}
 
-					if ( 0 < matchedProperty.length ) {
+					if ( matchedProperty && matchedProperty.length ) {
 						selectedAccount  = matchedProperty[0].accountId;
 						selectedProperty = matchedProperty[0].id;
 						const matchedProfile = responseData.profiles.filter( profile => {


### PR DESCRIPTION
## Summary

Addresses issue #367

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
