### PR TITLE
Simplify e2e puppeteer config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -85,7 +85,7 @@ script:
       npm run build || exit 1 # Build for tests.
       npm run env:start
       npm run env:reset-site
-      npm run test:e2e
+      npm run test:e2e:ci
       npm run env:stop
     fi
 

--- a/jest-puppeteer.config.js
+++ b/jest-puppeteer.config.js
@@ -1,7 +1,0 @@
-module.exports = {
-	launch: {
-		dumpio: true,
-		headless: process.env.HEADLESS !== 'false',
-	},
-	browserContext: 'default',
-};

--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
     "test:visualapprove": "backstop approve --config=backstop.js",
     "test:analyze": "webpack -p --mode=production --env.analyze=true --json --progress --profile > /tmp/stats.json && cp ./dist/assets/js/*.js /tmp && webpack-bundle-analyzer /tmp/stats.json",
     "test:e2e": "WP_BASE_URL=http://localhost:9002 wp-scripts test-e2e --config=tests/e2e/jest.config.js",
+    "test:e2e:interactive": "npm run test:e2e -- --puppeteer-interactive",
+    "test:e2e:ci": "npm run test:e2e -- --runInBand",
     "travis:visualtest": "start-server-and-test storybook http-get://localhost:9001 travis:backstopjs",
     "storybook": "start-storybook -s ./dist -p 9001 -c .storybook",
     "backstopjs": "backstop test --config=backstop.js --docker",


### PR DESCRIPTION
## Summary

Added new npm scripts for running e2e tests with `:interactive` (disabling headless and running in slowmo), and `:ci` (for continuous integration on travis). Also removed the custom puppeteer config file as it is not required. Suggested relevant edits to the docs as well.

<!-- Please reference the issue this PR addresses. -->
Addresses issue #328 

## Relevant technical choices

<!-- Please describe your changes. -->

## Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
