### PR TITLE
Add tag fetching query args to getExistingTag

### DIFF
--- a/assets/js/util/index.js
+++ b/assets/js/util/index.js
@@ -597,18 +597,24 @@ export const findTagInHtmlContent = ( html, module ) => {
 export const getExistingTag = async ( module ) => {
 	const CACHE_KEY = `${ module }::existingTag`;
 	const { homeURL, ampMode } = googlesitekit.admin;
+	const tagFetchQueryArgs = {
+		// Indicates a tag checking request. This lets Site Kit know not to output its own tags.
+		tagverify: 1,
+		// Add a timestamp for cache-busting.
+		timestamp: Date.now(),
+	};
 
 	let tagFound = data.getCache( CACHE_KEY, 300 );
 
 	if ( tagFound === undefined ) {
 		try {
-			tagFound = await scrapeTag( addQueryArgs( homeURL, { tagverify: 1, timestamp: Date.now() } ), module );
+			tagFound = await scrapeTag( addQueryArgs( homeURL, tagFetchQueryArgs ), module );
 
 			if ( ! tagFound && 'secondary' === ampMode ) {
 				tagFound = await apiFetch( { path: '/wp/v2/posts?per_page=1' } ).then(
 					// Scrape the first post in AMP mode, if there is one.
 					( posts ) => posts.slice( 0, 1 ).map( async ( post ) => {
-						return await scrapeTag( addQueryArgs( post.link, { amp: 1 } ), module );
+						return await scrapeTag( addQueryArgs( post.link, { ...tagFetchQueryArgs, amp: 1 } ), module );
 					} ).pop()
 				);
 			}


### PR DESCRIPTION
## Summary

This PR adds the same tag fetching query arguments to the new tag checking fetch requests for the secondary amp check that are used in the default tag check request.

<!-- Please reference the issue this PR addresses. -->
Addresses issue #432 

## Relevant technical choices

<!-- Please describe your changes. -->

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
