### PR TITLE
Don't use AMD parser for node_modules scripts.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22465,15 +22465,6 @@
       "integrity": "sha512-rlrc3yU3+JNOpZ9zj5pQtxnx2THmvRykwL4Xlxoa8I9lHBlVbbyPhgyPMioxVZ4NqyxaVVtaJnzsyOidQIhyyQ==",
       "dev": true
     },
-    "lodash-webpack-plugin": {
-      "version": "0.11.5",
-      "resolved": "https://registry.npmjs.org/lodash-webpack-plugin/-/lodash-webpack-plugin-0.11.5.tgz",
-      "integrity": "sha512-QWfEIYxpixOdbd6KBe5g6MDWcyTgP3trDXwKHFqTlXrWiLcs/67fGQ0IWeRyhWlTITQIgMpJAYd2oeIztuV5VA==",
-      "dev": true,
-      "requires": {
-        "lodash": "^4.17.4"
-      }
-    },
     "lodash._baseassign": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -168,8 +168,6 @@
     "jquery": "^3.4.1",
     "lint-staged": "^8.1.5",
     "lodash": "^4.17.15",
-    "lodash-es": "^4.17.15",
-    "lodash-webpack-plugin": "^0.11.5",
     "md5": "^2.2.1",
     "mini-css-extract-plugin": "^0.4.5",
     "natives": "^1.1.6",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -79,6 +79,11 @@ const webpackConfig = ( mode ) => {
 			module: {
 				rules: [
 					{
+						parser: {
+							amd: false,
+						},
+					},
+					{
 						test: /\.js$/,
 						exclude: /node_modules/,
 						use: [

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -34,6 +34,8 @@ const projectPath = ( relativePath ) => {
 	return path.resolve( fs.realpathSync( process.cwd() ), relativePath );
 };
 
+const noAMDParserRule = { parser: { amd: false } };
+
 const resolve = {
 	alias: {
 		'@wordpress/api-fetch__non-shim': require.resolve( '@wordpress/api-fetch' ),
@@ -78,11 +80,7 @@ const webpackConfig = ( mode ) => {
 			},
 			module: {
 				rules: [
-					{
-						parser: {
-							amd: false,
-						},
-					},
+					noAMDParserRule,
 					{
 						test: /\.js$/,
 						exclude: /node_modules/,
@@ -104,7 +102,7 @@ const webpackConfig = ( mode ) => {
 								},
 							},
 						],
-						parser: { amd: false },
+						...noAMDParserRule,
 					},
 				],
 			},
@@ -200,6 +198,7 @@ const testBundle = () => {
 		},
 		module: {
 			rules: [
+				noAMDParserRule,
 				{
 					test: /\.js$/,
 					exclude: /node_modules/,
@@ -221,6 +220,7 @@ const testBundle = () => {
 							},
 						},
 					],
+					...noAMDParserRule,
 				},
 			],
 		},

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -36,6 +36,33 @@ const projectPath = ( relativePath ) => {
 
 const noAMDParserRule = { parser: { amd: false } };
 
+const rules = [
+	noAMDParserRule,
+	{
+		test: /\.js$/,
+		exclude: /node_modules/,
+		use: [
+			{
+				loader: 'babel-loader',
+				query: {
+					presets: [ [ '@babel/env', {
+						useBuiltIns: 'entry',
+						corejs: 2,
+					} ], '@babel/preset-react' ],
+				},
+			},
+			{
+				loader: 'eslint-loader',
+				options: {
+					quiet: true,
+					formatter: require( 'eslint' ).CLIEngine.getFormatter( 'stylish' ),
+				},
+			},
+		],
+		...noAMDParserRule,
+	},
+];
+
 const resolve = {
 	alias: {
 		'@wordpress/api-fetch__non-shim': require.resolve( '@wordpress/api-fetch' ),
@@ -79,32 +106,7 @@ const webpackConfig = ( mode ) => {
 				maxEntrypointSize: 175000,
 			},
 			module: {
-				rules: [
-					noAMDParserRule,
-					{
-						test: /\.js$/,
-						exclude: /node_modules/,
-						use: [
-							{
-								loader: 'babel-loader',
-								query: {
-									presets: [ [ '@babel/env', {
-										useBuiltIns: 'entry',
-										corejs: 2,
-									} ], '@babel/preset-react' ],
-								},
-							},
-							{
-								loader: 'eslint-loader',
-								options: {
-									quiet: true,
-									formatter: require( 'eslint' ).CLIEngine.getFormatter( 'stylish' ),
-								},
-							},
-						],
-						...noAMDParserRule,
-					},
-				],
+				rules,
 			},
 			plugins: [
 				new ProvidePlugin( {
@@ -197,32 +199,7 @@ const testBundle = () => {
 			publicPath: '',
 		},
 		module: {
-			rules: [
-				noAMDParserRule,
-				{
-					test: /\.js$/,
-					exclude: /node_modules/,
-					use: [
-						{
-							loader: 'babel-loader',
-							query: {
-								presets: [ [ '@babel/env', {
-									useBuiltIns: 'entry',
-									corejs: 2,
-								} ], '@babel/preset-react' ],
-							},
-						},
-						{
-							loader: 'eslint-loader',
-							options: {
-								quiet: true,
-								formatter: require( 'eslint' ).CLIEngine.getFormatter( 'stylish' ),
-							},
-						},
-					],
-					...noAMDParserRule,
-				},
-			],
+			rules,
 		},
 		plugins: [
 			new WebpackBar( {


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #1141.

Fixes issue with lodash declaring a global (#1141).

Also removes unneeded lodash npm modules from package.json.

## Relevant technical choices

Rather than change to using `lodash-es`, this should protect us from other modules that tend to declare globals when imported using the AMD parser. My testing of this change didn't affect the site (which makes sense, all of our parsing/imports are not done using AMD style modules), and this rule was already in place in our own code.

It wasn't enforced for files in the `node_modules` folder as we wanted to exclude them from our babel transforms, but it can be safely enforced. All E2E tests also pass with this change, and it removes the `_` global from pages with Site Kit loaded 😄

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
