### PR TITLE
feat: Don't show logo in Dashboard; make side nav icon smaller

### DIFF
--- a/includes/Core/Admin/Dashboard.php
+++ b/includes/Core/Admin/Dashboard.php
@@ -97,25 +97,9 @@ final class Dashboard {
 			return;
 		}
 
-		$logo = $this->assets->svg_sprite(
-			'logo-g',
-			[
-				'height' => '19',
-				'width'  => '19',
-			]
-		); // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped.
-
-		$logo_text = $this->assets->svg_sprite(
-			'logo-sitekit',
-			[
-				'height' => '17',
-				'width'  => '78',
-			]
-		); // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped.
-
 		wp_add_dashboard_widget(
 			'google_dashboard_widget',
-			'<span class="googlesitekit-logo googlesitekit-logo--mini">' . $logo . $logo_text . '</span>',
+			__( 'Site Kit Summary', 'google-site-kit' ),
 			function () {
 				$this->render_googlesitekit_wp_dashboard();
 			}

--- a/includes/Core/Admin/Screens.php
+++ b/includes/Core/Admin/Screens.php
@@ -103,7 +103,7 @@ final class Screens {
 				?>
 				<style type="text/css">
 					#adminmenu .toplevel_page_googlesitekit-dashboard img {
-						width: 18px;
+						width: 16px;
 					}
 					#adminmenu .toplevel_page_googlesitekit-dashboard.current img,
 					#adminmenu .toplevel_page_googlesitekit-dashboard.wp-has-current-submenu img {


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #877. This removes the logo from the WP Dashboard home and reduces the icon size in the sidebar.

## Screenshots

<img width="164" alt="Screenshot 2019-11-19 17 23 56" src="https://user-images.githubusercontent.com/90871/69171028-0bd41300-0af3-11ea-8f00-b60a2bc79c3b.png">
<img width="561" alt="Screenshot 2019-11-19 17 23 51" src="https://user-images.githubusercontent.com/90871/69171030-0c6ca980-0af3-11ea-9ccb-f8cfb708b6c8.png">
<img width="800" alt="Screenshot 2019-11-19 17 23 48" src="https://user-images.githubusercontent.com/90871/69171031-0c6ca980-0af3-11ea-8f75-0b818b779f55.png">


## Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
