### PR TITLE
Refactor earnings datapoint to not use array_merge

### DIFF
--- a/includes/Modules/AdSense.php
+++ b/includes/Modules/AdSense.php
@@ -548,17 +548,7 @@ tag_partner: "site_kit"
 					$service = $this->get_service( 'adsense' );
 					return $service->urlchannels->listUrlchannels( $data['clientID'] );
 				case 'earnings':
-					$data = array_merge(
-						array(
-							// Named date range slug.
-							'dateRange'  => 'last-28-days',
-							// Array of dimension strings.
-							'dimensions' => array(),
-						),
-						$data
-					);
-
-					$dates = $this->date_range_to_dates( $data['dateRange'] );
+					$dates = $this->date_range_to_dates( $data['dateRange'] ?: 'last-28-days' );
 
 					if ( is_wp_error( $dates ) ) {
 						return $dates;
@@ -566,7 +556,7 @@ tag_partner: "site_kit"
 
 					list ( $start_date, $end_date ) = $dates;
 
-					$dimensions = (array) $data['dimensions'];
+					$dimensions = $data['dimensions'];
 					$args       = compact( 'start_date', 'end_date', 'dimensions' );
 
 					if ( isset( $data['limit'] ) ) {

--- a/includes/Modules/AdSense.php
+++ b/includes/Modules/AdSense.php
@@ -556,7 +556,7 @@ tag_partner: "site_kit"
 
 					list ( $start_date, $end_date ) = $dates;
 
-					$dimensions = $data['dimensions'];
+					$dimensions = (array) $data['dimensions'];
 					$args       = compact( 'start_date', 'end_date', 'dimensions' );
 
 					if ( isset( $data['limit'] ) ) {


### PR DESCRIPTION
## Summary

Addresses QA feedback in https://github.com/google/site-kit-wp/issues/558#issuecomment-546406259

Addresses issue #558, follow-up to #695 

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
