### PR TITLE
E2E Module Setup Flow | Analytics: Existing account, has existing tag

### DIFF
--- a/tests/e2e/mu-plugins/e2e-rest-access-token.php
+++ b/tests/e2e/mu-plugins/e2e-rest-access-token.php
@@ -2,6 +2,11 @@
 /**
  * Plugin Name: E2E Access Token Endpoint
  * Description: REST Endpoint for setting the access token for Site Kit during E2E tests.
+ *
+ * @package   Google\Site_Kit
+ * @copyright 2019 Google LLC
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
+ * @link      https://sitekit.withgoogle.com
  */
 
 use Google\Site_Kit\Core\REST_API\REST_Routes;

--- a/tests/e2e/mu-plugins/e2e-rest-analytics-existing-property-id.php
+++ b/tests/e2e/mu-plugins/e2e-rest-analytics-existing-property-id.php
@@ -1,7 +1,7 @@
 <?php
 /**
- * Plugin Name: E2E Site Verification Endpoint
- * Description: REST Endpoint for setting the site verification status of the current user during E2E tests.
+ * Plugin Name: E2E Access Token Endpoint
+ * Description: REST Endpoint for setting the access token for Site Kit during E2E tests.
  *
  * @package   Google\Site_Kit
  * @copyright 2019 Google LLC
@@ -18,20 +18,19 @@ add_action( 'rest_api_init', function () {
 
 	register_rest_route(
 		REST_Routes::REST_ROOT,
-		'e2e/setup/site-verification',
+		'e2e/analytics/existing-property-id',
 		array(
 			'methods'  => WP_REST_Server::EDITABLE,
 			'callback' => function ( WP_REST_Request $request ) {
-				if ( $request['verified'] ) {
-					update_user_option(
-						get_current_user_id(),
-						'googlesitekit_site_verified_meta',
-						'verified'
-					);
+				if ( $request['id'] ) {
+					update_option( 'googlesitekit_e2e_analytics_existing_property_id', $request['id'] );
 				} else {
-					delete_user_option( get_current_user_id(), 'googlesitekit_site_verified_meta' );
+					delete_option( 'googlesitekit_e2e_analytics_existing_property_id' );
 				}
+
+				return array( 'success' => true, 'id' => $request['id'] );
 			}
 		)
 	);
 }, 0 );
+

--- a/tests/e2e/mu-plugins/e2e-rest-credentials.php
+++ b/tests/e2e/mu-plugins/e2e-rest-credentials.php
@@ -2,6 +2,11 @@
 /**
  * Plugin Name: E2E Client Configuration Endpoint
  * Description: REST Endpoint for setting the client configuration for Site Kit during E2E tests.
+ *
+ * @package   Google\Site_Kit
+ * @copyright 2019 Google LLC
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
+ * @link      https://sitekit.withgoogle.com
  */
 
 use Google\Site_Kit\Core\REST_API\REST_Routes;

--- a/tests/e2e/mu-plugins/e2e-rest-search-console-property.php
+++ b/tests/e2e/mu-plugins/e2e-rest-search-console-property.php
@@ -2,6 +2,11 @@
 /**
  * Plugin Name: E2E Search Console Property Endpoint
  * Description: REST Endpoint for setting the Search Console property for Site Kit during E2E tests.
+ *
+ * @package   Google\Site_Kit
+ * @copyright 2019 Google LLC
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
+ * @link      https://sitekit.withgoogle.com
  */
 
 use Google\Site_Kit\Core\REST_API\REST_Routes;

--- a/tests/e2e/plugins/analytics-existing-tag.php
+++ b/tests/e2e/plugins/analytics-existing-tag.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Plugin Name: E2E Tests Analytics Existing Tag
+ * Plugin URI:  https://github.com/google/site-kit-wp
+ * Description: Utility plugin for rendering an existing Analytics tag during E2E tests.
+ * Author:      Google
+ * Author URI:  https://opensource.google.com
+ *
+ * @package   Google\Site_Kit
+ * @copyright 2019 Google LLC
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
+ * @link      https://sitekit.withgoogle.com
+ */
+
+register_activation_hook( __FILE__, function () {
+	delete_option( 'googlesitekit_e2e_analytics_existing_property_id' );
+} );
+
+register_deactivation_hook( __FILE__, function () {
+	delete_option( 'googlesitekit_e2e_analytics_existing_property_id' );
+} );
+
+add_action( 'wp_print_scripts', function () {
+	$UA_CODE = get_option( 'googlesitekit_e2e_analytics_existing_property_id' );
+
+	if ( ! $UA_CODE ) {
+		return;
+	}
+
+	echo <<<HTML
+<!-- Global site tag (gtag.js) - Google Analytics -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=$UA_CODE"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', '$UA_CODE');
+</script>
+HTML;
+} );

