### PR TITLE
Temporarily revert back to fully rely on dateRange filter.

### DIFF
--- a/assets/js/components/data.js
+++ b/assets/js/components/data.js
@@ -102,7 +102,7 @@ const dataAPI = {
 				const dateRangeSlug = stringToSlug( applyFilters( 'googlesitekit.dateRange', __( 'Last 28 days', 'google-site-kit' ) ) );
 				each( combinedRequest, ( request ) => {
 					request.data = request.data || {};
-					request.data.dateRange = request.data.dateRange || dateRangeSlug;
+					request.data.dateRange = dateRangeSlug;
 
 					request.key = this.getCacheKey( request.type, request.identifier, request.datapoint, request.data );
 
@@ -140,7 +140,7 @@ const dataAPI = {
 		let cacheDelay = 25;
 		each( combinedRequest, ( request ) => {
 			request.data = request.data || {};
-			request.data.dateRange = request.data.dateRange || dateRangeSlug;
+			request.data.dateRange = dateRangeSlug;
 
 			request.key = this.getCacheKey( request.type, request.identifier, request.datapoint, request.data );
 


### PR DESCRIPTION
## Summary

Addresses issue #406 

## Relevant technical choices

* I was a bit too eager to support passed params here. It updates the original object, causing it to never use the new `dateRange` from the filter.
* #447 will fix this anyway, so I just revert back.

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
