### PR TITLE
Whitelist feature/auth-proxy branch for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ branches:
   only:
     - master
     - develop
-    - datapoint-refactoring
+    - feature/auth-proxy
 
 # Before install, failures in this section will result in build status 'errored'
 before_install:


### PR DESCRIPTION
## Summary

Whitelists the `feature/auth-proxy` branch for enabling Travis to run on pushes and PRs to this branch.

## Relevant technical choices

Removed old `datapoint-refactoring` branch from whitelist

## Checklist

- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
