### PR TITLE
Tweak class autoloading for safety

### DIFF
--- a/includes/loader.php
+++ b/includes/loader.php
@@ -30,7 +30,7 @@ function autoload_classes() {
 
 	spl_autoload_register(
 		function ( $class ) use ( $class_map ) {
-			if ( isset( $class_map[ $class ] ) ) {
+			if ( isset( $class_map[ $class ] ) && file_exists( $class_map[ $class ] ) ) {
 				require_once $class_map[ $class ];
 
 				return true;


### PR DESCRIPTION
## Summary

This PR updates the new autoloader responsible for autoloading Site Kit's first and third-party classes to be slightly safer, particularly in regards to this line in the class map:

```php
'Composer\\Autoload\\ClassLoader' => $vendorDir . '/composer/ClassLoader.php',
```

Because we only take the generated class map from the generated Composer autoloader, this class will not exist, but could potentially be loaded by our autoloader if this class were requested by another plugin or theme due to its presence in the class map.

Rather than filtering out non-Google entries from the class map, we can simply add an additional check to ensure the mapped file exists before loading it.

Addresses issue #612 

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
