### PR TITLE
fix comma -> period

### DIFF
--- a/assets/js/components/data.js
+++ b/assets/js/components/data.js
@@ -277,7 +277,7 @@ const dataAPI = {
 	/**
 	 * Sets data in the cache.
 	 *
-	 * @param {string} key  The cache key,
+	 * @param {string} key  The cache key.
 	 * @param {mixed}  data The data to cache.
 	 */
 	setCache( key, data ) {
@@ -304,7 +304,7 @@ const dataAPI = {
 	/**
 	 * Gets data from the cache.
 	 *
-	 * @param {string} key    The cache key,
+	 * @param {string} key    The cache key.
 	 * @param {number} maxAge The cache TTL in seconds. If not provided, no TTL will be checked.
 	 *
 	 * @return {mixed} Cached data, or undefined if lookup failed.
@@ -340,7 +340,7 @@ const dataAPI = {
 	/**
 	 * Removes data from the cache.
 	 *
-	 * @param {string} key The cache key,
+	 * @param {string} key The cache key.
 	 */
 	deleteCache( key ) {
 		lazilySetupLocalCache();


### PR DESCRIPTION
## Summary

Addresses issue #406  

## Relevant technical choices

Sentences should end in periods not commas.

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.4.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