--- a/tests/e2e/plugins/auth.php
+++ b/tests/e2e/plugins/auth.php
@@ -5,6 +5,11 @@
  * Description: Utility plugin for bypassing set up and authentication during E2E tests.
  * Author:      Google
  * Author URI:  https://opensource.google.com
+ *
+ * @package   Google\Site_Kit
+ * @copyright 2019 Google LLC
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
+ * @link      https://sitekit.withgoogle.com
  */
 
 use Google\Site_Kit\Core\Authentication\Clients\OAuth_Client;

--- a/tests/e2e/plugins/demo.php
+++ b/tests/e2e/plugins/demo.php
@@ -5,6 +5,11 @@
  * Description: Demo Plugin that can be installed during E2E tests.
  * Author:      Google
  * Author URI:  https://opensource.google.com
+ *
+ * @package   Google\Site_Kit
+ * @copyright 2019 Google LLC
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
+ * @link      https://sitekit.withgoogle.com
  */
 
 // Silence is golden.

--- a/tests/e2e/plugins/module-setup-analytics.php
+++ b/tests/e2e/plugins/module-setup-analytics.php
@@ -5,6 +5,11 @@
  * Description: Utility plugin for mocking Analytics Setup API requests during E2E tests.
  * Author:      Google
  * Author URI:  https://opensource.google.com
+ *
+ * @package   Google\Site_Kit
+ * @copyright 2019 Google LLC
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
+ * @link      https://sitekit.withgoogle.com
  */
 
 namespace Google\Site_Kit\Tests\E2E\Modules\Analytics;

--- a/tests/e2e/plugins/oauth-callback.php
+++ b/tests/e2e/plugins/oauth-callback.php
@@ -5,6 +5,11 @@
  * Description: Utility plugin for bypassing oAuth during E2E tests.
  * Author:      Google
  * Author URI:  https://opensource.google.com
+ *
+ * @package   Google\Site_Kit
+ * @copyright 2019 Google LLC
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
+ * @link      https://sitekit.withgoogle.com
  */
 
 use Google\Site_Kit\Core\Authentication\Clients\OAuth_Client;

--- a/tests/e2e/plugins/reset.php
+++ b/tests/e2e/plugins/reset.php
@@ -5,6 +5,11 @@
  * Description: Utility plugin for resetting Site Kit during E2E tests.
  * Author:      Google
  * Author URI:  https://opensource.google.com
+ *
+ * @package   Google\Site_Kit
+ * @copyright 2019 Google LLC
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
+ * @link      https://sitekit.withgoogle.com
  */
 
 use Google\Site_Kit\Context;

--- a/tests/e2e/plugins/site-verification-api-mock.php
+++ b/tests/e2e/plugins/site-verification-api-mock.php
@@ -5,6 +5,11 @@
  * Description: Utility plugin for handling site verification for Site Kit during E2E tests.
  * Author:      Google
  * Author URI:  https://opensource.google.com
+ *
+ * @package   Google\Site_Kit
+ * @copyright 2019 Google LLC
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
+ * @link      https://sitekit.withgoogle.com
  */
 
 use Google\Site_Kit\Core\REST_API\REST_Routes;

--- a/tests/e2e/plugins/site-verification.php
+++ b/tests/e2e/plugins/site-verification.php
@@ -5,6 +5,11 @@
  * Description: Utility plugin for bypassing site verification during E2E tests.
  * Author:      Google
  * Author URI:  https://opensource.google.com
