### PR TITLE
Ensure that user credentials are consistently wiped on refresh token failure

### DIFF
--- a/includes/Core/Authentication/Authentication.php
+++ b/includes/Core/Authentication/Authentication.php
@@ -279,14 +279,7 @@ final class Authentication {
 	public function disconnect() {
 		$this->get_oauth_client()->revoke_token();
 
-		$this->user_options->delete( Clients\OAuth_Client::OPTION_ACCESS_TOKEN );
-		$this->user_options->delete( Clients\OAuth_Client::OPTION_ACCESS_TOKEN_EXPIRES_IN );
-		$this->user_options->delete( Clients\OAuth_Client::OPTION_ACCESS_TOKEN_CREATED );
-		$this->user_options->delete( Clients\OAuth_Client::OPTION_REFRESH_TOKEN );
-		$this->user_options->delete( Clients\OAuth_Client::OPTION_REDIRECT_URL );
-		$this->user_options->delete( Clients\OAuth_Client::OPTION_AUTH_SCOPES );
-		$this->user_options->delete( Clients\OAuth_Client::OPTION_ERROR_CODE );
-		$this->user_options->delete( Clients\OAuth_Client::OPTION_PROXY_ACCESS_CODE );
+		// Delete additional user data.
 		$this->user_options->delete( Verification::OPTION );
 		$this->user_options->delete( Verification_Tag::OPTION );
 		$this->user_options->delete( Profile::OPTION );
@@ -461,14 +454,6 @@ final class Authentication {
 
 		// Refresh auth token.
 		$auth_client->refresh_token();
-
-		// If 'invalid_grant' error, disconnect the account.
-		if ( 'invalid_grant' === $this->user_options->get( Clients\OAuth_Client::OPTION_ERROR_CODE ) ) {
-			$this->disconnect();
-
-			// We need to re-set this error so that it is displayed to the user.
-			$this->user_options->set( Clients\OAuth_Client::OPTION_ERROR_CODE, 'invalid_grant' );
-		}
 	}
 
 	/**

--- a/includes/Core/Authentication/Authentication.php
+++ b/includes/Core/Authentication/Authentication.php
@@ -449,11 +449,11 @@ final class Authentication {
 
 		$auth_client = $this->get_oauth_client();
 
-		// Initiates Google Client object.
-		$auth_client->get_client();
-
-		// Refresh auth token.
-		$auth_client->refresh_token();
+		// Make sure to refresh the access token if necessary.
+		$google_client = $auth_client->get_client();
+		if ( $auth_client->get_access_token() && $google_client->isAccessTokenExpired() ) {
+			$auth_client->refresh_token();
+		}
 	}
 
 	/**

--- a/includes/Core/Authentication/Clients/OAuth_Client.php
+++ b/includes/Core/Authentication/Clients/OAuth_Client.php
@@ -237,7 +237,9 @@ final class OAuth_Client {
 	public function refresh_token() {
 		$refresh_token = $this->get_refresh_token();
 		if ( empty( $refresh_token ) ) {
+			$this->revoke_token();
 			$this->user_options->set( self::OPTION_ERROR_CODE, 'refresh_token_not_exist' );
+			return;
 		}
 
 		// Stop if google_client not initialized yet.
@@ -257,7 +259,9 @@ final class OAuth_Client {
 				$error_code = $e->getMessage();
 			}
 			// Revoke and delete user connection data if the refresh token is invalid or expired.
-			$this->revoke_token();
+			if ( 'invalid_grant' === $error_code ) {
+				$this->revoke_token();
+			}
 			$this->user_options->set( self::OPTION_ERROR_CODE, $error_code );
 			return;
 		}

--- a/includes/Core/Authentication/Clients/OAuth_Client.php
+++ b/includes/Core/Authentication/Clients/OAuth_Client.php
@@ -257,9 +257,7 @@ final class OAuth_Client {
 				$error_code = $e->getMessage();
 			}
 			// Revoke and delete user connection data if the refresh token is invalid or expired.
-			if ( 'invalid_grant' === $error_code ) {
-				$this->revoke_token();
-			}
+			$this->revoke_token();
 			$this->user_options->set( self::OPTION_ERROR_CODE, $error_code );
 			return;
 		}

--- a/includes/Core/Authentication/Clients/OAuth_Client.php
+++ b/includes/Core/Authentication/Clients/OAuth_Client.php
@@ -284,7 +284,11 @@ final class OAuth_Client {
 			return;
 		}
 
-		$this->google_client->revokeToken();
+		try {
+			$this->google_client->revokeToken();
+		} catch ( \Exception $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement
+			// No special handling, we just need to make sure this goes through.
+		}
 
 		$this->delete_token();
 	}

--- a/tests/e2e/mu-plugins/e2e-rest-access-token.php
+++ b/tests/e2e/mu-plugins/e2e-rest-access-token.php
@@ -9,8 +9,9 @@
  * @link      https://sitekit.withgoogle.com
  */
 
+use Google\Site_Kit\Context;
+use Google\Site_Kit\Core\Authentication\Clients\OAuth_Client;
 use Google\Site_Kit\Core\REST_API\REST_Routes;
-use Google\Site_Kit\Core\Storage\Data_Encryption;
 
 add_action( 'rest_api_init', function () {
 	if ( ! defined( 'GOOGLESITEKIT_PLUGIN_MAIN_FILE' ) ) {
@@ -23,13 +24,8 @@ add_action( 'rest_api_init', function () {
 		array(
 			'methods'  => WP_REST_Server::EDITABLE,
 			'callback' => function ( WP_REST_Request $request ) {
-				update_user_option(
-					get_current_user_id(),
-					'googlesitekit_access_token',
-					( new Data_Encryption() )->encrypt(
-						serialize( array( 'access_token' => $request['token'] ) )
-					)
-				);
+				( new OAuth_Client( new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE ) ) )
+					->set_access_token( $request['token'], HOUR_IN_SECONDS );
 
 				return array( 'success' => true, 'token' => $request['token'] );
 			}

--- a/tests/e2e/specs/auth-flow.test.js
+++ b/tests/e2e/specs/auth-flow.test.js
@@ -51,12 +51,9 @@ const disconnectFromSiteKit = async () => {
 };
 
 describe( 'Site Kit set up flow for the first time', () => {
-	beforeAll( async () => {
-		await setSearchConsoleProperty();
-	} );
-
 	beforeEach( async () => {
 		await activatePlugin( 'e2e-tests-gcp-credentials-plugin' );
+		await setSearchConsoleProperty();
 	} );
 
 	afterEach( async () => {
@@ -80,7 +77,6 @@ describe( 'Site Kit set up flow for the first time', () => {
 	it( 'disconnects user from Site Kit', async () => {
 		await setAuthToken();
 		await setSiteVerification();
-		await setSearchConsoleProperty();
 		await visitAdminPage( 'admin.php', 'page=googlesitekit-dashboard' );
 
 		await disconnectFromSiteKit();

--- a/tests/phpunit/integration/Core/Authentication/AuthenticationTest.php
+++ b/tests/phpunit/integration/Core/Authentication/AuthenticationTest.php
@@ -165,31 +165,21 @@ class AuthenticationTest extends TestCase {
 			'fetchAccessTokenWithRefreshToken',
 			'revokeToken'
 		) );
-		$mock_google_client->expects( $this->once() )->method( 'fetchAccessTokenWithRefreshToken' )->with( 'test-refresh-token' );
+		$mock_google_client->expects( $this->once() )->method( 'fetchAccessTokenWithRefreshToken' )
+			->with( 'test-refresh-token' )
+			->willThrowException( new \Exception( 'invalid_grant' ) );
 		$mock_google_client->expects( $this->once() )->method( 'revokeToken' );
 		$this->force_set_property( $client, 'google_client', $mock_google_client );
 
-		// Force invalid_grant error to trigger disconnect.
-		add_filter(
-			'get_user_metadata',
-			function ( $given, $object_id, $meta_key, $single ) use ( $context, $user_id ) {
-				if ( $context->is_network_mode() ) {
-					$error_meta_key = OAuth_Client::OPTION_ERROR_CODE;
-				} else {
-					$error_meta_key = $GLOBALS['wpdb']->get_blog_prefix() . OAuth_Client::OPTION_ERROR_CODE;
-				}
-
-				if ( (int) $object_id === (int) $user_id && $error_meta_key === $meta_key ) {
-					return $single ? 'invalid_grant' : array( 'invalid_grant' );
-				}
-
-				return $given;
-			},
-			10,
-			4
-		);
-
 		do_action( 'wp_login' );
+
+		if ( $context->is_network_mode() ) {
+			$error_meta_key = OAuth_Client::OPTION_ERROR_CODE;
+		} else {
+			$error_meta_key = $GLOBALS['wpdb']->get_blog_prefix() . OAuth_Client::OPTION_ERROR_CODE;
+		}
+
+		$this->assertSame( 'invalid_grant', get_user_meta( $user_id, $error_meta_key, true ) );
 	}
 
 	public function test_get_oauth_client() {


### PR DESCRIPTION
## Summary

Addresses issue #831

## Relevant technical choices

* We need to also delete user credentials when refreshing a token fails outside of the login flow.
* Deleting that data should happen in the same method as the failure, to make sure this is always executed and to not violate DRY.
* We only need to wipe user credentials, not necessarily disconnect the entire user.
* There should never be a need to revoke a token without also deleting that data on the WordPress site, so we can combine this in one method now for ease of use.

## Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
