### PR TITLE
always check the homepage for an existing tag

### DIFF
--- a/assets/js/util/index.js
+++ b/assets/js/util/index.js
@@ -602,17 +602,17 @@ export const getExistingTag = async ( module ) => {
 		// Add a timestamp for cache-busting.
 		timestamp: Date.now(),
 	};
-	let tagFound;
 
-	if ( 'secondary' === ampMode ) {
+	// Always check the homepage regardless of AMP mode.
+	let tagFound = await scrapeTag( addQueryArgs( homeURL, tagFetchQueryArgs ), module );
+
+	if ( ! tagFound && 'secondary' === ampMode ) {
 		tagFound = await apiFetch( { path: '/wp/v2/posts?per_page=1' } ).then(
 			// Scrape the first post in AMP mode, if there is one.
 			( posts ) => posts.slice( 0, 1 ).map( async ( post ) => {
 				return await scrapeTag( addQueryArgs( post.link, { ...tagFetchQueryArgs, amp: 1 } ), module );
 			} ).pop()
 		);
-	} else {
-		tagFound = await scrapeTag( addQueryArgs( homeURL, tagFetchQueryArgs ), module );
 	}
 
 	return Promise.resolve( tagFound || null );


### PR DESCRIPTION
## Summary

Fixes a regression introduced in #630 which causes an existing tag (output in `wp_head` or some other hook that is not used in a secondary AMP render) to fail to be detected.

The solution is to simply always check the homepage regardless of amp mode.

Addresses issue #506 

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
