### PR TITLE
Ensure cached requests are never used during setup and module settings edit

### DIFF
--- a/assets/js/modules/analytics/setup.js
+++ b/assets/js/modules/analytics/setup.js
@@ -92,7 +92,7 @@ class AnalyticsSetup extends Component {
 		if ( existingTagProperty && existingTagProperty.length ) {
 			// Verify the user has access to existing tag if found. If no access request will return 403 error and catch err.
 			try {
-				const existingTagData = await data.get( TYPE_MODULES, 'analytics', 'tag-permission', { tag: existingTagProperty }, false );
+				const existingTagData = await data.get( TYPE_MODULES, 'analytics', 'tag-permission', { tag: existingTagProperty } );
 				await this.getAccounts( existingTagData );
 			} catch ( err ) {
 				this.setState(
@@ -257,7 +257,7 @@ class AnalyticsSetup extends Component {
 				existingPropertyId: existingTagData.propertyId,
 			} : {};
 
-			const responseData = await data.get( TYPE_MODULES, 'analytics', 'accounts-properties-profiles', queryArgs, false );
+			const responseData = await data.get( TYPE_MODULES, 'analytics', 'accounts-properties-profiles', queryArgs );
 			if ( 0 === responseData.accounts.length ) {
 				newState = {
 					...newState,

--- a/assets/js/modules/tagmanager/setup.js
+++ b/assets/js/modules/tagmanager/setup.js
@@ -131,7 +131,7 @@ class TagmanagerSetup extends Component {
 
 			let errorCode = false;
 			let errorMsg = '';
-			const responseData = await data.get( TYPE_MODULES, 'tagmanager', 'accounts-containers', queryArgs, false );
+			const responseData = await data.get( TYPE_MODULES, 'tagmanager', 'accounts-containers', queryArgs );
 
 			// Verify if user has access to the selected account.
 			if ( selectedAccount && ! responseData.accounts.find( ( account ) => account.accountId === selectedAccount ) ) {


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #506

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
