### PR TITLE
Mirror WordPress HTTP proxy configuration in Google client

### DIFF
--- a/includes/Core/Authentication/Clients/OAuth_Client.php
+++ b/includes/Core/Authentication/Clients/OAuth_Client.php
@@ -200,6 +200,8 @@ final class OAuth_Client {
 	/**
 	 * Sets up a fresh Google client instance.
 	 *
+	 * @since n.e.x.t
+	 *
 	 * @return Google_Site_Kit_Client|Google_Site_Kit_Proxy_Client
 	 */
 	private function setup_client() {

--- a/includes/Core/Authentication/Clients/OAuth_Client.php
+++ b/includes/Core/Authentication/Clients/OAuth_Client.php
@@ -23,6 +23,7 @@ use Google\Site_Kit\Core\Storage\Options;
 use Google\Site_Kit\Core\Storage\User_Options;
 use Google\Site_Kit\Modules\Search_Console;
 use Google\Site_Kit_Dependencies\Google_Service_PeopleService;
+use WP_HTTP_Proxy;
 
 /**
  * Class for connecting to Google APIs via OAuth.
@@ -116,6 +117,14 @@ final class OAuth_Client {
 	private $profile;
 
 	/**
+	 * WP_HTTP_Proxy instance.
+	 *
+	 * @since n.e.x.t
+	 * @var WP_HTTP_Proxy
+	 */
+	private $http_proxy;
+
+	/**
 	 * Access token for communication with Google APIs, for temporary storage.
 	 *
 	 * @since 1.0.0
@@ -144,12 +153,13 @@ final class OAuth_Client {
 	 *
 	 * @since 1.0.0
 	 *
-	 * @param Context      $context      Plugin context.
-	 * @param Options      $options      Optional. Option API instance. Default is a new instance.
-	 * @param User_Options $user_options Optional. User Option API instance. Default is a new instance.
-	 * @param Credentials  $credentials  Optional. Credentials instance. Default is a new instance from $options.
-	 * @param Google_Proxy $google_proxy Optional. Google proxy instance. Default is a new instance.
-	 * @param Profile      $profile Optional. Profile instance. Default is a new instance.
+	 * @param Context       $context      Plugin context.
+	 * @param Options       $options      Optional. Option API instance. Default is a new instance.
+	 * @param User_Options  $user_options Optional. User Option API instance. Default is a new instance.
+	 * @param Credentials   $credentials  Optional. Credentials instance. Default is a new instance from $options.
+	 * @param Google_Proxy  $google_proxy Optional. Google proxy instance. Default is a new instance.
+	 * @param Profile       $profile      Optional. Profile instance. Default is a new instance.
+	 * @param WP_HTTP_Proxy $http_proxy   Optional. WP_HTTP_Proxy instance. Default is a new instance.
 	 */
 	public function __construct(
 		Context $context,
@@ -157,7 +167,8 @@ final class OAuth_Client {
 		User_Options $user_options = null,
 		Credentials $credentials = null,
 		Google_Proxy $google_proxy = null,
-		Profile $profile = null
+		Profile $profile = null,
+		WP_HTTP_Proxy $http_proxy = null
 	) {
 		$this->context                = $context;
 		$this->options                = $options ?: new Options( $this->context );
@@ -167,6 +178,7 @@ final class OAuth_Client {
 		$this->credentials            = $credentials ?: new Credentials( $this->encrypted_options );
 		$this->google_proxy           = $google_proxy ?: new Google_Proxy( $this->context );
 		$this->profile                = $profile ?: new Profile( $this->user_options );
+		$this->http_proxy             = $http_proxy ?: new WP_HTTP_Proxy();
 	}
 
 	/**

--- a/includes/Core/Authentication/Clients/OAuth_Client.php
+++ b/includes/Core/Authentication/Clients/OAuth_Client.php
@@ -286,9 +286,8 @@ final class OAuth_Client {
 			}
 		);
 
-		$profile = $this->profile->get();
-		if ( ! empty( $profile['email'] ) ) {
-			$client->setLoginHint( $profile['email'] );
+		if ( $this->profile->has() ) {
+			$client->setLoginHint( $this->profile->get()['email'] );
 		}
 
 		$access_token = $this->get_access_token();


### PR DESCRIPTION
## Summary

Addresses issue #661

## Relevant technical choices

* Separated client retrieval and setup/configuration into dedicated methods
* Added `WP_HTTP_Proxy` as optional constructor dependency of `OAuth_Client`

Proxy in action, showing WP and Site Kit requests
![image](https://user-images.githubusercontent.com/1621608/72089358-9297b600-3314-11ea-9d47-d587b32eaa78.png)

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
