### PR TITLE
Use the clientId during AdSense setup. (Based on `develop`)

### DIFF
--- a/assets/js/modules/adsense/dashboard/adsense-module-status.js
+++ b/assets/js/modules/adsense/dashboard/adsense-module-status.js
@@ -272,13 +272,13 @@ class AdSenseModuleStatus extends Component {
 			this.setState( { loadingMessage: message } );
 		};
 
-		const status = await getAdSenseAccountStatus( existingTag, setLoadingMessage );
+		const { accountStatus, clientId } = await getAdSenseAccountStatus( existingTag, setLoadingMessage );
 
-		this.setState( { accountStatus: status.accountStatus } );
+		this.setState( { accountStatus, clientId } );
 	}
 
 	render() {
-		const { accountStatus, loadingMessage, instructionProps } = this.state;
+		const { accountStatus, clientId, loadingMessage, instructionProps } = this.state;
 
 		const showInProcess = ! accountStatus || ! googlesitekit.modules.adsense.setupComplete || [
 			'ads-display-pending',
@@ -323,6 +323,7 @@ class AdSenseModuleStatus extends Component {
 						<AdSenseSetupInstructions
 							{ ...instructionProps }
 							accountStatus={ accountStatus }
+							clientId={ clientId }
 							continueSetup={ this.continueSetup }
 							goBack={ this.goBack }
 						/>

--- a/assets/js/modules/adsense/setup/adsense-setup-instructions.js
+++ b/assets/js/modules/adsense/setup/adsense-setup-instructions.js
@@ -134,7 +134,7 @@ class AdSenseSetupInstructions extends Component {
 					}
 
 					<div className="googlesitekit-setup-module__action">
-						{ 'account-connected' === accountStatus && clientId &&
+						{ 'account-connected' === accountStatus &&
 							<Fragment>
 								<Button
 									disabled={ isSaving }
@@ -150,7 +150,7 @@ class AdSenseSetupInstructions extends Component {
 										const useSnippet = enableAutoAds && enableAutoAds.checked;
 
 										// Save the publisher clientId: AdSense setup is complete!
-										data.set( TYPE_MODULES, 'adsense', 'setup-complete', { clientId, useSnippet } ).then( () => {
+										data.set( TYPE_MODULES, 'adsense', 'setup-complete', { clientID: clientId, useSnippet } ).then( () => {
 											document.location = ctaLink;
 										} ).catch( () => {
 											this.setState( { isSaving: false } );
@@ -162,7 +162,7 @@ class AdSenseSetupInstructions extends Component {
 								<Spinner isSaving={ isSaving } />
 							</Fragment>
 						}
-						{ ( ! 'account-connected' === accountStatus || ! clientId ) && (
+						{ 'account-connected' !== accountStatus && (
 							<Link
 								className="googlesitekit-setup-module__cta-link"
 								external


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #891.

## Relevant technical choices

Ensures the `clientId`, required for this code path, is present. Removes a few unneeded checks around `clientId` in the component as well.

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
