### PR TITLE
Fix admin bar menu to show for home page latest posts as expected

### DIFF
--- a/includes/Context.php
+++ b/includes/Context.php
@@ -211,7 +211,7 @@ final class Context {
 
 		// Handle the home page URL.
 		if ( is_front_page() ) {
-			return $this->get_reference_site_url();
+			return user_trailingslashit( $this->get_reference_site_url() );
 		} elseif ( is_home() ) {
 			return $this->get_reference_permalink( get_option( 'page_for_posts' ) );
 		}


### PR DESCRIPTION
## Summary

Addresses issue #312

## Relevant technical choices

It appears that Google APIs have issues with empty paths. When testing, I didn't see any stats for my home page locally, because it didn't include a trailing slash and therefore had an empty path. If you set WordPress to use a static front page, you're covered because `get_permalink()` adds such a slash, but if you manually retrieve the home URL through another way, it is set to whatever it is set (with or without trailing slash).

To address this, I use `user_trailingslashit()`, since it should still only add the slash if permalinks are set up like this (99+% of cases they are).

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
