### PR TITLE
Fix bounce rate arrow color

### DIFF
--- a/assets/js/components/change-arrow.js
+++ b/assets/js/components/change-arrow.js
@@ -1,0 +1,40 @@
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+
+function ChangeArrow( { direction, invertColor } ) {
+	return (
+		<svg
+			className={
+				`
+				googlesitekit-change-arrow
+				googlesitekit-change-arrow--${ direction }
+				${ invertColor ? 'googlesitekit-change-arrow--inverted-color' : '' }
+				`
+			}
+			width="9"
+			height="9"
+			viewBox="0 0 10 10"
+			fill="none"
+			xmlns="http://www.w3.org/2000/svg"
+		>
+			<path
+				d="M5.625 10L5.625 2.375L9.125 5.875L10 5L5 -1.76555e-07L-2.7055e-07 5L0.875 5.875L4.375 2.375L4.375 10L5.625 10Z"
+				fill="currentColor"
+			/>
+		</svg>
+	);
+}
+
+ChangeArrow.propTypes = {
+	direction: PropTypes.string,
+	invertColor: PropTypes.bool,
+};
+
+ChangeArrow.defaultProps = {
+	direction: 'up',
+	invertColor: false,
+};
+
+export default ChangeArrow;

--- a/assets/js/components/data-block.js
+++ b/assets/js/components/data-block.js
@@ -21,12 +21,16 @@
  */
 import PropTypes from 'prop-types';
 import SourceLink from 'GoogleComponents/source-link';
