### PR TITLE
Pass a verification_nonce to the proxy when performing site verification after inserting token

### DIFF
--- a/includes/Core/Authentication/Authentication.php
+++ b/includes/Core/Authentication/Authentication.php
@@ -433,7 +433,13 @@ final class Authentication {
 		$code = (string) filter_input( INPUT_GET, 'googlesitekit_code' );
 
 		// We need to pass the 'missing_verification' error code here so that the URL includes a verification nonce.
-		wp_safe_redirect( add_query_arg( 'verify', 'true', $auth_client->get_proxy_setup_url( $code, 'missing_verification' ) ) );
+		wp_safe_redirect(
+			add_query_arg(
+				'verify',
+				'true',
+				$auth_client->get_proxy_setup_url( $code, 'missing_verification' )
+			)
+		);
 		exit;
 	}
 

--- a/includes/Core/Authentication/Authentication.php
+++ b/includes/Core/Authentication/Authentication.php
@@ -432,7 +432,8 @@ final class Authentication {
 
 		$code = (string) filter_input( INPUT_GET, 'googlesitekit_code' );
 
-		wp_safe_redirect( add_query_arg( 'verify', 'true', $auth_client->get_proxy_setup_url( $code ) ) );
+		// We need to pass the 'missing_verification' error code here so that the URL includes a verification nonce.
+		wp_safe_redirect( add_query_arg( 'verify', 'true', $auth_client->get_proxy_setup_url( $code, 'missing_verification' ) ) );
 		exit;
 	}
 


### PR DESCRIPTION
## Summary

Addresses issue #797

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
