### PR TITLE
Refactor AdSense legacy key handling with mapping.

### DIFF
--- a/includes/Modules/AdSense.php
+++ b/includes/Modules/AdSense.php
@@ -347,14 +347,6 @@ tag_partner: "site_kit"
 			case 'GET:account-status':
 				return function() {
 					$option = $this->get_settings()->get();
-					// TODO: Remove this at some point (migration of old option).
-					if ( isset( $option['account_status'] ) ) {
-						if ( ! isset( $option['accountStatus'] ) ) {
-							$option['accountStatus'] = $option['account_status'];
-						}
-						unset( $option['account_status'] );
-						$this->get_settings()->set( $option );
-					}
 					if ( empty( $option['accountStatus'] ) ) {
 						return new WP_Error( 'account_status_not_set', __( 'AdSense account status not set.', 'google-site-kit' ), array( 'status' => 404 ) );
 					}
@@ -395,14 +387,6 @@ tag_partner: "site_kit"
 			case 'GET:client-id':
 				return function() {
 					$option = $this->get_settings()->get();
-					// TODO: Remove this at some point (migration of old option).
-					if ( isset( $option['client_id'] ) ) {
-						if ( ! isset( $option['clientID'] ) ) {
-							$option['clientID'] = $option['client_id'];
-						}
-						unset( $option['client_id'] );
-						$this->get_settings()->set( $option );
-					}
 					if ( empty( $option['clientID'] ) ) {
 						return new WP_Error( 'client_id_not_set', __( 'AdSense client ID not set.', 'google-site-kit' ), array( 'status' => 404 ) );
 					}
@@ -424,45 +408,7 @@ tag_partner: "site_kit"
 				return $service->adclients->listAdclients();
 			case 'GET:connection':
 				return function() {
-					$option = $this->get_settings()->get();
-					// TODO: Remove this at some point (migration of old options).
-					if ( isset( $option['account_id'] ) || isset( $option['client_id'] ) || isset( $option['account_status'] ) ) {
-						if ( isset( $option['account_id'] ) ) {
-							if ( ! isset( $option['accountID'] ) ) {
-								$option['accountID'] = $option['account_id'];
-							}
-							unset( $option['account_id'] );
-						}
-						if ( isset( $option['client_id'] ) ) {
-							if ( ! isset( $option['clientID'] ) ) {
-								$option['clientID'] = $option['client_id'];
-							}
-							unset( $option['client_id'] );
-						}
-						if ( isset( $option['account_status'] ) ) {
-							if ( ! isset( $option['accountStatus'] ) ) {
-								$option['accountStatus'] = $option['account_status'];
-							}
-							unset( $option['account_status'] );
-						}
-						$this->get_settings()->set( $option );
-					}
-					// TODO: Remove this at some point (migration of old 'accountId' option).
-					if ( isset( $option['accountId'] ) ) {
-						if ( ! isset( $option['accountID'] ) ) {
-							$option['accountID'] = $option['accountId'];
-						}
-						unset( $option['accountId'] );
-					}
-
-					// TODO: Remove this at some point (migration of old 'clientId' option).
-					if ( isset( $option['clientId'] ) ) {
-						if ( ! isset( $option['clientID'] ) ) {
-							$option['clientID'] = $option['clientId'];
-						}
-						unset( $option['clientId'] );
-					}
-
+					$option   = $this->get_settings()->get();
 					$defaults = array(
 						'accountID'     => '',
 						'clientID'      => '',

--- a/includes/Modules/AdSense/Settings.php
+++ b/includes/Modules/AdSense/Settings.php
@@ -36,7 +36,11 @@ class Settings extends Module_Settings {
 		$this->register_legacy_keys_migration(
 			array(
 				'account_id'        => 'accountID',
+				'accountId'         => 'accountID',
+				'account_status'    => 'accountStatus',
 				'adsenseTagEnabled' => 'useSnippet',
+				'client_id'         => 'clientID',
+				'clientId'          => 'clientID',
 				'setup_complete'    => 'setupComplete',
 			)
 		);

--- a/tests/phpunit/integration/Modules/AdSense/SettingsTest.php
+++ b/tests/phpunit/integration/Modules/AdSense/SettingsTest.php
@@ -62,6 +62,8 @@ class SettingsTest extends SettingsTestCase {
 	public function test_legacy_options() {
 		$legacy_option = array(
 			'account_id'        => 'test-account-id',
+			'account_status'    => 'test-account-status',
+			'client_id'         => 'test-client-id',
 			'adsenseTagEnabled' => 'test-adsense-tag-enabled',
 			'setup_complete'    => 'test-setup-complete',
 		);
@@ -73,6 +75,8 @@ class SettingsTest extends SettingsTestCase {
 		$this->assertArraySubset(
 			array(
 				'accountID'     => 'test-account-id',
+				'accountStatus' => 'test-account-status',
+				'clientID'      => 'test-client-id',
 				'useSnippet'    => 'test-adsense-tag-enabled',
 				'setupComplete' => 'test-setup-complete',
 			),


### PR DESCRIPTION
## Summary

Addresses issue #859 

This PR adds what should be the last of the legacy key handling/migration that was missed in the original PR for #859.

## Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
