### PR TITLE
fix: Use "Setup new property" when none exists

### DIFF
--- a/assets/js/modules/analytics/setup.js
+++ b/assets/js/modules/analytics/setup.js
@@ -795,7 +795,7 @@ class AnalyticsSetup extends Component {
 						<Select
 							enhanced
 							name="properties"
-							value={ selectedProperty || '-1' }
+							value={ selectedProperty || selectedProperty === 0 ? selectedProperty.toString() : '-1' }
 							onEnhancedChange={ this.handlePropertyChange }
 							label={ __( 'Property', 'google-site-kit' ) }
 							disabled={ disabledProperty }
@@ -814,7 +814,7 @@ class AnalyticsSetup extends Component {
 						<Select
 							enhanced
 							name="profiles"
-							value={ selectedProfile || '-1' }
+							value={ selectedProfile || selectedProfile === 0 ? selectedProfile.toString() : '-1' }
 							onEnhancedChange={ this.handleProfileChange }
 							label={ __( 'View', 'google-site-kit' ) }
 							disabled={ disabledProfile }

--- a/includes/Modules/Analytics.php
+++ b/includes/Modules/Analytics.php
@@ -1001,11 +1001,7 @@ final class Analytics extends Module implements Module_With_Screen, Module_With_
 					);
 
 					if ( 0 === count( $properties ) ) {
-						return new WP_Error(
-							'google_analytics_properties_empty',
-							__( 'No Google Analytics properties found. Please go to Google Analytics to set one up.', 'google-site-kit' ),
-							array( 'status' => 500 )
-						);
+						return $response;
 					}
 
 					$found_property = new \Google_Service_Analytics_Webproperty();
@@ -1061,9 +1057,7 @@ final class Analytics extends Module implements Module_With_Screen, Module_With_
 				case 'profiles':
 					// TODO: Parse this response to a regular array.
 					$response = $response->getItems();
-					if ( 0 === count( $response ) ) {
-						return new WP_Error( 'google_analytics_profiles_empty', __( 'No Google Analytics profiles found. Please go to Google Anlytics to set one up.', 'google-site-kit' ), array( 'status' => 500 ) );
-					}
+
 					return $response;
 				case 'report':
 					if ( $this->_is_adsense_request ) {


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #398.

This removes error messaging for GA accounts without profiles/properties.

## Relevant technical choices

<!-- Please describe your changes. -->

The output for `selectedProperty` and `selectedProfile` were changed to strings to ensure they were selected. This still passes E2E tests and seems to work well in manual testing. 

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
