### PR TITLE
Fix undefined property warnings in Google_Proxy_Client class

### DIFF
--- a/includes/Core/Authentication/Clients/Google_Proxy_Client.php
+++ b/includes/Core/Authentication/Clients/Google_Proxy_Client.php
@@ -153,9 +153,9 @@ final class Google_Proxy_Client extends Google_Client {
 				'authorizationUri'   => self::OAUTH2_AUTH_URL,
 				'tokenCredentialUri' => self::OAUTH2_TOKEN_URI,
 				'redirectUri'        => $this->getRedirectUri(),
-				'issuer'             => $this->config['client_id'],
-				'signingKey'         => $this->config['signing_key'],
-				'signingAlgorithm'   => $this->config['signing_algorithm'],
+				'issuer'             => $this->getClientId(),
+				'signingKey'         => null,
+				'signingAlgorithm'   => null,
 			)
 		);
 


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #645 / PR #614

## Relevant technical choices

* The `Google_Client::$client` property is private, so it cannot be accessed from the derived `Google_Proxy_Client`, which was causing three PHP warnings.
* The only value out of the three that is actually relevant for our purposes is the client ID, which fortunately we can easily obtain via `getClientId()` method.
* All direct accesses of the `$client` property have been eliminated.

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
