### PR TITLE
GTM: Add AMP container select

### DIFF
--- a/assets/js/modules/tagmanager/setup.js
+++ b/assets/js/modules/tagmanager/setup.js
@@ -594,7 +594,8 @@ class TagmanagerSetup extends Component {
 						this.renderContainerSelect( {
 							selectedStateKey: 'selectedContainerAMP',
 							containers: containersAMP,
-							label: __( 'AMP Container', 'google-site-kit' ),
+							// Use the default label if it is the only select shown.
+							label: 'primary' === ampMode ? null : __( 'AMP Container', 'google-site-kit' ),
 						} )
 					}
 				</div>

--- a/assets/js/modules/tagmanager/setup.js
+++ b/assets/js/modules/tagmanager/setup.js
@@ -206,8 +206,6 @@ class TagmanagerSetup extends Component {
 			this.setState( {
 				isLoading: false,
 				accounts,
-				containersWeb: [],
-				containersAMP: [],
 			} );
 		} catch ( err ) {
 			this.setState( {
@@ -393,15 +391,11 @@ class TagmanagerSetup extends Component {
 			return;
 		}
 
-		this.setState( { selectedAccount: selectValue } );
-
-		if ( ! selectValue ) {
-			this.setState( {
-				selectedContainerWeb: '',
-				selectedContainerAMP: '',
-			} );
-			return;
-		}
+		this.setState( {
+			selectedAccount: selectValue,
+			selectedContainerWeb: '',
+			selectedContainerAMP: '',
+		} );
 
 		if ( ! isValidAccountID( selectValue ) ) {
 			return;
@@ -419,7 +413,8 @@ class TagmanagerSetup extends Component {
 				errorCode: false,
 				errorMsg: '',
 				selectedAccount: '',
-				selectedContainer: '',
+				selectedContainerWeb: '',
+				selectedContainerAMP: '',
 			},
 			this.requestTagManagerAccounts
 		);

--- a/assets/js/modules/tagmanager/setup.js
+++ b/assets/js/modules/tagmanager/setup.js
@@ -642,6 +642,7 @@ class TagmanagerSetup extends Component {
 			selectedAccount,
 			hasExistingTag,
 		} = this.state;
+		const hasContainers = !! containers.length;
 
 		if ( containersLoading ) {
 			return <ProgressBar small />;
@@ -654,7 +655,7 @@ class TagmanagerSetup extends Component {
 					googlesitekit-tagmanager__select-container--${ type }
 				` }
 				label={ label || __( 'Container', 'google-site-kit' ) }
-				value={ this.state[ selectedStateKey ] }
+				value={ hasContainers ? this.state[ selectedStateKey ] : CONTAINER_CREATE }
 				onEnhancedChange={ ( idx, item ) => this.setState( { [ selectedStateKey ]: item.dataset.value } ) }
 				disabled={ hasExistingTag || ! isValidAccountID( selectedAccount ) }
 				enhanced

--- a/assets/js/modules/tagmanager/setup.js
+++ b/assets/js/modules/tagmanager/setup.js
@@ -424,6 +424,8 @@ class TagmanagerSetup extends Component {
 	renderSettingsInfo() {
 		const { settings } = global.googlesitekit.modules.tagmanager;
 		const {
+			ampEnabled,
+			isSecondaryAMP,
 			hasExistingTag,
 			isLoading,
 		} = this.state;
@@ -444,27 +446,33 @@ class TagmanagerSetup extends Component {
 							{ __( 'Account', 'google-site-kit' ) }
 						</p>
 						<h5 className="googlesitekit-settings-module__meta-item-data">
-							{ accountID || __( 'Not set', 'google-site-kit' ) }
+							{ accountID || false }
 						</h5>
 					</div>
 
-					<div className="googlesitekit-settings-module__meta-item">
-						<p className="googlesitekit-settings-module__meta-item-type">
-							{ __( 'Web Container ID', 'google-site-kit' ) }
-						</p>
-						<h5 className="googlesitekit-settings-module__meta-item-data">
-							{ settings.containerID || __( 'Not set', 'google-site-kit' ) }
-						</h5>
-					</div>
+					{ ( ! ampEnabled || isSecondaryAMP ) && (
+						<div className="googlesitekit-settings-module__meta-item">
+							<p className="googlesitekit-settings-module__meta-item-type">
+								{ isSecondaryAMP && __( 'Web Container ID', 'google-site-kit' ) }
+								{ ! ampEnabled && __( 'Container ID', 'google-site-kit' ) }
+							</p>
+							<h5 className="googlesitekit-settings-module__meta-item-data">
+								{ settings.containerID || false }
+							</h5>
+						</div>
+					) }
 
-					<div className="googlesitekit-settings-module__meta-item">
-						<p className="googlesitekit-settings-module__meta-item-type">
-							{ __( 'AMP Container ID', 'google-site-kit' ) }
-						</p>
-						<h5 className="googlesitekit-settings-module__meta-item-data">
-							{ settings.ampContainerID || __( 'Not set', 'google-site-kit' ) }
-						</h5>
-					</div>
+					{ ampEnabled && (
+						<div className="googlesitekit-settings-module__meta-item">
+							<p className="googlesitekit-settings-module__meta-item-type">
+								{ isSecondaryAMP && __( 'AMP Container ID', 'google-site-kit' ) }
+								{ ! isSecondaryAMP && __( 'Container ID', 'google-site-kit' ) }
+							</p>
+							<h5 className="googlesitekit-settings-module__meta-item-data">
+								{ settings.ampContainerID || false }
+							</h5>
+						</div>
+					) }
 				</div>
 				<div className="googlesitekit-settings-module__meta-items">
 					<div className="googlesitekit-settings-module__meta-item">

--- a/assets/js/modules/tagmanager/setup.js
+++ b/assets/js/modules/tagmanager/setup.js
@@ -587,6 +587,7 @@ class TagmanagerSetup extends Component {
 						this.renderContainerSelect( {
 							selectedStateKey: 'selectedContainerWeb',
 							containers: containersWeb,
+							label: showAMPContainerSelect ? __( 'Web Container', 'google-site-kit' ) : null,
 						} )
 					}
 
@@ -595,7 +596,7 @@ class TagmanagerSetup extends Component {
 							selectedStateKey: 'selectedContainerAMP',
 							containers: containersAMP,
 							// Use the default label if it is the only select shown.
-							label: 'primary' === ampMode ? null : __( 'AMP Container', 'google-site-kit' ),
+							label: ! showWebContainerSelect ? __( 'AMP Container', 'google-site-kit' ) : null,
 						} )
 					}
 				</div>

--- a/assets/js/modules/tagmanager/setup.js
+++ b/assets/js/modules/tagmanager/setup.js
@@ -172,6 +172,7 @@ class TagmanagerSetup extends Component {
 				const { account, container } = await data.get( TYPE_MODULES, 'tagmanager', 'tag-permission', { tag: existingContainerID } );
 				const selectedContainerKey = container.usageContext.includes( USAGE_CONTEXT_AMP ) ? 'selectedContainerAMP' : 'selectedContainerWeb';
 
+				this.setContainers( [ container ] );
 				// If the user has access, they may continue but must use the found account+container.
 				this.setState(
 					{
@@ -182,7 +183,6 @@ class TagmanagerSetup extends Component {
 						hasExistingTag: true,
 					}
 				);
-				this.setContainers( [ container ] );
 			} catch ( err ) {
 				this.setState(
 					{
@@ -250,9 +250,10 @@ class TagmanagerSetup extends Component {
 			const { accounts, containers } = await data.get( TYPE_MODULES, 'tagmanager', 'accounts-containers', queryArgs );
 
 			this.validateAccounts( accounts, selectedAccount );
+			this.setContainers( containers );
 
 			// If the selected container is not in the list of containers, clear it.
-			const containerIDs = containers.map( ( container ) => container.publicId ); /* Capitalization rule exception: `publicId` is a property of an API returned value. */
+			const containerIDs = containers.map( ( { publicId } ) => publicId ); /* Capitalization rule exception: `publicId` is a property of an API returned value. */
 			if ( isValidContainerID( selectedContainerWeb ) && ! containerIDs.includes( selectedContainerWeb ) ) {
 				selectedContainerWeb = '';
 			}
@@ -269,7 +270,6 @@ class TagmanagerSetup extends Component {
 				errorCode: false,
 				errorMsg: '',
 			} );
-			this.setContainers( containers );
 		} catch ( err ) {
 			this.setState( {
 				isLoading: false,

--- a/assets/js/modules/tagmanager/setup.js
+++ b/assets/js/modules/tagmanager/setup.js
@@ -64,7 +64,7 @@ class TagmanagerSetup extends Component {
 			ampMode,
 			isLoading: true,
 			accounts: [],
-			containersWeb: [],
+			containers: [],
 			containersAMP: [],
 			errorCode: false,
 			errorMsg: '',
@@ -159,7 +159,7 @@ class TagmanagerSetup extends Component {
 			// Verify the user has access to existing tag if found.
 			try {
 				const { account, container } = await data.get( TYPE_MODULES, 'tagmanager', 'tag-permission', { tag: existingContainerID } );
-				const containersWeb = getContainers( [ container ] ).byContext( USAGE_CONTEXT_WEB );
+				const containers = getContainers( [ container ] ).byContext( USAGE_CONTEXT_WEB );
 				const containersAMP = getContainers( [ container ] ).byContext( USAGE_CONTEXT_AMP );
 
 				// If the user has access, they may continue but must use the found account+container.
@@ -167,7 +167,7 @@ class TagmanagerSetup extends Component {
 					{
 						isLoading: false,
 						selectedAccount: account.accountId, // Capitalization rule exception: `accountId` is a property of an API returned value.
-						selectedContainer: get( containersWeb, [ 0, 'publicId' ] ), // Capitalization rule exception: `publicId` is a property of an API returned value.
+						selectedContainer: get( containers, [ 0, 'publicId' ] ), // Capitalization rule exception: `publicId` is a property of an API returned value.
 						selectedContainerAMP: get( containersAMP, [ 0, 'publicId' ] ), // Capitalization rule exception: `publicId` is a property of an API returned value.
 						accounts: [ account ],
 						hasExistingTag: true,
@@ -254,7 +254,7 @@ class TagmanagerSetup extends Component {
 			this.setState( {
 				isLoading: false,
 				accounts,
-				containersWeb,
+				containers: containersWeb,
 				containersAMP,
 				selectedAccount: selectedAccount || get( containers, [ 0, 'accountId' ] ), // Capitalization rule exception: `accountId` is a property of an API returned value.
 				selectedContainer: selectedContainer || get( containersWeb, [ 0, 'publicId' ] ), // Capitalization rule exception: `publicId` is a property of an API returned value.
@@ -320,7 +320,7 @@ class TagmanagerSetup extends Component {
 
 			this.setState( {
 				containersLoading: false,
-				containersWeb: getContainers( containers ).byContext( USAGE_CONTEXT_WEB ),
+				containers: getContainers( containers ).byContext( USAGE_CONTEXT_WEB ),
 				containersAMP: getContainers( containers ).byContext( USAGE_CONTEXT_AMP ),
 				errorCode: false,
 			} );
@@ -489,7 +489,7 @@ class TagmanagerSetup extends Component {
 			ampMode,
 			accounts,
 			selectedAccount,
-			containersWeb,
+			containers,
 			containersAMP,
 			selectedContainer,
 			hasExistingTag,
@@ -587,7 +587,7 @@ class TagmanagerSetup extends Component {
 					{ showWebContainerSelect &&
 						this.renderContainerSelect( {
 							selectedStateKey: 'selectedContainer',
-							containers: containersWeb,
+							containers,
 							label: showAMPContainerSelect ? __( 'Web Container', 'google-site-kit' ) : null,
 							type: USAGE_CONTEXT_WEB,
 						} )

--- a/assets/js/modules/tagmanager/setup.js
+++ b/assets/js/modules/tagmanager/setup.js
@@ -675,18 +675,32 @@ class TagmanagerSetup extends Component {
 
 	canSaveSettings() {
 		const {
+			ampEnabled,
+			ampMode,
 			errorCode,
 			isLoading,
 			selectedAccount,
-			selectedContainer,
+			selectedContainerWeb,
+			selectedContainerAMP,
 		} = this.state;
 
 		if (
 			isLoading ||
 			'tag_manager_existing_tag_permission' === errorCode ||
-			! isValidAccountID( selectedAccount ) ||
-			( ! isValidContainerID( selectedContainer ) && CONTAINER_CREATE !== selectedContainer )
+			! isValidAccountID( selectedAccount )
 		) {
+			return false;
+		}
+
+		if (
+			( ! ampEnabled || 'secondary' === ampMode ) &&
+			! isValidContainerID( selectedContainerWeb ) &&
+			CONTAINER_CREATE !== selectedContainerWeb
+		) {
+			return false;
+		}
+
+		if ( ampEnabled && ! isValidContainerID( selectedContainerAMP ) && CONTAINER_CREATE !== selectedContainerAMP ) {
 			return false;
 		}
 

--- a/assets/js/modules/tagmanager/setup.js
+++ b/assets/js/modules/tagmanager/setup.js
@@ -174,18 +174,19 @@ class TagmanagerSetup extends Component {
 			// Verify the user has access to existing tag if found.
 			try {
 				const { account, container } = await data.get( TYPE_MODULES, 'tagmanager', 'tag-permission', { tag: existingContainerID } );
+				const selectedContainerKey = container.usageContext.includes( USAGE_CONTEXT_AMP ) ? 'selectedContainerAMP' : 'selectedContainerWeb';
 
 				// If the user has access, they may continue but must use the found account+container.
 				this.setState(
 					{
 						isLoading: false,
 						selectedAccount: account.accountId, // Capitalization rule exception: `accountId` is a property of an API returned value.
-						selectedContainer: container.publicId, // Capitalization rule exception: `publicId` is a property of an API returned value.
+						[ selectedContainerKey ]: container.publicId, // Capitalization rule exception: `publicId` is a property of an API returned value.
 						accounts: [ account ],
-						containers: [ container ],
 						hasExistingTag: true,
 					}
 				);
+				this.setContainers( [ container ] );
 			} catch ( err ) {
 				this.setState(
 					{

--- a/assets/js/modules/tagmanager/setup.js
+++ b/assets/js/modules/tagmanager/setup.js
@@ -211,10 +211,9 @@ class TagmanagerSetup extends Component {
 		try {
 			const {
 				selectedAccount,
-				usageContext,
 			} = this.state;
 
-			const accounts = await data.get( TYPE_MODULES, 'tagmanager', 'accounts', { usageContext } );
+			const accounts = await data.get( TYPE_MODULES, 'tagmanager', 'accounts' );
 
 			this.validateAccounts( accounts, selectedAccount );
 

--- a/assets/js/modules/tagmanager/setup.js
+++ b/assets/js/modules/tagmanager/setup.js
@@ -44,26 +44,30 @@ import { isValidAccountID, isValidContainerID } from './util';
 
 const ACCOUNT_CREATE = 'account_create';
 const CONTAINER_CREATE = 'container_create';
+const USAGE_CONTEXT_WEB = 'web';
+const USAGE_CONTEXT_AMP = 'amp';
 
 class TagmanagerSetup extends Component {
 	constructor( props ) {
 		super( props );
 
+		const { ampEnabled, ampMode } = global.googlesitekit.admin;
 		const { settings } = global.googlesitekit.modules.tagmanager;
-		const usageContext = global.googlesitekit.admin.ampMode === 'primary' ? 'amp' : 'web';
-		const containerKey = usageContext === 'amp' ? 'ampContainerID' : 'containerID';
+		const ampUsageContext = ampMode === 'primary' ? USAGE_CONTEXT_AMP : [ USAGE_CONTEXT_WEB, USAGE_CONTEXT_AMP ];
 
 		this.state = {
+			ampMode,
 			isLoading: true,
 			accounts: [],
-			containers: [],
+			containersWeb: [],
+			containersAMP: [],
 			errorCode: false,
 			errorMsg: '',
 			selectedAccount: settings.accountID,
-			selectedContainer: settings[ containerKey ],
+			selectedContainerWeb: settings.containerID,
+			selectedContainerAMP: settings.ampContainerID,
 			containersLoading: false,
-			usageContext,
-			containerKey,
+			usageContext: ampEnabled ? ampUsageContext : USAGE_CONTEXT_WEB,
 			hasExistingTag: false,
 			useSnippet: settings.useSnippet,
 		};

--- a/assets/js/modules/tagmanager/setup.js
+++ b/assets/js/modules/tagmanager/setup.js
@@ -68,6 +68,7 @@ class TagmanagerSetup extends Component {
 			containersAMP: [],
 			errorCode: false,
 			errorMsg: '',
+			existingContainer: '',
 			selectedAccount: settings.accountID,
 			selectedContainer: settings.containerID,
 			selectedContainerAMP: settings.ampContainerID,
@@ -166,6 +167,7 @@ class TagmanagerSetup extends Component {
 				this.setState(
 					{
 						isLoading: false,
+						existingContainer: existingContainerID,
 						selectedAccount: account.accountId, // Capitalization rule exception: `accountId` is a property of an API returned value.
 						selectedContainer: get( containers, [ 0, 'publicId' ] ), // Capitalization rule exception: `publicId` is a property of an API returned value.
 						selectedContainerAMP: get( containersAMP, [ 0, 'publicId' ] ), // Capitalization rule exception: `publicId` is a property of an API returned value.
@@ -180,6 +182,7 @@ class TagmanagerSetup extends Component {
 						errorCode: err.code,
 						errorMsg: err.message,
 						errorReason: err.data && err.data.reason ? err.data.reason : false,
+						existingContainer: existingContainerID,
 						hasExistingTag: !! existingContainerID,
 					}
 				);
@@ -498,7 +501,7 @@ class TagmanagerSetup extends Component {
 			selectedAccount,
 			containers,
 			containersAMP,
-			selectedContainer,
+			existingContainer,
 			hasExistingTag,
 			isLoading,
 			isSecondaryAMP,
@@ -545,7 +548,7 @@ class TagmanagerSetup extends Component {
 						{ sprintf(
 							// translators: %s: the existing container ID.
 							__( 'An existing tag was found on your site (%s). If you later decide to replace this tag, Site Kit can place the new tag for you. Make sure you remove the old tag first.', 'google-site-kit' ),
-							selectedContainer
+							existingContainer
 						) }
 					</p>
 				) }

--- a/assets/js/modules/tagmanager/setup.js
+++ b/assets/js/modules/tagmanager/setup.js
@@ -61,7 +61,6 @@ class TagmanagerSetup extends Component {
 
 		this.state = {
 			ampEnabled,
-			ampMode,
 			isLoading: true,
 			isSecondaryAMP: 'secondary' === ampMode,
 			accounts: [],

--- a/assets/js/modules/tagmanager/setup.js
+++ b/assets/js/modules/tagmanager/setup.js
@@ -151,11 +151,11 @@ class TagmanagerSetup extends Component {
 		if ( ! this.props.isEditing ) {
 			return;
 		}
-		const { containerKey } = this.state;
 
 		let settingsMapping = {
-			selectedContainer: containerKey,
-			selectedAccount: 'selectedAccount',
+			selectedContainerWeb: 'containerID',
+			selectedContainerAMP: 'ampContainerID',
+			selectedAccount: 'accountID',
 			useSnippet: 'useSnippet',
 		};
 
@@ -220,7 +220,8 @@ class TagmanagerSetup extends Component {
 			this.setState( {
 				isLoading: false,
 				accounts,
-				containers: [],
+				containersWeb: [],
+				containersAMP: [],
 			} );
 		} catch ( err ) {
 			this.setState( {
@@ -328,11 +329,10 @@ class TagmanagerSetup extends Component {
 			};
 
 			const containers = await data.get( TYPE_MODULES, 'tagmanager', 'containers', queryArgs );
+			this.setContainers( containers );
 
 			this.setState( {
 				containersLoading: false,
-				containers,
-				selectedContainer: get( containers, [ 0, 'publicId' ] ), // Capitalization rule exception: `publicId` is a property of an API returned value.
 				errorCode: false,
 			} );
 		} catch ( err ) {
@@ -404,7 +404,10 @@ class TagmanagerSetup extends Component {
 		this.setState( { selectedAccount: selectValue } );
 
 		if ( ! selectValue ) {
-			this.setState( { selectedContainer: '' } );
+			this.setState( {
+				selectedContainerWeb: '',
+				selectedContainerAMP: '',
+			} );
 			return;
 		}
 

--- a/assets/js/modules/tagmanager/setup.js
+++ b/assets/js/modules/tagmanager/setup.js
@@ -90,16 +90,12 @@ class TagmanagerSetup extends Component {
 	 * @param {Array} containers List of containers to set.
 	 */
 	setContainers( containers ) {
-		const { ampEnabled } = this.state;
 		const containersWeb = containers.filter(
 			( container ) => container.usageContext.includes( USAGE_CONTEXT_WEB )
 		);
-		let containersAMP = [];
-		if ( ampEnabled ) {
-			containersAMP = containers.filter(
-				( container ) => container.usageContext.includes( USAGE_CONTEXT_AMP )
-			);
-		}
+		const containersAMP = containers.filter(
+			( container ) => container.usageContext.includes( USAGE_CONTEXT_AMP )
+		);
 		this.setState( { containersWeb, containersAMP } );
 	}
 

--- a/assets/js/modules/tagmanager/setup.js
+++ b/assets/js/modules/tagmanager/setup.js
@@ -525,8 +525,9 @@ class TagmanagerSetup extends Component {
 			</Fragment>;
 		}
 
+		const isSecondaryAMP = 'secondary' === ampMode;
 		// Only show the web container select if AMP is not used, or AMP is in secondary mode.
-		const showWebContainerSelect = ( ! ampEnabled || 'secondary' === ampMode );
+		const showWebContainerSelect = ( ! ampEnabled || isSecondaryAMP );
 		// Show the AMP select if AMP is in primary or secondary mode (implies enabled).
 		const showAMPContainerSelect = [ 'primary', 'secondary' ].includes( ampMode );
 
@@ -541,9 +542,19 @@ class TagmanagerSetup extends Component {
 						) }
 					</p>
 				) }
-				{ ! hasExistingTag && (
-					<p>{ __( 'Please select your Tag Manager account and container below, the snippet will be inserted automatically into your site.', 'google-site-kit' ) }</p>
+
+				{ ( ! hasExistingTag && ! isSecondaryAMP ) && (
+					<p>
+						{ __( 'Please select your Tag Manager account and container below, the snippet will be inserted automatically on your site.', 'google-site-kit' ) }
+					</p>
 				) }
+
+				{ ( ! hasExistingTag && isSecondaryAMP ) && (
+					<p>
+						{ __( 'Looks like your site is using paired AMP. Please select your Tag Manager account and relevant containers below, the snippets will be inserted automatically on your site.', 'google-site-kit' ) }
+					</p>
+				) }
+
 				<div className="googlesitekit-setup-module__inputs">
 					<Select
 						className="googlesitekit-tagmanager__select-account"

--- a/assets/js/modules/tagmanager/setup.js
+++ b/assets/js/modules/tagmanager/setup.js
@@ -63,6 +63,7 @@ class TagmanagerSetup extends Component {
 			ampEnabled,
 			ampMode,
 			isLoading: true,
+			isSecondaryAMP: 'secondary' === ampMode,
 			accounts: [],
 			containers: [],
 			containersAMP: [],
@@ -486,7 +487,6 @@ class TagmanagerSetup extends Component {
 	renderAccountDropdownForm() {
 		const {
 			ampEnabled,
-			ampMode,
 			accounts,
 			selectedAccount,
 			containers,
@@ -494,6 +494,7 @@ class TagmanagerSetup extends Component {
 			selectedContainer,
 			hasExistingTag,
 			isLoading,
+			isSecondaryAMP,
 			errorCode,
 			useSnippet,
 		} = this.state;
@@ -525,11 +526,10 @@ class TagmanagerSetup extends Component {
 			</Fragment>;
 		}
 
-		const isSecondaryAMP = 'secondary' === ampMode;
 		// Only show the web container select if AMP is not used, or AMP is in secondary mode.
 		const showWebContainerSelect = ( ! ampEnabled || isSecondaryAMP );
 		// Show the AMP select if AMP is in primary or secondary mode (implies enabled).
-		const showAMPContainerSelect = [ 'primary', 'secondary' ].includes( ampMode );
+		const showAMPContainerSelect = ampEnabled;
 
 		return (
 			<Fragment>
@@ -693,7 +693,7 @@ class TagmanagerSetup extends Component {
 	canSaveSettings() {
 		const {
 			ampEnabled,
-			ampMode,
+			isSecondaryAMP,
 			errorCode,
 			isLoading,
 			selectedAccount,
@@ -710,7 +710,7 @@ class TagmanagerSetup extends Component {
 		}
 
 		if (
-			( ! ampEnabled || 'secondary' === ampMode ) &&
+			( ! ampEnabled || isSecondaryAMP ) &&
 			! isValidContainerID( selectedContainer ) &&
 			CONTAINER_CREATE !== selectedContainer
 		) {

--- a/assets/js/modules/tagmanager/setup.js
+++ b/assets/js/modules/tagmanager/setup.js
@@ -91,13 +91,12 @@ class TagmanagerSetup extends Component {
 	 * @param {Array} containers List of containers to set.
 	 */
 	setContainers( containers ) {
-		const containersWeb = containers.filter(
-			( container ) => container.usageContext.includes( USAGE_CONTEXT_WEB )
-		);
-		const containersAMP = containers.filter(
-			( container ) => container.usageContext.includes( USAGE_CONTEXT_AMP )
-		);
-		this.setState( { containersWeb, containersAMP } );
+		const containersByContext = ( context ) => containers.filter( ( c ) => c.usageContext.includes( context ) );
+
+		this.setState( {
+			containersWeb: containersByContext( USAGE_CONTEXT_WEB ),
+			containersAMP: containersByContext( USAGE_CONTEXT_AMP ),
+		} );
 	}
 
 	async componentDidMount() {

--- a/assets/js/modules/tagmanager/setup.js
+++ b/assets/js/modules/tagmanager/setup.js
@@ -85,6 +85,25 @@ class TagmanagerSetup extends Component {
 		}
 	}
 
+	/**
+	 * Separates and sets a list of containers into their state keys by usage context.
+	 *
+	 * @param {Array} containers List of containers to set.
+	 */
+	setContainers( containers ) {
+		const { ampEnabled } = this.state;
+		const containersWeb = containers.filter(
+			( container ) => container.usageContext.includes( USAGE_CONTEXT_WEB )
+		);
+		let containersAMP = [];
+		if ( ampEnabled ) {
+			containersAMP = containers.filter(
+				( container ) => container.usageContext.includes( USAGE_CONTEXT_AMP )
+			);
+		}
+		this.setState( { containersWeb, containersAMP } );
+	}
+
 	async componentDidMount() {
 		const {
 			isOpen,

--- a/assets/js/modules/tagmanager/setup.js
+++ b/assets/js/modules/tagmanager/setup.js
@@ -592,7 +592,7 @@ class TagmanagerSetup extends Component {
 							selectedStateKey: 'selectedContainerAMP',
 							containers: containersAMP,
 							// Use the default label if it is the only select shown.
-							label: ! showWebContainerSelect ? __( 'AMP Container', 'google-site-kit' ) : null,
+							label: showWebContainerSelect ? __( 'AMP Container', 'google-site-kit' ) : null,
 							type: USAGE_CONTEXT_AMP,
 						} )
 					}

--- a/assets/js/modules/tagmanager/setup.js
+++ b/assets/js/modules/tagmanager/setup.js
@@ -583,6 +583,7 @@ class TagmanagerSetup extends Component {
 							selectedStateKey: 'selectedContainerWeb',
 							containers: containersWeb,
 							label: showAMPContainerSelect ? __( 'Web Container', 'google-site-kit' ) : null,
+							type: USAGE_CONTEXT_WEB,
 						} )
 					}
 
@@ -592,6 +593,7 @@ class TagmanagerSetup extends Component {
 							containers: containersAMP,
 							// Use the default label if it is the only select shown.
 							label: ! showWebContainerSelect ? __( 'AMP Container', 'google-site-kit' ) : null,
+							type: USAGE_CONTEXT_AMP,
 						} )
 					}
 				</div>
@@ -638,6 +640,7 @@ class TagmanagerSetup extends Component {
 			label,
 			selectedStateKey,
 			containers,
+			type,
 		} = args;
 		const {
 			containersLoading,
@@ -651,7 +654,10 @@ class TagmanagerSetup extends Component {
 
 		return (
 			<Select
-				className="googlesitekit-tagmanager__select-container"
+				className={ `
+					googlesitekit-tagmanager__select-container
+					googlesitekit-tagmanager__select-container--${ type }
+				` }
 				label={ label || __( 'Container', 'google-site-kit' ) }
 				value={ this.state[ selectedStateKey ] }
 				onEnhancedChange={ ( idx, item ) => this.setState( { [ selectedStateKey ]: item.dataset.value } ) }

--- a/assets/js/modules/tagmanager/setup.js
+++ b/assets/js/modules/tagmanager/setup.js
@@ -434,7 +434,6 @@ class TagmanagerSetup extends Component {
 		const { settings } = global.googlesitekit.modules.tagmanager;
 		const {
 			hasExistingTag,
-			containerKey,
 			isLoading,
 		} = this.state;
 		const {
@@ -454,15 +453,25 @@ class TagmanagerSetup extends Component {
 							{ __( 'Account', 'google-site-kit' ) }
 						</p>
 						<h5 className="googlesitekit-settings-module__meta-item-data">
-							{ accountID || false }
+							{ accountID || __( 'Not set', 'google-site-kit' ) }
 						</h5>
 					</div>
+
 					<div className="googlesitekit-settings-module__meta-item">
 						<p className="googlesitekit-settings-module__meta-item-type">
-							{ __( 'Container ID', 'google-site-kit' ) }
+							{ __( 'Web Container ID', 'google-site-kit' ) }
 						</p>
 						<h5 className="googlesitekit-settings-module__meta-item-data">
-							{ settings[ containerKey ] || false }
+							{ settings.containerID || __( 'Not set', 'google-site-kit' ) }
+						</h5>
+					</div>
+
+					<div className="googlesitekit-settings-module__meta-item">
+						<p className="googlesitekit-settings-module__meta-item-type">
+							{ __( 'AMP Container ID', 'google-site-kit' ) }
+						</p>
+						<h5 className="googlesitekit-settings-module__meta-item-data">
+							{ settings.ampContainerID || __( 'Not set', 'google-site-kit' ) }
 						</h5>
 					</div>
 				</div>

--- a/assets/js/modules/tagmanager/setup.js
+++ b/assets/js/modules/tagmanager/setup.js
@@ -240,7 +240,10 @@ class TagmanagerSetup extends Component {
 				selectedAccount,
 				usageContext,
 			} = this.state;
-			let { selectedContainer } = this.state;
+			let {
+				selectedContainerWeb,
+				selectedContainerAMP,
+			} = this.state;
 
 			const queryArgs = {
 				accountID: selectedAccount,
@@ -251,20 +254,25 @@ class TagmanagerSetup extends Component {
 
 			this.validateAccounts( accounts, selectedAccount );
 
-			// If the selectedContainer is not in the list of containers, clear it.
-			if ( isValidContainerID( selectedContainer ) && ! containers.find( ( container ) => container.publicId === selectedContainer ) ) { /* Capitalization rule exception: `publicId` is a property of an API returned value. */
-				selectedContainer = null;
+			// If the selected container is not in the list of containers, clear it.
+			const containerIDs = containers.map( ( container ) => container.publicId ); /* Capitalization rule exception: `publicId` is a property of an API returned value. */
+			if ( isValidContainerID( selectedContainerWeb ) && ! containerIDs.includes( selectedContainerWeb ) ) {
+				selectedContainerWeb = '';
+			}
+			if ( isValidContainerID( selectedContainerAMP ) && ! containerIDs.includes( selectedContainerAMP ) ) {
+				selectedContainerAMP = '';
 			}
 
 			this.setState( {
 				isLoading: false,
 				accounts,
 				selectedAccount: selectedAccount || get( containers, [ 0, 'accountId' ] ), // Capitalization rule exception: `accountId` is a property of an API returned value.
-				containers,
-				selectedContainer: selectedContainer || get( containers, [ 0, 'publicId' ] ), // Capitalization rule exception: `publicId` is a property of an API returned value.
+				selectedContainerWeb,
+				selectedContainerAMP,
 				errorCode: false,
 				errorMsg: '',
 			} );
+			this.setContainers( containers );
 		} catch ( err ) {
 			this.setState( {
 				isLoading: false,

--- a/assets/js/modules/tagmanager/setup.js
+++ b/assets/js/modules/tagmanager/setup.js
@@ -69,7 +69,7 @@ class TagmanagerSetup extends Component {
 			errorCode: false,
 			errorMsg: '',
 			selectedAccount: settings.accountID,
-			selectedContainerWeb: settings.containerID,
+			selectedContainer: settings.containerID,
 			selectedContainerAMP: settings.ampContainerID,
 			containersLoading: false,
 			usageContext: ampEnabled ? ampUsageContext : USAGE_CONTEXT_WEB,
@@ -138,7 +138,7 @@ class TagmanagerSetup extends Component {
 		}
 
 		let settingsMapping = {
-			selectedContainerWeb: 'containerID',
+			selectedContainer: 'containerID',
 			selectedContainerAMP: 'ampContainerID',
 			selectedAccount: 'accountID',
 			useSnippet: 'useSnippet',
@@ -167,7 +167,7 @@ class TagmanagerSetup extends Component {
 					{
 						isLoading: false,
 						selectedAccount: account.accountId, // Capitalization rule exception: `accountId` is a property of an API returned value.
-						selectedContainerWeb: get( containersWeb, [ 0, 'publicId' ] ), // Capitalization rule exception: `publicId` is a property of an API returned value.
+						selectedContainer: get( containersWeb, [ 0, 'publicId' ] ), // Capitalization rule exception: `publicId` is a property of an API returned value.
 						selectedContainerAMP: get( containersAMP, [ 0, 'publicId' ] ), // Capitalization rule exception: `publicId` is a property of an API returned value.
 						accounts: [ account ],
 						hasExistingTag: true,
@@ -226,7 +226,7 @@ class TagmanagerSetup extends Component {
 				usageContext,
 			} = this.state;
 			let {
-				selectedContainerWeb,
+				selectedContainer,
 				selectedContainerAMP,
 			} = this.state;
 
@@ -241,8 +241,8 @@ class TagmanagerSetup extends Component {
 
 			// If the selected container is not in the list of containers, clear it.
 			const containerIDs = containers.map( ( { publicId } ) => publicId ); /* Capitalization rule exception: `publicId` is a property of an API returned value. */
-			if ( isValidContainerID( selectedContainerWeb ) && ! containerIDs.includes( selectedContainerWeb ) ) {
-				selectedContainerWeb = '';
+			if ( isValidContainerID( selectedContainer ) && ! containerIDs.includes( selectedContainer ) ) {
+				selectedContainer = '';
 			}
 			if ( isValidContainerID( selectedContainerAMP ) && ! containerIDs.includes( selectedContainerAMP ) ) {
 				selectedContainerAMP = '';
@@ -257,7 +257,7 @@ class TagmanagerSetup extends Component {
 				containersWeb,
 				containersAMP,
 				selectedAccount: selectedAccount || get( containers, [ 0, 'accountId' ] ), // Capitalization rule exception: `accountId` is a property of an API returned value.
-				selectedContainerWeb: selectedContainerWeb || get( containersWeb, [ 0, 'publicId' ] ), // Capitalization rule exception: `publicId` is a property of an API returned value.
+				selectedContainer: selectedContainer || get( containersWeb, [ 0, 'publicId' ] ), // Capitalization rule exception: `publicId` is a property of an API returned value.
 				selectedContainerAMP: selectedContainerAMP || get( containersAMP, [ 0, 'publicId' ] ), // Capitalization rule exception: `accountId` is a property of an API returned value.
 				errorCode: false,
 				errorMsg: '',
@@ -337,7 +337,7 @@ class TagmanagerSetup extends Component {
 		const {
 			hasExistingTag,
 			selectedAccount,
-			selectedContainerWeb,
+			selectedContainer,
 			selectedContainerAMP,
 			usageContext,
 			useSnippet,
@@ -348,7 +348,7 @@ class TagmanagerSetup extends Component {
 		try {
 			const dataParams = {
 				accountID: selectedAccount,
-				containerID: selectedContainerWeb,
+				containerID: selectedContainer,
 				ampContainerID: selectedContainerAMP,
 				usageContext,
 				useSnippet: hasExistingTag ? false : useSnippet,
@@ -393,7 +393,7 @@ class TagmanagerSetup extends Component {
 
 		this.setState( {
 			selectedAccount: selectValue,
-			selectedContainerWeb: '',
+			selectedContainer: '',
 			selectedContainerAMP: '',
 		} );
 
@@ -413,7 +413,7 @@ class TagmanagerSetup extends Component {
 				errorCode: false,
 				errorMsg: '',
 				selectedAccount: '',
-				selectedContainerWeb: '',
+				selectedContainer: '',
 				selectedContainerAMP: '',
 			},
 			this.requestTagManagerAccounts
@@ -586,7 +586,7 @@ class TagmanagerSetup extends Component {
 
 					{ showWebContainerSelect &&
 						this.renderContainerSelect( {
-							selectedStateKey: 'selectedContainerWeb',
+							selectedStateKey: 'selectedContainer',
 							containers: containersWeb,
 							label: showAMPContainerSelect ? __( 'Web Container', 'google-site-kit' ) : null,
 							type: USAGE_CONTEXT_WEB,
@@ -697,7 +697,7 @@ class TagmanagerSetup extends Component {
 			errorCode,
 			isLoading,
 			selectedAccount,
-			selectedContainerWeb,
+			selectedContainer,
 			selectedContainerAMP,
 		} = this.state;
 
@@ -711,8 +711,8 @@ class TagmanagerSetup extends Component {
 
 		if (
 			( ! ampEnabled || 'secondary' === ampMode ) &&
-			! isValidContainerID( selectedContainerWeb ) &&
-			CONTAINER_CREATE !== selectedContainerWeb
+			! isValidContainerID( selectedContainer ) &&
+			CONTAINER_CREATE !== selectedContainer
 		) {
 			return false;
 		}

--- a/assets/js/modules/tagmanager/setup.js
+++ b/assets/js/modules/tagmanager/setup.js
@@ -342,10 +342,10 @@ class TagmanagerSetup extends Component {
 
 	async handleSubmit() {
 		const {
-			containerKey,
 			hasExistingTag,
 			selectedAccount,
-			selectedContainer,
+			selectedContainerWeb,
+			selectedContainerAMP,
 			usageContext,
 			useSnippet,
 		} = this.state;
@@ -355,7 +355,8 @@ class TagmanagerSetup extends Component {
 		try {
 			const dataParams = {
 				accountID: selectedAccount,
-				[ containerKey ]: selectedContainer,
+				containerID: selectedContainerWeb,
+				ampContainerID: selectedContainerAMP,
 				usageContext,
 				useSnippet: hasExistingTag ? false : useSnippet,
 			};

--- a/assets/js/modules/tagmanager/setup.js
+++ b/assets/js/modules/tagmanager/setup.js
@@ -56,6 +56,7 @@ class TagmanagerSetup extends Component {
 		const ampUsageContext = ampMode === 'primary' ? USAGE_CONTEXT_AMP : [ USAGE_CONTEXT_WEB, USAGE_CONTEXT_AMP ];
 
 		this.state = {
+			ampEnabled,
 			ampMode,
 			isLoading: true,
 			accounts: [],

--- a/assets/js/modules/tagmanager/util/get-containers.js
+++ b/assets/js/modules/tagmanager/util/get-containers.js
@@ -1,0 +1,16 @@
+/**
+ * Gets an object of utility functions for filtering the given list of containers.
+ *
+ * @param {Array} containers Containers to filter.
+ * @return {Object} Object with keys mapping to utility functions to operate on given containers.
+ */
+export default function getContainers( containers ) {
+	return {
+		/**
+		 * Gets containers that include the given usage context.
+		 * @param {string} context The context to filter by.
+		 * @return {Array} Containers with the given usage context.
+		 */
+		byContext: ( context ) => containers.filter( ( c ) => c.usageContext.includes( context ) ),
+	};
+}

--- a/assets/js/modules/tagmanager/util/index.js
+++ b/assets/js/modules/tagmanager/util/index.js
@@ -1,3 +1,4 @@
+export { default as getContainers } from './get-containers';
 export { default as isValidAccountID } from './is-valid-account-id';
 export { default as isValidContainerID } from './is-valid-container-id';
 export { default as tagMatchers } from './tag-matchers';

--- a/includes/Core/Modules/Module.php
+++ b/includes/Core/Modules/Module.php
@@ -719,7 +719,7 @@ abstract class Module {
 	 * @param string    $datapoint Datapoint originally requested.
 	 * @return WP_Error WordPress error object.
 	 */
-	private function exception_to_error( Exception $e, $datapoint ) {
+	protected function exception_to_error( Exception $e, $datapoint ) {
 		$code = $e->getCode();
 		if ( empty( $code ) ) {
 			$code = 'unknown';

--- a/includes/Core/Modules/Module.php
+++ b/includes/Core/Modules/Module.php
@@ -725,21 +725,6 @@ abstract class Module {
 			$code = 'unknown';
 		}
 
-		// This is not great to have here, but is completely internal so it can be improved/removed at any time.
-		if ( $this instanceof \Google\Site_Kit\Modules\AdSense ) {
-			switch ( $datapoint ) {
-				case 'accounts':
-				case 'alerts':
-				case 'clients':
-				case 'urlchannels':
-					$errors = json_decode( $e->getMessage() );
-					if ( $errors ) {
-						return new \WP_Error( $e->getCode(), $errors, array( 'status' => 500 ) );
-					}
-					break;
-			}
-		}
-
 		$reason = '';
 
 		if ( $e instanceof Google_Service_Exception ) {

--- a/includes/Modules/AdSense.php
+++ b/includes/Modules/AdSense.php
@@ -10,6 +10,7 @@
 
 namespace Google\Site_Kit\Modules;
 
+use Exception;
 use Google\Site_Kit\Core\Modules\Module;
 use Google\Site_Kit\Core\Modules\Module_Settings;
 use Google\Site_Kit\Core\Modules\Module_With_Screen;
@@ -746,5 +747,25 @@ tag_partner: "site_kit"
 	 */
 	protected function setup_settings() {
 		return new Settings( $this->options );
+	}
+
+	/**
+	 * Transforms an exception into a WP_Error object.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param Exception $e         Exception object.
+	 * @param string    $datapoint Datapoint originally requested.
+	 * @return WP_Error WordPress error object.
+	 */
+	protected function exception_to_error( Exception $e, $datapoint ) {
+		if ( in_array( $datapoint, array( 'accounts', 'alerts', 'clients', 'urlchannels' ), true ) ) {
+			$errors = json_decode( $e->getMessage() );
+			if ( $errors ) {
+				return new WP_Error( $e->getCode(), $errors, array( 'status' => 500 ) );
+			}
+		}
+
+		return parent::exception_to_error( $e, $datapoint );
 	}
 }

--- a/includes/Modules/Tag_Manager.php
+++ b/includes/Modules/Tag_Manager.php
@@ -652,7 +652,7 @@ final class Tag_Manager extends Module implements Module_With_Scopes, Module_Wit
 				$containers = array_filter(
 					(array) $response->getContainer(),
 					function ( Google_Service_TagManager_Container $container ) use ( $usage_context ) {
-						return in_array( $usage_context, $container->getUsageContext(), true );
+						return array_intersect( (array) $usage_context, $container->getUsageContext() );
 					}
 				);
 

--- a/includes/Modules/Tag_Manager.php
+++ b/includes/Modules/Tag_Manager.php
@@ -564,6 +564,10 @@ final class Tag_Manager extends Module implements Module_With_Scopes, Module_Wit
 
 		// Use site name for container, fallback to domain of reference URL.
 		$container_name = get_bloginfo( 'name' ) ?: wp_parse_url( $this->context->get_reference_site_url(), PHP_URL_HOST );
+		// Prevent naming conflict (Tag Manager does not allow more than one with same name).
+		if ( self::USAGE_CONTEXT_AMP === $usage_context ) {
+			$container_name .= ' AMP';
+		}
 		$container_name = self::sanitize_container_name( $container_name );
 
 		$container = new Google_Service_TagManager_Container();

--- a/includes/Modules/Tag_Manager.php
+++ b/includes/Modules/Tag_Manager.php
@@ -558,6 +558,7 @@ final class Tag_Manager extends Module implements Module_With_Scopes, Module_Wit
 	 * @param string|array $usage_context The container usage context(s).
 	 *
 	 * @return string Container public ID.
+	 * @throws Exception Throws an exception if raised during container creation.
 	 */
 	protected function create_container( $account_id, $usage_context = self::USAGE_CONTEXT_WEB ) {
 		$restore_defer = $this->with_client_defer( false );
@@ -574,7 +575,12 @@ final class Tag_Manager extends Module implements Module_With_Scopes, Module_Wit
 		$container->setName( $container_name );
 		$container->setUsageContext( (array) $usage_context );
 
-		$new_container = $this->get_tagmanager_service()->accounts_containers->create( "accounts/{$account_id}", $container );
+		try {
+			$new_container = $this->get_tagmanager_service()->accounts_containers->create( "accounts/{$account_id}", $container );
+		} catch ( Exception $exception ) {
+			$restore_defer();
+			throw $exception;
+		}
 
 		$restore_defer();
 

--- a/includes/Modules/Tag_Manager.php
+++ b/includes/Modules/Tag_Manager.php
@@ -566,10 +566,10 @@ final class Tag_Manager extends Module implements Module_With_Scopes, Module_Wit
 	 * Creates GTM Container.
 	 *
 	 * @since 1.0.0
-	 * @param string       $account_id The account ID.
+	 * @param string       $account_id    The account ID.
 	 * @param string|array $usage_context The container usage context(s).
 	 *
-	 * @return mixed Container ID on success, or WP_Error on failure.
+	 * @return string Container public ID.
 	 */
 	protected function create_container( $account_id, $usage_context = self::USAGE_CONTEXT_WEB ) {
 		$restore_defer = $this->with_client_defer( false );
@@ -582,22 +582,11 @@ final class Tag_Manager extends Module implements Module_With_Scopes, Module_Wit
 		$container->setName( $container_name );
 		$container->setUsageContext( (array) $usage_context );
 
-		try {
-			$container = $this->get_tagmanager_service()->accounts_containers->create( "accounts/{$account_id}", $container );
-		} catch ( Google_Service_Exception $e ) {
-			$restore_defer();
-			$message = $e->getErrors();
-			if ( isset( $message[0]['message'] ) ) {
-				$message = $message[0]['message'];
-			}
-			return new WP_Error( $e->getCode(), $message );
-		} catch ( Exception $e ) {
-			$restore_defer();
-			return new WP_Error( $e->getCode(), $e->getMessage() );
-		}
+		$new_container = $this->get_tagmanager_service()->accounts_containers->create( "accounts/{$account_id}", $container );
 
 		$restore_defer();
-		return $container->getPublicId();
+
+		return $new_container->getPublicId();
 	}
 
 	/**

--- a/includes/Modules/Tag_Manager.php
+++ b/includes/Modules/Tag_Manager.php
@@ -646,7 +646,6 @@ final class Tag_Manager extends Module implements Module_With_Scopes, Module_Wit
 				return array_merge( $response, compact( 'containers' ) );
 			case 'GET:containers':
 				/* @var Google_Service_TagManager_ListContainersResponse $response Response object. */
-				$account_id    = $data['accountID'];
 				$usage_context = $data['usageContext'] ?: self::USAGE_CONTEXT_WEB;
 				/* @var Google_Service_TagManager_Container[] $containers Filtered containers. */
 				$containers = array_filter(
@@ -655,17 +654,6 @@ final class Tag_Manager extends Module implements Module_With_Scopes, Module_Wit
 						return array_intersect( (array) $usage_context, $container->getUsageContext() );
 					}
 				);
-
-				if ( ! $containers && $account_id ) {
-					// If no containers, attempt to create a new container.
-					$new_container = $this->create_container( $account_id, $usage_context );
-
-					if ( is_wp_error( $new_container ) ) {
-						return $new_container;
-					}
-
-					return $this->get_data( 'containers', array( 'accountID' => $account_id ) );
-				}
 
 				return array_values( $containers );
 		}

--- a/includes/Modules/Tag_Manager.php
+++ b/includes/Modules/Tag_Manager.php
@@ -493,9 +493,21 @@ final class Tag_Manager extends Module implements Module_With_Scopes, Module_Wit
 				}
 				return $this->get_tagmanager_service()->accounts_containers->listAccountsContainers( "accounts/{$data['accountID']}" );
 			case 'POST:settings':
-				if ( ! isset( $data['accountID'] ) ) {
-					/* translators: %s: Missing parameter name */
-					return new WP_Error( 'missing_required_param', sprintf( __( 'Request parameter is empty: %s.', 'google-site-kit' ), 'accountID' ), array( 'status' => 400 ) );
+				$required_params = array( 'accountID', 'usageContext' );
+
+				if ( self::USAGE_CONTEXT_WEB === $data['usageContext'] ) { // No AMP.
+					$required_params[] = $this->context_map[ self::USAGE_CONTEXT_WEB ];
+				} elseif ( self::USAGE_CONTEXT_AMP === $data['usageContext'] ) { // Primary AMP.
+					$required_params[] = $this->context_map[ self::USAGE_CONTEXT_AMP ];
+				} else { // Secondary AMP.
+					array_push( $required_params, ...array_values( $this->context_map ) );
+				}
+
+				foreach ( $required_params as $required_param ) {
+					if ( ! isset( $data[ $required_param ] ) ) {
+						/* translators: %s: Missing parameter name */
+						return new WP_Error( 'missing_required_param', sprintf( __( 'Request parameter is empty: %s.', 'google-site-kit' ), $required_param ), array( 'status' => 400 ) );
+					}
 				}
 
 				return function() use ( $data ) {

--- a/includes/Modules/Tag_Manager.php
+++ b/includes/Modules/Tag_Manager.php
@@ -693,7 +693,13 @@ final class Tag_Manager extends Module implements Module_With_Scopes, Module_Wit
 	private function get_account_for_container( $container_id, $accounts ) {
 		foreach ( (array) $accounts as $account ) {
 			/* @var Google_Service_TagManager_Account $account Tag manager account */
-			$containers = $this->get_data( 'containers', array( 'accountID' => $account->getAccountId() ) );
+			$containers = $this->get_data(
+				'containers',
+				array(
+					'accountID'    => $account->getAccountId(),
+					'usageContext' => array_keys( $this->context_map ),
+				)
+			);
 
 			if ( is_wp_error( $containers ) ) {
 				break;

--- a/tests/e2e/plugins/module-setup-tagmanager.php
+++ b/tests/e2e/plugins/module-setup-tagmanager.php
@@ -19,11 +19,15 @@ use Google\Site_Kit\Core\REST_API\REST_Routes;
 const ACCOUNT_ID_A = '100';
 const ACCOUNT_ID_B = '101';
 
-const PUBLIC_ID_X = 'GTM-ABCXYZ';
-const PUBLIC_ID_Y = 'GTM-BCDWXY';
+const PUBLIC_ID_X  = 'GTM-ABCXYZ';
+const PUBLIC_ID_Y  = 'GTM-BCDWXY';
+const PUBLIC_ID_AX = 'GTM-AMPXYZ';
+const PUBLIC_ID_AY = 'GTM-AMPWXY';
 
-const CONTAINER_ID_X = '200';
-const CONTAINER_ID_Y = '201';
+const CONTAINER_ID_X  = '200';
+const CONTAINER_ID_Y  = '201';
+const CONTAINER_ID_AX = '210';
+const CONTAINER_ID_AY = '211';
 
 function filter_by_account_id( $items, $account_id ) {
 	return array_values(
@@ -31,6 +35,17 @@ function filter_by_account_id( $items, $account_id ) {
 			$items,
 			function ( $item ) use ( $account_id ) {
 				return $item['accountId'] === $account_id;
+			}
+		)
+	);
+}
+
+function filter_by_context( $items, $context ) {
+	return array_values(
+		array_filter(
+			$items,
+			function ( $item ) use ( $context ) {
+				return (bool) array_intersect( (array) $context, $item['usageContext'] );
 			}
 		)
 	);
@@ -52,16 +67,32 @@ add_action(
 		);
 		$containers = array(
 			array(
-				'accountId'   => ACCOUNT_ID_A,
-				'publicId'    => PUBLIC_ID_X,
-				'containerId' => CONTAINER_ID_X,
-				'name'        => 'Test Container X',
+				'accountId'    => ACCOUNT_ID_A,
+				'publicId'     => PUBLIC_ID_X,
+				'containerId'  => CONTAINER_ID_X,
+				'name'         => 'Test Container X',
+				'usageContext' => array( 'web' ),
 			),
 			array(
-				'accountId'   => ACCOUNT_ID_B,
-				'publicId'    => PUBLIC_ID_Y,
-				'containerId' => CONTAINER_ID_Y,
-				'name'        => 'Test Container Y',
+				'accountId'    => ACCOUNT_ID_B,
+				'publicId'     => PUBLIC_ID_Y,
+				'containerId'  => CONTAINER_ID_Y,
+				'name'         => 'Test Container Y',
+				'usageContext' => array( 'web' ),
+			),
+			array(
+				'accountId'    => ACCOUNT_ID_A,
+				'publicId'     => PUBLIC_ID_AX,
+				'containerId'  => CONTAINER_ID_AX,
+				'name'         => 'Test AMP Container AX',
+				'usageContext' => array( 'amp' ),
+			),
+			array(
+				'accountId'    => ACCOUNT_ID_B,
+				'publicId'     => PUBLIC_ID_AY,
+				'containerId'  => CONTAINER_ID_AY,
+				'name'         => 'Test AMP Container AY',
+				'usageContext' => array( 'amp' ),
 			),
 		);
 
@@ -84,6 +115,7 @@ add_action(
 				'methods'  => 'GET',
 				'callback' => function ( $request ) use ( $accounts, $containers ) {
 					$account_id = $request['accountID'] ?: $accounts[0]['accountId'];
+					$containers = filter_by_context( $containers, $request['usageContext'] );
 
 					return array(
 						'accounts'   => $accounts,
@@ -100,6 +132,8 @@ add_action(
 			array(
 				'methods'  => 'GET',
 				'callback' => function ( $request ) use ( $containers ) {
+					$containers = filter_by_context( $containers, $request['usageContext'] );
+
 					return filter_by_account_id( $containers, $request['accountID'] );
 				},
 			),

--- a/tests/e2e/specs/modules/tagmanager/setup.test.js
+++ b/tests/e2e/specs/modules/tagmanager/setup.test.js
@@ -121,9 +121,12 @@ describe( 'Tag Manager module setup', () => {
 			expect( page ).toClick( '.mdc-menu-surface--open .mdc-list-item', { text: /test account b/i } ),
 		] );
 
-		// Ensure proper account and container are now selected.
+		// Ensure account is selected.
 		await expect( page ).toMatchElement( '.googlesitekit-tagmanager__select-account .mdc-select__selected-text', { text: /test account b/i } );
-		await expect( page ).toMatchElement( '.googlesitekit-tagmanager__select-container .mdc-select__selected-text', { text: /test container y/i } );
+
+		// Select a container.
+		await expect( page ).toClick( '.googlesitekit-tagmanager__select-container' );
+		await expect( page ).toClick( '.mdc-menu-surface--open .mdc-list-item', { text: /test container y/i } );
 
 		await page.waitFor( 1000 );
 		await expect( page ).toClick( 'button', { text: /confirm \& continue/i } );

--- a/tests/e2e/specs/modules/tagmanager/setup.test.js
+++ b/tests/e2e/specs/modules/tagmanager/setup.test.js
@@ -110,6 +110,10 @@ describe( 'Tag Manager module setup', () => {
 		await activatePlugin( 'e2e-tests-module-setup-tagmanager-api-mock' );
 		await proceedToTagManagerSetup();
 
+		// Ensure only web container select is shown.
+		await expect( page ).toMatchElement( '.googlesitekit-tagmanager__select-container--web' );
+		await expect( page ).not.toMatchElement( '.googlesitekit-tagmanager__select-container--amp' );
+
 		// Ensure account and container are selected by default.
 		await expect( page ).toMatchElement( '.googlesitekit-tagmanager__select-account .mdc-select__selected-text', { text: /test account a/i } );
 		await expect( page ).toMatchElement( '.googlesitekit-tagmanager__select-container .mdc-select__selected-text', { text: /test container x/i } );
@@ -126,6 +130,11 @@ describe( 'Tag Manager module setup', () => {
 
 		// Select a container.
 		await expect( page ).toClick( '.googlesitekit-tagmanager__select-container' );
+		// Ensure no AMP containers are shown as options.
+		// expect(...).not.toMatchElement with textContent matching does not work as expected.
+		await expect(
+			await page.$$eval( '.mdc-menu-surface--open .mdc-list-item', ( nodes ) => !! nodes.find( ( e ) => e.textContent.match( /test amp container/i ) ) )
+		).toStrictEqual( false );
 		await expect( page ).toClick( '.mdc-menu-surface--open .mdc-list-item', { text: /test container y/i } );
 
 		await page.waitFor( 1000 );


### PR DESCRIPTION
## Summary

Addresses issue #413 

## Relevant technical choices

* Updated `GET:tag-permission` to be usage context agnostic
* Updated `GET:container` to accept an array of `usageContext`s
* Updated `Module::exception_to_error` from private to protected
    - Allows the method to be used from Module datapoint callbacks
    - Allowed for some module-specific logic (AdSense) to be moved to that module rather than in the base class
    - Used by `POST:settings` now as part of larger simplification around container creation logic
* Updated `GET:containers` to not automatically create a container if the account has none
    - Updated setup interface to automatically select `create_container` if no containers exist
* Updated E2E tests for setup to ensure AMP containers are not listed in web container select
* Updated labelling of containers in settings and in setup UI
    - Container select is labeled "Container" unless both selects are shown
* Updated settings to show "Not set" instead of `false` when setting is not set yet
* Tweaked language around snippet insertion to "on your site" rather than "into" or "to your site"
* Update container name generated for AMP container to prevent naming conflict

**No AMP**
![image](https://user-images.githubusercontent.com/1621608/74669913-c803af00-51b0-11ea-88a4-d76369858fee.png)

**AMP Secondary**
![image](https://user-images.githubusercontent.com/1621608/74669969-e7024100-51b0-11ea-97f6-c4ef6b7f4558.png)

![image](https://user-images.githubusercontent.com/1621608/74670100-29c41900-51b1-11ea-899a-7c8ab7c9087d.png)

**AMP Primary**
![image](https://user-images.githubusercontent.com/1621608/74670036-039e7900-51b1-11ea-8f66-1b23f81e1c8b.png)

**Settings**
![image](https://user-images.githubusercontent.com/1621608/74670429-d43c3c00-51b1-11ea-9842-c967523dffbc.png)

Always displays items for both container IDs


## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
