### PR TITLE
Add zero data check for PageSpeed Insights widget

### DIFF
--- a/assets/js/modules/pagespeed-insights/dashboard/dashboard-widget-homepage-speed-column.js
+++ b/assets/js/modules/pagespeed-insights/dashboard/dashboard-widget-homepage-speed-column.js
@@ -20,6 +20,7 @@
  * External dependencies
  */
 import withData from 'GoogleComponents/higherorder/withdata';
+import getDataErrorComponent from 'GoogleComponents/notifications/data-error';
 import { TYPE_MODULES } from 'GoogleComponents/data';
 import { getTimeInSeconds } from 'GoogleUtil';
 import {
@@ -59,6 +60,14 @@ class PageSpeedInsightsDashboardWidgetHomepageSpeedColumn extends Component {
 		// Waiting for withData resolution.
 		if ( ! data || data.error ) {
 			return null;
+		}
+
+		if ( isZeroData( data ) ) {
+			return getDataErrorComponent(
+				__( 'PageSpeed Insights', 'google-site-kit' ),
+				__( 'An unknown error occurred while trying to fetch PageSpeed Insights data. Please try again later.', 'google-site-kit' ),
+				true
+			);
 		}
 
 		const headers = [];
@@ -133,7 +142,6 @@ export const PageSpeedInsightsDashboardWidgetHomepageSpeedMobile = withData(
 	{
 		inGrid: true,
 	},
-	isZeroData
 );
 
 export const PageSpeedInsightsDashboardWidgetHomepageSpeedDesktop = withData(
@@ -156,5 +164,4 @@ export const PageSpeedInsightsDashboardWidgetHomepageSpeedDesktop = withData(
 	{
 		inGrid: true,
 	},
-	isZeroData
 );

--- a/assets/js/modules/pagespeed-insights/dashboard/dashboard-widget-homepage-speed-column.js
+++ b/assets/js/modules/pagespeed-insights/dashboard/dashboard-widget-homepage-speed-column.js
@@ -40,7 +40,7 @@ const { Component } = wp.element;
 const { __ } = wp.i18n;
 
 const isZeroData = ( data ) => {
-	return data.categories.performance.score < 0.01;
+	return 0 === data.categories.performance.score;
 };
 
 class PageSpeedInsightsDashboardWidgetHomepageSpeedColumn extends Component {

--- a/assets/js/modules/pagespeed-insights/dashboard/dashboard-widget-homepage-speed-column.js
+++ b/assets/js/modules/pagespeed-insights/dashboard/dashboard-widget-homepage-speed-column.js
@@ -38,6 +38,10 @@ import {
 const { Component } = wp.element;
 const { __ } = wp.i18n;
 
+const isZeroData = ( data ) => {
+	return data.categories.performance.score < 0.01;
+};
+
 class PageSpeedInsightsDashboardWidgetHomepageSpeedColumn extends Component {
 	componentDidMount() {
 		const {
@@ -129,6 +133,7 @@ export const PageSpeedInsightsDashboardWidgetHomepageSpeedMobile = withData(
 	{
 		inGrid: true,
 	},
+	isZeroData
 );
 
 export const PageSpeedInsightsDashboardWidgetHomepageSpeedDesktop = withData(
@@ -151,4 +156,5 @@ export const PageSpeedInsightsDashboardWidgetHomepageSpeedDesktop = withData(
 	{
 		inGrid: true,
 	},
+	isZeroData
 );


### PR DESCRIPTION
## Summary

This PR adds a zero data check to the render method for the PageSpeed Insights dashboard widget to prevent possibly displaying a score of zero which should never happen.

Addresses issue #723

Without the added zero-data check
![image](https://user-images.githubusercontent.com/1621608/67748497-bd6faf00-fa33-11e9-8af2-b4cebd3eb90a.png)

With the zero-data check
![image](https://user-images.githubusercontent.com/1621608/67749035-f3f9f980-fa34-11e9-8d2f-fe9279aecf7b.png)

## Relevant technical choices

- Was unable to reproduce the zero-score result so I manipulated the score manually to simulate this
- Not passing the zero data function as an argument to `withData` as this returns a "Gathering Data" CTA type component rather than the error state described in the AC

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
