### PR TITLE
Pass currently required scopes to proxy setup URL

### DIFF
--- a/includes/Core/Authentication/Clients/OAuth_Client.php
+++ b/includes/Core/Authentication/Clients/OAuth_Client.php
@@ -607,6 +607,8 @@ final class OAuth_Client {
 
 		$credentials = $this->get_client_credentials();
 
+		$scope = implode( ' ', $this->get_required_scopes() );
+
 		if ( ! is_object( $credentials ) || empty( $credentials->web->client_id ) ) {
 			$home_url           = home_url();
 			$home_url_no_scheme = str_replace( array( 'http://', 'https://' ), '', $home_url );
@@ -627,6 +629,7 @@ final class OAuth_Client {
 					'url'        => rawurlencode( $home_url ),
 					'rest_root'  => rawurlencode( $rest_root ),
 					'admin_root' => rawurlencode( $admin_root ),
+					'scope'      => rawurlencode( $scope ),
 				),
 				$url
 			);
@@ -635,6 +638,7 @@ final class OAuth_Client {
 		$query_args = array(
 			'site_id' => $credentials->web->client_id,
 			'code'    => $access_code,
+			'scope'   => rawurlencode( $scope ),
 		);
 		if ( 'missing_verification' === $error_code ) {
 			$query_args['verification_nonce'] = wp_create_nonce( 'googlesitekit_verification' );

--- a/tests/phpunit/integration/Core/Authentication/Clients/OAuth_ClientTest.php
+++ b/tests/phpunit/integration/Core/Authentication/Clients/OAuth_ClientTest.php
@@ -279,6 +279,7 @@ class OAuth_ClientTest extends TestCase {
 		$this->assertContains( 'url=', $url );
 		$this->assertContains( 'rest_root=', $url );
 		$this->assertContains( 'admin_root=', $url );
+		$this->assertContains( 'scope=', $url );
 		$this->assertNotContains( 'site_id=', $url );
 
 		// Otherwise, pass site ID and given temporary access code.
@@ -287,6 +288,7 @@ class OAuth_ClientTest extends TestCase {
 		$url = $client->get_proxy_setup_url( 'temp-code' );
 		$this->assertContains( 'site_id=' . self::SITE_ID, $url );
 		$this->assertContains( 'code=temp-code', $url );
+		$this->assertContains( 'scope=', $url );
 		$this->assertNotContains( 'name=', $url );
 		$this->assertNotContains( 'url=', $url );
 		$this->assertNotContains( 'rest_root=', $url );


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #677 

## Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
