### PR TITLE
Enhance existing tag detection

### DIFF
--- a/assets/js/util/index.js
+++ b/assets/js/util/index.js
@@ -654,39 +654,39 @@ export const extractTag = ( string, tag ) => {
 		case 'analytics':
 
 			// Detect gtag script calls.
-			reg = new RegExp( /<script [^>]*src=['|"]https:\/\/www.googletagmanager.com\/gtag\/js\?id=(.*?)['|"][^>]*><\/script>/gm );
+			reg = new RegExp( /<script [^>]*src=['|"]https:\/\/www.googletagmanager.com\/gtag\/js\?id=(UA-.*?)['|"][^>]*><\/script>/gm );
 			result = reg.exec( string );
 			result = result ? result[ 1 ] : false;
 
 			// Detect common analytics code usage.
 			if ( ! result ) {
-				reg = new RegExp( /__gaTracker\( ?['|"]create['|"], ?['|"](.*?)['|"], ?['|"]auto['|"] ?\)/gm );
+				reg = new RegExp( /__gaTracker\( ?['|"]create['|"], ?['|"](UA-.*?)['|"], ?['|"]auto['|"] ?\)/gm );
 				result = reg.exec( string );
 				result = result ? result[ 1 ] : false;
 			}
 
 			// Detect ga create calls.
 			if ( ! result ) {
-				reg = new RegExp( /ga\( ?['|"]create['|"], ?['|"](.*?)['|"], ?['|"]auto['|"] ?\)/gm );
+				reg = new RegExp( /ga\( ?['|"]create['|"], ?['|"](UA-.*?)['|"], ?['|"]auto['|"] ?\)/gm );
 				result = reg.exec( string );
 				result = result ? result[ 1 ] : false;
 			}
 			if ( ! result ) {
-				reg = new RegExp( /_gaq.push\( ?\[ ?['|"]_setAccount['|"], ?['|"](.*?)['|"] ?] ?\)/gm );
+				reg = new RegExp( /_gaq.push\( ?\[ ?['|"]_setAccount['|"], ?['|"](UA-.*?)['|"] ?] ?\)/gm );
 				result = reg.exec( string );
 				result = result ? result[ 1 ] : false;
 			}
 
 			// Detect amp-analytics gtag.
 			if ( ! result ) {
-				reg = new RegExp( /<amp-analytics [^>]*type="gtag"[^>]*>[^<]*<script type="application\/json">[^<]*"gtag_id":\s*"([^"]+)"/gm );
+				reg = new RegExp( /<amp-analytics [^>]*type="gtag"[^>]*>[^<]*<script type="application\/json">[^<]*"gtag_id":\s*"(UA-[^"]+)"/gm );
 				result = reg.exec( string );
 				result = result ? result[ 1 ] : false;
 			}
 
 			// Detect amp-analytics googleanalytics.
 			if ( ! result ) {
-				reg = new RegExp( /<amp-analytics [^>]*type="googleanalytics"[^>]*>[^<]*<script type="application\/json">[^<]*"account":\s*"([^"]+)"/gm );
+				reg = new RegExp( /<amp-analytics [^>]*type="googleanalytics"[^>]*>[^<]*<script type="application\/json">[^<]*"account":\s*"(UA-[^"]+)"/gm );
 				result = reg.exec( string );
 				result = result ? result[ 1 ] : false;
 			}

--- a/assets/js/util/index.js
+++ b/assets/js/util/index.js
@@ -632,7 +632,7 @@ export const getExistingTag = async ( module ) => {
  */
 export const scrapeTag = async ( url, module ) => {
 	try {
-		const html = await fetch( url ).then( ( res ) => res.text() );
+		const html = await fetch( url, { credentials: 'omit' } ).then( ( res ) => res.text() );
 		return extractTag( html, module ) || null;
 	} catch ( error ) {
 		return null;

--- a/assets/js/util/index.js
+++ b/assets/js/util/index.js
@@ -660,6 +660,12 @@ export const extractTag = ( string, tag ) => {
 
 			// Detect common analytics code usage.
 			if ( ! result ) {
+				reg = new RegExp( /<script[^>]*>[^<]+google-analytics\.com\/analytics\.js[^<]+(UA-\d+-\d+)/gm );
+				result = reg.exec( string );
+				result = result ? result[ 1 ] : false;
+			}
+
+			if ( ! result ) {
 				reg = new RegExp( /__gaTracker\( ?['|"]create['|"], ?['|"](UA-.*?)['|"], ?['|"]auto['|"] ?\)/gm );
 				result = reg.exec( string );
 				result = result ? result[ 1 ] : false;

--- a/tests/qunit/assets/js/util/index.js
+++ b/tests/qunit/assets/js/util/index.js
@@ -116,6 +116,12 @@ valuesToTest = [
 		expected: 'UA-XXXXX-Y'
 	},
 	{
+		html: '<script>(window,document,\'script\',\'//www.google-analytics.com/analytics.js\',\'ga\');\
+				ga(\'create\', \'UA-12345-1\', \'auto\');ga(\'send\', \'pageview\');</script>',
+		module: 'analytics',
+		expected: 'UA-12345-1',
+	},
+	{
 		html: '<script> window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date; ga(\'create\', \'UA-XXXXX-Y\', \'auto\'); ga(\'send\', \'pageview\'); </script><script async src=\'https://www.google-analytics.com/analytics.js\'></script>',
 		module: 'analytics',
 		expected: 'UA-XXXXX-Y'


### PR DESCRIPTION
## Summary

Addresses issue #793 #744 

## Relevant technical choices

* Prefixed all Analytics tag matches with `UA-` to ensure only Analytics tags are matched
    - Existing AdSense tag patterns are in AdSense-specific locations, so no changes were made to these
* Tag detection `fetch` request is always without authentication now
* Added a new generic pattern to address missed matches for Analytics

## Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
