### PR TITLE
Don't cache existingTag presence

### DIFF
--- a/assets/js/modules/analytics/setup.js
+++ b/assets/js/modules/analytics/setup.js
@@ -103,7 +103,6 @@ class AnalyticsSetup extends Component {
 						errorReason: err.data && err.data.reason ? err.data.reason : false,
 					}
 				);
-				data.deleteCache( 'analytics', 'existingTag' );
 			}
 		} else {
 			await this.getAccounts();

--- a/assets/js/util/index.js
+++ b/assets/js/util/index.js
@@ -595,7 +595,6 @@ export const findTagInHtmlContent = ( html, module ) => {
  * @param {string|null} The tag id if found, otherwise null.
  */
 export const getExistingTag = async ( module ) => {
-	const CACHE_KEY = `${ module }::existingTag`;
 	const { homeURL, ampMode } = googlesitekit.admin;
 	const tagFetchQueryArgs = {
 		// Indicates a tag checking request. This lets Site Kit know not to output its own tags.
@@ -603,24 +602,17 @@ export const getExistingTag = async ( module ) => {
 		// Add a timestamp for cache-busting.
 		timestamp: Date.now(),
 	};
+	let tagFound;
 
-	let tagFound = data.getCache( CACHE_KEY, 300 );
-
-	if ( tagFound === undefined ) {
-		try {
-			tagFound = await scrapeTag( addQueryArgs( homeURL, tagFetchQueryArgs ), module );
-
-			if ( ! tagFound && 'secondary' === ampMode ) {
-				tagFound = await apiFetch( { path: '/wp/v2/posts?per_page=1' } ).then(
-					// Scrape the first post in AMP mode, if there is one.
-					( posts ) => posts.slice( 0, 1 ).map( async ( post ) => {
-						return await scrapeTag( addQueryArgs( post.link, { ...tagFetchQueryArgs, amp: 1 } ), module );
-					} ).pop()
-				);
-			}
-
-			data.setCache( CACHE_KEY, tagFound || null );
-		} catch ( err ) {}
+	if ( 'secondary' === ampMode ) {
+		tagFound = await apiFetch( { path: '/wp/v2/posts?per_page=1' } ).then(
+			// Scrape the first post in AMP mode, if there is one.
+			( posts ) => posts.slice( 0, 1 ).map( async ( post ) => {
+				return await scrapeTag( addQueryArgs( post.link, { ...tagFetchQueryArgs, amp: 1 } ), module );
+			} ).pop()
+		);
+	} else {
+		tagFound = await scrapeTag( addQueryArgs( homeURL, tagFetchQueryArgs ), module );
 	}
 
 	return Promise.resolve( tagFound || null );


### PR DESCRIPTION
## Summary

Addresses issue #506

Follow up to #605

## Relevant technical choices

- `getExistingTag` no longer caches the presence of an existing tag or not. This simplifies the utility while providing the desired behavior. Should we wish to cache this in the future, it should likely be done at a higher level (per-module perhaps), leaving this utility as more of a low level tool.
- This iteration also saves an additional tag checking request if the site is using secondary amp
- The existing call to `deleteCache` was not working as expected either as this method only takes a single cache key as the argument. 

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
