### PR TITLE
Ensure the Site Kit admin menu cannot be accidentally overridden by other plugins

### DIFF
--- a/includes/Core/Admin/Screen.php
+++ b/includes/Core/Admin/Screen.php
@@ -129,8 +129,7 @@ final class Screen {
 						function() use ( $context ) {
 							$this->render( $context );
 						},
-						$context->url( 'dist/assets/images/logo-g_white_small.png' ),
-						3
+						$context->url( 'dist/assets/images/logo-g_white_small.png' )
 					);
 					$menu_slug = $this->slug;
 				}

--- a/includes/Core/Admin/Screens.php
+++ b/includes/Core/Admin/Screens.php
@@ -127,6 +127,21 @@ final class Screens {
 		add_action( 'admin_notices', $remove_notices_callback, -9999 );
 		add_action( 'network_admin_notices', $remove_notices_callback, -9999 );
 		add_action( 'all_admin_notices', $remove_notices_callback, -9999 );
+
+		add_filter( 'custom_menu_order', '__return_true' );
+		add_filter(
+			'menu_order',
+			function( array $menu_order ) {
+				$new_order = array();
+				foreach ( $menu_order as $index => $item ) {
+					if ( 'index.php' === $item || 0 === strpos( $item, self::PREFIX ) ) {
+						$new_order[] = $item;
+						unset( $menu_order[ $index ] );
+					}
+				}
+				return array_values( array_merge( $new_order, $menu_order ) );
+			}
+		);
 	}
 
 	/**

--- a/tests/phpunit/integration/Core/Admin/ScreensTest.php
+++ b/tests/phpunit/integration/Core/Admin/ScreensTest.php
@@ -95,4 +95,31 @@ class ScreensTest extends TestCase {
 		do_action( $hookname );
 		$this->assertNotEmpty( ob_get_clean() );
 	}
+
+	public function test_menu_order() {
+		$menu_order = array(
+			'index.php',
+			'third-party-plugin',
+			'edit.php',
+			'options-general.php',
+			'googlesitekit-dashboard',
+		);
+
+		$this->screens->register();
+
+		// Imitate WordPress core running these filters.
+		if ( apply_filters( 'custom_menu_order', false ) ) {
+			$menu_order = apply_filters( 'menu_order', $menu_order );
+		}
+
+		$expected_order = array(
+			'index.php',
+			'googlesitekit-dashboard',
+			'third-party-plugin',
+			'edit.php',
+			'options-general.php',
+		);
+
+		$this->assertEquals( $expected_order, $menu_order );
+	}
 }


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #401 

## Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
