### PR TITLE
Update PHP version checks

### DIFF
--- a/google-site-kit.php
+++ b/google-site-kit.php
@@ -39,9 +39,10 @@ define( 'GOOGLESITEKIT_PHP_MINIMUM', '5.6.0' );
  * @param bool $network_wide Whether to activate network-wide.
  */
 function googlesitekit_activate_plugin( $network_wide ) {
-	if ( version_compare( PHP_VERSION, '5.6.0', '<' ) ) {
+	if ( version_compare( PHP_VERSION, GOOGLESITEKIT_PHP_MINIMUM, '<' ) ) {
 		wp_die(
-			esc_html__( 'Site Kit requires PHP version 5.6.', 'google-site-kit' ),
+			/* translators: %s: version number */
+			esc_html( sprintf( __( 'Site Kit requires PHP version %s', 'google-site-kit' ), GOOGLESITEKIT_PHP_MINIMUM ) ),
 			esc_html__( 'Error Activating', 'google-site-kit' )
 		);
 	}

--- a/google-site-kit.php
+++ b/google-site-kit.php
@@ -26,6 +26,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 // Define most essential constants.
 define( 'GOOGLESITEKIT_VERSION', '1.2.0' );
 define( 'GOOGLESITEKIT_PLUGIN_MAIN_FILE', __FILE__ );
+define( 'GOOGLESITEKIT_PHP_MINIMUM', '5.6.0' );
 
 /**
  * Handles plugin activation.

--- a/google-site-kit.php
+++ b/google-site-kit.php
@@ -63,7 +63,7 @@ register_activation_hook( __FILE__, 'googlesitekit_activate_plugin' );
  * @param bool $network_wide Whether to deactivate network-wide.
  */
 function googlesitekit_deactivate_plugin( $network_wide ) {
-	if ( version_compare( PHP_VERSION, '5.4.0', '<' ) ) {
+	if ( version_compare( PHP_VERSION, GOOGLESITEKIT_PHP_MINIMUM, '<' ) ) {
 		return;
 	}
 
@@ -76,6 +76,6 @@ function googlesitekit_deactivate_plugin( $network_wide ) {
 
 register_deactivation_hook( __FILE__, 'googlesitekit_deactivate_plugin' );
 
-if ( version_compare( PHP_VERSION, '5.4.0', '>=' ) ) {
+if ( version_compare( PHP_VERSION, GOOGLESITEKIT_PHP_MINIMUM, '>=' ) ) {
 	require_once plugin_dir_path( __FILE__ ) . 'includes/loader.php';
 }


### PR DESCRIPTION
## Summary

Addresses issue #547

## Relevant technical choices

* This PR is a follow up to 547 mainly to fix a few PHP version checks that were missed in the update
* A new `GOOGLESITEKIT_PHP_MINIMUM` constant has been added to make this a single line change in the future
* The error message during activation is now independent of the specific version, using a placeholder instead

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
