### PR TITLE
E2E stability enhancements

### DIFF
--- a/tests/e2e/plugins/reset.php
+++ b/tests/e2e/plugins/reset.php
@@ -16,6 +16,10 @@ use Google\Site_Kit\Context;
 use Google\Site_Kit\Core\Util\Reset;
 
 register_activation_hook( __FILE__, static function () {
+	if ( ! defined( 'GOOGLESITEKIT_PLUGIN_MAIN_FILE' ) ) {
+		wp_die( 'Site Kit must be active to reset! Check the error log.' );
+	}
+
 	( new Reset( new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE ) ) )->all();
 
 	/**

--- a/tests/e2e/specs/dashboard/search.test.js
+++ b/tests/e2e/specs/dashboard/search.test.js
@@ -23,6 +23,7 @@ describe( 'Site Kit dashboard post search', () => {
 		const postSearcher = await page.$( '.googlesitekit-post-searcher' );
 
 		await expect( postSearcher ).toFill( 'input', 'hello' );
+		await page.waitForResponse( ( res ) => res.url().match( 'core/search/data/post-search' ) );
 
 		// Ensure expected options appear.
 		await expect( postSearcher ).toMatchElement( '.autocomplete__option', { text: /hello world/i } );
@@ -47,6 +48,7 @@ describe( 'Site Kit dashboard post search', () => {
 		const postSearcher = await page.$( '.googlesitekit-post-searcher' );
 
 		await expect( postSearcher ).toFill( 'input', createURL( 'hello-world' ) );
+		await page.waitForResponse( ( res ) => res.url().match( 'core/search/data/post-search' ) );
 
 		// Ensure expected options appear.
 		await expect( postSearcher ).toMatchElement( '.autocomplete__option', { text: /hello world/i } );
@@ -71,6 +73,7 @@ describe( 'Site Kit dashboard post search', () => {
 		const postSearcher = await page.$( '.googlesitekit-post-searcher' );
 
 		await expect( postSearcher ).toFill( 'input', 'non-existent title' );
+		await page.waitForResponse( ( res ) => res.url().match( 'core/search/data/post-search' ) );
 
 		await expect( postSearcher ).toMatchElement( '.autocomplete__option', { text: /no results found/i } );
 
@@ -82,6 +85,7 @@ describe( 'Site Kit dashboard post search', () => {
 		const postSearcher = await page.$( '.googlesitekit-post-searcher' );
 
 		await expect( postSearcher ).toFill( 'input', createURL( 'non-existent' ) );
+		await page.waitForResponse( ( res ) => res.url().match( 'core/search/data/post-search' ) );
 
 		await expect( postSearcher ).toMatchElement( '.autocomplete__option', { text: /no results found/i } );
 
@@ -94,6 +98,7 @@ describe( 'Site Kit dashboard post search', () => {
 		const postSearcher = await page.$( '.googlesitekit-post-searcher' );
 
 		await expect( postSearcher ).toFill( 'input', 'Spéçïåł' );
+		await page.waitForResponse( ( res ) => res.url().match( 'core/search/data/post-search' ) );
 
 		// Ensure expected options appear.
 		await expect( postSearcher ).toMatchElement( '.autocomplete__option', { text: TITLE_SPECIAL_CHARACTERS } );

--- a/tests/e2e/specs/modules/adsense/setup-new-user.test.js
+++ b/tests/e2e/specs/modules/adsense/setup-new-user.test.js
@@ -137,6 +137,7 @@ describe( 'setting up the AdSense module', () => {
 
 		await proceedToAdsenseSetup();
 
+		await page.waitForResponse( ( res ) => res.url().match( 'modules/adsense/data/account-status' ) );
 		await expect( page ).toMatchElement( '.googlesitekit-setup-module__title', { text: /We’re getting your site ready for ads/i } );
 		await expect( page ).toMatchElement( '.googlesitekit-cta-link', { text: /Go to your AdSense account to check on your site’s status/i } );
 
@@ -195,6 +196,7 @@ describe( 'setting up the AdSense module', () => {
 
 		await proceedToAdsenseSetup();
 
+		await page.waitForResponse( ( res ) => res.url().match( 'modules/adsense/data/account-status' ) );
 		await expect( page ).toMatchElement( '.googlesitekit-setup-module__title', { text: /We’re getting your site ready for ads/i } );
 		await expect( page ).toMatchElement( '.googlesitekit-cta-link', { text: /Go to your AdSense account to check on your site’s status/i } );
 
@@ -267,6 +269,7 @@ describe( 'setting up the AdSense module', () => {
 
 		await proceedToAdsenseSetup();
 
+		await page.waitForResponse( ( res ) => res.url().match( 'modules/adsense/data/account-status' ) );
 		await expect( page ).toMatchElement( '.googlesitekit-setup-module__title', { text: /Create your AdSense account/i } );
 		await expect( page ).toMatchElement( '.googlesitekit-setup-module__action button', { text: /Create AdSense Account/i } );
 

--- a/tests/e2e/specs/modules/adsense/setup-new-user.test.js
+++ b/tests/e2e/specs/modules/adsense/setup-new-user.test.js
@@ -26,6 +26,7 @@ async function proceedToAdsenseSetup() {
 		expect( page ).toClick( '.googlesitekit-cta-link', { text: /set up adsense/i } ),
 		page.waitForSelector( '.googlesitekit-setup-module--adsense' ),
 		page.waitForResponse( ( res ) => res.url().match( 'modules/adsense/data/accounts' ) ),
+		page.waitForResponse( ( res ) => res.url().match( 'modules/adsense/data/account-status' ) ),
 	] );
 }
 
@@ -137,7 +138,6 @@ describe( 'setting up the AdSense module', () => {
 
 		await proceedToAdsenseSetup();
 
-		await page.waitForResponse( ( res ) => res.url().match( 'modules/adsense/data/account-status' ) );
 		await expect( page ).toMatchElement( '.googlesitekit-setup-module__title', { text: /We’re getting your site ready for ads/i } );
 		await expect( page ).toMatchElement( '.googlesitekit-cta-link', { text: /Go to your AdSense account to check on your site’s status/i } );
 
@@ -196,7 +196,6 @@ describe( 'setting up the AdSense module', () => {
 
 		await proceedToAdsenseSetup();
 
-		await page.waitForResponse( ( res ) => res.url().match( 'modules/adsense/data/account-status' ) );
 		await expect( page ).toMatchElement( '.googlesitekit-setup-module__title', { text: /We’re getting your site ready for ads/i } );
 		await expect( page ).toMatchElement( '.googlesitekit-cta-link', { text: /Go to your AdSense account to check on your site’s status/i } );
 
@@ -269,7 +268,6 @@ describe( 'setting up the AdSense module', () => {
 
 		await proceedToAdsenseSetup();
 
-		await page.waitForResponse( ( res ) => res.url().match( 'modules/adsense/data/account-status' ) );
 		await expect( page ).toMatchElement( '.googlesitekit-setup-module__title', { text: /Create your AdSense account/i } );
 		await expect( page ).toMatchElement( '.googlesitekit-setup-module__action button', { text: /Create AdSense Account/i } );
 

--- a/tests/e2e/specs/modules/analytics/setup-with-account-with-tag.test.js
+++ b/tests/e2e/specs/modules/analytics/setup-with-account-with-tag.test.js
@@ -85,6 +85,7 @@ describe( 'setting up the Analytics module with an existing account and existing
 		await setAnalyticsExistingPropertyId( EXISTING_PROPERTY_ID );
 		await proceedToSetUpAnalytics();
 
+		await page.waitForResponse( ( res ) => res.url().match( 'modules/analytics/data/accounts-properties-profiles' ) );
 		await expect( page ).toMatchElement( '.googlesitekit-setup-module--analytics p', { text: new RegExp( `An existing analytics tag was found on your site with the id ${ EXISTING_PROPERTY_ID }`, 'i' ) } );
 
 		await expect( page ).toMatchElement( '.mdc-select--disabled .mdc-select__selected-text', { text: /test account a/i } );

--- a/tests/e2e/specs/modules/search-console/dashboard-date-range.test.js
+++ b/tests/e2e/specs/modules/search-console/dashboard-date-range.test.js
@@ -87,6 +87,7 @@ describe( 'date range filtering on dashboard views', () => {
 		const postSearcher = await page.$( '.googlesitekit-post-searcher' );
 
 		await expect( postSearcher ).toFill( 'input', 'hello world' );
+		await page.waitForResponse( ( res ) => res.url().match( 'core/search/data/post-search' ) );
 		await expect( postSearcher ).toClick( '.autocomplete__option', { text: /hello world/i } );
 
 		mockBatchResponse = last28Days;

--- a/tests/e2e/utils/switch-date-range.js
+++ b/tests/e2e/utils/switch-date-range.js
@@ -7,6 +7,11 @@
  * @param {string} toRange The new date range to select.
  */
 export async function switchDateRange( fromRange, toRange ) {
-	await expect( page ).toClick( '.mdc-select__selected-text', { text: new RegExp( fromRange, 'i' ) } );
-	await expect( page ).toClick( '.mdc-menu-surface--open .mdc-list-item', { text: new RegExp( toRange, 'i' ) } );
+	await Promise.all( [
+		expect( page ).toClick( '.mdc-select__selected-text', { text: new RegExp( fromRange, 'i' ) } ),
+		page.waitForSelector( '.mdc-select.mdc-select--focused' ),
+		page.waitForSelector( '.mdc-menu-surface--open .mdc-list-item' ),
+	] );
+	// Intentionally left off the '--open' suffix here as it proved problematic for stability.
+	await expect( page ).toClick( '.mdc-menu-surface .mdc-list-item', { text: new RegExp( toRange, 'i' ) } );
 }


### PR DESCRIPTION
## Summary

This PR addresses a number points of possible instability during a few E2E tests where tests could fail. We found this most consistently reproducible when running with `--no-cache`. Otherwise it seemed to be more random and more likely to happen in some environments over others.

Follows merged PRs #562, #557, #545, #416

## Relevant technical choices

Most of the changes here add additional waits for particular responses before continuing on with the rest of the test.

For the date range select test specifically, there was a strange edge case that caused the click/selection of the next date range to fail somewhat randomly. This was fixed by removing the `--open` scope on the css selector. It's still unknown as to why exactly this fails sometimes but much investigation was done into this and it isn't worth further investigation at this point. It's also worth noting that this odd behavior was only observable in a headless context, so it may be unique to e2e tests run in this way and likely not a risk to real user interaction or behavior.

Regarding the change to `reset.php`, this is an effort to make it more obvious if reset is attempted if Site Kit is inactive. It's still unknown exactly how this can happen, but we've seen a few times where - possibly just by things erroring during normal dev/testing - that Site Kit becomes deactivated. It then silently causes the rest of the tests to fail as it is assumed that Site Kit is active. This is more useful for tests done in an interactive context since the failure will be visible, but still better than letting it go to a fatal error.

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
