### PR TITLE
feat: Add editorconfig for consistent JS styles

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,6 +8,10 @@ trim_trailing_whitespace = true
 indent_style = tab
 indent_size = 4
 
+[{*.js}]
+indent_style = tab
+indent_size = 2
+
 [{*.json,*.yml}]
 indent_style = space
 indent_size = 2


### PR DESCRIPTION
## Summary

Adds a `.js` set of `.editorconfig` rules so JavaScript files are styled appropriately for users with editors that respect the `.editorconfig`. I ran into files not being tabbed correctly in VSCode; this fixes that issue.