### PR TITLE
Ensure opcache_reset exists before calling.

### DIFF
--- a/google-site-kit.php
+++ b/google-site-kit.php
@@ -90,6 +90,10 @@ function googlesitekit_opcache_reset() {
 		return;
 	}
 
+	if ( ! function_exists( 'opcache_reset' ) ) {
+		return;
+	}
+
 	if ( ! empty( ini_get( 'opcache.restrict_api' ) ) && strpos( __FILE__, ini_get( 'opcache.restrict_api' ) ) !== 0 ) {
 		return;
 	}


### PR DESCRIPTION
## Summary

Addresses issue #1136 

## Relevant technical choices
* Hotfix based on `master`

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
