### PR TITLE
Fix missing view during analytics connection

### DIFF
--- a/includes/Modules/Analytics.php
+++ b/includes/Modules/Analytics.php
@@ -959,6 +959,7 @@ final class Analytics extends Module implements Module_With_Screen, Module_With_
 
 					if ( $existing_tag['accountId'] ) {
 						// If there is an existing tag, pass it through to ensure only the existing tag is matched.
+						// The datapoint will inherit the existing tag state from this request.
 						$properties_profiles = $this->get_data( 'properties-profiles', $existing_tag );
 					} else {
 						// Get the account ID from the saved settings - returns WP_Error if not set.

--- a/includes/Modules/Analytics.php
+++ b/includes/Modules/Analytics.php
@@ -561,8 +561,7 @@ final class Analytics extends Module implements Module_With_Screen, Module_With_
 							'propertyId' => $data['existingPropertyId'],
 						);
 					}
-					$service = $this->get_service( 'analytics' );
-					return $service->management_accounts->listManagementAccounts();
+					return $this->get_service( 'analytics' )->management_accounts->listManagementAccounts();
 				case 'properties-profiles':
 					if ( ! isset( $data['accountId'] ) ) {
 						/* translators: %s: Missing parameter name */
@@ -574,8 +573,8 @@ final class Analytics extends Module implements Module_With_Screen, Module_With_
 							'propertyId' => $data['existingPropertyId'],
 						);
 					}
-					$service = $this->get_service( 'analytics' );
-					return $service->management_webproperties->listManagementWebproperties( $data['accountId'] );
+
+					return $this->get_service( 'analytics' )->management_webproperties->listManagementWebproperties( $data['accountId'] );
 				case 'profiles':
 					if ( ! isset( $data['accountId'] ) ) {
 						/* translators: %s: Missing parameter name */
@@ -585,8 +584,8 @@ final class Analytics extends Module implements Module_With_Screen, Module_With_
 						/* translators: %s: Missing parameter name */
 						return new WP_Error( 'missing_required_param', sprintf( __( 'Request parameter is empty: %s.', 'google-site-kit' ), 'propertyId' ), array( 'status' => 400 ) );
 					}
