### PR TITLE
AdSense setup/status - improve check for existing tag

### DIFF
--- a/assets/js/modules/adsense/dashboard/adsense-module-status.js
+++ b/assets/js/modules/adsense/dashboard/adsense-module-status.js
@@ -55,7 +55,7 @@ class AdSenseModuleStatus extends Component {
 
 	async componentDidMount() {
 		let existingTag = await getExistingTag( 'adsense' );
-		existingTag = existingTag.length ? existingTag : false;
+		existingTag = existingTag ? existingTag : false;
 
 		this.setState( { existingTag } );
 


### PR DESCRIPTION
## Summary

* Check for `existingTag` object instead of its length, fixing a console error if it didn't exist.

Addresses issue #

#486

## Relevant technical choices

As @aaemnnosttv  [pointed out](https://github.com/google/site-kit-wp/issues/406#issuecomment-529460242) we only need to check the object, an empty string will be falsey.

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.4.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
