### PR TITLE
Update core/search route to not restrict characters

### DIFF
--- a/assets/js/components/post-searcher.js
+++ b/assets/js/components/post-searcher.js
@@ -81,7 +81,6 @@ if ( ! wp.sanitize ) {
 		},
 	};
 }
-const { stripTags } = wp.sanitize;
 
 class PostSearcher extends Component {
 	constructor( props ) {
@@ -108,7 +107,8 @@ class PostSearcher extends Component {
 		populateResults( [ __( 'Loading...', 'google-site-kit' ) ] );
 
 		try {
-			const results = await data.get( 'core', 'search', encodeURIComponent( stripTags( query ) ) );
+			const results = await data.get( 'core', 'search', '', { query: encodeURIComponent( query ) } );
+
 			if ( 0 < results.length ) {
 				populateResults( map( results, ( result ) => {
 					return result.post_title;

--- a/assets/js/components/post-searcher.js
+++ b/assets/js/components/post-searcher.js
@@ -107,7 +107,7 @@ class PostSearcher extends Component {
 		populateResults( [ __( 'Loading...', 'google-site-kit' ) ] );
 
 		try {
-			const results = await data.get( 'core', 'search', '', { query: encodeURIComponent( query ) } );
+			const results = await data.get( 'core', 'search', 'post-search', { query: encodeURIComponent( query ) } );
 
 			if ( 0 < results.length ) {
 				populateResults( map( results, ( result ) => {

--- a/includes/Core/REST_API/REST_Routes.php
+++ b/includes/Core/REST_API/REST_Routes.php
@@ -576,7 +576,7 @@ final class REST_Routes {
 			),
 			// TODO: Remove this and replace usage with calls to wp/v1/posts.
 			new REST_Route(
-				'core/search/data/(?P<query>.+)',
+				'core/search/data',
 				array(
 					array(
 						'methods'  => WP_REST_Server::READABLE,
@@ -622,6 +622,7 @@ final class REST_Routes {
 						'query' => array(
 							'type'        => 'string',
 							'description' => __( 'Text content to search for.', 'google-site-kit' ),
+							'required'    => true,
 						),
 					),
 				)

--- a/includes/Core/REST_API/REST_Routes.php
+++ b/includes/Core/REST_API/REST_Routes.php
@@ -576,7 +576,7 @@ final class REST_Routes {
 			),
 			// TODO: Remove this and replace usage with calls to wp/v1/posts.
 			new REST_Route(
-				'core/search/data/(?P<query>[0-9A-Za-z%.\-]+)',
+				'core/search/data/(?P<query>.+)',
 				array(
 					array(
 						'methods'  => WP_REST_Server::READABLE,

--- a/includes/Core/REST_API/REST_Routes.php
+++ b/includes/Core/REST_API/REST_Routes.php
@@ -576,7 +576,7 @@ final class REST_Routes {
 			),
 			// TODO: Remove this and replace usage with calls to wp/v1/posts.
 			new REST_Route(
-				'core/search/data',
+				'core/search/data/post-search',
 				array(
 					array(
 						'methods'  => WP_REST_Server::READABLE,

--- a/tests/phpunit/integration/Core/REST_API/REST_RoutesTest.php
+++ b/tests/phpunit/integration/Core/REST_API/REST_RoutesTest.php
@@ -51,7 +51,7 @@ class REST_RoutesTest extends TestCase {
 			'/' . REST_Routes::REST_ROOT . '/modules/(?P<slug>[a-z\\-]+)/data/(?P<datapoint>[a-z\\-]+)',
 			'/' . REST_Routes::REST_ROOT . '/data',
 			'/' . REST_Routes::REST_ROOT . '/modules/(?P<slug>[a-z\\-]+)/notifications',
-			'/' . REST_Routes::REST_ROOT . '/core/search/data/(?P<query>.+)',
+			'/' . REST_Routes::REST_ROOT . '/core/search/data',
 		);
 
 		$this->assertEqualSets( $routes, array_keys( $server->get_routes() ) );

--- a/tests/phpunit/integration/Core/REST_API/REST_RoutesTest.php
+++ b/tests/phpunit/integration/Core/REST_API/REST_RoutesTest.php
@@ -51,7 +51,7 @@ class REST_RoutesTest extends TestCase {
 			'/' . REST_Routes::REST_ROOT . '/modules/(?P<slug>[a-z\\-]+)/data/(?P<datapoint>[a-z\\-]+)',
 			'/' . REST_Routes::REST_ROOT . '/data',
 			'/' . REST_Routes::REST_ROOT . '/modules/(?P<slug>[a-z\\-]+)/notifications',
-			'/' . REST_Routes::REST_ROOT . '/core/search/data',
+			'/' . REST_Routes::REST_ROOT . '/core/search/data/post-search',
 		);
 
 		$this->assertEqualSets( $routes, array_keys( $server->get_routes() ) );

--- a/tests/phpunit/integration/Core/REST_API/REST_RoutesTest.php
+++ b/tests/phpunit/integration/Core/REST_API/REST_RoutesTest.php
@@ -51,7 +51,7 @@ class REST_RoutesTest extends TestCase {
 			'/' . REST_Routes::REST_ROOT . '/modules/(?P<slug>[a-z\\-]+)/data/(?P<datapoint>[a-z\\-]+)',
 			'/' . REST_Routes::REST_ROOT . '/data',
 			'/' . REST_Routes::REST_ROOT . '/modules/(?P<slug>[a-z\\-]+)/notifications',
-			'/' . REST_Routes::REST_ROOT . '/core/search/data/(?P<query>[0-9A-Za-z%.\\-]+)',
+			'/' . REST_Routes::REST_ROOT . '/core/search/data/(?P<query>.+)',
 		);
 
 		$this->assertEqualSets( $routes, array_keys( $server->get_routes() ) );


### PR DESCRIPTION
## Summary

Fixes the issue where searching with special characters in the dashboard "Search for individual page or post information". This was due to a restricted set of allowed characters as part of the route definition.

Addresses issue #431 

## Relevant technical choices

<!-- Please describe your changes. -->

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
