### PR TITLE
Improve handling of potentially outdated files

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,8 @@
       "@autoload-includes",
       "@autoload-third-party",
       "@composer dump-autoload --no-dev",
-      "cp vendor/composer/autoload_files.php third-party/vendor/"
+      "cp vendor/composer/autoload_files.php third-party/vendor/",
+      "@composer dump-autoload"
     ],
     "autoload-includes": [
       "echo '{ \"autoload\": { \"classmap\": [\"\"] } }' > includes/composer.json",

--- a/composer.json
+++ b/composer.json
@@ -52,6 +52,7 @@
       "php-scoper/vendor/bin/php-scoper add --output-dir=./third-party --force --quiet",
       "@autoload-includes",
       "@autoload-third-party",
+      "@composer dump-autoload --no-dev",
       "cp vendor/composer/autoload_files.php third-party/vendor/"
     ],
     "autoload-includes": [

--- a/google-site-kit.php
+++ b/google-site-kit.php
@@ -75,6 +75,26 @@ function googlesitekit_deactivate_plugin( $network_wide ) {
 
 register_deactivation_hook( __FILE__, 'googlesitekit_deactivate_plugin' );
 
+/**
+ * Resets opcache if possible.
+ *
+ * @access private
+ * @since n.e.x.t
+ */
+function googlesitekit_opcache_reset() {
+	if ( ! empty( ini_get( 'opcache.restrict_api' ) ) && strpos( __FILE__, ini_get( 'opcache.restrict_api' ) ) !== 0 ) {
+		return;
+	}
+
+	// `opcache_reset` is prohibited on the WordPress VIP platform due to memory corruption.
+	if ( function_exists( 'is_wpcom_vip' ) || defined( 'VIP_GO_APP_ENVIRONMENT' ) ) {
+		return;
+	}
+
+	opcache_reset(); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.opcache_opcache_reset
+}
+add_action( 'upgrader_process_complete', 'googlesitekit_opcache_reset' );
+
 if ( version_compare( PHP_VERSION, '5.4.0', '>=' ) ) {
 	require_once plugin_dir_path( __FILE__ ) . 'includes/loader.php';
 }

--- a/google-site-kit.php
+++ b/google-site-kit.php
@@ -87,7 +87,7 @@ function googlesitekit_opcache_reset() {
 	}
 
 	// `opcache_reset` is prohibited on the WordPress VIP platform due to memory corruption.
-	if ( function_exists( 'is_wpcom_vip' ) || defined( 'VIP_GO_APP_ENVIRONMENT' ) ) {
+	if ( defined( 'WPCOM_IS_VIP_ENV' ) && WPCOM_IS_VIP_ENV ) {
 		return;
 	}
 

--- a/includes/loader.php
+++ b/includes/loader.php
@@ -30,7 +30,7 @@ function autoload_classes() {
 
 	spl_autoload_register(
 		function ( $class ) use ( $class_map ) {
-			if ( isset( $class_map[ $class ] ) && file_exists( $class_map[ $class ] ) ) {
+			if ( isset( $class_map[ $class ] ) ) {
 				require_once $class_map[ $class ];
 
 				return true;
@@ -52,9 +52,7 @@ function autoload_vendor_files() {
 	// Third-party files.
 	$files = require GOOGLESITEKIT_PLUGIN_DIR_PATH . 'third-party/vendor/autoload_files.php';
 	foreach ( $files as $file_identifier => $file ) {
-		if ( file_exists( $file ) ) {
-			require_once $file;
-		}
+		require_once $file;
 	}
 }
 autoload_vendor_files();

--- a/scoper.inc.php
+++ b/scoper.inc.php
@@ -76,7 +76,8 @@ return array(
 		Finder::create()
 			->files()
 			->ignoreVCS( true )
-			->name( "#($google_services)\.php#" )
+			->name( "#^($google_services)\.php$#" )
+			->depth( '== 0' )
 			->in( 'vendor/google/apiclient-services/src/Google/Service' ),
 	),
 	'files-whitelist'            => array(


### PR DESCRIPTION
## Summary

Addresses issue #1066

## Relevant technical choices

* Added checks for WP VIP environments as `opcache_reset` is not allowed on the platform
* An additional call to `dump-autoload` was necessary after the file loader was copied to for development dependencies to work. This does not affect the final resulting autoloader when running `install` with `--no-dev`

**Composer install with no dev generates autoloader with `2` classes**
```
composer install --no-dev -vvv
...
> prefix-dependencies: @composer dump-autoload --no-dev
Executing command (CWD): '/usr/local/Cellar/php@7.2/7.2.25/bin/php' -d allow_url_fopen='1' -d disable_functions='' -d memory_limit='1536M' '/usr/local/bin/composer' dump-autoload --no-dev
Generated autoload files containing 2 classes
> prefix-dependencies: cp vendor/composer/autoload_files.php third-party/vendor/
Executing command (CWD): cp vendor/composer/autoload_files.php third-party/vendor/
> prefix-dependencies: @composer dump-autoload
Executing command (CWD): '/usr/local/Cellar/php@7.2/7.2.25/bin/php' -d allow_url_fopen='1' -d disable_functions='' -d memory_limit='1536M' '/usr/local/bin/composer' dump-autoload
Generated autoload files containing 2 classes
```

**Composer install with dev generates autoloader with `467` classes**
```
composer install -vvv
...
> prefix-dependencies: @composer dump-autoload --no-dev
Executing command (CWD): '/usr/local/Cellar/php@7.2/7.2.25/bin/php' -d allow_url_fopen='1' -d disable_functions='' -d memory_limit='1536M' '/usr/local/bin/composer' dump-autoload --no-dev
Generated autoload files containing 2 classes
> prefix-dependencies: cp vendor/composer/autoload_files.php third-party/vendor/
Executing command (CWD): cp vendor/composer/autoload_files.php third-party/vendor/
> prefix-dependencies: @composer dump-autoload
Executing command (CWD): '/usr/local/Cellar/php@7.2/7.2.25/bin/php' -d allow_url_fopen='1' -d disable_functions='' -d memory_limit='1536M' '/usr/local/bin/composer' dump-autoload
Generated autoload files containing 467 classes
```

This works because as of [v1.3](https://github.com/composer/composer/releases/tag/1.3.0) Composer sets a `COMPOSER_DEV_MODE` environment variable when it is run to forward the dev mode to script handlers. That is that `@composer` scripts will inherit the dev flag from the main process if not specifically. By calling `@composer dump-autoload` at the end of dependency prefixing, the resulting final autoloader is always consistent with the context of the main install command.

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
