### PR TITLE
feat: Use wp_generate_password for nonces

### DIFF
--- a/includes/Core/Authentication/Authentication.php
+++ b/includes/Core/Authentication/Authentication.php
@@ -297,7 +297,7 @@ final class Authentication {
 			'splash',
 			array(
 				'googlesitekit_connect' => 1,
-				'nonce'                 => wp_generate_password(),
+				'nonce'                 => wp_create_nonce( 'connect' ),
 			)
 		);
 	}
@@ -314,7 +314,7 @@ final class Authentication {
 			'splash',
 			array(
 				'googlesitekit_disconnect' => 1,
-				'nonce'                    => wp_generate_password(),
+				'nonce'                    => wp_create_nonce( 'disconnect' ),
 			)
 		);
 	}

--- a/includes/Core/Authentication/Authentication.php
+++ b/includes/Core/Authentication/Authentication.php
@@ -297,7 +297,7 @@ final class Authentication {
 			'splash',
 			array(
 				'googlesitekit_connect' => 1,
-				'nonce'                 => wp_create_nonce( 'connect' ),
+				'nonce'                 => wp_generate_password(),
 			)
 		);
 	}
@@ -314,7 +314,7 @@ final class Authentication {
 			'splash',
 			array(
 				'googlesitekit_disconnect' => 1,
-				'nonce'                    => wp_create_nonce( 'disconnect' ),
+				'nonce'                    => wp_generate_password(),
 			)
 		);
 	}

--- a/includes/Core/Authentication/Clients/OAuth_Client.php
+++ b/includes/Core/Authentication/Clients/OAuth_Client.php
@@ -633,7 +633,7 @@ final class OAuth_Client {
 
 			$nonce = $this->options->get( self::OPTION_PROXY_NONCE );
 			if ( empty( $nonce ) ) {
-				$nonce = wp_create_nonce( 'googlesitekit_proxy' );
+				$nonce = wp_generate_password();
 				$this->options->set( self::OPTION_PROXY_NONCE, $nonce );
 			}
 
@@ -658,7 +658,7 @@ final class OAuth_Client {
 			'scope'   => rawurlencode( $scope ),
 		);
 		if ( 'missing_verification' === $error_code ) {
-			$query_args['verification_nonce'] = wp_create_nonce( 'googlesitekit_verification' );
+			$query_args['verification_nonce'] = wp_generate_password();
 		}
 
 		return add_query_arg( $query_args, $url );

--- a/includes/Core/Authentication/Clients/OAuth_Client.php
+++ b/includes/Core/Authentication/Clients/OAuth_Client.php
@@ -658,7 +658,7 @@ final class OAuth_Client {
 			'scope'   => rawurlencode( $scope ),
 		);
 		if ( 'missing_verification' === $error_code ) {
-			$query_args['verification_nonce'] = wp_generate_password();
+			$query_args['verification_nonce'] = wp_create_nonce( 'googlesitekit_verification' );
 		}
 
 		return add_query_arg( $query_args, $url );


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #756.

## Relevant technical choices

Replaces nonces created for setup/auth/disconnect URLs with a slightly more secure/random `wp_generate_password()`. I think it was appropriate to replace all three of these calls and no other ones to `wp_create_nonce()` based on the IB in #756, but let me know if I'm off 😄

## Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
