### PR TITLE
Fix Reset option matching

### DIFF
--- a/includes/Core/Authentication/Authentication.php
+++ b/includes/Core/Authentication/Authentication.php
@@ -326,7 +326,7 @@ final class Authentication {
 
 		// Delete all user data.
 		$user_id = $this->user_options->get_user_id();
-		$prefix  = 'googlesitekit_%';
+		$prefix  = 'googlesitekit\_%';
 		if ( ! $this->context->is_network_mode() ) {
 			$prefix = $wpdb->get_blog_prefix() . $prefix;
 		}

--- a/includes/Core/Util/Migration_1_0_0.php
+++ b/includes/Core/Util/Migration_1_0_0.php
@@ -112,7 +112,7 @@ class Migration_1_0_0 {
 
 		// Delete all user data. Tokens will not actually be revoked because
 		// of external API requests causing overhead.
-		$prefix = 'googlesitekit_%';
+		$prefix = 'googlesitekit\_%';
 		if ( ! $this->context->is_network_mode() ) {
 			$prefix = $wpdb->get_blog_prefix() . $prefix;
 		}

--- a/tests/e2e/plugins/reset.php
+++ b/tests/e2e/plugins/reset.php
@@ -21,17 +21,4 @@ register_activation_hook( __FILE__, static function () {
 	}
 
 	( new Reset( new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE ) ) )->all();
-
-	/**
-	 * Remove anything left behind.
-	 * @link https://github.com/google/site-kit-wp/issues/351
-	 */
-	global $wpdb;
-
-	$wpdb->query(
-		"DELETE FROM $wpdb->options WHERE option_name LIKE '%googlesitekit%'"
-	);
-	$wpdb->query(
-		"DELETE FROM $wpdb->usermeta WHERE meta_key LIKE '%googlesitekit%'"
-	);
 } );

--- a/tests/phpunit/integration/Core/Util/ResetTest.php
+++ b/tests/phpunit/integration/Core/Util/ResetTest.php
@@ -26,8 +26,14 @@ class ResetTest extends TestCase {
 	public function test_all() {
 		$context = new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE );
 		$this->assertFalse( $context->is_network_mode() );
+		update_option( 'googlesitekitkeep', 'keep' );
+		update_option( 'googlesitekit-keep', 'keep' );
 
 		$this->run_reset( $context );
+
+		// Ensure options that don't start with googlesitekit_ are not deleted.
+		$this->assertEquals( 'keep', get_option( 'googlesitekitkeep' ) );
+		$this->assertEquals( 'keep', get_option( 'googlesitekit-keep' ) );
 	}
 
 	/**

--- a/uninstall.php
+++ b/uninstall.php
@@ -17,7 +17,7 @@ if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) && empty( $googlesitekit_reset_context )
 
 global $wpdb;
 
-$prefix = 'googlesitekit_%';
+$prefix = 'googlesitekit\_%';
 
 // Delete options and transients.
 $wpdb->query( // phpcs:ignore WordPress.VIP.DirectDatabaseQuery


### PR DESCRIPTION
## Summary

Addresses issue #968 

## Relevant technical choices

* Updates all instances of `googlesitekit_%` in direct db queries
* Removes extra db queries in the E2E reset utility plugin, fixed in #809

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
