### PR TITLE
fix: Return non-reference variables when caching

### DIFF
--- a/assets/js/components/data.js
+++ b/assets/js/components/data.js
@@ -67,7 +67,7 @@ const lazilySetupLocalCache = () => {
 const nonReferencedValue = ( value ) => {
 	if ( Array.isArray( value ) ) {
 		return [ ...value ];
-	} else if ( typeof value === 'object' ) {
+	} else if ( typeof value === 'object' && value !== null ) {
 		return { ...value };
 	}
 

--- a/assets/js/components/data.js
+++ b/assets/js/components/data.js
@@ -349,7 +349,7 @@ const dataAPI = {
 				// Set variable cache.
 				googlesitekit.admin.datacache[ key ] = nonReferencedValue( cache.value );
 
-				return googlesitekit.admin.datacache[ key ];
+				return nonReferencedValue( googlesitekit.admin.datacache[ key ] );
 			}
 		}
 

--- a/assets/js/components/data.js
+++ b/assets/js/components/data.js
@@ -59,6 +59,22 @@ const lazilySetupLocalCache = () => {
 };
 
 /**
+ * Return a non-referenced value if this variable is a compound type (eg Object or Array).
+ *
+ * @param {any} value Variable data to set/get from cache.
+ * @return {any} A copy, not a reference to, the `value` passed to this function.
+ */
+const nonReferencedValue = ( value ) => {
+	if ( Array.isArray( value ) ) {
+		return [ ...value ];
+	} else if ( typeof value === 'object' ) {
+		return { ...value };
+	}
+
+	return value;
+};
+
+/**
  * Gets a copy of the given data request object with the data.dateRange populated via filter, if not set.
  * Respects the current dateRange value, if set.
  *
@@ -295,7 +311,7 @@ const dataAPI = {
 
 		lazilySetupLocalCache();
 
-		googlesitekit.admin.datacache[ key ] = data;
+		googlesitekit.admin.datacache[ key ] = nonReferencedValue( data );
 
 		const toStore = {
 			value: data,
@@ -331,9 +347,9 @@ const dataAPI = {
 			// Only return value if no maximum age given or if cache age is less than the maximum.
 			if ( ! maxAge || ( Date.now() / 1000 ) - cache.date < maxAge ) {
 				// Set variable cache.
-				googlesitekit.admin.datacache[ key ] = cache.value;
+				googlesitekit.admin.datacache[ key ] = nonReferencedValue( cache.value );
 
-				return cache.value;
+				return googlesitekit.admin.datacache[ key ];
 			}
 		}
 

--- a/assets/js/components/data.js
+++ b/assets/js/components/data.js
@@ -30,7 +30,7 @@ import {
 	sortObjectProperties,
 } from 'SiteKitCore/util';
 
-const { each, sortBy } = lodash;
+const { cloneDeep, each, sortBy } = lodash;
 const { addQueryArgs } = wp.url;
 const {
 	addAction,
@@ -56,22 +56,6 @@ const lazilySetupLocalCache = () => {
 	if ( 'object' !== typeof googlesitekit.admin.datacache ) {
 		googlesitekit.admin.datacache = {};
 	}
-};
-
-/**
- * Return a non-referenced value if this variable is a compound type (eg Object or Array).
- *
- * @param {any} value Variable data to set/get from cache.
- * @return {any} A copy, not a reference to, the `value` passed to this function.
- */
-const nonReferencedValue = ( value ) => {
-	if ( Array.isArray( value ) ) {
-		return [ ...value ];
-	} else if ( typeof value === 'object' && value !== null ) {
-		return { ...value };
-	}
-
-	return value;
 };
 
 /**
@@ -311,7 +295,7 @@ const dataAPI = {
 
 		lazilySetupLocalCache();
 
-		googlesitekit.admin.datacache[ key ] = nonReferencedValue( data );
+		googlesitekit.admin.datacache[ key ] = cloneDeep( data );
 
 		const toStore = {
 			value: data,
@@ -347,9 +331,9 @@ const dataAPI = {
 			// Only return value if no maximum age given or if cache age is less than the maximum.
 			if ( ! maxAge || ( Date.now() / 1000 ) - cache.date < maxAge ) {
 				// Set variable cache.
-				googlesitekit.admin.datacache[ key ] = nonReferencedValue( cache.value );
+				googlesitekit.admin.datacache[ key ] = cloneDeep( cache.value );
 
-				return nonReferencedValue( googlesitekit.admin.datacache[ key ] );
+				return cloneDeep( googlesitekit.admin.datacache[ key ] );
 			}
 		}
 


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #522.

## Relevant technical choices

This prevents cache data being stored in-memory as a reference, causing issues with mutating cache data.

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
