### PR TITLE
Add auth proxy upgrade routine

### DIFF
--- a/includes/Core/Admin/Notice.php
+++ b/includes/Core/Admin/Notice.php
@@ -124,7 +124,7 @@ final class Notice {
 		}
 
 		?>
-		<div id="<?php echo esc_attr( '#googlesitekit-notice-' . $this->slug ); ?>" class="<?php echo esc_attr( $class ); ?>">
+		<div id="<?php echo esc_attr( 'googlesitekit-notice-' . $this->slug ); ?>" class="<?php echo esc_attr( $class ); ?>">
 			<?php echo $content; /* phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped */ ?>
 		</div>
 		<?php

--- a/includes/Core/Util/Beta_Migration.php
+++ b/includes/Core/Util/Beta_Migration.php
@@ -24,11 +24,6 @@ use Google\Site_Kit\Core\Storage\Options;
  */
 class Beta_Migration {
 	/**
-	 * Target database version.
-	 */
-	const DB_VERSION = '1.0.0';
-
-	/**
 	 * Option name to identify a site which was previously configured without the proxy.
 	 */
 	const OPTION_IS_PRE_PROXY_INSTALL = 'googlesitekit_pre_proxy_install';
@@ -104,30 +99,22 @@ class Beta_Migration {
 			}
 		);
 
-		add_action( 'admin_init', array( $this, 'maybe_run_upgrade' ) );
+		add_action( 'admin_init', array( $this, 'migrate_old_credentials' ) );
 	}
 
 	/**
-	 * Runs the upgrade based on the current DB version.
+	 * Migrates old GCP credentials if saved in the option.
+	 *
+	 * GCP credentials are still possible to use (for now), but only via filter
+	 * so they should never be present in the option / Credentials anymore.
 	 */
