### PR TITLE
Fix PageSpeed Insights setup link on settings page

### DIFF
--- a/assets/js/modules/pagespeed-insights/dashboard/dashboard-cta.js
+++ b/assets/js/modules/pagespeed-insights/dashboard/dashboard-cta.js
@@ -11,7 +11,7 @@ import {
 /**
  * Internal dependencies
  */
-import { getSiteKitAdminURL } from '../../../util';
+import { getReAuthUrl } from '../../../util';
 
 const { __ } = wp.i18n;
 
@@ -30,16 +30,7 @@ const PageSpeedInsightsCTA = () => {
 	const handleSetUpClick = async () => {
 		try {
 			await activateOrDeactivateModule( data, 'pagespeed-insights', true );
-
-			window.location.assign(
-				getSiteKitAdminURL(
-					'googlesitekit-dashboard',
-					{
-						notification: 'authentication_success',
-						slug: 'pagespeed-insights',
-					},
-				)
-			);
+			window.location = getReAuthUrl( 'pagespeed-insights' );
 		} catch ( err ) {
 			showErrorNotification( GenericError, {
 				id: 'pagespeed-insights-setup-error',

--- a/assets/js/util/index.js
+++ b/assets/js/util/index.js
@@ -364,13 +364,21 @@ export const getReAuthUrl = ( slug, status ) => {
 
 	const { screenId } = googlesitekit.modules[ slug ];
 
-	let redirect = addQueryArgs(
-		adminRoot, {
+	// Special case handling for PageSpeed Insights.
+	// TODO: Refactor this out.
+	const pageSpeedQueryArgs = 'pagespeed-insights' === slug ? {
+		notification: 'authentication_success',
+		reAuth: undefined,
+	} : {};
 
+	let redirect = addQueryArgs(
+		adminRoot,
+		{
 			// If the module has a submenu page, and is being activated, redirect back to the module page.
 			page: ( slug && status && screenId ) ? screenId : 'googlesitekit-dashboard',
-			reAuth: status,
 			slug,
+			reAuth: status,
+			...pageSpeedQueryArgs,
 		}
 	);
 

--- a/tests/e2e/specs/modules/pagespeed-insights/activation.test.js
+++ b/tests/e2e/specs/modules/pagespeed-insights/activation.test.js
@@ -38,11 +38,27 @@ describe( 'PageSpeed Insights Activation', () => {
 		await resetSiteKit();
 	} );
 
-	it( 'leads you to the Site Kit dashboard after activation', async () => {
+	it( 'leads you to the Site Kit dashboard after activation via CTA', async () => {
 		await visitAdminPage( 'admin.php', 'page=googlesitekit-dashboard' );
 		await Promise.all( [
 			page.waitForNavigation(),
-			expect( page ).toClick( '.googlesitekit-cta-link', { text: 'Activate PageSpeed Insights' } ),
+			expect( page ).toClick( '.googlesitekit-cta-link', { text: /Activate PageSpeed Insights/i } ),
+		] );
+
+		await page.waitForSelector( '.googlesitekit-publisher-win__title' );
+		await expect( page ).toMatchElement( '.googlesitekit-publisher-win__title', { text: /Congrats on completing the setup for PageSpeed Insights!/i } );
+	} );
+
+	it( 'leads you to the Site Kit dashboard after activation via the settings page', async () => {
+		await visitAdminPage( 'admin.php', 'page=googlesitekit-settings' );
+
+		await page.waitForSelector( '.mdc-tab-bar' );
+		await expect( page ).toClick( '.mdc-tab', { text: /connect more services/i } );
+		await page.waitForSelector( '.googlesitekit-settings-connect-module--pagespeed-insights' );
+
+		await Promise.all( [
+			page.waitForNavigation(),
+			expect( page ).toClick( '.googlesitekit-cta-link', { text: /Set up PageSpeed Insights/i } ),
 		] );
 
 		await page.waitForSelector( '.googlesitekit-publisher-win__title' );

--- a/tests/qunit/assets/js/util/index.js
+++ b/tests/qunit/assets/js/util/index.js
@@ -407,30 +407,29 @@ QUnit.test( 'fillFilterWithComponent::', function ( assert ) {
  * Test getReAuthUrl.
  */
 valuesToTest = [
-
 	{
 		slug: 'pagespeed-insights',
 		status: false,
 		apikey: false,
-		expected: 'http://sitekit.withgoogle.com/wp-admin/admin.php?page=googlesitekit-dashboard&reAuth=false&slug=pagespeed-insights'
+		expected: 'http://sitekit.withgoogle.com/wp-admin/admin.php?page=googlesitekit-dashboard&slug=pagespeed-insights&notification=authentication_success'
 	},
 	{
 		slug: 'pagespeed-insights',
 		status: true,
 		apikey: false,
-		expected: 'http://sitekit.withgoogle.com/wp-admin/admin.php?page=googlesitekit-module-pagespeed-insights&reAuth=true&slug=pagespeed-insights'
+		expected: 'http://sitekit.withgoogle.com/wp-admin/admin.php?page=googlesitekit-module-pagespeed-insights&slug=pagespeed-insights&notification=authentication_success'
 	},
 	{
 		slug: 'pagespeed-insights',
 		status: false,
 		apikey: 'abc123',
-		expected: 'http://sitekit.withgoogle.com/wp-admin/admin.php?page=googlesitekit-dashboard&reAuth=false&slug=pagespeed-insights'
+		expected: 'http://sitekit.withgoogle.com/wp-admin/admin.php?page=googlesitekit-dashboard&slug=pagespeed-insights&notification=authentication_success'
 	},
 	{
 		slug: 'pagespeed-insights',
 		status: true,
 		apikey: 'abc123',
-		expected: 'http://sitekit.withgoogle.com/wp-admin/admin.php?page=googlesitekit-module-pagespeed-insights&reAuth=true&slug=pagespeed-insights'
+		expected: 'http://sitekit.withgoogle.com/wp-admin/admin.php?page=googlesitekit-module-pagespeed-insights&slug=pagespeed-insights&notification=authentication_success'
 	},
 ];
 


### PR DESCRIPTION
## Summary

Addresses issue #511 (#607)

## Relevant technical choices

* Re-adds logic to `reAuthUrl` to handle the special case for PSI
* Updated PSI activation E2E test to cover expected behavior

## Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
