### PR TITLE
Fix 186 - replace slashes too when decoding

### DIFF
--- a/assets/js/util/index.js
+++ b/assets/js/util/index.js
@@ -907,6 +907,8 @@ export const showErrorNotification = ( ErrorComponent, props = {} ) => {
 export const decodeHtmlEntity = ( str ) => {
 	const decoded =  str.replace( /&#(\d+);/g, function( match, dec ) {
 		return String.fromCharCode( dec );
+	} ).replace( /(\\)/g, function( ) {
+		return '';
 	} );
 
 	return unescape( decoded );

--- a/assets/js/util/index.js
+++ b/assets/js/util/index.js
@@ -907,9 +907,7 @@ export const showErrorNotification = ( ErrorComponent, props = {} ) => {
 export const decodeHtmlEntity = ( str ) => {
 	const decoded =  str.replace( /&#(\d+);/g, function( match, dec ) {
 		return String.fromCharCode( dec );
-	} ).replace( /(\\)/g, function( ) {
-		return '';
-	} );
+	} ).replace( /(\\)/g, '' );
 
 	return unescape( decoded );
 };


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #186 

## Relevant technical choices

<!-- Please describe your changes. -->
Remove slashes from string used in page title

## Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
