### PR TITLE
Add support for File-based Site Verification

### DIFF
--- a/includes/Core/Authentication/Authentication.php
+++ b/includes/Core/Authentication/Authentication.php
@@ -164,13 +164,6 @@ final class Authentication {
 		);
 
 		add_action(
-			'admin_init',
-			function() {
-				$this->handle_verification_token();
-			}
-		);
-
-		add_action(
 			'wp_login',
 			function() {
 				$this->refresh_auth_token_on_login();
@@ -397,42 +390,6 @@ final class Authentication {
 			header( 'Location: ' . filter_var( $auth_client->get_authentication_url( $redirect_url ), FILTER_SANITIZE_URL ) );
 			exit();
 		}
-	}
-
-	/**
-	 * Handles receiving a verification token for a user by the authentication proxy.
-	 *
-	 * @since 1.0.0
-	 */
-	private function handle_verification_token() {
-		$auth_client = $this->get_oauth_client();
-		if ( ! $auth_client->using_proxy() ) {
-			return;
-		}
-
-		$verification_token = filter_input( INPUT_GET, 'googlesitekit_verification_token' );
-		if ( empty( $verification_token ) ) {
-			return;
-		}
-
-		$verification_nonce = filter_input( INPUT_GET, 'googlesitekit_verification_nonce' );
-		if ( empty( $verification_nonce ) || ! wp_verify_nonce( $verification_nonce, 'googlesitekit_verification' ) ) {
-			wp_die( esc_html__( 'Invalid nonce.', 'google-site-kit' ) );
-		}
-
-		$this->verification_tag->set( $verification_token );
-
-		$code = (string) filter_input( INPUT_GET, 'googlesitekit_code' );
-
-		// We need to pass the 'missing_verification' error code here so that the URL includes a verification nonce.
-		wp_safe_redirect(
-			add_query_arg(
-				'verify',
-				'true',
-				$auth_client->get_proxy_setup_url( $code, 'missing_verification' )
-			)
-		);
-		exit;
 	}
 
 	/**

--- a/includes/Core/Authentication/Authentication.php
+++ b/includes/Core/Authentication/Authentication.php
@@ -97,7 +97,7 @@ final class Authentication {
 	/**
 	 * Verification file instance.
 	 *
-	 * @since 1.0.5
+	 * @since n.e.x.t
 	 * @var Verification_File
 	 */
 	protected $verification_file;
@@ -243,7 +243,7 @@ final class Authentication {
 	/**
 	 * Gets the verification file instance.
 	 *
-	 * @since 1.0.5
+	 * @since n.e.x.t
 	 *
 	 * @return Verification_File Verification file instance.
 	 */

--- a/includes/Core/Authentication/Authentication.php
+++ b/includes/Core/Authentication/Authentication.php
@@ -206,13 +206,6 @@ final class Authentication {
 				return $this->authentication_admin_notices( $notices );
 			}
 		);
-
-		$print_site_verification_meta = function() {
-			$this->print_site_verification_meta();
-		};
-
-		add_action( 'wp_head', $print_site_verification_meta );
-		add_action( 'login_head', $print_site_verification_meta );
 	}
 
 	/**
@@ -515,40 +508,6 @@ final class Authentication {
 		$data['moduleToSetup'] = $module_to_setup;
 
 		return $data;
-	}
-
-	/**
-	 * Prints site verification meta in wp_head().
-	 *
-	 * @since 1.0.0
-	 *
-	 * @global wpdb $wpdb WordPress database abstraction object.
-	 */
-	private function print_site_verification_meta() {
-		global $wpdb;
-
-		// Get verification meta tags for all users.
-		$verification_tags = $this->verification_tag->get_all();
-
-		if ( empty( $verification_tags ) ) {
-			return;
-		}
-
-		$allowed_html = array(
-			'meta' => array(
-				'name'    => array(),
-				'content' => array(),
-			),
-		);
-
-		foreach ( $verification_tags as $verification_tag ) {
-			$verification_tag = html_entity_decode( $verification_tag );
-			if ( 0 !== strpos( $verification_tag, '<meta ' ) ) {
-				$verification_tag = '<meta name="google-site-verification" content="' . esc_attr( $verification_tag ) . '">';
-			}
-
-			echo wp_kses( $verification_tag, $allowed_html );
-		}
 	}
 
 	/**

--- a/includes/Core/Authentication/Authentication.php
+++ b/includes/Core/Authentication/Authentication.php
@@ -95,6 +95,14 @@ final class Authentication {
 	protected $verification_tag;
 
 	/**
+	 * Verification file instance.
+	 *
+	 * @since 1.0.5
+	 * @var Verification_File
+	 */
+	protected $verification_file;
+
+	/**
 	 * Profile instance.
 	 *
 	 * @since 1.0.0
@@ -141,13 +149,14 @@ final class Authentication {
 		if ( ! $transients ) {
 			$transients = new Transients( $this->context );
 		}
-		$this->transients = $transients;
 
-		$this->credentials      = new Credentials( $this->options );
-		$this->verification     = new Verification( $this->user_options );
-		$this->verification_tag = new Verification_Meta( $this->user_options, $this->transients );
-		$this->profile          = new Profile( $user_options, $this->get_oauth_client() );
-		$this->first_admin      = new First_Admin( $this->options );
+		$this->transients        = $transients;
+		$this->credentials       = new Credentials( $this->options );
+		$this->verification      = new Verification( $this->user_options );
+		$this->verification_tag  = new Verification_Meta( $this->user_options, $this->transients );
+		$this->verification_file = new Verification_File( $this->user_options );
+		$this->profile           = new Profile( $user_options, $this->get_oauth_client() );
+		$this->first_admin       = new First_Admin( $this->options );
 	}
 
 	/**
@@ -236,6 +245,17 @@ final class Authentication {
 	 */
 	public function verification_tag() {
 		return $this->verification_tag;
+	}
+
+	/**
+	 * Gets the verification file instance.
+	 *
+	 * @since 1.0.5
+	 *
+	 * @return Verification_File Verification file instance.
+	 */
+	public function verification_file() {
+		return $this->verification_file;
 	}
 
 	/**

--- a/includes/Core/Authentication/Authentication.php
+++ b/includes/Core/Authentication/Authentication.php
@@ -90,7 +90,7 @@ final class Authentication {
 	 * Verification tag instance.
 	 *
 	 * @since 1.0.0
-	 * @var Verification_Tag
+	 * @var Verification_Meta
 	 */
 	protected $verification_tag;
 
@@ -145,7 +145,7 @@ final class Authentication {
 
 		$this->credentials      = new Credentials( $this->options );
 		$this->verification     = new Verification( $this->user_options );
-		$this->verification_tag = new Verification_Tag( $this->user_options, $this->transients );
+		$this->verification_tag = new Verification_Meta( $this->user_options, $this->transients );
 		$this->profile          = new Profile( $user_options, $this->get_oauth_client() );
 		$this->first_admin      = new First_Admin( $this->options );
 	}
