### PR TITLE
Fix Search Console domain property matching and related PHP warning

### DIFF
--- a/includes/Modules/Search_Console.php
+++ b/includes/Modules/Search_Console.php
@@ -255,7 +255,7 @@ final class Search_Console extends Module implements Module_With_Screen, Module_
 					$property_matches = array_filter(
 						$sites,
 						function ( array $site ) use ( $current_host ) {
-							$site_host = wp_parse_url( $site['siteUrl'], PHP_URL_HOST );
+							$site_host = wp_parse_url( str_replace( 'sc-domain:', 'https://', $site['siteUrl'] ), PHP_URL_HOST );
 
 							// Ensure host names overlap, from right to left.
 							return 0 === strpos( strrev( $current_host ), strrev( $site_host ) );


### PR DESCRIPTION
## Summary

Addresses issue #702

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
