### PR TITLE
Fix data block change logic

### DIFF
--- a/assets/js/components/data-block.js
+++ b/assets/js/components/data-block.js
@@ -109,7 +109,7 @@ class DataBlock extends Component {
 						{ change && <Fragment>
 							<span className="googlesitekit-data-block__arrow">
 								<ChangeArrow
-									direction={ change ? 'up' : 'down' }
+									direction={ 0 < parseFloat( change ) ? 'up' : 'down' }
 									invertColor={ invertChangeColor }
 								/>
 							</span>


### PR DESCRIPTION
## Summary

Follow up to #1091 which fixes the way the arrow direction is implemented within `DataBlock` components.

Addresses issue #481

## Relevant technical choices
* Change usually is passed in as a string and needs to be parsed into a number for proper handling
* Direction is then determined by up: positive and down: negative change

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
