### PR TITLE
Made asset handle names consistent

### DIFF
--- a/google-site-kit.php
+++ b/google-site-kit.php
@@ -51,7 +51,7 @@ function googlesitekit_activate_plugin( $network_wide ) {
 		return;
 	}
 
-	do_action( 'googlesitekit_activation', $network_wide );
+	do_action( 'googlesitekit-activation', $network_wide );
 }
 
 register_activation_hook( __FILE__, 'googlesitekit_activate_plugin' );

--- a/includes/Core/Admin/Dashboard.php
+++ b/includes/Core/Admin/Dashboard.php
@@ -75,11 +75,11 @@ final class Dashboard {
 				$this->assets->enqueue_fonts();
 
 				// Enqueue styles.
-				$this->assets->enqueue_asset( 'googlesitekit_wp_dashboard_css' );
+				$this->assets->enqueue_asset( 'googlesitekit-wp-dashboard-css' );
 
 				// Enqueue scripts.
-				$this->assets->enqueue_asset( 'googlesitekit_wp_dashboard' );
-				$this->assets->enqueue_asset( 'googlesitekit_modules' );
+				$this->assets->enqueue_asset( 'googlesitekit-wp-dashboard' );
+				$this->assets->enqueue_asset( 'googlesitekit-modules' );
 			}
 		};
 

