### PR TITLE
Add reset button to setup screen

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -13,6 +13,7 @@ import {
 	createRef,
 	Fragment,
 	createElement,
+	createPortal,
 } from '@wordpress/element';
 import {
 	withFilters,
@@ -68,6 +69,7 @@ wp.element.Component = Component;
 wp.element.createRef = createRef;
 wp.element.Fragment = Fragment;
 wp.element.createElement = createElement;
+wp.element.createPortal = createPortal;
 wp.components.withFilters = withFilters;
 window.lodash = lodash;
 wp.i18n.__ = __ || {};

--- a/assets/js/components/modal.js
+++ b/assets/js/components/modal.js
@@ -23,7 +23,7 @@ export default class Modal extends Component {
 		super( props );
 		this.el = document.createElement( 'div' );
 		// This class is the outermost wrapper which is present on all Site Kit pages.
-		this.root = document.querySelector( '.googlesitekit-plugin' );
+		this.root = document.querySelector( '.googlesitekit-plugin' ) || document.body;
 	}
 
 	componentDidMount() {

--- a/assets/js/components/modal.js
+++ b/assets/js/components/modal.js
@@ -1,0 +1,43 @@
+/**
+ * Modal component.
+ *
+ * Site Kit by Google, Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const { Component, createPortal } = wp.element;
+
+export default class Modal extends Component {
+	constructor( props ) {
+		super( props );
+		this.el = document.createElement( 'div' );
+		// This class is the outermost wrapper which is present on all Site Kit pages.
+		this.root = document.querySelector( '.googlesitekit-plugin' );
+	}
+
+	componentDidMount() {
+		this.root.appendChild( this.el );
+	}
+
+	componentWillUnmount() {
+		this.root.removeChild( this.el );
+	}
+
+	render() {
+		return createPortal(
+			this.props.children,
+			this.el,
+		);
+	}
+}

--- a/assets/js/components/reset-button.js
+++ b/assets/js/components/reset-button.js
@@ -1,0 +1,112 @@
+/**
+ * ResetButton component.
+ *
+ * Site Kit by Google, Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import Link from './link';
+import Modal from './modal';
+const { __ } = wp.i18n;
+
+/**
+ * External dependencies
+ */
+import data, { TYPE_CORE } from 'GoogleComponents/data';
+import {
+	clearAppLocalStorage,
+	getSiteKitAdminURL,
+} from 'GoogleUtil';
+import Dialog from 'GoogleComponents/dialog';
+import { Fragment } from 'react';
+const { Component } = wp.element;
+
+export default class ResetButton extends Component {
+	constructor( props ) {
+		super( props );
+
+		this.state = {
+			dialogActive: false,
+		};
+
+		this.handleDialog = this.handleDialog.bind( this );
+		this.handleUnlinkConfirm = this.handleUnlinkConfirm.bind( this );
+		this.handleCloseModal = this.handleCloseModal.bind( this );
+	}
+
+	componentDidMount() {
+		window.addEventListener( 'keyup', this.handleCloseModal, false );
+	}
+
+	componentWillUnmount() {
+		window.removeEventListener( 'keyup', this.handleCloseModal );
+	}
+
+	async handleUnlinkConfirm() {
+		await data.set( TYPE_CORE, 'site', 'reset' );
+		clearAppLocalStorage();
+		this.handleDialog();
+		document.location = getSiteKitAdminURL( 'googlesitekit-splash' );
+	}
+
+	handleCloseModal( e ) {
+		if ( 27 === e.keyCode ) {
+			this.setState( {
+				dialogActive: false,
+			} );
+		}
+	}
+
+	handleDialog() {
+		this.setState( ( prevState ) => {
+			return {
+				dialogActive: ! prevState.dialogActive,
+			};
+		} );
+	}
+
+	render() {
+		const {
+			children,
+		} = this.props;
+		const {
+			dialogActive,
+		} = this.state;
+
+		return (
+			<Fragment>
+				<Link
+					onClick={ () => this.setState( { dialogActive: true } ) }
+					inherit
+				>
+					{ children || __( 'Reset Site Kit', 'google-site-kit' ) }
+				</Link>
+				<Modal>
+					<Dialog
+						dialogActive={ dialogActive }
+						handleConfirm={ this.handleUnlinkConfirm }
+						handleDialog={ this.handleDialog }
+						title={ __( 'Reset Site Kit', 'google-site-kit' ) }
+						subtitle={ __( 'Resetting this site will remove access to all services. After disconnecting, you will need to re-authorize your access to restore service.', 'google-site-kit' ) }
+						confirmButton={ __( 'Reset', 'google-site-kit' ) }
+						provides={ [] }
+					/>
+				</Modal>
+			</Fragment>
+		);
+	}
+}

--- a/assets/js/components/reset-button.js
+++ b/assets/js/components/reset-button.js
@@ -90,6 +90,7 @@ export default class ResetButton extends Component {
 		return (
 			<Fragment>
 				<Link
+					className="googlesitekit-reset-button"
 					onClick={ () => this.setState( { dialogActive: true } ) }
 					inherit
 				>

--- a/assets/js/components/settings/settings-admin.js
+++ b/assets/js/components/settings/settings-admin.js
@@ -20,14 +20,12 @@
  * External dependencies
  */
 import Layout from 'GoogleComponents/layout/layout';
-import Link from 'GoogleComponents/link';
-import Dialog from 'GoogleComponents/dialog';
 import Optin from 'GoogleComponents/optin';
-import data, { TYPE_CORE } from 'GoogleComponents/data';
-import {
-	clearAppLocalStorage,
-	getSiteKitAdminURL,
-} from 'GoogleUtil';
+
+/**
+ * Internal dependencies
+ */
+import ResetButton from '../reset-button';
 
 const { Component, Fragment } = wp.element;
 const { __ } = wp.i18n;
@@ -44,50 +42,10 @@ class SettingsAdmin extends Component {
 				img: picture,
 				user: name,
 			},
-			dialogActive: false,
 		};
-
-		this.handleDialog = this.handleDialog.bind( this );
-		this.handleUnlinkConfirm = this.handleUnlinkConfirm.bind( this );
-		this.handleCloseModal = this.handleCloseModal.bind( this );
-	}
-
-	componentDidMount() {
-		window.addEventListener( 'keyup', this.handleCloseModal, false );
-	}
-
-	componentWillUnmount() {
-		window.removeEventListener( 'keyup', this.handleCloseModal );
-	}
-
-	handleDialog() {
-		this.setState( ( prevState ) => {
-			return {
-				dialogActive: ! prevState.dialogActive,
-			};
-		} );
-	}
-
-	async handleUnlinkConfirm() {
-		await data.set( TYPE_CORE, 'site', 'reset' );
-		clearAppLocalStorage();
-		this.handleDialog();
-		document.location = getSiteKitAdminURL( 'googlesitekit-splash' );
-	}
-
-	handleCloseModal( e ) {
-		if ( 27 === e.keyCode ) {
-			this.setState( {
-				dialogActive: false,
-			} );
-		}
 	}
 
 	render() {
-		const {
-			dialogActive,
-		} = this.state;
-
 		return (
 			<Fragment>
 				<div className="
@@ -152,12 +110,7 @@ class SettingsAdmin extends Component {
 											mdc-layout-grid__cell--span-8-tablet
 											mdc-layout-grid__cell--span-4-phone
 										">
-											<Link
-												onClick={ this.handleDialog }
-												inherit
-											>
-												{ __( 'Reset Site Kit', 'google-site-kit' ) }
-											</Link>
+											<ResetButton />
 										</div>
 									</div>
 								</div>
@@ -199,15 +152,6 @@ class SettingsAdmin extends Component {
 						</div>
 					</Layout>
 				</div>
-				<Dialog
-					dialogActive={ dialogActive }
-					handleConfirm={ this.handleUnlinkConfirm }
-					handleDialog={ this.handleDialog }
-					title={ __( 'Reset Site Kit', 'google-site-kit' ) }
-					subtitle={ __( 'Resetting this site will remove access to all services. After disconnecting, you will need to re-authorize your access to restore service.', 'google-site-kit' ) }
-					confirmButton={ __( 'Reset', 'google-site-kit' ) }
-					provides={ [] }
-				/>
 			</Fragment>
 		);
 	}

--- a/assets/js/components/setup/setup-proxy.js
+++ b/assets/js/components/setup/setup-proxy.js
@@ -21,6 +21,7 @@
  */
 import Header from 'GoogleComponents/header';
 import Button from 'GoogleComponents/button';
+import ResetButton from 'GoogleComponents/reset-button';
 import Layout from 'GoogleComponents/layout/layout';
 import Optin from 'GoogleComponents/optin';
 import { sendAnalyticsTrackingEvent } from 'GoogleUtil';
@@ -118,6 +119,7 @@ class SetupUsingProxy extends Component {
 															</Fragment>
 														) }
 														<Button
+															className="googlesitekit-start-setup"
 															href={ proxySetupURL }
 															onClick={ () => {
 																sendAnalyticsTrackingEvent( 'plugin_setup', 'proxy_start_setup_landing_page' );
@@ -125,6 +127,7 @@ class SetupUsingProxy extends Component {
 														>
 															{ __( 'Start setup', 'google-site-kit' ) }
 														</Button>
+														<ResetButton />
 														<Optin />
 													</div>
 												</div>

--- a/assets/sass/admin.scss
+++ b/assets/sass/admin.scss
@@ -126,6 +126,7 @@
 @import "components/dashboard/wizard/googlesitekit-wizard-progress";
 @import "components/dashboard/wizard/googlesitekit-wizard-progress-step";
 @import "components/dashboard/wizard/googlesitekit-wizard-step";
+@import "components/dashboard/wizard/googlesitekit-wizard-setup";
 
 // Setup
 @import "components/setup/googlesitekit-setup";

--- a/assets/sass/components/dashboard/wizard/_googlesitekit-wizard-setup.scss
+++ b/assets/sass/components/dashboard/wizard/_googlesitekit-wizard-setup.scss
@@ -1,0 +1,6 @@
+.googlesitekit-wizard {
+
+	.googlesitekit-start-setup {
+		margin-right: 16px;
+	}
+}


### PR DESCRIPTION
## Summary

Addresses issue #753

![image](https://user-images.githubusercontent.com/1621608/67979680-747f4c80-fc25-11e9-9afb-3982696698cc.png)

![image](https://user-images.githubusercontent.com/1621608/67979684-75b07980-fc25-11e9-80c0-95e6302c7611.png)

## Relevant technical choices

* Adds a new generic `Modal` component which uses a React Portal to render its children as a child of the `.googlesitekit-plugin` wrapper
* Styles the gap between "Start Setup" button and reset link using the same spacing as used in the Dialog component.
* Reset button in both places uses the same underlying component

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
