### PR TITLE
AdSense: add currency to dashboard widget earnings

### DIFF
--- a/assets/js/modules/adsense/dashboard/dashboard-widget-estimate-earnings.js
+++ b/assets/js/modules/adsense/dashboard/dashboard-widget-estimate-earnings.js
@@ -239,39 +239,40 @@ class AdSenseEstimateEarningsWidget extends Component {
 			return null;
 		}
 
-		const currency = today.headers.find( header => null !== header.currency && 0 < header.currency.length ).currency;
+		const currencyHeader = today.headers.find( header => null !== header.currency && 0 < header.currency.length );
+		const currencyCode = currencyHeader ? currencyHeader.currency : false;
 
 		const dataBlocks = today.totals ? [
 			{
 				className: 'googlesitekit-data-block--today',
 				title: __( 'Today so far', 'google-site-kit' ),
-				datapoint: readableLargeNumber( today.totals[0], currency ),
+				datapoint: readableLargeNumber( today.totals[0], currencyCode ),
 			},
 			{
 				className: 'googlesitekit-data-block--yesterday',
 				title: __( 'Yesterday', 'google-site-kit' ),
-				datapoint: readableLargeNumber( yesterday.totals[0], currency ),
+				datapoint: readableLargeNumber( yesterday.totals[0], currencyCode ),
 				change: sameDayLastWeek.totals[0],
 				changeDataUnit: '%',
 			},
 			{
 				className: 'googlesitekit-data-block--7days',
 				title: __( 'Last 7 days', 'google-site-kit' ),
-				datapoint: readableLargeNumber( sevenDays.totals[0], currency ),
+				datapoint: readableLargeNumber( sevenDays.totals[0], currencyCode ),
 				change: prev7Days.totals[0],
 				changeDataUnit: '%',
 			},
 			{
 				className: 'googlesitekit-data-block--month',
 				title: __( 'This month', 'google-site-kit' ),
-				datapoint: readableLargeNumber( month.totals[0], currency ),
+				datapoint: readableLargeNumber( month.totals[0], currencyCode ),
 				change: monthLastYear.totals[0],
 				changeDataUnit: '%',
 			},
 			{
 				className: 'googlesitekit-data-block--28days',
 				title: __( 'Last 28 days', 'google-site-kit' ),
-				datapoint: readableLargeNumber( twentyEightDays.totals[0], currency ),
+				datapoint: readableLargeNumber( twentyEightDays.totals[0], currencyCode ),
 				change: prev28Days.totals[0],
 				changeDataUnit: '%',
 			},

--- a/assets/js/modules/adsense/dashboard/dashboard-widget-main-summary.js
+++ b/assets/js/modules/adsense/dashboard/dashboard-widget-main-summary.js
@@ -109,7 +109,8 @@ class AdSenseDashboardMainSummary extends Component {
 			{}
 		);
 
-		const currency = period.headers.find( header => null !== header.currency && 0 < header.currency.length ).currency;
+		const currencyHeader = period.headers.find( header => null !== header.currency && 0 < header.currency.length );
+		const currencyCode = currencyHeader ? currencyHeader.currency : false;
 
 		return (
 			<Fragment>
@@ -128,7 +129,7 @@ class AdSenseDashboardMainSummary extends Component {
 									<DataBlock
 										className="overview-adsense-rpm"
 										title={ __( 'RPM', 'google-site-kit' ) }
-										datapoint={ readableLargeNumber( period.totals[1], currency ) }
+										datapoint={ readableLargeNumber( period.totals[1], currencyCode ) }
 										source={ {
 											name: __( 'AdSense', 'google-site-kit' ),
 											link: href,
@@ -151,7 +152,7 @@ class AdSenseDashboardMainSummary extends Component {
 									<DataBlock
 										className="overview-adsense-earnings"
 										title={ __( 'Total Earnings', 'google-site-kit' ) }
-										datapoint={ readableLargeNumber( period.totals[0], currency ) }
+										datapoint={ readableLargeNumber( period.totals[0], currencyCode ) }
 										source={ {
 											name: __( 'AdSense', 'google-site-kit' ),
 											link: href,

--- a/assets/js/modules/adsense/dashboard/dashboard-widget-main-summary.js
+++ b/assets/js/modules/adsense/dashboard/dashboard-widget-main-summary.js
@@ -109,6 +109,8 @@ class AdSenseDashboardMainSummary extends Component {
 			{}
 		);
 
+		const currency = period.headers.find( header => null !== header.currency && 0 < header.currency.length ).currency;
+
 		return (
 			<Fragment>
 				<div className="
@@ -126,7 +128,7 @@ class AdSenseDashboardMainSummary extends Component {
 									<DataBlock
 										className="overview-adsense-rpm"
 										title={ __( 'RPM', 'google-site-kit' ) }
-										datapoint={ readableLargeNumber( period.totals[1] ) }
+										datapoint={ readableLargeNumber( period.totals[1], currency ) }
 										source={ {
 											name: __( 'AdSense', 'google-site-kit' ),
 											link: href,
@@ -149,7 +151,7 @@ class AdSenseDashboardMainSummary extends Component {
 									<DataBlock
 										className="overview-adsense-earnings"
 										title={ __( 'Total Earnings', 'google-site-kit' ) }
-										datapoint={ readableLargeNumber( period.totals[0] ) }
+										datapoint={ readableLargeNumber( period.totals[0], currency ) }
 										source={ {
 											name: __( 'AdSense', 'google-site-kit' ),
 											link: href,


### PR DESCRIPTION
## Summary
Modify AdSense earnings formatting in the summary dashboard widget  by adding the currency.

<!-- Please reference the issue this PR addresses. -->
Addresses issue https://github.com/google/site-kit-wp/issues/93

## Relevant technical choices

<!-- Please describe your changes. -->

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
