### PR TITLE
Update setup screen and disconnect handling

### DIFF
--- a/assets/js/components/user-menu.js
+++ b/assets/js/components/user-menu.js
@@ -23,10 +23,10 @@ import Button from 'GoogleComponents/button';
 import Menu from 'GoogleComponents/menu';
 import { clearAppLocalStorage } from 'GoogleUtil';
 import data, { TYPE_CORE } from 'GoogleComponents/data';
+import { getSiteKitAdminURL } from 'SiteKitCore/util';
 
 const { Component, Fragment, createRef } = wp.element;
 const { __ } = wp.i18n;
-const { addQueryArgs } = wp.url;
 
 class UserMenu extends Component {
 	constructor( props ) {
@@ -131,13 +131,13 @@ class UserMenu extends Component {
 		// Clear caches.
 		clearAppLocalStorage();
 
-		// Return to the Site Kit Dashboard.
-		const { adminRoot } = googlesitekit.admin;
-
-		document.location = addQueryArgs( adminRoot.replace( 'admin.php', '' ),
+		// Navigate back to the splash screen to reconnect.
+		document.location = getSiteKitAdminURL(
+			'googlesitekit-splash',
 			{
-				notification: 'googlesitekit_user_disconnected',
-			} );
+				googlesitekit_context: 'revoked',
+			}
+		);
 	}
 
 	render() {

--- a/assets/js/components/user-menu.js
+++ b/assets/js/components/user-menu.js
@@ -22,7 +22,6 @@ import Dialog from 'GoogleComponents/dialog';
 import Button from 'GoogleComponents/button';
 import Menu from 'GoogleComponents/menu';
 import { clearAppLocalStorage } from 'GoogleUtil';
-import data, { TYPE_CORE } from 'GoogleComponents/data';
 import { getSiteKitAdminURL } from 'SiteKitCore/util';
 
 const { Component, Fragment, createRef } = wp.element;
@@ -120,9 +119,6 @@ class UserMenu extends Component {
 
 	// Log the user out if they confirm the dialog.
 	async handleUnlinkConfirm() {
-		// Disconnect the user.
-		await data.set( TYPE_CORE, 'user', 'disconnect' );
-
 		// Close the modal.
 		this.setState( {
 			dialogActive: false,

--- a/includes/Core/Admin/Screens.php
+++ b/includes/Core/Admin/Screens.php
@@ -11,6 +11,7 @@
 namespace Google\Site_Kit\Core\Admin;
 
 use Google\Site_Kit\Context;
+use Google\Site_Kit\Core\Authentication\Authentication;
 use Google\Site_Kit\Core\Permissions\Permissions;
 use Google\Site_Kit\Core\Assets\Assets;
 
@@ -307,6 +308,17 @@ final class Screens {
 
 				// This callback will redirect to the dashboard on successful authentication.
 				'initialize_callback' => function( Context $context ) {
+					$splash_context = filter_input( INPUT_GET, 'googlesitekit_context' );
+					$authentication = new Authentication( $context );
+
+					// If the user is authenticated, redirect them to the disconnect URL and then send them back here.
+					if ( empty( $_GET['googlesitekit_reset_session'] ) && 'revoked' === $splash_context && $authentication->is_authenticated() ) { // phpcs:ignore WordPress.Security.NonceVerification.NoNonceVerification
+						$authentication->disconnect();
+
+						wp_safe_redirect( add_query_arg( array( 'googlesitekit_reset_session' => 1 ) ) );
+						exit;
+					}
+
 					$notification = filter_input( INPUT_GET, 'notification' );
 					$error        = filter_input( INPUT_GET, 'error' );
 

--- a/includes/Core/Authentication/Authentication.php
+++ b/includes/Core/Authentication/Authentication.php
@@ -277,9 +277,7 @@ final class Authentication {
 	 * @since 1.0.0
 	 */
 	public function disconnect() {
-		$auth_client = $this->get_oauth_client();
-
-		$auth_client->revoke_token();
+		$this->get_oauth_client()->revoke_token();
 
 		$this->user_options->delete( Clients\OAuth_Client::OPTION_ACCESS_TOKEN );
 		$this->user_options->delete( Clients\OAuth_Client::OPTION_ACCESS_TOKEN_EXPIRES_IN );

--- a/includes/Core/Authentication/Authentication.php
+++ b/includes/Core/Authentication/Authentication.php
@@ -607,40 +607,8 @@ final class Authentication {
 
 		$notices[] = $this->get_reauthentication_needed_notice();
 		$notices[] = $this->get_authentication_oauth_error_notice();
-		$notices[] = $this->get_disconnected_user_notice();
 
 		return $notices;
-	}
-
-	/**
-	 * Gets disconnected user notice.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @return Notice Notice object.
-	 */
-	private function get_disconnected_user_notice() {
-		return new Notice(
-			'googlesitekit_user_disconnected',
-			array(
-				'content'         => function() {
-					ob_start();
-					?>
-					<p>
-						<?php esc_html_e( 'Successfully disconnected from Site Kit by Google.', 'google-site-kit' ); ?>
-					</p>
-					<?php
-					return ob_get_clean();
-				},
-				'type'            => Notice::TYPE_SUCCESS,
-				'active_callback' => function() {
-					if ( isset( $_GET['notification'] ) && 'googlesitekit_user_disconnected' === $_GET['notification'] ) { // phpcs:ignore WordPress.Security.NonceVerification.NoNonceVerification
-						return true;
-					}
-					return false;
-				},
-			)
-		);
 	}
 
 	/**

--- a/tests/e2e/specs/auth-flow.test.js
+++ b/tests/e2e/specs/auth-flow.test.js
@@ -38,7 +38,7 @@ function stubGoogleSignIn( request ) {
 	}
 }
 
-const signOut = async () => {
+const disconnectFromSiteKit = async () => {
 	await page.waitForSelector( 'button[aria-controls="user-menu"]' );
 	await page.click( 'button[aria-controls="user-menu"]' );
 
@@ -83,7 +83,7 @@ describe( 'Site Kit set up flow for the first time', () => {
 		await setSearchConsoleProperty();
 		await visitAdminPage( 'admin.php', 'page=googlesitekit-dashboard' );
 
-		await signOut();
+		await disconnectFromSiteKit();
 
 		await expect( page ).toMatchElement(
 			'.notice-success',

--- a/tests/e2e/specs/auth-flow.test.js
+++ b/tests/e2e/specs/auth-flow.test.js
@@ -85,9 +85,10 @@ describe( 'Site Kit set up flow for the first time', () => {
 
 		await disconnectFromSiteKit();
 
+		// Ensure the user is on step one of the setup wizard.
 		await expect( page ).toMatchElement(
-			'.notice-success',
-			{ text: /Successfully disconnected from Site Kit by Google./i }
+			'.googlesitekit-wizard-progress-step__number-text--inprogress',
+			{ text: '1' }
 		);
 	} );
 } );

--- a/tests/phpunit/integration/Core/Authentication/AuthenticationTest.php
+++ b/tests/phpunit/integration/Core/Authentication/AuthenticationTest.php
@@ -53,7 +53,6 @@ class AuthenticationTest extends TestCase {
 		);
 		$this->assertEqualSets(
 			array(
-				'googlesitekit_user_disconnected',
 				'needs_reauthentication',
 				'oauth_error',
 			),


### PR DESCRIPTION
## Summary

This PR updates the setup screen to display alternate content when the user revokes access to their site from the proxy. It also updates the existing disconnect action from the user menu to follow the same behavior. The previous notice displayed after disconnecting has been removed.

Addresses issue #724

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
