### PR TITLE
Use inverse y-axis for Search Console Average Position

### DIFF
--- a/assets/js/modules/search-console/dashboard/dashboard-widget-sitestats.js
+++ b/assets/js/modules/search-console/dashboard/dashboard-widget-sitestats.js
@@ -103,7 +103,6 @@ class SearchConsoleDashboardWidgetSiteStats extends Component {
 			options.vAxis.textPosition = 'none';
 			options.vAxis.gridlines.color = '#fff';
 			options.vAxis.minorGridlines.color = '#fff';
-			options.vAxes = {};
 			options.chartArea.width = '98%';
 		}
 

--- a/assets/js/modules/search-console/dashboard/dashboard-widget.js
+++ b/assets/js/modules/search-console/dashboard/dashboard-widget.js
@@ -133,7 +133,15 @@ class GoogleSitekitSearchConsoleDashboardWidget extends Component {
 		};
 
 		return selectedStats.map( function( stat ) {
-			return { title: vAxesMap[ stat ] };
+			const otherSettings = {};
+			// The third index refers to the "Average Position" stat.
+			// We need to reverse the y-axis for this stat, see:
+			// https://github.com/google/site-kit-wp/issues/874
+			if ( stat === 3 ) {
+				otherSettings.direction = -1;
+			}
+
+			return { title: vAxesMap[ stat ], ...otherSettings };
 		} );
 	}
 

--- a/assets/js/modules/search-console/dashboard/dashboard-widget.js
+++ b/assets/js/modules/search-console/dashboard/dashboard-widget.js
@@ -126,10 +126,10 @@ class GoogleSitekitSearchConsoleDashboardWidget extends Component {
 		const { selectedStats } = this.state;
 
 		const vAxesMap = {
-			0: 'Clicks',
-			1: 'Impressions',
-			2: 'Average CTR',
-			3: 'Average Position',
+			0: __( 'Clicks', 'google-site-kit' ),
+			1: __( 'Impressions', 'google-site-kit' ),
+			2: __( 'Average CTR', 'google-site-kit' ),
+			3: __( 'Average Position', 'google-site-kit' ),
 		};
 
 		return selectedStats.map( function( stat ) {


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #874.

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
