### PR TITLE
Fix duplicate datapoint array key and missing service in Site Verification module

### DIFF
--- a/includes/Modules/Site_Verification.php
+++ b/includes/Modules/Site_Verification.php
@@ -72,13 +72,11 @@ final class Site_Verification extends Module implements Module_With_Scopes {
 	 */
 	protected function get_datapoint_services() {
 		return array(
-			// GET.
+			// GET / POST.
 			'verification'       => 'siteverification',
+			// GET.
 			'verification-token' => 'siteverification',
 			'verified-sites'     => 'siteverification',
-
-			// POST.
-			'verification'       => '',
 		);
 	}
 


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #448 

@schlessera noticed there was a duplicate `verification` array key in the list of datapoints. That was an oversight related to the above issue, where the two datapoints were unified for `GET / POST`. Furthermore, the `POST` version was missing the declaration of the service it uses. The string should only be empty for datapoints that don't rely on an Google API service instance.

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
