### PR TITLE
chore: Remove performance monitoring

### DIFF
--- a/assets/js/components/data.js
+++ b/assets/js/components/data.js
@@ -117,9 +117,6 @@ const data = {
 					if ( cache ) {
 						responseData[ hashlessKey ] = cache;
 
-						// Trigger an action when cached data is used.
-						doAction( 'googlesitekit.cachedDataUsed', request.datapoint );
-
 						this.resolve( request, cache );
 					}
 				} );
@@ -188,9 +185,6 @@ const data = {
 			const cache = this.getCache( request.dataObject, key, request.maxAge, hashlessKey );
 			if ( cache ) {
 				setTimeout( () => {
-					// Trigger an action when cached data is used.
-					doAction( 'googlesitekit.cachedDataUsed', request.datapoint );
-
 					this.resolve( request, cache );
 				}, cacheDelay );
 				cacheDelay += 25;
@@ -286,8 +280,6 @@ const data = {
 
 					each( keyIndexesMap[ key ], ( index ) => {
 						const request = dataRequest[ index ];
-
-						doAction( 'googlesitekit.dataReceived', request.key );
 
 						this.setCache( request.dataObject, request.key, result );
 						this.resolve( request, result );

--- a/assets/js/googlesitekit-dashboard-details.js
+++ b/assets/js/googlesitekit-dashboard-details.js
@@ -20,7 +20,6 @@
 /**
  * External dependencies
  */
-import { addPerformanceMonitoring } from 'GoogleUtil';
 import Notification from 'GoogleComponents/notifications/notification';
 
 const { setLocaleData } = wp.i18n;
@@ -39,10 +38,6 @@ class GoogleSitekitDashboardDetails extends Component {
 
 		// Set up translations.
 		setLocaleData( googlesitekit.locale, 'google-site-kit' );
-
-		if ( window.googlesitekit.admin.debug ) {
-			addPerformanceMonitoring();
-		}
 	}
 
 	componentDidCatch( error, info ) {
@@ -51,10 +46,6 @@ class GoogleSitekitDashboardDetails extends Component {
 			error,
 			info,
 		} );
-	}
-
-	componentDidMount() {
-		doAction( 'googlesitekit.rootAppDidMount' );
 	}
 
 	render() {

--- a/assets/js/googlesitekit-dashboard-splash.js
+++ b/assets/js/googlesitekit-dashboard-splash.js
@@ -19,10 +19,7 @@
 /**
  * External dependencies
  */
-import {
-	addPerformanceMonitoring,
-	clearAppLocalStorage,
-} from 'GoogleUtil';
+import { clearAppLocalStorage } from 'GoogleUtil';
 import Notification from 'GoogleComponents/notifications/notification';
 
 const { setLocaleData } = wp.i18n;
@@ -44,10 +41,6 @@ class GoogleSitekitDashboardSplash extends Component {
 
 		// Set up translations.
 		setLocaleData( googlesitekit.locale, 'google-site-kit' );
-
-		if ( window.googlesitekit.admin.debug ) {
-			addPerformanceMonitoring();
-		}
 	}
 
 	componentDidCatch( error, info ) {
@@ -56,10 +49,6 @@ class GoogleSitekitDashboardSplash extends Component {
 			error,
 			info,
 		} );
-	}
-
-	componentDidMount() {
-		doAction( 'googlesitekit.rootAppDidMount' );
 	}
 
 	render() {

--- a/assets/js/googlesitekit-dashboard.js
+++ b/assets/js/googlesitekit-dashboard.js
@@ -19,10 +19,7 @@
 /**
  * External dependencies
  */
-import {
-	addPerformanceMonitoring,
-	clearAppLocalStorage,
-} from 'GoogleUtil';
+import { clearAppLocalStorage } from 'GoogleUtil';
 import Notification from 'GoogleComponents/notifications/notification';
 import Setup from 'GoogleComponents/setup/setup-wrapper';
 import DashboardApp from 'GoogleComponents/dashboard/dashboard-app';
@@ -41,10 +38,6 @@ class GoogleSitekitDashboard extends Component {
 
 		// Set up translations.
 		setLocaleData( googlesitekit.locale, 'google-site-kit' );
-
-		if ( window.googlesitekit.admin.debug ) {
-			addPerformanceMonitoring();
-		}
 	}
 
 	componentDidCatch( error, info ) {
@@ -53,10 +46,6 @@ class GoogleSitekitDashboard extends Component {
 			error,
 			info,
 		} );
-	}
-
-	componentDidMount() {
-		doAction( 'googlesitekit.rootAppDidMount' );
 	}
 
 	render() {

--- a/assets/js/googlesitekit-module.js
+++ b/assets/js/googlesitekit-module.js
@@ -20,7 +20,6 @@
  * External dependencies
  */
 import ProgressBar from 'GoogleComponents/progress-bar';
-import { addPerformanceMonitoring } from 'GoogleUtil';
 import Notification from 'GoogleComponents/notifications/notification';
 
 // Load the data module.
@@ -47,10 +46,6 @@ class GoogleSitekitModule extends Component {
 		// Set up translations.
 		setLocaleData( googlesitekit.locale, 'google-site-kit' );
 
-		if ( window.googlesitekit.admin.debug ) {
-			addPerformanceMonitoring();
-		}
-
 		const {
 			showModuleSetupWizard,
 		} = googlesitekit.setup;
@@ -66,10 +61,6 @@ class GoogleSitekitModule extends Component {
 			error,
 			info,
 		} );
-	}
-
-	componentDidMount() {
-		doAction( 'googlesitekit.rootAppDidMount' );
 	}
 
 	render() {

--- a/assets/js/googlesitekit-settings.js
+++ b/assets/js/googlesitekit-settings.js
@@ -21,7 +21,6 @@
  * External dependencies
  */
 import SettingsApp from 'GoogleComponents/settings/settings-app';
-import { addPerformanceMonitoring } from 'GoogleUtil';
 import Notification from 'GoogleComponents/notifications/notification';
 
 const { setLocaleData } = wp.i18n;
@@ -35,10 +34,6 @@ class GoogleSitekitSettings extends Component {
 
 		// Set up translations.
 		setLocaleData( googlesitekit.locale, 'google-site-kit' );
-
-		if ( window.googlesitekit.admin.debug ) {
-			addPerformanceMonitoring();
-		}
 	}
 
 	componentDidCatch( error, info ) {
@@ -47,10 +42,6 @@ class GoogleSitekitSettings extends Component {
 			error,
 			info,
 		} );
-	}
-
-	componentDidMount() {
-		doAction( 'googlesitekit.rootAppDidMount' );
 	}
 
 	render() {

--- a/assets/js/googlesitekit-wp-dashboard.js
+++ b/assets/js/googlesitekit-wp-dashboard.js
@@ -20,7 +20,6 @@
 /**
  * External dependencies
  */
-import { addPerformanceMonitoring } from 'GoogleUtil';
 import Notification from 'GoogleComponents/notifications/notification';
 
 const { setLocaleData } = wp.i18n;
@@ -45,10 +44,6 @@ class GoogleSitekitWPDashboard extends Component {
 
 		// Set up translations.
 		setLocaleData( googlesitekit.locale, 'google-site-kit' );
-
-		if ( window.googlesitekit.admin.debug ) {
-			addPerformanceMonitoring();
-		}
 	}
 
 	componentDidCatch( error, info ) {
@@ -57,10 +52,6 @@ class GoogleSitekitWPDashboard extends Component {
 			error,
 			info,
 		} );
-	}
-
-	componentDidMount() {
-		doAction( 'googlesitekit.rootAppDidMount' );
 	}
 
 	render() {

--- a/assets/js/util/index.js
+++ b/assets/js/util/index.js
@@ -22,7 +22,6 @@ import data from 'GoogleComponents/data';
 import SvgIcon from 'GoogleUtil/svg-icon';
 
 const {
-	addAction,
 	addFilter,
 	applyFilters,
 } = wp.hooks;
@@ -268,44 +267,6 @@ export const changeToPercent = ( previous, current ) => {
 
 	return change;
 };
-
-export function addPerformanceMonitoring() {
-	const googlesitekitPerformance = window.googlesitekitPerformance || {};
-	addAction( 'googlesitekit.moduleLoaded', 'googlesitekit.PerformanceMetrics.moduleLoaded', function( context ) {
-		googlesitekitPerformance.loadedActionTriggered = ( new Date() ).getTime();
-		const elapsed = ( googlesitekitPerformance.loadedActionTriggered - googlesitekitPerformance.domReady ) + 'ms';
-		googlesitekitPerformance._timeToLoadedActionTriggered = elapsed;
-		googlesitekitPerformance.loadedActionContext = context;
-		console.log( 'Performance Metrics: App loaded', elapsed ); // eslint-disable-line no-console
-	} );
-
-	addAction( 'googlesitekit.dataReceived', 'googlesitekit.PerformanceMetrics.dataReceived', function( datapoint ) {
-		const currentlyAt = ( new Date() ).getTime();
-		googlesitekitPerformance.dataReceived = googlesitekitPerformance.dataReceived || [];
-		googlesitekitPerformance._timeToDataReceived = googlesitekitPerformance._timeToDataReceived || [];
-		googlesitekitPerformance.dataReceived.push( currentlyAt );
-		const elapsed = ( currentlyAt - googlesitekitPerformance.domReady ) + 'ms';
-		googlesitekitPerformance._timeToDataReceived.push( elapsed );
-		console.log( 'Performance Metrics: Async Data loaded: ' + datapoint, elapsed ); // eslint-disable-line no-console
-	} );
-
-	addAction( 'googlesitekit.cachedDataUsed', 'googlesitekit.PerformanceMetrics.cachedDataUsed', function( datapoint ) {
-		const currentlyAt = ( new Date() ).getTime();
-		googlesitekitPerformance.cachedDataUsed = googlesitekitPerformance.cachedDataUsed || [];
-		googlesitekitPerformance._timeToCachedDataUsed = googlesitekitPerformance._timeToCachedDataUsed || [];
-		googlesitekitPerformance.cachedDataUsed.push( currentlyAt );
-		const elapsed = ( currentlyAt - googlesitekitPerformance.domReady ) + 'ms';
-		googlesitekitPerformance._timeToCachedDataUsed.push( elapsed );
-		console.log( 'Performance Metrics: Cached Data loaded: ' + datapoint, elapsed ); // eslint-disable-line no-console
-	} );
-
-	addAction( 'googlesitekit.rootAppDidMount', 'googlesitekit.PerformanceMetrics.rootAppDidMount', function() {
-		googlesitekitPerformance.rootAppMounted = ( new Date() ).getTime();
-		const elapsed = ( googlesitekitPerformance.rootAppMounted - googlesitekitPerformance.domReady ) + 'ms';
-		googlesitekitPerformance._timeToAppMounted = elapsed;
-		console.log( 'Performance Metrics: App mounted', elapsed ); // eslint-disable-line no-console
-	} );
-}
 
 /**
  * Fallback helper to get a query parameter from the current URL.

--- a/includes/Core/Assets/Assets.php
+++ b/includes/Core/Assets/Assets.php
@@ -459,7 +459,6 @@ final class Assets {
 				json_encode( $cache->get_current_cache_data() ) : // phpcs:ignore WordPress.WP.AlternativeFunctions.json_encode_json_encode
 				false,
 			'timestamp'        => time(),
-			'debug'            => ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ),
 			'currentScreen'    => is_admin() ? get_current_screen() : null,
 			'currentAdminPage' => ( is_admin() && isset( $_GET['page'] ) ) ? sanitize_key( $_GET['page'] ) : null, // phpcs:ignore WordPress.Security.NonceVerification.NoNonceVerification
 			'resetSession'     => isset( $_GET['googlesitekit_reset_session'] ), // phpcs:ignore WordPress.Security.NonceVerification.NoNonceVerification

--- a/includes/Core/Util/Tracking.php
+++ b/includes/Core/Util/Tracking.php
@@ -106,27 +106,6 @@ final class Tracking {
 				$this->register_settings();
 			}
 		);
-
-		// In debug mode, enable performance metric monitoring.
-		$script_debug = ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG );
-		if ( $script_debug ) {
-			// Start script as early as possible.
-			add_action(
-				'admin_head',
-				function() {
-					$this->add_performance_metrics_header_script();
-				},
-				0
-			);
-			// Collect results as late as possible.
-			add_action(
-				'admin_footer',
-				function() {
-					$this->add_performance_metrics_footer_script();
-				},
-				99
-			);
-		}
 	}
 
 	/**
@@ -221,34 +200,5 @@ final class Tracking {
 			'show_in_rest' => true,
 		);
 		register_setting( 'google-site-kit', self::TRACKING_OPTIN_KEY, $args );
-	}
-
-	/**
-	 * Add performance metrics monitoring in the header.
-	 */
-	private function add_performance_metrics_header_script() {
-		?>
-		<script type="text/javascript">
-			var googlesitekitPerformance = {
-				startTime: ( new Date() ).getTime()
-			};
-		</script>
-		<?php
-	}
-
-	/**
-	 * Add performance metrics monitoring in the footer.
-	 */
-	private function add_performance_metrics_footer_script() {
-		?>
-		<script type="text/javascript">
-			document.addEventListener( 'DOMContentLoaded', function() {
-				googlesitekitPerformance.domReady = ( new Date() ).getTime();
-				googlesitekitPerformance.timeToDomReady = ( googlesitekitPerformance.domReady - googlesitekitPerformance.startTime ) + 'ms';
-				console.log( 'Performance Metrics: DomReady', googlesitekitPerformance );
-			} );
-
-		</script>
-		<?php
 	}
 }


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #168. Removes all performance monitoring code from JS and removes PHP functions/values related to perf monitoring.

**DO NOT MERGE UNTIL THURSDAY.**

## Relevant technical choices

<!-- Please describe your changes. -->

## Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
