### PR TITLE
Force OAuth prompt again so that a refresh token is always returned

### DIFF
--- a/includes/Core/Authentication/Clients/OAuth_Client.php
+++ b/includes/Core/Authentication/Clients/OAuth_Client.php
@@ -190,6 +190,7 @@ final class OAuth_Client {
 
 		// Offline access so we can access the refresh token even when the user is logged out.
 		$this->google_client->setAccessType( 'offline' );
+		$this->google_client->setPrompt( 'consent' );
 
 		$this->google_client->setRedirectUri( $this->get_redirect_uri() );
 


### PR DESCRIPTION
## Summary

Addresses issue #690

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