+ *
+ * @package   Google\Site_Kit
+ * @copyright 2019 Google LLC
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
+ * @link      https://sitekit.withgoogle.com
  */
 
 /**

--- a/tests/e2e/specs/modules/analytics/setup-with-account-with-tag.test.js
+++ b/tests/e2e/specs/modules/analytics/setup-with-account-with-tag.test.js
@@ -1,0 +1,121 @@
+/**
+ * WordPress dependencies
+ */
+import { activatePlugin, visitAdminPage } from '@wordpress/e2e-test-utils';
+
+/**
+ * Internal dependencies
+ */
+import {
+	deactivateAllOtherPlugins,
+	resetSiteKit,
+	useRequestInterception,
+	setAnalyticsExistingPropertyId,
+	setAuthToken,
+	setClientConfig,
+	setSearchConsoleProperty,
+	setSiteVerification,
+} from '../../../utils';
+
+async function proceedToSetUpAnalytics() {
+	await Promise.all( [
+		expect( page ).toClick( '.googlesitekit-cta-link', { text: /set up analytics/i } ),
+		page.waitForSelector( '.googlesitekit-setup-module--analytics' ),
+		page.waitForResponse( res => res.url().match( 'analytics/data' ) ),
+	] );
+}
+
+const EXISTING_PROPERTY_ID = 'UA-00000001-1';
+const EXISTING_NO_MATCH_PROPERTY_ID = 'UA-99999999-1';
+
+let getAccountsRequestHandler;
+let tagPermissionRequestHandler;
+
+describe( 'setting up the Analytics module with an existing account and existing tag', () => {
+	beforeAll( async() => {
+		await page.setRequestInterception( true );
+		useRequestInterception( request => {
+			if ( request.url().match( 'modules/analytics/data/get-accounts' ) ) {
+				getAccountsRequestHandler && getAccountsRequestHandler( request );
+			} else if ( request.url().match( 'modules/analytics/data/tag-permission' ) ) {
+				tagPermissionRequestHandler && tagPermissionRequestHandler( request );
+			} else if ( request.url().match( '/wp-json/google-site-kit/v1/data/' ) ) {
+				request.respond( {
+					status: 200
+				} );
+			}
+
+			if ( ! request._interceptionHandled ) {
+				request.continue();
+			}
+		} );
+	} );
+
+	beforeEach( async() => {
+		await activatePlugin( 'e2e-tests-auth-plugin' );
+		await activatePlugin( 'e2e-tests-analytics-existing-tag' );
+		await activatePlugin( 'e2e-tests-module-setup-analytics-api-mock' );
+
+		await setClientConfig();
+		await setAuthToken();
+		await setSiteVerification();
+		await setSearchConsoleProperty();
+
+		await visitAdminPage( 'admin.php', 'page=googlesitekit-settings' );
+		await page.waitForSelector( '.mdc-tab-bar' );
+		await expect( page ).toClick( '.mdc-tab', { text: /connect more services/i } );
+		await page.waitForSelector( '.googlesitekit-settings-connect-module--analytics' );
+	} );
+
+	afterEach( async() => {
+		await deactivateAllOtherPlugins();
+		await resetSiteKit();
+	} );
+
+	it( 'pre-selects account and property if an existing tag is found that matches one belonging to the user and prevents them from being changed', async() => {
+		tagPermissionRequestHandler = request => {
+			request.respond( {
+				status: 200,
+				body: 'true',
+			} );
+		};
+		await setAnalyticsExistingPropertyId( EXISTING_PROPERTY_ID );
+		await proceedToSetUpAnalytics();
+
+		await expect( page ).toMatchElement( '.googlesitekit-setup-module--analytics p', { text: new RegExp( `An existing analytics tag was found on your site with the id ${EXISTING_PROPERTY_ID}`, 'i' ) } );
+
+		await expect( page ).toMatchElement( '.mdc-select--disabled .mdc-select__selected-text', { text: /test account a/i } );
+		await expect( page ).toMatchElement( '.mdc-select--disabled .mdc-select__selected-text', { text: /test property x/i } );
+		await expect( page ).toMatchElement( '.mdc-select:not(.mdc-select--disabled) .mdc-select__selected-text', { text: /test profile x/i } );
+
+		// Ensure that Views are not disabled
+		await expect( page ).toClick( '.mdc-select', { text: /test profile x/i } );
+		await expect( page ).toClick( '.mdc-menu-surface--open .mdc-list-item', { text: /test profile x/i } ),
+
+		await Promise.all( [
+			expect( page ).toClick( 'button', { text: /configure analytics/i } ),
+			page.waitForSelector( '.googlesitekit-publisher-win__title' ),
+		] );
+
+		await expect( page ).toMatchElement( '.googlesitekit-publisher-win__title', { text: /Congrats on completing the setup for Analytics!/i } );
+	} );
+
+	it( 'does not allow Analytics to be set up with an existing tag that does not match a property of the user', async() => {
+		getAccountsRequestHandler = request => {
+			request.respond( {
+				status: 500,
+				body: JSON.stringify( {
+					code: 'google_analytics_existing_tag_permission',
+					message: 'google_analytics_existing_tag_permission',
+				} )
+			} );
+		};
+
+		await setAnalyticsExistingPropertyId( EXISTING_NO_MATCH_PROPERTY_ID );
+		await proceedToSetUpAnalytics();
+
+		await expect( page ).toMatchElement( '.googlesitekit-setup-module--analytics p', { text: /google_analytics_existing_tag_permission/i } );
+		await expect( page ).toMatchElement( '.googlesitekit-setup-module--analytics button', { text: /create an account/i } );
+		await expect( page ).toMatchElement( '.googlesitekit-setup-module--analytics button', { text: /re-fetch my account/i } );
+	} );
+} );

