### PR TITLE
Move REST routes into separate classes

### DIFF
--- a/includes/Core/Authentication/Authentication.php
+++ b/includes/Core/Authentication/Authentication.php
@@ -651,7 +651,8 @@ final class Authentication {
 					array(
 						'methods'             => WP_REST_Server::EDITABLE,
 						'callback'            => function( WP_REST_Request $request ) {
-							return new WP_REST_Response( $this->disconnect() );
+							$this->disconnect();
+							return new WP_REST_Response( true );
 						},
 						'permission_callback' => $can_authenticate,
 					),

--- a/includes/Core/Authentication/Authentication.php
+++ b/includes/Core/Authentication/Authentication.php
@@ -13,11 +13,15 @@ namespace Google\Site_Kit\Core\Authentication;
 use Google\Site_Kit\Context;
 use Google\Site_Kit\Core\Authentication\Clients\OAuth_Client;
 use Google\Site_Kit\Core\Permissions\Permissions;
+use Google\Site_Kit\Core\REST_API\REST_Route;
 use Google\Site_Kit\Core\Storage\Encrypted_Options;
 use Google\Site_Kit\Core\Storage\Options;
 use Google\Site_Kit\Core\Storage\User_Options;
 use Google\Site_Kit\Core\Storage\Transients;
 use Google\Site_Kit\Core\Admin\Notice;
+use WP_REST_Server;
+use WP_REST_Request;
+use WP_REST_Response;
 use Exception;
 
 /**
@@ -181,6 +185,13 @@ final class Authentication {
 			'init',
 			function() {
 				$this->handle_oauth();
+			}
+		);
+
+		add_filter(
+			'googlesitekit_rest_routes',
+			function( $routes ) {
+				return array_merge( $routes, $this->get_rest_routes() );
 			}
 		);
 
@@ -598,6 +609,55 @@ final class Authentication {
 		$hosts[] = wp_parse_url( $this->google_proxy->url(), PHP_URL_HOST );
 
 		return $hosts;
+	}
+
+	/**
+	 * Gets related REST routes.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @return array List of REST_Route objects.
+	 */
+	private function get_rest_routes() {
+		$can_authenticate = function() {
+			return current_user_can( Permissions::AUTHENTICATE );
+		};
+
+		return array(
+			new REST_Route(
+				'core/user/data/authentication',
+				array(
+					array(
+						'methods'             => WP_REST_Server::READABLE,
+						'callback'            => function( WP_REST_Request $request ) {
+							$oauth_client = $this->get_oauth_client();
+							$access_token = $oauth_client->get_access_token();
+
+							$data = array(
+								'isAuthenticated' => ! empty( $access_token ),
+								'requiredScopes'  => $oauth_client->get_required_scopes(),
+								'grantedScopes'   => ! empty( $access_token ) ? $oauth_client->get_granted_scopes() : array(),
+							);
+
+							return new WP_REST_Response( $data );
+						},
+						'permission_callback' => $can_authenticate,
+					),
+				)
+			),
+			new REST_Route(
+				'core/user/data/disconnect',
+				array(
+					array(
+						'methods'             => WP_REST_Server::EDITABLE,
+						'callback'            => function( WP_REST_Request $request ) {
+							return new WP_REST_Response( $this->disconnect() );
+						},
+						'permission_callback' => $can_authenticate,
+					),
+				)
+			),
+		);
 	}
 
 	/**

--- a/includes/Core/REST_API/REST_Routes.php
+++ b/includes/Core/REST_API/REST_Routes.php
@@ -153,21 +153,6 @@ final class REST_Routes {
 
 		$routes = array(
 			new REST_Route(
-				'core/site/data/setup-tag',
-				array(
-					array(
-						'methods'             => WP_REST_Server::EDITABLE,
-						'callback'            => function( WP_REST_Request $request ) {
-							$token = wp_generate_uuid4();
-							set_transient( 'googlesitekit_setup_token', $token, 5 * MINUTE_IN_SECONDS );
-
-							return new WP_REST_Response( array( 'token' => $token ) );
-						},
-						'permission_callback' => $can_setup,
-					),
-				)
-			),
-			new REST_Route(
 				'core/site/data/developer-plugin',
 				array(
 					array(

--- a/includes/Core/REST_API/REST_Routes.php
+++ b/includes/Core/REST_API/REST_Routes.php
@@ -138,24 +138,6 @@ final class REST_Routes {
 	 * @return array List of REST_Route instances.
 	 */
 	private function get_routes() {
-		$can_authenticate = function() {
-			return current_user_can( Permissions::AUTHENTICATE );
-		};
-
-		$can_view_insights_cron = function() {
-			// If an internal cron request, simply grant access.
-			if ( defined( 'DOING_CRON' ) && DOING_CRON ) {
-				return true;
-			}
-
-			// This accounts for routes that need to be called before user has completed setup flow.
-			if ( current_user_can( Permissions::SETUP ) ) {
-				return true;
-			}
-
-			return current_user_can( Permissions::VIEW_POSTS_INSIGHTS );
-		};
-
 		$can_view_insights = function() {
 			// This accounts for routes that need to be called before user has completed setup flow.
 			if ( current_user_can( Permissions::SETUP ) ) {
@@ -165,35 +147,11 @@ final class REST_Routes {
 			return current_user_can( Permissions::VIEW_POSTS_INSIGHTS );
 		};
 
-		$can_manage_options = function() {
-			// This accounts for routes that need to be called before user has completed setup flow.
-			if ( current_user_can( Permissions::SETUP ) ) {
-				return true;
-			}
-
-			return current_user_can( Permissions::MANAGE_OPTIONS );
-		};
-
 		$can_setup = function() {
 			return current_user_can( Permissions::SETUP );
 		};
 
 		$routes = array(
-			// This route is forward-compatible with a potential 'core/(?P<slug>[a-z\-]+)/data/(?P<datapoint>[a-z\-]+)'.
-			new REST_Route(
-				'core/site/data/reset',
-				array(
-					array(
-						'methods'             => WP_REST_Server::EDITABLE,
-						'callback'            => function( WP_REST_Request $request ) {
-							$reset = new Reset( $this->context );
-							$reset->all();
-							return new WP_REST_Response( true );
-						},
-						'permission_callback' => $can_setup,
-					),
-				)
-			),
 			new REST_Route(
 				'core/site/data/setup-tag',
 				array(
@@ -253,197 +211,6 @@ final class REST_Routes {
 					),
 				)
 			),
-			// This route is forward-compatible with a potential 'core/(?P<slug>[a-z\-]+)/data/(?P<datapoint>[a-z\-]+)'.
-			new REST_Route(
-				'core/user/data/authentication',
-				array(
-					array(
-						'methods'             => WP_REST_Server::READABLE,
-						'callback'            => function( WP_REST_Request $request ) {
-							$oauth_client = $this->authentication->get_oauth_client();
-							$access_token = $oauth_client->get_access_token();
-
-							$data = array(
-								'isAuthenticated' => ! empty( $access_token ),
-								'requiredScopes'  => $oauth_client->get_required_scopes(),
-								'grantedScopes'   => ! empty( $access_token ) ? $oauth_client->get_granted_scopes() : array(),
-							);
-
-							return new WP_REST_Response( $data );
-						},
-						'permission_callback' => $can_authenticate,
-					),
-				)
-			),
-			// This route is forward-compatible with a potential 'core/(?P<slug>[a-z\-]+)/data/(?P<datapoint>[a-z\-]+)'.
-			new REST_Route(
-				'core/user/data/disconnect',
-				array(
-					array(
-						'methods'             => WP_REST_Server::EDITABLE,
-						'callback'            => function( WP_REST_Request $request ) {
-							return new WP_REST_Response( $this->authentication->disconnect() );
-						},
-						'permission_callback' => $can_authenticate,
-					),
-				)
-			),
-			new REST_Route(
-				'modules',
-				array(
-					array(
-						'methods'             => WP_REST_Server::READABLE,
-						'callback'            => function( WP_REST_Request $request ) {
-							$modules = array_map(
-								array( $this, 'prepare_module_data_for_response' ),
-								$this->modules->get_available_modules()
-							);
-							return new WP_REST_Response( array_values( $modules ) );
-						},
-						'permission_callback' => $can_authenticate,
-					),
-				),
-				array(
-					'schema' => $this->get_module_schema(),
-				)
-			),
-			new REST_Route(
-				'modules/(?P<slug>[a-z\-]+)',
-				array(
-					array(
-						'methods'             => WP_REST_Server::READABLE,
-						'callback'            => function( WP_REST_Request $request ) {
-							$slug = $request['slug'];
-							try {
-								$module = $this->modules->get_module( $slug );
-							} catch ( \Exception $e ) {
-								return new WP_Error( 'invalid_module_slug', __( 'Invalid module slug.', 'google-site-kit' ), array( 'status' => 404 ) );
-							}
-							return new WP_REST_Response( $this->prepare_module_data_for_response( $module ) );
-						},
-						'permission_callback' => $can_authenticate,
-					),
-					array(
-						'methods'             => WP_REST_Server::EDITABLE,
-						'callback'            => function( WP_REST_Request $request ) {
-							$slug = $request['slug'];
-							$modules = $this->modules->get_available_modules();
-							if ( ! isset( $modules[ $slug ] ) ) {
-								return new WP_Error( 'invalid_module_slug', __( 'Invalid module slug.', 'google-site-kit' ), array( 'status' => 404 ) );
-							}
-							if ( $request['active'] ) {
-								// Prevent activation if one of the dependencies is not active.
-								$dependency_slugs = $this->modules->get_module_dependencies( $slug );
-								foreach ( $dependency_slugs as $dependency_slug ) {
-									if ( ! $this->modules->is_module_active( $dependency_slug ) ) {
-										/* translators: %s: module name */
-										return new WP_Error( 'inactive_dependencies', sprintf( __( 'Module cannot be activated because of inactive dependency %s.', 'google-site-kit' ), $modules[ $dependency_slug ]->name ), array( 'status' => 500 ) );
-									}
-								}
-								if ( ! $this->modules->activate_module( $slug ) ) {
-									return new WP_Error( 'cannot_activate_module', __( 'An internal error occurred while trying to activate the module.', 'google-site-kit' ), array( 'status' => 500 ) );
-								}
-							} else {
-								// Automatically deactivate dependants.
-								$dependant_slugs = $this->modules->get_module_dependants( $slug );
-								foreach ( $dependant_slugs as $dependant_slug ) {
-									if ( $this->modules->is_module_active( $dependant_slug ) ) {
-										if ( ! $this->modules->deactivate_module( $dependant_slug ) ) {
-											/* translators: %s: module name */
-											return new WP_Error( 'cannot_deactivate_dependant', sprintf( __( 'Module cannot be deactivated because deactivation of dependant %s failed.', 'google-site-kit' ), $modules[ $dependant_slug ]->name ), array( 'status' => 500 ) );
-										}
-									}
-								}
-								if ( ! $this->modules->deactivate_module( $slug ) ) {
-									return new WP_Error( 'cannot_deactivate_module', __( 'An internal error occurred while trying to deactivate the module.', 'google-site-kit' ), array( 'status' => 500 ) );
-								}
-							}
-							return new WP_REST_Response( $this->prepare_module_data_for_response( $modules[ $slug ] ) );
-						},
-						'permission_callback' => $can_manage_options,
-						'args'                => array(
-							'active' => array(
-								'type'        => 'boolean',
-								'description' => __( 'Whether to activate or deactivate the module.', 'google-site-kit' ),
-								'required'    => true,
-							),
-						),
-					),
-				),
-				array(
-					'args'   => array(
-						'slug' => array(
-							'type'              => 'string',
-							'description'       => __( 'Identifier for the module.', 'google-site-kit' ),
-							'sanitize_callback' => 'sanitize_key',
-						),
-					),
-					'schema' => $this->get_module_schema(),
-				)
-			),
-			new REST_Route(
-				'modules/(?P<slug>[a-z\-]+)/data/(?P<datapoint>[a-z\-]+)',
-				array(
-					array(
-						'methods'             => WP_REST_Server::READABLE,
-						'callback'            => function( WP_REST_Request $request ) {
-							$slug = $request['slug'];
-							try {
-								$module = $this->modules->get_module( $slug );
-							} catch ( \Exception $e ) {
-								return new WP_Error( 'invalid_module_slug', __( 'Invalid module slug.', 'google-site-kit' ), array( 'status' => 404 ) );
-							}
-							$data = $module->get_data( $request['datapoint'], $request->get_params() );
-							if ( is_wp_error( $data ) ) {
-								return $data;
-							}
-							return new WP_REST_Response( $data );
-						},
-						'permission_callback' => $can_view_insights_cron,
-					),
-					array(
-						'methods'             => WP_REST_Server::EDITABLE,
-						'callback'            => function( WP_REST_Request $request ) {
-							$slug = $request['slug'];
-							try {
-								$module = $this->modules->get_module( $slug );
-							} catch ( \Exception $e ) {
-								return new WP_Error( 'invalid_module_slug', __( 'Invalid module slug.', 'google-site-kit' ), array( 'status' => 404 ) );
-							}
-							$data = isset( $request['data'] ) ? (array) $request['data'] : array();
-							$data = $module->set_data( $request['datapoint'], $data );
-							if ( is_wp_error( $data ) ) {
-								return $data;
-							}
-							return new WP_REST_Response( $data );
-						},
-						'permission_callback' => $can_manage_options,
-						'args'                => array(
-							'data' => array(
-								'type'              => 'object',
-								'description'       => __( 'Data to set.', 'google-site-kit' ),
-								'validate_callback' => function( $value ) {
-									return is_array( $value );
-								},
-							),
-						),
-					),
-				),
-				array(
-					'args' => array(
-						'slug'      => array(
-							'type'              => 'string',
-							'description'       => __( 'Identifier for the module.', 'google-site-kit' ),
-							'sanitize_callback' => 'sanitize_key',
-						),
-						'datapoint' => array(
-							'type'              => 'string',
-							'description'       => __( 'Module data point to address.', 'google-site-kit' ),
-							'sanitize_callback' => 'sanitize_key',
-						),
-					),
-				)
-			),
 			// TODO: This route is super-complex to use and needs to be simplified.
 			new REST_Route(
 				'data',
@@ -492,7 +259,7 @@ final class REST_Routes {
 
 							return new WP_REST_Response( $responses );
 						},
-						'permission_callback' => $can_view_insights_cron,
+						'permission_callback' => $can_view_insights,
 						'args'                => array(
 							'request' => array(
 								'type'        => 'array',
@@ -502,43 +269,6 @@ final class REST_Routes {
 									'type' => 'object',
 								),
 							),
-						),
-					),
-				)
-			),
-			new REST_Route(
-				'modules/(?P<slug>[a-z\-]+)/notifications',
-				array(
-					array(
-						'methods'             => WP_REST_Server::READABLE,
-						'callback'            => function( WP_REST_Request $request ) {
-							$slug = $request['slug'];
-							$modules = $this->modules->get_available_modules();
-							if ( ! isset( $modules[ $slug ] ) ) {
-								return new WP_Error( 'invalid_module_slug', __( 'Invalid module slug.', 'google-site-kit' ), array( 'status' => 404 ) );
-							}
-							$notifications = array();
-							if ( $this->modules->is_module_active( $slug ) ) {
-								$notifications = $modules[ $slug ]->get_data( 'notifications' );
-								if ( is_wp_error( $notifications ) ) {
-									// Don't consider it an error if the module does not have a 'notifications' datapoint.
-									if ( 'invalid_datapoint' !== $notifications->get_error_code() ) {
-										return $notifications;
-									}
-									$notifications = array();
-								}
-							}
-							return new WP_REST_Response( $notifications );
-						},
-						'permission_callback' => $can_authenticate,
-					),
-				),
-				array(
-					'args' => array(
-						'slug' => array(
-							'type'              => 'string',
-							'description'       => __( 'Identifier for the module.', 'google-site-kit' ),
-							'sanitize_callback' => 'sanitize_key',
 						),
 					),
 				)
@@ -603,99 +333,14 @@ final class REST_Routes {
 			),
 		);
 
-		return $routes;
-	}
-
-	/**
-	 * Prepares module data for a REST response according to the schema.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @param Module $module Module instance.
-	 * @return array Module REST response data.
-	 */
-	private function prepare_module_data_for_response( Module $module ) {
-		$manager = $this->modules;
-
-		return array(
-			'slug'         => $module->slug,
-			'name'         => $module->name,
-			'description'  => $module->description,
-			'homepage'     => $module->homepage,
-			'internal'     => $module->internal,
-			'active'       => $manager->is_module_active( $module->slug ),
-			'connected'    => $manager->is_module_connected( $module->slug ),
-			'dependencies' => $manager->get_module_dependencies( $module->slug ),
-			'dependants'   => $manager->get_module_dependants( $module->slug ),
-		);
-	}
-
-	/**
-	 * Gets the REST schema for a module.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @return array Module REST schema.
-	 */
-	private function get_module_schema() {
-		return array(
-			'$schema'    => 'http://json-schema.org/draft-04/schema#',
-			'title'      => 'module',
-			'type'       => 'object',
-			'properties' => array(
-				'slug'         => array(
-					'type'        => 'string',
-					'description' => __( 'Identifier for the module.', 'google-site-kit' ),
-					'readonly'    => true,
-				),
-				'name'         => array(
-					'type'        => 'string',
-					'description' => __( 'Name of the module.', 'google-site-kit' ),
-					'readonly'    => true,
-				),
-				'description'  => array(
-					'type'        => 'string',
-					'description' => __( 'Description of the module.', 'google-site-kit' ),
-					'readonly'    => true,
-				),
-				'homepage'     => array(
-					'type'        => 'string',
-					'description' => __( 'The module homepage.', 'google-site-kit' ),
-					'format'      => 'uri',
-					'readonly'    => true,
-				),
-				'internal'     => array(
-					'type'        => 'boolean',
-					'description' => __( 'Whether the module is internal, thus without any UI.', 'google-site-kit' ),
-					'readonly'    => true,
-				),
-				'active'       => array(
-					'type'        => 'boolean',
-					'description' => __( 'Whether the module is active.', 'google-site-kit' ),
-				),
-				'connected'    => array(
-					'type'        => 'boolean',
-					'description' => __( 'Whether the module setup has been completed.', 'google-site-kit' ),
-					'readonly'    => true,
-				),
-				'dependencies' => array(
-					'type'        => 'array',
-					'description' => __( 'List of slugs of other modules that the module depends on.', 'google-site-kit' ),
-					'items'       => array(
-						'type' => 'string',
-					),
-					'readonly'    => true,
-				),
-				'dependants'   => array(
-					'type'        => 'array',
-					'description' => __( 'List of slugs of other modules depending on the module.', 'google-site-kit' ),
-					'items'       => array(
-						'type' => 'string',
-					),
-					'readonly'    => true,
-				),
-			),
-		);
+		/**
+		 * Filters the list of available REST routes.
+		 *
+		 * @since n.e.x.t
+		 *
+		 * @param array $routes List of REST_Route objects.
+		 */
+		return apply_filters( 'googlesitekit_rest_routes', $routes );
 	}
 
 	/**

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -151,6 +151,7 @@ final class Plugin {
 
 		( new Core\Util\Activation( $this->context, $options, $assets ) )->register();
 		( new Core\Util\Migration_n_e_x_t( $this->context, $options ) )->register();
+		( new Core\Util\Reset( $this->context ) )->register();
 
 		if ( ! defined( 'GOOGLESITEKITDEVSETTINGS_VERSION' ) ) {
 			( new Core\Util\Developer_Plugin_Installer() )->register();

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -179,10 +179,7 @@ final class Plugin {
 		( new Core\Util\Activation( $this->context, $options, $assets ) )->register();
 		( new Core\Util\Migration_n_e_x_t( $this->context, $options ) )->register();
 		( new Core\Util\Reset( $this->context ) )->register();
-
-		if ( ! defined( 'GOOGLESITEKITDEVSETTINGS_VERSION' ) ) {
-			( new Core\Util\Developer_Plugin_Installer() )->register();
-		}
+		( new Core\Util\Developer_Plugin_Installer( $this->context ) )->register();
 	}
 
 	/**

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -87,6 +87,33 @@ final class Plugin {
 			return;
 		}
 
+		// REST route to set up a temporary tag to verify meta tag output works reliably.
+		add_filter(
+			'googlesitekit_rest_routes',
+			function( $routes ) {
+				$can_setup = function() {
+					return current_user_can( Core\Permissions\Permissions::SETUP );
+				};
+				$routes[]  = new Core\REST_API\REST_Route(
+					'core/site/data/setup-tag',
+					array(
+						array(
+							'methods'             => \WP_REST_Server::EDITABLE,
+							'callback'            => function( \WP_REST_Request $request ) {
+								$token = wp_generate_uuid4();
+								set_transient( 'googlesitekit_setup_token', $token, 5 * MINUTE_IN_SECONDS );
+
+								return new \WP_REST_Response( array( 'token' => $token ) );
+							},
+							'permission_callback' => $can_setup,
+						),
+					)
+				);
+				return $routes;
+			}
+		);
+
+		// Output temporary tag if set.
 		add_action(
 			'wp_head',
 			function () {

--- a/tests/phpunit/integration/Core/REST_API/REST_RoutesTest.php
+++ b/tests/phpunit/integration/Core/REST_API/REST_RoutesTest.php
@@ -37,6 +37,7 @@ class REST_RoutesTest extends TestCase {
 		// Assert that routes with the site-kit namespace were registered.
 		$this->assertEquals( array( REST_Routes::REST_ROOT ), $server->get_namespaces() );
 
+		// While most of these routes are added via filter, they should all be in this list.
 		$routes = array(
 			'/',
 			'/' . REST_Routes::REST_ROOT,


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #166 

## Relevant technical choices

* In addition to the routes from the issue ACs, two new routes were added in the meantime:
    * `core/site/data/setup-tag` is now in `Plugin` main class because that is where the setup tag is rendered
    * `core/site/data/developer-plugin` is now in `Core\Util\Developer_Plugin_Installer` because that is where the other developer plugin-related logic happens

## Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
