### PR TITLE
Fix JSX issue by making condition a boolean.

### DIFF
--- a/assets/js/components/dialog.js
+++ b/assets/js/components/dialog.js
@@ -67,6 +67,7 @@ class Dialog extends Component {
 
 		const labelledByID = `googlesitekit-dialog-label-${ instanceId }`;
 		const describedByID = `googlesitekit-dialog-description-${ instanceId }`;
+		const hasProvides = !! ( provides && provides.length );
 
 		return (
 			<div
@@ -75,7 +76,7 @@ class Dialog extends Component {
 				role="alertdialog"
 				aria-modal="true"
 				aria-labelledby={ title ? labelledByID : undefined }
-				aria-describedby={ ( provides && provides.length ) ? describedByID : undefined }
+				aria-describedby={ hasProvides ? describedByID : undefined }
 				aria-hidden={ dialogActive ? 'false' : 'true' }
 				tabIndex="-1"
 			>
@@ -94,7 +95,7 @@ class Dialog extends Component {
 										{ subtitle }
 									</p>
 								}
-								{ ( provides && provides.length ) &&
+								{ hasProvides &&
 									<section id={ describedByID } className="mdc-dialog__content">
 										<ul className="mdc-list mdc-list--underlined mdc-list--non-interactive">
 											{ provides.map( ( attribute ) => (


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #345

Follow-up to #1082 

## Relevant technical choices

* Including `provides && provides.length` as a condition within JSX causes the dialog to actually render `0` because that is the value of `provides.length`.
* Turning that into a single clause boolean resolves the problem.

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
