### PR TITLE
Set the name of the Docker Compose project for E2E.

### DIFF
--- a/bin/local-env/includes.sh
+++ b/bin/local-env/includes.sh
@@ -6,6 +6,8 @@ DOCKER_COMPOSE_FILE_OPTIONS="-f $(dirname "$0")/docker-compose.yml"
 CLI='cli'
 CONTAINER='wordpress'
 SITE_TITLE='Google Site Kit Dev'
+# Set the name of the Docker Compose project.
+export COMPOSE_PROJECT_NAME='googlesitekit-e2e'
 
 ##
 # Ask a Yes/No question, and way for a reply.


### PR DESCRIPTION
## Summary

By default, docker compose uses the directory name of its compose file for the name of the project which is shared by all containers. This has the potential to create conflicts should other projects borrow our configuration as a starting point for their own E2E tests. This also makes it a bit clearer when reviewing your local running containers. Instead of needing to know that `local-env_*` containers are for Site Kit, we should give them a proper name.

By defining the [`COMPOSE_PROJECT_NAME`](https://docs.docker.com/compose/reference/envvars/) environment variable, we can override the default used when running `docker-compose up`.

This PR sets the project name to `googlesitekit-e2e` which can be seen when running `env:start`

```
STATUS: Starting Docker containers...
Creating network "googlesitekit-e2e_default" with the default driver
Creating googlesitekit-e2e_mysql_1 ... done
Creating googlesitekit-e2e_wordpress_1 ... done
Creating googlesitekit-e2e_cli_1       ... done
```

Addresses issue #

## Relevant technical choices



## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.4.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
