### PR TITLE
Update batch requests to use POST instead of GET.

### DIFF
--- a/assets/js/components/data/index.js
+++ b/assets/js/components/data/index.js
@@ -202,7 +202,7 @@ const dataAPI = {
 				{
 					request: JSON.stringify( currentRequest ),
 				} ),
-			method: 'GET',
+			method: 'POST',
 		} ).then( ( results ) => {
 			each( results, ( result, key ) => {
 				if ( result.xdebug_message ) {

--- a/assets/js/components/data/index.js
+++ b/assets/js/components/data/index.js
@@ -198,10 +198,8 @@ const dataAPI = {
 
 		const datacache = null !== getQueryParameter( 'datacache' );
 		return apiFetch( {
-			path: addQueryArgs( `/google-site-kit/v1/data/${ datacache ? '?datacache' : '' }`,
-				{
-					request: JSON.stringify( currentRequest ),
-				} ),
+			path: addQueryArgs( '/google-site-kit/v1/data/', { datacache: datacache || undefined } ),
+			data: { request: currentRequest },
 			method: 'POST',
 		} ).then( ( results ) => {
 			each( results, ( result, key ) => {

--- a/includes/Core/REST_API/REST_Routes.php
+++ b/includes/Core/REST_API/REST_Routes.php
@@ -392,7 +392,7 @@ final class REST_Routes {
 				'data',
 				array(
 					array(
-						'methods'             => WP_REST_Server::READABLE,
+						'methods'             => WP_REST_Server::CREATABLE,
 						'callback'            => function( WP_REST_Request $request ) {
 							$datasets = json_decode( $request['request'] );
 							if ( ! $datasets || empty( $datasets ) ) {

--- a/includes/Core/REST_API/REST_Routes.php
+++ b/includes/Core/REST_API/REST_Routes.php
@@ -394,10 +394,18 @@ final class REST_Routes {
 					array(
 						'methods'             => WP_REST_Server::CREATABLE,
 						'callback'            => function( WP_REST_Request $request ) {
-							$datasets = json_decode( $request['request'] );
-							if ( ! $datasets || empty( $datasets ) ) {
+							if ( ! $request['request'] ) {
 								return new WP_Error( 'no_data_requested', __( 'Missing request data.', 'google-site-kit' ), array( 'status' => 400 ) );
 							}
+
+							// Datasets are expected to be objects but the REST API parses the JSON into an array.
+							$datasets = array_map(
+								function ( $dataset_array ) {
+									return (object) $dataset_array;
+								},
+								$request['request']
+							);
+
 							$modules   = $this->modules->get_active_modules();
 							$responses = array();
 							foreach ( $modules as $module ) {
@@ -420,9 +428,12 @@ final class REST_Routes {
 						'permission_callback' => $can_view_insights_cron,
 						'args'                => array(
 							'request' => array(
-								'type'        => 'string',
-								'description' => __( 'JSON-encoded list of request objects.', 'google-site-kit' ),
+								'type'        => 'array',
+								'description' => __( 'List of request objects.', 'google-site-kit' ),
 								'required'    => true,
+								'items'       => array(
+									'type' => 'object',
+								),
 							),
 						),
 					),


### PR DESCRIPTION
## Summary

Addresses issue #779

## Relevant technical choices

This PR fixes a potential problem where batch requests can fail in some environments if the `request` query parameter is too long by changing these requests to be made as POST requests instead.

See more info about this here https://github.com/google/site-kit-wp/issues/779#issuecomment-559876343

Confirmed that this change fixes the problem on the aforementioned site.

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
