### PR TITLE
Fix date range string UI regression

### DIFF
--- a/assets/js/components/data.js
+++ b/assets/js/components/data.js
@@ -24,7 +24,7 @@ import md5 from 'md5';
 
 import {
 	getStorage,
-	getCurrentDateRange,
+	getCurrentDateRangeSlug,
 	fillFilterWithComponent,
 	getQueryParameter,
 	sortObjectProperties,
@@ -109,7 +109,7 @@ const dataAPI = {
 		return new Promise( ( resolve, reject ) => {
 			try {
 				const responseData = [];
-				const dateRange = getCurrentDateRange();
+				const dateRange = getCurrentDateRangeSlug();
 				each( combinedRequest, ( originalRequest ) => {
 					const request = requestWithDateRange( originalRequest, dateRange );
 					request.key = this.getCacheKey( request.type, request.identifier, request.datapoint, request.data );
@@ -139,7 +139,7 @@ const dataAPI = {
 		// First, resolve any cache matches immediately, queue resolution of the rest.
 		let dataRequest = [];
 		let cacheDelay = 25;
-		const dateRange = getCurrentDateRange();
+		const dateRange = getCurrentDateRangeSlug();
 		each( combinedRequest, ( originalRequest ) => {
 			const request = requestWithDateRange( originalRequest, dateRange );
 			request.key = this.getCacheKey( request.type, request.identifier, request.datapoint, request.data );

--- a/assets/js/util/index.js
+++ b/assets/js/util/index.js
@@ -836,9 +836,9 @@ export function stringToSlug( string ) {
 }
 
 /**
- * Gets the current dateRange slug.
+ * Gets the current dateRange string.
  *
- * @return {string} the date range slug.
+ * @return {string} the date range string.
  */
 export function getCurrentDateRange() {
 	/**
@@ -846,7 +846,7 @@ export function getCurrentDateRange() {
 	 *
 	 * @param String The selected date range. Default 'Last 28 days'.
 	 */
-	return stringToSlug( applyFilters( 'googlesitekit.dateRange', __( 'Last 28 days', 'google-site-kit' ) ) );
+	return applyFilters( 'googlesitekit.dateRange', __( 'Last 28 days', 'google-site-kit' ) );
 }
 
 /**

--- a/assets/js/util/index.js
+++ b/assets/js/util/index.js
@@ -858,6 +858,15 @@ export function getDateRangeFrom() {
 }
 
 /**
+ * Gets the current dateRange slug.
+ *
+ * @return {string} the date range slug.
+ */
+export function getCurrentDateRangeSlug() {
+	return stringToSlug( getCurrentDateRange() );
+}
+
+/**
  * Get the icon for a module.
  *
  * @param {string}  module                The module slug.


### PR DESCRIPTION
## Summary

Resolves a regression in the UI where the current date range slug was returned instead of the full human-readable string.

#### Before
![image](https://user-images.githubusercontent.com/1621608/64856194-1de49180-d62a-11e9-9e19-67e1ecf7abb2.png)

#### After
![image](https://user-images.githubusercontent.com/1621608/64856240-33f25200-d62a-11e9-96a4-97425e4e7f6c.png)


<!-- Please reference the issue this PR addresses. -->
Addresses issue #479 

## Relevant technical choices

This is not ideal or proper use of translation functions, it's merely restoring the previous behavior, and introducing a new utility for getting the slug.

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
