### PR TITLE
chore: Add admin disconnect E2E test

### DIFF
--- a/tests/e2e/specs/auth-flow.test.js
+++ b/tests/e2e/specs/auth-flow.test.js
@@ -13,6 +13,9 @@ import {
 	setSearchConsoleProperty,
 	testClientConfig,
 	useRequestInterception,
+	setClientConfig,
+	setAuthToken,
+	setSiteVerification,
 } from '../utils';
 
 function stubGoogleSignIn( request ) {
@@ -80,6 +83,10 @@ describe( 'Site Kit set up flow for the first time', () => {
 	} );
 
 	it( 'disconnects user from SiteKit', async () => {
+		await setClientConfig();
+		await setAuthToken();
+		await setSiteVerification();
+		await setSearchConsoleProperty();
 		await visitAdminPage( 'admin.php', 'page=googlesitekit-dashboard' );
 
 		await signOut();

--- a/tests/e2e/specs/auth-flow.test.js
+++ b/tests/e2e/specs/auth-flow.test.js
@@ -82,7 +82,7 @@ describe( 'Site Kit set up flow for the first time', () => {
 		await expect( page ).toMatchElement( '.googlesitekit-publisher-win__title', { text: /Congrats on completing the setup for Site Kit!/i } );
 	} );
 
-	it( 'disconnects user from SiteKit', async () => {
+	it( 'disconnects user from Site Kit', async () => {
 		await setClientConfig();
 		await setAuthToken();
 		await setSiteVerification();
@@ -91,8 +91,10 @@ describe( 'Site Kit set up flow for the first time', () => {
 
 		await signOut();
 
-		await expect( page ).toMatchElement( '*',
-			{ text: 'Successfully disconnected from Site Kit by Google.' } );
+		await expect( page ).toMatchElement(
+			'.notice-success',
+			{ text: /Successfully disconnected from Site Kit by Google./i }
+		);
 	} );
 } );
 

--- a/tests/e2e/specs/auth-flow.test.js
+++ b/tests/e2e/specs/auth-flow.test.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { activatePlugin, createURL, deactivatePlugin, visitAdminPage } from '@wordpress/e2e-test-utils';
+import { activatePlugin, createURL, visitAdminPage } from '@wordpress/e2e-test-utils';
 
 /**
  * Internal dependencies

--- a/tests/e2e/specs/auth-flow.test.js
+++ b/tests/e2e/specs/auth-flow.test.js
@@ -7,7 +7,8 @@ import { activatePlugin, createURL, visitAdminPage } from '@wordpress/e2e-test-u
  * Internal dependencies
  */
 import {
-	// resetSiteKit,
+	deactivateAllOtherPlugins,
+	resetSiteKit,
 	pasteText,
 	setSearchConsoleProperty,
 	testClientConfig,
@@ -53,6 +54,11 @@ describe( 'Site Kit set up flow for the first time', () => {
 	beforeAll( async () => {
 		await activatePlugin( 'e2e-tests-oauth-callback-plugin' );
 		await setSearchConsoleProperty();
+	} );
+
+	afterEach( async () => {
+		await deactivateAllOtherPlugins();
+		await resetSiteKit();
 	} );
 
 	it( 'authenticates from splash page', async () => {

--- a/tests/e2e/specs/auth-flow.test.js
+++ b/tests/e2e/specs/auth-flow.test.js
@@ -1,12 +1,13 @@
 /**
  * WordPress dependencies
  */
-import { activatePlugin, createURL, visitAdminPage } from '@wordpress/e2e-test-utils';
+import { activatePlugin, createURL, deactivatePlugin, visitAdminPage } from '@wordpress/e2e-test-utils';
 
 /**
  * Internal dependencies
  */
 import {
+	// resetSiteKit,
 	pasteText,
 	setSearchConsoleProperty,
 	testClientConfig,
@@ -36,6 +37,18 @@ function stubGoogleSignIn( request ) {
 	}
 }
 
+const signOut = async () => {
+	await page.waitForSelector( 'button[aria-controls="user-menu"]' );
+	await page.click( 'button[aria-controls="user-menu"]' );
+
+	await page.waitForSelector( '#user-menu .mdc-list-item' );
+	await page.click( '#user-menu .mdc-list-item' );
+
+	await page.waitForSelector( '.mdc-dialog__container button.mdc-button--danger' );
+	await page.click( '.mdc-dialog__container button.mdc-button--danger' );
+	await page.waitForNavigation();
+};
+
 describe( 'Site Kit set up flow for the first time', () => {
 	beforeAll( async () => {
 		await activatePlugin( 'e2e-tests-oauth-callback-plugin' );
@@ -58,6 +71,15 @@ describe( 'Site Kit set up flow for the first time', () => {
 
 		await expect( page ).toMatchElement( '#js-googlesitekit-dashboard' );
 		await expect( page ).toMatchElement( '.googlesitekit-publisher-win__title', { text: /Congrats on completing the setup for Site Kit!/i } );
+	} );
+
+	it( 'disconnects user from SiteKit', async () => {
+		await visitAdminPage( 'admin.php', 'page=googlesitekit-dashboard' );
+
+		await signOut();
+
+		await expect( page ).toMatchElement( '*',
+			{ text: 'Successfully disconnected from Site Kit by Google.' } );
 	} );
 } );
 


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #252. Adds an E2E test that disconnects an authenticated user from Site Kit.

## Relevant technical choices

I'm a bit concerned about the isolation/order of tests here, but in general it seems like most E2E tests are not 100% isolated. 😓 But this test adds a check to ensure a user can sign out of Site Kit.

Possibly because of other plugins involved, the test doesn't verify that after sign out the dashboard doesn't show data—right now the user is still signed in after clicking "disconnect", but this might be related to other plugins enabled in the E2E tests. @aaemnnosttv—any ideas on this one?

## Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
