### PR TITLE
Pass instance User_Options to Profile.

### DIFF
--- a/includes/Core/Authentication/Authentication.php
+++ b/includes/Core/Authentication/Authentication.php
@@ -171,7 +171,7 @@ final class Authentication {
 		$this->verification      = new Verification( $this->user_options );
 		$this->verification_meta = new Verification_Meta( $this->user_options, $this->transients );
 		$this->verification_file = new Verification_File( $this->user_options );
-		$this->profile           = new Profile( $user_options );
+		$this->profile           = new Profile( $this->user_options );
 		$this->first_admin       = new First_Admin( $this->options );
 	}
 


### PR DESCRIPTION
## Summary

This PR ensures the `User_Options` instance passed to Profile is correct. I don't think this is breaking anything as-is since all constructor dependencies are provided when the plugin runs normally. I noticed this when working on #1029 

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
