### PR TITLE
Ensure verification token is also accepted without the wrapping meta tag

### DIFF
--- a/google-site-kit.php
+++ b/google-site-kit.php
@@ -11,7 +11,7 @@
  * Plugin Name: Site Kit by Google
  * Plugin URI:  https://sitekit.withgoogle.com
  * Description: Site Kit is a one-stop solution for WordPress users to use everything Google has to offer to make them successful on the web.
- * Version:     1.0.0
+ * Version:     1.0.1
  * Author:      Google
  * Author URI:  https://opensource.google.com
  * License:     Apache License 2.0
@@ -24,7 +24,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 // Define most essential constants.
-define( 'GOOGLESITEKIT_VERSION', '1.0.0' );
+define( 'GOOGLESITEKIT_VERSION', '1.0.1' );
 define( 'GOOGLESITEKIT_PLUGIN_MAIN_FILE', __FILE__ );
 
 /**

--- a/includes/Core/Authentication/Authentication.php
+++ b/includes/Core/Authentication/Authentication.php
@@ -567,7 +567,12 @@ final class Authentication {
 		);
 
 		foreach ( $verification_tags as $verification_tag ) {
-			echo wp_kses( html_entity_decode( $verification_tag ), $allowed_html );
+			$verification_tag = html_entity_decode( $verification_tag );
+			if ( 0 !== strpos( $verification_tag, '<meta ' ) ) {
+				$verification_tag = '<meta name="google-site-verification" content="' . esc_attr( $verification_tag ) . '">';
+			}
+
+			echo wp_kses( $verification_tag, $allowed_html );
 		}
 	}
 

--- a/includes/Core/Authentication/Clients/OAuth_Client.php
+++ b/includes/Core/Authentication/Clients/OAuth_Client.php
@@ -635,6 +635,7 @@ final class OAuth_Client {
 					'rest_root'  => rawurlencode( $rest_root ),
 					'admin_root' => rawurlencode( $admin_root ),
 					'scope'      => rawurlencode( $scope ),
+					'version'    => GOOGLESITEKIT_VERSION,
 				),
 				$url
 			);
@@ -644,6 +645,7 @@ final class OAuth_Client {
 			'site_id' => $credentials->web->client_id,
 			'code'    => $access_code,
 			'scope'   => rawurlencode( $scope ),
+			'version' => GOOGLESITEKIT_VERSION,
 		);
 		if ( 'missing_verification' === $error_code ) {
 			$query_args['verification_nonce'] = wp_create_nonce( 'googlesitekit_verification' );

--- a/includes/Core/Authentication/Clients/OAuth_Client.php
+++ b/includes/Core/Authentication/Clients/OAuth_Client.php
@@ -632,10 +632,10 @@ final class OAuth_Client {
 					'nonce'      => $nonce,
 					'name'       => rawurlencode( wp_specialchars_decode( get_bloginfo( 'name' ) ) ),
 					'url'        => rawurlencode( $home_url ),
+					'version'    => GOOGLESITEKIT_VERSION,
 					'rest_root'  => rawurlencode( $rest_root ),
 					'admin_root' => rawurlencode( $admin_root ),
 					'scope'      => rawurlencode( $scope ),
-					'version'    => GOOGLESITEKIT_VERSION,
 				),
 				$url
 			);
@@ -644,8 +644,8 @@ final class OAuth_Client {
 		$query_args = array(
 			'site_id' => $credentials->web->client_id,
 			'code'    => $access_code,
-			'scope'   => rawurlencode( $scope ),
 			'version' => GOOGLESITEKIT_VERSION,
+			'scope'   => rawurlencode( $scope ),
 		);
 		if ( 'missing_verification' === $error_code ) {
 			$query_args['verification_nonce'] = wp_create_nonce( 'googlesitekit_verification' );

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Contributors:      google
 Requires at least: 4.7
 Tested up to:      5.3
 Requires PHP:      5.4
-Stable tag:        1.0.0
+Stable tag:        1.0.1
 License:           Apache License 2.0
 License URI:       https://www.apache.org/licenses/LICENSE-2.0
 Tags:              google, search-console, analytics, adsense, pagespeed-insights, optimize, tag-manager, site-kit

--- a/tests/phpunit/integration/Core/Authentication/AuthenticationTest.php
+++ b/tests/phpunit/integration/Core/Authentication/AuthenticationTest.php
@@ -95,23 +95,39 @@ class AuthenticationTest extends TestCase {
 		);
 	}
 
-	public function test_register_head_verification_tags() {
+	/**
+	 * @dataProvider data_register_head_verification_tags
+	 */
+	public function test_register_head_verification_tags( $saved_tag, $expected_output ) {
 		remove_all_actions( 'wp_head' );
 		remove_all_actions( 'login_head' );
 		$auth = new Authentication( new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE ) );
 		$auth->register();
 
-		$tag_html = '<meta name="google-site-verification" content="test-verification-content">';
-		set_transient( 'googlesitekit_verification_meta_tags', array( $tag_html ) );
+		set_transient( 'googlesitekit_verification_meta_tags', array( $saved_tag ) );
 
 		$this->assertContains(
-			$tag_html,
+			$expected_output,
 			$this->capture_action( 'wp_head' )
 		);
 
 		$this->assertContains(
-			$tag_html,
+			$expected_output,
 			$this->capture_action( 'login_head' )
+		);
+	}
+
+	public function data_register_head_verification_tags() {
+		return array(
+			array( // Full meta tag stored.
+				'<meta name="google-site-verification" content="test-verification-content">',
+				'<meta name="google-site-verification" content="test-verification-content">',
+			),
+			array(
+				// Only verification token stored.
+				'test-verification-content-2',
+				'<meta name="google-site-verification" content="test-verification-content-2">',
+			),
 		);
 	}
 

--- a/tests/phpunit/integration/Core/Authentication/Clients/OAuth_ClientTest.php
+++ b/tests/phpunit/integration/Core/Authentication/Clients/OAuth_ClientTest.php
@@ -274,6 +274,7 @@ class OAuth_ClientTest extends TestCase {
 		$url = $client->get_proxy_setup_url();
 		$this->assertContains( 'name=', $url );
 		$this->assertContains( 'url=', $url );
+		$this->assertContains( 'version=', $url );
 		$this->assertContains( 'rest_root=', $url );
 		$this->assertContains( 'admin_root=', $url );
 		$this->assertContains( 'scope=', $url );
@@ -285,6 +286,7 @@ class OAuth_ClientTest extends TestCase {
 		$url = $client->get_proxy_setup_url( 'temp-code' );
 		$this->assertContains( 'site_id=' . self::SITE_ID, $url );
 		$this->assertContains( 'code=temp-code', $url );
+		$this->assertContains( 'version=', $url );
 		$this->assertContains( 'scope=', $url );
 		$this->assertNotContains( 'name=', $url );
 		$this->assertNotContains( 'url=', $url );


### PR DESCRIPTION
## Summary

Addresses issue #765 
(in combination with authentication service fix)

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
