### PR TITLE
fix: Don't show an error when user cannot access Tag Manager

### DIFF
--- a/assets/js/modules/tagmanager/setup.js
+++ b/assets/js/modules/tagmanager/setup.js
@@ -133,6 +133,18 @@ class TagmanagerSetup extends Component {
 			let errorMsg = '';
 			const responseData = await data.get( TYPE_MODULES, 'tagmanager', 'accounts-containers', queryArgs );
 
+			if ( ! selectedAccount && 0 === responseData.accounts.length ) {
+				data.deleteCache( 'tagmanager', 'list-accounts' );
+
+				throw {
+					code: 'accountEmpty',
+					message: __(
+						'We didn’t find an associated Google Tag Manager account, would you like to set it up now? If you’ve just set up an account please re-fetch your account to sync it with Site Kit.',
+						'google-site-kit'
+					),
+				};
+			}
+
 			// Verify if user has access to the selected account.
 			if ( selectedAccount && ! responseData.accounts.find( ( account ) => account.accountId === selectedAccount ) ) {
 				data.invalidateCacheGroup( TYPE_MODULES, 'tagmanager', 'accounts-containers' );

--- a/assets/js/modules/tagmanager/setup.js
+++ b/assets/js/modules/tagmanager/setup.js
@@ -134,15 +134,11 @@ class TagmanagerSetup extends Component {
 			const responseData = await data.get( TYPE_MODULES, 'tagmanager', 'accounts-containers', queryArgs );
 
 			if ( ! selectedAccount && 0 === responseData.accounts.length ) {
-				data.deleteCache( 'tagmanager', 'list-accounts' );
-
-				throw {
-					code: 'accountEmpty',
-					message: __(
-						'We didn’t find an associated Google Tag Manager account, would you like to set it up now? If you’ve just set up an account please re-fetch your account to sync it with Site Kit.',
-						'google-site-kit'
-					),
-				};
+				errorCode = 'accountEmpty';
+				errorMsg = __(
+					'We didn’t find an associated Google Tag Manager account, would you like to set it up now? If you’ve just set up an account please re-fetch your account to sync it with Site Kit.',
+					'google-site-kit'
+				);
 			}
 
 			// Verify if user has access to the selected account.

--- a/assets/js/modules/tagmanager/setup.js
+++ b/assets/js/modules/tagmanager/setup.js
@@ -155,12 +155,15 @@ class TagmanagerSetup extends Component {
 			responseData.containers.push( chooseContainer );
 
 			if ( this._isMounted ) {
+				const accountId = responseData.accounts[ 0 ] ? responseData.accounts[ 0 ].accountId : null;
+				const publicId = responseData.containers[ 0 ] ? responseData.containers[ 0 ].publicId : null;
+
 				this.setState( {
 					isLoading: false,
 					accounts: responseData.accounts,
-					selectedAccount: ( selectedAccount ) ? selectedAccount : responseData.accounts[ 0 ].accountId,
+					selectedAccount: ( selectedAccount ) ? selectedAccount : accountId,
 					containers: responseData.containers,
-					selectedContainer: ( selectedContainer ) ? selectedContainer : responseData.containers[ 0 ].publicId,
+					selectedContainer: ( selectedContainer ) ? selectedContainer : publicId,
 					refetch: false,
 					errorCode,
 					errorMsg,

--- a/includes/Modules/TagManager.php
+++ b/includes/Modules/TagManager.php
@@ -494,7 +494,7 @@ final class TagManager extends Module implements Module_With_Scopes {
 						'containers' => array(),
 					);
 					if ( 0 === count( $response['accounts'] ) ) {
-						return new WP_Error( 'google_tagmanager_account_empty', __( 'We didn’t find an associated Google Tag Manager account, would you like to set it up now? If you’ve just set up an account please re-fetch your account to sync it with Site Kit.', 'google-site-kit' ), array( 'status' => 500 ) );
+						return $response;
 					}
 					if ( is_array( $this->_list_accounts_data ) && isset( $this->_list_accounts_data['accountId'] ) ) {
 						$account_id                = $this->_list_accounts_data['accountId'];


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #346.

## Relevant technical choices

Don't return a `WP_Error` when a (secondary) user does not have access to the Tag Manager properties set up by another user.

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
