### PR TITLE
exclude unnecessary files in release build

### DIFF
--- a/gulp-tasks/copy.js
+++ b/gulp-tasks/copy.js
@@ -42,7 +42,12 @@ gulp.task( 'copy', () => {
 			'vendor/autoload.php',
 			'!vendor/**/**/{tests,Tests,doc?(s),examples}/**/*',
 			'!vendor/**/**/{*.md,*.yml,phpunit.*}',
-			'!**/*.map'
+			'!**/*.map',
+			'!bin/local-env/**/*',
+			'!bin/local-env/',
+			'!dist/admin.js',
+			'!dist/adminbar.js',
+			'!dist/wpdashboard.js',
 		],
 		{ base: '.' }
 	)


### PR DESCRIPTION
## Summary

Exclude unnecessary files in release build by adding them as excluded files in the gulp copy task.

<!-- Please reference the issue this PR addresses. -->
Addresses issue #362 

## Relevant technical choices

<!-- Please describe your changes. -->

## Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
