### PR TITLE
Fix Plugin activation E2E test failures.

### DIFF
--- a/tests/e2e/specs/plugin-activation.test.js
+++ b/tests/e2e/specs/plugin-activation.test.js
@@ -47,8 +47,7 @@ describe( 'Plugin Activation Notice', () => {
 	it( 'Should be displayed', async () => {
 		await activateSiteKit();
 
-		await page.waitForSelector( '.googlesitekit-activation' );
-		await page.waitForSelector( 'h3.googlesitekit-activation__title' );
+		await page.waitForSelector( '.googlesitekit-activation__title' );
 
 		await expect( page ).toMatchElement( 'h3.googlesitekit-activation__title', { text: 'Congratulations, the Site Kit plugin is now activated.' } );
 
@@ -58,7 +57,6 @@ describe( 'Plugin Activation Notice', () => {
 	it( 'Should lead you to the setup wizard', async () => {
 		await activateSiteKit();
 
-		await page.waitForSelector( '.googlesitekit-activation' );
 		await page.waitForSelector( '.googlesitekit-start-setup' );
 
 		await expect( page ).toMatchElement( '.googlesitekit-start-setup', { text: 'Start setup' } );

--- a/tests/e2e/specs/plugin-activation.test.js
+++ b/tests/e2e/specs/plugin-activation.test.js
@@ -48,6 +48,7 @@ describe( 'Plugin Activation Notice', () => {
 		await activateSiteKit();
 
 		await page.waitForSelector( '.googlesitekit-activation' );
+		await page.waitForSelector( 'h3.googlesitekit-activation__title' );
 
 		await expect( page ).toMatchElement( 'h3.googlesitekit-activation__title', { text: 'Congratulations, the Site Kit plugin is now activated.' } );
 
@@ -58,6 +59,7 @@ describe( 'Plugin Activation Notice', () => {
 		await activateSiteKit();
 
 		await page.waitForSelector( '.googlesitekit-activation' );
+		await page.waitForSelector( '.googlesitekit-start-setup' );
 
 		await expect( page ).toMatchElement( '.googlesitekit-start-setup', { text: 'Start setup' } );
 


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #1130.

## Relevant technical choices

Use the correct selectors for the activation E2E test now that it renders asynchronously (because it isn't being rendered entirely by PHP anymore).

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
