### PR TITLE
Refactor class autoloading

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,13 +43,30 @@
       "@prefix-dependencies"
     ],
     "prefix-dependencies": [
-      "rm -rf php-scoper && mkdir php-scoper",
-      "cd php-scoper && composer init -q && composer config minimum-stability dev && composer config prefer-stable true && composer require humbug/php-scoper",
-      "php-scoper/vendor/bin/php-scoper add --output-dir=./third-party --force",
-      "cd includes && echo '{ \"autoload\": { \"classmap\": [\"\"] } }' > composer.json && composer dump-autoload --classmap-authoritative --no-interaction && rm composer.json",
-      "cd third-party && echo '{ \"autoload\": { \"classmap\": [\"\"] } }' > composer.json && composer dump-autoload --classmap-authoritative --no-interaction && rm composer.json",
-      "cp vendor/composer/autoload_files.php third-party/vendor/composer/autoload_files.php",
+      "rm -rf php-scoper",
+      "@install-php-scoper",
+      "php-scoper/vendor/bin/php-scoper add --output-dir=./third-party --force --quiet",
+      "@autoload-includes",
+      "@autoload-third-party",
+      "cp vendor/composer/autoload_files.php third-party/vendor/composer/",
       "rm -rf php-scoper"
+    ],
+    "autoload-includes": [
+      "echo '{ \"autoload\": { \"classmap\": [\"\"] } }' > includes/composer.json",
+      "@composer --working-dir=includes dump-autoload --classmap-authoritative --no-interaction",
+      "rm includes/composer.json"
+    ],
+    "autoload-third-party": [
+      "echo '{ \"autoload\": { \"classmap\": [\"\"] } }' > third-party/composer.json",
+      "@composer --working-dir=third-party dump-autoload --classmap-authoritative --no-interaction",
+      "rm third-party/composer.json"
+    ],
+    "install-php-scoper": [
+      "mkdir php-scoper",
+      "@composer --working-dir=php-scoper init -q",
+      "@composer --working-dir=php-scoper config minimum-stability dev",
+      "@composer --working-dir=php-scoper config prefer-stable true",
+      "@composer --working-dir=php-scoper require humbug/php-scoper"
     ],
     "lint": "vendor/bin/phpcs",
     "lint-fix": "vendor/bin/phpcbf"

--- a/includes/loader.php
+++ b/includes/loader.php
@@ -14,9 +14,31 @@ namespace Google\Site_Kit;
 define( 'GOOGLESITEKIT_PLUGIN_BASENAME', plugin_basename( GOOGLESITEKIT_PLUGIN_MAIN_FILE ) );
 define( 'GOOGLESITEKIT_PLUGIN_DIR_PATH', plugin_dir_path( GOOGLESITEKIT_PLUGIN_MAIN_FILE ) );
 
-// Autoload files.
-require_once GOOGLESITEKIT_PLUGIN_DIR_PATH . 'includes/vendor/autoload.php';
-require_once GOOGLESITEKIT_PLUGIN_DIR_PATH . 'third-party/vendor/autoload.php';
+/**
+ * Loads generated class maps for autoloading.
+ *
+ * @since 1.0.0
+ * @access private
+ */
+function autoload_classes() {
+	$class_map = array_merge(
+		include GOOGLESITEKIT_PLUGIN_DIR_PATH . 'third-party/vendor/composer/autoload_classmap.php',
+		include GOOGLESITEKIT_PLUGIN_DIR_PATH . 'includes/vendor/composer/autoload_classmap.php'
+	);
+
+	spl_autoload_register(
+		function ( $class ) use ( $class_map ) {
+			if ( isset( $class_map[ $class ] ) ) {
+				require_once $class_map[ $class ];
+
+				return true;
+			}
+		},
+		true,
+		true
+	);
+}
+autoload_classes();
 
 /**
  * Loads vendor files containing functions etc.


### PR DESCRIPTION
## Summary

This PR refactors the class autoloading with the classmap autoloaders generated by Composer, without using any Composer generated autoloader classes that may potentially collide with another plugin loading 

Addresses issue #612, follow-up to PR #696 

## Relevant technical choices

<!-- Please describe your changes. -->

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
