### PR TITLE
Upgrades Travis dist to Xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@
 
 sudo: required
 
-dist: trusty
+dist: xenial
 
 language: php
 
@@ -126,3 +126,4 @@ jobs:
 
 services:
   - docker
+  - mysql


### PR DESCRIPTION
## Summary

This PR upgrades the Travis dist from `trusty` to `xenial`
 

## Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