-	public function maybe_run_upgrade() {
-		if ( version_compare( get_option( 'googlesitekit_db_version', '0' ), self::DB_VERSION, '<' ) ) {
-			$this->run_upgrade();
-		}
-	}
-
-	/**
-	 * Runs the upgrade.
-	 */
-	private function run_upgrade() {
+	public function migrate_old_credentials() {
 		$credentials = $this->credentials->get();
 
 		if ( ! strpos( $credentials['oauth2_client_id'], '.apps.sitekit.withgoogle.com' ) ) {
 			$this->options->delete( Credentials::OPTION );
 			$this->options->set( self::OPTION_IS_PRE_PROXY_INSTALL, 1 );
 		}
-
-		update_option( 'googlesitekit_db_version', self::DB_VERSION );
 	}
 
 	/**

--- a/includes/Core/Util/Beta_Migration.php
+++ b/includes/Core/Util/Beta_Migration.php
@@ -111,7 +111,7 @@ class Beta_Migration {
 	public function migrate_old_credentials() {
 		$credentials = $this->credentials->get();
 
-		if ( ! strpos( $credentials['oauth2_client_id'], '.apps.sitekit.withgoogle.com' ) ) {
+		if ( $credentials['oauth2_client_id'] && ! strpos( $credentials['oauth2_client_id'], '.apps.sitekit.withgoogle.com' ) ) {
 			$this->options->delete( Credentials::OPTION );
 			$this->options->set( self::OPTION_IS_PRE_PROXY_INSTALL, 1 );
 		}

--- a/includes/Core/Util/Beta_Migration.php
+++ b/includes/Core/Util/Beta_Migration.php
@@ -1,0 +1,196 @@
+<?php
+/**
+ * Beta_Migration
+ *
+ * @package   Google\Site_Kit\Core\Util
+ * @copyright 2019 Google LLC
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
+ * @link      https://sitekit.withgoogle.com
+ */
+
+namespace Google\Site_Kit\Core\Util;
+
+use Google\Site_Kit\Context;
+use Google\Site_Kit\Core\Admin\Notice;
+use Google\Site_Kit\Core\Authentication\Clients\OAuth_Client;
+use Google\Site_Kit\Core\Authentication\Credentials;
+use Google\Site_Kit\Core\Permissions\Permissions;
+use Google\Site_Kit\Core\Storage\Options;
+
+/**
+ * Class Beta_Migration
+ *
+ * @package Google\Site_Kit\Core\Util
+ */
+class Beta_Migration {
+	/**
+	 * Target database version.
+	 */
+	const DB_VERSION = '1.0.0';
+
+	/**
+	 * Option name to identify a site which was previously configured without the proxy.
+	 */
+	const OPTION_IS_PRE_PROXY_INSTALL = 'googlesitekit_pre_proxy_install';
+
+	/**
+	 * Query parameter for identifying a pre-proxy action.
+	 */
+	const PARAM_PRE_PROXY_ACTION = 'googlesitekit_pre_proxy_action';
+
+	/**
+	 * WP Nonce Action.
+	 */
+	const ACTION = 'dismiss_reconnect_notice';
+
+	/**
+	 * Options instance.
+	 *
+	 * @var Options
+	 */
+	protected $options;
+
+	/**
+	 * Credentials instance.
+	 *
+	 * @var Credentials
+	 */
+	protected $credentials;
+
+	/**
+	 * OAuth Client instance.
+	 *
+	 * @var OAuth_Client
+	 */
+	protected $oauth_client;
+
+	/**
+	 * Beta_Migration constructor.
+	 *
+	 * @param Context $context Plugin context instance.
+	 */
+	public function __construct( Context $context ) {
+		$this->options      = new Options( $context );
+		$this->credentials  = new Credentials( $this->options );
+		$this->oauth_client = new OAuth_Client( $context );
+	}
+
+	/**
+	 * Registers hooks.
+	 */
+	public function register() {
+		$notice = new Notice(
+			'beta-migration',
+			array(
+				'content'         => function () {
+					return $this->get_notice_content();
+				},
+				'active_callback' => function () {
+					return $this->options->get( self::OPTION_IS_PRE_PROXY_INSTALL ) && current_user_can( Permissions::SETUP );
+				},
+			)
+		);
+
+		add_action( 'admin_init', array( $this, 'handle_action' ) );
+		add_action( 'admin_init', array( $this, 'maybe_run_upgrade' ) );
+		add_action( 'admin_notices', array( $notice, 'render' ) );
+		add_action( 'network_admin_notices', array( $notice, 'render' ) );
+	}
+
+	/**
+	 * Runs the upgrade based on the current DB version.
+	 */
+	public function maybe_run_upgrade() {
+		if ( version_compare( get_option( 'googlesitekit_db_version', '0' ), self::DB_VERSION, '<' ) ) {
+			$this->run_upgrade();
+		}
+	}
+
+	/**
+	 * Handles the pre-proxy action chosen by the user.
+	 */
+	public function handle_action() {
+		$action = filter_input( INPUT_GET, self::PARAM_PRE_PROXY_ACTION );
+
+		if ( ! $action ) {
+			return;
+		}
+
+		if ( ! check_admin_referer( self::ACTION ) || ! in_array( $action, array( 'reconnect', 'ignore' ), true ) ) {
+			return;
+		}
+
+		$this->options->delete( self::OPTION_IS_PRE_PROXY_INSTALL );
+
+		if ( 'reconnect' === $action ) {
+			wp_safe_redirect( $this->oauth_client->get_proxy_setup_url() );
+		} elseif ( 'ignore' === $action ) {
+			// Redirect to the current URL without the action params.
+			wp_safe_redirect(
+				add_query_arg(
+					array(
+						self::PARAM_PRE_PROXY_ACTION => false,
+						'_wpnonce'                   => false,
+					)
+				)
+			);
+		}
+
+		exit;
+	}
+
+	/**
+	 * Runs the upgrade.
+	 */
+	private function run_upgrade() {
+		$credentials = $this->credentials->get();
+
+		if ( ! strpos( $credentials['oauth2_client_id'], '.apps.sitekit.withgoogle.com' ) ) {
+			$this->options->delete( Credentials::OPTION );
+			$this->options->set( self::OPTION_IS_PRE_PROXY_INSTALL, 1 );
+		}
+
+		update_option( 'googlesitekit_db_version', self::DB_VERSION );
+	}
+
+	/**
+	 * Gets the content to render in the reconnect notice.
+	 *
+	 * @return string
+	 */
+	private function get_notice_content() {
+		ob_start();
+		?>
+		<p>
+			<?php esc_html_e( 'We’ve made a lot of improvements to get Site Kit ready for general release! In order to use this new version, you’ll need to go through the updated setup flow to re-generate your credentials. Once you’re done, all your data will still be there.', 'google-site-kit' ); ?>
+		</p>
+		<p style="display: flex; align-items: center;">
+			<a href="<?php echo esc_url( $this->get_action_url( 'reconnect' ) ); ?>" class="button button-primary button-large">
+				<?php esc_html_e( 'Reconnect Site Kit', 'google-site-kit' ); ?>
+			</a>
+			<span style="width: 1rem;"></span>
+			<a href="<?php echo esc_url( $this->get_action_url( 'ignore' ) ); ?>">
+				<?php echo esc_html_x( 'Ignore', 'ignore/dismiss the notice', 'google-site-kit' ); ?>
+			</a>
+		</p>
+		<?php
+
+		return ob_get_clean();
+	}
+
+	/**
+	 * Gets the URL for performing the given action.
+	 *
+	 * @param string $action Action to perform.
+	 *
+	 * @return string
+	 */
+	private function get_action_url( $action ) {
+		return add_query_arg(
+			array(
+				self::PARAM_PRE_PROXY_ACTION => $action,
+				'_wpnonce'                   => wp_create_nonce( self::ACTION ),
+			)
+		);
+	}
+}

--- a/includes/Core/Util/Beta_Migration.php
+++ b/includes/Core/Util/Beta_Migration.php
@@ -104,7 +104,6 @@ class Beta_Migration {
 			}
 		);
 
