### PR TITLE
fix: Always set window.googlesitekitTrackingEnabled in optIn

### DIFF
--- a/assets/js/components/optin.js
+++ b/assets/js/components/optin.js
@@ -60,8 +60,6 @@ class Optin extends Component {
 						return;
 					}
 
-					window.googlesitekitTrackingEnabled = !! checked;
-
 					document.body.insertAdjacentHTML( 'beforeend', `
 						<script async src="https://www.googletagmanager.com/gtag/js?id=${ googlesitekit.admin.trackingID }"></script>
 					` );
@@ -74,6 +72,8 @@ class Optin extends Component {
 						</script>
 					` );
 				}
+
+				window.googlesitekitTrackingEnabled = !! checked;
 
 				this.setState( {
 					optIn: !! checked,


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #633.

## Relevant technical choices

Always set `window.googlesitekitTrackingEnabled` when `optIn` is changed.

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
