### PR TITLE
Remove commit date from release zip

### DIFF
--- a/gulp-tasks/zip.js
+++ b/gulp-tasks/zip.js
@@ -27,12 +27,10 @@ function getPluginVersion() {
  * @return {Object} Data related to the latest commit.
  */
 function getGit() {
-	const { abbreviatedSha, branch, committerDate } = getRepoInfo();
-	const [ date, time ] = committerDate.split( /[T\.]/ );
+	const { abbreviatedSha, branch } = getRepoInfo();
 
 	return {
 		branch: sanitizeFilename( branch, { replacement: '-' } ),
-		date: `${ date }.${ time.replace( ':', '' ) }`,
 		shortSha: abbreviatedSha,
 	};
 }

--- a/gulp-tasks/zip.js
+++ b/gulp-tasks/zip.js
@@ -42,10 +42,15 @@ function getGit() {
  */
 function generateFilename() {
 	const version = getPluginVersion();
-	const { branch, date, shortSha } = getGit();
+
+	let gitSuffix = '';
+	try {
+		const { branch, shortSha } = getGit();
+		gitSuffix = `.${ branch }@${ shortSha }`;
+	} catch {}
 
 	return sanitizeFilename(
-		`google-site-kit.v${ version }.${ branch }@${ shortSha }.${ date }.zip`
+		`google-site-kit.v${ version }${ gitSuffix }.zip`
 	);
 }
 


### PR DESCRIPTION
## Summary

This is a followup bug-fix to #1098 

Addresses issue #1041

## Relevant technical choices

* Removes commit date as part of the generated zip filename  
This is due to the way `git-repo-info` works by parsing commit data from `.git/objects/xx/...` rather than running `git` (see https://github.com/rwjblue/git-repo-info/issues/46). However, these objects may not exist (such as after a fresh clone) causing the `commiterDate` to be `null` and thus the zip creation errors out when formatting the date (`Cannot read property 'split' of null`).
* Makes `.git` optional, so that the release zip can still be built without it

If `.git` is present (even after a fresh clone) the file format will be:
`google-site-kit.v1.2.3.branch-name@shortsha.zip`

If `.git` is not present (i.e. zip download from GitHub) the file format will be:
`google-site-kit.v1.2.3.zip`

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
