### PR TITLE
Add support for setting analytics on amp stories

### DIFF
--- a/includes/Modules/Analytics.php
+++ b/includes/Modules/Analytics.php
@@ -127,7 +127,7 @@ final class Analytics extends Module implements Module_With_Screen, Module_With_
 			}
 			$this->print_amp_gtag();
 		};
-		add_action( 'amp_print_analytics', $print_amp_gtag );
+		add_action( 'amp_print_analytics', $print_amp_gtag ); // For AMP plugin v1.3+.
 		add_action( 'wp_footer', $print_amp_gtag, 20 ); // For AMP Native and Transitional.
 		add_action( 'amp_post_template_footer', $print_amp_gtag, 20 ); // For AMP Reader.
 

--- a/includes/Modules/Analytics.php
+++ b/includes/Modules/Analytics.php
@@ -122,10 +122,14 @@ final class Analytics extends Module implements Module_With_Screen, Module_With_
 		);
 
 		$print_amp_gtag = function() {
+			if ( ! doing_action( 'amp_print_analytics' ) && did_action( 'amp_print_analytics' ) ) {
+				return;
+			}
 			$this->print_amp_gtag();
 		};
-		add_action( 'wp_footer', $print_amp_gtag ); // For AMP Native and Transitional.
-		add_action( 'amp_post_template_footer', $print_amp_gtag ); // For AMP Reader.
+		add_action( 'amp_print_analytics', $print_amp_gtag );
+		add_action( 'wp_footer', $print_amp_gtag, 20 ); // For AMP Native and Transitional.
+		add_action( 'amp_post_template_footer', $print_amp_gtag, 20 ); // For AMP Reader.
 
 		$print_amp_client_id_optin = function() {
 			$this->print_amp_client_id_optin();

--- a/includes/Modules/TagManager.php
+++ b/includes/Modules/TagManager.php
@@ -77,10 +77,14 @@ final class TagManager extends Module implements Module_With_Scopes {
 		);
 
 		$print_amp_gtm = function() {
+			if ( ! doing_action( 'amp_print_analytics' ) && did_action( 'amp_print_analytics' ) ) {
+				return;
+			}
 			$this->print_amp_gtm();
 		};
-		add_action( 'wp_footer', $print_amp_gtm ); // For AMP Native and Transitional.
-		add_action( 'amp_post_template_footer', $print_amp_gtm ); // For AMP Reader.
+		add_action( 'amp_print_analytics', $print_amp_gtm );
+		add_action( 'wp_footer', $print_amp_gtm, 20 ); // For AMP Native and Transitional.
+		add_action( 'amp_post_template_footer', $print_amp_gtm, 20 ); // For AMP Reader.
 
 		add_filter( // Load amp-analytics component for AMP Reader.
 			'amp_post_template_data',

--- a/includes/Modules/TagManager.php
+++ b/includes/Modules/TagManager.php
@@ -82,7 +82,7 @@ final class TagManager extends Module implements Module_With_Scopes {
 			}
 			$this->print_amp_gtm();
 		};
-		add_action( 'amp_print_analytics', $print_amp_gtm );
+		add_action( 'amp_print_analytics', $print_amp_gtm ); // For AMP plugin v1.3+.
 		add_action( 'wp_footer', $print_amp_gtm, 20 ); // For AMP Native and Transitional.
 		add_action( 'amp_post_template_footer', $print_amp_gtm, 20 ); // For AMP Reader.
 


### PR DESCRIPTION
## Summary

Adds support for adding analytics for AMP Stories created by the AMP plugin using new action added in ampproject/amp-wp#3106

Addresses issue #435

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
