### PR TITLE
AdSense: verify if decimal is undefined before replacing readable number

### DIFF
--- a/assets/js/util/index.js
+++ b/assets/js/util/index.js
@@ -135,16 +135,12 @@ export const readableLargeNumber = ( number, currencyCode = false ) =>  {
 	if ( false !== currencyCode && '' !== readableNumber ) {
 		const formatedParts = new Intl.NumberFormat( navigator.language, { style: 'currency', currency: currencyCode } ).formatToParts( number );
 
-		let decimal = formatedParts.find( part => 'decimal' === part.type );
-		if ( ! isUndefined( decimal ) ) {
-			decimal = decimal.value;
+		const decimal = formatedParts.find( part => 'decimal' === part.type );
+		if ( ! isUndefined( decimal ) && ! isUndefined( decimal.value ) && 1000 > number ) {
+			readableNumber = Number.isInteger( number ) ? number : number.replace( '.', decimal.value );
 		}
 
 		const currency = formatedParts.find( part => 'currency' === part.type ).value;
-
-		if ( 1000 > number && ! isUndefined( decimal ) ) {
-			readableNumber = Number.isInteger( number ) ? number : number.replace( '.', decimal );
-		}
 
 		return `${currency}${readableNumber}`;
 	}

--- a/assets/js/util/index.js
+++ b/assets/js/util/index.js
@@ -140,7 +140,8 @@ export const readableLargeNumber = ( number, currencyCode = false ) =>  {
 			readableNumber = Number.isInteger( number ) ? number : number.replace( '.', decimal.value );
 		}
 
-		const currency = formatedParts.find( part => 'currency' === part.type ).value;
+		const currencyFound = formatedParts.find( part => 'currency' === part.type );
+		const currency = currencyFound ? currencyFound.value : '';
 
 		return `${currency}${readableNumber}`;
 	}

--- a/assets/js/util/index.js
+++ b/assets/js/util/index.js
@@ -135,10 +135,14 @@ export const readableLargeNumber = ( number, currencyCode = false ) =>  {
 	if ( false !== currencyCode && '' !== readableNumber ) {
 		const formatedParts = new Intl.NumberFormat( navigator.language, { style: 'currency', currency: currencyCode } ).formatToParts( number );
 
-		const decimal = formatedParts.find( part => 'decimal' === part.type ).value;
+		let decimal = formatedParts.find( part => 'decimal' === part.type );
+		if ( ! isUndefined( decimal ) ) {
+			decimal = decimal.value;
+		}
+
 		const currency = formatedParts.find( part => 'currency' === part.type ).value;
 
-		if ( 1000 > number ) {
+		if ( 1000 > number && ! isUndefined( decimal ) ) {
 			readableNumber = Number.isInteger( number ) ? number : number.replace( '.', decimal );
 		}
 


### PR DESCRIPTION
## Summary
Fix console error for non decimal currencies.

<!-- Please reference the issue this PR addresses. -->
Addresses issue https://github.com/google/site-kit-wp/issues/114

## Relevant technical choices

<!-- Please describe your changes. -->

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [X] My code is backward-compatible with WordPress 4.7 and PHP 5.4.
- [X] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [X] My code has proper inline documentation.
- [X] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
