### PR TITLE
small work on #828

### DIFF
--- a/includes/Modules/AdSense.php
+++ b/includes/Modules/AdSense.php
@@ -220,7 +220,17 @@ final class AdSense extends Module implements Module_With_Screen, Module_With_Sc
 		if ( false === $tag_enabled ) {
 			return;
 		}
-
+		// check if user is logged in and is a subscriber or contributor or customer
+		if(is_user_logged_in()) {
+			$user = wp_get_current_user();
+			$roles = ( array ) $user->roles;
+			if(!(in_array('Subscriber', $roles) || in_array('Contributor', $roles) || in_array('Customer', $roles))) {
+				echo "<!-- AdSense tag was not printed by site kit to avoid invalid clicks -->";
+				return;
+			}
+			
+			
+		}
 		// On AMP, preferably use the new 'wp_body_open' hook, falling back to 'the_content' below.
 		if ( $this->context->is_amp() ) {
 			add_action(


### PR DESCRIPTION
## Summary
I have added small code snippet inside output_adsense_script() which will not output the AdSense script if the user logged is not a Subscriber, Contributor, or Customer (for woocommerce). This approach can be extended by the team by adding the choice in a site kit dashboard if the administrator wants this to happen or not.

<!-- Please reference the issue this PR addresses. -->
Addresses issue #828 

## Relevant technical choices

<!-- Please describe your changes. -->

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
