### PR TITLE
Update PageSpeed Insights widget error message

### DIFF
--- a/assets/js/modules/pagespeed-insights/dashboard/dashboard-widget-homepage-speed.js
+++ b/assets/js/modules/pagespeed-insights/dashboard/dashboard-widget-homepage-speed.js
@@ -51,9 +51,9 @@ class PageSpeedInsightsDashboardWidgetHomepageSpeed extends Component {
 		} );
 	}
 
-	handleDataError() {
+	handleDataError( error ) {
 		this.setState( {
-			error: true,
+			error,
 		} );
 	}
 
@@ -77,7 +77,7 @@ class PageSpeedInsightsDashboardWidgetHomepageSpeed extends Component {
 					{
 						getDataErrorComponent(
 							__( 'PageSpeed Insights', 'google-site-kit' ),
-							__( 'Issue accessing data, please ensure the API key is set correctly.', 'google-site-kit' ),
+							error,
 							true,
 							true,
 							false


### PR DESCRIPTION
The displayed message was specific to an API key which was no longer relevant but also not very useful. This PR updates the error component to render the error message that came back which caused the error.

## Summary

Addresses issue #687

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
