### PR TITLE
Analytics: Don't return WP_Errors when user has no properties/profiles

### DIFF
--- a/includes/Modules/Analytics.php
+++ b/includes/Modules/Analytics.php
@@ -1001,11 +1001,7 @@ final class Analytics extends Module implements Module_With_Screen, Module_With_
 					);
 
 					if ( 0 === count( $properties ) ) {
-						return new WP_Error(
-							'google_analytics_properties_empty',
-							__( 'No Google Analytics properties found. Please go to Google Analytics to set one up.', 'google-site-kit' ),
-							array( 'status' => 500 )
-						);
+						return $response;
 					}
 
 					$found_property = new \Google_Service_Analytics_Webproperty();
@@ -1059,12 +1055,7 @@ final class Analytics extends Module implements Module_With_Screen, Module_With_
 
 					return $response;
 				case 'profiles':
-					// TODO: Parse this response to a regular array.
-					$response = $response->getItems();
-					if ( 0 === count( $response ) ) {
-						return new WP_Error( 'google_analytics_profiles_empty', __( 'No Google Analytics profiles found. Please go to Google Anlytics to set one up.', 'google-site-kit' ), array( 'status' => 500 ) );
-					}
-					return $response;
+					return $response->getItems();
 				case 'report':
 					if ( $this->_is_adsense_request ) {
 						if ( isset( $response->error ) ) {


### PR DESCRIPTION
## Summary

Addresses issue #398

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