@@ -238,9 +238,8 @@ final class Authentication {
 	/**
 	 * Gets the verification tag instance.
 	 *
+	 * @return Verification_Meta Verification tag instance.
 	 * @since 1.0.0
-	 *
-	 * @return Verification_Tag Verification tag instance.
 	 */
 	public function verification_tag() {
 		return $this->verification_tag;
@@ -281,7 +280,7 @@ final class Authentication {
 
 		// Delete additional user data.
 		$this->user_options->delete( Verification::OPTION );
-		$this->user_options->delete( Verification_Tag::OPTION );
+		$this->user_options->delete( Verification_Meta::OPTION );
 		$this->user_options->delete( Profile::OPTION );
 	}
 

--- a/includes/Core/Authentication/Authentication.php
+++ b/includes/Core/Authentication/Authentication.php
@@ -233,10 +233,13 @@ final class Authentication {
 	/**
 	 * Gets the verification tag instance.
 	 *
+	 * @deprecated n.e.x.t
+	 *
 	 * @return Verification_Meta Verification tag instance.
 	 * @since 1.0.0
 	 */
 	public function verification_tag() {
+		_deprecated_function( __METHOD__, 'n.e.x.t', __CLASS__ . '\\verification_meta' );
 		return $this->verification_meta;
 	}
 

--- a/includes/Core/Authentication/Authentication.php
+++ b/includes/Core/Authentication/Authentication.php
@@ -239,7 +239,7 @@ final class Authentication {
 	 * @since 1.0.0
 	 */
 	public function verification_tag() {
-		_deprecated_function( __METHOD__, 'n.e.x.t', __CLASS__ . '\\verification_meta' );
+		_deprecated_function( __METHOD__, 'n.e.x.t', __CLASS__ . '::verification_meta' );
 		return $this->verification_meta;
 	}
 

--- a/includes/Core/Authentication/Authentication.php
+++ b/includes/Core/Authentication/Authentication.php
@@ -239,7 +239,7 @@ final class Authentication {
 	 * @return Verification_Meta Verification tag instance.
 	 */
 	public function verification_tag() {
-		_deprecated_function( __METHOD__, 'n.e.x.t', __CLASS__ . '::verification_meta' );
+		_deprecated_function( __METHOD__, 'n.e.x.t', __CLASS__ . '::verification_meta()' );
 		return $this->verification_meta;
 	}
 

--- a/includes/Core/Authentication/Authentication.php
+++ b/includes/Core/Authentication/Authentication.php
@@ -233,10 +233,10 @@ final class Authentication {
 	/**
 	 * Gets the verification tag instance.
 	 *
+	 * @since 1.0.0
 	 * @deprecated n.e.x.t
 	 *
 	 * @return Verification_Meta Verification tag instance.
-	 * @since 1.0.0
 	 */
 	public function verification_tag() {
 		_deprecated_function( __METHOD__, 'n.e.x.t', __CLASS__ . '::verification_meta' );

--- a/includes/Core/Authentication/Authentication.php
+++ b/includes/Core/Authentication/Authentication.php
@@ -244,6 +244,17 @@ final class Authentication {
 	}
 
 	/**
+	 * Gets the verification meta instance.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @return Verification_Meta Verification tag instance.
+	 */
+	public function verification_meta() {
+		return $this->verification_meta;
+	}
+
+	/**
 	 * Gets the verification file instance.
 	 *
 	 * @since n.e.x.t

--- a/includes/Core/Authentication/Authentication.php
+++ b/includes/Core/Authentication/Authentication.php
@@ -87,12 +87,12 @@ final class Authentication {
 	protected $verification;
 
 	/**
-	 * Verification tag instance.
+	 * Verification meta instance.
 	 *
-	 * @since 1.0.0
+	 * @since n.e.x.t
 	 * @var Verification_Meta
 	 */
-	protected $verification_tag;
+	protected $verification_meta;
 
 	/**
 	 * Verification file instance.
@@ -153,7 +153,7 @@ final class Authentication {
 		$this->transients        = $transients;
 		$this->credentials       = new Credentials( $this->options );
 		$this->verification      = new Verification( $this->user_options );
-		$this->verification_tag  = new Verification_Meta( $this->user_options, $this->transients );
+		$this->verification_meta = new Verification_Meta( $this->user_options, $this->transients );
 		$this->verification_file = new Verification_File( $this->user_options );
 		$this->profile           = new Profile( $user_options, $this->get_oauth_client() );
 		$this->first_admin       = new First_Admin( $this->options );
@@ -237,7 +237,7 @@ final class Authentication {
 	 * @since 1.0.0
 	 */
 	public function verification_tag() {
-		return $this->verification_tag;
+		return $this->verification_meta;
 	}
 
 	/**

--- a/includes/Core/Authentication/Clients/OAuth_Client.php
+++ b/includes/Core/Authentication/Clients/OAuth_Client.php
@@ -660,6 +660,23 @@ final class OAuth_Client {
 	}
 
 	/**
+	 * Checks if the site supports file-based site verification.
+	 *
+	 * The site must be a root install, with no path in the home URL
+	 * to be able to serve the verification response properly.
+	 *
+	 * @since n.e.x.t
+	 * @see \WP_Rewrite::rewrite_rules for robots.txt
+	 *
+	 * @return bool
+	 */
+	private function supports_file_verification() {
+		$home_path = wp_parse_url( home_url(), PHP_URL_PATH );
+
+		return ( ! $home_path || '/' === $home_path );
+	}
+
+	/**
 	 * Returns the permissions URL to the authentication proxy.
 	 *
 	 * This only returns a URL if the user already has an access token set.

--- a/includes/Core/Authentication/Verification_File.php
+++ b/includes/Core/Authentication/Verification_File.php
@@ -13,7 +13,7 @@ namespace Google\Site_Kit\Core\Authentication;
 use Google\Site_Kit\Core\Storage\User_Options;
 
 /**
- * Class representing the site verification file for a user.
+ * Class representing the site verification file token for a user.
  *
  * @since n.e.x.t
  * @access private
@@ -46,35 +46,34 @@ final class Verification_File {
 	}
 
 	/**
-	 * Retrieves the user verification file.
+	 * Retrieves the user verification file token.
 	 *
 	 * @since n.e.x.t
 	 *
-	 * @return string|bool Verification file, or false if not set.
+	 * @return string|bool Verification file token, or false if not set.
 	 */
 	public function get() {
 		return $this->user_options->get( self::OPTION );
 	}
 
 	/**
-	 * Saves the user verification file.
+	 * Saves the user verification file token.
 	 *
 	 * @since n.e.x.t
-	 *
-	 * @param string $filename File name to store.
+	 * @param string $token Token portion of file name to store.
 	 *
 	 * @return bool True on success, false on failure.
 	 */
-	public function set( $filename ) {
-		return $this->user_options->set( self::OPTION, $filename );
+	public function set( $token ) {
+		return $this->user_options->set( self::OPTION, $token );
 	}
 
 	/**
-	 * Checks whether a verification file for the user is present.
+	 * Checks whether a verification file token for the user is present.
 	 *
 	 * @since n.e.x.t
 	 *
-	 * @return bool True if verification file file is set, false otherwise.
+	 * @return bool True if verification file token is set, false otherwise.
 	 */
 	public function has() {
 		return (bool) $this->get();

--- a/includes/Core/Authentication/Verification_File.php
+++ b/includes/Core/Authentication/Verification_File.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * Class Verification_File
+ *
+ * @package   Google\Site_Kit
+ * @copyright 2019 Google LLC
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
+ * @link      https://sitekit.withgoogle.com
+ */
+
+namespace Google\Site_Kit\Core\Authentication;
+
+use Google\Site_Kit\Core\Storage\User_Options;
+
+/**
+ * Class representing the site verification file for a user.
+ *
+ * @since 1.0.5
+ * @access private
+ * @ignore
+ */
+final class Verification_File {
+
+	/**
+	 * User option key.
+	 */
+	const OPTION = 'googlesitekit_site_verification_file';
+
+	/**
+	 * User_Options object.
+	 *
+	 * @since 1.0.5
+	 * @var User_Options
+	 */
+	private $user_options;
+
+	/**
+	 * Constructor.
+	 *
+	 * @since 1.0.5
+	 *
+	 * @param User_Options $user_options User Options instance.
+	 */
+	public function __construct( User_Options $user_options ) {
+		$this->user_options = $user_options;
+	}
+
+	/**
+	 * Retrieves the user verification file.
+	 *
+	 * @since 1.0.5
+	 *
+	 * @return string|bool Verification file, or false if not set.
+	 */
+	public function get() {
+		return $this->user_options->get( self::OPTION );
+	}
+
+	/**
+	 * Saves the user verification file.
+	 *
+	 * @since 1.0.5
+	 *
+	 * @param string $filename File name to store.
+	 *
+	 * @return bool True on success, false on failure.
+	 */
+	public function set( $filename ) {
+		return $this->user_options->set( self::OPTION, $filename );
+	}
+
+	/**
+	 * Checks whether a verification file for the user is present.
+	 *
+	 * @since 1.0.5
+	 *
+	 * @return bool True if verification file file is set, false otherwise.
+	 */
+	public function has() {
+		return (bool) $this->get();
+	}
+}

--- a/includes/Core/Authentication/Verification_File.php
+++ b/includes/Core/Authentication/Verification_File.php
@@ -15,7 +15,7 @@ use Google\Site_Kit\Core\Storage\User_Options;
 /**
  * Class representing the site verification file for a user.
  *
- * @since 1.0.5
+ * @since n.e.x.t
  * @access private
  * @ignore
  */
@@ -29,7 +29,7 @@ final class Verification_File {
 	/**
 	 * User_Options object.
 	 *
-	 * @since 1.0.5
+	 * @since n.e.x.t
 	 * @var User_Options
 	 */
 	private $user_options;
@@ -37,7 +37,7 @@ final class Verification_File {
 	/**
 	 * Constructor.
 	 *
-	 * @since 1.0.5
+	 * @since n.e.x.t
 	 *
 	 * @param User_Options $user_options User Options instance.
 	 */
@@ -48,7 +48,7 @@ final class Verification_File {
 	/**
 	 * Retrieves the user verification file.
 	 *
-	 * @since 1.0.5
+	 * @since n.e.x.t
 	 *
 	 * @return string|bool Verification file, or false if not set.
 	 */
@@ -59,7 +59,7 @@ final class Verification_File {
 	/**
 	 * Saves the user verification file.
 	 *
-	 * @since 1.0.5
+	 * @since n.e.x.t
 	 *
 	 * @param string $filename File name to store.
 	 *
@@ -72,7 +72,7 @@ final class Verification_File {
 	/**
 	 * Checks whether a verification file for the user is present.
 	 *
-	 * @since 1.0.5
+	 * @since n.e.x.t
 	 *
 	 * @return bool True if verification file file is set, false otherwise.
 	 */

--- a/includes/Core/Authentication/Verification_Meta.php
+++ b/includes/Core/Authentication/Verification_Meta.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Class Google\Site_Kit\Core\Authentication\Verification_Tag
+ * Class Verification_Meta
  *
  * @package   Google\Site_Kit
  * @copyright 2019 Google LLC
@@ -20,7 +20,7 @@ use Google\Site_Kit\Core\Storage\Transients;
  * @access private
  * @ignore
  */
-final class Verification_Tag {
+final class Verification_Meta {
 
 	/**
 	 * User option key.

--- a/includes/Core/Authentication/Verification_Meta.php
+++ b/includes/Core/Authentication/Verification_Meta.php
@@ -14,9 +14,9 @@ use Google\Site_Kit\Core\Storage\User_Options;
 use Google\Site_Kit\Core\Storage\Transients;
 
 /**
- * Class representing the site verification tag for a user.
+ * Class representing the site verification meta tag for a user.
  *
- * @since 1.0.0
+ * @since n.e.x.t
  * @access private
  * @ignore
  */

--- a/includes/Core/Util/Exit_Handler.php
+++ b/includes/Core/Util/Exit_Handler.php
@@ -33,6 +33,7 @@ class Exit_Handler {
 			 * Allows the callback to be filtered during tests.
 			 *
 			 * @since n.e.x.t
+			 * @param \Closure $callback Exit handler callback.
 			 */
 			$callback = apply_filters( 'googlesitekit_exit_handler', $callback );
 		}

--- a/includes/Core/Util/Exit_Handler.php
+++ b/includes/Core/Util/Exit_Handler.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Exit_Handler
+ *
+ * @package   Google\Site_Kit\Core\Util
+ * @copyright 2019 Google LLC
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
+ * @link      https://sitekit.withgoogle.com
+ */
+
+namespace Google\Site_Kit\Core\Util;
+
+/**
+ * Exit_Handler class.
+ *
+ * @since n.e.x.t
+ * @access private
+ * @ignore
+ */
+class Exit_Handler {
+	/**
+	 * Invokes the handler.
+	 *
+	 * @since n.e.x.t
+	 */
+	public function invoke() {
+		$callback = static function () {
+			exit;
+		};
+
+		if ( defined( 'GOOGLESITEKIT_TESTS' ) ) {
+			/**
+			 * Allows the callback to be filtered during tests.
+			 *
+			 * @since n.e.x.t
+			 */
+			$callback = apply_filters( 'googlesitekit_exit_handler', $callback );
+		}
+
+		if ( $callback instanceof \Closure ) {
+			$callback();
+		}
+	}
+}

--- a/includes/Core/Util/Migration_1_0_0.php
+++ b/includes/Core/Util/Migration_1_0_0.php
@@ -13,7 +13,7 @@ namespace Google\Site_Kit\Core\Util;
 use Google\Site_Kit\Context;
 use Google\Site_Kit\Core\Authentication\Authentication;
 use Google\Site_Kit\Core\Authentication\Clients\OAuth_Client;
-use Google\Site_Kit\Core\Authentication\Verification_Tag;
+use Google\Site_Kit\Core\Authentication\Verification_Meta;
 use Google\Site_Kit\Core\Authentication\Credentials;
 use Google\Site_Kit\Core\Storage\Encrypted_Options;
 use Google\Site_Kit\Core\Storage\Options;
@@ -121,7 +121,7 @@ class Migration_1_0_0 {
 				'meta_query' => array(
 					'relation' => 'OR',
 					array(
-						'key'     => $key_prefix . Verification_Tag::OPTION,
+						'key'     => $key_prefix . Verification_Meta::OPTION,
 						'compare' => 'EXISTS',
 					),
 					array(

--- a/includes/Core/Util/Reset.php
+++ b/includes/Core/Util/Reset.php
@@ -11,21 +11,21 @@
 namespace Google\Site_Kit\Core\Util;
 
 use Google\Site_Kit\Context;
+use Google\Site_Kit\Core\Authentication\Clients\OAuth_Client;
+use Google\Site_Kit\Core\Authentication\Credentials;
+use Google\Site_Kit\Core\Authentication\First_Admin;
+use Google\Site_Kit\Core\Authentication\Profile;
+use Google\Site_Kit\Core\Authentication\Verification;
 use Google\Site_Kit\Core\Authentication\Verification_File;
+use Google\Site_Kit\Core\Authentication\Verification_Meta;
 use Google\Site_Kit\Core\Storage\Options;
 use Google\Site_Kit\Core\Storage\Transients;
 use Google\Site_Kit\Core\Storage\User_Options;
-use Google\Site_Kit\Core\Authentication\Credentials;
-use Google\Site_Kit\Core\Authentication\First_Admin;
-use Google\Site_Kit\Core\Authentication\Verification;
-use Google\Site_Kit\Core\Authentication\Verification_Meta;
-use Google\Site_Kit\Core\Authentication\Profile;
-use Google\Site_Kit\Core\Authentication\Clients\OAuth_Client;
-use Google\Site_Kit\Modules\Search_Console;
 use Google\Site_Kit\Modules\AdSense;
 use Google\Site_Kit\Modules\Analytics;
-use Google\Site_Kit\Modules\PageSpeed_Insights;
 use Google\Site_Kit\Modules\Optimize;
+use Google\Site_Kit\Modules\PageSpeed_Insights;
+use Google\Site_Kit\Modules\Search_Console;
 use Google\Site_Kit\Modules\Tag_Manager;
 
 /**

--- a/includes/Core/Util/Reset.php
+++ b/includes/Core/Util/Reset.php
@@ -11,6 +11,7 @@
 namespace Google\Site_Kit\Core\Util;
 
 use Google\Site_Kit\Context;
+use Google\Site_Kit\Core\Authentication\Verification_File;
 use Google\Site_Kit\Core\Storage\Options;
 use Google\Site_Kit\Core\Storage\Transients;
 use Google\Site_Kit\Core\Storage\User_Options;
@@ -181,6 +182,7 @@ final class Reset {
 			$user_options->delete( OAuth_Client::OPTION_PROXY_ACCESS_CODE );
 			$user_options->delete( Verification::OPTION );
 			$user_options->delete( Verification_Meta::OPTION );
+			$user_options->delete( Verification_File::OPTION );
 			$user_options->delete( Profile::OPTION );
 
 			// Clean up old user  api key data, moved to options.

--- a/includes/Core/Util/Reset.php
+++ b/includes/Core/Util/Reset.php
@@ -17,7 +17,7 @@ use Google\Site_Kit\Core\Storage\User_Options;
 use Google\Site_Kit\Core\Authentication\Credentials;
 use Google\Site_Kit\Core\Authentication\First_Admin;
 use Google\Site_Kit\Core\Authentication\Verification;
-use Google\Site_Kit\Core\Authentication\Verification_Tag;
+use Google\Site_Kit\Core\Authentication\Verification_Meta;
 use Google\Site_Kit\Core\Authentication\Profile;
 use Google\Site_Kit\Core\Authentication\Clients\OAuth_Client;
 use Google\Site_Kit\Modules\Search_Console;
@@ -123,7 +123,7 @@ final class Reset {
 		// Also clean up other old unused options.
 		// @todo remove after RC.
 		$this->options->delete( Verification::OPTION );
-		$this->options->delete( Verification_Tag::OPTION );
+		$this->options->delete( Verification_Meta::OPTION );
 		$this->options->delete( 'googlesitekit_api_key' );
 		$this->options->delete( 'googlesitekit_available_modules' );
 		$this->options->delete( 'googlesitekit_secret_token' );
@@ -147,7 +147,7 @@ final class Reset {
 				'meta_query' => array(
 					'relation' => 'OR',
 					array(
-						'key'     => $key_prefix . Verification_Tag::OPTION,
+						'key'     => $key_prefix . Verification_Meta::OPTION,
 						'compare' => 'EXISTS',
 					),
 					array(
@@ -180,7 +180,7 @@ final class Reset {
 			$user_options->delete( OAuth_Client::OPTION_ERROR_CODE );
 			$user_options->delete( OAuth_Client::OPTION_PROXY_ACCESS_CODE );
 			$user_options->delete( Verification::OPTION );
-			$user_options->delete( Verification_Tag::OPTION );
+			$user_options->delete( Verification_Meta::OPTION );
 			$user_options->delete( Profile::OPTION );
 
 			// Clean up old user  api key data, moved to options.

--- a/includes/Modules/Site_Verification.php
+++ b/includes/Modules/Site_Verification.php
@@ -16,6 +16,7 @@ use Google\Site_Kit\Core\Modules\Module_With_Scopes;
 use Google\Site_Kit\Core\Modules\Module_With_Scopes_Trait;
 use Google\Site_Kit\Core\Permissions\Permissions;
 use Google\Site_Kit\Core\REST_API\Data_Request;
+use Google\Site_Kit\Core\Util\Exit_Handler;
 use Google\Site_Kit_Dependencies\Google_Client;
 use Google\Site_Kit_Dependencies\Google_Service_Exception;
 use Google\Site_Kit_Dependencies\Google_Service_SiteVerification;
@@ -470,9 +471,7 @@ final class Site_Verification extends Module implements Module_With_Scopes {
 
 		if ( $user_id && user_can( $user_id, Permissions::SETUP ) ) {
 			printf( 'google-site-verification: google%s.html', esc_html( $verification_token ) );
-			if ( ! defined( 'GOOGLESITEKIT_TESTS' ) ) {
-				exit;
-			}
+			( new Exit_Handler() )->invoke();
 		}
 
 		// If the user does not have the necessary permissions then let the request pass through.

--- a/includes/Modules/Site_Verification.php
+++ b/includes/Modules/Site_Verification.php
@@ -145,7 +145,7 @@ final class Site_Verification extends Module implements Module_With_Scopes {
 				case 'verification':
 					return $this->get_siteverification_service()->webResource->listWebResource();
 				case 'verification-token':
-					$existing_token = $this->authentication->verification_tag()->get();
+					$existing_token = $this->authentication->verification_meta()->get();
 
 					if ( ! empty( $existing_token ) ) {
 						return function() use ( $existing_token ) {
@@ -200,7 +200,7 @@ final class Site_Verification extends Module implements Module_With_Scopes {
 								return $token;
 							}
 
-							$this->authentication->verification_tag()->set( $token['token'] );
+							$this->authentication->verification_meta()->set( $token['token'] );
 
 							$client     = $this->get_client();
 							$orig_defer = $client->shouldDefer();
@@ -412,7 +412,7 @@ final class Site_Verification extends Module implements Module_With_Scopes {
 				$authentication->verification_file()->set( $_GET['googlesitekit_verification_token'] );
 				break;
 			case self::VERIFICATION_TYPE_META:
-				$authentication->verification_tag()->set( $_GET['googlesitekit_verification_token'] );
+				$authentication->verification_meta()->set( $_GET['googlesitekit_verification_token'] );
 		}
 
 		$code = isset( $_GET['googlesitekit_code'] ) ? $_GET['googlesitekit_code'] : '';
@@ -437,7 +437,7 @@ final class Site_Verification extends Module implements Module_With_Scopes {
 	 */
 	private function print_site_verification_meta() {
 		// Get verification meta tags for all users.
-		$verification_tags = $this->authentication->verification_tag()->get_all();
+		$verification_tags = $this->authentication->verification_meta()->get_all();
 		$allowed_html      = array(
 			'meta' => array(
 				'name'    => array(),

--- a/includes/Modules/Site_Verification.php
+++ b/includes/Modules/Site_Verification.php
@@ -393,8 +393,10 @@ final class Site_Verification extends Module implements Module_With_Scopes {
 		// We need to pass the 'missing_verification' error code here so that the URL includes a verification nonce.
 		wp_safe_redirect(
 			add_query_arg(
-				'verify',
-				'true',
+				array(
+					'verify'              => 'true',
+					'verification_method' => $verification_type,
+				),
 				$auth_client->get_proxy_setup_url( $code, 'missing_verification' )
 			)
 		);

--- a/includes/Modules/Site_Verification.php
+++ b/includes/Modules/Site_Verification.php
@@ -385,25 +385,23 @@ final class Site_Verification extends Module implements Module_With_Scopes {
 		$authentication = $this->authentication;
 		$auth_client    = $authentication->get_oauth_client();
 
-		if (
-			! filter_input( INPUT_GET, 'googlesitekit_verification_token' )
-			|| ! filter_input( INPUT_GET, 'googlesitekit_verification_nonce' )
-			|| ! $auth_client->using_proxy()
-		) {
+		$verification_token = filter_input( INPUT_GET, 'googlesitekit_verification_token' );
+		if ( empty( $verification_token ) ) {
 			return;
 		}
 
-		if ( ! wp_verify_nonce( filter_input( INPUT_GET, 'googlesitekit_verification_nonce' ), 'googlesitekit_verification' ) ) {
+		$verification_nonce = filter_input( INPUT_GET, 'googlesitekit_verification_nonce' );
+		if ( empty( $verification_nonce ) || ! wp_verify_nonce( $verification_nonce, 'googlesitekit_verification' ) ) {
 			wp_die( esc_html__( 'Invalid nonce.', 'google-site-kit' ) );
 		}
 
 		$verification_type = filter_input( INPUT_GET, 'googlesitekit_verification_token_type' ) ?: self::VERIFICATION_TYPE_META;
 		switch ( $verification_type ) {
 			case self::VERIFICATION_TYPE_FILE:
-				$authentication->verification_file()->set( filter_input( INPUT_GET, 'googlesitekit_verification_token' ) );
+				$authentication->verification_file()->set( $verification_token );
 				break;
 			case self::VERIFICATION_TYPE_META:
-				$authentication->verification_meta()->set( filter_input( INPUT_GET, 'googlesitekit_verification_token' ) );
+				$authentication->verification_meta()->set( $verification_token );
 		}
 
 		wp_safe_redirect(

--- a/includes/Modules/Site_Verification.php
+++ b/includes/Modules/Site_Verification.php
@@ -400,10 +400,10 @@ final class Site_Verification extends Module implements Module_With_Scopes {
 		$verification_type = filter_input( INPUT_GET, 'googlesitekit_verification_token_type' ) ?: self::VERIFICATION_TYPE_META;
 		switch ( $verification_type ) {
 			case self::VERIFICATION_TYPE_FILE:
-				$authentication->verification_file()->set( $_GET['googlesitekit_verification_token'] );
+				$authentication->verification_file()->set( filter_input( INPUT_GET, 'googlesitekit_verification_token' ) );
 				break;
 			case self::VERIFICATION_TYPE_META:
-				$authentication->verification_meta()->set( $_GET['googlesitekit_verification_token'] );
+				$authentication->verification_meta()->set( filter_input( INPUT_GET, 'googlesitekit_verification_token' ) );
 		}
 
 		wp_safe_redirect(

--- a/includes/Modules/Site_Verification.php
+++ b/includes/Modules/Site_Verification.php
@@ -466,9 +466,11 @@ final class Site_Verification extends Module implements Module_With_Scopes {
 	private function serve_verification_file( $verification_file_name ) {
 		global $wpdb;
 
-		$user_ids = ( new \WP_User_Query(
+		// User option keys are prefixed in single site and multisite when not in network mode.
+		$key_prefix = $this->context->is_network_mode() ? '' : $wpdb->get_blog_prefix();
+		$user_ids   = ( new \WP_User_Query(
 			array(
-				'meta_key'   => $wpdb->get_blog_prefix() . Verification_File::OPTION,
+				'meta_key'   => $key_prefix . Verification_File::OPTION,
 				'meta_value' => $verification_file_name,
 				'fields'     => 'id',
 				'number'     => 1,

--- a/includes/Modules/Site_Verification.php
+++ b/includes/Modules/Site_Verification.php
@@ -362,7 +362,7 @@ final class Site_Verification extends Module implements Module_With_Scopes {
 	/**
 	 * Handles receiving a verification token for a user by the authentication proxy.
 	 *
-	 * @since 1.0.0
+	 * @since 1.0.5
 	 */
 	private function handle_verification_token() {
 		$authentication = $this->authentication;

--- a/includes/Modules/Site_Verification.php
+++ b/includes/Modules/Site_Verification.php
@@ -479,7 +479,7 @@ final class Site_Verification extends Module implements Module_With_Scopes {
 
 		$user_id = array_shift( $user_ids ) ?: 0;
 
-		if ( user_can( $user_id, Permissions::SETUP ) ) {
+		if ( $user_id && user_can( $user_id, Permissions::SETUP ) ) {
 			printf( 'google-site-verification: %s', esc_html( $verification_file_name ) );
 			call_user_func( $this->post_serve_verification_file_callback );
 		}

--- a/includes/Modules/Site_Verification.php
+++ b/includes/Modules/Site_Verification.php
@@ -36,6 +36,16 @@ final class Site_Verification extends Module implements Module_With_Scopes {
 	use Module_With_Scopes_Trait;
 
 	/**
+	 * Meta site verification type.
+	 */
+	const VERIFICATION_TYPE_META = 'META';
+
+	/**
+	 * File site verification type.
+	 */
+	const VERIFICATION_TYPE_FILE = 'FILE';
+
+	/**
 	 * Registers functionality through WordPress hooks.
 	 *
 	 * @since 1.0.0
@@ -362,7 +372,15 @@ final class Site_Verification extends Module implements Module_With_Scopes {
 			wp_die( esc_html__( 'Invalid nonce.', 'google-site-kit' ) );
 		}
 
-		$authentication->verification_tag()->set( $_GET['googlesitekit_verification_token'] );
+		$verification_type = isset( $_GET['googlesitekit_verification_token_type'] ) ? $_GET['googlesitekit_verification_token_type'] : self::VERIFICATION_TYPE_META;
+		switch ( $verification_type ) {
+			case self::VERIFICATION_TYPE_FILE:
+				$authentication->verification_file()->set( $_GET['googlesitekit_verification_token'] );
+				break;
+			case self::VERIFICATION_TYPE_META:
+				$authentication->verification_tag()->set( $_GET['googlesitekit_verification_token'] );
+		}
+
 		$code = isset( $_GET['googlesitekit_code'] ) ? $_GET['googlesitekit_code'] : '';
 
 		// We need to pass the 'missing_verification' error code here so that the URL includes a verification nonce.

--- a/includes/Modules/Site_Verification.php
+++ b/includes/Modules/Site_Verification.php
@@ -486,21 +486,4 @@ final class Site_Verification extends Module implements Module_With_Scopes {
 
 		// If the user does not have the necessary permissions then let the request pass through.
 	}
-
-	/**
-	 * Checks if the site supports file-based site verification.
-	 *
-	 * The site must be a root install, with no path in the home URL
-	 * to be able to serve the verification response properly.
-	 *
-	 * @since n.e.x.t
-	 * @see \WP_Rewrite::rewrite_rules for robots.txt
-	 *
-	 * @return bool
-	 */
-	private function supports_file_verification() {
-		$home_path = wp_parse_url( home_url(), PHP_URL_PATH );
-
-		return ( ! $home_path || '/' === $home_path );
-	}
 }

--- a/includes/Modules/Site_Verification.php
+++ b/includes/Modules/Site_Verification.php
@@ -59,6 +59,13 @@ final class Site_Verification extends Module implements Module_With_Scopes {
 				$this->handle_verification_token();
 			}
 		);
+
+		$print_site_verification_meta = function() {
+			$this->print_site_verification_meta();
+		};
+
+		add_action( 'wp_head', $print_site_verification_meta );
+		add_action( 'login_head', $print_site_verification_meta );
 	}
 
 	/**
@@ -392,5 +399,31 @@ final class Site_Verification extends Module implements Module_With_Scopes {
 			)
 		);
 		exit;
+	}
+
+	/**
+	 * Prints site verification meta in wp_head().
+	 *
+	 * @since 1.0.5
+	 */
+	private function print_site_verification_meta() {
+		// Get verification meta tags for all users.
+		$verification_tags = $this->authentication->verification_tag()->get_all();
+		$allowed_html      = array(
+			'meta' => array(
+				'name'    => array(),
+				'content' => array(),
+			),
+		);
+
+		foreach ( $verification_tags as $verification_tag ) {
+			$verification_tag = html_entity_decode( $verification_tag );
+
+			if ( 0 !== strpos( $verification_tag, '<meta ' ) ) {
+				$verification_tag = '<meta name="google-site-verification" content="' . esc_attr( $verification_tag ) . '">';
+			}
+
+			echo wp_kses( $verification_tag, $allowed_html );
+		}
 	}
 }

--- a/includes/Modules/Site_Verification.php
+++ b/includes/Modules/Site_Verification.php
@@ -410,8 +410,6 @@ final class Site_Verification extends Module implements Module_With_Scopes {
 		switch ( $verification_type ) {
 			case self::VERIFICATION_TYPE_FILE:
 				$authentication->verification_file()->set( $_GET['googlesitekit_verification_token'] );
-				// Ensure rewrite rules include file handler.
-				flush_rewrite_rules();
 				break;
 			case self::VERIFICATION_TYPE_META:
 				$authentication->verification_tag()->set( $_GET['googlesitekit_verification_token'] );

--- a/includes/Modules/Site_Verification.php
+++ b/includes/Modules/Site_Verification.php
@@ -48,15 +48,6 @@ final class Site_Verification extends Module implements Module_With_Scopes {
 	const VERIFICATION_TYPE_FILE = 'FILE';
 
 	/**
-	 * Callback invoked after serving verification file.
-	 *
-	 * @since n.e.x.t
-	 *
-	 * @var \Closure
-	 */
-	private $post_serve_verification_file_callback;
-
-	/**
 	 * Registers functionality through WordPress hooks.
 	 *
 	 * @since 1.0.0
@@ -78,10 +69,6 @@ final class Site_Verification extends Module implements Module_With_Scopes {
 		add_action( 'wp_head', $print_site_verification_meta );
 		add_action( 'login_head', $print_site_verification_meta );
 
-		// Exit handled by callback for testability.
-		$this->post_serve_verification_file_callback = function () {
-			exit;
-		};
 		add_action(
 			'init',
 			function () {
@@ -483,7 +470,9 @@ final class Site_Verification extends Module implements Module_With_Scopes {
 
 		if ( $user_id && user_can( $user_id, Permissions::SETUP ) ) {
 			printf( 'google-site-verification: google%s.html', esc_html( $verification_token ) );
-			call_user_func( $this->post_serve_verification_file_callback );
+			if ( ! defined( 'GOOGLESITEKIT_TESTS' ) ) {
+				exit;
+			}
 		}
 
 		// If the user does not have the necessary permissions then let the request pass through.

--- a/includes/Modules/Site_Verification.php
+++ b/includes/Modules/Site_Verification.php
@@ -50,6 +50,8 @@ final class Site_Verification extends Module implements Module_With_Scopes {
 	/**
 	 * Callback invoked after serving verification file.
 	 *
+	 * @since n.e.x.t
+	 *
 	 * @var \Closure
 	 */
 	private $post_serve_verification_file_callback;

--- a/includes/Modules/Site_Verification.php
+++ b/includes/Modules/Site_Verification.php
@@ -86,9 +86,9 @@ final class Site_Verification extends Module implements Module_With_Scopes {
 				if (
 					isset( $_SERVER['REQUEST_URI'], $_SERVER['REQUEST_METHOD'] )
 					&& 'GET' === strtoupper( $_SERVER['REQUEST_METHOD'] )
-					&& preg_match( '/^\/(?P<filename>google[a-z0-9]+\.html)$/', $_SERVER['REQUEST_URI'], $matches )
+					&& preg_match( '/^\/google(?P<token>[a-z0-9]+)\.html$/', $_SERVER['REQUEST_URI'], $matches )
 				) {
-					$this->serve_verification_file( $matches['filename'] );
+					$this->serve_verification_file( $matches['token'] );
 				}
 			}
 		);
@@ -459,11 +459,11 @@ final class Site_Verification extends Module implements Module_With_Scopes {
 	/**
 	 * Serves the verification file response.
 	 *
-	 * @since n.e.x.t
+	 * @param string $verification_token Token portion of verification.
 	 *
-	 * @param string $verification_file_name File name of verification.
+	 * @since n.e.x.t
 	 */
-	private function serve_verification_file( $verification_file_name ) {
+	private function serve_verification_file( $verification_token ) {
 		global $wpdb;
 
 		// User option keys are prefixed in single site and multisite when not in network mode.
@@ -471,7 +471,7 @@ final class Site_Verification extends Module implements Module_With_Scopes {
 		$user_ids   = ( new \WP_User_Query(
 			array(
 				'meta_key'   => $key_prefix . Verification_File::OPTION,
-				'meta_value' => $verification_file_name,
+				'meta_value' => $verification_token,
 				'fields'     => 'id',
 				'number'     => 1,
 			)
@@ -480,7 +480,7 @@ final class Site_Verification extends Module implements Module_With_Scopes {
 		$user_id = array_shift( $user_ids ) ?: 0;
 
 		if ( $user_id && user_can( $user_id, Permissions::SETUP ) ) {
-			printf( 'google-site-verification: %s', esc_html( $verification_file_name ) );
+			printf( 'google-site-verification: google%s.html', esc_html( $verification_token ) );
 			call_user_func( $this->post_serve_verification_file_callback );
 		}
 

--- a/includes/Modules/Site_Verification.php
+++ b/includes/Modules/Site_Verification.php
@@ -393,7 +393,7 @@ final class Site_Verification extends Module implements Module_With_Scopes {
 	/**
 	 * Handles receiving a verification token for a user by the authentication proxy.
 	 *
-	 * @since 1.0.5
+	 * @since n.e.x.t
 	 */
 	private function handle_verification_token() {
 		$authentication = $this->authentication;
@@ -439,7 +439,7 @@ final class Site_Verification extends Module implements Module_With_Scopes {
 	/**
 	 * Prints site verification meta in wp_head().
 	 *
-	 * @since 1.0.5
+	 * @since n.e.x.t
 	 */
 	private function print_site_verification_meta() {
 		// Get verification meta tags for all users.

--- a/includes/Modules/Site_Verification.php
+++ b/includes/Modules/Site_Verification.php
@@ -15,7 +15,6 @@ use Google\Site_Kit\Core\Modules\Module_With_Scopes;
 use Google\Site_Kit\Core\Modules\Module_With_Scopes_Trait;
 use Google\Site_Kit\Core\REST_API\Data_Request;
 use Google\Site_Kit_Dependencies\Google_Client;
-use Google\Site_Kit_Dependencies\Google_Service;
 use Google\Site_Kit_Dependencies\Google_Service_Exception;
 use Google\Site_Kit_Dependencies\Google_Service_SiteVerification;
 use Google\Site_Kit_Dependencies\Google_Service_SiteVerification_SiteVerificationWebResourceGettokenRequest;
@@ -23,7 +22,6 @@ use Google\Site_Kit_Dependencies\Google_Service_SiteVerification_SiteVerificatio
 use Google\Site_Kit_Dependencies\Google_Service_SiteVerification_SiteVerificationWebResourceResource;
 use Google\Site_Kit_Dependencies\Google_Service_SiteVerification_SiteVerificationWebResourceResourceSite;
 use Google\Site_Kit_Dependencies\Psr\Http\Message\RequestInterface;
-use Google\Site_Kit_Dependencies\Psr\Http\Message\ResponseInterface;
 use WP_Error;
 use Exception;
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -12,5 +12,6 @@
         <ini name="error_reporting" value="32767" />
         <ini name="display_errors" value="1" />
         <ini name="display_startup_errors" value="1" />
+        <const name="GOOGLESITEKIT_TESTS" value="1" />
     </php>
 </phpunit>

--- a/tests/phpunit/integration/Core/Authentication/AuthenticationTest.php
+++ b/tests/phpunit/integration/Core/Authentication/AuthenticationTest.php
@@ -185,6 +185,9 @@ class AuthenticationTest extends TestCase {
 		);
 	}
 
+	/**
+	 * @expectedDeprecated Google\Site_Kit\Core\Authentication\Authentication::verification_tag
+	 */
 	public function test_verification_tag() {
 		$auth = new Authentication( new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE ) );
 

--- a/tests/phpunit/integration/Core/Authentication/AuthenticationTest.php
+++ b/tests/phpunit/integration/Core/Authentication/AuthenticationTest.php
@@ -197,6 +197,15 @@ class AuthenticationTest extends TestCase {
 		);
 	}
 
+	public function test_verification_meta() {
+		$auth = new Authentication( new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE ) );
+
+		$this->assertInstanceOf(
+			'\Google\Site_Kit\Core\Authentication\Verification_Meta',
+			$auth->verification_meta()
+		);
+	}
+
 	public function test_verification_file() {
 		$auth = new Authentication( new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE ) );
 

--- a/tests/phpunit/integration/Core/Authentication/AuthenticationTest.php
+++ b/tests/phpunit/integration/Core/Authentication/AuthenticationTest.php
@@ -16,7 +16,7 @@ use Google\Site_Kit\Core\Authentication\Authentication;
 use Google\Site_Kit\Core\Authentication\Clients\OAuth_Client;
 use Google\Site_Kit\Core\Authentication\Profile;
 use Google\Site_Kit\Core\Authentication\Verification;
-use Google\Site_Kit\Core\Authentication\Verification_Tag;
+use Google\Site_Kit\Core\Authentication\Verification_Meta;
 use Google\Site_Kit\Core\Storage\Options;
 use Google\Site_Kit\Core\Storage\User_Options;
 use Google\Site_Kit\Tests\TestCase;
@@ -225,7 +225,7 @@ class AuthenticationTest extends TestCase {
 		$auth = new Authentication( new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE ) );
 
 		$this->assertInstanceOf(
-			'\Google\Site_Kit\Core\Authentication\Verification_Tag',
+			'\Google\Site_Kit\Core\Authentication\Verification_Meta',
 			$auth->verification_tag()
 		);
 	}
@@ -306,7 +306,7 @@ class AuthenticationTest extends TestCase {
 			OAuth_Client::OPTION_REFRESH_TOKEN,
 			Profile::OPTION,
 			Verification::OPTION,
-			Verification_Tag::OPTION,
+			Verification_Meta::OPTION,
 		);
 	}
 }

--- a/tests/phpunit/integration/Core/Authentication/AuthenticationTest.php
+++ b/tests/phpunit/integration/Core/Authentication/AuthenticationTest.php
@@ -96,42 +96,6 @@ class AuthenticationTest extends TestCase {
 		);
 	}
 
-	/**
-	 * @dataProvider data_register_head_verification_tags
-	 */
-	public function test_register_head_verification_tags( $saved_tag, $expected_output ) {
-		remove_all_actions( 'wp_head' );
-		remove_all_actions( 'login_head' );
-		$auth = new Authentication( new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE ) );
-		$auth->register();
-
-		set_transient( 'googlesitekit_verification_meta_tags', array( $saved_tag ) );
-
-		$this->assertContains(
-			$expected_output,
-			$this->capture_action( 'wp_head' )
-		);
-
-		$this->assertContains(
-			$expected_output,
-			$this->capture_action( 'login_head' )
-		);
-	}
-
-	public function data_register_head_verification_tags() {
-		return array(
-			array( // Full meta tag stored.
-				'<meta name="google-site-verification" content="test-verification-content">',
-				'<meta name="google-site-verification" content="test-verification-content">',
-			),
-			array(
-				// Only verification token stored.
-				'test-verification-content-2',
-				'<meta name="google-site-verification" content="test-verification-content-2">',
-			),
-		);
-	}
-
 	public function test_register_allowed_redirect_hosts() {
 		remove_all_filters( 'allowed_redirect_hosts' );
 		$auth = new Authentication( new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE ) );

--- a/tests/phpunit/integration/Core/Authentication/AuthenticationTest.php
+++ b/tests/phpunit/integration/Core/Authentication/AuthenticationTest.php
@@ -230,6 +230,15 @@ class AuthenticationTest extends TestCase {
 		);
 	}
 
+	public function test_verification_file() {
+		$auth = new Authentication( new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE ) );
+
+		$this->assertInstanceOf(
+			'\Google\Site_Kit\Core\Authentication\Verification_File',
+			$auth->verification_file()
+		);
+	}
+
 	public function test_profile() {
 		$auth = new Authentication( new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE ) );
 

--- a/tests/phpunit/integration/Core/Authentication/Verification_FileTest.php
+++ b/tests/phpunit/integration/Core/Authentication/Verification_FileTest.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Verification_FileTest
+ *
+ * @package   Google\Site_Kit\Tests\Core\Authentication
+ * @copyright 2019 Google LLC
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
+ * @link      https://sitekit.withgoogle.com
+ */
+
+namespace Google\Site_Kit\Tests\Core\Authentication;
+
+use Google\Site_Kit\Context;
+use Google\Site_Kit\Core\Authentication\Verification_File;
+use Google\Site_Kit\Core\Storage\User_Options;
+use Google\Site_Kit\Tests\TestCase;
+
+/**
+ * @group Authentication
+ */
+class Verification_FileTest extends TestCase {
+
+	public function test_get() {
+		$user_id      = $this->factory()->user->create();
+		$context      = new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE );
+		$user_options = new User_Options( $context, $user_id );
+
+		$verification_file = new Verification_File( $user_options );
+
+		$this->assertFalse( $user_options->get( Verification_File::OPTION ) );
+		$this->assertFalse( $verification_file->get() );
+		$user_options->set( Verification_File::OPTION, 'google123456789.html' );
+		$this->assertEquals( 'google123456789.html', $verification_file->get() );
+	}
+
+	public function test_set() {
+		$user_id      = $this->factory()->user->create();
+		$context      = new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE );
+		$user_options = new User_Options( $context, $user_id );
+
+		$verification_file = new Verification_File( $user_options );
+
+		$this->assertTrue( $verification_file->set( 'google123456789.html' ) );
+		$this->assertEquals( 'google123456789.html', $user_options->get( Verification_File::OPTION ) );
+	}
+
+	public function test_has() {
+		$user_id      = $this->factory()->user->create();
+		$context      = new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE );
+		$user_options = new User_Options( $context, $user_id );
+
+		$verification_file = new Verification_File( $user_options );
+
+		$this->assertFalse( $verification_file->has() );
+		$user_options->set( Verification_File::OPTION, 'google123456789.html' );
+		$this->assertTrue( $verification_file->has() );
+	}
+}

--- a/tests/phpunit/integration/Core/Authentication/Verification_FileTest.php
+++ b/tests/phpunit/integration/Core/Authentication/Verification_FileTest.php
@@ -29,8 +29,8 @@ class Verification_FileTest extends TestCase {
 
 		$this->assertFalse( $user_options->get( Verification_File::OPTION ) );
 		$this->assertFalse( $verification_file->get() );
-		$user_options->set( Verification_File::OPTION, 'google123456789.html' );
-		$this->assertEquals( 'google123456789.html', $verification_file->get() );
+		$user_options->set( Verification_File::OPTION, 'a1b2c3d4f5' );
+		$this->assertEquals( 'a1b2c3d4f5', $verification_file->get() );
 	}
 
 	public function test_set() {
@@ -40,8 +40,8 @@ class Verification_FileTest extends TestCase {
 
 		$verification_file = new Verification_File( $user_options );
 
-		$this->assertTrue( $verification_file->set( 'google123456789.html' ) );
-		$this->assertEquals( 'google123456789.html', $user_options->get( Verification_File::OPTION ) );
+		$this->assertTrue( $verification_file->set( 'a1b2c3d4f5' ) );
+		$this->assertEquals( 'a1b2c3d4f5', $user_options->get( Verification_File::OPTION ) );
 	}
 
 	public function test_has() {
@@ -52,7 +52,7 @@ class Verification_FileTest extends TestCase {
 		$verification_file = new Verification_File( $user_options );
 
 		$this->assertFalse( $verification_file->has() );
-		$user_options->set( Verification_File::OPTION, 'google123456789.html' );
+		$user_options->set( Verification_File::OPTION, 'a1b2c3d4f5' );
 		$this->assertTrue( $verification_file->has() );
 	}
 }

--- a/tests/phpunit/integration/Core/Authentication/Verification_MetaTest.php
+++ b/tests/phpunit/integration/Core/Authentication/Verification_MetaTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Verification_TagTest
+ * Verification_MetaTest
  *
  * @package   Google\Site_Kit\Tests\Core\Authentication
  * @copyright 2019 Google LLC
@@ -11,7 +11,7 @@
 namespace Google\Site_Kit\Tests\Core\Authentication;
 
 use Google\Site_Kit\Context;
-use Google\Site_Kit\Core\Authentication\Verification_Tag;
+use Google\Site_Kit\Core\Authentication\Verification_Meta;
 use Google\Site_Kit\Core\Storage\Transients;
 use Google\Site_Kit\Core\Storage\User_Options;
 use Google\Site_Kit\Tests\TestCase;
@@ -19,7 +19,7 @@ use Google\Site_Kit\Tests\TestCase;
 /**
  * @group Authentication
  */
-class Verification_TagTest extends TestCase {
+class Verification_MetaTest extends TestCase {
 
 	public function test_get() {
 		$user_id      = $this->factory()->user->create();
@@ -27,12 +27,12 @@ class Verification_TagTest extends TestCase {
 		$user_options = new User_Options( $context, $user_id );
 		$transients   = new Transients( $context );
 
-		$verification_tag = new Verification_Tag( $user_options, $transients );
+		$verification_meta = new Verification_Meta( $user_options, $transients );
 
-		$this->assertFalse( $user_options->get( Verification_Tag::OPTION ) );
-		$this->assertFalse( $verification_tag->get() );
-		$user_options->set( Verification_Tag::OPTION, 'test-verification-tag' );
-		$this->assertEquals( 'test-verification-tag', $verification_tag->get() );
+		$this->assertFalse( $user_options->get( Verification_Meta::OPTION ) );
+		$this->assertFalse( $verification_meta->get() );
+		$user_options->set( Verification_Meta::OPTION, 'test-verification-tag' );
+		$this->assertEquals( 'test-verification-tag', $verification_meta->get() );
 	}
 
 	public function test_set() {
@@ -42,18 +42,18 @@ class Verification_TagTest extends TestCase {
 		$transients   = new Transients( $context );
 
 		$transients->set( 'googlesitekit_verification_meta_tags', 'test-verification-meta-tags' );
-		$verification_tag = new Verification_Tag( $user_options, $transients );
+		$verification_meta = new Verification_Meta( $user_options, $transients );
 
 		$this->assertEquals( 'test-verification-meta-tags', get_transient( 'googlesitekit_verification_meta_tags' ) );
-		$this->assertTrue( $verification_tag->set( 'test-verification-tag' ) );
-		$this->assertEquals( 'test-verification-tag', $user_options->get( Verification_Tag::OPTION ) );
+		$this->assertTrue( $verification_meta->set( 'test-verification-tag' ) );
+		$this->assertEquals( 'test-verification-tag', $user_options->get( Verification_Meta::OPTION ) );
 		$this->assertFalse( get_transient( 'googlesitekit_verification_meta_tags' ) );
 
 		// Test transient is only deleted when option is successfully updated.
 		// User_Options->set() will return false if new value === old value.
 		$transients->set( 'googlesitekit_verification_meta_tags', 'test-verification-meta-tags' );
 		$this->assertEquals( 'test-verification-meta-tags', get_transient( 'googlesitekit_verification_meta_tags' ) );
-		$this->assertFalse( $verification_tag->set( 'test-verification-tag' ) );
+		$this->assertFalse( $verification_meta->set( 'test-verification-tag' ) );
 		$this->assertEquals( 'test-verification-meta-tags', get_transient( 'googlesitekit_verification_meta_tags' ) );
 	}
 
@@ -63,11 +63,11 @@ class Verification_TagTest extends TestCase {
 		$user_options = new User_Options( $context, $user_id );
 		$transients   = new Transients( $context );
 
-		$verification_tag = new Verification_Tag( $user_options, $transients );
+		$verification_meta = new Verification_Meta( $user_options, $transients );
 
-		$this->assertFalse( $verification_tag->has() );
-		$user_options->set( Verification_Tag::OPTION, 'test-verification-tag' );
-		$this->assertTrue( $verification_tag->has() );
+		$this->assertFalse( $verification_meta->has() );
+		$user_options->set( Verification_Meta::OPTION, 'test-verification-tag' );
+		$this->assertTrue( $verification_meta->has() );
 	}
 
 	public function test_get_all() {
@@ -76,17 +76,17 @@ class Verification_TagTest extends TestCase {
 		$user_options = new User_Options( $context, $user_id );
 		$transients   = new Transients( $context );
 
-		$verification_tag = new Verification_Tag( $user_options, $transients );
+		$verification_meta = new Verification_Meta( $user_options, $transients );
 
 		// Always returns an array
 		$transients->set( 'googlesitekit_verification_meta_tags', 'test-meta-tags' );
-		$this->assertEquals( array( 'test-meta-tags' ), $verification_tag->get_all() );
+		$this->assertEquals( array( 'test-meta-tags' ), $verification_meta->get_all() );
 
-		update_user_option( 99, Verification_Tag::OPTION, 'verification-tag-99', $context->is_network_mode() );
-		update_user_option( 98, Verification_Tag::OPTION, 'verification-tag-98', $context->is_network_mode() );
-		update_user_option( 97, Verification_Tag::OPTION, 'verification-tag-97', $context->is_network_mode() );
+		update_user_option( 99, Verification_Meta::OPTION, 'verification-tag-99', $context->is_network_mode() );
+		update_user_option( 98, Verification_Meta::OPTION, 'verification-tag-98', $context->is_network_mode() );
+		update_user_option( 97, Verification_Meta::OPTION, 'verification-tag-97', $context->is_network_mode() );
 
-		$this->assertEquals( array( 'test-meta-tags' ), $verification_tag->get_all() );
+		$this->assertEquals( array( 'test-meta-tags' ), $verification_meta->get_all() );
 		$transients->delete( 'googlesitekit_verification_meta_tags' );
 		// If the transient is not set, it will regenerate it when get_all is called
 		$all_tags = array(
@@ -96,7 +96,7 @@ class Verification_TagTest extends TestCase {
 		);
 		$this->assertEqualSets(
 			$all_tags,
-			$verification_tag->get_all()
+			$verification_meta->get_all()
 		);
 		$this->assertEqualSets(
 			$all_tags,

--- a/tests/phpunit/integration/Core/Util/Exit_HandlerTest.php
+++ b/tests/phpunit/integration/Core/Util/Exit_HandlerTest.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Exit_HandlerTest
+ *
+ * @package   Google\Site_Kit\Tests\Core\Util
+ * @copyright 2019 Google LLC
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
+ * @link      https://sitekit.withgoogle.com
+ */
+
+namespace Google\Site_Kit\Tests\Core\Util;
+
+use Google\Site_Kit\Core\Util\Exit_Handler;
+use Google\Site_Kit\Tests\MethodSpy;
+use Google\Site_Kit\Tests\TestCase;
+
+/**
+ * Class Exit_HandlerTest
+ *
+ * @group Util
+ */
+class Exit_HandlerTest extends TestCase {
+
+	public function test_invoke() {
+		remove_all_filters( 'googlesitekit_exit_handler' );
+		$spy     = new MethodSpy();
+		$handler = new Exit_Handler();
+
+		add_filter( 'googlesitekit_exit_handler', function () use ( $spy ) {
+			return function () use ( $spy ) {
+				$spy->invoke();
+			};
+		} );
+		$this->assertArrayNotHasKey( 'invoke', $spy->invocations );
+
+		$handler->invoke();
+		$handler->invoke();
+		$handler->invoke();
+
+		$this->assertCount( 3, $spy->invocations['invoke'] );
+	}
+}

--- a/tests/phpunit/integration/Core/Util/ResetTest.php
+++ b/tests/phpunit/integration/Core/Util/ResetTest.php
@@ -16,7 +16,7 @@ use Google\Site_Kit\Core\Authentication\Credentials;
 use Google\Site_Kit\Core\Authentication\First_Admin;
 use Google\Site_Kit\Core\Authentication\Profile;
 use Google\Site_Kit\Core\Authentication\Verification;
-use Google\Site_Kit\Core\Authentication\Verification_Tag;
+use Google\Site_Kit\Core\Authentication\Verification_Meta;
 use Google\Site_Kit\Core\Util\Activation;
 use Google\Site_Kit\Core\Util\Beta_Migration;
 use Google\Site_Kit\Core\Util\Reset;
@@ -99,7 +99,7 @@ class ResetTest extends TestCase {
 			OAuth_Client::OPTION_REFRESH_TOKEN,
 			Profile::OPTION,
 			Verification::OPTION,
-			Verification_Tag::OPTION,
+			Verification_Meta::OPTION,
 		);
 	}
 

--- a/tests/phpunit/integration/Core/Util/ResetTest.php
+++ b/tests/phpunit/integration/Core/Util/ResetTest.php
@@ -16,6 +16,7 @@ use Google\Site_Kit\Core\Authentication\Credentials;
 use Google\Site_Kit\Core\Authentication\First_Admin;
 use Google\Site_Kit\Core\Authentication\Profile;
 use Google\Site_Kit\Core\Authentication\Verification;
+use Google\Site_Kit\Core\Authentication\Verification_File;
 use Google\Site_Kit\Core\Authentication\Verification_Meta;
 use Google\Site_Kit\Core\Util\Activation;
 use Google\Site_Kit\Core\Util\Beta_Migration;
@@ -100,6 +101,7 @@ class ResetTest extends TestCase {
 			Profile::OPTION,
 			Verification::OPTION,
 			Verification_Meta::OPTION,
+			Verification_File::OPTION,
 		);
 	}
 

--- a/tests/phpunit/integration/Modules/Site_VerificationTest.php
+++ b/tests/phpunit/integration/Modules/Site_VerificationTest.php
@@ -115,15 +115,15 @@ class Site_VerificationTest extends TestCase {
 		$this->assertNotContains( 'google-site-verification', $this->capture_action( 'init' ) );
 
 		// Set correct verification for user
-		$user_options->set( Verification_File::OPTION, 'google1234.html' );
+		$user_options->set( Verification_File::OPTION, '1234' );
 		$this->assertEquals( 'google-site-verification: google1234.html', $this->capture_action( 'init' ) );
 
 		// Ensure that the verification isn't served if there is no match
-		$user_options->set( Verification_File::OPTION, 'google9999.html' );
+		$user_options->set( Verification_File::OPTION, '9999' );
 		$this->assertEquals( '', $this->capture_action( 'init' ) );
 
 		// Ensure that the verification isn't served if there is a match, but the user does not have the permission.
-		$user_options->set( Verification_File::OPTION, 'google1234.html' );
+		$user_options->set( Verification_File::OPTION, '1234' );
 		$this->assertTrue( user_can( $user_id, Permissions::SETUP ) );
 		( new \WP_User( $user_id ) )->remove_role( 'administrator' );
 		$this->assertFalse( user_can( $user_id, Permissions::SETUP ) );

--- a/tests/phpunit/integration/Modules/Site_VerificationTest.php
+++ b/tests/phpunit/integration/Modules/Site_VerificationTest.php
@@ -11,6 +11,7 @@
 namespace Google\Site_Kit\Tests\Modules;
 
 use Google\Site_Kit\Context;
+use Google\Site_Kit\Core\Authentication\Authentication;
 use Google\Site_Kit\Core\Modules\Module_With_Scopes;
 use Google\Site_Kit\Modules\Site_Verification;
 use Google\Site_Kit\Tests\Core\Modules\Module_With_Scopes_ContractTests;
@@ -47,6 +48,42 @@ class Site_VerificationTest extends TestCase {
 			apply_filters( 'googlesitekit_auth_scopes', array() )
 		);
 		$this->assertTrue( has_action( 'admin_init' ) );
+	}
+
+	/**
+	 * @dataProvider data_register_head_verification_tags
+	 */
+	public function test_register_head_verification_tags( $saved_tag, $expected_output ) {
+		remove_all_actions( 'wp_head' );
+		remove_all_actions( 'login_head' );
+		$site_verification = new Site_Verification( new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE ) );
+		$site_verification->register();
+
+		set_transient( 'googlesitekit_verification_meta_tags', array( $saved_tag ) );
+
+		$this->assertContains(
+			$expected_output,
+			$this->capture_action( 'wp_head' )
+		);
+
+		$this->assertContains(
+			$expected_output,
+			$this->capture_action( 'login_head' )
+		);
+	}
+
+	public function data_register_head_verification_tags() {
+		return array(
+			array( // Full meta tag stored.
+				'<meta name="google-site-verification" content="test-verification-content">',
+				'<meta name="google-site-verification" content="test-verification-content">',
+			),
+			array(
+				// Only verification token stored.
+				'test-verification-content-2',
+				'<meta name="google-site-verification" content="test-verification-content-2">',
+			),
+		);
 	}
 
 	public function test_get_module_scopes() {

--- a/tests/phpunit/integration/Modules/Site_VerificationTest.php
+++ b/tests/phpunit/integration/Modules/Site_VerificationTest.php
@@ -108,7 +108,6 @@ class Site_VerificationTest extends TestCase {
 		$user_options      = new User_Options( $context, $user_id );
 		remove_all_actions( 'init' );
 		$site_verification->register();
-		$this->force_set_property( $site_verification, 'post_serve_verification_file_callback', function () {} );
 
 		// Ensure no verification file response if the user does not have one.
 		$this->go_to( '/google1234.html' );

--- a/tests/phpunit/integration/Modules/Site_VerificationTest.php
+++ b/tests/phpunit/integration/Modules/Site_VerificationTest.php
@@ -108,6 +108,7 @@ class Site_VerificationTest extends TestCase {
 		$user_options      = new User_Options( $context, $user_id );
 		remove_all_actions( 'init' );
 		$site_verification->register();
+		add_filter( 'googlesitekit_exit_handler', '__return_null' );
 
 		// Ensure no verification file response if the user does not have one.
 		$this->go_to( '/google1234.html' );

--- a/tests/phpunit/integration/Modules/Site_VerificationTest.php
+++ b/tests/phpunit/integration/Modules/Site_VerificationTest.php
@@ -35,6 +35,7 @@ class Site_VerificationTest extends TestCase {
 		$site_verification = new Site_Verification( new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE ) );
 
 		remove_all_filters( 'googlesitekit_auth_scopes' );
+		remove_all_filters( 'admin_init' );
 
 		$this->assertEmpty( apply_filters( 'googlesitekit_auth_scopes', array() ) );
 
@@ -45,6 +46,7 @@ class Site_VerificationTest extends TestCase {
 			$site_verification->get_scopes(),
 			apply_filters( 'googlesitekit_auth_scopes', array() )
 		);
+		$this->assertTrue( has_action( 'admin_init' ) );
 	}
 
 	public function test_get_module_scopes() {


### PR DESCRIPTION
## Summary

Addresses issue #836

## Relevant technical choices

* `Verification_File` is a simpler version of `Verification_Meta` (no need for `get_all()`)
* File is only served on GET requests to `^/google[a-z0-9]+.html$` if a user currently has the same file stored in their options and the user can `Permissions::SETUP`

## Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