-import SvgIcon from 'GoogleUtil/svg-icon';
 
 /**
  * WordPress dependencies
  */
 import { Component, Fragment } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import ChangeArrow from './change-arrow';
 
 class DataBlock extends Component {
 	constructor( props ) {
@@ -63,11 +67,10 @@ class DataBlock extends Component {
 			handleStatSelection,
 			source,
 			sparkline,
-			reverseArrowDirection,
+			invertChangeColor,
 		} = this.props;
 
 		const role = ( 'button' === context ) ? 'button' : '';
-		const changeType = 0 <= change ? '-positive' : '-negative';
 
 		return (
 			<div
@@ -101,15 +104,19 @@ class DataBlock extends Component {
 					</div>
 				}
 				<div className="googlesitekit-data-block__change-source-wrapper">
-					<div className={ `
-						googlesitekit-data-block__change
-						googlesitekit-data-block__change--${ 0 <= change ? 'positive' : 'negative' }
-					` }>
+					<div className="googlesitekit-data-block__change">
 						{ '' === change && <Fragment>&nbsp;</Fragment> }
-						{ change && [
-							<span key="arrow" className={ `googlesitekit-data-block__arrow ${ reverseArrowDirection ? 'googlesitekit-data-block__arrow--reverse' : '' }` }><SvgIcon id={ `arrow${ changeType }` } height="9" width="9" /></span>,
-							<span key="values" className="googlesitekit-data-block__value">{ `${ Math.abs( change ) }${ changeDataUnit } ${ period }` }</span>,
-						] }
+						{ change && <Fragment>
+							<div className="googlesitekit-data-block__arrow">
+								<ChangeArrow
+									direction={ change ? 'up' : 'down' }
+									invertColor={ invertChangeColor }
+								/>
+							</div>
+							<span key="values" className="googlesitekit-data-block__value">
+								{ `${ Math.abs( change ) }${ changeDataUnit } ${ period }` }
+							</span>
+						</Fragment> }
 					</div>
 					{ source && (
 						<SourceLink
@@ -143,7 +150,7 @@ DataBlock.propTypes = {
 	period: PropTypes.string,
 	selected: PropTypes.bool,
 	handleStatSelection: PropTypes.func,
-	reverseArrowDirection: PropTypes.bool,
+	invertChangeColor: PropTypes.bool,
 };
 
 DataBlock.defaultProps = {
@@ -159,7 +166,7 @@ DataBlock.defaultProps = {
 	period: '',
 	selected: false,
 	handleStatSelection: null,
-	reverseArrowDirection: false,
+	invertChangeColor: false,
 };
 
 export default DataBlock;

--- a/assets/js/components/data-block.js
+++ b/assets/js/components/data-block.js
@@ -107,13 +107,13 @@ class DataBlock extends Component {
 					<div className="googlesitekit-data-block__change">
 						{ '' === change && <Fragment>&nbsp;</Fragment> }
 						{ change && <Fragment>
-							<div className="googlesitekit-data-block__arrow">
+							<span className="googlesitekit-data-block__arrow">
 								<ChangeArrow
 									direction={ change ? 'up' : 'down' }
 									invertColor={ invertChangeColor }
 								/>
-							</div>
-							<span key="values" className="googlesitekit-data-block__value">
+							</span>
+							<span className="googlesitekit-data-block__value">
 								{ `${ Math.abs( change ) }${ changeDataUnit } ${ period }` }
 							</span>
 						</Fragment> }

--- a/assets/js/modules/analytics/dashboard/dashboard-widget-overview.js
+++ b/assets/js/modules/analytics/dashboard/dashboard-widget-overview.js
@@ -101,7 +101,7 @@ class AnalyticsDashboardWidgetOverview extends Component {
 				selected: selectedStats.includes( 2 ),
 				handleStatSelection,
 				datapointUnit: '%',
-				reverseArrowDirection: true,
+				invertChangeColor: true,
 			},
 			{
 				className: 'googlesitekit-data-block--duration googlesitekit-data-block--button-4',
@@ -141,7 +141,7 @@ class AnalyticsDashboardWidgetOverview extends Component {
 									selected={ block.selected }
 									handleStatSelection={ block.handleStatSelection }
 									datapointUnit={ block.datapointUnit }
-									reverseArrowDirection={ block.reverseArrowDirection }
+									invertChangeColor={ block.invertChangeColor }
 								/>
 							</div>
 						);

--- a/assets/js/modules/analytics/dashboard/dashboard-widget-top-level.js
+++ b/assets/js/modules/analytics/dashboard/dashboard-widget-top-level.js
@@ -161,7 +161,7 @@ class AnalyticsDashboardWidgetTopLevel extends Component {
 								datapointUnit={ __( '%', 'google-site-kit' ) }
 								change={ averageBounceRateChange }
 								changeDataUnit="%"
-								reverseArrowDirection
+								invertChangeColor
 								source={ {
 									name: _x( 'Analytics', 'Service name', 'google-site-kit' ),
 									link: href,

--- a/assets/sass/admin.scss
+++ b/assets/sass/admin.scss
@@ -75,6 +75,7 @@
 // Global
 @import "components/global/googlesitekit-accordion";
 @import "components/global/googlesitekit-autocomplete";
+@import "components/global/googlesitekit-change-arrow";
 @import "components/global/googlesitekit-chart";
 @import "components/global/googlesitekit-chart-loading";
 @import "components/global/googlesitekit-cta";

--- a/assets/sass/adminbar.scss
+++ b/assets/sass/adminbar.scss
@@ -44,6 +44,7 @@
 @import "components/adminbar/googlesitekit-wp-adminbar";
 
 // Global
+@import "components/global/googlesitekit-change-arrow";
 @import "components/global/googlesitekit-cta";
 @import "components/global/googlesitekit-cta-link";
 @import "components/global/googlesitekit-data-block";

--- a/assets/sass/components/global/_googlesitekit-change-arrow.scss
+++ b/assets/sass/components/global/_googlesitekit-change-arrow.scss
@@ -1,0 +1,39 @@
+/**
+ * Change Arrow styles.
+ *
+ * Site Kit by Google, Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+.googlesitekit-change-arrow {
+	--color-up: #{$c-chateau-green};
+	--color-down: #{$c-thunderbird};
+
+	&--inverted-color {
+		--color-up: #{$c-thunderbird};
+		--color-down: #{$c-chateau-green};
+	}
+
+	&--up {
+		color: var(--color-up);
+	}
+
+	&--down {
+		color: var(--color-up);
+		transform: rotate(180deg);
+
+		path {
+			fill: var(--color-down);
+		}
+	}
+}

--- a/assets/sass/wpdashboard.scss
+++ b/assets/sass/wpdashboard.scss
@@ -32,6 +32,7 @@
  */
 
 // Global
+@import "components/global/googlesitekit-change-arrow";
 @import "components/global/googlesitekit-cta";
 @import "components/global/googlesitekit-cta-link";
 @import "components/global/googlesitekit-data-block";


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #481 

## Relevant technical choices

* Colors used in the svg did not match any defined in the scss variables, so I used existing green and red colors from the current pallet
* Styles use CSS custom properties for simplicity, although I'm not sure if these fit within minimum browser requirements (would be good to add this to the wiki)
    - Edit: mdc layout grid [uses custom properties](https://user-images.githubusercontent.com/1621608/73665182-594f2d80-46a9-11ea-84a1-890a569b0f57.png) so it must be!


![Screen Recording 2020-02-03 at 2 46 27 PM](https://user-images.githubusercontent.com/1621608/73654593-cdcba180-4694-11ea-82db-daa9e93e04ff.gif)

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