--- a/includes/Core/Admin/Screen.php
+++ b/includes/Core/Admin/Screen.php
@@ -179,11 +179,11 @@ final class Screen {
 		$assets->enqueue_fonts();
 
 		// Enqueue base admin screen stylesheet.
-		$assets->enqueue_asset( 'googlesitekit_admin_css' );
+		$assets->enqueue_asset( 'googlesitekit-admin-css' );
 
 		// Helps detection of enabled ad blockers to warn users before activating or setup AdSense module.
 		if ( $this->is_ad_blocker_detection_required() ) {
-			$assets->enqueue_asset( 'googlesitekit_ads_detect' );
+			$assets->enqueue_asset( 'googlesitekit-ads-detect' );
 		}
 
 		if ( $this->args['enqueue_callback'] ) {
@@ -191,7 +191,7 @@ final class Screen {
 		}
 
 		// Enqueue module hooks.
-		$assets->enqueue_asset( 'googlesitekit_modules' );
+		$assets->enqueue_asset( 'googlesitekit-modules' );
 	}
 
 	/**

--- a/includes/Core/Admin/Screens.php
+++ b/includes/Core/Admin/Screens.php
@@ -217,9 +217,9 @@ final class Screens {
 					'capability'       => Permissions::VIEW_DASHBOARD,
 					'enqueue_callback' => function( Assets $assets ) {
 						if ( $this->context->input()->filter( INPUT_GET, 'permaLink' ) ) {
-							$assets->enqueue_asset( 'googlesitekit_dashboard_details' );
+							$assets->enqueue_asset( 'googlesitekit-dashboard-details' );
 						} else {
-							$assets->enqueue_asset( 'googlesitekit_dashboard' );
+							$assets->enqueue_asset( 'googlesitekit-dashboard' );
 						}
 					},
 					'render_callback'  => function( Context $context ) {
@@ -277,7 +277,7 @@ final class Screens {
 				'title'            => __( 'Settings', 'google-site-kit' ),
 				'capability'       => Permissions::MANAGE_OPTIONS,
 				'enqueue_callback' => function( Assets $assets ) {
-					$assets->enqueue_asset( 'googlesitekit_settings' );
+					$assets->enqueue_asset( 'googlesitekit-settings' );
 				},
 				'render_callback'  => function( Context $context ) {
 					?>
@@ -344,7 +344,7 @@ final class Screens {
 					exit;
 				},
 				'enqueue_callback'    => function( Assets $assets ) {
-					$assets->enqueue_asset( 'googlesitekit_dashboard_splash' );
+					$assets->enqueue_asset( 'googlesitekit-dashboard-splash' );
 				},
 				'render_callback'     => function( Context $context ) {
 					?>

--- a/includes/Core/Admin_Bar/Admin_Bar.php
+++ b/includes/Core/Admin_Bar/Admin_Bar.php
@@ -79,7 +79,7 @@ final class Admin_Bar {
 			$this->assets->enqueue_fonts();
 
 			// Enqueue styles.
-			$this->assets->enqueue_asset( 'googlesitekit_adminbar_css' );
+			$this->assets->enqueue_asset( 'googlesitekit-adminbar-css' );
 
 			if ( $this->context->is_amp() ) {
 				if ( ! $this->is_amp_dev_mode() ) {
@@ -90,8 +90,8 @@ final class Admin_Bar {
 			}
 
 			// Enqueue scripts.
-			$this->assets->enqueue_asset( 'googlesitekit_adminbar_loader' );
-			$this->assets->enqueue_asset( 'googlesitekit_modules' );
+			$this->assets->enqueue_asset( 'googlesitekit-adminbar-loader' );
+			$this->assets->enqueue_asset( 'googlesitekit-modules' );
 		};
 		add_action( 'admin_enqueue_scripts', $admin_bar_callback, 40 );
 		add_action( 'wp_enqueue_scripts', $admin_bar_callback, 40 );

--- a/includes/Core/Assets/Assets.php
+++ b/includes/Core/Assets/Assets.php
@@ -316,7 +316,7 @@ final class Assets {
 	 * @since 1.0.0
 	 */
 	private function enqueue_minimal_admin_script() {
-		$this->enqueue_asset( 'googlesitekit_admin' );
+		$this->enqueue_asset( 'googlesitekit-admin' );
 	}
 
 	/**
@@ -340,13 +340,13 @@ final class Assets {
 		foreach ( $external_assets as $asset ) {
 			$dependencies[] = $asset->get_handle();
 		}
-		$dependencies[] = 'sitekit-commons';
-		$dependencies[] = 'googlesitekit_admin';
+		$dependencies[] = 'googlesitekit-commons';
+		$dependencies[] = 'googlesitekit-admin';
 
 		// Register plugin scripts.
 		$assets = array(
 			new Script(
-				'sitekit-commons',
+				'googlesitekit-commons',
 				array(
 					'src'          => false,
 					'before_print' => function( $handle ) {
@@ -355,7 +355,7 @@ final class Assets {
 				)
 			),
 			new Script(
-				'googlesitekit_modules',
+				'googlesitekit-modules',
 				array(
 					'src'          => $base_url . 'js/allmodules.js',
 					'dependencies' => $dependencies,
@@ -363,14 +363,14 @@ final class Assets {
 			),
 			// Admin assets.
 			new Script(
-				'googlesitekit_activation',
+				'googlesitekit-activation',
 				array(
 					'src'          => $base_url . 'js/googlesitekit-activation.js',
 					'dependencies' => $dependencies,
 				)
 			),
 			new Script( // TODO: Rename this to 'googlesitekit_base'.
-				'googlesitekit_admin',
+				'googlesitekit-admin',
 				array(
 					'src'          => $base_url . 'js/googlesitekit-admin.js',
 					'dependencies' => array( 'wp-i18n' ),
@@ -401,55 +401,55 @@ final class Assets {
 			),
 			// End JSR Assets.
 			new Script(
-				'googlesitekit_ads_detect',
+				'googlesitekit-ads-detect',
 				array(
 					'src' => $base_url . 'js/ads.js',
 				)
 			),
 			new Script(
-				'googlesitekit_dashboard_splash',
+				'googlesitekit-dashboard-splash',
 				array(
 					'src'          => $base_url . 'js/googlesitekit-dashboard-splash.js',
 					'dependencies' => $dependencies,
 				)
 			),
 			new Script(
-				'googlesitekit_dashboard_details',
+				'googlesitekit-dashboard-details',
 				array(
 					'src'          => $base_url . 'js/googlesitekit-dashboard-details.js',
 					'dependencies' => $dependencies,
 				)
 			),
 			new Script(
-				'googlesitekit_dashboard',
+				'googlesitekit-dashboard',
 				array(
 					'src'          => $base_url . 'js/googlesitekit-dashboard.js',
 					'dependencies' => $dependencies,
 				)
 			),
 			new Script(
-				'googlesitekit_module_page',
+				'googlesitekit-module-page',
 				array(
 					'src'          => $base_url . 'js/googlesitekit-module.js',
 					'dependencies' => $dependencies,
 				)
 			),
 			new Script(
-				'googlesitekit_settings',
+				'googlesitekit-settings',
 				array(
 					'src'          => $base_url . 'js/googlesitekit-settings.js',
 					'dependencies' => $dependencies,
 				)
 			),
 			new Stylesheet(
-				'googlesitekit_admin_css',
+				'googlesitekit-admin-css',
 				array(
 					'src' => $base_url . 'css/admin.css',
 				)
 			),
 			// WP Dashboard assets.
 			new Script(
-				'googlesitekit_wp_dashboard',
+				'googlesitekit-wp-dashboard',
 				array(
 					'src'          => $base_url . 'js/googlesitekit-wp-dashboard.js',
 					'dependencies' => $dependencies,
@@ -457,14 +457,14 @@ final class Assets {
 				)
 			),
 			new Stylesheet(
-				'googlesitekit_wp_dashboard_css',
+				'googlesitekit-wp-dashboard-css',
 				array(
 					'src' => $base_url . 'css/wpdashboard.css',
 				)
 			),
 			// Admin bar assets.
 			new Script(
-				'googlesitekit_adminbar_loader',
+				'googlesitekit-adminbar-loader',
 				array(
 					'src'          => $base_url . 'js/googlesitekit-adminbar-loader.js',
 					'dependencies' => $dependencies,
@@ -480,7 +480,7 @@ final class Assets {
 				)
 			),
 			new Stylesheet(
-				'googlesitekit_adminbar_css',
+				'googlesitekit-adminbar-css',
 				array(
 					'src' => $base_url . 'css/adminbar.css',
 				)

--- a/includes/Core/Modules/Module_With_Screen_Trait.php
+++ b/includes/Core/Modules/Module_With_Screen_Trait.php
@@ -48,7 +48,7 @@ trait Module_With_Screen_Trait {
 					'title'            => $this->name,
 					'capability'       => Permissions::VIEW_MODULE_DETAILS,
 					'enqueue_callback' => function( Assets $assets ) {
-						$assets->enqueue_asset( 'googlesitekit_module_page' );
+						$assets->enqueue_asset( 'googlesitekit-module-page' );
 					},
 					'render_callback'  => function( Context $context ) {
 						$module_info = $this->prepare_info_for_js();

--- a/includes/Core/Util/Activation.php
+++ b/includes/Core/Util/Activation.php
@@ -100,7 +100,7 @@ final class Activation {
 		);
 
 		add_action(
-			'googlesitekit_activation',
+			'googlesitekit-activation',
 			function( $network_wide ) {
 				// Set activation flag.
 				$this->set_activation_flag( $network_wide );
@@ -135,8 +135,8 @@ final class Activation {
 				unset( $_GET['activate'] ); // phpcs:ignore WordPress.Security.NonceVerification, WordPress.VIP.SuperGlobalInputUsage
 
 				$this->assets->enqueue_fonts();
-				$this->assets->enqueue_asset( 'googlesitekit_admin_css' );
-				$this->assets->enqueue_asset( 'googlesitekit_activation' );
+				$this->assets->enqueue_asset( 'googlesitekit-admin-css' );
+				$this->assets->enqueue_asset( 'googlesitekit-activation' );
 			}
 		);
 	}

--- a/tests/phpunit/integration/Core/Admin/DashboardTest.php
+++ b/tests/phpunit/integration/Core/Admin/DashboardTest.php
@@ -63,10 +63,10 @@ class DashboardTest extends TestCase {
 		// Check that the dashboard widget was registered
 		$this->assertArrayHasKey( 'google_dashboard_widget', $wp_meta_boxes['dashboard']['normal']['core'] );
 		// Check that expected assets are enqueued
-		$this->assertFalse( wp_style_is( 'googlesitekit_wp_dashboard_css', 'enqueued' ) );
-		$this->assertFalse( wp_script_is( 'googlesitekit_wp_dashboard', 'enqueued' ) );
+		$this->assertFalse( wp_style_is( 'googlesitekit-wp-dashboard-css', 'enqueued' ) );
+		$this->assertFalse( wp_script_is( 'googlesitekit-wp-dashboard', 'enqueued' ) );
 		do_action( 'admin_enqueue_scripts' );
-		$this->assertTrue( wp_script_is( 'googlesitekit_wp_dashboard', 'enqueued' ) );
-		$this->assertTrue( wp_style_is( 'googlesitekit_wp_dashboard_css', 'enqueued' ) );
+		$this->assertTrue( wp_script_is( 'googlesitekit-wp-dashboard', 'enqueued' ) );
+		$this->assertTrue( wp_style_is( 'googlesitekit-wp-dashboard-css', 'enqueued' ) );
 	}
 }

--- a/tests/phpunit/integration/Core/Admin/ScreenTest.php
+++ b/tests/phpunit/integration/Core/Admin/ScreenTest.php
@@ -102,8 +102,8 @@ class ScreenTest extends TestCase {
 	}
 
 	public function test_enqueue_assets() {
-		wp_dequeue_style( 'googlesitekit_admin_css' );
-		wp_dequeue_script( 'googlesitekit_modules' );
+		wp_dequeue_style( 'googlesitekit-admin-css' );
+		wp_dequeue_script( 'googlesitekit-modules' );
 
 		$invocations = array();
 		$callback    = function () use ( &$invocations ) {
@@ -116,14 +116,14 @@ class ScreenTest extends TestCase {
 			) 
 		);
 
-		$this->assertFalse( wp_style_is( 'googlesitekit_admin_css', 'enqueued' ) );
-		$this->assertFalse( wp_script_is( 'googlesitekit_modules', 'enqueued' ) );
+		$this->assertFalse( wp_style_is( 'googlesitekit-admin-css', 'enqueued' ) );
+		$this->assertFalse( wp_script_is( 'googlesitekit-modules', 'enqueued' ) );
 
 		$assets = new Assets( new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE ) );
 		$screen->enqueue_assets( $assets );
 
-		$this->assertTrue( wp_style_is( 'googlesitekit_admin_css', 'enqueued' ) );
-		$this->assertTrue( wp_script_is( 'googlesitekit_modules', 'enqueued' ) );
+		$this->assertTrue( wp_style_is( 'googlesitekit-admin-css', 'enqueued' ) );
+		$this->assertTrue( wp_script_is( 'googlesitekit-modules', 'enqueued' ) );
 		$this->assertCount( 1, $invocations );
 		$this->assertEquals( array( $assets ), $invocations[0] );
 	}

--- a/tests/phpunit/integration/Core/Assets/AssetsTest.php
+++ b/tests/phpunit/integration/Core/Assets/AssetsTest.php
@@ -51,15 +51,15 @@ class AssetsTest extends TestCase {
 
 	public function test_enqueue_asset() {
 		// Also check registration since that is automatically done in the method if needed.
-		$this->assertFalse( wp_script_is( 'googlesitekit_admin', 'registered' ) );
-		$this->assertFalse( wp_script_is( 'googlesitekit_admin', 'enqueued' ) );
+		$this->assertFalse( wp_script_is( 'googlesitekit-admin', 'registered' ) );
+		$this->assertFalse( wp_script_is( 'googlesitekit-admin', 'enqueued' ) );
 
 		$assets = new Assets( new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE ) );
 
-		$assets->enqueue_asset( 'googlesitekit_admin' );
+		$assets->enqueue_asset( 'googlesitekit-admin' );
 
-		$this->assertTrue( wp_script_is( 'googlesitekit_admin', 'registered' ) );
-		$this->assertTrue( wp_script_is( 'googlesitekit_admin', 'enqueued' ) );
+		$this->assertTrue( wp_script_is( 'googlesitekit-admin', 'registered' ) );
+		$this->assertTrue( wp_script_is( 'googlesitekit-admin', 'enqueued' ) );
 	}
 
 	public function test_enqueue_asset_with_unknown() {
@@ -98,17 +98,17 @@ class AssetsTest extends TestCase {
 		remove_all_actions( 'wp_print_scripts' );
 		$assets->register();
 
-		// Enqueue script that has 'sitekit-commons' as dependency.
-		$assets->enqueue_asset( 'googlesitekit_modules' );
+		// Enqueue script that has 'googlesitekit-commons' as dependency.
+		$assets->enqueue_asset( 'googlesitekit-modules' );
 
-		// Ensure that 'sitekit-commons' is enqueued too.
-		$this->assertTrue( wp_script_is( 'googlesitekit_modules', 'enqueued' ) );
-		$this->assertTrue( wp_script_is( 'sitekit-commons', 'enqueued' ) );
+		// Ensure that 'googlesitekit-commons' is enqueued too.
+		$this->assertTrue( wp_script_is( 'googlesitekit-modules', 'enqueued' ) );
+		$this->assertTrue( wp_script_is( 'googlesitekit-commons', 'enqueued' ) );
 
 		do_action( 'wp_print_scripts' );
 
-		// Ensure that before_print callback for 'sitekit-commons' was run (its localized script should be there).
-		$localized_script = wp_scripts()->get_data( 'sitekit-commons', 'data' );
+		// Ensure that before_print callback for 'googlesitekit-commons' was run (its localized script should be there).
+		$localized_script = wp_scripts()->get_data( 'googlesitekit-commons', 'data' );
 		$this->assertContains( 'var googlesitekit = ', $localized_script );
 	}
 }

--- a/tests/phpunit/integration/Core/Util/ActivationTest.php
+++ b/tests/phpunit/integration/Core/Util/ActivationTest.php
@@ -38,7 +38,7 @@ class ActivationTest extends TestCase {
 		$this->assets  = new Assets( $context );
 		remove_all_filters( 'googlesitekit_admin_notices' );
 		remove_all_filters( 'googlesitekit_admin_data' );
-		remove_all_actions( 'googlesitekit_activation' );
+		remove_all_actions( 'googlesitekit-activation' );
 		remove_all_actions( 'admin_enqueue_scripts' );
 
 		$activation->register();
@@ -63,7 +63,7 @@ class ActivationTest extends TestCase {
 		$this->assertTrue( $context->is_network_mode() );
 		remove_all_filters( 'googlesitekit_admin_notices' );
 		remove_all_filters( 'googlesitekit_admin_data' );
-		remove_all_actions( 'googlesitekit_activation' );
+		remove_all_actions( 'googlesitekit-activation' );
 		remove_all_actions( 'admin_enqueue_scripts' );
 
 		$activation->register();
@@ -102,7 +102,7 @@ class ActivationTest extends TestCase {
 		);
 		$this->factory()->post->create( array( 'post_status' => 'publish' ) ); // first post
 
-		do_action( 'googlesitekit_activation', $network_wide );
+		do_action( 'googlesitekit-activation', $network_wide );
 
 		$this->assertNotEmpty( $this->options->get( Activation::OPTION_SHOW_ACTIVATION_NOTICE ) );
 		$this->assertEquals( 1, $this->options->get( Activation::OPTION_NEW_SITE_POSTS ) );
@@ -118,11 +118,11 @@ class ActivationTest extends TestCase {
 		wp_styles()->queue = array();
 		$this->assertNotEmpty( $this->options->get( Activation::OPTION_SHOW_ACTIVATION_NOTICE ) );
 		// googlesitekit-fonts is only enqueued in AMP context, only need to check admin css.
-		$this->assertFalse( wp_style_is( 'googlesitekit_admin_css', 'enqueued' ) );
+		$this->assertFalse( wp_style_is( 'googlesitekit-admin-css', 'enqueued' ) );
 
 		do_action( 'admin_enqueue_scripts', 'plugins.php' );
 
-		$this->assertTrue( wp_style_is( 'googlesitekit_admin_css', 'enqueued' ) );
+		$this->assertTrue( wp_style_is( 'googlesitekit-admin-css', 'enqueued' ) );
 	}
 
 	protected function network_activate_site_kit() {


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #1040 

## Relevant technical choices

Updated script handles to so they are 
- prefixed with `googlesitekit`
- kebab-cased
 
## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
