### PR TITLE
Analytics Setup: don't render form if no tag permission

### DIFF
--- a/assets/js/modules/analytics/setup.js
+++ b/assets/js/modules/analytics/setup.js
@@ -703,6 +703,7 @@ class AnalyticsSetup extends Component {
 			selectedProfile,
 			useSnippet,
 			existingTag,
+			errorCode,
 		} = this.state;
 
 		const {
@@ -720,6 +721,10 @@ class AnalyticsSetup extends Component {
 
 		if ( isLoading ) {
 			return <ProgressBar />;
+		}
+
+		if ( 'google_analytics_existing_tag_permission' === errorCode ) {
+			return null;
 		}
 
 		if ( 0 >= accounts.length ) {

--- a/tests/e2e/specs/modules/analytics/setup-with-account-with-tag.test.js
+++ b/tests/e2e/specs/modules/analytics/setup-with-account-with-tag.test.js
@@ -117,7 +117,7 @@ describe( 'setting up the Analytics module with an existing account and existing
 		await proceedToSetUpAnalytics();
 
 		await expect( page ).toMatchElement( '.googlesitekit-setup-module--analytics p', { text: /google_analytics_existing_tag_permission/i } );
-		await expect( page ).toMatchElement( '.googlesitekit-setup-module--analytics button', { text: /create an account/i } );
-		await expect( page ).toMatchElement( '.googlesitekit-setup-module--analytics button', { text: /re-fetch my account/i } );
+		await expect( page ).not.toMatchElement( '.googlesitekit-setup-module--analytics button', { text: /create an account/i } );
+		await expect( page ).not.toMatchElement( '.googlesitekit-setup-module--analytics button', { text: /re-fetch my account/i } );
 	} );
 } );


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #417 


## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