--- a/tests/e2e/specs/modules/analytics/setup-with-account-with-tag.test.js
+++ b/tests/e2e/specs/modules/analytics/setup-with-account-with-tag.test.js
@@ -9,12 +9,12 @@ import { activatePlugin, visitAdminPage } from '@wordpress/e2e-test-utils';
 import {
 	deactivateAllOtherPlugins,
 	resetSiteKit,
-	useRequestInterception,
 	setAnalyticsExistingPropertyId,
 	setAuthToken,
 	setClientConfig,
 	setSearchConsoleProperty,
 	setSiteVerification,
+	useRequestInterception,
 } from '../../../utils';
 
 async function proceedToSetUpAnalytics() {
@@ -26,7 +26,6 @@ async function proceedToSetUpAnalytics() {
 }
 
 const EXISTING_PROPERTY_ID = 'UA-00000001-1';
-const EXISTING_NO_MATCH_PROPERTY_ID = 'UA-99999999-1';
 
 let getAccountsRequestHandler;
 let tagPermissionRequestHandler;
@@ -88,7 +87,7 @@ describe( 'setting up the Analytics module with an existing account and existing
 		await expect( page ).toMatchElement( '.mdc-select--disabled .mdc-select__selected-text', { text: /test property x/i } );
 		await expect( page ).toMatchElement( '.mdc-select:not(.mdc-select--disabled) .mdc-select__selected-text', { text: /test profile x/i } );
 
-		// Ensure that Views are not disabled
+		// Ensure that Views dropdown is not disabled
 		await expect( page ).toClick( '.mdc-select', { text: /test profile x/i } );
 		await expect( page ).toClick( '.mdc-menu-surface--open .mdc-list-item', { text: /test profile x/i } ),
 
@@ -111,7 +110,6 @@ describe( 'setting up the Analytics module with an existing account and existing
 			} );
 		};
 
-		await setAnalyticsExistingPropertyId( EXISTING_NO_MATCH_PROPERTY_ID );
 		await proceedToSetUpAnalytics();
 
 		await expect( page ).toMatchElement( '.googlesitekit-setup-module--analytics p', { text: /google_analytics_existing_tag_permission/i } );

--- a/tests/e2e/utils/index.js
+++ b/tests/e2e/utils/index.js
@@ -3,6 +3,7 @@ export { deactivateAllOtherPlugins } from './deactivate-all-other-plugins';
 export { logoutUser } from './logout-user';
 export { pasteText } from './paste-text';
 export { resetSiteKit } from './reset';
+export { setAnalyticsExistingPropertyId } from './set-analytics-existing-property-id';
 export { setAuthToken } from './set-auth-token';
 export { setClientConfig } from './set-client-config';
 export { setSiteVerification } from './set-site-verification';

--- a/tests/e2e/utils/set-analytics-existing-property-id.js
+++ b/tests/e2e/utils/set-analytics-existing-property-id.js
@@ -1,0 +1,19 @@
+
+/**
+ * Internal dependencies
+ */
+import { wpApiFetch } from './wp-api-fetch';
+
+/**
+ * Set the property ID to render on the site, outside of Site Kit.
+ *
+ * @param {string} token Access token to set.
+ * @returns {*} resolved value from apiFetch promise.
+ */
+export async function setAnalyticsExistingPropertyId( id ) {
+	return await wpApiFetch( {
+		path: 'google-site-kit/v1/e2e/analytics/existing-property-id',
+		method: 'post',
+		data: { id },
+	} );
+}


### PR DESCRIPTION
## Summary

Addresses issue #357

## Relevant technical choices

* Introduces a new utility plugin for rendering an analytics tag outside of Site Kit to test an existing tag
* Introduces a persistent e2e rest route for setting the Property ID rendered by the utility plugin (if active).
* Adds missing license info to utility plugins

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
