### PR TITLE
Fix proxy OAuth error by reverting clientID back to clientId in third-party reference

### DIFF
--- a/includes/Core/Authentication/Clients/Google_Proxy_Client.php
+++ b/includes/Core/Authentication/Clients/Google_Proxy_Client.php
@@ -148,7 +148,7 @@ final class Google_Proxy_Client extends Google_Client {
 	protected function createOAuth2Service() {
 		$auth = new OAuth2(
 			array(
-				'clientID'           => $this->getClientId(),
+				'clientId'           => $this->getClientId(),
 				'clientSecret'       => $this->getClientSecret(),
 				'authorizationUri'   => self::OAUTH2_AUTH_URL,
 				'tokenCredentialUri' => self::OAUTH2_TOKEN_URI,

--- a/includes/Core/Authentication/Clients/OAuth_Client.php
+++ b/includes/Core/Authentication/Clients/OAuth_Client.php
@@ -491,7 +491,11 @@ final class OAuth_Client {
 			wp_safe_redirect( $this->get_proxy_setup_url( $e->getAccessCode(), $e->getMessage() ) );
 			exit();
 		} catch ( Exception $e ) {
-			$this->user_options->set( self::OPTION_ERROR_CODE, 'invalid_code' );
+			$error_code = 'invalid_code';
+			if ( $this->using_proxy() ) { // Only the Google_Proxy_Client exposes the real error response.
+				$error_code = $e->getMessage();
+			}
+			$this->user_options->set( self::OPTION_ERROR_CODE, $error_code );
 			wp_safe_redirect( admin_url() );
 			exit();
 		}


### PR DESCRIPTION
## Summary

Addresses issue #668 / follow-up to #694 

## Relevant technical choices

* One occurrence of `clientID` was not internal, but an argument to third-party code. This was making proxy OAuth requests fail. This PR reverts that one instance to fix it.
* Kind of unrelated, but still related, this PR improves error handling by relying on the exact error response given from the server, when in proxy mode. The proxy client has improved handling to return the exact error code (improved over the regular `Google_Client`), so let's also use that to provide more accurate error messages. For example, by making that change I was able to track down the above issue.

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
