### PR TITLE
Identify Site Kit in User-Agent

### DIFF
--- a/includes/Core/Authentication/Clients/OAuth_Client.php
+++ b/includes/Core/Authentication/Clients/OAuth_Client.php
@@ -190,7 +190,14 @@ final class OAuth_Client {
 			$this->google_client = new Google_Client();
 		}
 
-		$this->google_client->setApplicationName( 'wordpress/google-site-kit/' . GOOGLESITEKIT_VERSION );
+		$application_name = 'wordpress/google-site-kit/' . GOOGLESITEKIT_VERSION;
+		// The application name is included in the Google client's user-agent for requests to Google APIs.
+		$this->google_client->setApplicationName( $application_name );
+		// Override the default user-agent for the Guzzle client. This is used for oauth/token requests.
+		// By default this header uses the generic Guzzle client's user-agent and includes
+		// Guzzle, cURL, and PHP versions as it is normally shared.
+		// In our case however, the client is namespaced to be used by Site Kit only.
+		$this->google_client->getHttpClient()->setDefaultOption( 'headers/User-Agent', $application_name );
 
 		// Return unconfigured client if credentials not yet set.
 		$client_credentials = $this->get_client_credentials();

--- a/includes/Core/Authentication/Clients/OAuth_Client.php
+++ b/includes/Core/Authentication/Clients/OAuth_Client.php
@@ -190,6 +190,8 @@ final class OAuth_Client {
 			$this->google_client = new Google_Client();
 		}
 
+		$this->google_client->setApplicationName( 'wordpress/google-site-kit/' . GOOGLESITEKIT_VERSION );
+
 		// Return unconfigured client if credentials not yet set.
 		$client_credentials = $this->get_client_credentials();
 		if ( ! $client_credentials ) {

--- a/includes/Core/Authentication/Clients/OAuth_Client.php
+++ b/includes/Core/Authentication/Clients/OAuth_Client.php
@@ -713,12 +713,14 @@ final class OAuth_Client {
 	 *
 	 * @since 1.1.0
 	 * @since 1.1.2 Added 'credentials_retrieval'
+	 * @since n.e.x.t Added 'short_verification_token' (Supported as of 1.0.1)
 	 * @return array Array of supported features.
 	 */
 	private function get_proxy_setup_supports() {
 		return array_filter(
 			array(
 				'credentials_retrieval',
+				'short_verification_token',
 				$this->supports_file_verification() ? 'file_verification' : false,
 			)
 		);

--- a/includes/Core/Authentication/Clients/OAuth_Client.php
+++ b/includes/Core/Authentication/Clients/OAuth_Client.php
@@ -669,7 +669,6 @@ final class OAuth_Client {
 	 */
 	public function get_proxy_setup_url( $access_code = '', $error_code = '' ) {
 		$query_params = array(
-			'version'  => GOOGLESITEKIT_VERSION,
 			'scope'    => rawurlencode( implode( ' ', $this->get_required_scopes() ) ),
 			'supports' => rawurlencode( implode( ' ', $this->get_proxy_setup_supports() ) ),
 			'nonce'    => rawurlencode( wp_create_nonce( Google_Proxy::ACTION_SETUP ) ),

--- a/tests/phpunit/integration/Core/Authentication/Clients/OAuth_ClientTest.php
+++ b/tests/phpunit/integration/Core/Authentication/Clients/OAuth_ClientTest.php
@@ -324,7 +324,6 @@ class OAuth_ClientTest extends TestCase {
 		$url = $client->get_proxy_setup_url();
 		$this->assertContains( 'name=', $url );
 		$this->assertContains( 'url=', $url );
-		$this->assertContains( 'version=', $url );
 		$this->assertContains( 'rest_root=', $url );
 		$this->assertContains( 'admin_root=', $url );
 		$this->assertContains( 'scope=', $url );
@@ -337,7 +336,6 @@ class OAuth_ClientTest extends TestCase {
 		$url = $client->get_proxy_setup_url( 'temp-code' );
 		$this->assertContains( 'site_id=' . self::SITE_ID, $url );
 		$this->assertContains( 'code=temp-code', $url );
-		$this->assertContains( 'version=', $url );
 		$this->assertContains( 'scope=', $url );
 		$this->assertContains( 'nonce=', $url );
 		$this->assertNotContains( 'name=', $url );


### PR DESCRIPTION
## Summary

Addresses issue #989

This PR enhances the requests made by Site Kit to identify the platform and plugin version.

## Relevant technical choices

* Set's user-agent via "Application Name" configuration for Google Client
_This affects requests that are made to Google APIs only_
* Sets the default user-agent for our bundled Guzzle client to use the same platform+version string used in the application name  
_This affects requests for access codes and tokens (e.g. `/o/oauth2/token`)_
    - It wasn't originally obvious that these wouldn't both use the application name (I'm not sure why they don't)

**Google Service API Request**
![image](https://user-images.githubusercontent.com/1621608/71681089-7768fb80-2d94-11ea-8d05-712473231331.png)

**Token Request**
![image](https://user-images.githubusercontent.com/1621608/71681057-63bd9500-2d94-11ea-95a3-0a42aaba6f33.png)


## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
