### PR TITLE
Fix AdSense snippet default

### DIFF
--- a/includes/Modules/AdSense.php
+++ b/includes/Modules/AdSense.php
@@ -76,6 +76,13 @@ final class AdSense extends Module implements Module_With_Screen, Module_With_Sc
 				// Ensure the old key is removed regardless. No-op if not set.
 				unset( $option['adsenseTagEnabled'] );
 
+				/**
+				 * Enable the snippet by default.
+				 */
+				if ( ! isset( $option['useSnippet'] ) ) {
+					$option['useSnippet'] = true;
+				}
+
 				return $option;
 			}
 		);

--- a/includes/Modules/AdSense.php
+++ b/includes/Modules/AdSense.php
@@ -141,13 +141,7 @@ final class AdSense extends Module implements Module_With_Screen, Module_With_Sc
 			__( 'Intelligent, automatic ad placement', 'google-site-kit' ),
 		);
 
-		// If useSnippet is not saved, default to true.
-		$info['settings'] = array_merge(
-			array(
-				'useSnippet' => true,
-			),
-			(array) $this->options->get( self::OPTION )
-		);
+		$info['settings'] = $this->options->get( self::OPTION );
 
 		// Clear datapoints that don't need to be localized.
 		$idenfifier_args = array(

--- a/tests/e2e/specs/modules/adsense/setup-new-user.test.js
+++ b/tests/e2e/specs/modules/adsense/setup-new-user.test.js
@@ -198,9 +198,7 @@ describe( 'setting up the AdSense module', () => {
 		await expect( page ).toMatchElement( '.googlesitekit-setup-module__title', { text: /We’re getting your site ready for ads/i } );
 		await expect( page ).toMatchElement( '.googlesitekit-cta-link', { text: /Go to your AdSense account to check on your site’s status/i } );
 
-		// Note this _should_ output a tag but currently does not as `useSnippet` is not defaulting to true.
-		// await expect( '/' ).toHaveAdSenseTag();
-		await expect( '/' ).not.toHaveAdSenseTag();
+		await expect( '/' ).toHaveAdSenseTag();
 	} );
 
 	it( 'displays “Your site isn’t ready to show ads yet” when the users account is disapproved', async () => {

--- a/tests/phpunit/integration/Modules/AdSenseTest.php
+++ b/tests/phpunit/integration/Modules/AdSenseTest.php
@@ -53,7 +53,7 @@ class AdSenseTest extends TestCase {
 		add_filter( 'googlesitekit_adsense_account_id', function () {
 			return 'filtered-adsense-account-id';
 		} );
-		$this->assertEquals( array( 'accountId' => 'filtered-adsense-account-id' ), get_option( AdSense::OPTION ) );
+		$this->assertArraySubset( array( 'accountId' => 'filtered-adsense-account-id' ), get_option( AdSense::OPTION ) );
 	}
 
 	public function test_get_module_scope() {

--- a/tests/phpunit/integration/Modules/AdSenseTest.php
+++ b/tests/phpunit/integration/Modules/AdSenseTest.php
@@ -54,6 +54,12 @@ class AdSenseTest extends TestCase {
 			return 'filtered-adsense-account-id';
 		} );
 		$this->assertArraySubset( array( 'accountId' => 'filtered-adsense-account-id' ), get_option( AdSense::OPTION ) );
+
+		// Default value filtered into saved value.
+		$this->assertArraySubset( array( 'useSnippet' => true ), get_option( AdSense::OPTION ) );
+		update_option( AdSense::OPTION, array( 'useSnippet' => false ) );
+		// Default respects saved value.
+		$this->assertArraySubset( array( 'useSnippet' => false ), get_option( AdSense::OPTION ) );
 	}
 
 	public function test_get_module_scope() {


### PR DESCRIPTION
## Summary

Addresses issue #556 

## Relevant technical choices

<!-- Please describe your changes. -->

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
