### PR TITLE
Add permissions link to user menu

### DIFF
--- a/assets/js/components/user-menu.js
+++ b/assets/js/components/user-menu.js
@@ -78,6 +78,8 @@ class UserMenu extends Component {
 	}
 
 	handleMenuItemSelect( index, e ) {
+		const { proxyPermissionsURL } = googlesitekit.admin;
+
 		if (
 			( ( 'keydown' === e.type && (
 				13 === e.keyCode || // Enter
@@ -88,6 +90,9 @@ class UserMenu extends Component {
 			switch ( index ) {
 				case 0:
 					this.handleDialog();
+					break;
+				case 1:
+					window.location.assign( proxyPermissionsURL );
 					break;
 				default:
 					this.handleMenu();
@@ -136,7 +141,10 @@ class UserMenu extends Component {
 	}
 
 	render() {
-		const { userData: { email = '', picture = '' } } = googlesitekit.admin;
+		const {
+			userData: { email = '', picture = '' },
+			proxyPermissionsURL,
+		} = googlesitekit.admin;
 		const { dialogActive, menuOpen } = this.state;
 
 		return (
@@ -160,7 +168,15 @@ class UserMenu extends Component {
 					<Menu
 						ref={ this.menuRef }
 						menuOpen={ menuOpen }
-						menuItems={ [ __( 'Disconnect', 'google-site-kit' ) ] }
+						menuItems={
+							[
+								__( 'Disconnect', 'google-site-kit' ),
+							].concat(
+								proxyPermissionsURL ? [
+									__( 'Manage sites...', 'google-site-kit' ),
+								] : []
+							)
+						}
 						onSelected={ this.handleMenuItemSelect }
 						id="user-menu" />
 				</div>


### PR DESCRIPTION
## Summary

Adds a link to the user's menu to navigate to the Site Kit Service's permissions/site management page if the site is currently using the proxy.

![image](https://user-images.githubusercontent.com/1621608/66992673-dcd11880-f0d2-11e9-99d4-c584ee4b89e3.png)

Addresses issue #643 

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