-		add_action( 'admin_init', array( $this, 'handle_action' ) );
 		add_action( 'admin_init', array( $this, 'maybe_run_upgrade' ) );
 	}
 

--- a/includes/Core/Util/Beta_Migration.php
+++ b/includes/Core/Util/Beta_Migration.php
@@ -74,16 +74,23 @@ class Beta_Migration {
 	 * Registers hooks.
 	 */
 	public function register() {
-		$notice = new Notice(
-			'beta-migration',
-			array(
-				'content'         => function () {
-					return $this->get_notice_content();
-				},
-				'active_callback' => function () {
-					return $this->options->get( self::OPTION_IS_PRE_PROXY_INSTALL ) && current_user_can( Permissions::SETUP );
-				},
-			)
+		add_filter(
+			'googlesitekit_admin_notices',
+			function ( $notices ) {
+				$notices[] = new Notice(
+					'beta-migration',
+					array(
+						'content'         => function () {
+							return $this->get_notice_content();
+						},
+						'active_callback' => function () {
+							return $this->options->get( self::OPTION_IS_PRE_PROXY_INSTALL ) && current_user_can( Permissions::SETUP );
+						},
+					)
+				);
+
+				return $notices;
+			}
 		);
 
 		add_action(
@@ -99,8 +106,6 @@ class Beta_Migration {
 
 		add_action( 'admin_init', array( $this, 'handle_action' ) );
 		add_action( 'admin_init', array( $this, 'maybe_run_upgrade' ) );
-		add_action( 'admin_notices', array( $notice, 'render' ) );
-		add_action( 'network_admin_notices', array( $notice, 'render' ) );
 	}
 
 	/**

--- a/includes/Core/Util/Beta_Migration.php
+++ b/includes/Core/Util/Beta_Migration.php
@@ -34,14 +34,9 @@ class Beta_Migration {
 	const OPTION_IS_PRE_PROXY_INSTALL = 'googlesitekit_pre_proxy_install';
 
 	/**
-	 * Query parameter for identifying a pre-proxy action.
+	 * WP Ajax Dismiss Action.
 	 */
-	const PARAM_PRE_PROXY_ACTION = 'googlesitekit_pre_proxy_action';
-
-	/**
-	 * WP Nonce Action.
-	 */
-	const ACTION = 'dismiss_reconnect_notice';
+	const ACTION_DISMISS = 'googlesitekit_dismiss';
 
 	/**
 	 * Options instance.
@@ -92,9 +87,9 @@ class Beta_Migration {
 		);
 
 		add_action(
-			'wp_ajax_googlesitekit_' . self::ACTION,
+			'wp_ajax_' . self::ACTION_DISMISS,
 			function () {
-				check_ajax_referer( self::ACTION );
+				check_ajax_referer( self::ACTION_DISMISS );
 
 				$this->options->delete( self::OPTION_IS_PRE_PROXY_INSTALL );
 
@@ -162,8 +157,8 @@ class Beta_Migration {
 				$notice
 					.on( 'click', 'a', function () {
 						$.post( ajaxurl, {
-							action: "<?php echo esc_js( 'googlesitekit_' . self::ACTION ); ?>",
-							_wpnonce: "<?php echo esc_js( wp_create_nonce( self::ACTION ) ); ?>"
+							action: "<?php echo esc_js( self::ACTION_DISMISS ); ?>",
+							_wpnonce: "<?php echo esc_js( wp_create_nonce( self::ACTION_DISMISS ) ); ?>"
 						} );
 					} )
 					.on( 'click', '[data-dismiss]', function( event ) {

--- a/includes/Core/Util/Reset.php
+++ b/includes/Core/Util/Reset.php
@@ -117,6 +117,8 @@ final class Reset {
 		$this->options->delete( TagManager::OPTION );
 		$this->options->delete( First_Admin::OPTION );
 		$this->options->delete( OAuth_Client::OPTION_PROXY_NONCE );
+		$this->options->delete( Beta_Migration::OPTION_IS_PRE_PROXY_INSTALL );
+		$this->options->delete( 'googlesitekit_db_version' );
 
 		// Clean up old site verification data, moved to user options.
 		// Also clean up other old unused options.

--- a/includes/Core/Util/Reset.php
+++ b/includes/Core/Util/Reset.php
@@ -118,7 +118,6 @@ final class Reset {
 		$this->options->delete( First_Admin::OPTION );
 		$this->options->delete( OAuth_Client::OPTION_PROXY_NONCE );
 		$this->options->delete( Beta_Migration::OPTION_IS_PRE_PROXY_INSTALL );
-		$this->options->delete( 'googlesitekit_db_version' );
 
 		// Clean up old site verification data, moved to user options.
 		// Also clean up other old unused options.

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -151,6 +151,7 @@ final class Plugin {
 		$reset = new Core\Util\Reset( $this->context, $options );
 
 		( new Core\Util\Activation( $this->context, $options, $assets ) )->register();
+		( new Core\Util\Beta_Migration( $this->context ) )->register();
 		( new Core\Util\Uninstallation( $reset ) )->register();
 		( new Core\Util\Updater() )->register();
 		( new Core\Util\Deactivation() )->register();

--- a/tests/e2e/plugins/auth.php
+++ b/tests/e2e/plugins/auth.php
@@ -19,16 +19,7 @@ use Google\Site_Kit\Plugin;
 /**
  * Provide dummy client configuration, normally provided in step 1 of the set up.
  */
-add_filter( 'pre_option_googlesitekit_credentials', function () {
-	return ( new Data_Encryption() )->encrypt(
-		serialize(
-			array(
-				'oauth2_client_id'     => '1234567890-asdfasdfasdfasdfzxcvzxcvzxcvzxcv.apps.googleusercontent.com',
-				'oauth2_client_secret' => 'x_xxxxxxxxxxxxxxxxxxxxxx',
-			)
-		)
-	);
-} );
+require_once __DIR__ . '/gcp-credentials.php';
 
 /**
  * Provide a dummy access token to fake an authenticated state.

--- a/tests/e2e/plugins/gcp-credentials.php
+++ b/tests/e2e/plugins/gcp-credentials.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Plugin Name: E2E Tests GCP Credentials Plugin
+ * Plugin URI:  https://github.com/google/site-kit-wp
+ * Description: Utility plugin for forcing legacy Google Cloud Project OAuth credentials during E2E tests.
+ * Author:      Google
+ * Author URI:  https://opensource.google.com
+ *
+ * @package   Google\Site_Kit
+ * @copyright 2019 Google LLC
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
+ * @link      https://sitekit.withgoogle.com
+ */
+
+use Google\Site_Kit\Core\Storage\Data_Encryption;
+
+/**
+ * Provide dummy client configuration, normally provided in step 1 of the set up.
+ * We need to filter the credentials option here due to `isSiteKitConnected`'s dependence
+ * on `Credentials` in `\Google\Site_Kit\Core\Authentication\Authentication::inline_js_setup_data`
+ * which is option-based.
+ */
+add_filter( 'pre_option_googlesitekit_credentials', function () {
+	return ( new Data_Encryption() )->encrypt(
+		serialize(
+			array(
+				'oauth2_client_id'     => '1234567890-asdfasdfasdfasdfzxcvzxcvzxcvzxcv.apps.googleusercontent.com',
+				'oauth2_client_secret' => 'x_xxxxxxxxxxxxxxxxxxxxxx',
+			)
+		)
+	);
+} );

--- a/tests/e2e/specs/auth-flow-admin-2.test.js
+++ b/tests/e2e/specs/auth-flow-admin-2.test.js
@@ -14,7 +14,6 @@ import {
 import {
 	logoutUser,
 	setAuthToken,
-	setClientConfig,
 	setSearchConsoleProperty,
 	setSiteVerification,
 	useRequestInterception,
@@ -39,9 +38,9 @@ describe( 'the set up flow for the second administrator', () => {
 	} );
 
 	beforeEach( async () => {
+		await activatePlugin( 'e2e-tests-gcp-credentials-plugin' );
 		await activatePlugin( 'e2e-tests-oauth-callback-plugin' );
 		await activatePlugin( 'e2e-tests-site-verification-api-mock' );
-		await setClientConfig();
 		await setAuthToken();
 		await setSiteVerification();
 		await setSearchConsoleProperty();

--- a/tests/e2e/specs/auth-flow.test.js
+++ b/tests/e2e/specs/auth-flow.test.js
@@ -11,7 +11,6 @@ import {
 	resetSiteKit,
 	setSearchConsoleProperty,
 	useRequestInterception,
-	setClientConfig,
 	setAuthToken,
 	setSiteVerification,
 } from '../utils';
@@ -53,8 +52,11 @@ const signOut = async () => {
 
 describe( 'Site Kit set up flow for the first time', () => {
 	beforeAll( async () => {
-		await activatePlugin( 'e2e-tests-oauth-callback-plugin' );
 		await setSearchConsoleProperty();
+	} );
+
+	beforeEach( async () => {
+		await activatePlugin( 'e2e-tests-gcp-credentials-plugin' );
 	} );
 
 	afterEach( async () => {
@@ -63,9 +65,8 @@ describe( 'Site Kit set up flow for the first time', () => {
 	} );
 
 	it( 'authenticates from splash page', async () => {
-		await setClientConfig();
+		await activatePlugin( 'e2e-tests-oauth-callback-plugin' );
 		await visitAdminPage( 'admin.php', 'page=googlesitekit-splash' );
-
 		// Sign in with Google
 		await page.setRequestInterception( true );
 		useRequestInterception( stubGoogleSignIn );
@@ -77,7 +78,6 @@ describe( 'Site Kit set up flow for the first time', () => {
 	} );
 
 	it( 'disconnects user from Site Kit', async () => {
-		await setClientConfig();
 		await setAuthToken();
 		await setSiteVerification();
 		await setSearchConsoleProperty();

--- a/tests/e2e/specs/auth-setup-search-console.test.js
+++ b/tests/e2e/specs/auth-setup-search-console.test.js
@@ -9,7 +9,6 @@ import { activatePlugin, createURL, visitAdminPage } from '@wordpress/e2e-test-u
 import {
 	deactivateUtilityPlugins,
 	resetSiteKit,
-	setClientConfig,
 	useRequestInterception,
 	wpApiFetch,
 } from '../utils';
@@ -36,6 +35,7 @@ describe( 'Site Kit set up flow for the first time with search console setup', (
 	} );
 
 	beforeEach( async () => {
+		await activatePlugin( 'e2e-tests-gcp-credentials-plugin' );
 		await activatePlugin( 'e2e-tests-oauth-callback-plugin' );
 		await activatePlugin( 'e2e-tests-site-verification-api-mock' );
 
@@ -52,7 +52,6 @@ describe( 'Site Kit set up flow for the first time with search console setup', (
 	} );
 
 	it( 'inserts property to search console when site does not exist', async () => {
-		await setClientConfig();
 		await visitAdminPage( 'admin.php', 'page=googlesitekit-splash' );
 
 		await expect( page ).toClick( '.googlesitekit-wizard-step button', { text: /sign in with Google/i } );
@@ -71,7 +70,6 @@ describe( 'Site Kit set up flow for the first time with search console setup', (
 	} );
 
 	it( 'saves search console property when site exists', async () => {
-		await setClientConfig();
 		await visitAdminPage( 'admin.php', 'page=googlesitekit-splash' );
 
 		await expect( page ).toClick( '.googlesitekit-wizard-step button', { text: /sign in with Google/i } );

--- a/tests/e2e/specs/auth-setup-verification.test.js
+++ b/tests/e2e/specs/auth-setup-verification.test.js
@@ -9,7 +9,6 @@ import { activatePlugin, createURL, visitAdminPage } from '@wordpress/e2e-test-u
 import {
 	deactivateUtilityPlugins,
 	resetSiteKit,
-	setClientConfig,
 	useRequestInterception,
 	wpApiFetch,
 } from '../utils';
@@ -36,6 +35,7 @@ describe( 'Site Kit set up flow for the first time with site verification', () =
 	} );
 
 	beforeEach( async () => {
+		await activatePlugin( 'e2e-tests-gcp-credentials-plugin' );
 		await activatePlugin( 'e2e-tests-oauth-callback-plugin' );
 		await activatePlugin( 'e2e-tests-site-verification-api-mock' );
 	} );
@@ -50,7 +50,6 @@ describe( 'Site Kit set up flow for the first time with site verification', () =
 	} );
 
 	it( 'prompts for confirmation if user is not verified for the site', async () => {
-		await setClientConfig();
 		await visitAdminPage( 'admin.php', 'page=googlesitekit-splash' );
 
 		await expect( page ).toClick( '.googlesitekit-wizard-step button', { text: /sign in with Google/i } );
@@ -73,7 +72,6 @@ describe( 'Site Kit set up flow for the first time with site verification', () =
 	} );
 
 	it( 'does not prompt for verification if the user is already verified for the site', async () => {
-		await setClientConfig();
 		// Simulate that the user is already verified.
 		await wpApiFetch( {
 			path: 'google-site-kit/v1/e2e/verify-site',

--- a/tests/e2e/utils/test-client-config.js
+++ b/tests/e2e/utils/test-client-config.js
@@ -1,7 +1,7 @@
 /* eslint-disable camelcase */
 export const testClientConfig = {
 	web: {
-		client_id: '1234567890-asdfasdfasdfasdfzxcvzxcvzxcvzxcv.apps.googleusercontent.com',
+		client_id: '1234567890-asdfasdfasdfasdfzxcvzxcvzxcvzxcv.apps.sitekit.withgoogle.com',
 		client_secret: 'x_xxxxxxxxxxxxxxxxxxxxxx',
 		project_id: 'test-project-id',
 		auth_uri: 'https://accounts.google.com/o/oauth2/auth',

--- a/tests/phpunit/integration/Core/Util/Beta_MigrationTest.php
+++ b/tests/phpunit/integration/Core/Util/Beta_MigrationTest.php
@@ -21,15 +21,13 @@ class Beta_MigrationTest extends TestCase {
 	public function test_register() {
 		$migration = new Beta_Migration( new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE ) );
 		remove_all_actions( 'admin_init' );
-		remove_all_actions( 'admin_notices' );
-		remove_all_actions( 'network_admin_notices' );
+		remove_all_filters( 'googlesitekit_admin_notices' );
 		remove_all_actions( 'wp_ajax_' . Beta_Migration::ACTION_DISMISS );
 
 		$migration->register();
 
 		$this->assertTrue( has_action( 'admin_init' ) );
-		$this->assertTrue( has_action( 'admin_notices' ) );
-		$this->assertTrue( has_action( 'network_admin_notices' ) );
+		$this->assertTrue( has_filter( 'googlesitekit_admin_notices' ) );
 		$this->assertTrue( has_action( 'wp_ajax_' . Beta_Migration::ACTION_DISMISS ) );
 	}
 

--- a/tests/phpunit/integration/Core/Util/Beta_MigrationTest.php
+++ b/tests/phpunit/integration/Core/Util/Beta_MigrationTest.php
@@ -1,0 +1,107 @@
+<?php
+/**
+ * Beta_MigrationTest
+ *
+ * @package   Google\Site_Kit\Tests\Core\Util
+ * @copyright 2019 Google LLC
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
+ * @link      https://sitekit.withgoogle.com
+ */
+
+namespace Google\Site_Kit\Tests\Core\Util;
+
+use Google\Site_Kit\Context;
+use Google\Site_Kit\Core\Authentication\Credentials;
+use Google\Site_Kit\Core\Storage\Options;
+use Google\Site_Kit\Core\Util\Beta_Migration;
+use Google\Site_Kit\Tests\TestCase;
+
+class Beta_MigrationTest extends TestCase {
+
+	public function test_register() {
+		$migration = new Beta_Migration( new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE ) );
+		remove_all_actions( 'admin_init' );
+		remove_all_actions( 'admin_notices' );
+		remove_all_actions( 'network_admin_notices' );
+		remove_all_actions( 'wp_ajax_googlesitekit_' . Beta_Migration::ACTION );
+
+		$migration->register();
+
+		$this->assertTrue( has_action( 'admin_init' ) );
+		$this->assertTrue( has_action( 'admin_notices' ) );
+		$this->assertTrue( has_action( 'network_admin_notices' ) );
+		$this->assertTrue( has_action( 'wp_ajax_googlesitekit_' . Beta_Migration::ACTION ) );
+	}
+
+	public function test_maybe_run_upgrade() {
+		$context     = new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE );
+		$options     = new Options( $context );
+		$credentials = new Credentials( $options );
+		$migration   = new Beta_Migration( $context );
+
+		// Upgrade will update the DB version if run.
+		$this->delete_db_version();
+		$this->delete_credentials();
+
+		$migration->maybe_run_upgrade();
+
+		$this->assertEquals( Beta_Migration::DB_VERSION, $options->get( 'googlesitekit_db_version' ) );
+		$this->assertFalse( $credentials->has() );
+
+		// The upgrade will delete old GCP credentials if present.
+		$this->delete_db_version();
+		$this->set_gcp_credentials();
+		$this->assertTrue( $credentials->has() );
+
+		$migration->maybe_run_upgrade();
+
+		$this->assertFalse( $credentials->has() );
+		$this->assertEquals( Beta_Migration::DB_VERSION, $options->get( 'googlesitekit_db_version' ) );
+
+		// The upgrade will not delete proxy credentials if present.
+		$this->delete_db_version();
+		$this->set_proxy_credentials();
+		$this->assertTrue( $credentials->has() );
+
+		$migration->maybe_run_upgrade();
+
+		$this->assertTrue( $credentials->has() );
+		$this->assertEquals( Beta_Migration::DB_VERSION, $options->get( 'googlesitekit_db_version' ) );
+
+		// The upgrade will not run if the DB version is greater than or equal to DB_VERSION.
+		$options->set( 'googlesitekit_db_version', Beta_Migration::DB_VERSION );
+		// Set GCP credentials which would be deleted if the upgrade were to run.
+		$this->set_gcp_credentials();
+		$this->assertTrue( $credentials->has() );
+		$credentials_before = $credentials->get();
+
+		$migration->maybe_run_upgrade();
+
+		$this->assertTrue( $credentials->has() );
+		// Credentials are the same as before.
+		$this->assertEquals( $credentials_before, $credentials->get() );
+		$this->assertEquals( Beta_Migration::DB_VERSION, $options->get( 'googlesitekit_db_version' ) );
+	}
+
+	private function delete_db_version() {
+		( new Options( new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE ) ) )->delete( 'googlesitekit_db_version' );
+	}
+
+	private function delete_credentials() {
+		( new Options( new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE ) ) )->delete( Credentials::OPTION );
+	}
+
+	private function set_gcp_credentials() {
+		( new Credentials( new Options( new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE ) ) ) )->set( array(
+			'oauth2_client_id'     => 'test-client-id.apps.googleusercontent.com',
+			'oauth2_client_secret' => 'test-client-secret',
+		) );
+	}
+
+	private function set_proxy_credentials() {
+		( new Credentials( new Options( new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE ) ) ) )->set( array(
+			'oauth2_client_id'     => 'test-site-id.apps.sitekit.withgoogle.com',
+			'oauth2_client_secret' => 'test-site-secret',
+		) );
+	}
+}

--- a/tests/phpunit/integration/Core/Util/Beta_MigrationTest.php
+++ b/tests/phpunit/integration/Core/Util/Beta_MigrationTest.php
@@ -23,14 +23,14 @@ class Beta_MigrationTest extends TestCase {
 		remove_all_actions( 'admin_init' );
 		remove_all_actions( 'admin_notices' );
 		remove_all_actions( 'network_admin_notices' );
-		remove_all_actions( 'wp_ajax_googlesitekit_' . Beta_Migration::ACTION );
+		remove_all_actions( 'wp_ajax_' . Beta_Migration::ACTION_DISMISS );
 
 		$migration->register();
 
 		$this->assertTrue( has_action( 'admin_init' ) );
 		$this->assertTrue( has_action( 'admin_notices' ) );
 		$this->assertTrue( has_action( 'network_admin_notices' ) );
-		$this->assertTrue( has_action( 'wp_ajax_googlesitekit_' . Beta_Migration::ACTION ) );
+		$this->assertTrue( has_action( 'wp_ajax_' . Beta_Migration::ACTION_DISMISS ) );
 	}
 
 	public function test_maybe_run_upgrade() {

--- a/tests/phpunit/integration/Core/Util/Beta_MigrationTest.php
+++ b/tests/phpunit/integration/Core/Util/Beta_MigrationTest.php
@@ -38,51 +38,27 @@ class Beta_MigrationTest extends TestCase {
 		$migration   = new Beta_Migration( $context );
 
 		// Upgrade will update the DB version if run.
-		$this->delete_db_version();
 		$this->delete_credentials();
 
-		$migration->maybe_run_upgrade();
+		$migration->migrate_old_credentials();
 
-		$this->assertEquals( Beta_Migration::DB_VERSION, $options->get( 'googlesitekit_db_version' ) );
 		$this->assertFalse( $credentials->has() );
 
 		// The upgrade will delete old GCP credentials if present.
-		$this->delete_db_version();
 		$this->set_gcp_credentials();
 		$this->assertTrue( $credentials->has() );
 
-		$migration->maybe_run_upgrade();
+		$migration->migrate_old_credentials();
 
 		$this->assertFalse( $credentials->has() );
-		$this->assertEquals( Beta_Migration::DB_VERSION, $options->get( 'googlesitekit_db_version' ) );
 
 		// The upgrade will not delete proxy credentials if present.
-		$this->delete_db_version();
 		$this->set_proxy_credentials();
 		$this->assertTrue( $credentials->has() );
 
-		$migration->maybe_run_upgrade();
+		$migration->migrate_old_credentials();
 
 		$this->assertTrue( $credentials->has() );
-		$this->assertEquals( Beta_Migration::DB_VERSION, $options->get( 'googlesitekit_db_version' ) );
-
-		// The upgrade will not run if the DB version is greater than or equal to DB_VERSION.
-		$options->set( 'googlesitekit_db_version', Beta_Migration::DB_VERSION );
-		// Set GCP credentials which would be deleted if the upgrade were to run.
-		$this->set_gcp_credentials();
-		$this->assertTrue( $credentials->has() );
-		$credentials_before = $credentials->get();
-
-		$migration->maybe_run_upgrade();
-
-		$this->assertTrue( $credentials->has() );
-		// Credentials are the same as before.
-		$this->assertEquals( $credentials_before, $credentials->get() );
-		$this->assertEquals( Beta_Migration::DB_VERSION, $options->get( 'googlesitekit_db_version' ) );
-	}
-
-	private function delete_db_version() {
-		( new Options( new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE ) ) )->delete( 'googlesitekit_db_version' );
 	}
 
 	private function delete_credentials() {

--- a/tests/phpunit/integration/Core/Util/ResetTest.php
+++ b/tests/phpunit/integration/Core/Util/ResetTest.php
@@ -85,7 +85,6 @@ class ResetTest extends TestCase {
 			Search_Console::PROPERTY_OPTION,
 			TagManager::OPTION,
 			Beta_Migration::OPTION_IS_PRE_PROXY_INSTALL,
-			'googlesitekit_db_version',
 		);
 	}
 

--- a/tests/phpunit/integration/Core/Util/ResetTest.php
+++ b/tests/phpunit/integration/Core/Util/ResetTest.php
@@ -18,6 +18,7 @@ use Google\Site_Kit\Core\Authentication\Profile;
 use Google\Site_Kit\Core\Authentication\Verification;
 use Google\Site_Kit\Core\Authentication\Verification_Tag;
 use Google\Site_Kit\Core\Util\Activation;
+use Google\Site_Kit\Core\Util\Beta_Migration;
 use Google\Site_Kit\Core\Util\Reset;
 use Google\Site_Kit\Modules\AdSense;
 use Google\Site_Kit\Modules\Analytics;
@@ -83,6 +84,8 @@ class ResetTest extends TestCase {
 			PageSpeed_Insights::OPTION,
 			Search_Console::PROPERTY_OPTION,
 			TagManager::OPTION,
+			Beta_Migration::OPTION_IS_PRE_PROXY_INSTALL,
+			'googlesitekit_db_version',
 		);
 	}
 


### PR DESCRIPTION
## Summary

This PR adds an upgrade routine which checks for a database version in the site's options.
If the version is less than `1.0.0` it runs the upgrade which checks for GCP credentials. If found, they are deleted and the site gets another option added used to trigger a notice that informs the user that Site Kit needs to be reconnected.

If no credentials are found, or if proxy credentials are found, no action is taken and the DB version is updated to prevent the upgrade from happening again.

Addresses issue #646

## Relevant technical choices

* Notice layout uses very minimal inline flexbox styles to position the buttons
* Dismisses notice via ajax using jQuery with dismiss animations mirroring those used by core `is-dismissible` notices
    - ajax dismissal was preferred to a full page refresh with redirects

![image](https://user-images.githubusercontent.com/1621608/67032029-73292c80-f11b-11e9-8096-83059e3d1c42.png)

Looks great on mobile with Ectoplasm 😄 
![image](https://user-images.githubusercontent.com/1621608/67033084-98b73580-f11d-11e9-98b6-6815774a2ef1.png)


## Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
