### PR TITLE
Lazy load profile data

### DIFF
--- a/google-site-kit.php
+++ b/google-site-kit.php
@@ -11,7 +11,7 @@
  * Plugin Name: Site Kit by Google
  * Plugin URI:  https://sitekit.withgoogle.com
  * Description: Site Kit is a one-stop solution for WordPress users to use everything Google has to offer to make them successful on the web.
- * Version:     1.0.3
+ * Version:     1.0.4
  * Author:      Google
  * Author URI:  https://opensource.google.com
  * License:     Apache License 2.0
@@ -24,7 +24,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 // Define most essential constants.
-define( 'GOOGLESITEKIT_VERSION', '1.0.3' );
+define( 'GOOGLESITEKIT_VERSION', '1.0.4' );
 define( 'GOOGLESITEKIT_PLUGIN_MAIN_FILE', __FILE__ );
 
 /**

--- a/includes/Core/Authentication/Authentication.php
+++ b/includes/Core/Authentication/Authentication.php
@@ -466,7 +466,11 @@ final class Authentication {
 	 */
 	private function inline_js_admin_data( $data ) {
 		if ( ! isset( $data['userData'] ) ) {
-			$data['userData'] = array();
+			$current_user     = wp_get_current_user();
+			$data['userData'] = array(
+				'email'   => $current_user->user_email,
+				'picture' => get_avatar_url( $current_user->user_email ),
+			);
 		}
 		$profile_data = $this->profile->get();
 		if ( $profile_data ) {

--- a/includes/Core/Authentication/Clients/OAuth_Client.php
+++ b/includes/Core/Authentication/Clients/OAuth_Client.php
@@ -287,13 +287,8 @@ final class OAuth_Client {
 	 * @since 1.0.0
 	 */
 	public function revoke_token() {
-		// Stop if google_client not initialized yet.
-		if ( ! $this->google_client instanceof Google_Client ) {
-			return;
-		}
-
 		try {
-			$this->google_client->revokeToken();
+			$this->get_client()->revokeToken();
 		} catch ( \Exception $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement
 			// No special handling, we just need to make sure this goes through.
 		}

--- a/includes/Core/Authentication/Profile.php
+++ b/includes/Core/Authentication/Profile.php
@@ -112,13 +112,7 @@ final class Profile {
 	 */
 	private function retrieve_google_profile_from_api() {
 
-		// Fall back to the user's WordPress profile information.
-		$current_user = wp_get_current_user();
-		$profile_data = array(
-			'email'     => $current_user->user_email,
-			'photo'     => get_avatar_url( $current_user->user_email ),
-			'timestamp' => 0, // Don't cache WP user data.
-		);
+		$profile_data = false;
 
 		// Retrieve and store the user's Google profile data.
 		try {

--- a/includes/Core/Authentication/Profile.php
+++ b/includes/Core/Authentication/Profile.php
@@ -54,19 +54,6 @@ final class Profile {
 	public function __construct( User_Options $user_options, OAuth_Client $auth_client ) {
 		$this->user_options = $user_options;
 		$this->auth_client  = $auth_client;
-
-		// Ensure we have fresh profile data.
-		$profile_data = $this->get();
-		$timestamp    = isset( $profile_data['timestamp'] ) ? (int) $profile_data['timestamp'] : 0;
-		$currenttime  = time();
-
-		// If the stored profile data is missing, or older than a week, re-fetch it.
-		if ( ! $profile_data || ( ( $currenttime - $timestamp ) > ( 7 * DAY_IN_SECONDS ) ) ) {
-			$profile_data = $this->retrieve_google_profile_from_api();
-		}
-		if ( 0 !== $profile_data['timestamp'] ) {
-			$this->set( $profile_data );
-		}
 	}
 
 	/**
@@ -77,7 +64,17 @@ final class Profile {
 	 * @return array|bool Value set for the profile, or false if not set.
 	 */
 	public function get() {
-		return $this->user_options->get( self::OPTION );
+		// Ensure we have fresh profile data.
+		$profile_data = $this->user_options->get( self::OPTION );
+		$profile_time = isset( $profile_data['timestamp'] ) ? (int) $profile_data['timestamp'] : 0;
+		$current_time = current_time( 'timestamp' );
+
+		// If the stored profile data is missing, or older than a week, re-fetch it.
+		if ( ! $profile_data || ( $current_time - $profile_time ) > WEEK_IN_SECONDS ) {
+			$profile_data = $this->retrieve_google_profile_from_api();
+		}
+
+		return $profile_data;
 	}
 
 	/**

--- a/includes/Core/Authentication/Profile.php
+++ b/includes/Core/Authentication/Profile.php
@@ -10,7 +10,6 @@
 
 namespace Google\Site_Kit\Core\Authentication;
 
-use Google\Site_Kit\Helpers;
 use Google\Site_Kit\Core\Storage\User_Options;
 use Google\Site_Kit\Core\Authentication\Clients\OAuth_Client;
 use Google\Site_Kit_Dependencies\Google_Service_PeopleService;

--- a/includes/Core/Authentication/Profile.php
+++ b/includes/Core/Authentication/Profile.php
@@ -126,14 +126,14 @@ final class Profile {
 			$people_service = new Google_Service_PeopleService( $client );
 			$profile        = $people_service->people->get( 'people/me', array( 'personFields' => 'emailAddresses,photos' ) );
 
-			if ( isset( $profile['emailAddresses'][0]['value'] ) && isset( $profile['photos'][0]['url'] ) ) {
-
-				// Success - we have the profile data from the People API.
+			if ( isset( $profile['emailAddresses'][0]['value'], $profile['photos'][0]['url'] ) ) {
 				$profile_data = array(
 					'email'     => $profile['emailAddresses'][0]['value'],
 					'photo'     => $profile['photos'][0]['url'],
-					'timestamp' => time(),
+					'timestamp' => current_time( 'timestamp' ),
 				);
+
+				$this->set( $profile_data );
 			}
 		} catch ( \Exception $e ) {
 			return $profile_data;

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Contributors:      google
 Requires at least: 4.7
 Tested up to:      5.3
 Requires PHP:      5.4
-Stable tag:        1.0.3
+Stable tag:        1.0.4
 License:           Apache License 2.0
 License URI:       https://www.apache.org/licenses/LICENSE-2.0
 Tags:              google, search-console, analytics, adsense, pagespeed-insights, optimize, tag-manager, site-kit

--- a/tests/phpunit/integration/Core/Authentication/Clients/OAuth_ClientTest.php
+++ b/tests/phpunit/integration/Core/Authentication/Clients/OAuth_ClientTest.php
@@ -49,8 +49,7 @@ class OAuth_ClientTest extends TestCase {
 
 		$client->refresh_token();
 
-		// Google client must be initialized first
-		$this->assertEquals( 'refresh_token_not_exist', get_user_option( OAuth_Client::OPTION_ERROR_CODE, $user_id ) );
+		$this->assertEquals( 'access_token_not_received', get_user_option( OAuth_Client::OPTION_ERROR_CODE, $user_id ) );
 
 		$client->get_client()->setHttpClient( new FakeHttpClient() );
 		$client->refresh_token();


### PR DESCRIPTION
## Summary

Addresses issue #854

## Relevant technical choices

This PR moves the profile query from happening during `__construct` to loading it on-the-fly during `Profile::get()`, but only if the existing data is stale.

It also removes the "fallback" profile data which was taken from the logged in WordPress user. This shouldn't be used as `Profile` should only return data associated with the authenticated _Google account_.

This PR touches some refresh token related code because the initial changes included here caused the `\Google\Site_Kit\Tests\Core\Util\Migration_1_0_0Test::test_migrate` test to fail where the user's access tokens were no longer being deleted.

I realized this was because the `Profile` request happens during test bootstrapping which initializes the  Google client. Once this was fixed, the `disconnect` method was failing to delete the tokens because it was returning early since the Google client wasn't initialized.

This could be the cause of another bug where disconnecting could fail if the user was logged in and `disconnect` was called before the client had been initialized since it would not be auto-initialized by the `Profile` request if the user already had valid profile data.

After removing this early return and replacing it with `$this->get_client()` to ensure that the client was always available, it caused another test to fail regarding an error code that assumed the early return that was removed. Fixing this logical failure to expect a different error, the tests all pass again.

## Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
