### PR TITLE
Add get/set/invalidateCache methods to API

### DIFF
--- a/assets/js/googlesitekit-api.js
+++ b/assets/js/googlesitekit-api.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import API from 'assets/js/googlesitekit/api';
+import * as API from 'assets/js/googlesitekit/api';
 
 if ( typeof window.googlesitekit === 'undefined' ) {
 	throw new Error( '`googlesitekit` is undefined. You need to import `googlesitekit` to use the `googlesitekit-api` library.' );

--- a/assets/js/googlesitekit/api/index.js
+++ b/assets/js/googlesitekit/api/index.js
@@ -196,3 +196,5 @@ export const invalidateCache = async ( type, identifier, datapoint ) => {
 		}
 	} );
 };
+
+export * from './cache';

--- a/assets/js/googlesitekit/api/index.js
+++ b/assets/js/googlesitekit/api/index.js
@@ -139,12 +139,16 @@ export const set = async (
 	data,
 	{ method = 'POST', queryParams = {} } = {}
 ) => {
-	return siteKitRequest( type, identifier, datapoint, {
+	const response = await siteKitRequest( type, identifier, datapoint, {
 		data,
 		method,
 		queryParams,
 		useCache: false,
 	} );
+
+	await invalidateCache( type, identifier, datapoint );
+
+	return response;
 };
 
 /**

--- a/assets/js/googlesitekit/api/index.js
+++ b/assets/js/googlesitekit/api/index.js
@@ -140,7 +140,7 @@ export const set = async (
 	{ method = 'POST', queryParams = {} } = {}
 ) => {
 	const response = await siteKitRequest( type, identifier, datapoint, {
-		data,
+		bodyParams: data,
 		method,
 		queryParams,
 		useCache: false,

--- a/assets/js/googlesitekit/api/index.js
+++ b/assets/js/googlesitekit/api/index.js
@@ -19,12 +19,14 @@ import { createCacheKey } from './index.private';
 let cachingEnabled = true;
 
 /**
+ * Make a request to a WP REST API Site Kit endpoint.
  *
  * @param {string} type        The data to access. One of 'core' or 'modules'.
  * @param {string} identifier  The data identifier, eg. a module slug like `'search-console'`.
  * @param {string} datapoint   The endpoint to request data from.
  * @param {Object} queryParams Query params to send with the request.
  * @param {Object} data        Request data to send.
+ * @param {Object} useCache    Set to `true` to use the caching. Caching is only used for `GET` requests.
  */
 const siteKitRequest = async ( {
 	cacheTTL = 3600,
@@ -40,7 +42,10 @@ const siteKitRequest = async ( {
 	invariant( identifier, '`identifier` argument for requests is required.' );
 	invariant( datapoint, '`datapoint` argument for requests is required.' );
 
-	const useCacheForRequest = useCache !== undefined ? useCache : usingCache();
+	// Don't check for a `false`-y `useCache` value to ensure we don't fallback
+	// to the `usingCache()` behaviour when caching is manually disabled on a
+	// per-request basis.
+	const useCacheForRequest = method === 'GET' && ( useCache !== undefined ? useCache : usingCache() );
 	const cacheKey = createCacheKey( type, identifier, datapoint, queryParams );
 
 	if ( useCacheForRequest ) {

--- a/assets/js/googlesitekit/api/index.js
+++ b/assets/js/googlesitekit/api/index.js
@@ -21,21 +21,21 @@ let cachingEnabled = true;
 /**
  * Make a request to a WP REST API Site Kit endpoint.
  *
- * @param {string} type        The data to access. One of 'core' or 'modules'.
- * @param {string} identifier  The data identifier, eg. a module slug like `'search-console'`.
- * @param {string} datapoint   The endpoint to request data from.
- * @param {Object} queryParams Query params to send with the request.
- * @param {Object} data        Request data to send.
- * @param {Object} useCache    Set to `true` to use the caching. Caching is only used for `GET` requests.
+ * @param {string}  type                The data to access. One of 'core' or 'modules'.
+ * @param {string}  identifier          The data identifier, eg. a module slug like `'search-console'`.
+ * @param {string}  datapoint           The endpoint to request data from.
+ * @param {Object}  options             Options to pass to the request
+ * @param {number}  options.cacheTTL    The oldest cache data to use, in seconds.
+ * @param {Object}  options.data        Request data to send.
+ * @param {number}  options.method      HTTP method to use for this request.
+ * @param {Object}  options.queryParams Query params to send with the request.
+ * @param {boolean} options.useCache    Set to `true` to use the caching. Caching is only used for `GET` requests.
  */
-const siteKitRequest = async ( {
+const siteKitRequest = async ( type, identifier, datapoint, {
 	cacheTTL = 3600,
 	data,
-	datapoint,
-	identifier,
 	method = 'GET',
 	queryParams,
-	type,
 	useCache = undefined,
 } = {} ) => {
 	invariant( type, '`type` argument for requests is required.' );
@@ -88,10 +88,13 @@ const siteKitRequest = async ( {
  * This method automatically handles authentication, so no credentials
  * are required to use this method.
  *
- * @param {string} type        The data to access. One of 'core' or 'modules'.
- * @param {string} identifier  The data identifier, eg. a module slug like `'search-console'`.
- * @param {string} datapoint   The endpoint to request data from.
- * @param {Object} queryParams Query params to send with the request.
+ * @param {string}  type             The data to access. One of 'core' or 'modules'.
+ * @param {string}  identifier       The data identifier, eg. a module slug like `'search-console'`.
+ * @param {string}  datapoint        The endpoint to request data from.
+ * @param {Object}  queryParams      Query params to send with the request.
+ * @param {Object}  options          Extra options for this request.
+ * @param {number}  options.cacheTTL The oldest cache data to use, in seconds.
+ * @param {boolean} options.useCache Enable or disable caching for this request only.
  *
  * @return {Promise} A promise for the `fetch` request.
  */
@@ -102,12 +105,9 @@ export const get = async (
 	queryParams,
 	{ cacheTTL = 3600, useCache = undefined } = {}
 ) => {
-	return siteKitRequest( {
+	return siteKitRequest( type, identifier, datapoint, {
 		cacheTTL,
-		datapoint,
-		identifier,
 		queryParams,
-		type,
 		useCache,
 	} );
 };
@@ -122,10 +122,13 @@ export const get = async (
  * This method automatically handles authentication, so no credentials
  * are required to use this method.
  *
- * @param {string} type       The data to access. One of 'core' or 'modules'.
- * @param {string} identifier The data identifier, eg. a module slug like `'adsense'`.
- * @param {string} datapoint  The endpoint to send data to.
- * @param {Object} data       Request data (eg. post data) to send with the request.
+ * @param {string} type                 The data to access. One of 'core' or 'modules'.
+ * @param {string} identifier           The data identifier, eg. a module slug like `'adsense'`.
+ * @param {string} datapoint            The endpoint to send data to.
+ * @param {Object} data                 Request data (eg. post data) to send with the request.
+ * @param {Object}  options             Extra options for this request.
+ * @param {number}  options.method      HTTP method to use for this request.
+ * @param {boolean} options.queryParams Query params to send with the request.
  *
  * @return {Promise} A promise for the `fetch` request.
  */
@@ -136,13 +139,10 @@ export const set = async (
 	data,
 	{ method = 'POST', queryParams = {} } = {}
 ) => {
-	return siteKitRequest( {
+	return siteKitRequest( type, identifier, datapoint, {
 		data,
-		datapoint,
-		identifier,
 		method,
 		queryParams,
-		type,
 		useCache: false,
 	} );
 };

--- a/assets/js/googlesitekit/api/index.js
+++ b/assets/js/googlesitekit/api/index.js
@@ -1,3 +1,15 @@
+/**
+ * WordPress dependencies
+ */
+// import apiFetch from '@wordpress/api-fetch';
+
+/**
+ * Internal dependencies
+ */
+import { getKeys, deleteItem } from './cache';
+import { createCacheKey } from './index.private';
+
+// Caching is enabled by default.
 let cachingEnabled = true;
 
 /**
@@ -100,7 +112,14 @@ export const usingCache = () => {
  *
  * @return {void}
  */
-// eslint-disable-next-line no-unused-vars
-export const invalidateCache = ( type, identifier, datapoint ) => {
-	throw new Error( 'Not yet implemented.' );
+export const invalidateCache = async ( type, identifier, datapoint ) => {
+	const groupPrefix = createCacheKey( type, identifier, datapoint );
+
+	const allKeys = await getKeys();
+
+	allKeys.forEach( ( key ) => {
+		if ( key.indexOf( groupPrefix ) === 0 ) {
+			deleteItem( key );
+		}
+	} );
 };

--- a/assets/js/googlesitekit/api/index.js
+++ b/assets/js/googlesitekit/api/index.js
@@ -26,14 +26,14 @@ let cachingEnabled = true;
  * @param {string}  datapoint           The endpoint to request data from.
  * @param {Object}  options             Options to pass to the request
  * @param {number}  options.cacheTTL    The oldest cache data to use, in seconds.
- * @param {Object}  options.data        Request data to send.
+ * @param {Object}  options.bodyParams  Request body data to send. (Eg. used for `POST`/`PUT` request variables.)
  * @param {number}  options.method      HTTP method to use for this request.
  * @param {Object}  options.queryParams Query params to send with the request.
- * @param {boolean} options.useCache    Set to `true` to use the caching. Caching is only used for `GET` requests.
+ * @param {boolean} options.useCache    Enable or disable caching for this request only. (Caching is only used for `GET` requests.)
  */
 const siteKitRequest = async ( type, identifier, datapoint, {
+	bodyParams,
 	cacheTTL = 3600,
-	data,
 	method = 'GET',
 	queryParams,
 	useCache = undefined,
@@ -59,7 +59,7 @@ const siteKitRequest = async ( type, identifier, datapoint, {
 	// Make an API request to retrieve the results.
 	try {
 		const response = await apiFetch( {
-			data,
+			data: bodyParams,
 			method,
 			path: addQueryArgs(
 				`/google-site-kit/v1/${ type }/${ identifier }/data/${ datapoint }`,
@@ -91,7 +91,7 @@ const siteKitRequest = async ( type, identifier, datapoint, {
  * @param {string}  type             The data to access. One of 'core' or 'modules'.
  * @param {string}  identifier       The data identifier, eg. a module slug like `'search-console'`.
  * @param {string}  datapoint        The endpoint to request data from.
- * @param {Object}  queryParams      Query params to send with the request.
+ * @param {Object}  data             Data (query params) to send with the request.
  * @param {Object}  options          Extra options for this request.
  * @param {number}  options.cacheTTL The oldest cache data to use, in seconds.
  * @param {boolean} options.useCache Enable or disable caching for this request only.
@@ -102,12 +102,12 @@ export const get = async (
 	type,
 	identifier,
 	datapoint,
-	queryParams,
+	data,
 	{ cacheTTL = 3600, useCache = undefined } = {}
 ) => {
 	return siteKitRequest( type, identifier, datapoint, {
 		cacheTTL,
-		queryParams,
+		queryParams: data,
 		useCache,
 	} );
 };
@@ -125,7 +125,7 @@ export const get = async (
  * @param {string} type                 The data to access. One of 'core' or 'modules'.
  * @param {string} identifier           The data identifier, eg. a module slug like `'adsense'`.
  * @param {string} datapoint            The endpoint to send data to.
- * @param {Object} data                 Request data (eg. post data) to send with the request.
+ * @param {Object} data                 Request body data (eg. post data) to send with the request.
  * @param {Object}  options             Extra options for this request.
  * @param {number}  options.method      HTTP method to use for this request.
  * @param {boolean} options.queryParams Query params to send with the request.

--- a/assets/js/googlesitekit/api/index.private.js
+++ b/assets/js/googlesitekit/api/index.private.js
@@ -27,8 +27,8 @@ export const createCacheKey = ( type, identifier, datapoint, queryParams = {} ) 
 
 	if (
 		keySections.length === 3 &&
-    ( !! queryParams ) && ( queryParams.constructor === Object ) &&
-    Object.keys( queryParams ).length
+		( !! queryParams ) && ( queryParams.constructor === Object ) &&
+		Object.keys( queryParams ).length
 	) {
 		keySections.push(
 			md5( JSON.stringify( sortObjectProperties( queryParams ) ) )

--- a/assets/js/googlesitekit/api/index.private.js
+++ b/assets/js/googlesitekit/api/index.private.js
@@ -1,0 +1,39 @@
+/**
+ * External dependencies
+ */
+import md5 from 'md5';
+
+/**
+ * Internal dependencies
+ */
+import { sortObjectProperties } from 'assets/js/util';
+
+const KEY_SEPARATOR = '::';
+
+/**
+ * Create a cache key for a set of type/identifier/datapoint values.
+ *
+ * @param {string} type        The data to access. One of 'core' or 'modules'.
+ * @param {string} identifier  The data identifier, eg. a module slug like `'search-console'`.
+ * @param {string} datapoint   The endpoint to request data from.
+ * @param {Object} queryParams Query params to send with the request.
+ *
+ * @return {string} The cache key to use for this set of values.
+ */
+export const createCacheKey = ( type, identifier, datapoint, queryParams = {} ) => {
+	const keySections = [ type, identifier, datapoint ].filter( ( keySection ) => {
+		return !! keySection && keySection.length;
+	} );
+
+	if (
+		keySections.length === 3 &&
+    ( !! queryParams ) && ( queryParams.constructor === Object ) &&
+    Object.keys( queryParams ).length
+	) {
+		keySections.push(
+			md5( JSON.stringify( sortObjectProperties( queryParams ) ) )
+		);
+	}
+
+	return keySections.join( KEY_SEPARATOR );
+};

--- a/assets/js/googlesitekit/api/index.test.js
+++ b/assets/js/googlesitekit/api/index.test.js
@@ -1,17 +1,28 @@
 /**
  * Internal dependencies
  */
-import { setItem, getItem } from './cache';
+// eslint-disable-next-line @wordpress/dependency-group
+import { unexpectedSuccess } from 'tests/js/utils';
+import * as CacheModule from './cache';
 import { setSelectedStorageBackend } from './cache.private';
 import { invalidateCache, usingCache, get, set, setUsingCache } from './index';
 import { createCacheKey } from './index.private';
 
 describe( 'googlesitekit.api', () => {
+	// We import the entire caching module so we can use
+	// `jest.spyOn(CacheModule, 'getItem')` to monitor caching calls.
+	const { getItem, setItem } = CacheModule;
 	let storageMechanism;
+
 	beforeAll( () => {
 		const backend = 'localStorage';
 		storageMechanism = global[ backend ];
 		setSelectedStorageBackend( storageMechanism );
+	} );
+
+	afterEach( () => {
+		// Re-enable the default caching setting after each test.
+		setUsingCache( true );
 	} );
 
 	afterAll( () => {
@@ -21,6 +32,219 @@ describe( 'googlesitekit.api', () => {
 
 	it( 'should have caching enabled by default', () => {
 		expect( usingCache() ).toEqual( true );
+	} );
+
+	describe( 'get', () => {
+		it( 'should throw an error when required arguments are missing', async () => {
+			try {
+				await get();
+
+				return unexpectedSuccess();
+			} catch ( error ) {
+				expect( error.message ).toEqual( '`type` argument for GET requests is required.' );
+			}
+
+			try {
+				await get( 'core' );
+
+				return unexpectedSuccess();
+			} catch ( error ) {
+				expect( error.message ).toEqual( '`identifier` argument for GET requests is required.' );
+			}
+
+			try {
+				await get( 'core', 'search-console' );
+
+				return unexpectedSuccess();
+			} catch ( error ) {
+				expect( error.message ).toEqual( '`datapoint` argument for GET requests is required.' );
+			}
+		} );
+
+		it( 'should return a response', async () => {
+			// TODO: Maybe refactor this into a helper once we know how we usually
+			// mock requests.
+			fetch
+				.doMockOnceIf(
+					/^\/google-site-kit\/v1\/core\/search-console\/data\/users/
+				)
+				.mockResponseOnce( JSON.stringify( { foo: 'bar' } ), { status: 200 } );
+
+			const response = await get( 'core', 'search-console', 'users' );
+
+			// Ensure the correct URL was used to make this HTTP fetch request.
+			expect( response ).toEqual( { foo: 'bar' } );
+		} );
+
+		it( 'should throw an error if the fetch request encounters a 404 error code', async () => {
+			const errorResponse = {
+				code: 'rest_no_route',
+				message: 'No route was found matching the URL and request method',
+				data: { status: 404 },
+			};
+
+			fetch
+				.doMockOnceIf(
+					/^\/google-site-kit\/v1\/core\/search-console\/data\/other/
+				)
+				.mockResponseOnce( JSON.stringify( errorResponse ), { status: 404 } );
+
+			try {
+				await get( 'core', 'search-console', 'other' );
+			} catch ( err ) {
+				expect( err ).toEqual( errorResponse );
+			}
+		} );
+
+		it( 'should throw an error if the fetch request encounters a 500 error code', async () => {
+			const errorResponse = {
+				code: 'internal_server_error',
+				message: 'Internal server error',
+				data: { status: 500 },
+			};
+
+			fetch
+				.doMockOnceIf(
+					/^\/google-site-kit\/v1\/core\/search-console\/data\/users/
+				)
+				.mockResponseOnce( JSON.stringify( errorResponse ), { status: 500 } );
+
+			try {
+				await get( 'core', 'search-console', 'users' );
+			} catch ( err ) {
+				expect( err ).toEqual( errorResponse );
+			}
+		} );
+
+		it( 'should cache requests by default', async () => {
+			const getItemSpy = jest.spyOn( CacheModule, 'getItem' );
+			const setItemSpy = jest.spyOn( CacheModule, 'setItem' );
+			expect( fetch ).toHaveBeenCalledTimes( 0 );
+
+			fetch
+				.doMockIf(
+					/^\/google-site-kit\/v1\/core\/search-console\/data\/users/
+				)
+				.mockResponse( JSON.stringify( { foo: 'bar' } ), { status: 200 } );
+
+			const firstResponse = await get( 'core', 'search-console', 'users' );
+			expect( fetch ).toHaveBeenCalledTimes( 1 );
+			// Ensure the response was saved to the cache.
+			expect( setItemSpy ).toHaveBeenCalledWith(
+				createCacheKey( 'core', 'search-console', 'users' ),
+				firstResponse
+			);
+
+			// Ensure `fetch()` is not called a second time, because we have a cached
+			// version of this response.
+			const secondResponse = await get( 'core', 'search-console', 'users' );
+
+			expect( secondResponse ).toEqual( firstResponse );
+			expect( fetch ).toHaveBeenCalledTimes( 1 );
+
+			// Ensure cache functions were used.
+			expect( getItemSpy ).toHaveBeenCalledWith(
+				createCacheKey( 'core', 'search-console', 'users' ),
+				3600
+			);
+		} );
+
+		it( 'should not use cache if caching is disabled globally', async () => {
+			const getItemSpy = jest.spyOn( CacheModule, 'getItem' );
+			const setItemSpy = jest.spyOn( CacheModule, 'setItem' );
+
+			setUsingCache( false );
+
+			fetch
+				.doMockIf(
+					/^\/google-site-kit\/v1\/core\/search-console\/data\/notifications/
+				)
+				.mockResponse( JSON.stringify( { foo: 'bar' } ), { status: 200 } );
+
+			await get( 'core', 'search-console', 'notifications' );
+			expect( setItemSpy ).not.toHaveBeenCalledWith(
+				createCacheKey( 'core', 'search-console', 'notifications' ),
+				{ foo: 'bar' }
+			);
+			expect( fetch ).toHaveBeenCalledTimes( 1 );
+
+			// Ensure `fetch()` is called a second time; the cache is disabled.
+			await get( 'core', 'search-console', 'notifications' );
+			expect( fetch ).toHaveBeenCalledTimes( 2 );
+
+			// Ensure the cache was never used.
+			expect( getItemSpy ).not.toHaveBeenCalledWith(
+				createCacheKey( 'core', 'search-console', 'notifications' ),
+				3600
+			);
+		} );
+
+		it( 'should not use cache if caching is disabled with arguments', async () => {
+			const getItemSpy = jest.spyOn( CacheModule, 'getItem' );
+			const setItemSpy = jest.spyOn( CacheModule, 'setItem' );
+
+			fetch
+				.doMockIf(
+					/^\/google-site-kit\/v1\/core\/search-console\/data\/other/
+				)
+				.mockResponse( JSON.stringify( { foo: 'bar' } ), { status: 200 } );
+
+			await get( 'core', 'search-console', 'other', undefined, { useCache: false } );
+			expect( setItemSpy ).not.toHaveBeenCalledWith(
+				createCacheKey( 'core', 'search-console', 'other' ),
+				{ foo: 'bar' }
+			);
+			expect( fetch ).toHaveBeenCalledTimes( 1 );
+
+			// Ensure `fetch()` is called a second time; the cache is disabled.
+			await get( 'core', 'search-console', 'other', undefined, { useCache: false } );
+			expect( fetch ).toHaveBeenCalledTimes( 2 );
+
+			// Ensure the cache was never used.
+			expect( getItemSpy ).not.toHaveBeenCalledWith(
+				createCacheKey( 'core', 'search-console', 'other' ),
+				3600
+			);
+		} );
+
+		it( 'should not use cache even if cached values exist', async () => {
+			const getItemSpy = jest.spyOn( CacheModule, 'getItem' );
+			const setItemSpy = jest.spyOn( CacheModule, 'setItem' );
+
+			fetch
+				.doMockIf(
+					/^\/google-site-kit\/v1\/core\/search-console\/data\/cached/
+				)
+				.mockResponse( JSON.stringify( { foo: 'bar' } ), { status: 200 } );
+
+			await get( 'core', 'search-console', 'cached' );
+			expect( setItemSpy ).toHaveBeenCalledWith(
+				createCacheKey( 'core', 'search-console', 'cached' ),
+				{ foo: 'bar' }
+			);
+			expect( fetch ).toHaveBeenCalledTimes( 1 );
+
+			// Ensure `fetch()` is called a second time; the cache is disabled.
+			getItemSpy.mockReset();
+			await get( 'core', 'search-console', 'cached', undefined, { useCache: false } );
+			expect( fetch ).toHaveBeenCalledTimes( 2 );
+
+			// Ensure the cache was never used.
+			expect( getItemSpy ).not.toHaveBeenCalledWith(
+				createCacheKey( 'core', 'search-console', 'cached' ),
+				3600
+			);
+		} );
+	} );
+
+	describe( 'set', () => {
+		it( 'should throw an error while not implemented', async () => {
+			try {
+				await set();
+			} catch ( error ) {
+				expect( error.message ).toEqual( 'Not yet implemented.' );
+			}
+		} );
 	} );
 
 	describe( 'invalidateCache', () => {
@@ -93,32 +317,7 @@ describe( 'googlesitekit.api', () => {
 		} );
 	} );
 
-	describe( 'get', () => {
-		it( 'should throw an error while not implemented', async () => {
-			try {
-				await get();
-			} catch ( error ) {
-				expect( error.message ).toEqual( 'Not yet implemented.' );
-			}
-		} );
-	} );
-
-	describe( 'set', () => {
-		it( 'should throw an error while not implemented', async () => {
-			try {
-				await set();
-			} catch ( error ) {
-				expect( error.message ).toEqual( 'Not yet implemented.' );
-			}
-		} );
-	} );
-
 	describe( 'setUsingCache', () => {
-		afterEach( () => {
-			// Re-enable the default caching setting after each test.
-			setUsingCache( true );
-		} );
-
 		it( 'should enable the caching API', () => {
 			// The cache is enabled by default, so ensure it is disabled first
 			// to ensure re-enabling works as expected.

--- a/assets/js/googlesitekit/api/index.test.js
+++ b/assets/js/googlesitekit/api/index.test.js
@@ -354,6 +354,23 @@ describe( 'googlesitekit.api', () => {
 
 			expect( Object.keys( storageMechanism.__STORE__ ).length ).toBe( 0 );
 		} );
+
+		it( 'should remove everything in the cache when called without arguments', async () => {
+			await setItem(
+				createCacheKey( 'core', 'search-console', 'accounts' ),
+				'data'
+			);
+			await setItem(
+				createCacheKey( 'modules', 'analytics', 'something' ),
+				'other-data'
+			);
+
+			expect( Object.keys( storageMechanism.__STORE__ ).length ).toBe( 2 );
+
+			await invalidateCache();
+
+			expect( Object.keys( storageMechanism.__STORE__ ).length ).toBe( 0 );
+		} );
 	} );
 
 	describe( 'setUsingCache', () => {

--- a/assets/js/googlesitekit/api/index.test.js
+++ b/assets/js/googlesitekit/api/index.test.js
@@ -89,6 +89,26 @@ describe( 'googlesitekit.api', () => {
 			expect( response ).toEqual( { foo: 'bar' } );
 		} );
 
+		it( 'should send query string params from data params', async () => {
+			fetch
+				.doMockIf(
+					/^\/google-site-kit\/v1\/core\/search-console\/data\/search/
+				)
+				.mockResponse( JSON.stringify( { foo: 'bar' } ), { status: 200 } );
+
+			const dataBody = { somethingElse: 'to-set', foo: 1, arrayValue: [ 1, 2 ] };
+			await get( 'core', 'search-console', 'search', dataBody );
+			expect( fetch ).toHaveBeenCalledWith(
+				'/google-site-kit/v1/core/search-console/data/search?somethingElse=to-set&foo=1&arrayValue%5B0%5D=1&arrayValue%5B1%5D=2&_locale=user',
+				{
+					body: undefined,
+					credentials: 'include',
+					headers: { Accept: 'application/json, */*;q=0.1' },
+					method: 'GET',
+				}
+			);
+		} );
+
 		it( 'should throw an error if the fetch request encounters a 404 error code', async () => {
 			const errorResponse = {
 				code: 'rest_no_route',
@@ -267,6 +287,55 @@ describe( 'googlesitekit.api', () => {
 			} catch ( error ) {
 				expect( error.message ).toEqual( '`datapoint` argument for requests is required.' );
 			}
+		} );
+
+		it( 'should send request body data from data params', async () => {
+			fetch
+				.doMockIf(
+					/^\/google-site-kit\/v1\/core\/search-console\/data\/settings/
+				)
+				.mockResponse( JSON.stringify( { foo: 'bar' } ), { status: 200 } );
+
+			const dataBody = { somethingElse: 'to-set', foo: 1, arrayValue: [ 1, 2 ] };
+			await set( 'core', 'search-console', 'settings', dataBody );
+			expect( fetch ).toHaveBeenCalledWith(
+				'/google-site-kit/v1/core/search-console/data/settings?_locale=user',
+				{
+					body: JSON.stringify( dataBody ),
+					credentials: 'include',
+					headers: {
+						Accept: 'application/json, */*;q=0.1',
+						'Content-Type': 'application/json',
+					},
+					method: 'POST',
+				}
+			);
+		} );
+
+		it( 'should send request body data from data params and query params if set', async () => {
+			fetch
+				.doMockIf(
+					/^\/google-site-kit\/v1\/core\/search-console\/data\/settings/
+				)
+				.mockResponse( JSON.stringify( { foo: 'bar' } ), { status: 200 } );
+
+			const dataBody = { somethingElse: 'to-set', foo: 1, arrayValue: [ 1, 2 ] };
+			await set( 'core', 'search-console', 'settings', dataBody, {
+				queryParams: { foo: 'bar' },
+			} );
+
+			expect( fetch ).toHaveBeenCalledWith(
+				'/google-site-kit/v1/core/search-console/data/settings?foo=bar&_locale=user',
+				{
+					body: JSON.stringify( dataBody ),
+					credentials: 'include',
+					headers: {
+						Accept: 'application/json, */*;q=0.1',
+						'Content-Type': 'application/json',
+					},
+					method: 'POST',
+				}
+			);
 		} );
 
 		it( 'should never use the cache for set requests', async () => {

--- a/assets/js/googlesitekit/api/index.test.js
+++ b/assets/js/googlesitekit/api/index.test.js
@@ -188,6 +188,9 @@ describe( 'googlesitekit.api', () => {
 		} );
 
 		it( 'should not use cache if caching is disabled with arguments', async () => {
+			// Ensure global caching is enabled when we disable caching on a per-request basis.
+			setUsingCache( true );
+
 			fetch
 				.doMockIf(
 					/^\/google-site-kit\/v1\/core\/search-console\/data\/other/

--- a/assets/js/googlesitekit/api/index.test.js
+++ b/assets/js/googlesitekit/api/index.test.js
@@ -1,18 +1,95 @@
 /**
  * Internal dependencies
  */
+import { setItem, getItem } from './cache';
+import { setSelectedStorageBackend } from './cache.private';
 import { invalidateCache, usingCache, get, set, setUsingCache } from './index';
+import { createCacheKey } from './index.private';
 
 describe( 'googlesitekit.api', () => {
+	let storageMechanism;
+	beforeAll( () => {
+		const backend = 'localStorage';
+		storageMechanism = global[ backend ];
+		setSelectedStorageBackend( storageMechanism );
+	} );
+
+	afterAll( () => {
+		// Reset the backend storage mechanism.
+		setSelectedStorageBackend( undefined );
+	} );
+
 	it( 'should have caching enabled by default', () => {
 		expect( usingCache() ).toEqual( true );
 	} );
 
 	describe( 'invalidateCache', () => {
-		it( 'should throw an error while not implemented', () => {
-			expect( () => {
-				invalidateCache();
-			} ).toThrow( 'Not yet implemented.' );
+		it( 'should remove all cached items when called', async () => {
+			await setItem(
+				createCacheKey( 'core', 'search-console', 'accounts' ),
+				'data'
+			);
+			await setItem(
+				createCacheKey( 'core', 'search-console', 'accounts', { foo: 'test' } ),
+				'other-data'
+			);
+
+			expect( Object.keys( storageMechanism.__STORE__ ).length ).toBe( 2 );
+
+			await invalidateCache( 'core', 'search-console', 'accounts' );
+
+			expect( Object.keys( storageMechanism.__STORE__ ).length ).toBe( 0 );
+		} );
+
+		it( 'should remove cached item with query params', async () => {
+			await setItem(
+				createCacheKey( 'core', 'search-console', 'accounts', { foo: 'bar' } ),
+				'data'
+			);
+
+			expect( Object.keys( storageMechanism.__STORE__ ).length ).toBe( 1 );
+
+			await invalidateCache( 'core', 'search-console', 'accounts' );
+
+			expect( Object.keys( storageMechanism.__STORE__ ).length ).toBe( 0 );
+		} );
+
+		it( 'should only remove keys in the right scope', async () => {
+			await setItem(
+				createCacheKey( 'core', 'search-console', 'accounts' ),
+				'data'
+			);
+			await setItem(
+				createCacheKey( 'core', 'search-console', 'users' ),
+				'other-data'
+			);
+
+			expect( Object.keys( storageMechanism.__STORE__ ).length ).toBe( 2 );
+
+			await invalidateCache( 'core', 'search-console', 'accounts' );
+			const { value } = await getItem(
+				createCacheKey( 'core', 'search-console', 'users' )
+			);
+
+			expect( value ).toEqual( 'other-data' );
+			expect( Object.keys( storageMechanism.__STORE__ ).length ).toBe( 1 );
+		} );
+
+		it( 'should remove all keys when scope is broad', async () => {
+			await setItem(
+				createCacheKey( 'core', 'search-console', 'accounts' ),
+				'data'
+			);
+			await setItem(
+				createCacheKey( 'core', 'search-console', 'users' ),
+				'other-data'
+			);
+
+			expect( Object.keys( storageMechanism.__STORE__ ).length ).toBe( 2 );
+
+			await invalidateCache( 'core', 'search-console' );
+
+			expect( Object.keys( storageMechanism.__STORE__ ).length ).toBe( 0 );
 		} );
 	} );
 
@@ -54,6 +131,55 @@ describe( 'googlesitekit.api', () => {
 		it( 'should disable the caching API', () => {
 			expect( setUsingCache( false ) ).toEqual( false );
 			expect( usingCache() ).toEqual( false );
+		} );
+	} );
+
+	describe( 'createCacheKey', () => {
+		it( 'should create a cache key with all sections in order', () => {
+			expect(
+				createCacheKey( 'core', 'search-console', 'users' )
+			).toEqual( 'core::search-console::users' );
+
+			expect(
+				createCacheKey( 'core', 'adsense', 'accounts' )
+			).toEqual( 'core::adsense::accounts' );
+		} );
+
+		it( 'should create a cache key with query params when provided', () => {
+			const queryParams = {
+				hello: 'world',
+				test: 2,
+				foo: 'bar',
+			};
+			expect(
+				// Query params are stored in the key as an MD5-hash of key-sorted
+				// params, eg:
+				// `md5( JSON.stringify( sortObjectProperties( queryParams ) ) )`
+				// We manually set the value here to ensure all the external functions
+				// are working as expected. :-)
+				createCacheKey( 'core', 'search-console', 'users', queryParams )
+			).toEqual( 'core::search-console::users::a9e286c390a430f5dd1fbab4b31dd2a6' );
+		} );
+
+		it( 'should create a cache key without query params when params are empty', () => {
+			const queryParams = {};
+			expect(
+				createCacheKey( 'core', 'search-console', 'users', queryParams )
+			).toEqual( 'core::search-console::users' );
+		} );
+
+		it( 'should ignore non-object query params', () => {
+			expect(
+				createCacheKey( 'core', 'search-console', 'users', 0 )
+			).toEqual( 'core::search-console::users' );
+
+			expect(
+				createCacheKey( 'core', 'search-console', 'users', [ 1, 2 ] )
+			).toEqual( 'core::search-console::users' );
+
+			expect(
+				createCacheKey( 'core', 'search-console', 'users', new Date() )
+			).toEqual( 'core::search-console::users' );
 		} );
 	} );
 } );

--- a/assets/js/googlesitekit/api/index.test.js
+++ b/assets/js/googlesitekit/api/index.test.js
@@ -287,6 +287,72 @@ describe( 'googlesitekit.api', () => {
 			expect( getItemSpy ).not.toHaveBeenCalled();
 			expect( setItemSpy ).not.toHaveBeenCalled();
 		} );
+
+		it( 'should invalidate the cache for matching type+identifier+datapoint combo', async () => {
+			// Mock all requests for this URL.
+			fetch
+				.doMockIf(
+					/^\/google-site-kit\/v1\/core\/search-console\/data\/will-cache/
+				)
+				.mockResponse( JSON.stringify( { foo: 'bar' } ), { status: 200 } );
+
+			// Contents should not be found in the cache on first request.
+			let cacheData = await getItem(
+				createCacheKey( 'core', 'search-console', 'will-cache' )
+			);
+			expect( cacheData.cacheHit ).toEqual( false );
+
+			// Make the request to prime the cache
+			await get( 'core', 'search-console', 'will-cache' );
+
+			// Now cached data will appear.
+			cacheData = await getItem(
+				createCacheKey( 'core', 'search-console', 'will-cache' )
+			);
+			expect( cacheData.cacheHit ).toEqual( true );
+			expect( cacheData.value ).toEqual( { foo: 'bar' } );
+
+			await set( 'core', 'search-console', 'will-cache', { somethingElse: 'to-set' } );
+
+			cacheData = await getItem(
+				createCacheKey( 'core', 'search-console', 'will-cache' )
+			);
+			expect( cacheData.cacheHit ).toEqual( false );
+		} );
+
+		it( 'should invalidate the cache for matching type+identifier+datapoint with query params', async () => {
+			// Mock all requests for this URL.
+			fetch
+				.doMockIf(
+					/^\/google-site-kit\/v1\/core\/search-console\/data\/will-cache/
+				)
+				.mockResponse( JSON.stringify( { foo: 'bar' } ), { status: 200 } );
+
+			const queryParams = { surf: 'board' };
+
+			// Contents should not be found in the cache on first request.
+			let cacheData = await getItem(
+				createCacheKey( 'core', 'search-console', 'will-cache', queryParams )
+			);
+			expect( cacheData.cacheHit ).toEqual( false );
+
+			// Make the request to prime the cache
+			await get( 'core', 'search-console', 'will-cache', queryParams );
+
+			// Now cached data will appear.
+			cacheData = await getItem(
+				createCacheKey( 'core', 'search-console', 'will-cache', queryParams )
+			);
+			expect( cacheData.cacheHit ).toEqual( true );
+			expect( cacheData.value ).toEqual( { foo: 'bar' } );
+
+			await set( 'core', 'search-console', 'will-cache', { somethingElse: 'to-set' } );
+
+			cacheData = await getItem(
+				createCacheKey( 'core', 'search-console', 'will-cache', queryParams )
+			);
+			expect( cacheData.cacheHit ).toEqual( false );
+		} );
 	} );
 
 	describe( 'invalidateCache', () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11554,6 +11554,24 @@
         "gud": "^1.0.0"
       }
     },
+    "cross-fetch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.0.4.tgz",
+      "integrity": "sha512-MSHgpjQqgbT/94D4CyADeNoYh52zMkCX4pcJvPP5WqPsLFMKjr2TCMg381ox5qI0ii2dPwaLx/00477knXqXVw==",
+      "dev": true,
+      "requires": {
+        "node-fetch": "2.6.0",
+        "whatwg-fetch": "3.0.0"
+      },
+      "dependencies": {
+        "node-fetch": {
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+          "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==",
+          "dev": true
+        }
+      }
+    },
     "cross-spawn": {
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
@@ -18701,7 +18719,6 @@
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
       "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
-      "dev": true,
       "requires": {
         "loose-envify": "^1.0.0"
       }
@@ -19892,6 +19909,24 @@
             "escape-string-regexp": "^1.0.5",
             "supports-color": "^5.3.0"
           }
+        }
+      }
+    },
+    "jest-fetch-mock": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/jest-fetch-mock/-/jest-fetch-mock-3.0.1.tgz",
+      "integrity": "sha512-R5GVbQLVjk+PCfzf4vFoYDXt+oCEWuYigyaAnucdeVCXkElAgAYXDFFikHxLyCVjSNDc7TCYQZ1ItLNOE6OCrQ==",
+      "dev": true,
+      "requires": {
+        "cross-fetch": "^3.0.4",
+        "promise-polyfill": "^8.1.3"
+      },
+      "dependencies": {
+        "promise-polyfill": {
+          "version": "8.1.3",
+          "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.1.3.tgz",
+          "integrity": "sha512-MG5r82wBzh7pSKDRa9y+vllNHz3e3d4CNj1PQE4BQYxLme0gKYYBm9YENq+UkEikyZ0XbiGWxYlVw3Rl9O/U8g==",
+          "dev": true
         }
       }
     },
@@ -21163,8 +21198,7 @@
     "js-tokens": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
-      "dev": true
+      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
     },
     "js-yaml": {
       "version": "3.12.0",
@@ -22460,7 +22494,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
       "requires": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -18719,6 +18719,7 @@
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
       "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "dev": true,
       "requires": {
         "loose-envify": "^1.0.0"
       }
@@ -21198,7 +21199,8 @@
     "js-tokens": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
+      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+      "dev": true
     },
     "js-yaml": {
       "version": "3.12.0",
@@ -22494,6 +22496,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
       "requires": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -164,6 +164,7 @@
     "husky": "^1.3.1",
     "intl": "^1.2.5",
     "intl-locales-supported": "^1.6.0",
+    "jest-fetch-mock": "^3.0.1",
     "jest-localstorage-mock": "^2.4.0",
     "lint-staged": "^8.1.5",
     "lodash": "^4.17.11",
@@ -201,5 +202,8 @@
     "webpack-stream": "^5.2.1",
     "webpackbar": "^3.1.5",
     "whatwg-fetch": "^3.0.0"
+  },
+  "dependencies": {
+    "invariant": "^2.2.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -164,6 +164,7 @@
     "husky": "^1.3.1",
     "intl": "^1.2.5",
     "intl-locales-supported": "^1.6.0",
+    "invariant": "^2.2.4",
     "jest-fetch-mock": "^3.0.1",
     "jest-localstorage-mock": "^2.4.0",
     "lint-staged": "^8.1.5",
@@ -203,7 +204,5 @@
     "webpackbar": "^3.1.5",
     "whatwg-fetch": "^3.0.0"
   },
-  "dependencies": {
-    "invariant": "^2.2.4"
-  }
+  "dependencies": {}
 }

--- a/tests/js/jest.config.js
+++ b/tests/js/jest.config.js
@@ -8,6 +8,7 @@ module.exports = {
 	},
 	setupFiles: [
 		'<rootDir>/tests/js/setup-globals',
+		'<rootDir>/tests/js/setup-mocks',
 		'jest-localstorage-mock',
 	],
 	setupFilesAfterEnv: [

--- a/tests/js/setup-before-after.js
+++ b/tests/js/setup-before-after.js
@@ -7,4 +7,6 @@ beforeEach( () => {
 		localStorage[ method ].mockClear();
 		sessionStorage[ method ].mockClear();
 	} );
+
+	fetch.resetMocks();
 } );

--- a/tests/js/setup-mocks.js
+++ b/tests/js/setup-mocks.js
@@ -1,0 +1,2 @@
+// Mock `window.fetch`.
+require( 'jest-fetch-mock' ).enableMocks();

--- a/tests/js/utils.js
+++ b/tests/js/utils.js
@@ -1,3 +1,23 @@
+/**
+ * Return a rejection.
+ *
+ * Used to ensure that a test will fail if it reaches this point.
+ * Useful for asynchronous code that has multiple code paths, eg:
+ *
+ * ```js
+ * try {
+ *   await codeThatThrowsAnError();
+ *   return unexpectedSuccess();
+ * } catch (err) {
+ *   expect(err.message).toEqual('Some error.');
+ * }
+ * ```
+ *
+ * Use this to ensure that the unintended path throws an error rather than
+ * silently succeed.
+ *
+ * @return {Promise} A rejected promise.
+ */
 export const unexpectedSuccess = () => {
 	return Promise.reject( new Error(
 		'Some code (likely a Promise) succeeded unexpectedly; check your test.'


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #572.

## Relevant technical choices

Added just a bunch of unit tests so we can be sure these APIs behave as expected. This includes some nice Jest mocking for `fetch` which should help us with more tests down the line.

I've opted to throw errors on any non-200 HTTP status code as our code going forward will likely be `async/await` style and use `try/catch` blocks to handle code paths.

Right now bits of the API could change—especially the error handling—as we aren't using this anywhere yet so the API isn't 100% real-world used. But the tests cover it pretty well. 😄

<!-- Please describe your changes. -->

## Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
