### PR TITLE
Require setup to be completed for all users to access dashboard

### DIFF
--- a/includes/Core/Permissions/Permissions.php
+++ b/includes/Core/Permissions/Permissions.php
@@ -226,6 +226,11 @@ final class Permissions {
 					$prevent_access = ! $this->authentication->verification()->has();
 				}
 
+				// For all users, require setup to have been completed.
+				if ( ! $prevent_access ) {
+					$prevent_access = ! $this->is_setup_complete();
+				}
+
 				if ( $prevent_access ) {
 					$caps[] = 'do_not_allow';
 				}

--- a/tests/e2e/specs/auth-flow.test.js
+++ b/tests/e2e/specs/auth-flow.test.js
@@ -6,7 +6,12 @@ import { activatePlugin, createURL, visitAdminPage } from '@wordpress/e2e-test-u
 /**
  * Internal dependencies
  */
-import { pasteText, testClientConfig, useRequestInterception } from '../utils';
+import {
+	pasteText,
+	setSearchConsoleProperty,
+	testClientConfig,
+	useRequestInterception,
+} from '../utils';
 
 function stubGoogleSignIn( request ) {
 	if ( request.url().startsWith( 'https://accounts.google.com/o/oauth2/auth' ) ) {
@@ -34,6 +39,7 @@ describe( 'Site Kit set up flow for the first time', () => {
 
 	beforeAll( async() => {
 		await activatePlugin( 'e2e-tests-oauth-callback-plugin' );
+		await setSearchConsoleProperty();
 	} );
 
 	it( 'authenticates from splash page', async() => {

--- a/tests/e2e/specs/modules/analytics/setup-with-account-no-tag.test.js
+++ b/tests/e2e/specs/modules/analytics/setup-with-account-no-tag.test.js
@@ -6,7 +6,13 @@ import { activatePlugin, createURL, visitAdminPage } from '@wordpress/e2e-test-u
 /**
  * Internal dependencies
  */
-import { wpApiFetch, deactivateAllOtherPlugins, resetSiteKit } from '../../../utils';
+import {
+	deactivateAllOtherPlugins,
+	resetSiteKit,
+	setSearchConsoleProperty,
+	wpApiFetch,
+	useRequestInterception,
+} from '../../../utils';
 
 async function proceedToSetUpAnalytics() {
 	await Promise.all( [
@@ -29,13 +35,7 @@ const setReferenceUrl = async() => {
 describe( 'setting up the Analytics module with an existing account and no existing tag', () => {
 	beforeAll( async() => {
 		await page.setRequestInterception( true );
-		page.on( 'request', request => {
-			if ( ! request._allowInterception ) {
-
-				// prevent errors for requests that happen after interception is disabled.
-				return;
-			}
-
+		useRequestInterception( request => {
 			if ( request.url().startsWith( 'https://accounts.google.com/o/oauth2/auth' ) ) {
 				request.respond( {
 					status: 302,
@@ -63,6 +63,7 @@ describe( 'setting up the Analytics module with an existing account and no exist
 		await activatePlugin( 'e2e-tests-site-verification-plugin' );
 		await activatePlugin( 'e2e-tests-oauth-callback-plugin' );
 		await activatePlugin( 'e2e-tests-module-setup-analytics-api-mock' );
+		await setSearchConsoleProperty();
 
 		await visitAdminPage( 'admin.php', 'page=googlesitekit-settings' );
 		await page.waitForSelector( '.mdc-tab-bar' );

--- a/tests/e2e/specs/modules/pagespeed-insights/activation.test.js
+++ b/tests/e2e/specs/modules/pagespeed-insights/activation.test.js
@@ -6,19 +6,25 @@ import { visitAdminPage, activatePlugin } from '@wordpress/e2e-test-utils';
 /**
  * Internal dependencies
  */
-import { resetSiteKit, deactivateAllOtherPlugins } from '../../../utils';
+import {
+	deactivateAllOtherPlugins,
+	pasteText,
+	resetSiteKit,
+	setSearchConsoleProperty,
+	setSiteVerification,
+} from '../../../utils';
 
 describe( 'PageSpeed Insights Activation', () => {
 	beforeEach( async() => {
 		await activatePlugin( 'e2e-tests-auth-plugin' );
-		await activatePlugin( 'e2e-tests-site-verification-plugin' );
+		await setSiteVerification();
+		await setSearchConsoleProperty();
 	} );
 
 	afterEach( async() => {
 		await deactivateAllOtherPlugins();
 		await resetSiteKit();
 	} );
-
 	it( 'should lead you to the activation page', async() => {
 		await visitAdminPage( 'admin.php', 'page=googlesitekit-dashboard' );
 
@@ -38,7 +44,7 @@ describe( 'PageSpeed Insights Activation', () => {
 
 		await expect( page ).toMatchElement( 'h2.googlesitekit-setup-module__title', { text: 'PageSpeed Insights' } );
 
-		await page.type( 'input.mdc-text-field__input', 'PSIKEYTOSUBMITANDTEST' );
+		await pasteText( 'input.mdc-text-field__input', 'PSIKEYTOSUBMITANDTEST' );
 
 		await expect( page ).toClick( 'button.mdc-button', { text: 'Proceed' } );
 


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #352

## Relevant technical choices

* Updates broken E2E tests

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
