### PR TITLE
set errorCode state to true if no accounts are found

### DIFF
--- a/assets/js/modules/analytics/setup.js
+++ b/assets/js/modules/analytics/setup.js
@@ -261,8 +261,8 @@ class AnalyticsSetup extends Component {
 			if ( 0 === responseData.accounts.length ) {
 				newState = {
 					...newState,
-					errorCode: true,
-					errorReason: 'noAccounts',
+					errorCode: 'no_account',
+					errorReason: 'noAccount',
 				};
 
 				// clear the cache.
@@ -304,7 +304,7 @@ class AnalyticsSetup extends Component {
 
 				newState = {
 					...newState,
-					errorCode: true,
+					errorCode: 'insufficient_permissions',
 					errorReason: 'insufficientPermissions',
 				};
 			}

--- a/assets/js/modules/analytics/setup.js
+++ b/assets/js/modules/analytics/setup.js
@@ -259,6 +259,12 @@ class AnalyticsSetup extends Component {
 
 			const responseData = await data.get( 'modules', 'analytics', 'get-accounts', queryArgs, false );
 			if ( 0 === responseData.accounts.length ) {
+				newState = {
+					...newState,
+					errorCode: true,
+					errorReason: 'noAccounts',
+				};
+
 				// clear the cache.
 				data.deleteCache( 'analytics', 'get-accounts' );
 			} else if ( ! selectedAccount ) {
@@ -859,6 +865,10 @@ class AnalyticsSetup extends Component {
 		const {
 			onSettingsPage,
 		} = this.props;
+
+		if ( ! errorCode ) {
+			return null;
+		}
 
 		let showErrorFormat = true; // default error message.
 		let message = errorMsg;


### PR DESCRIPTION
## Summary
Incorrect message appearing while loading. 

<!-- Please reference the issue this PR addresses. -->
Addresses issue https://github.com/google/site-kit-wp/issues/83
Related to https://github.com/google/site-kit-wp/issues/83#issuecomment-525764429
Fix regression introduced by https://github.com/google/site-kit-wp/pull/471

## Relevant technical choices

<!-- Please describe your changes. -->

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.4.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
