### PR TITLE
Add 1.0 Migration

### DIFF
--- a/includes/Core/Util/Migration_1_0_0.php
+++ b/includes/Core/Util/Migration_1_0_0.php
@@ -21,7 +21,9 @@ use Google\Site_Kit\Core\Storage\User_Options;
 /**
  * Class Migration_1_0_0
  *
- * @package Google\Site_Kit\Core\Util
+ * @since 1.0.0
+ * @access private
+ * @ignore
  */
 class Migration_1_0_0 {
 
@@ -47,6 +49,8 @@ class Migration_1_0_0 {
 	/**
 	 * Constructor.
 	 *
+	 * @since 1.0.0
+	 *
 	 * @param Context $context Plugin context instance.
 	 */
 	public function __construct( Context $context ) {
@@ -56,6 +60,8 @@ class Migration_1_0_0 {
 
 	/**
 	 * Registers hooks.
+	 *
+	 * @since 1.0.0
 	 */
 	public function register() {
 		add_action( 'admin_init', array( $this, 'migrate' ) );
@@ -63,6 +69,8 @@ class Migration_1_0_0 {
 
 	/**
 	 * Migrates the DB.
+	 *
+	 * @since 1.0.0
 	 */
 	public function migrate() {
 		$db_version = $this->options->get( 'googlesitekit_db_version' );
@@ -76,6 +84,8 @@ class Migration_1_0_0 {
 
 	/**
 	 * Migrates old credentials and disconnects users.
+	 *
+	 * @since 1.0.0
 	 */
 	private function migrate_install() {
 		$credentials = ( new Encrypted_Options( $this->options ) )->get( Credentials::OPTION );
@@ -93,6 +103,8 @@ class Migration_1_0_0 {
 
 	/**
 	 * Disconnects authenticated users.
+	 *
+	 * @since 1.0.0
 	 */
 	private function disconnect_users() {
 		global $wpdb;

--- a/includes/Core/Util/Migration_1_0_0.php
+++ b/includes/Core/Util/Migration_1_0_0.php
@@ -45,7 +45,7 @@ class Migration_1_0_0 {
 	protected $options;
 
 	/**
-	 * Migration_1_0_0 constructor.
+	 * Constructor.
 	 *
 	 * @param Context $context Plugin context instance.
 	 */

--- a/includes/Core/Util/Migration_1_0_0.php
+++ b/includes/Core/Util/Migration_1_0_0.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * Migration for v1.0
+ *
+ * @package   Google\Site_Kit\Core\Util
+ * @copyright 2019 Google LLC
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
+ * @link      https://sitekit.withgoogle.com
+ */
+
+namespace Google\Site_Kit\Core\Util;
+
+use Google\Site_Kit\Context;
+use Google\Site_Kit\Core\Authentication\Authentication;
+use Google\Site_Kit\Core\Authentication\Clients\OAuth_Client;
+use Google\Site_Kit\Core\Authentication\Credentials;
+use Google\Site_Kit\Core\Storage\Encrypted_Options;
+use Google\Site_Kit\Core\Storage\Options;
+use Google\Site_Kit\Core\Storage\User_Options;
+
+/**
+ * Class Migration_1_0_0
+ *
+ * @package Google\Site_Kit\Core\Util
+ */
+class Migration_1_0_0 {
+
+	/**
+	 * Target DB version.
+	 */
+	const DB_VERSION = '1.0.0';
+
+	/**
+	 * Context instance.
+	 *
+	 * @var Context
+	 */
+	protected $context;
+
+	/**
+	 * Options instance.
+	 *
+	 * @var Options
+	 */
+	protected $options;
+
+	/**
+	 * Migration_1_0_0 constructor.
+	 *
+	 * @param Context $context Plugin context instance.
+	 */
+	public function __construct( Context $context ) {
+		$this->context = $context;
+		$this->options = new Options( $context );
+	}
+
+	/**
+	 * Registers hooks.
+	 */
+	public function register() {
+		add_action( 'admin_init', array( $this, 'migrate' ) );
+	}
+
+	/**
+	 * Migrates the DB.
+	 */
+	public function migrate() {
+		$db_version = $this->options->get( 'googlesitekit_db_version' );
+
+		if ( ! $db_version || version_compare( $db_version, self::DB_VERSION, '<' ) ) {
+			$this->migrate_install();
+
+			$this->options->set( 'googlesitekit_db_version', self::DB_VERSION );
+		}
+	}
+
+	/**
+	 * Migrates old credentials and disconnects users.
+	 */
+	private function migrate_install() {
+		$credentials = ( new Encrypted_Options( $this->options ) )->get( Credentials::OPTION );
+
+		// Credentials can be filtered in so we must also check if there is a saved option present.
+		if ( isset( $credentials['oauth2_client_id'] ) && strpos( $credentials['oauth2_client_id'], '.apps.sitekit.withgoogle.com' ) ) {
+			$this->options->delete( Credentials::OPTION );
+			$this->options->set( Beta_Migration::OPTION_IS_PRE_PROXY_INSTALL, 1 );
+
+			$this->disconnect_users();
+
+			wp_cache_flush();
+		}
+	}
+
+	/**
+	 * Disconnects authenticated users.
+	 */
+	private function disconnect_users() {
+		global $wpdb;
+
+		$user_options   = new User_Options( $this->context );
+		$authentication = new Authentication( $this->context, $this->options, $user_options );
+
+		$user_ids = $wpdb->get_col(
+			$wpdb->prepare(
+				"
+				SELECT user_id
+				FROM {$wpdb->usermeta}
+				WHERE meta_key IN ( %s, %s )
+				",
+				OAuth_Client::OPTION_ACCESS_TOKEN,
+				$wpdb->get_blog_prefix() . OAuth_Client::OPTION_ACCESS_TOKEN
+			)
+		);
+
+		foreach ( $user_ids as $user_id ) {
+			$user_options->switch_user( (int) $user_id );
+			$authentication->disconnect();
+		}
+	}
+}

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -148,6 +148,7 @@ final class Plugin {
 
 		( new Core\Util\Activation( $this->context, $options, $assets ) )->register();
 		( new Core\Util\Beta_Migration( $this->context ) )->register();
+		( new Core\Util\Migration_1_0_0( $this->context ) )->register();
 		( new Core\Util\Uninstallation( $reset ) )->register();
 
 		if ( defined( 'WP_DEBUG' ) && true === WP_DEBUG ) {

--- a/tests/phpunit/integration/Core/Util/Migration_1_0_0Test.php
+++ b/tests/phpunit/integration/Core/Util/Migration_1_0_0Test.php
@@ -1,0 +1,139 @@
+<?php
+/**
+ * \Google\Site_Kit\Core\Util\Migration_1_0_0Test
+ *
+ * @package   Google\Site_Kit\Tests\Core\Util
+ * @copyright 2019 Google LLC
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
+ * @link      https://sitekit.withgoogle.com
+ */
+
+namespace Google\Site_Kit\Tests\Core\Util;
+
+use Google\Site_Kit\Context;
+use Google\Site_Kit\Core\Authentication\Clients\OAuth_Client;
+use Google\Site_Kit\Core\Authentication\Credentials;
+use Google\Site_Kit\Core\Storage\Options;
+use Google\Site_Kit\Core\Util\Migration_1_0_0;
+use Google\Site_Kit\Tests\TestCase;
+
+class Migration_1_0_0Test extends TestCase {
+
+	public function test_register() {
+		$migration = new Migration_1_0_0( new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE ) );
+		remove_all_actions( 'admin_init' );
+
+		$migration->register();
+
+		$this->assertTrue( has_action( 'admin_init' ) );
+	}
+
+	public function test_migrate() {
+		$context     = new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE );
+		$options     = new Options( $context );
+		$credentials = new Credentials( $options );
+		$migration   = new Migration_1_0_0( $context );
+
+		// Upgrade will update the DB version if run.
+		$this->delete_db_version();
+
+		$migration->migrate();
+
+		$this->assertEquals( Migration_1_0_0::DB_VERSION, $this->get_db_version() );
+
+		// The upgrade will NOT delete old GCP credentials if present.
+		$this->delete_db_version();
+		$this->set_gcp_credentials();
+		$this->assertTrue( $credentials->has() );
+
+		$migration->migrate();
+
+		$this->assertTrue( $credentials->has() );
+		$this->assertEquals( Migration_1_0_0::DB_VERSION, $this->get_db_version() );
+
+		// The upgrade WILL delete proxy credentials if present.
+		$this->delete_db_version();
+		$this->set_proxy_credentials();
+		$this->assertTrue( $credentials->has() );
+
+		$migration->migrate();
+
+		$this->assertFalse( $credentials->has() );
+		$this->assertEquals( Migration_1_0_0::DB_VERSION, $this->get_db_version() );
+
+		// The upgrade will not disconnect any user if GCP credentials are present.
+		$this->delete_db_version();
+		$this->set_gcp_credentials();
+
+		$users_with_tokens = array(
+			$this->create_user_with_access_token(),
+			$this->create_user_with_access_token(),
+			$this->create_user_with_access_token(),
+		);
+		$users_without     = array(
+			$this->factory()->user->create(),
+			$this->factory()->user->create(),
+			$this->factory()->user->create(),
+		);
+
+		$migration->migrate();
+
+		foreach ( $users_with_tokens as $user_with_token ) {
+			$this->assertUserHasAccessToken( $user_with_token );
+		}
+
+		// The upgrade will disconnect any user with an auth token if proxy credentials are present.
+		$this->delete_db_version();
+		$this->set_proxy_credentials();
+
+		$migration->migrate();
+
+		foreach ( $users_with_tokens as $user_who_had_token ) {
+			$this->assertUserNotHasAccessToken( $user_who_had_token );
+		}
+		foreach ( $users_without as $user_without ) {
+			$this->assertUserNotHasAccessToken( $user_without );
+		}
+	}
+
+	private function assertUserHasAccessToken( $user_id ) {
+		$this->assertNotEmpty( get_user_option( OAuth_Client::OPTION_ACCESS_TOKEN, $user_id ) );
+	}
+
+	private function assertUserNotHasAccessToken( $user_id ) {
+		$this->assertEmpty( get_user_option( OAuth_Client::OPTION_ACCESS_TOKEN, $user_id ) );
+	}
+
+	private function create_user_with_access_token() {
+		$user_id = $this->factory()->user->create();
+		update_user_option( $user_id, OAuth_Client::OPTION_ACCESS_TOKEN, "test-access-token-$user_id" );
+
+		return $user_id;
+	}
+
+	private function get_db_version() {
+		return ( new Options( new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE ) ) )->get( 'googlesitekit_db_version' );
+	}
+
+	private function delete_db_version() {
+		( new Options( new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE ) ) )->delete( 'googlesitekit_db_version' );
+	}
+
+	private function delete_credentials() {
+		( new Options( new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE ) ) )->delete( Credentials::OPTION );
+	}
+
+	private function set_gcp_credentials() {
+		( new Credentials( new Options( new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE ) ) ) )->set( array(
+			'oauth2_client_id'     => 'test-client-id.apps.googleusercontent.com',
+			'oauth2_client_secret' => 'test-client-secret',
+		) );
+	}
+
+	private function set_proxy_credentials() {
+		( new Credentials( new Options( new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE ) ) ) )->set( array(
+			'oauth2_client_id'     => 'test-site-id.apps.sitekit.withgoogle.com',
+			'oauth2_client_secret' => 'test-site-secret',
+		) );
+	}
+}


### PR DESCRIPTION
## Summary

This PR adds the migration handler for the 1.0 release.

Addresses issue #755

## Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
