### PR TITLE
Remove dynamic loading of allmodules.js in onViewAdminBarMenu.

### DIFF
--- a/assets/js/googlesitekit-adminbar-loader.js
+++ b/assets/js/googlesitekit-adminbar-loader.js
@@ -113,37 +113,8 @@ window.addEventListener( 'load', function() {
 			}
 		}
 
-		const { isAdmin } = window.googlesitekitAdminbar.properties;
-		const isPostScreen = isAdmin && window.googlesitekit.admin.currentScreen && 'post' === window.googlesitekit.admin.currentScreen.id;
-		const scriptPath = `${ window.googlesitekitAdminbar.publicPath }allmodules.js`;
-		const isScriptLoaded = document.querySelector( `script[src="${ scriptPath }"]` );
-
-		// Dynamically load the script if not loaded yet.
-		if ( ! isAdmin || ( isAdmin && isPostScreen && ! isScriptLoaded ) ) {
-			// Load all modules.
-			const script = document.createElement( 'script' );
-			script.type = 'text/javascript';
-			script.onload = () => {
-				// Cleanup onload handler
-				script.onload = null;
-
-				initAdminbar();
-			};
-
-			// Add the script to the DOM
-			( document.getElementsByTagName( 'head' )[ 0 ] ).appendChild( script );
-
-			// Set the `src` to begin transport
-			script.src = scriptPath;
-
-			// Set adminbar as loaded.
-			isAdminbarLoaded = true;
-		} else {
-			initAdminbar();
-
-			// Set adminbar as loaded.
-			isAdminbarLoaded = true;
-		}
+		initAdminbar();
+		isAdminbarLoaded = true;
 	};
 
 	if ( 'true' === getQueryParameter( 'googlesitekit_adminbar_open' ) ) {


### PR DESCRIPTION
## Summary

Addresses issue #521

## Relevant technical choices

* The code which detects the presence of the script is fragile and checks for the `src` of a script tag. It did not account for any query string so it was falsely failing to detect it, causing the script to be loaded multiple times.
* Dynamic loading of `allmodules.js` should no longer be necessary as that logic is moving to the `Admin_Bar` class
    - if we wanted to keep it for some reason, then we should change how it detects if the script has been loaded instead, based on some global state, etc rather than an element on the page

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
