### PR TITLE
Ensure global opt-in state is changed.

### DIFF
--- a/assets/js/components/optin.js
+++ b/assets/js/components/optin.js
@@ -57,15 +57,15 @@ class Optin extends Component {
 			method: 'POST',
 		} )
 			.then( () => {
+				const { document } = window;
+
+				if ( ! document ) {
+					return;
+				}
+
+				window.googlesitekitTrackingEnabled = !! checked;
+
 				if ( !! checked && ! this.state.scriptOnPage ) {
-					const { document } = window;
-
-					if ( ! document ) {
-						return;
-					}
-
-					window.googlesitekitTrackingEnabled = !! checked;
-
 					document.body.insertAdjacentHTML( 'beforeend', `
 						<script async src="https://www.googletagmanager.com/gtag/js?id=${ googlesitekit.admin.trackingID }"></script>
 					` );

--- a/assets/js/components/optin.js
+++ b/assets/js/components/optin.js
@@ -57,15 +57,15 @@ class Optin extends Component {
 			method: 'POST',
 		} )
 			.then( () => {
-				const { document } = window;
-
-				if ( ! document ) {
-					return;
-				}
-
 				window.googlesitekitTrackingEnabled = !! checked;
 
 				if ( !! checked && ! this.state.scriptOnPage ) {
+					const { document } = window;
+
+					if ( ! document ) {
+						return;
+					}
+
 					document.body.insertAdjacentHTML( 'beforeend', `
 						<script async src="https://www.googletagmanager.com/gtag/js?id=${ googlesitekit.admin.trackingID }"></script>
 					` );


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #727.

## Relevant technical choices

This ensures the global `window.googlesitekitTrackingEnabled` is always changed when the opt-in checkbox is changed. Fixes the error @cole10up mentioned in https://github.com/google/site-kit-wp/issues/727#issuecomment-559366300

## Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
