### PR TITLE
Add core/site/data/connection route and Options_Interface::has()

### DIFF
--- a/includes/Core/Authentication/Authentication.php
+++ b/includes/Core/Authentication/Authentication.php
@@ -177,6 +177,8 @@ final class Authentication {
 	 * @since 1.0.0
 	 */
 	public function register() {
+		$this->credentials->register();
+
 		add_action(
 			'init',
 			function() {

--- a/includes/Core/Authentication/Authentication.php
+++ b/includes/Core/Authentication/Authentication.php
@@ -556,7 +556,7 @@ final class Authentication {
 		$access_token = $auth_client->get_access_token();
 
 		$data['isSiteKitConnected'] = $this->credentials->has();
-		$data['isResettable']       = (bool) $this->options->get( Credentials::OPTION );
+		$data['isResettable']       = $this->options->has( Credentials::OPTION );
 		$data['isAuthenticated']    = ! empty( $access_token );
 		$data['requiredScopes']     = $auth_client->get_required_scopes();
 		$data['grantedScopes']      = ! empty( $access_token ) ? $auth_client->get_granted_scopes() : array();

--- a/includes/Core/Authentication/Authentication.php
+++ b/includes/Core/Authentication/Authentication.php
@@ -621,11 +621,32 @@ final class Authentication {
 	 * @return array List of REST_Route objects.
 	 */
 	private function get_rest_routes() {
+		$can_setup = function() {
+			return current_user_can( Permissions::SETUP );
+		};
+
 		$can_authenticate = function() {
 			return current_user_can( Permissions::AUTHENTICATE );
 		};
 
 		return array(
+			new REST_Route(
+				'core/site/data/connection',
+				array(
+					array(
+						'methods'             => WP_REST_Server::READABLE,
+						'callback'            => function( WP_REST_Request $request ) {
+							$data = array(
+								'connected'  => $this->credentials->has(),
+								'resettable' => $this->options->has( Credentials::OPTION ),
+							);
+
+							return new WP_REST_Response( $data );
+						},
+						'permission_callback' => $can_setup,
+					),
+				)
+			),
 			new REST_Route(
 				'core/user/data/authentication',
 				array(

--- a/includes/Core/Storage/Encrypted_Options.php
+++ b/includes/Core/Storage/Encrypted_Options.php
@@ -48,6 +48,18 @@ final class Encrypted_Options implements Options_Interface {
 	}
 
 	/**
+	 * Checks whether or not a value is set for the given option.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param string $option Option name.
+	 * @return bool True if value set, false otherwise.
+	 */
+	public function has( $option ) {
+		return $this->options->has( $option );
+	}
+
+	/**
 	 * Gets the value of the given option.
 	 *
 	 * @since 1.0.0
@@ -57,8 +69,10 @@ final class Encrypted_Options implements Options_Interface {
 	 */
 	public function get( $option ) {
 		$raw_value = $this->options->get( $option );
-		if ( ! $raw_value ) {
-			return false;
+
+		// If there is no value stored, return the default which will not be encrypted.
+		if ( ! $this->options->has( $option ) ) {
+			return $raw_value;
 		}
 
 		$data = $this->encryption->decrypt( $raw_value );

--- a/includes/Core/Storage/Options.php
+++ b/includes/Core/Storage/Options.php
@@ -43,6 +43,28 @@ final class Options implements Options_Interface {
 	}
 
 	/**
+	 * Checks whether or not a value is set for the given option.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param string $option Option name.
+	 * @return bool True if value set, false otherwise.
+	 */
+	public function has( $option ) {
+		// Call without getting the value to ensure 'notoptions' cache is fresh for the option.
+		$this->get( $option );
+
+		if ( $this->context->is_network_mode() ) {
+			$network_id = get_current_network_id();
+			$notoptions = wp_cache_get( "$network_id:notoptions", 'site-options' );
+		} else {
+			$notoptions = wp_cache_get( 'notoptions', 'options' );
+		}
+
+		return ! isset( $notoptions[ $option ] );
+	}
+
+	/**
 	 * Gets the value of the given option.
 	 *
 	 * @since 1.0.0

--- a/includes/Core/Storage/Options_Interface.php
+++ b/includes/Core/Storage/Options_Interface.php
@@ -20,6 +20,16 @@ namespace Google\Site_Kit\Core\Storage;
 interface Options_Interface {
 
 	/**
+	 * Checks whether or not a value is set for the given option.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param string $option Option name.
+	 * @return bool True if value set, false otherwise.
+	 */
+	public function has( $option );
+
+	/**
 	 * Gets the value of the given option.
 	 *
 	 * @since 1.2.0

--- a/includes/Core/Storage/Setting.php
+++ b/includes/Core/Storage/Setting.php
@@ -65,11 +65,12 @@ abstract class Setting {
 	 * Checks whether or not the option is set with a valid value.
 	 *
 	 * @since 1.2.0
+	 * @since n.e.x.t Now relies on {@see Options_Interface::has()}.
 	 *
 	 * @return bool True on success, false on failure.
 	 */
 	public function has() {
-		return (bool) $this->get();
+		return $this->options->has( static::OPTION );
 	}
 
 	/**

--- a/tests/phpunit/integration/Core/Authentication/CredentialsTest.php
+++ b/tests/phpunit/integration/Core/Authentication/CredentialsTest.php
@@ -21,17 +21,22 @@ use Google\Site_Kit\Tests\TestCase;
  */
 class CredentialsTest extends TestCase {
 
+	private $registered_default = array(
+		'oauth2_client_id'     => '',
+		'oauth2_client_secret' => '',
+	);
+
 	public function test_get() {
 		$options           = new Options( new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE ) );
 		$encrypted_options = new Encrypted_Options( $options );
 		$credentials       = new Credentials( $encrypted_options );
 
-		$this->assertFalse( $encrypted_options->get( Credentials::OPTION ) );
 		$this->assertEqualSets(
-			array(
-				'oauth2_client_id'     => '',
-				'oauth2_client_secret' => '',
-			),
+			$this->registered_default,
+			$encrypted_options->get( Credentials::OPTION )
+		);
+		$this->assertEqualSets(
+			$this->registered_default,
 			$credentials->get()
 		);
 
@@ -51,7 +56,7 @@ class CredentialsTest extends TestCase {
 			array(
 				'oauth2_client_id'     => 'test-client-id',
 				'oauth2_client_secret' => 'test-client-secret',
-			) 
+			)
 		);
 
 		$this->assertEqualSets(
@@ -68,7 +73,7 @@ class CredentialsTest extends TestCase {
 		$encrypted_options = new Encrypted_Options( $options );
 		$credentials       = new Credentials( $encrypted_options );
 
-		$this->assertFalse( $encrypted_options->get( Credentials::OPTION ) );
+		$this->assertEqualSets( $this->registered_default, $encrypted_options->get( Credentials::OPTION ) );
 		$this->assertTrue( $credentials->set( array( 'test-credentials' ) ) );
 		$this->assertEquals( array( 'test-credentials' ), $encrypted_options->get( Credentials::OPTION ) );
 	}
@@ -78,7 +83,8 @@ class CredentialsTest extends TestCase {
 		$encrypted_options = new Encrypted_Options( $options );
 		$credentials       = new Credentials( $encrypted_options );
 
-		$this->assertFalse( $options->get( Credentials::OPTION ) );
+		$this->assertFalse( $options->has( Credentials::OPTION ) );
+		$this->assertFalse( $encrypted_options->has( Credentials::OPTION ) );
 		$this->assertFalse( $credentials->has() );
 		// Credentials missing all required keys are considered missing
 		// Test dummy credentials
@@ -96,7 +102,7 @@ class CredentialsTest extends TestCase {
 			array(
 				'oauth2_client_id'     => 'test-client-id',
 				'oauth2_client_secret' => '',
-			) 
+			)
 		);
 		$this->assertFalse( $credentials->has() );
 		// Test empty client id with a secret
@@ -105,7 +111,7 @@ class CredentialsTest extends TestCase {
 			array(
 				'oauth2_client_id'     => '',
 				'oauth2_client_secret' => 'test-client-secret',
-			) 
+			)
 		);
 		$this->assertFalse( $credentials->has() );
 		// Test with provided client id and secret
@@ -114,7 +120,7 @@ class CredentialsTest extends TestCase {
 			array(
 				'oauth2_client_id'     => 'test-client-id',
 				'oauth2_client_secret' => 'test-client-secret',
-			) 
+			)
 		);
 		$this->assertTrue( $credentials->has() );
 	}

--- a/tests/phpunit/integration/Core/REST_API/REST_RoutesTest.php
+++ b/tests/phpunit/integration/Core/REST_API/REST_RoutesTest.php
@@ -52,6 +52,7 @@ class REST_RoutesTest extends TestCase {
 			'/' . REST_Routes::REST_ROOT . '/core/search/data/post-search',
 			'/' . REST_Routes::REST_ROOT . '/core/site/data/developer-plugin',
 			'/' . REST_Routes::REST_ROOT . '/core/site/data/setup-tag',
+			'/' . REST_Routes::REST_ROOT . '/core/site/data/connection',
 		);
 
 		$this->assertEqualSets( $routes, array_keys( $server->get_routes() ) );

--- a/tests/phpunit/integration/Core/Storage/OptionsTest.php
+++ b/tests/phpunit/integration/Core/Storage/OptionsTest.php
@@ -19,6 +19,20 @@ use Google\Site_Kit\Tests\TestCase;
  */
 class OptionsTest extends TestCase {
 
+	public function test_has() {
+		$options = new Options( new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE ) );
+
+		// Ensure default is a truthy value.
+		add_filter( 'default_option_test_option', '__return_true' );
+		delete_option( 'test_option' );
+		$this->assertFalse( $options->has( 'test_option' ) );
+
+		// Ensure default is a truthy value.
+		add_filter( 'default_option_test_option', '__return_false' );
+		update_option( 'test_option', '1' );
+		$this->assertTrue( $options->has( 'test_option' ) );
+	}
+
 	public function test_get() {
 		$options = new Options( new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE ) );
 		delete_option( 'test_option' );

--- a/tests/phpunit/integration/Core/Storage/OptionsTest.php
+++ b/tests/phpunit/integration/Core/Storage/OptionsTest.php
@@ -25,6 +25,7 @@ class OptionsTest extends TestCase {
 		// Ensure default is a truthy value.
 		add_filter( 'default_option_test_option', '__return_true' );
 		delete_option( 'test_option' );
+		$this->assertTrue( get_option( 'test_option' ) );
 		$this->assertFalse( $options->has( 'test_option' ) );
 
 		// Ensure default is a truthy value.

--- a/tests/phpunit/integration/Core/Storage/SettingTest.php
+++ b/tests/phpunit/integration/Core/Storage/SettingTest.php
@@ -29,6 +29,16 @@ class SettingTest extends TestCase {
 		$this->context = new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE );
 	}
 
+	public function test_has() {
+		$setting = new FakeSetting( new Options( $this->context ) );
+		delete_option( FakeSetting::OPTION );
+
+		$this->assertFalse( $setting->has() );
+		update_option( FakeSetting::OPTION, 'test-value' );
+
+		$this->assertTrue( $setting->has() );
+	}
+
 	public function test_get() {
 		$setting = new FakeSetting( new Options( $this->context ) );
 		delete_option( FakeSetting::OPTION );
@@ -50,7 +60,7 @@ class SettingTest extends TestCase {
 						'default' => 'test-default-value',
 					)
 				);
-			} 
+			}
 		);
 		delete_option( FakeSetting::OPTION );
 		$this->assertFalse( $setting->get() );


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #998

## Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
