### PR TITLE
fix: Don't use null fallback when creating a property

### DIFF
--- a/assets/js/modules/analytics/setup.js
+++ b/assets/js/modules/analytics/setup.js
@@ -466,9 +466,9 @@ class AnalyticsSetup extends Component {
 
 		const analyticAccount = {
 			accountId: selectedAccount || accounts[ 0 ].id || null,
-			profileId: selectedProfile || profiles[ 0 ].id || null,
-			propertyId: selectedProperty || properties[ 0 ].id || null,
-			internalWebPropertyId: selectedinternalWebProperty || properties[ 0 ].internalWebPropertyId || null,
+			profileId: selectedProfile || profiles[ 0 ].id || '0',
+			propertyId: selectedProperty || properties[ 0 ].id || '0',
+			internalWebPropertyId: selectedinternalWebProperty || properties[ 0 ].internalWebPropertyId || '0',
 			useSnippet: useSnippet || false,
 			ampClientIdOptIn: ampClientIdOptIn || false,
 		};


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #

## Relevant technical choices

<!-- Please describe your changes. -->

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.4.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
