### PR TITLE
Update input superglobal access to use new Input class in all places.

### DIFF
--- a/includes/Core/Admin/Screens.php
+++ b/includes/Core/Admin/Screens.php
@@ -308,19 +308,20 @@ final class Screens {
 
 				// This callback will redirect to the dashboard on successful authentication.
 				'initialize_callback' => function( Context $context ) {
-					$splash_context = filter_input( INPUT_GET, 'googlesitekit_context' );
+					$splash_context = $context->input()->filter( INPUT_GET, 'googlesitekit_context' );
+					$reset_session  = $context->input()->filter( INPUT_GET, 'googlesitekit_reset_session', FILTER_VALIDATE_BOOLEAN );
 					$authentication = new Authentication( $context );
 
 					// If the user is authenticated, redirect them to the disconnect URL and then send them back here.
-					if ( empty( $_GET['googlesitekit_reset_session'] ) && 'revoked' === $splash_context && $authentication->is_authenticated() ) { // phpcs:ignore WordPress.Security.NonceVerification.NoNonceVerification
+					if ( ! $reset_session && 'revoked' === $splash_context && $authentication->is_authenticated() ) {
 						$authentication->disconnect();
 
 						wp_safe_redirect( add_query_arg( array( 'googlesitekit_reset_session' => 1 ) ) );
 						exit;
 					}
 
-					$notification = filter_input( INPUT_GET, 'notification' );
-					$error        = filter_input( INPUT_GET, 'error' );
+					$notification = $context->input()->filter( INPUT_GET, 'notification' );
+					$error        = $context->input()->filter( INPUT_GET, 'error' );
 
 					// Bail if no success parameter indicator.
 					if ( 'authentication_success' !== $notification || ! empty( $error ) ) {

--- a/includes/Core/Admin/Screens.php
+++ b/includes/Core/Admin/Screens.php
@@ -216,7 +216,7 @@ final class Screens {
 					'title'            => __( 'Dashboard', 'google-site-kit' ),
 					'capability'       => Permissions::VIEW_DASHBOARD,
 					'enqueue_callback' => function( Assets $assets ) {
-						if ( filter_input( INPUT_GET, 'permaLink' ) ) {
+						if ( $this->context->input()->filter( INPUT_GET, 'permaLink' ) ) {
 							$assets->enqueue_asset( 'googlesitekit_dashboard_details' );
 						} else {
 							$assets->enqueue_asset( 'googlesitekit_dashboard' );
@@ -226,7 +226,7 @@ final class Screens {
 						?>
 						<div class="googlesitekit-plugin">
 							<?php
-							if ( filter_input( INPUT_GET, 'permaLink' ) ) {
+							if ( $context->input()->filter( INPUT_GET, 'permaLink' ) ) {
 								/**
 								 * Fires before the Dashboard Details App wrapper is rendered.
 								 *

--- a/includes/Core/Authentication/Authentication.php
+++ b/includes/Core/Authentication/Authentication.php
@@ -417,7 +417,7 @@ final class Authentication {
 				)
 			);
 
-			header( 'Location: ' . filter_var( $redirect_url, FILTER_SANITIZE_URL ) );
+			wp_safe_redirect( $redirect_url );
 			exit();
 		}
 
@@ -437,7 +437,7 @@ final class Authentication {
 			}
 
 			// User is trying to authenticate, but access token hasn't been set.
-			header( 'Location: ' . filter_var( $auth_client->get_authentication_url( $redirect_url ), FILTER_SANITIZE_URL ) );
+			wp_safe_redirect( $auth_client->get_authentication_url( $redirect_url ) );
 			exit();
 		}
 	}

--- a/includes/Core/Authentication/Authentication.php
+++ b/includes/Core/Authentication/Authentication.php
@@ -387,9 +387,10 @@ final class Authentication {
 		}
 
 		$auth_client = $this->get_oauth_client();
+		$input       = $this->context->input();
 
 		// Handles Direct OAuth client request.
-		if ( filter_input( INPUT_GET, 'oauth2callback' ) ) {
+		if ( $input->filter( INPUT_GET, 'oauth2callback' ) ) {
 			$auth_client->authorize_user();
 		}
 
@@ -397,8 +398,8 @@ final class Authentication {
 			return;
 		}
 
-		if ( filter_input( INPUT_GET, 'googlesitekit_disconnect' ) ) {
-			$nonce = filter_input( INPUT_GET, 'nonce' );
+		if ( $input->filter( INPUT_GET, 'googlesitekit_disconnect' ) ) {
+			$nonce = $input->filter( INPUT_GET, 'nonce' );
 			if ( empty( $nonce ) || ! wp_verify_nonce( $nonce, 'disconnect' ) ) {
 				wp_die( esc_html__( 'Invalid nonce.', 'google-site-kit' ), 400 );
 			}
@@ -420,8 +421,8 @@ final class Authentication {
 			exit();
 		}
 
-		if ( filter_input( INPUT_GET, 'googlesitekit_connect' ) ) {
-			$nonce = filter_input( INPUT_GET, 'nonce' );
+		if ( $input->filter( INPUT_GET, 'googlesitekit_connect' ) ) {
+			$nonce = $input->filter( INPUT_GET, 'nonce' );
 			if ( empty( $nonce ) || ! wp_verify_nonce( $nonce, 'connect' ) ) {
 				wp_die( esc_html__( 'Invalid nonce.', 'google-site-kit' ), 400 );
 			}
@@ -430,9 +431,9 @@ final class Authentication {
 				wp_die( esc_html__( 'You don\'t have permissions to perform this action.', 'google-site-kit' ), 403 );
 			}
 
-			$redirect_url = '';
-			if ( ! empty( $_GET['redirect'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.NoNonceVerification
-				$redirect_url = esc_url_raw( wp_unslash( $_GET['redirect'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.NoNonceVerification
+			$redirect_url = $input->filter( INPUT_GET, 'redirect' );
+			if ( $redirect_url ) {
+				$redirect_url = esc_url_raw( wp_unslash( $redirect_url ) );
 			}
 
 			// User is trying to authenticate, but access token hasn't been set.
@@ -524,11 +525,9 @@ final class Authentication {
 			$data['hasSearchConsoleProperty'] = false;
 		}
 
-		$reauth                        = isset( $_GET['reAuth'] ) ? ( 'true' === $_GET['reAuth'] ) : false; // phpcs:ignore WordPress.CSRF.NoNonceVerification.
-		$data['showModuleSetupWizard'] = $reauth;
+		$data['showModuleSetupWizard'] = $this->context->input()->filter( INPUT_GET, 'reAuth', FILTER_VALIDATE_BOOLEAN );
 
-		$module_to_setup       = isset( $_GET['slug'] ) ? sanitize_key( $_GET['slug'] ) : ''; // phpcs:ignore WordPress.CSRF.NoNonceVerification.
-		$data['moduleToSetup'] = $module_to_setup;
+		$data['moduleToSetup'] = sanitize_key( $this->context->input()->filter( INPUT_GET, 'slug' ) );
 
 		return $data;
 	}

--- a/includes/Core/Authentication/Authentication.php
+++ b/includes/Core/Authentication/Authentication.php
@@ -531,7 +531,7 @@ final class Authentication {
 
 		$data['showModuleSetupWizard'] = $this->context->input()->filter( INPUT_GET, 'reAuth', FILTER_VALIDATE_BOOLEAN );
 
-		$data['moduleToSetup'] = sanitize_key( $this->context->input()->filter( INPUT_GET, 'slug' ) );
+		$data['moduleToSetup'] = sanitize_key( (string) $this->context->input()->filter( INPUT_GET, 'slug' ) );
 
 		return $data;
 	}

--- a/includes/Core/Authentication/Authentication.php
+++ b/includes/Core/Authentication/Authentication.php
@@ -391,7 +391,6 @@ final class Authentication {
 		// Handles Direct OAuth client request.
 		if ( filter_input( INPUT_GET, 'oauth2callback' ) ) {
 			$auth_client->authorize_user();
-			exit;
 		}
 
 		if ( ! is_admin() ) {

--- a/includes/Core/Authentication/Authentication.php
+++ b/includes/Core/Authentication/Authentication.php
@@ -431,13 +431,17 @@ final class Authentication {
 				wp_die( esc_html__( 'You don\'t have permissions to perform this action.', 'google-site-kit' ), 403 );
 			}
 
-			$redirect_url = $input->filter( INPUT_GET, 'redirect' );
+			$redirect_url = $input->filter( INPUT_GET, 'redirect', FILTER_VALIDATE_URL );
 			if ( $redirect_url ) {
 				$redirect_url = esc_url_raw( wp_unslash( $redirect_url ) );
 			}
 
 			// User is trying to authenticate, but access token hasn't been set.
-			wp_safe_redirect( $auth_client->get_authentication_url( $redirect_url ) );
+			wp_safe_redirect(
+				esc_url_raw(
+					$auth_client->get_authentication_url( $redirect_url )
+				)
+			);
 			exit();
 		}
 	}

--- a/includes/Core/Authentication/Clients/OAuth_Client.php
+++ b/includes/Core/Authentication/Clients/OAuth_Client.php
@@ -501,8 +501,9 @@ final class OAuth_Client {
 	 * @since 1.0.0
 	 */
 	public function authorize_user() {
-		// If the OAuth redirects with an error code, handle it.
+		$code       = $this->context->input()->filter( INPUT_GET, 'code', FILTER_SANITIZE_STRING );
 		$error_code = $this->context->input()->filter( INPUT_GET, 'error', FILTER_SANITIZE_STRING );
+		// If the OAuth redirects with an error code, handle it.
 		if ( ! empty( $error_code ) ) {
 			$this->user_options->set( self::OPTION_ERROR_CODE, $error_code );
 			wp_safe_redirect( admin_url() );
@@ -516,7 +517,7 @@ final class OAuth_Client {
 		}
 
 		try {
-			$authentication_token = $this->get_client()->fetchAccessTokenWithAuthCode( $_GET['code'] ); // phpcs:ignore WordPress.Security.NonceVerification.NoNonceVerification
+			$authentication_token = $this->get_client()->fetchAccessTokenWithAuthCode( $code );
 		} catch ( Google_Proxy_Exception $e ) {
 			wp_safe_redirect( $this->get_proxy_setup_url( $e->getAccessCode(), $e->getMessage() ) );
 			exit();
@@ -549,8 +550,9 @@ final class OAuth_Client {
 		// Update granted scopes.
 		if ( isset( $authentication_token['scope'] ) ) {
 			$scopes = explode( ' ', $authentication_token['scope'] );
-		} elseif ( isset( $_GET['scope'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.NoNonceVerification
-			$scopes = explode( ' ', $_GET['scope'] ); // phpcs:ignore WordPress.Security.NonceVerification.NoNonceVerification
+		} elseif ( $this->context->input()->filter( INPUT_GET, 'scope' ) ) {
+			$scope  = $this->context->input()->filter( INPUT_GET, 'scope', FILTER_SANITIZE_STRING );
+			$scopes = explode( ' ', $scope );
 		} else {
 			$scopes = $this->get_required_scopes();
 		}

--- a/includes/Core/Modules/Module.php
+++ b/includes/Core/Modules/Module.php
@@ -373,9 +373,9 @@ abstract class Module {
 
 		// Cache the results for storybook.
 		if (
-			current_user_can( 'manage_options' ) &&
-			isset( $_GET['datacache'] ) // phpcs:ignore WordPress.Security.NonceVerification.NoNonceVerification
-			&& ! empty( $results )
+			! empty( $results )
+			&& null !== $this->context->input()->filter( INPUT_GET, 'datacache' )
+			&& current_user_can( 'manage_options' )
 		) {
 			$cache = new Cache();
 			$cache->cache_batch_results( $datasets, $results );

--- a/includes/Core/Util/Activation.php
+++ b/includes/Core/Util/Activation.php
@@ -145,10 +145,12 @@ final class Activation {
 			'activated',
 			array(
 				'content'         => function() {
-					// Remove the default WordPress "Plugin Activated" notice.
-					if ( isset( $_GET['activate'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.NoNonceVerification
-						unset( $_GET['activate'] ); // phpcs:ignore WordPress.Security.NonceVerification.NoNonceVerification
-					}
+					/**
+					 * Prevent the default WordPress "Plugin Activated" notice from rendering.
+					 *
+					 * @link https://github.com/WordPress/WordPress/blob/e1996633228749cdc2d92bc04cc535d45367bfa4/wp-admin/plugins.php#L569-L570
+					 */
+					unset( $_GET['activate'] ); // phpcs:ignore WordPress.Security.NonceVerification.NoNonceVerification
 
 					$sitekit_splash_url = $this->context->admin_url( 'splash' );
 

--- a/includes/Core/Util/Input.php
+++ b/includes/Core/Util/Input.php
@@ -23,9 +23,10 @@ class Input {
 	 *
 	 * For use as fallback only.
 	 *
+	 * @since n.e.x.t
 	 * @var array
 	 */
-	protected $map;
+	protected $fallback_map;
 
 	/**
 	 * Constructor.
@@ -33,7 +34,8 @@ class Input {
 	 * @since n.e.x.t
 	 */
 	public function __construct() {
-		$this->map = array(
+		// Fallback map for environments where filter_input may not work with ENV or SERVER types.
+		$this->fallback_map = array(
 			INPUT_ENV    => $_ENV,
 			INPUT_SERVER => $_SERVER,
 		);
@@ -61,16 +63,16 @@ class Input {
 	public function filter( $type, $variable_name, $filter = FILTER_DEFAULT, $options = null ) {
 		$value = filter_input( $type, $variable_name, $filter, $options );
 
-		// Fallback for environments where filter_input may not work with SERVER or ENV types.
+		// Fallback for environments where filter_input may not work with specific types.
 		if (
 			// Only use this fallback for affected input types.
-			in_array( $type, array( INPUT_SERVER, INPUT_ENV ), true )
+			isset( $this->fallback_map[ $type ] )
 			// Only use the fallback if the value is not-set (could be either depending on FILTER_NULL_ON_FAILURE).
 			&& in_array( $value, array( null, false ), true )
 			// Only use the fallback if the key exists in the input map.
-			&& array_key_exists( $variable_name, $this->map[ $type ] )
+			&& array_key_exists( $variable_name, $this->fallback_map[ $type ] )
 		) {
-			return filter_var( $this->map[ $type ][ $variable_name ], $filter, $options );
+			return filter_var( $this->fallback_map[ $type ][ $variable_name ], $filter, $options );
 		}
 
 		return $value;

--- a/includes/Modules/AdSense.php
+++ b/includes/Modules/AdSense.php
@@ -203,8 +203,7 @@ final class AdSense extends Module implements Module_With_Screen, Module_With_Sc
 	protected function output_adsense_script() {
 
 		// Bail early if we are checking for the tag presence from the back end.
-		$tag_verify = ! empty( $_GET['tagverify'] ) ? true : false; // phpcs:ignore WordPress.Security.NonceVerification.NoNonceVerification
-		if ( $tag_verify ) {
+		if ( $this->context->input()->filter( INPUT_GET, 'tagverify', FILTER_VALIDATE_BOOLEAN ) ) {
 			return;
 		}
 

--- a/includes/Modules/Analytics.php
+++ b/includes/Modules/Analytics.php
@@ -270,8 +270,7 @@ final class Analytics extends Module implements Module_With_Screen, Module_With_
 	 */
 	protected function enqueue_gtag_js() {
 		// Bail early if we are checking for the tag presence from the back end.
-		$tag_verify = ! empty( $_GET['tagverify'] ) ? true : false; // phpcs:ignore WordPress.Security.NonceVerification.NoNonceVerification
-		if ( $tag_verify ) {
+		if ( $this->context->input()->filter( INPUT_GET, 'tagverify', FILTER_VALIDATE_BOOLEAN ) ) {
 			return;
 		}
 
@@ -348,8 +347,7 @@ final class Analytics extends Module implements Module_With_Screen, Module_With_
 	 */
 	protected function print_amp_gtag() {
 		// Bail early if we are checking for the tag presence from the back end.
-		$tag_verify = ! empty( $_GET['tagverify'] ) ? true : false; // phpcs:ignore WordPress.Security.NonceVerification.NoNonceVerification
-		if ( $tag_verify ) {
+		if ( $this->context->input()->filter( INPUT_GET, 'tagverify', FILTER_VALIDATE_BOOLEAN ) ) {
 			return;
 		}
 

--- a/includes/Modules/Site_Verification.php
+++ b/includes/Modules/Site_Verification.php
@@ -75,10 +75,13 @@ final class Site_Verification extends Module implements Module_With_Scopes {
 		add_action(
 			'init',
 			function () {
+				$request_uri    = $this->context->input()->filter( INPUT_SERVER, 'REQUEST_URI' );
+				$request_method = $this->context->input()->filter( INPUT_SERVER, 'REQUEST_METHOD' );
+
 				if (
-					isset( $_SERVER['REQUEST_URI'], $_SERVER['REQUEST_METHOD'] )
-					&& 'GET' === strtoupper( $_SERVER['REQUEST_METHOD'] )
-					&& preg_match( '/^\/google(?P<token>[a-z0-9]+)\.html$/', $_SERVER['REQUEST_URI'], $matches )
+					( $request_uri && $request_method )
+					&& 'GET' === strtoupper( $request_method )
+					&& preg_match( '/^\/google(?P<token>[a-z0-9]+)\.html$/', $request_uri, $matches )
 				) {
 					$this->serve_verification_file( $matches['token'] );
 				}

--- a/tests/e2e/plugins/oauth-callback.php
+++ b/tests/e2e/plugins/oauth-callback.php
@@ -33,10 +33,9 @@ add_action( 'init', function () {
 			$redirect_url = esc_url_raw( wp_unslash( $_GET['redirect'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.NoNonceVerification
 		}
 
-		status_header( 302 );
 		$auth_client = new OAuth_Client( $context );
 		// User is trying to authenticate, but access token hasn't been set.
-		header( 'Location: ' . filter_var( $auth_client->get_authentication_url( $redirect_url ), FILTER_SANITIZE_URL ) );
+		wp_safe_redirect( $auth_client->get_authentication_url( $redirect_url ) );
 		exit();
 	}
 

--- a/tests/phpunit/integration/Core/Authentication/Clients/OAuth_ClientTest.php
+++ b/tests/phpunit/integration/Core/Authentication/Clients/OAuth_ClientTest.php
@@ -16,6 +16,7 @@ use Google\Site_Kit\Tests\Exception\RedirectException;
 use Google\Site_Kit\Core\Storage\User_Options;
 use Google\Site_Kit\Tests\MutableInput;
 use Google\Site_Kit\Tests\FakeHttpClient;
+use Google\Site_Kit\Tests\MutableInput;
 use Google\Site_Kit\Tests\TestCase;
 
 /**

--- a/tests/phpunit/integration/Core/Authentication/Clients/OAuth_ClientTest.php
+++ b/tests/phpunit/integration/Core/Authentication/Clients/OAuth_ClientTest.php
@@ -14,7 +14,6 @@ use Google\Site_Kit\Context;
 use Google\Site_Kit\Core\Authentication\Clients\OAuth_Client;
 use Google\Site_Kit\Tests\Exception\RedirectException;
 use Google\Site_Kit\Core\Storage\User_Options;
-use Google\Site_Kit\Tests\MutableInput;
 use Google\Site_Kit\Tests\FakeHttpClient;
 use Google\Site_Kit\Tests\MutableInput;
 use Google\Site_Kit\Tests\TestCase;

--- a/tests/phpunit/integration/Modules/Site_VerificationTest.php
+++ b/tests/phpunit/integration/Modules/Site_VerificationTest.php
@@ -133,7 +133,7 @@ class Site_VerificationTest extends TestCase {
 	}
 
 	public function test_file_verification() {
-		$context           = new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE );
+		$context           = new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE, new MutableInput() );
 		$site_verification = new Site_Verification( $context );
 		$user_id           = $this->factory()->user->create( array( 'role' => 'administrator' ) );
 		$user_options      = new User_Options( $context, $user_id );


### PR DESCRIPTION
## Summary

This PR picks up where #916 leaves off to update all remaining usage to use the new Input class via `Context`.

This PR currently uses `enhance/905-credentials-provisioning` as the base as that PR has not been merged yet so that only the added changes are shown here.

Addresses issue #886

## Relevant technical choices

* Updates all references to `$_GET`, and `$_SERVER` (nothing else to update)
* Updates all existing code using `filter_input`
* Also updates "manual" redirects using `header( 'Location: '` code to use `wp_safe_redirect` instead for consistency and testability

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
