### PR TITLE
Update Travis PHP jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -87,7 +87,7 @@ script:
 
 jobs:
   allow_failures:
-    - php: 7.4snapshot
+    - php: nightly
   include:
     - stage: test
       name: Lint
@@ -105,9 +105,9 @@ jobs:
     - name: JS Tests
       php: 7.3
       env: WP_VERSION=latest JS=1
-    - name: PHP Tests (PHP 7.4, WordPress trunk)
+    - name: PHP Tests (PHP nightly, WordPress trunk)
       stage: test
-      php: 7.4snapshot
+      php: nightly
       env: WP_VERSION=master PHP=1 PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
     - stage: test
       name: E2E Tests (WordPress latest)

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ before_install:
     fi
   - |
     if [[ "$JS" == "1" ]]; then
-      composer require johnpbloch/wordpress-core
+      docker run --rm -v "$PWD:/app" composer install --no-scripts
     fi
   - |
     if [[ "$WP_VERSION" == "latest" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ branches:
 # Before install, failures in this section will result in build status 'errored'
 before_install:
   - |
-    if [[ "$JS" == "1" ]] || [[ "$E2E" == "1" ]]; then
+    if [[ "$JS" == "1" ]] || [[ "$E2E" == "1" ]] || [[ "$SNIFF" == "1" ]]; then
       nvm install
       npm ci
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,10 @@ before_install:
       docker run --rm -v "$PWD:/app" composer install
     fi
   - |
+    if [[ "$JS" == "1" ]]; then
+      composer require johnpbloch/wordpress-core
+    fi
+  - |
     if [[ "$WP_VERSION" == "latest" ]]; then
       curl -s http://api.wordpress.org/core/version-check/1.7/ > /tmp/wp-latest.json
       WP_VERSION=$(grep -o '"version":"[^"]*' /tmp/wp-latest.json | sed 's/"version":"//')

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,10 +48,6 @@ before_install:
       docker run --rm -v "$PWD:/app" composer install
     fi
   - |
-    if [[ "$PHP" == "1" ]] || [[ "$JS" == "1" ]] || [[ "$SNIFF" == "1" ]]; then
-      npm install -g gulp-cli
-    fi
-  - |
     if [[ "$WP_VERSION" == "latest" ]]; then
       curl -s http://api.wordpress.org/core/version-check/1.7/ > /tmp/wp-latest.json
       WP_VERSION=$(grep -o '"version":"[^"]*' /tmp/wp-latest.json | sed 's/"version":"//')

--- a/.travis.yml
+++ b/.travis.yml
@@ -91,19 +91,19 @@ jobs:
   include:
     - stage: test
       name: Lint
-      php: 7.3
+      php: 7.4
       env: WP_VERSION=4.7 PHPCS_PHP_VERSION='5.4' SNIFF=1 PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
     - name: PHP Tests (PHP 5.6, WordPress latest)
       php: 5.6
       env: WP_VERSION=latest PHP=1 PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
-    - name: PHP Tests (PHP 7.3, WordPress latest)
-      php: 7.3
+    - name: PHP Tests (PHP 7.4, WordPress latest)
+      php: 7.4
       env: WP_VERSION=latest PHP=1 PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
-    - name: PHP Tests (PHP 7.3, WordPress Multisite latest)
-      php: 7.3
+    - name: PHP Tests (PHP 7.4, WordPress Multisite latest)
+      php: 7.4
       env: WP_VERSION=latest WP_MULTISITE=1 PHP=1 PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
     - name: JS Tests
-      php: 7.3
+      php: 7.4
       env: WP_VERSION=latest JS=1
     - name: PHP Tests (PHP nightly, WordPress trunk)
       stage: test

--- a/.travis.yml
+++ b/.travis.yml
@@ -68,7 +68,7 @@ before_install:
 script:
   - |
     if [[ "$SNIFF" == "1" ]]; then
-      gulp phpcs || exit 1
+      composer lint || exit 1
       npm run lint:js || exit 1
       npm run lint:css || exit 1
     fi
@@ -81,7 +81,7 @@ script:
     fi
   - |
     if [[ "$PHP" == "1" ]]; then
-      gulp phpunit || exit 1
+      composer test || exit 1
     fi
   - |
     if [[ "$E2E" == "1" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,9 +38,15 @@ branches:
 
 # Before install, failures in this section will result in build status 'errored'
 before_install:
-  - nvm install
-  - npm ci
-  - docker run --rm -v "$PWD:/app" composer install
+  - |
+    if [[ "$JS" == "1" ]] || [[ "$E2E" == "1" ]]; then
+      nvm install
+      npm ci
+    fi
+  - |
+    if [[ "$PHP" == "1" ]] || [[ "$E2E" == "1" ]] || [[ "$SNIFF" == "1" ]]; then
+      docker run --rm -v "$PWD:/app" composer install
+    fi
   - |
     if [[ "$PHP" == "1" ]] || [[ "$JS" == "1" ]] || [[ "$SNIFF" == "1" ]]; then
       npm install -g gulp-cli

--- a/.travis.yml
+++ b/.travis.yml
@@ -97,7 +97,7 @@ jobs:
   include:
     - stage: test
       name: Lint
-      php: 7.4
+      php: 7.3
       env: WP_VERSION=4.7 PHPCS_PHP_VERSION='5.4' SNIFF=1 PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
     - name: PHP Tests (PHP 5.6, WordPress latest)
       php: 5.6

--- a/composer.json
+++ b/composer.json
@@ -73,6 +73,7 @@
       "@composer --working-dir=php-scoper require humbug/php-scoper"
     ],
     "lint": "vendor/bin/phpcs",
-    "lint-fix": "vendor/bin/phpcbf"
+    "lint-fix": "vendor/bin/phpcbf",
+    "test":  "phpunit"
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -72,8 +72,8 @@
       "@composer --working-dir=php-scoper config prefer-stable true",
       "@composer --working-dir=php-scoper require humbug/php-scoper"
     ],
-    "lint": "vendor/bin/phpcs",
-    "lint-fix": "vendor/bin/phpcbf",
+    "lint": "phpcs",
+    "lint-fix": "phpcbf",
     "test":  "phpunit"
   }
 }


### PR DESCRIPTION
## Summary

Addresses issue #945

## Relevant technical choices

* Updates jobs that were previously using `7.3` to use `7.4`
    * PHP linting still uses PHP `7.3` as it was failing with 7.4
* Updates "bleeding edge" job with WP trunk to use PHP `nightly`
    * Failures are only allowed on this job
* Added new `test` script to Composer for invoking `phpunit`
* Removed unnecessary prefixes from Composer-installed binaries in composer scripts 
* Optimizes PHP job execution
    - Only install Composer dependencies for jobs that need it (previously was run on all jobs)
    - Run PHP tasks via Composer (eliminates the need for installing JS dependencies which saves a lot of time)
    - Remove unnecessary installation of global `gulp` package

PHP Test jobs now run in ~1.5min where before they were taking over 3 min.

#### [Before](https://travis-ci.com/google/site-kit-wp/builds/139517866)

![image](https://user-images.githubusercontent.com/1621608/70309534-6e791e80-1816-11ea-8ec4-e0056a21dc33.png)

#### [After](https://travis-ci.com/google/site-kit-wp/builds/139665104)

![image](https://user-images.githubusercontent.com/1621608/70309510-60c39900-1816-11ea-9511-11f0e7bf4568.png)


## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