-					$service = $this->get_service( 'analytics' );
-					return $service->management_profiles->listManagementProfiles( $data['accountId'], $data['propertyId'] );
+
+					return $this->get_service( 'analytics' )->management_profiles->listManagementProfiles( $data['accountId'], $data['propertyId'] );
 				case 'tag-permission':
 					return function() use ( $data ) {
 						if ( ! isset( $data['tag'] ) ) {

--- a/includes/Modules/Analytics.php
+++ b/includes/Modules/Analytics.php
@@ -37,9 +37,9 @@ final class Analytics extends Module implements Module_With_Screen, Module_With_
 	 * Temporary storage for existing analytics tag found.
 	 *
 	 * @since 1.0.0
-	 * @var string|null
+	 * @var array
 	 */
-	private $_existing_tag_account = false;
+	private $_existing_tag_account;
 
 	/**
 	 * Temporary storage for adsense request.

--- a/includes/Modules/Analytics.php
+++ b/includes/Modules/Analytics.php
@@ -559,6 +559,12 @@ final class Analytics extends Module implements Module_With_Screen, Module_With_
 						/* translators: %s: Missing parameter name */
 						return new WP_Error( 'missing_required_param', sprintf( __( 'Request parameter is empty: %s.', 'google-site-kit' ), 'accountId' ), array( 'status' => 400 ) );
 					}
+					if ( ! empty( $data['existingAccountId'] ) && ! empty( $data['existingPropertyId'] ) ) {
+						$this->_existing_tag_account = array(
+							'accountId'  => $data['existingAccountId'],
+							'propertyId' => $data['existingPropertyId'],
+						);
+					}
 					$service = $this->get_service( 'analytics' );
 					return $service->management_webproperties->listManagementWebproperties( $data['accountId'] );
 				case 'profiles':

--- a/includes/Modules/Analytics.php
+++ b/includes/Modules/Analytics.php
@@ -1011,13 +1011,15 @@ final class Analytics extends Module implements Module_With_Screen, Module_With_
 
 					return $result;
 				case 'properties-profiles':
-					$response = array(
+					/* @var \Google_Service_Analytics_Webproperties $response listManagementWebproperties response. */
+					$properties = $response->getItems();
+					$response   = array(
 						// TODO: Parse this response to a regular array.
-						'properties' => $response->getItems(),
+						'properties' => $properties,
 						'profiles'   => array(),
 					);
 
-					if ( 0 === count( $response['properties'] ) ) {
+					if ( 0 === count( $properties ) ) {
 						return new WP_Error(
 							'google_analytics_properties_empty',
 							__( 'No Google Analytics properties found. Please go to Google Analytics to set one up.', 'google-site-kit' ),
@@ -1030,7 +1032,7 @@ final class Analytics extends Module implements Module_With_Screen, Module_With_
 					// Initialize an empty property as a null object if no match is found.
 					$found_property = new \Google_Service_Analytics_Webproperty();
 
-					foreach ( $response['properties'] as $property ) {
+					foreach ( $properties as $property ) {
 						/* @var \Google_Service_Analytics_Webproperty $property Property instance. */
 						if (
 							// Attempt to match by property ID.

--- a/includes/Modules/Analytics.php
+++ b/includes/Modules/Analytics.php
@@ -1017,7 +1017,11 @@ final class Analytics extends Module implements Module_With_Screen, Module_With_
 						'profiles'   => array(),
 					);
 					if ( 0 === count( $response['properties'] ) ) {
-						return new WP_Error( 'google_analytics_properties_empty', __( 'No Google Analytics properties found. Please go to Google Anlytics to set one up.', 'google-site-kit' ), array( 'status' => 500 ) );
+						return new WP_Error(
+							'google_analytics_properties_empty',
+							__( 'No Google Analytics properties found. Please go to Google Analytics to set one up.', 'google-site-kit' ),
+							array( 'status' => 500 )
+						);
 					}
 					$found_account_id  = false;
 					$found_property_id = false;

--- a/includes/Modules/Analytics.php
+++ b/includes/Modules/Analytics.php
@@ -555,34 +555,34 @@ final class Analytics extends Module implements Module_With_Screen, Module_With_
 					$service = $this->get_service( 'analytics' );
 					return $service->management_goals->listManagementGoals( $connection['accountId'], $connection['propertyId'], $connection['profileId'] );
 				case 'accounts-properties-profiles':
-					if ( ! empty( $data['existingAccountId'] ) && ! empty( $data['existingPropertyId'] ) ) {
-						$this->_existing_tag_account = array(
-							'accountId'  => $data['existingAccountId'],
-							'propertyId' => $data['existingPropertyId'],
-						);
-					}
 					return $this->get_service( 'analytics' )->management_accounts->listManagementAccounts();
 				case 'properties-profiles':
 					if ( ! isset( $data['accountId'] ) ) {
-						/* translators: %s: Missing parameter name */
-						return new WP_Error( 'missing_required_param', sprintf( __( 'Request parameter is empty: %s.', 'google-site-kit' ), 'accountId' ), array( 'status' => 400 ) );
-					}
-					if ( ! empty( $data['existingAccountId'] ) && ! empty( $data['existingPropertyId'] ) ) {
-						$this->_existing_tag_account = array(
-							'accountId'  => $data['existingAccountId'],
-							'propertyId' => $data['existingPropertyId'],
+						return new WP_Error(
+							'missing_required_param',
+							/* translators: %s: Missing parameter name */
+							sprintf( __( 'Request parameter is empty: %s.', 'google-site-kit' ), 'accountId' ),
+							array( 'status' => 400 )
 						);
 					}
 
 					return $this->get_service( 'analytics' )->management_webproperties->listManagementWebproperties( $data['accountId'] );
 				case 'profiles':
 					if ( ! isset( $data['accountId'] ) ) {
-						/* translators: %s: Missing parameter name */
-						return new WP_Error( 'missing_required_param', sprintf( __( 'Request parameter is empty: %s.', 'google-site-kit' ), 'accountId' ), array( 'status' => 400 ) );
+						return new WP_Error(
+							'missing_required_param',
+							/* translators: %s: Missing parameter name */
+							sprintf( __( 'Request parameter is empty: %s.', 'google-site-kit' ), 'accountId' ),
+							array( 'status' => 400 )
+						);
 					}
 					if ( ! isset( $data['propertyId'] ) ) {
-						/* translators: %s: Missing parameter name */
-						return new WP_Error( 'missing_required_param', sprintf( __( 'Request parameter is empty: %s.', 'google-site-kit' ), 'propertyId' ), array( 'status' => 400 ) );
+						return new WP_Error(
+							'missing_required_param',
+							/* translators: %s: Missing parameter name */
+							sprintf( __( 'Request parameter is empty: %s.', 'google-site-kit' ), 'propertyId' ),
+							array( 'status' => 400 )
+						);
 					}
 
 					return $this->get_service( 'analytics' )->management_profiles->listManagementProfiles( $data['accountId'], $data['propertyId'] );

--- a/includes/Modules/Analytics.php
+++ b/includes/Modules/Analytics.php
@@ -34,6 +34,13 @@ final class Analytics extends Module implements Module_With_Screen, Module_With_
 	const OPTION = 'googlesitekit_analytics_settings';
 
 	/**
+	 * Temporary storage for datapoint $data object for use in response parsing.
+	 *
+	 * @var array
+	 */
+	private $_data;
+
+	/**
 	 * Temporary storage for existing analytics tag found.
 	 *
 	 * @since 1.0.0
@@ -468,6 +475,8 @@ final class Analytics extends Module implements Module_With_Screen, Module_With_
 	 * @return RequestInterface|callable|WP_Error Request object or callable on success, or WP_Error on failure.
 	 */
 	protected function create_data_request( $method, $datapoint, array $data = array() ) {
+		$this->_data = $data;
+
 		if ( 'GET' === $method ) {
 			switch ( $datapoint ) {
 				case 'connection':
@@ -934,6 +943,8 @@ final class Analytics extends Module implements Module_With_Screen, Module_With_
 	 * @return mixed Parsed response data on success, or WP_Error on failure.
 	 */
 	protected function parse_data_response( $method, $datapoint, $response ) {
+		$data = $this->_data ?: array();
+
 		if ( 'GET' === $method ) {
 			switch ( $datapoint ) {
 				case 'goals':

--- a/includes/Modules/Analytics.php
+++ b/includes/Modules/Analytics.php
@@ -1066,6 +1066,21 @@ final class Analytics extends Module implements Module_With_Screen, Module_With_
 	}
 
 	/**
+	 * Gets the existing tag IDs.
+	 *
+	 * @return array
+	 */
+	private function get_existing_tag() {
+		return array_merge(
+			array(
+				'accountId'  => '',
+				'propertyId' => '',
+			),
+			(array) $this->_existing_tag_account
+		);
+	}
+
+	/**
 	 * Creates a new Analytics site request for the current site and given arguments.
 	 *
 	 * @since 1.0.0

--- a/includes/Modules/Analytics.php
+++ b/includes/Modules/Analytics.php
@@ -963,7 +963,6 @@ final class Analytics extends Module implements Module_With_Screen, Module_With_
 							$found_account_id = $account_id;
 						} else {
 							foreach ( $accounts as $account ) {
-								// TODO: permute URLs?
 								$properties_profiles = $this->get_data( 'properties-profiles', array( 'accountId' => $account->getId() ) );
 
 								if ( ! is_wp_error( $properties_profiles ) && isset( $properties_profiles['matchedProperty'] ) ) {
@@ -1001,8 +1000,9 @@ final class Analytics extends Module implements Module_With_Screen, Module_With_
 					}
 
 					$property_id    = $this->get_data( 'property-id' );
-					$current_url    = $this->context->get_reference_site_url();
 					$found_property = new \Google_Service_Analytics_Webproperty();
+					$current_url    = untrailingslashit( $this->context->get_reference_site_url() );
+					$current_urls   = $this->permute_site_url( $current_url );
 
 					// If there's no match for the saved account ID, try to find a match using the properties of each account.
 					foreach ( $properties as $property ) {
@@ -1010,8 +1010,8 @@ final class Analytics extends Module implements Module_With_Screen, Module_With_
 						if (
 							// Attempt to match by property ID.
 							$property->getId() === $property_id ||
-							// Attempt to match by site URL.
-							( trailingslashit( $current_url ) === trailingslashit( $property->getWebsiteUrl() ) )
+							// Attempt to match by site URL, with and without http/https and 'www' subdomain.
+							in_array( untrailingslashit( $property->getWebsiteUrl() ), $current_urls, true )
 						) {
 							$found_property              = $property;
 							$response['matchedProperty'] = $property;

--- a/includes/Modules/Analytics.php
+++ b/includes/Modules/Analytics.php
@@ -999,10 +999,17 @@ final class Analytics extends Module implements Module_With_Screen, Module_With_
 						);
 					}
 
-					$property_id    = $this->get_data( 'property-id' );
+					$existing_tag   = $this->get_existing_tag();
+					$property_id    = $existing_tag['propertyId'] ?: $this->get_data( 'property-id' );
 					$found_property = new \Google_Service_Analytics_Webproperty();
 					$current_url    = untrailingslashit( $this->context->get_reference_site_url() );
-					$current_urls   = $this->permute_site_url( $current_url );
+
+					// If there is an existing tag, only match by property ID.
+					if ( $existing_tag['propertyId'] ) {
+						$current_urls = array();
+					} else {
+						$current_urls = $this->permute_site_url( $current_url );
+					}
 
 					// If there's no match for the saved account ID, try to find a match using the properties of each account.
 					foreach ( $properties as $property ) {

--- a/includes/Modules/Analytics.php
+++ b/includes/Modules/Analytics.php
@@ -945,13 +945,6 @@ final class Analytics extends Module implements Module_With_Screen, Module_With_
 					// TODO: Parse this response to a regular array.
 					break;
 				case 'accounts-properties-profiles':
-					$data = array_merge(
-						array(
-							'existingAccountId'  => '',
-							'existingPropertyId' => '',
-						),
-						$data
-					);
 					/* @var \Google_Service_Analytics_Accounts $response listManagementAccounts response. */
 					$accounts            = (array) $response->getItems();
 					$account_ids         = array_map(
@@ -1000,7 +993,6 @@ final class Analytics extends Module implements Module_With_Screen, Module_With_
 
 					return array_merge( compact( 'accounts' ), $properties_profiles );
 				case 'properties-profiles':
-					$data = array_merge( array( 'propertyId' => '' ), $data );
 					/* @var \Google_Service_Analytics_Webproperties $response listManagementWebproperties response. */
 					$properties = (array) $response->getItems();
 					$response   = array(

--- a/includes/Modules/Analytics.php
+++ b/includes/Modules/Analytics.php
@@ -1022,6 +1022,9 @@ final class Analytics extends Module implements Module_With_Screen, Module_With_
 					// If no match is found, fetch profiles for the first property if available.
 					if ( ! $found_property->getAccountId() && $properties ) {
 						$found_property = array_shift( $properties );
+					} elseif ( ! $found_property->getAccountId() ) {
+						// If no found property, skip the call to 'profiles' as it would be empty/fail.
+						return $response;
 					}
 
 					$profiles = $this->get_data(

--- a/includes/Modules/Analytics.php
+++ b/includes/Modules/Analytics.php
@@ -958,13 +958,13 @@ final class Analytics extends Module implements Module_With_Screen, Module_With_
 						'profiles'   => array(),
 					);
 
-					if ( $data['existingAccountId'] && $data['existingPropertyId'] ) {
+					if ( ! empty( $data['existingAccountId'] ) && ! empty( $data['existingPropertyId'] ) ) {
 						// If there is an existing tag, pass it through to ensure only the existing tag is matched.
 						$properties_profiles = $this->get_data(
 							'properties-profiles',
 							array(
-								'accountId'  => $data['existingAccountId'],
-								'propertyId' => $data['existingPropertyId'],
+								'accountId'          => $data['existingAccountId'],
+								'existingPropertyId' => $data['existingPropertyId'],
 							)
 						);
 					} else {
@@ -1008,14 +1008,15 @@ final class Analytics extends Module implements Module_With_Screen, Module_With_
 						);
 					}
 
-					$property_id    = $data['propertyId'] ?: $this->get_data( 'property-id' );
 					$found_property = new \Google_Service_Analytics_Webproperty();
 					$current_url    = untrailingslashit( $this->context->get_reference_site_url() );
 
 					// If requested for a specific property, only match by property ID.
-					if ( $data['propertyId'] ) {
+					if ( ! empty( $data['existingPropertyId'] ) ) {
+						$property_id  = $data['existingPropertyId'];
 						$current_urls = array();
 					} else {
+						$property_id  = $this->get_data( 'property-id' );
 						$current_urls = $this->permute_site_url( $current_url );
 					}
 


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #89

## Relevant technical choices

* Updated Analytics endpoints for `accounts-properties-profiles` and `properties-profiles` for simplicity and readability. 
* Removed duplicated logic between these endpoints for property matching.
    * Moved `matchedProperty` to `properties-profiles`
* Matched property now no longer concerned with position in list of properties

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
