### PR TITLE
add filter to modify amp gtag configuration

### DIFF
--- a/includes/Modules/Analytics.php
+++ b/includes/Modules/Analytics.php
@@ -267,6 +267,8 @@ final class Analytics extends Module implements Module_With_Screen, Module_With_
 		/**
 		 * Filters the gtag configuration options for the Analytics snippet.
 		 *
+		 * You can use the {@see 'googlesitekit_amp_gtag_opt'} filter to do the same for gtag in AMP.
+		 *
 		 * @since 1.0.0
 		 *
 		 * @see https://developers.google.com/gtagjs/devguide/configure
@@ -328,11 +330,13 @@ final class Analytics extends Module implements Module_With_Screen, Module_With_
 		/**
 		 * Filters the gtag configuration options for the amp-analytics tag.
 		 *
+		 * You can use the {@see 'googlesitekit_gtag_opt'} filter to do the same for gtag in non-AMP.
+		 *
 		 * @since 1.0.0
 		 *
 		 * @see https://developers.google.com/gtagjs/devguide/amp
 		 *
-		 * @param array $gtag_amp_opt gtag amp options.
+		 * @param array $gtag_amp_opt gtag config options for AMP.
 		 */
 		$gtag_amp_opt_filtered = apply_filters( 'googlesitekit_amp_gtag_opt', $gtag_amp_opt );
 

--- a/includes/Modules/Analytics.php
+++ b/includes/Modules/Analytics.php
@@ -326,7 +326,7 @@ final class Analytics extends Module implements Module_With_Screen, Module_With_
 		);
 
 		/**
-		 * Filters the gtag configuration options for the object that is passed to amp-analytics as a JSON component.
+		 * Filters the gtag configuration options for the amp-analytics tag.
 		 *
 		 * @since 1.0.0
 		 *
@@ -338,7 +338,7 @@ final class Analytics extends Module implements Module_With_Screen, Module_With_
 
 		// Ensure gtag_id is set to the correct value.
 		if ( ! is_array( $gtag_amp_opt_filtered ) ) {
-			$gtag_amp_opt_filtered = array();
+			$gtag_amp_opt_filtered = $gtag_amp_opt;
 		}
 
 		if ( ! isset( $gtag_amp_opt_filtered['vars'] ) || ! is_array( $gtag_amp_opt_filtered['vars'] ) ) {

--- a/includes/Modules/Analytics.php
+++ b/includes/Modules/Analytics.php
@@ -265,7 +265,7 @@ final class Analytics extends Module implements Module_With_Screen, Module_With_
 		}
 
 		/**
-		 * Filters the gtag config options.
+		 * Filters the gtag configuration options for the Analytics snippet.
 		 *
 		 * @since 1.0.0
 		 *
@@ -314,7 +314,7 @@ final class Analytics extends Module implements Module_With_Screen, Module_With_
 			return;
 		}
 
-		$config = array(
+		$gtag_amp_opt = array(
 			'vars' => array(
 				'gtag_id' => $tracking_id,
 				'config'  => array(
@@ -325,6 +325,23 @@ final class Analytics extends Module implements Module_With_Screen, Module_With_
 			),
 		);
 
+		/**
+		 * Filters configuration options for the object that is passed to amp-analytics as a JSON component.
+		 *
+		 * @since 1.0.0
+		 *
+		 * @see https://developers.google.com/gtagjs/devguide/amp
+		 *
+		 * @param array $gtag_amp_opt gtag amp options.
+		 */
+		$config = apply_filters( 'googlesitekit_amp_gtag_opt', $gtag_amp_opt );
+
+		// Ensure gtag_id is set to the correct value.
+		if ( ! is_array( $config ) ) {
+			return;
+		}
+		$config['vars']            = isset( $config['vars'] ) && is_array( $config['vars'] ) ? $config['vars'] : $gtag_amp_opt['vars'];
+		$config['vars']['gtag_id'] = $tracking_id;
 		?>
 		<amp-analytics type="gtag" data-credentials="include">
 			<script type="application/json">

--- a/includes/Modules/Analytics.php
+++ b/includes/Modules/Analytics.php
@@ -326,7 +326,7 @@ final class Analytics extends Module implements Module_With_Screen, Module_With_
 		);
 
 		/**
-		 * Filters configuration options for the object that is passed to amp-analytics as a JSON component.
+		 * Filters the gtag configuration options for the object that is passed to amp-analytics as a JSON component.
 		 *
 		 * @since 1.0.0
 		 *
@@ -334,18 +334,22 @@ final class Analytics extends Module implements Module_With_Screen, Module_With_
 		 *
 		 * @param array $gtag_amp_opt gtag amp options.
 		 */
-		$config = apply_filters( 'googlesitekit_amp_gtag_opt', $gtag_amp_opt );
+		$gtag_amp_opt_filtered = apply_filters( 'googlesitekit_amp_gtag_opt', $gtag_amp_opt );
 
 		// Ensure gtag_id is set to the correct value.
-		if ( ! is_array( $config ) ) {
-			return;
+		if ( ! is_array( $gtag_amp_opt_filtered ) ) {
+			$gtag_amp_opt_filtered = array();
 		}
-		$config['vars']            = isset( $config['vars'] ) && is_array( $config['vars'] ) ? $config['vars'] : $gtag_amp_opt['vars'];
-		$config['vars']['gtag_id'] = $tracking_id;
+
+		if ( ! isset( $gtag_amp_opt_filtered['vars'] ) || ! is_array( $gtag_amp_opt_filtered['vars'] ) ) {
+			$gtag_amp_opt_filtered['vars'] = $gtag_amp_opt['vars'];
+		}
+
+		$gtag_amp_opt_filtered['vars']['gtag_id'] = $tracking_id;
 		?>
 		<amp-analytics type="gtag" data-credentials="include">
 			<script type="application/json">
-				<?php echo wp_json_encode( $config ); ?>
+				<?php echo wp_json_encode( $gtag_amp_opt_filtered ); ?>
 			</script>
 		</amp-analytics>
 		<?php


### PR DESCRIPTION
## Summary
Adds filter hook to modify amp gtag configuration options.

<!-- Please reference the issue this PR addresses. -->
Addresses issue https://github.com/google/site-kit-wp/issues/55

## Relevant technical choices

<!-- Please describe your changes. -->

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
