### PR TITLE
Enhance settings page component rendering

### DIFF
--- a/assets/js/components/settings/settings-module.js
+++ b/assets/js/components/settings/settings-module.js
@@ -314,7 +314,7 @@ class SettingsModule extends Component {
 													mdc-layout-grid__cell
 													mdc-layout-grid__cell--span-12
 												">
-											<FilteredModuleSettingsDetails module={ moduleKey } isEditing={ isEditing[ moduleKey ] } />
+											<FilteredModuleSettingsDetails module={ moduleKey } isEditing={ isEditing[ moduleKey ] } isOpen={ isOpen } />
 										</div>
 									</Fragment>
 									}

--- a/assets/js/components/settings/settings-modules.js
+++ b/assets/js/components/settings/settings-modules.js
@@ -67,7 +67,6 @@ class SettingsModules extends Component {
 		this.setState( ( prevState ) => {
 			return {
 				openModules: {
-					...prevState.openModules,
 					[ module ]: ! prevState.openModules[ module ],
 				},
 			};

--- a/assets/js/modules/adsense/setup/adsense-setup.js
+++ b/assets/js/modules/adsense/setup/adsense-setup.js
@@ -43,6 +43,16 @@ class AdSenseSetupWidget extends Component {
 	}
 
 	componentDidMount() {
+		const {
+			isOpen,
+			onSettingsPage,
+		} = this.props;
+
+		// If on settings page, only run the rest if the module is "open".
+		if ( onSettingsPage && ! isOpen ) {
+			return;
+		}
+
 		this.getAccounts();
 	}
 

--- a/assets/js/modules/analytics/setup.js
+++ b/assets/js/modules/analytics/setup.js
@@ -85,7 +85,16 @@ class AnalyticsSetup extends Component {
 	}
 
 	async componentDidMount() {
+		const {
+			isOpen,
+			onSettingsPage,
+		} = this.props;
 		this._isMounted = true;
+
+		// If on settings page, only run the rest if the module is "open".
+		if ( onSettingsPage && ! isOpen ) {
+			return;
+		}
 
 		const existingTagProperty = await getExistingTag( 'analytics' );
 

--- a/assets/js/modules/tagmanager/setup.js
+++ b/assets/js/modules/tagmanager/setup.js
@@ -64,7 +64,17 @@ class TagmanagerSetup extends Component {
 	}
 
 	componentDidMount() {
+		const {
+			isOpen,
+			onSettingsPage,
+		} = this.props;
 		this._isMounted = true;
+
+		// If on settings page, only run the rest if the module is "open".
+		if ( onSettingsPage && ! isOpen ) {
+			return;
+		}
+
 		this.requestTagManagerAccounts();
 
 		// Handle save hook from the settings page.


### PR DESCRIPTION
## Summary

Addresses issue #742 

This PR makes a few changes to the React app and its components rendered on the settings page. As described in the issue, due to changes state changes such as `openModules` or `activeTab`, it causes all of the child modules to be rerendered. Since many module setup components dispatch uncached data requests in their `componentDidMount` methods (usually fetching accounts), this causes common actions on the page to trigger these requests to happen again and again in the background. This becomes apparent to the user when the modules change into a loading state when these requests are made.

The main change made here is to pass the `isOpen` state to the inner component and add a check within the relevant `componentDidMount` methods: if it's on the settings page, and not open, it returns early. All other cases, such as initial module setup are unaffected.

Additionally, the SettingsModules component now only allows for a single module to be expanded at at time. This ensures that only one module is making requests at a time.

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
