### PR TITLE
Fix global google library loading

### DIFF
--- a/assets/js/components/google-chart.js
+++ b/assets/js/components/google-chart.js
@@ -30,6 +30,11 @@ import { Component, createRef } from '@wordpress/element';
 import { doAction, addAction } from '@wordpress/hooks';
 import { debounce } from 'lodash';
 
+/**
+ * Flag for tracking loaded state of Google Charts library.
+ */
+let googleChartsLoaded = global.google && global.google.charts;
+
 class GoogleChart extends Component {
 	constructor( props ) {
 		super( props );
@@ -47,8 +52,8 @@ class GoogleChart extends Component {
 		this.chartRef = createRef();
 
 		// Inject the script if not already loaded.
-		if ( ! global.google && ! global.googleChartLoaded ) {
-			global.googleChartLoaded = true;
+		if ( ! googleChartsLoaded ) {
+			googleChartsLoaded = true;
 			const script = document.createElement( 'script' );
 			script.type = 'text/javascript';
 			script.onload = () => {

--- a/assets/js/components/google-chart.js
+++ b/assets/js/components/google-chart.js
@@ -44,6 +44,7 @@ class GoogleChart extends Component {
 			chart: null,
 		};
 
+		this.onChartsLoad = this.onChartsLoad.bind( this );
 		this.waitForChart = this.waitForChart.bind( this );
 		this.getData = this.getData.bind( this );
 		this.prepareChart = this.prepareChart.bind( this );
@@ -65,12 +66,7 @@ class GoogleChart extends Component {
 					packages: [ 'corechart' ],
 				} );
 
-				global.google.charts.setOnLoadCallback( () => {
-					this.getData();
-					this.prepareChart();
-					this.drawChart();
-					this.setState( { loading: false } );
-				} );
+				global.google.charts.setOnLoadCallback( this.onChartsLoad );
 
 				doAction( 'googlesitekit.ChartLoaderLoaded' );
 			};
@@ -83,20 +79,19 @@ class GoogleChart extends Component {
 		} else if ( ! global.google || ! global.google.charts ) {
 			// When the google chart object not loaded, load draw chart later.
 			addAction( 'googlesitekit.ChartLoaderLoaded', 'googlesitekit.HandleChartLoaderLoaded', () => {
-				global.google.charts.setOnLoadCallback( () => {
-					this.getData();
-					this.prepareChart();
-					this.drawChart();
-				} );
+				global.google.charts.setOnLoadCallback( this.onChartsLoad );
 			} );
 		} else {
 			// When the google chart object loaded, draw chart now.
-			global.google.charts.setOnLoadCallback( () => {
-				this.getData();
-				this.prepareChart();
-				this.drawChart();
-			} );
+			global.google.charts.setOnLoadCallback( this.onChartsLoad );
 		}
+	}
+
+	onChartsLoad() {
+		this.getData();
+		this.prepareChart();
+		this.drawChart();
+		this.setState( { loading: false } );
 	}
 
 	componentDidMount() {


### PR DESCRIPTION
## Summary

Addresses issue #939

## Relevant technical choices
* Refactors on load handler to use a single method to remove unnecessary duplication

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
