### PR TITLE
Add option to create Analytics account

### DIFF
--- a/assets/js/googlesitekit-dashboard-details.js
+++ b/assets/js/googlesitekit-dashboard-details.js
@@ -64,7 +64,7 @@ class GoogleSitekitDashboardDetails extends Component {
 			return <Notification
 				id={ 'googlesitekit-error' }
 				key={ 'googlesitekit-error' }
-				title={ error }
+				title={ error.message }
 				description={ info.componentStack }
 				dismiss={ '' }
 				isDismissable={ false }

--- a/assets/js/googlesitekit-dashboard-splash.js
+++ b/assets/js/googlesitekit-dashboard-splash.js
@@ -67,7 +67,7 @@ class GoogleSitekitDashboardSplash extends Component {
 			return <Notification
 				id={ 'googlesitekit-error' }
 				key={ 'googlesitekit-error' }
-				title={ error }
+				title={ error.message }
 				description={ info.componentStack }
 				dismiss={ '' }
 				isDismissable={ false }

--- a/assets/js/googlesitekit-dashboard.js
+++ b/assets/js/googlesitekit-dashboard.js
@@ -74,7 +74,7 @@ class GoogleSitekitDashboard extends Component {
 			return <Notification
 				id={ 'googlesitekit-error' }
 				key={ 'googlesitekit-error' }
-				title={ error }
+				title={ error.message }
 				description={ info.componentStack }
 				dismiss={ '' }
 				isDismissable={ false }

--- a/assets/js/googlesitekit-module.js
+++ b/assets/js/googlesitekit-module.js
@@ -75,7 +75,7 @@ class GoogleSitekitModule extends Component {
 			return <Notification
 				id={ 'googlesitekit-error' }
 				key={ 'googlesitekit-error' }
-				title={ error }
+				title={ error.message }
 				description={ info.componentStack }
 				dismiss={ '' }
 				isDismissable={ false }

--- a/assets/js/googlesitekit-settings.js
+++ b/assets/js/googlesitekit-settings.js
@@ -60,7 +60,7 @@ class GoogleSitekitSettings extends Component {
 			return <Notification
 				id={ 'googlesitekit-error' }
 				key={ 'googlesitekit-error' }
-				title={ error }
+				title={ error.message }
 				description={ info.componentStack }
 				dismiss={ '' }
 				isDismissable={ false }

--- a/assets/js/googlesitekit-wp-dashboard.js
+++ b/assets/js/googlesitekit-wp-dashboard.js
@@ -69,7 +69,7 @@ class GoogleSitekitWPDashboard extends Component {
 			return <Notification
 				id={ 'googlesitekit-error' }
 				key={ 'googlesitekit-error' }
-				title={ error }
+				title={ error.message }
 				description={ info.componentStack }
 				dismiss={ '' }
 				isDismissable={ false }

--- a/assets/js/modules/analytics/setup.js
+++ b/assets/js/modules/analytics/setup.js
@@ -745,7 +745,13 @@ class AnalyticsSetup extends Component {
 						value={ account.id }
 					>
 						{ account.name }
-					</Option> ) }
+					</Option>
+				) }
+				{ ! existingTag && (
+					<Option value="-1">
+						{ __( 'Set up a new account', 'google-site-kit' ) }
+					</Option>
+				) }
 			</Select>
 		);
 	}

--- a/assets/js/modules/analytics/setup.js
+++ b/assets/js/modules/analytics/setup.js
@@ -209,7 +209,10 @@ class AnalyticsSetup extends Component {
 		// Track selection.
 		sendAnalyticsTrackingEvent( 'analytics_setup', 'account_change', selectValue );
 
-		this.processAccountChange( selectValue );
+		// Don't query accounts if "setup a new account" was chosen.
+		if ( '-1' !== selectValue ) {
+			this.processAccountChange( selectValue );
+		}
 	}
 
 	handlePropertyChange( index, item ) {

--- a/assets/js/modules/analytics/setup.js
+++ b/assets/js/modules/analytics/setup.js
@@ -809,13 +809,19 @@ class AnalyticsSetup extends Component {
 			return null;
 		}
 
-		if ( 0 >= accounts.length ) {
+		if ( ! accounts.length || '-1' === selectedAccount ) {
 			if ( ! isEditing ) {
 				return __( 'No account found.', 'google-site-kit' );
 			}
 			if ( ! setupComplete || isEditing ) {
 				return (
 					<Fragment>
+						{ '-1' === selectedAccount &&
+							<Fragment>
+								<p>{ __( 'To create a new account, click the button below which will open the Google Analytics account creation screen in a new window.', 'google-site-kit' ) }</p>
+								<p>{ __( 'Once completed, click the link below to re-fetch your accounts to continue.', 'google-site-kit' ) }</p>
+							</Fragment>
+						}
 						<div className="googlesitekit-setup-module__action">
 							<Button onClick={ AnalyticsSetup.createNewAccount }>{ __( 'Create an account', 'google-site-kit' ) }</Button>
 

--- a/assets/js/modules/analytics/setup.js
+++ b/assets/js/modules/analytics/setup.js
@@ -176,7 +176,7 @@ class AnalyticsSetup extends Component {
 
 	handleAccountChange( index, item ) {
 		const { selectedAccount } = this.state;
-		const selectValue = item.getAttribute( 'data-value' );
+		const selectValue = item.dataset.value;
 
 		if ( selectValue === selectedAccount ) {
 			return;
@@ -214,7 +214,7 @@ class AnalyticsSetup extends Component {
 
 	handlePropertyChange( index, item ) {
 		const { selectedProperty } = this.state;
-		const selectValue = item.getAttribute( 'data-value' );
+		const selectValue = item.dataset.value;
 
 		if ( selectValue === selectedProperty ) {
 			return;
@@ -245,7 +245,7 @@ class AnalyticsSetup extends Component {
 	}
 
 	handleProfileChange( index, item ) {
-		const selectValue = item.getAttribute( 'data-value' );
+		const selectValue = item.dataset.value;
 
 		this.setState( {
 			selectedProfile: selectValue,

--- a/assets/js/modules/analytics/setup.js
+++ b/assets/js/modules/analytics/setup.js
@@ -578,18 +578,19 @@ class AnalyticsSetup extends Component {
 	}
 
 	handleRefetchAccount() {
-		this.setState( {
-			isLoading: true,
-			errorCode: false,
-			errorMsg: '',
-			selectedAccount: '',
-			selectedProperty: '-1',
-			selectedProfile: '-1',
-			propertiesLoading: false,
-			profilesLoading: false,
-		} );
-
-		this.getAccounts();
+		this.setState(
+			{
+				isLoading: true,
+				errorCode: false,
+				errorMsg: '',
+				selectedAccount: '0',
+				selectedProperty: '-1',
+				selectedProfile: '-1',
+				propertiesLoading: false,
+				profilesLoading: false,
+			},
+			this.getAccounts
+		);
 	}
 
 	handleExclusionsChange( e ) {

--- a/assets/js/modules/analytics/setup.js
+++ b/assets/js/modules/analytics/setup.js
@@ -760,19 +760,21 @@ class AnalyticsSetup extends Component {
 				disabled={ disabled }
 				outlined
 			>
-				{ accounts.map( ( account, id ) =>
-					<Option
-						key={ id }
-						value={ account.id }
-					>
-						{ account.name }
-					</Option>
-				) }
-				{ ! existingTag && (
-					<Option value="-1">
-						{ __( 'Set up a new account', 'google-site-kit' ) }
-					</Option>
-				) }
+				<Fragment>
+					{ accounts.map( ( account, id ) =>
+						<Option
+							key={ id }
+							value={ account.id }
+						>
+							{ account.name }
+						</Option>
+					) }
+					{ ! existingTag && (
+						<Option value="-1">
+							{ __( 'Set up a new account', 'google-site-kit' ) }
+						</Option>
+					) }
+				</Fragment>
 			</Select>
 		);
 	}

--- a/assets/js/modules/analytics/setup.js
+++ b/assets/js/modules/analytics/setup.js
@@ -317,6 +317,12 @@ class AnalyticsSetup extends Component {
 						name: __( 'Select one...', 'google-site-kit' ),
 					} );
 				}
+			} else if ( '0' === selectedAccount ) {
+				// Accounts were just refreshed.
+				responseData.accounts.unshift( {
+					id: 0,
+					name: __( 'Select one...', 'google-site-kit' ),
+				} );
 			} else if ( selectedAccount && ! responseData.accounts.find( ( account ) => account.id === selectedAccount ) ) {
 				data.invalidateCacheGroup( TYPE_MODULES, 'analytics', 'accounts-properties-profiles' );
 

--- a/assets/js/modules/analytics/setup.js
+++ b/assets/js/modules/analytics/setup.js
@@ -751,6 +751,7 @@ class AnalyticsSetup extends Component {
 
 		return (
 			<Select
+				className="googlesitekit-analytics__select-account"
 				enhanced
 				name="accounts"
 				value={ selectedAccount || '0' }
@@ -938,6 +939,7 @@ class AnalyticsSetup extends Component {
 					{ this.accountsDropdown() }
 					{ propertiesLoading ? ( <ProgressBar small /> ) : (
 						<Select
+							className="googlesitekit-analytics__select-property"
 							enhanced
 							name="properties"
 							value={ selectedProperty || selectedProperty === 0 ? selectedProperty.toString() : '-1' }
@@ -957,6 +959,7 @@ class AnalyticsSetup extends Component {
 					) }
 					{ profilesLoading ? ( <ProgressBar small /> ) : (
 						<Select
+							className="googlesitekit-analytics__select-profile"
 							enhanced
 							name="profiles"
 							value={ selectedProfile || selectedProfile === 0 ? selectedProfile.toString() : '-1' }

--- a/assets/js/modules/analytics/setup.js
+++ b/assets/js/modules/analytics/setup.js
@@ -582,6 +582,7 @@ class AnalyticsSetup extends Component {
 			isLoading: true,
 			errorCode: false,
 			errorMsg: '',
+			selectedAccount: '',
 		} );
 
 		this.getAccounts();

--- a/assets/js/modules/analytics/setup.js
+++ b/assets/js/modules/analytics/setup.js
@@ -583,6 +583,10 @@ class AnalyticsSetup extends Component {
 			errorCode: false,
 			errorMsg: '',
 			selectedAccount: '',
+			selectedProperty: '-1',
+			selectedProfile: '-1',
+			propertiesLoading: false,
+			profilesLoading: false,
 		} );
 
 		this.getAccounts();

--- a/assets/js/modules/analytics/setup.js
+++ b/assets/js/modules/analytics/setup.js
@@ -160,7 +160,7 @@ class AnalyticsSetup extends Component {
 			return;
 		}
 
-		const settingsMapping = {
+		let settingsMapping = {
 			anonymizeIP: 'anonymizeIP',
 			selectedAccount: 'accountID',
 			selectedProperty: 'propertyID',
@@ -170,6 +170,11 @@ class AnalyticsSetup extends Component {
 			ampClientIDOptIn: 'ampClientIDOptIn',
 			trackingDisabled: 'trackingDisabled',
 		};
+
+		// Prevent saving if "setup account" is chosen.
+		if ( '-1' === this.state.selectedAccount ) {
+			settingsMapping = {};
+		}
 
 		toggleConfirmModuleSettings( 'analytics', settingsMapping, this.state );
 	}

--- a/assets/js/modules/analytics/setup.js
+++ b/assets/js/modules/analytics/setup.js
@@ -760,8 +760,9 @@ class AnalyticsSetup extends Component {
 				disabled={ disabled }
 				outlined
 			>
-				<Fragment>
-					{ accounts.map( ( account, id ) =>
+				{ accounts
+					.concat( ! existingTag ? [ { id: '-1', name: __( 'Set up a new account', 'google-site-kit' ) } ] : [] )
+					.map( ( account, id ) =>
 						<Option
 							key={ id }
 							value={ account.id }
@@ -769,12 +770,6 @@ class AnalyticsSetup extends Component {
 							{ account.name }
 						</Option>
 					) }
-					{ ! existingTag && (
-						<Option value="-1">
-							{ __( 'Set up a new account', 'google-site-kit' ) }
-						</Option>
-					) }
-				</Fragment>
 			</Select>
 		);
 	}

--- a/tests/e2e/specs/modules/analytics/setup-no-account-no-tag.test.js
+++ b/tests/e2e/specs/modules/analytics/setup-no-account-no-tag.test.js
@@ -88,9 +88,9 @@ describe( 'setting up the Analytics module with no existing account and no exist
 
 		await page.waitForSelector( '.googlesitekit-setup-module__inputs' );
 
-		await expect( page ).toMatchElement( '.mdc-select__selected-text', { text: /test account a/i } );
-		await expect( page ).toMatchElement( '.mdc-select__selected-text', { text: /test property x/i } );
-		await expect( page ).toMatchElement( '.mdc-select__selected-text', { text: /test profile x/i } );
+		await expect( page ).toMatchElement( '.googlesitekit-analytics__select-account .mdc-select__selected-text', { text: /select one.../i } );
+		await expect( page ).toMatchElement( '.googlesitekit-analytics__select-property .mdc-select__selected-text', { text: /select an account/i } );
+		await expect( page ).toMatchElement( '.googlesitekit-analytics__select-profile .mdc-select__selected-text', { text: /select an account/i } );
 
 		await page.waitFor( 1000 );
 		await expect( page ).toClick( 'button', { text: /configure analytics/i } );

--- a/tests/e2e/specs/modules/analytics/setup-with-account-no-tag.test.js
+++ b/tests/e2e/specs/modules/analytics/setup-with-account-no-tag.test.js
@@ -148,4 +148,30 @@ describe( 'setting up the Analytics module with an existing account and no exist
 		await page.waitForSelector( '.googlesitekit-publisher-win--win-success' );
 		await expect( page ).toMatchElement( '.googlesitekit-publisher-win__title', { text: /Congrats on completing the setup for Analytics!/i } );
 	} );
+
+	it( 'includes an option to setup a new account', async () => {
+		await proceedToSetUpAnalytics();
+
+		await expect( page ).toMatchElement( '.mdc-select__selected-text', { text: /test account a/i } );
+		await expect( page ).toMatchElement( '.mdc-select__selected-text', { text: /test property x/i } );
+		await expect( page ).toMatchElement( '.mdc-select__selected-text', { text: /test profile x/i } );
+
+		await expect( page ).toClick( '.googlesitekit-analytics__select-account .mdc-select__selected-text' );
+		await expect( page ).toClick( '.mdc-menu-surface--open .mdc-list-item', { text: /set up a new account/i } );
+
+		// Ensure dropdowns are now hidden.
+		await expect( page ).not.toMatchElement( '.googlesitekit-setup-module--analytics select' );
+		await expect( page ).toMatchElement( 'button', { text: /create an account/i } );
+		await expect( page ).toMatchElement( 'button', { text: /re-fetch my account/i } );
+
+		await Promise.all( [
+			page.waitForResponse( ( res ) => res.url().match( 'modules/analytics/data' ) ),
+			expect( page ).toClick( 'button', { text: /re-fetch my account/i } ),
+		] );
+
+		// Dropdowns are revealed and reset on refetch.
+		await expect( page ).toMatchElement( '.googlesitekit-analytics__select-account .mdc-select__selected-text', { text: /select one.../i } );
+		await expect( page ).toMatchElement( '.googlesitekit-analytics__select-property .mdc-select__selected-text', { text: /select an account/i } );
+		await expect( page ).toMatchElement( '.googlesitekit-analytics__select-profile .mdc-select__selected-text', { text: /select an account/i } );
+	} );
 } );

--- a/tests/e2e/specs/modules/analytics/setup-with-account-with-tag.test.js
+++ b/tests/e2e/specs/modules/analytics/setup-with-account-with-tag.test.js
@@ -88,9 +88,9 @@ describe( 'setting up the Analytics module with an existing account and existing
 		await page.waitForResponse( ( res ) => res.url().match( 'modules/analytics/data/accounts-properties-profiles' ) );
 		await expect( page ).toMatchElement( '.googlesitekit-setup-module--analytics p', { text: new RegExp( `An existing analytics tag was found on your site with the id ${ EXISTING_PROPERTY_ID }`, 'i' ) } );
 
-		await expect( page ).toMatchElement( '.mdc-select--disabled .mdc-select__selected-text', { text: /test account a/i } );
-		await expect( page ).toMatchElement( '.mdc-select--disabled .mdc-select__selected-text', { text: /test property x/i } );
-		await expect( page ).toMatchElement( '.mdc-select:not(.mdc-select--disabled) .mdc-select__selected-text', { text: /test profile x/i } );
+		await expect( page ).toMatchElement( '.googlesitekit-analytics__select-account .mdc-select__selected-text', { text: /test account a/i } );
+		await expect( page ).toMatchElement( '.googlesitekit-analytics__select-property .mdc-select__selected-text', { text: /test property x/i } );
+		await expect( page ).toMatchElement( '.googlesitekit-analytics__select-profile .mdc-select__selected-text', { text: /test profile x/i } );
 
 		// Ensure that Views dropdown is not disabled
 		await expect( page ).toClick( '.mdc-select', { text: /test profile x/i } );


### PR DESCRIPTION
## Summary

Addresses issue #198 

## Relevant technical choices

* The new setup option is only added if there is no existing tag
* During some e2e troubleshooting, I fixed what seems to be the cause for the blank screen with our existing error boundaries where an error object was used for the notification title instead of the string representation (message) https://github.com/google/site-kit-wp/pull/1021/commits/c063ba95a35ca959efee5db99f660cc5770f0053
* Some e2e coverage exists with the current test which uses refetch accounts, nothing added yet for this case specifically https://github.com/google/site-kit-wp/pull/1021/commits/3d4f463ae8b3f860dc5bb4abccc3393aaca9158b

New option to "Set up a new account"
![image](https://user-images.githubusercontent.com/1621608/72094384-017a0c80-331f-11ea-8e5d-b5300926985b.png)

When the create account option is chosen, new copy is displayed (otherwise there would be nothing) and dropdowns are not rendered. Continue button is also disabled to prevent the user from accidentally saving an invalid account ID.
![image](https://user-images.githubusercontent.com/1621608/72094648-82390880-331f-11ea-9f36-5f915374334b.png)

After refreshing, dropdowns are reset with nothing preselected allowing the user to choose their new account, if they created one.
![image](https://user-images.githubusercontent.com/1621608/72102887-b2d56e00-3330-11ea-90ca-0e478ffacb2b.png)

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
