### PR TITLE
Don't fail E2E tests if page evaluation is interrupted on load

### DIFF
--- a/tests/e2e/config/bootstrap.js
+++ b/tests/e2e/config/bootstrap.js
@@ -65,9 +65,11 @@ function capturePageEventsForTearDown() {
  */
 function optOutOfEventTracking() {
 	page.on( 'load', () => {
-		page.evaluate( () => {
-			window._gaUserPrefs = { ioo: () => true };
-		} );
+		try {
+			page.evaluate( () => {
+				window._gaUserPrefs = { ioo: () => true };
+			} );
+		} catch ( err ) {}
 	} );
 }
 

--- a/tests/e2e/config/bootstrap.js
+++ b/tests/e2e/config/bootstrap.js
@@ -64,9 +64,9 @@ function capturePageEventsForTearDown() {
  * @link https://tools.google.com/dlpage/gaoptout
  */
 function optOutOfEventTracking() {
-	page.on( 'load', () => {
+	page.on( 'load', async () => {
 		try {
-			page.evaluate( () => {
+			await page.evaluate( () => {
 				window._gaUserPrefs = { ioo: () => true };
 			} );
 		} catch ( err ) {}


### PR DESCRIPTION
## Summary

Addresses E2E instability introduced in #441 

Addresses issue #

## Relevant technical choices

<!-- Please describe your changes. -->

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
