### PR TITLE
Update E2E plugin deactivation utility to only touch utility plugins

### DIFF
--- a/tests/e2e/config/bootstrap.js
+++ b/tests/e2e/config/bootstrap.js
@@ -18,7 +18,7 @@ import { getQueryArg } from '@wordpress/url';
  */
 import {
 	clearSessionStorage,
-	deactivateAllOtherPlugins,
+	deactivateUtilityPlugins,
 	resetSiteKit,
 } from '../utils';
 import {
@@ -210,7 +210,7 @@ beforeAll( async () => {
 	}
 	await setBrowserViewport( 'large' );
 
-	await deactivateAllOtherPlugins();
+	await deactivateUtilityPlugins();
 	await resetSiteKit();
 } );
 
@@ -221,7 +221,7 @@ afterEach( async () => {
 } );
 
 afterAll( async () => {
-	await deactivateAllOtherPlugins();
+	await deactivateUtilityPlugins();
 	await resetSiteKit();
 	removePageEvents();
 	await page.setRequestInterception( false );

--- a/tests/e2e/specs/auth-flow.test.js
+++ b/tests/e2e/specs/auth-flow.test.js
@@ -7,7 +7,7 @@ import { activatePlugin, createURL, visitAdminPage } from '@wordpress/e2e-test-u
  * Internal dependencies
  */
 import {
-	deactivateAllOtherPlugins,
+	deactivateUtilityPlugins,
 	resetSiteKit,
 	pasteText,
 	setSearchConsoleProperty,
@@ -60,7 +60,7 @@ describe( 'Site Kit set up flow for the first time', () => {
 	} );
 
 	afterEach( async () => {
-		await deactivateAllOtherPlugins();
+		await deactivateUtilityPlugins();
 		await resetSiteKit();
 	} );
 

--- a/tests/e2e/specs/auth-setup-search-console.test.js
+++ b/tests/e2e/specs/auth-setup-search-console.test.js
@@ -7,7 +7,7 @@ import { activatePlugin, createURL, visitAdminPage } from '@wordpress/e2e-test-u
  * Internal dependencies
  */
 import {
-	deactivateAllOtherPlugins,
+	deactivateUtilityPlugins,
 	pasteText,
 	resetSiteKit,
 	testClientConfig,
@@ -48,7 +48,7 @@ describe( 'Site Kit set up flow for the first time with search console setup', (
 	} );
 
 	afterEach( async () => {
-		await deactivateAllOtherPlugins();
+		await deactivateUtilityPlugins();
 		await resetSiteKit();
 	} );
 

--- a/tests/e2e/specs/auth-setup-verification.test.js
+++ b/tests/e2e/specs/auth-setup-verification.test.js
@@ -7,7 +7,7 @@ import { activatePlugin, createURL, visitAdminPage } from '@wordpress/e2e-test-u
  * Internal dependencies
  */
 import {
-	deactivateAllOtherPlugins,
+	deactivateUtilityPlugins,
 	pasteText,
 	resetSiteKit,
 	testClientConfig,
@@ -42,7 +42,7 @@ describe( 'Site Kit set up flow for the first time with site verification', () =
 	} );
 
 	afterEach( async () => {
-		await deactivateAllOtherPlugins();
+		await deactivateUtilityPlugins();
 		await resetSiteKit();
 	} );
 

--- a/tests/e2e/specs/modules/adsense/setup-new-user.test.js
+++ b/tests/e2e/specs/modules/adsense/setup-new-user.test.js
@@ -7,7 +7,7 @@ import { createURL, activatePlugin, visitAdminPage } from '@wordpress/e2e-test-u
  * Internal dependencies
  */
 import {
-	deactivateAllOtherPlugins,
+	deactivateUtilityPlugins,
 	resetSiteKit,
 	setAuthToken,
 	setClientConfig,
@@ -89,7 +89,7 @@ describe( 'setting up the AdSense module', () => {
 
 	afterEach( async () => {
 		Object.keys( datapointHandlers ).forEach( ( key ) => datapointHandlers[ key ] = defaultHandler );
-		await deactivateAllOtherPlugins();
+		await deactivateUtilityPlugins();
 		await resetSiteKit();
 	} );
 

--- a/tests/e2e/specs/modules/analytics/setup-no-account-no-tag.test.js
+++ b/tests/e2e/specs/modules/analytics/setup-no-account-no-tag.test.js
@@ -7,7 +7,7 @@ import { activatePlugin, createURL, visitAdminPage } from '@wordpress/e2e-test-u
  * Internal dependencies
  */
 import {
-	deactivateAllOtherPlugins,
+	deactivateUtilityPlugins,
 	resetSiteKit,
 	useRequestInterception,
 	setSearchConsoleProperty,
@@ -48,7 +48,7 @@ describe( 'setting up the Analytics module with no existing account and no exist
 	} );
 
 	afterEach( async () => {
-		await deactivateAllOtherPlugins();
+		await deactivateUtilityPlugins();
 		await resetSiteKit();
 	} );
 

--- a/tests/e2e/specs/modules/analytics/setup-no-account-with-tag.test.js
+++ b/tests/e2e/specs/modules/analytics/setup-no-account-with-tag.test.js
@@ -7,7 +7,7 @@ import { activatePlugin, visitAdminPage } from '@wordpress/e2e-test-utils';
  * Internal dependencies
  */
 import {
-	deactivateAllOtherPlugins,
+	deactivateUtilityPlugins,
 	resetSiteKit,
 	setAnalyticsExistingPropertyId,
 	setAuthToken,
@@ -66,7 +66,7 @@ describe( 'setting up the Analytics module with no existing account and with an 
 	} );
 
 	afterEach( async () => {
-		await deactivateAllOtherPlugins();
+		await deactivateUtilityPlugins();
 		await resetSiteKit();
 	} );
 

--- a/tests/e2e/specs/modules/analytics/setup-with-account-no-tag.test.js
+++ b/tests/e2e/specs/modules/analytics/setup-with-account-no-tag.test.js
@@ -7,7 +7,7 @@ import { activatePlugin, createURL, visitAdminPage } from '@wordpress/e2e-test-u
  * Internal dependencies
  */
 import {
-	deactivateAllOtherPlugins,
+	deactivateUtilityPlugins,
 	resetSiteKit,
 	setSearchConsoleProperty,
 	wpApiFetch,
@@ -73,7 +73,7 @@ describe( 'setting up the Analytics module with an existing account and no exist
 	} );
 
 	afterEach( async () => {
-		await deactivateAllOtherPlugins();
+		await deactivateUtilityPlugins();
 		await resetSiteKit();
 	} );
 

--- a/tests/e2e/specs/modules/analytics/setup-with-account-with-tag.test.js
+++ b/tests/e2e/specs/modules/analytics/setup-with-account-with-tag.test.js
@@ -7,7 +7,7 @@ import { activatePlugin, visitAdminPage } from '@wordpress/e2e-test-utils';
  * Internal dependencies
  */
 import {
-	deactivateAllOtherPlugins,
+	deactivateUtilityPlugins,
 	resetSiteKit,
 	setAnalyticsExistingPropertyId,
 	setAuthToken,
@@ -68,7 +68,7 @@ describe( 'setting up the Analytics module with an existing account and existing
 	} );
 
 	afterEach( async () => {
-		await deactivateAllOtherPlugins();
+		await deactivateUtilityPlugins();
 		await resetSiteKit();
 	} );
 

--- a/tests/e2e/specs/modules/pagespeed-insights/activation.test.js
+++ b/tests/e2e/specs/modules/pagespeed-insights/activation.test.js
@@ -7,7 +7,7 @@ import { visitAdminPage, activatePlugin } from '@wordpress/e2e-test-utils';
  * Internal dependencies
  */
 import {
-	deactivateAllOtherPlugins,
+	deactivateUtilityPlugins,
 	pasteText,
 	resetSiteKit,
 	setSearchConsoleProperty,
@@ -22,7 +22,7 @@ describe( 'PageSpeed Insights Activation', () => {
 	} );
 
 	afterEach( async () => {
-		await deactivateAllOtherPlugins();
+		await deactivateUtilityPlugins();
 		await resetSiteKit();
 	} );
 

--- a/tests/e2e/specs/modules/tagmanager/setup.test.js
+++ b/tests/e2e/specs/modules/tagmanager/setup.test.js
@@ -7,7 +7,7 @@ import { activatePlugin, visitAdminPage, createURL } from '@wordpress/e2e-test-u
  * Internal dependencies
  */
 import {
-	deactivateAllOtherPlugins,
+	deactivateUtilityPlugins,
 	resetSiteKit,
 	useRequestInterception,
 	setSearchConsoleProperty,
@@ -49,7 +49,7 @@ describe( 'setting up the TagManager module with no existing account', () => {
 	} );
 
 	afterEach( async () => {
-		await deactivateAllOtherPlugins();
+		await deactivateUtilityPlugins();
 		await resetSiteKit();
 	} );
 

--- a/tests/e2e/utils/deactivate-utility-plugins.js
+++ b/tests/e2e/utils/deactivate-utility-plugins.js
@@ -26,8 +26,8 @@ export async function deactivateUtilityPlugins() {
 	}
 
 	// Check the boxes of plugins to deactivate.
-	await page.$$eval( '.active[data-plugin^="google-site-kit-test-plugins/"] input[type="checkbox"]', ( checkbox ) => {
-		checkbox.checked = true;
+	await page.$$eval( '.active[data-plugin^="google-site-kit-test-plugins/"] input[type="checkbox"]', ( checkboxes ) => {
+		checkboxes.forEach( ( checkbox ) => checkbox.checked = true );
 	} );
 
 	// Bulk deactivate

--- a/tests/e2e/utils/deactivate-utility-plugins.js
+++ b/tests/e2e/utils/deactivate-utility-plugins.js
@@ -5,30 +5,30 @@
 import { switchUserToAdmin, visitAdminPage, switchUserToTest, isCurrentURL } from '@wordpress/e2e-test-utils';
 
 /**
- * Deactivate all plugins except Site Kit.
+ * Deactivate Site Kit utility plugins.
  */
-export async function deactivateAllOtherPlugins() {
+export async function deactivateUtilityPlugins() {
 	await switchUserToAdmin();
 
 	if ( ! isCurrentURL( 'wp-admin/plugins.php' ) ) {
 		await visitAdminPage( 'plugins.php' );
 	}
 
-	await page.waitForSelector( 'input[type="checkbox"][value="google-site-kit/google-site-kit.php"]' );
-	const activePlugins = await page.$$eval( '.active[data-plugin]', ( rows ) => {
+	await page.waitForSelector( '#wpfooter' );
+
+	const activeUtilities = await page.$$eval( '.active[data-plugin^="google-site-kit-test-plugins/"]', ( rows ) => {
 		return rows.map( ( row ) => row.dataset.plugin );
 	} );
 
 	// Bail if there are no plugins to deactivate
-	if ( 1 === activePlugins.length && 'google-site-kit/google-site-kit.php' === activePlugins[ 0 ] ) {
+	if ( ! activeUtilities.length ) {
 		return;
 	}
 
-	// Select all plugins
-	await page.click( '#cb-select-all-1' );
-
-	// Uncheck Site Kit
-	await page.click( 'input[type="checkbox"][value="google-site-kit/google-site-kit.php"]' );
+	// Check the boxes of plugins to deactivate.
+	await page.$$eval( '.active[data-plugin^="google-site-kit-test-plugins/"] input[type="checkbox"]', ( checkbox ) => {
+		checkbox.checked = true;
+	} );
 
 	// Bulk deactivate
 	await page.select( 'select#bulk-action-selector-bottom', 'deactivate-selected' );

--- a/tests/e2e/utils/index.js
+++ b/tests/e2e/utils/index.js
@@ -1,5 +1,5 @@
 export { clearSessionStorage } from './clear-session-storage';
-export { deactivateAllOtherPlugins } from './deactivate-all-other-plugins';
+export { deactivateUtilityPlugins } from './deactivate-utility-plugins';
 export { logoutUser } from './logout-user';
 export { pasteText } from './paste-text';
 export { resetSiteKit } from './reset';


### PR DESCRIPTION
## Summary

This PR fixes a bug in the E2E utility module `deactivateAllOtherPlugins` which was designed to deactivate all other plugins except Site Kit.

This is unnecessarily broad and causes our E2E test suite that includes Gutenberg to actually be deactivated and not tested at all.

The solution here is to update this utility to only deactivate Site Kit _utility plugins_ which was the main intention anyways. These are easy to target as well since they're all under the same "parent" `google-site-kit-test-plugins/`.

Addresses issue #

## Relevant technical choices

Reimplements `deactivateAllOtherPlugins` as `deactivateUtilityPlugins` and update references accordingly.

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
