### PR TITLE
feat: Add a login page for use with the proxy

### DIFF
--- a/assets/js/components/dashboard-splash/dashboard-splash-app.js
+++ b/assets/js/components/dashboard-splash/dashboard-splash-app.js
@@ -114,6 +114,8 @@ class DashboardSplashApp extends Component {
 			__webpack_public_path__ = window.googlesitekit.publicPath;
 		}
 
+		const { proxySetupURL } = googlesitekit.admin;
+
 		if ( ! this.state.showAuthenticationSetupWizard && ! this.state.showModuleSetupWizard ) {
 			let introDescription, outroDescription, buttonLabel, onButtonClick;
 
@@ -150,7 +152,10 @@ class DashboardSplashApp extends Component {
 
 		let Setup = null;
 
-		if ( this.state.showAuthenticationSetupWizard ) {
+		// proxySetupURL is only set if the proxy is in use.
+		if ( proxySetupURL ) {
+			Setup = lazy( () => import( /* webpackChunkName: "chunk-googlesitekit-setup-wizard-proxy" */'../setup/setup-proxy' ) );
+		} else if ( this.state.showAuthenticationSetupWizard ) {
 			Setup = lazy( () => import( /* webpackChunkName: "chunk-googlesitekit-setup-wizard" */'../setup' ) );
 		} else {
 			Setup = lazy( () => import( /* webpackChunkName: "chunk-googlesitekit-setup-wrapper" */'../setup/setup-wrapper' ) );

--- a/assets/js/components/setup/setup-proxy.js
+++ b/assets/js/components/setup/setup-proxy.js
@@ -81,7 +81,7 @@ class SetupUsingProxy extends Component {
 				},
 			);
 
-			delay( function() {
+			delay( () => {
 				window.location.replace( redirectUrl );
 			}, 500, 'later' );
 		}

--- a/assets/js/components/setup/setup-proxy.js
+++ b/assets/js/components/setup/setup-proxy.js
@@ -33,29 +33,15 @@ class SetupUsingProxy extends Component {
 	constructor( props ) {
 		super( props );
 
-		const { connectUrl } = googlesitekit.admin;
-
-		const {
-			isAuthenticated,
-			hasSearchConsoleProperty,
-			isSiteKitConnected,
-			isVerified,
-			needReauthenticate,
-		} = googlesitekit.setup;
-
+		const { proxySetupURL } = googlesitekit.admin;
+		const { isSiteKitConnected } = googlesitekit.setup;
 		const { canSetup } = googlesitekit.permissions;
 
 		this.state = {
 			canSetup,
-			isAuthenticated,
-			isVerified,
-			needReauthenticate,
-			hasSearchConsoleProperty,
-			hasSearchConsolePropertyFromTheStart: hasSearchConsoleProperty,
-			connectUrl,
-			errorMsg: '',
 			isSiteKitConnected,
 			completeSetup: false,
+			proxySetupURL,
 		};
 	}
 
@@ -69,10 +55,6 @@ class SetupUsingProxy extends Component {
 	}
 
 	render() {
-		const {
-			connectUrl,
-		} = this.state;
-
 		if ( this.isSetupFinished() ) {
 			const redirectUrl = getSiteKitAdminURL(
 				'googlesitekit-dashboard',
@@ -86,7 +68,7 @@ class SetupUsingProxy extends Component {
 			}, 500, 'later' );
 		}
 
-		const { proxySetupURL } = googlesitekit.admin;
+		const { proxySetupURL } = this.state;
 
 		return (
 			<Fragment>
@@ -117,9 +99,10 @@ class SetupUsingProxy extends Component {
 															href={ proxySetupURL }
 															onClick={ () => {
 																sendAnalyticsTrackingEvent( 'plugin_setup', 'signin_with_google' );
-																document.location = connectUrl;
 															} }
-														>{ __( 'Start setup', 'google-site-kit' ) }</Button>
+														>
+															{ __( 'Start setup', 'google-site-kit' ) }
+														</Button>
 													</div>
 												</div>
 											</div>

--- a/assets/js/components/setup/setup-proxy.js
+++ b/assets/js/components/setup/setup-proxy.js
@@ -90,7 +90,7 @@ class SetupUsingProxy extends Component {
 														mdc-layout-grid__cell--span-12
 													">
 														<h1 className="googlesitekit-setup__title">
-															{ __( 'Time to set up the Site Kit plugin', 'google-site-kit' ) }
+															{ __( 'The Site Kit plugin is active but requires setup', 'google-site-kit' ) }
 														</h1>
 														<p className="googlesitekit-setup__description">
 															{ __( 'Site Kit Service will guide you through 3 simple setup steps.', 'google-site-kit' ) }

--- a/assets/js/components/setup/setup-proxy.js
+++ b/assets/js/components/setup/setup-proxy.js
@@ -1,0 +1,138 @@
+/**
+ * Setup component.
+ *
+ * Site Kit by Google, Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import Header from 'GoogleComponents/header';
+import Button from 'GoogleComponents/button';
+import Layout from 'GoogleComponents/layout/layout';
+import { sendAnalyticsTrackingEvent } from 'GoogleUtil';
+import { getSiteKitAdminURL } from 'SiteKitCore/util';
+
+const { __ } = wp.i18n;
+const { Component, Fragment } = wp.element;
+const { delay } = lodash;
+
+class SetupUsingProxy extends Component {
+	constructor( props ) {
+		super( props );
+
+		const { connectUrl } = googlesitekit.admin;
+
+		const {
+			isAuthenticated,
+			hasSearchConsoleProperty,
+			isSiteKitConnected,
+			isVerified,
+			needReauthenticate,
+		} = googlesitekit.setup;
+
+		const { canSetup } = googlesitekit.permissions;
+
+		this.state = {
+			canSetup,
+			isAuthenticated,
+			isVerified,
+			needReauthenticate,
+			hasSearchConsoleProperty,
+			hasSearchConsolePropertyFromTheStart: hasSearchConsoleProperty,
+			connectUrl,
+			errorMsg: '',
+			isSiteKitConnected,
+			completeSetup: false,
+		};
+	}
+
+	isSetupFinished() {
+		const {
+			isSiteKitConnected,
+			completeSetup,
+		} = this.state;
+
+		return isSiteKitConnected && completeSetup;
+	}
+
+	render() {
+		const {
+			connectUrl,
+		} = this.state;
+
+		if ( this.isSetupFinished() ) {
+			const redirectUrl = getSiteKitAdminURL(
+				'googlesitekit-dashboard',
+				{
+					notification: 'authentication_success',
+				},
+			);
+
+			delay( function() {
+				window.location.replace( redirectUrl );
+			}, 500, 'later' );
+		}
+
+		const { proxySetupURL } = googlesitekit.admin;
+
+		return (
+			<Fragment>
+				<Header />
+				<div className="googlesitekit-wizard">
+					<div className="mdc-layout-grid">
+						<div className="mdc-layout-grid__inner">
+							<div className="
+								mdc-layout-grid__cell
+								mdc-layout-grid__cell--span-12
+							">
+								<Layout>
+									<section className="googlesitekit-wizard-progress">
+										<div className="googlesitekit-setup__footer">
+											<div className="mdc-layout-grid">
+												<div className="mdc-layout-grid__inner">
+													<div className="
+														mdc-layout-grid__cell
+														mdc-layout-grid__cell--span-12
+													">
+														<h1 className="googlesitekit-setup__title">
+															{ __( 'Time to set up the Site Kit plugin', 'google-site-kit' ) }
+														</h1>
+														<p className="googlesitekit-setup__description">
+															{ __( 'Site Kit Service will guide you through 3 simple setup steps.', 'google-site-kit' ) }
+														</p>
+														<Button
+															href={ proxySetupURL }
+															onClick={ () => {
+																sendAnalyticsTrackingEvent( 'plugin_setup', 'signin_with_google' );
+																document.location = connectUrl;
+															} }
+														>{ __( 'Start setup', 'google-site-kit' ) }</Button>
+													</div>
+												</div>
+											</div>
+										</div>
+									</section>
+								</Layout>
+							</div>
+						</div>
+					</div>
+				</div>
+			</Fragment>
+		);
+	}
+}
+
+export default SetupUsingProxy;

--- a/includes/Core/Admin/Screens.php
+++ b/includes/Core/Admin/Screens.php
@@ -334,20 +334,6 @@ final class Screens {
 					$assets->enqueue_asset( 'googlesitekit_dashboard_splash' );
 				},
 				'render_callback'     => function( Context $context ) {
-					$auth_client = new \Google\Site_Kit\Core\Authentication\Clients\OAuth_Client( $this->context );
-					if ( $auth_client->using_proxy() ) {
-						$setup_url = $auth_client->get_proxy_setup_url();
-						?>
-						<div class="wrap">
-							<h1>Temporary Setup</h1>
-
-							<p>
-								<a href="<?php echo esc_url( $setup_url ); ?>">Go To Setup</a>
-							</p>
-						</div>
-						<?php
-						return;
-					}
 					?>
 					<div class="googlesitekit-plugin">
 						<?php

--- a/includes/Core/Assets/Assets.php
+++ b/includes/Core/Assets/Assets.php
@@ -11,7 +11,6 @@
 namespace Google\Site_Kit\Core\Assets;
 
 use Google\Site_Kit\Context;
-use Google\Site_Kit\Core\Authentication\Clients\OAuth_Client;
 use Google\Site_Kit\Core\Permissions\Permissions;
 use Google\Site_Kit\Core\Storage\Cache;
 
@@ -443,8 +442,6 @@ final class Assets {
 		$cache        = new Cache();
 		$current_user = wp_get_current_user();
 		$site_url     = $this->context->get_reference_site_url();
-
-		$auth_client = new \Google\Site_Kit\Core\Authentication\Clients\OAuth_Client( $this->context );
 
 		$admin_data = array(
 			'siteURL'          => esc_url_raw( $site_url ),

--- a/includes/Core/Assets/Assets.php
+++ b/includes/Core/Assets/Assets.php
@@ -447,7 +447,6 @@ final class Assets {
 		$auth_client = new \Google\Site_Kit\Core\Authentication\Clients\OAuth_Client( $this->context );
 
 		$admin_data = array(
-			'usingProxy'       => $auth_client->using_proxy(),
 			'siteURL'          => esc_url_raw( $site_url ),
 			'siteName'         => get_bloginfo( 'name' ),
 			'siteUserId'       => md5( $site_url . $current_user->ID ),

--- a/includes/Core/Assets/Assets.php
+++ b/includes/Core/Assets/Assets.php
@@ -11,6 +11,7 @@
 namespace Google\Site_Kit\Core\Assets;
 
 use Google\Site_Kit\Context;
+use Google\Site_Kit\Core\Authentication\Clients\OAuth_Client;
 use Google\Site_Kit\Core\Permissions\Permissions;
 use Google\Site_Kit\Core\Storage\Cache;
 
@@ -443,7 +444,10 @@ final class Assets {
 		$current_user = wp_get_current_user();
 		$site_url     = $this->context->get_reference_site_url();
 
+		$auth_client = new \Google\Site_Kit\Core\Authentication\Clients\OAuth_Client( $this->context );
+
 		$admin_data = array(
+			'usingProxy'       => $auth_client->using_proxy(),
 			'siteURL'          => esc_url_raw( $site_url ),
 			'siteName'         => get_bloginfo( 'name' ),
 			'siteUserId'       => md5( $site_url . $current_user->ID ),

--- a/tests/e2e/specs/plugin-activation.test.js
+++ b/tests/e2e/specs/plugin-activation.test.js
@@ -6,9 +6,11 @@ import { deactivatePlugin, activatePlugin } from '@wordpress/e2e-test-utils';
 describe( 'Plugin Activation Notice', () => {
 	beforeEach( async () => {
 		await deactivatePlugin( 'google-site-kit' );
+		await activatePlugin( 'e2e-tests-gcp-credentials-plugin' );
 	} );
 
 	afterEach( async () => {
+		await deactivatePlugin( 'e2e-tests-gcp-credentials-plugin' );
 		await activatePlugin( 'google-site-kit' );
 	} );
 

--- a/tests/e2e/specs/plugin-activation.test.js
+++ b/tests/e2e/specs/plugin-activation.test.js
@@ -36,7 +36,5 @@ describe( 'Plugin Activation Notice', () => {
 
 		// Ensure we're on the first step.
 		await expect( page ).toMatchElement( '.googlesitekit-wizard-progress-step__number--inprogress', { text: '1' } );
-
-		await deactivatePlugin( 'google-site-kit' );
 	} );
 } );

--- a/tests/e2e/specs/plugin-reset.test.js
+++ b/tests/e2e/specs/plugin-reset.test.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { visitAdminPage } from '@wordpress/e2e-test-utils';
+import { activatePlugin, deactivatePlugin, visitAdminPage } from '@wordpress/e2e-test-utils';
 
 /**
  * Internal dependencies
@@ -19,6 +19,7 @@ describe( 'Plugin Reset', () => {
 		await setAuthToken();
 		await setSiteVerification();
 		await setSearchConsoleProperty();
+		await activatePlugin( 'e2e-tests-gcp-credentials-plugin' );
 	} );
 
 	beforeEach( async () => {
@@ -30,6 +31,10 @@ describe( 'Plugin Reset', () => {
 		// Click on Admin Settings Tab.
 		await expect( page ).toClick( 'button.mdc-tab', { text: 'Admin Settings' } );
 		await page.waitForSelector( '.googlesitekit-settings-module__footer' );
+	} );
+
+	afterAll( async () => {
+		await deactivatePlugin( 'e2e-tests-gcp-credentials-plugin' );
 	} );
 
 	it( 'displays a confirmation dialog when clicking the "Reset Site Kit" link', async () => {
@@ -47,6 +52,7 @@ describe( 'Plugin Reset', () => {
 	} );
 
 	it( 'disconnects Site Kit by clicking the "Reset" button in the confirmation dialog', async () => {
+		await page.waitForSelector( 'button.googlesitekit-cta-link' );
 		await expect( page ).toClick( 'button.googlesitekit-cta-link', { text: 'Reset Site Kit' } );
 		await page.waitForSelector( '.mdc-dialog--open .mdc-button' );
 


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #642.

Adds a setup screen that links the user to the proxy, if the proxy is enabled.

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
