### PR TITLE
feat: Add googlesite.api scaffold/tests

### DIFF
--- a/assets/js/googlesitekit-api.js
+++ b/assets/js/googlesitekit-api.js
@@ -1,0 +1,10 @@
+/**
+ * External dependencies
+ */
+import API from 'js/googlesitekit/api';
+
+if ( typeof global.googlesitekit === 'undefined' ) {
+	throw new Error( '`googlesitekit` is undefined. You need to import `googlesitekit` to use the `googlesitekit-api` library.' );
+}
+
+global.googlesitekit.api = API;

--- a/assets/js/googlesitekit-api.js
+++ b/assets/js/googlesitekit-api.js
@@ -3,8 +3,8 @@
  */
 import API from 'assets/js/googlesitekit/api';
 
-if ( typeof global.googlesitekit === 'undefined' ) {
+if ( typeof window.googlesitekit === 'undefined' ) {
 	throw new Error( '`googlesitekit` is undefined. You need to import `googlesitekit` to use the `googlesitekit-api` library.' );
 }
 
-global.googlesitekit.api = API;
+window.googlesitekit.api = API;

--- a/assets/js/googlesitekit-api.js
+++ b/assets/js/googlesitekit-api.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import API from 'js/googlesitekit/api';
+import API from 'assets/js/googlesitekit/api';
 
 if ( typeof global.googlesitekit === 'undefined' ) {
 	throw new Error( '`googlesitekit` is undefined. You need to import `googlesitekit` to use the `googlesitekit-api` library.' );

--- a/assets/js/googlesitekit/api/index.js
+++ b/assets/js/googlesitekit/api/index.js
@@ -69,8 +69,7 @@ export const set = async (
  *
  * @return {boolean} The new caching state (`true` for on, `false` for off).
  */
-// eslint-disable-next-line no-unused-vars
-export const useCache = ( shouldUseCache ) => {
+export const setUsingCache = ( shouldUseCache ) => {
 	cachingEnabled = !! shouldUseCache;
 
 	return cachingEnabled;
@@ -81,7 +80,7 @@ export const useCache = ( shouldUseCache ) => {
  *
  * @return {boolean} The current caching state (`true` for on, `false` for off).
  */
-export const isAPICachingEnabled = () => {
+export const usingCache = () => {
 	return cachingEnabled;
 };
 

--- a/assets/js/googlesitekit/api/index.js
+++ b/assets/js/googlesitekit/api/index.js
@@ -1,3 +1,5 @@
+let cachingEnabled = true;
+
 /**
  * Get Google Site Kit data.
  *
@@ -65,13 +67,22 @@ export const set = async (
  *
  * @param {boolean} shouldUseCache Set to `true` to use this cache across requests; set to `false` to disable caching.
  *
- * @return {boolean} The current caching state (`true` for on, `false` for off).
+ * @return {boolean} The new caching state (`true` for on, `false` for off).
  */
 // eslint-disable-next-line no-unused-vars
 export const useCache = ( shouldUseCache ) => {
-	API._useCache = !! shouldUseCache;
+	cachingEnabled = !! shouldUseCache;
 
-	return API._useCache;
+	return cachingEnabled;
+};
+
+/**
+ * Get current caching state for the API.
+ *
+ * @return {boolean} The current caching state (`true` for on, `false` for off).
+ */
+export const isAPICachingEnabled = () => {
+	return cachingEnabled;
 };
 
 /**
@@ -94,13 +105,3 @@ export const useCache = ( shouldUseCache ) => {
 export const invalidateCache = ( type, identifier, datapoint ) => {
 	throw new Error( 'Not yet implemented.' );
 };
-
-const API = {
-	_useCache: true,
-	invalidateCache,
-	get,
-	set,
-	useCache,
-};
-
-export default API;

--- a/assets/js/googlesitekit/api/index.js
+++ b/assets/js/googlesitekit/api/index.js
@@ -1,0 +1,106 @@
+/**
+ * Get Google Site Kit data.
+ *
+ * Makes a request to this site's WordPress REST API, which will in
+ * turn make GET requests to the relevant Google services' APIs.
+ *
+ * This method automatically handles authentication, so no credentials
+ * are required to use this method.
+ *
+ * @param {string} type        The data to access. One of 'core' or 'modules'.
+ * @param {string} identifier  The data identifier, eg. a module slug like `'search-console'`.
+ * @param {string} datapoint   The endpoint to request data from.
+ * @param {Object} queryParams Query params to send with the request.
+ *
+ * @return {Promise} A promise for the `fetch` request.
+ */
+// eslint-disable-next-line no-unused-vars
+export const get = async (
+	type,
+	identifier,
+	datapoint,
+	queryParams,
+	// eslint-disable-next-line no-unused-vars
+	{ disableCache = false } = {}
+) => {
+	throw new Error( 'Not yet implemented.' );
+};
+
+/**
+ * Set Google Site Kit data.
+ *
+ * Makes a request to this site's WordPress REST API, which will in
+ * turn make requests to the relevant Google services' APIs to save
+ * the data sent in the request.
+ *
+ * This method automatically handles authentication, so no credentials
+ * are required to use this method.
+ *
+ * @param {string} type       The data to access. One of 'core' or 'modules'.
+ * @param {string} identifier The data identifier, eg. a module slug like `'adsense'`.
+ * @param {string} datapoint  The endpoint to send data to.
+ * @param {Object} data       Request data (eg. post data) to send with the request.
+ *
+ * @return {Promise} A promise for the `fetch` request.
+ */
+// eslint-disable-next-line no-unused-vars
+export const set = async (
+	type,
+	identifier,
+	datapoint,
+	data,
+	// eslint-disable-next-line no-unused-vars
+	{ disableCache = false, queryParams = {} } = {}
+) => {
+	throw new Error( 'Not yet implemented.' );
+};
+
+/**
+ * Enable/disable caching.
+ *
+ * Set the caching to on/off for the entire API library.
+ *
+ * Individual requests can still be overridden to _disable_ caching,
+ * but if caching is turned off it cannot be turned on for a specific request.
+ *
+ * @param {boolean} shouldUseCache Set to `true` to use this cache across requests; set to `false` to disable caching.
+ *
+ * @return {boolean} The current caching state (`true` for on, `false` for off).
+ */
+// eslint-disable-next-line no-unused-vars
+export const useCache = ( shouldUseCache ) => {
+	API._useCache = !! shouldUseCache;
+
+	return API._useCache;
+};
+
+/**
+ * Invalid the cache for a specific datapoint or all data.
+ *
+ * Invalidate cache data for either a specific datapoint, identifier, type, or
+ * all data. The more specificity supplied the more granularly cache data will
+ * be invalidated.
+ *
+ * Calling `invalidateCache()` will invalidate _all_ cached data, while calling
+ * `invalidateCache( 'core', 'adsense' )` will invalidate all AdSense data only.
+ *
+ * @param {string} type       The data type to operate on. One of 'core' or 'modules'.
+ * @param {string} identifier The data identifier, eg. a module slug like `'adsense'`.
+ * @param {string} datapoint  The endpoint to invalidate cache data for.
+ *
+ * @return {void}
+ */
+// eslint-disable-next-line no-unused-vars
+export const invalidateCache = ( type, identifier, datapoint ) => {
+	throw new Error( 'Not yet implemented.' );
+};
+
+const API = {
+	_useCache: true,
+	invalidateCache,
+	get,
+	set,
+	useCache,
+};
+
+export default API;

--- a/assets/js/googlesitekit/api/index.test.js
+++ b/assets/js/googlesitekit/api/index.test.js
@@ -1,0 +1,59 @@
+/**
+ * Internal dependencies
+ */
+import API, { invalidateCache, get, set, useCache } from './index';
+
+describe( 'googlesitekit.api', () => {
+	it( 'should have caching enabled by default', () => {
+		expect( API._useCache ).toEqual( true );
+	} );
+
+	describe( 'invalidateCache', () => {
+		it( 'should throw an error while not implemented', () => {
+			expect( () => {
+				invalidateCache();
+			} ).toThrow( 'Not yet implemented.' );
+		} );
+	} );
+
+	describe( 'get', () => {
+		it( 'should throw an error while not implemented', async () => {
+			try {
+				await get();
+			} catch ( error ) {
+				expect( error.message ).toEqual( 'Not yet implemented.' );
+			}
+		} );
+	} );
+
+	describe( 'set', () => {
+		it( 'should throw an error while not implemented', async () => {
+			try {
+				await set();
+			} catch ( error ) {
+				expect( error.message ).toEqual( 'Not yet implemented.' );
+			}
+		} );
+	} );
+
+	describe( 'useCache', () => {
+		afterEach( () => {
+			// Re-enable the default caching setting after each test.
+			useCache( true );
+		} );
+
+		it( 'should enable the caching API', () => {
+			// The cache is enabled by default, so ensure it is disabled first
+			// to ensure re-enabling works as expected.
+			useCache( false );
+
+			expect( useCache( true ) ).toEqual( true );
+			expect( API._useCache ).toEqual( true );
+		} );
+
+		it( 'should disable the caching API', () => {
+			expect( useCache( false ) ).toEqual( false );
+			expect( API._useCache ).toEqual( false );
+		} );
+	} );
+} );

--- a/assets/js/googlesitekit/api/index.test.js
+++ b/assets/js/googlesitekit/api/index.test.js
@@ -1,11 +1,11 @@
 /**
  * Internal dependencies
  */
-import API, { invalidateCache, get, set, useCache } from './index';
+import { invalidateCache, isAPICachingEnabled, get, set, useCache } from './index';
 
 describe( 'googlesitekit.api', () => {
 	it( 'should have caching enabled by default', () => {
-		expect( API._useCache ).toEqual( true );
+		expect( isAPICachingEnabled() ).toEqual( true );
 	} );
 
 	describe( 'invalidateCache', () => {
@@ -48,12 +48,12 @@ describe( 'googlesitekit.api', () => {
 			useCache( false );
 
 			expect( useCache( true ) ).toEqual( true );
-			expect( API._useCache ).toEqual( true );
+			expect( isAPICachingEnabled() ).toEqual( true );
 		} );
 
 		it( 'should disable the caching API', () => {
 			expect( useCache( false ) ).toEqual( false );
-			expect( API._useCache ).toEqual( false );
+			expect( isAPICachingEnabled() ).toEqual( false );
 		} );
 	} );
 } );

--- a/assets/js/googlesitekit/api/index.test.js
+++ b/assets/js/googlesitekit/api/index.test.js
@@ -1,11 +1,11 @@
 /**
  * Internal dependencies
  */
-import { invalidateCache, isAPICachingEnabled, get, set, useCache } from './index';
+import { invalidateCache, usingCache, get, set, setUsingCache } from './index';
 
 describe( 'googlesitekit.api', () => {
 	it( 'should have caching enabled by default', () => {
-		expect( isAPICachingEnabled() ).toEqual( true );
+		expect( usingCache() ).toEqual( true );
 	} );
 
 	describe( 'invalidateCache', () => {
@@ -36,24 +36,24 @@ describe( 'googlesitekit.api', () => {
 		} );
 	} );
 
-	describe( 'useCache', () => {
+	describe( 'setUsingCache', () => {
 		afterEach( () => {
 			// Re-enable the default caching setting after each test.
-			useCache( true );
+			setUsingCache( true );
 		} );
 
 		it( 'should enable the caching API', () => {
 			// The cache is enabled by default, so ensure it is disabled first
 			// to ensure re-enabling works as expected.
-			useCache( false );
+			setUsingCache( false );
 
-			expect( useCache( true ) ).toEqual( true );
-			expect( isAPICachingEnabled() ).toEqual( true );
+			expect( setUsingCache( true ) ).toEqual( true );
+			expect( usingCache() ).toEqual( true );
 		} );
 
 		it( 'should disable the caching API', () => {
-			expect( useCache( false ) ).toEqual( false );
-			expect( isAPICachingEnabled() ).toEqual( false );
+			expect( setUsingCache( false ) ).toEqual( false );
+			expect( usingCache() ).toEqual( false );
 		} );
 	} );
 } );

--- a/includes/Core/Assets/Assets.php
+++ b/includes/Core/Assets/Assets.php
@@ -274,7 +274,9 @@ final class Assets {
 	 */
 	private function enqueue_minimal_admin_script() {
 		$this->enqueue_asset( 'googlesitekit_admin' );
-		$this->enqueue_asset( 'googlesitekit-api' );
+		if ( GOOGLESITEKIT_JS_REFACTOR === true ) {
+			$this->enqueue_asset( 'googlesitekit-api' );
+		}
 	}
 
 	/**

--- a/includes/Core/Assets/Assets.php
+++ b/includes/Core/Assets/Assets.php
@@ -274,6 +274,7 @@ final class Assets {
 	 */
 	private function enqueue_minimal_admin_script() {
 		$this->enqueue_asset( 'googlesitekit_admin' );
+		$this->enqueue_asset( 'googlesitekit-api' );
 	}
 
 	/**
@@ -352,6 +353,15 @@ final class Assets {
 					},
 				)
 			),
+			// Begin JSR Assets.
+			new Script(
+				'googlesitekit-api',
+				array(
+					'src'          => $base_url . 'js/googlesitekit-api.js',
+					'dependencies' => $dependencies,
+				)
+			),
+			// End JSR Assets.
 			new Script(
 				'googlesitekit_ads_detect',
 				array(

--- a/includes/Core/Assets/Assets.php
+++ b/includes/Core/Assets/Assets.php
@@ -274,9 +274,6 @@ final class Assets {
 	 */
 	private function enqueue_minimal_admin_script() {
 		$this->enqueue_asset( 'googlesitekit_admin' );
-		if ( GOOGLESITEKIT_JS_REFACTOR === true ) {
-			$this->enqueue_asset( 'googlesitekit-api' );
-		}
 	}
 
 	/**

--- a/includes/loader.php
+++ b/includes/loader.php
@@ -14,6 +14,13 @@ namespace Google\Site_Kit;
 define( 'GOOGLESITEKIT_PLUGIN_BASENAME', plugin_basename( GOOGLESITEKIT_PLUGIN_MAIN_FILE ) );
 define( 'GOOGLESITEKIT_PLUGIN_DIR_PATH', plugin_dir_path( GOOGLESITEKIT_PLUGIN_MAIN_FILE ) );
 
+// Enable this ENV variable to load the new, refactored JavaScript code.
+if ( false !== getenv( 'GOOGLESITEKIT_JS_REFACTOR' ) ) {
+	define( 'GOOGLESITEKIT_JS_REFACTOR', bool( getenv( 'GOOGLESITEKIT_JS_REFACTOR' ) ) );
+} else {
+	define( 'GOOGLESITEKIT_JS_REFACTOR', false );
+}
+
 /**
  * Loads generated class maps for autoloading.
  *

--- a/includes/loader.php
+++ b/includes/loader.php
@@ -14,13 +14,6 @@ namespace Google\Site_Kit;
 define( 'GOOGLESITEKIT_PLUGIN_BASENAME', plugin_basename( GOOGLESITEKIT_PLUGIN_MAIN_FILE ) );
 define( 'GOOGLESITEKIT_PLUGIN_DIR_PATH', plugin_dir_path( GOOGLESITEKIT_PLUGIN_MAIN_FILE ) );
 
-// Enable this ENV variable to load the new, refactored JavaScript code.
-if ( false !== getenv( 'GOOGLESITEKIT_JS_REFACTOR' ) ) {
-	define( 'GOOGLESITEKIT_JS_REFACTOR', bool( getenv( 'GOOGLESITEKIT_JS_REFACTOR' ) ) );
-} else {
-	define( 'GOOGLESITEKIT_JS_REFACTOR', false );
-}
-
 /**
  * Loads generated class maps for autoloading.
  *

--- a/tests/e2e/jest.config.js
+++ b/tests/e2e/jest.config.js
@@ -7,6 +7,7 @@ module.exports = {
 		'expect-puppeteer',
 	],
 	testMatch: [
+		'<rootDir>/**/*.test.js',
 		'<rootDir>/specs/**/__tests__/**/*.js',
 		'<rootDir>/specs/**/?(*.)(spec|test).js',
 		'<rootDir>/specs/**/test/*.js',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -109,7 +109,7 @@ const resolve = {
 		GoogleUtil: path.resolve( 'assets/js/util/' ),
 		GoogleModules: path.resolve( './assets/js/modules/' ),
 	},
-	modules: [ projectPath( 'assets' ), projectPath( '.' ), 'node_modules' ],
+	modules: [ projectPath( '.' ), 'node_modules' ],
 };
 
 module.exports = ( env, argv ) => {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -16,9 +16,17 @@
  * limitations under the License.
  */
 
+/**
+ * Node dependencies
+ */
+const fs = require( 'fs' );
+const path = require( 'path' );
+
+/**
+ * External dependencies
+ */
 const glob = require( 'glob' );
 const MiniCssExtractPlugin = require( 'mini-css-extract-plugin' );
-const path = require( 'path' );
 const TerserPlugin = require( 'terser-webpack-plugin' );
 const WebpackBar = require( 'webpackbar' );
 
@@ -44,6 +52,10 @@ function camelCaseDash( string ) {
 	);
 }
 
+const projectPath = ( relativePath ) => {
+	return path.resolve( fs.realpathSync( process.cwd() ), relativePath );
+};
+
 const externalPackages = [
 	'api-fetch',
 	'compose',
@@ -64,6 +76,7 @@ const externals = {
 	jquery: 'jQuery',
 	lodash: 'lodash',
 	'lodash-es': 'lodash',
+	'js/googlesitekit/api': [ 'googlesitekit', 'api' ],
 };
 
 [
@@ -96,14 +109,17 @@ const resolve = {
 		GoogleUtil: path.resolve( 'assets/js/util/' ),
 		GoogleModules: path.resolve( './assets/js/modules/' ),
 	},
+	modules: [ projectPath( 'assets' ), projectPath( '.' ), 'node_modules' ],
 };
 
 module.exports = ( env, argv ) => {
 	return [
-
 		// Build the settings js..
 		{
 			entry: {
+				// New Modules (Post-JSR).
+				'googlesitekit-api': './assets/js/googlesitekit-api.js',
+				// Old Modules
 				'googlesitekit-settings': './assets/js/googlesitekit-settings.js',
 				'googlesitekit-dashboard': './assets/js/googlesitekit-dashboard.js',
 				'googlesitekit-dashboard-details': './assets/js/googlesitekit-dashboard-details.js',


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #570.

## Relevant technical choices

Added `**/*.test.js` to the `jest.config.js` to allow for co-located tests (without the ugly `__tests__` directories). This will allow us to more easily:

* Move files and their tests around without needing to change import paths
* Better reason about where test files are and what they relate to.

## Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
