### PR TITLE
Fix notifications REST route to not consider lack of a notifications datapoint an error

### DIFF
--- a/includes/Core/REST_API/REST_Routes.php
+++ b/includes/Core/REST_API/REST_Routes.php
@@ -556,7 +556,11 @@ final class REST_Routes {
 							if ( $this->modules->is_module_active( $slug ) ) {
 								$notifications = $modules[ $slug ]->get_data( 'notifications' );
 								if ( is_wp_error( $notifications ) ) {
-									return $notifications;
+									// Don't consider it an error if the module does not have a 'notifications' datapoint.
+									if ( 'invalid_datapoint' !== $notifications->get_error_code() ) {
+										return $notifications;
+									}
+									$notifications = array();
 								}
 							}
 							return new WP_REST_Response( $notifications );


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #408 

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
