### PR TITLE
Fix potentially incorrect site title in URL

### DIFF
--- a/includes/Core/Authentication/Clients/OAuth_Client.php
+++ b/includes/Core/Authentication/Clients/OAuth_Client.php
@@ -623,7 +623,7 @@ final class OAuth_Client {
 			return add_query_arg(
 				array(
 					'nonce'      => $nonce,
-					'name'       => rawurlencode( get_bloginfo( 'name' ) ),
+					'name'       => rawurlencode( wp_specialchars_decode( get_bloginfo( 'name' ) ) ),
 					'url'        => rawurlencode( $home_url ),
 					'rest_root'  => rawurlencode( $rest_root ),
 					'admin_root' => rawurlencode( $admin_root ),


### PR DESCRIPTION
## Summary

Addresses issue #645 (follow-up to #614)

## Relevant technical choices

* If the site title includes special characters like `&`, before this fix they would have been included in the URL with HTML-encoded special characters URL-encoded (e.g. `%26amp%3B` instead of just `%26`).

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
