### PR TITLE
Fix error in Pagespeed Insights component

### DIFF
--- a/includes/Modules/PageSpeed_Insights.php
+++ b/includes/Modules/PageSpeed_Insights.php
@@ -153,8 +153,7 @@ final class PageSpeed_Insights extends Module {
 	protected function parse_data_response( $method, $datapoint, $response ) {
 		if ( 'GET' === $method ) {
 			switch ( $datapoint ) {
-				case 'site-pagespeed-mobile':
-				case 'site-pagespeed-desktop':
+				case 'pagespeed':
 					// TODO: Parse this response to a regular array.
 					return $response->getLighthouseResult();
 			}


### PR DESCRIPTION
## Summary

Fixes error in Pagespeed Insights widgets by fixing missed datapoint response parsing in #488.

<!-- Please reference the issue this PR addresses. -->
Addresses issue #500

This change fixes the error and restores the component to its former glory.
![image](https://user-images.githubusercontent.com/1621608/64798892-77967e80-d58c-11e9-8916-8fde0b021565.png)


## Relevant technical choices

<!-- Please describe your changes. -->

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
