### PR TITLE
Fix re-fetch in analytics setup flow

### DIFF
--- a/assets/js/modules/analytics/setup.js
+++ b/assets/js/modules/analytics/setup.js
@@ -259,65 +259,58 @@ class AnalyticsSetup extends Component {
 
 				// clear the cache.
 				data.deleteCache( 'analytics', 'get-accounts' );
-			} else {
+			} else if ( ! selectedAccount ) {
+				let matchedProperty = null;
 
-				if ( ! selectedAccount ) {
-					let matchedProperty = null;
+				if ( responseData.existingTag ) {
 
-					if ( responseData.existingTag ) {
-
-						// Select account and property of existing tag.
-						matchedProperty = responseData.existingTag.property;
-						if ( this._isMounted ) {
-							this.setState( {
-								existingTag: responseData.existingTag.property[0].id,
-							} );
-						}
-					} else {
-						if ( responseData.matchedProperty ) {
-							matchedProperty = responseData.matchedProperty;
-						}
-					}
-
-					if ( matchedProperty && matchedProperty.length ) {
-						selectedAccount  = matchedProperty[0].accountId;
-						selectedProperty = matchedProperty[0].id;
-						const matchedProfile = responseData.profiles.filter( profile => {
-							return profile.accountId === selectedAccount;
-						} );
-						if ( 0 < matchedProfile.length ) {
-							selectedProfile = matchedProfile[0].id;
-						}
-					} else {
-						responseData.accounts.unshift( {
-							id: 0,
-							name: __( 'Select one...', 'google-site-kit' )
+					// Select account and property of existing tag.
+					matchedProperty = responseData.existingTag.property;
+					if ( this._isMounted ) {
+						this.setState( {
+							existingTag: responseData.existingTag.property[0].id,
 						} );
 					}
 				} else {
-
-					// Verify user has access to selected property.
-					if ( selectedAccount && ! responseData.accounts.find( account => account.id === selectedAccount ) ) {
-						data.deleteCache( 'analytics', 'get-accounts' );
-
-						responseData.accounts.unshift( {
-							id: 0,
-							name: __( 'Select one...', 'google-site-kit' )
-						} );
-
-						if ( isEditing ) {
-							selectedAccount = '0';
-							selectedProperty = '-1';
-							selectedProfile = '-1';
-						}
-
-						if ( this._isMounted ) {
-							this.setState( {
-								errorCode: true,
-								errorReason: 'insufficientPermissions',
-							} );
-						}
+					if ( responseData.matchedProperty ) {
+						matchedProperty = responseData.matchedProperty;
 					}
+				}
+
+				if ( matchedProperty && matchedProperty.length ) {
+					selectedAccount  = matchedProperty[0].accountId;
+					selectedProperty = matchedProperty[0].id;
+					const matchedProfile = responseData.profiles.filter( profile => {
+						return profile.accountId === selectedAccount;
+					} );
+					if ( 0 < matchedProfile.length ) {
+						selectedProfile = matchedProfile[0].id;
+					}
+				} else {
+					responseData.accounts.unshift( {
+						id: 0,
+						name: __( 'Select one...', 'google-site-kit' )
+					} );
+				}
+			} else if ( selectedAccount && ! responseData.accounts.find( account => account.id === selectedAccount ) ) {
+				data.deleteCache( 'analytics', 'get-accounts' );
+
+				responseData.accounts.unshift( {
+					id: 0,
+					name: __( 'Select one...', 'google-site-kit' )
+				} );
+
+				if ( isEditing ) {
+					selectedAccount = '0';
+					selectedProperty = '-1';
+					selectedProfile = '-1';
+				}
+
+				if ( this._isMounted ) {
+					this.setState( {
+						errorCode: true,
+						errorReason: 'insufficientPermissions',
+					} );
 				}
 			}
 

--- a/assets/js/modules/analytics/setup.js
+++ b/assets/js/modules/analytics/setup.js
@@ -245,13 +245,15 @@ class AnalyticsSetup extends Component {
 	}
 
 	async getAccounts() {
+		let {
+			selectedAccount,
+			selectedProperty,
+			selectedProfile,
+		} = this.state;
 		const { isEditing } = this.props;
 
 		try {
 			let responseData = await data.get( 'modules', 'analytics', 'get-accounts', {}, false );
-			let selectedAccount = this.state.selectedAccount;
-			let selectedProperty = this.state.selectedProperty;
-			let selectedProfile = this.state.selectedProfile;
 
 			if ( 0 === responseData.accounts.length ) {
 

--- a/assets/js/modules/analytics/setup.js
+++ b/assets/js/modules/analytics/setup.js
@@ -246,12 +246,13 @@ class AnalyticsSetup extends Component {
 
 	async getAccounts() {
 		let {
+			errorCode,
 			selectedAccount,
 			selectedProperty,
 			selectedProfile,
 		} = this.state;
 		const { isEditing } = this.props;
-		let newState;
+		let newState = {};
 
 		try {
 			let responseData = await data.get( 'modules', 'analytics', 'get-accounts', {}, false );
@@ -267,11 +268,10 @@ class AnalyticsSetup extends Component {
 
 					// Select account and property of existing tag.
 					matchedProperty = responseData.existingTag.property;
-					if ( this._isMounted ) {
-						this.setState( {
-							existingTag: responseData.existingTag.property[0].id,
-						} );
-					}
+					newState = {
+						...newState,
+						existingTag: responseData.existingTag.property[0].id,
+					};
 				} else {
 					if ( responseData.matchedProperty ) {
 						matchedProperty = responseData.matchedProperty;
@@ -307,12 +307,11 @@ class AnalyticsSetup extends Component {
 					selectedProfile = '-1';
 				}
 
-				if ( this._isMounted ) {
-					this.setState( {
-						errorCode: true,
-						errorReason: 'insufficientPermissions',
-					} );
-				}
+				newState = {
+					...newState,
+					errorCode: true,
+					errorReason: 'insufficientPermissions',
+				};
 			}
 
 			// Return only existing tag account and property for dropdown options.
@@ -345,9 +344,10 @@ class AnalyticsSetup extends Component {
 			responseData.profiles.push( chooseProfile );
 
 			newState = {
+				...newState,
 				isLoading: false,
 				accounts: responseData.accounts,
-				errorCode: this.state.errorCode,
+				errorCode: errorCode || newState.errorCode,
 				selectedAccount: selectedAccount,
 				selectedProperty: selectedProperty,
 				selectedProfile: selectedProfile,
@@ -374,9 +374,9 @@ class AnalyticsSetup extends Component {
 
 		return new Promise( ( resolve ) => {
 			if ( this._isMounted ) {
-				resolve( newState );
+				this.setState( newState, resolve );
 			} else {
-				resolve( newState );
+				resolve();
 			}
 		} );
 	}

--- a/assets/js/modules/analytics/setup.js
+++ b/assets/js/modules/analytics/setup.js
@@ -220,7 +220,7 @@ class AnalyticsSetup extends Component {
 			selectedProfile,
 			useSnippet,
 		} = this.state;
-		const { isEditing, onSettingsPage } = this.props;
+		const { isEditing } = this.props;
 		let newState = {};
 
 		try {
@@ -341,7 +341,7 @@ class AnalyticsSetup extends Component {
 					await data.get( 'modules', 'analytics', 'tag-permission', { tag: existingTag }, false );
 					newState = Object.assign( newState, {
 						existingTag,
-						useSnippet: ( ! existingTag && ! onSettingsPage ) ? true : useSnippet,
+						useSnippet,
 					} );
 				}
 			}

--- a/assets/js/modules/analytics/setup.js
+++ b/assets/js/modules/analytics/setup.js
@@ -251,6 +251,7 @@ class AnalyticsSetup extends Component {
 			selectedProfile,
 		} = this.state;
 		const { isEditing } = this.props;
+		let newState;
 
 		try {
 			let responseData = await data.get( 'modules', 'analytics', 'get-accounts', {}, false );
@@ -343,7 +344,7 @@ class AnalyticsSetup extends Component {
 			};
 			responseData.profiles.push( chooseProfile );
 
-			let newState = {
+			newState = {
 				isLoading: false,
 				accounts: responseData.accounts,
 				errorCode: this.state.errorCode,
@@ -362,22 +363,22 @@ class AnalyticsSetup extends Component {
 					selectedinternalWebProperty: ( responseData.properties[0] ) ? responseData.properties[0].internalWebPropertyId : 0,
 				} );
 			}
-
-			return new Promise( ( resolve ) => {
-				resolve( newState );
-			} );
 		} catch ( err ) {
-			const errState = {
+			newState = {
 				isLoading: false,
 				errorCode: err.code,
 				errorMsg: err.message,
 				errorReason: err.data && err.data.reason ? err.data.reason : false,
 			};
-
-			return new Promise( ( resolve ) => {
-				resolve( errState );
-			} );
 		}
+
+		return new Promise( ( resolve ) => {
+			if ( this._isMounted ) {
+				resolve( newState );
+			} else {
+				resolve( newState );
+			}
+		} );
 	}
 
 	async processAccountChange( selectValue ) {

--- a/assets/js/modules/analytics/setup.js
+++ b/assets/js/modules/analytics/setup.js
@@ -330,27 +330,25 @@ class AnalyticsSetup extends Component {
 			};
 
 			if ( ! this.state.existingTag ) {
-				const chooseProperty = {
+				responseData.properties.push( {
 					id: 0,
 					name: __( 'Setup a New Property', 'google-site-kit' )
-				};
-				responseData.properties.push( chooseProperty );
+				} );
 			}
 
-			const chooseProfile = {
+			responseData.profiles.push( {
 				id: 0,
 				name: __( 'Setup a New Profile', 'google-site-kit' )
-			};
-			responseData.profiles.push( chooseProfile );
+			} );
 
 			newState = {
 				...newState,
 				isLoading: false,
 				accounts: responseData.accounts,
 				errorCode: errorCode || newState.errorCode,
-				selectedAccount: selectedAccount,
-				selectedProperty: selectedProperty,
-				selectedProfile: selectedProfile,
+				selectedAccount,
+				selectedProperty,
+				selectedProfile,
 				properties: [ chooseAccount ],
 				profiles: [ chooseAccount ],
 				existingTag: responseData.existingTag ? responseData.existingTag.property[0].id : false,


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #154

## Relevant technical choices

* Consolidated use of state and props at the top
* Collapsed/flattened a few nested if statements
* Revisited if `this._isMounted` check is necessary
Without it, this warning below raised. It seems as though there are alternate solutions to this but this appears to be a common and simple solution.
> Warning: Can't perform a React state update on an unmounted component. This is a no-op, but it indicates a memory leak in your application. To fix, cancel all subscriptions and asynchronous tasks in the componentWillUnmount method.

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
