### PR TITLE
E2E: Module Setup Flow | Analytics: No existing account, has existing tag

### DIFF
--- a/tests/e2e/plugins/module-setup-analytics-no-account.php
+++ b/tests/e2e/plugins/module-setup-analytics-no-account.php
@@ -15,7 +15,6 @@
 namespace Google\Site_Kit\Tests\E2E\Modules\AnalyticsNoAccount;
 
 use Google\Site_Kit\Core\REST_API\REST_Routes;
-use WP_Error;
 
 add_action( 'rest_api_init', function () {
 
@@ -24,16 +23,10 @@ add_action( 'rest_api_init', function () {
 		'modules/analytics/data/get-accounts',
 		array(
 			'callback' => function () {
-				/**
-				 * Returned by \Google\Site_Kit\Core\Modules\Module::exception_to_error
-				 */
-				return new WP_Error(
-					403,
-					'User does not have any Google Analytics account.',
-					array(
-						'status' => 500,
-						'reason' => 'insufficientPermissions',
-					)
+				return array(
+					'accounts'   => array(),
+					'properties' => array(),
+					'profiles'   => array(),
 				);
 			}
 		),

--- a/tests/e2e/plugins/module-setup-analytics-no-account.php
+++ b/tests/e2e/plugins/module-setup-analytics-no-account.php
@@ -15,6 +15,7 @@
 namespace Google\Site_Kit\Tests\E2E\Modules\AnalyticsNoAccount;
 
 use Google\Site_Kit\Core\REST_API\REST_Routes;
+use WP_Error;
 
 add_action( 'rest_api_init', function () {
 
@@ -23,10 +24,16 @@ add_action( 'rest_api_init', function () {
 		'modules/analytics/data/get-accounts',
 		array(
 			'callback' => function () {
-				return array(
-					'accounts'   => array(),
-					'properties' => array(),
-					'profiles'   => array(),
+				/**
+				 * Returned by \Google\Site_Kit\Core\Modules\Module::exception_to_error
+				 */
+				return new WP_Error(
+					403,
+					'User does not have any Google Analytics account.',
+					array(
+						'status' => 500,
+						'reason' => 'insufficientPermissions',
+					)
 				);
 			}
 		),

--- a/tests/e2e/specs/modules/analytics/setup-no-account-with-tag.test.js
+++ b/tests/e2e/specs/modules/analytics/setup-no-account-with-tag.test.js
@@ -1,0 +1,84 @@
+/**
+ * WordPress dependencies
+ */
+import { activatePlugin, visitAdminPage } from '@wordpress/e2e-test-utils';
+
+/**
+ * Internal dependencies
+ */
+import {
+	deactivateAllOtherPlugins,
+	resetSiteKit,
+	setAnalyticsExistingPropertyId,
+	setAuthToken,
+	setClientConfig,
+	setSearchConsoleProperty,
+	setSiteVerification,
+	useRequestInterception,
+} from '../../../utils';
+
+async function proceedToSetUpAnalytics() {
+	await Promise.all( [
+		expect( page ).toClick( '.googlesitekit-cta-link', { text: /set up analytics/i } ),
+		page.waitForSelector( '.googlesitekit-setup-module--analytics' ),
+		page.waitForResponse( ( res ) => res.url().match( 'analytics/data' ) ),
+	] );
+}
+
+const EXISTING_PROPERTY_ID = 'UA-00000001-1';
+
+describe( 'setting up the Analytics module with no existing account and with an existing tag', () => {
+	beforeAll( async () => {
+		await page.setRequestInterception( true );
+		useRequestInterception( ( request ) => {
+			if ( request.url().match( 'modules/analytics/data/tag-permission' ) ) {
+				request.respond( {
+					status: 403,
+					body: JSON.stringify( {
+						code: 'google_analytics_existing_tag_permission',
+						message: 'google_analytics_existing_tag_permission',
+					} ),
+				} );
+			} else if ( request.url().match( '/wp-json/google-site-kit/v1/data/' ) ) {
+				request.respond( {
+					status: 200,
+				} );
+			} else {
+				request.continue();
+			}
+		} );
+	} );
+
+	beforeEach( async () => {
+		await activatePlugin( 'e2e-tests-auth-plugin' );
+		await activatePlugin( 'e2e-tests-analytics-existing-tag' );
+		await activatePlugin( 'e2e-tests-module-setup-analytics-api-mock-no-account' );
+
+		await setClientConfig();
+		await setAuthToken();
+		await setSiteVerification();
+		await setSearchConsoleProperty();
+
+		await visitAdminPage( 'admin.php', 'page=googlesitekit-settings' );
+		await page.waitForSelector( '.mdc-tab-bar' );
+		await expect( page ).toClick( '.mdc-tab', { text: /connect more services/i } );
+		await page.waitForSelector( '.googlesitekit-settings-connect-module--analytics' );
+	} );
+
+	afterEach( async () => {
+		await deactivateAllOtherPlugins();
+		await resetSiteKit();
+	} );
+
+	it( 'does not allow Analytics to be set up with an existing tag that does not match a property of the user', async () => {
+		await setAnalyticsExistingPropertyId( EXISTING_PROPERTY_ID );
+
+		await proceedToSetUpAnalytics();
+
+		// The specific message comes from the datapoint which we've mocked to return the error code instead.
+		await expect( page ).toMatchElement( '.googlesitekit-setup-module--analytics p', { text: /google_analytics_existing_tag_permission/i } );
+		// Buttons to proceed are not displayed; the user is blocked from completing setup.
+		await expect( page ).not.toMatchElement( '.googlesitekit-setup-module--analytics button', { text: /create an account/i } );
+		await expect( page ).not.toMatchElement( '.googlesitekit-setup-module--analytics button', { text: /re-fetch my account/i } );
+	} );
+} );


### PR DESCRIPTION
## Summary

Addresses issue #358 

This test likely will not require datapoint naming changes once #500 is merged, since the only datapoint to change is in the mock API plugin which is already part of that changeset.

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
