### PR TITLE
fix: Don't split requests when low priority

### DIFF
--- a/assets/js/components/data.js
+++ b/assets/js/components/data.js
@@ -163,9 +163,12 @@ const dataAPI = {
 		const toRequest = [];
 		const deferredRequests = [];
 		const keyIndexesMap = {};
+		const noLowPriorityRequests = !! dataRequest.find( ( request ) => {
+			return request.priority < 10;
+		} );
 		each( dataRequest, ( request, index ) => {
 			// Defer any datapoints with a priority of 10 or greater into a second request.
-			if ( ! secondaryRequest && 10 <= request.priority ) {
+			if ( ! secondaryRequest && 10 <= request.priority && noLowPriorityRequests ) {
 				deferredRequests.push( request );
 			} else if ( ! keyIndexesMap[ request.key ] ) {
 				keyIndexesMap[ request.key ] = [ index ];


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #339.

## Relevant technical choices

Checks for low-priority requests; if there are _only_ low-priority requests don't push them into a secondary request.

<!-- Please describe your changes. -->

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
