### PR TITLE
fix: Always show proxy setup page when proxy is on

### DIFF
--- a/assets/js/components/dashboard-splash/dashboard-splash-app.js
+++ b/assets/js/components/dashboard-splash/dashboard-splash-app.js
@@ -116,7 +116,11 @@ class DashboardSplashApp extends Component {
 
 		const { proxySetupURL } = googlesitekit.admin;
 
-		if ( ! this.state.showAuthenticationSetupWizard && ! this.state.showModuleSetupWizard ) {
+		// If `proxySetupURL` is set it means the proxy is in use. We should never
+		// show the GCP splash screen when the proxy is being used, so skip this
+		// when `proxySetupURL` is set.
+		// See: https://github.com/google/site-kit-wp/issues/704.
+		if ( ! proxySetupURL && ! this.state.showAuthenticationSetupWizard && ! this.state.showModuleSetupWizard ) {
 			let introDescription, outroDescription, buttonLabel, onButtonClick;
 
 			switch ( this.state.buttonMode ) {
@@ -152,7 +156,7 @@ class DashboardSplashApp extends Component {
 
 		let Setup = null;
 
-		// proxySetupURL is only set if the proxy is in use.
+		// `proxySetupURL` is only set if the proxy is in use.
 		if ( proxySetupURL ) {
 			Setup = lazy( () => import( /* webpackChunkName: "chunk-googlesitekit-setup-wizard-proxy" */'../setup/setup-proxy' ) );
 		} else if ( this.state.showAuthenticationSetupWizard ) {


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #704.

## Relevant technical choices

Always show the proxy setup screen when accessing `/wp-admin/admin.php?page=googlesitekit-splash`, if the proxy URL is set.

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
