### PR TITLE
Invert chart colour along with arrow colour in data-block.

### DIFF
--- a/assets/js/components/data-block.js
+++ b/assets/js/components/data-block.js
@@ -25,7 +25,7 @@ import SourceLink from 'GoogleComponents/source-link';
 /**
  * WordPress dependencies
  */
-import { Component, Fragment } from '@wordpress/element';
+import { Component, Fragment, cloneElement } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -72,6 +72,14 @@ class DataBlock extends Component {
 
 		const role = ( 'button' === context ) ? 'button' : '';
 
+		// The `sparkline` prop is passed as a component, but if `invertChangeColor`
+		// is set, we should pass that to `<Sparkline>`. In that case, we clone
+		// the element and add the prop.
+		let sparklineComponent = sparkline;
+		if ( sparklineComponent && invertChangeColor ) {
+			sparklineComponent = cloneElement( sparkline, { invertChangeColor } );
+		}
+
 		return (
 			<div
 				className={ `
@@ -98,9 +106,9 @@ class DataBlock extends Component {
 						{ `${ datapoint }${ datapointUnit }` }
 					</div>
 				</div>
-				{ sparkline &&
+				{ sparklineComponent &&
 					<div className="googlesitekit-data-block__sparkline">
-						{ sparkline }
+						{ sparklineComponent }
 					</div>
 				}
 				<div className="googlesitekit-data-block__change-source-wrapper">

--- a/assets/js/components/sparkline.js
+++ b/assets/js/components/sparkline.js
@@ -71,7 +71,7 @@ class Sparkline extends Component {
 			},
 			axes: [],
 			colors: [
-				0 <= parseFloat( change ) ? positiveColor : negativeColor,
+				0 <= ( parseFloat( change ) || 0 ) ? positiveColor : negativeColor,
 			],
 		};
 
@@ -92,7 +92,7 @@ class Sparkline extends Component {
 }
 
 Sparkline.propTypes = {
-	instanceId: PropTypes.string.isRequired,
+	instanceId: PropTypes.number.isRequired,
 	invertChangeColor: PropTypes.bool,
 	loadSmall: PropTypes.bool,
 	loadCompressed: PropTypes.bool,

--- a/assets/js/components/sparkline.js
+++ b/assets/js/components/sparkline.js
@@ -25,6 +25,7 @@ import PropTypes from 'prop-types';
 /**
  * WordPress dependencies
  */
+import { withInstanceId } from '@wordpress/compose';
 import { Component } from '@wordpress/element';
 
 class Sparkline extends Component {
@@ -106,4 +107,4 @@ Sparkline.defaultProps = {
 	loadText: false,
 };
 
-export default Sparkline;
+export default withInstanceId( Sparkline );

--- a/assets/js/components/sparkline.js
+++ b/assets/js/components/sparkline.js
@@ -33,6 +33,7 @@ class Sparkline extends Component {
 			data,
 			change,
 			id,
+			invertChangeColor,
 			loadSmall,
 			loadCompressed,
 			loadHeight,
@@ -42,6 +43,9 @@ class Sparkline extends Component {
 		if ( ! data ) {
 			return 'loading...';
 		}
+
+		const positiveColor = ! invertChangeColor ? 'green' : 'red';
+		const negativeColor = ! invertChangeColor ? 'red' : 'green';
 
 		const chartOptions = {
 			title: '',
@@ -66,7 +70,7 @@ class Sparkline extends Component {
 			},
 			axes: [],
 			colors: [
-				0 <= +change ? 'green' : 'red', // Converts change to number.
+				0 <= parseFloat( change ) ? positiveColor : negativeColor,
 			],
 		};
 
@@ -87,6 +91,7 @@ class Sparkline extends Component {
 }
 
 Sparkline.propTypes = {
+	invertChangeColor: PropTypes.bool,
 	loadSmall: PropTypes.bool,
 	loadCompressed: PropTypes.bool,
 	loadHeight: PropTypes.number,
@@ -94,6 +99,7 @@ Sparkline.propTypes = {
 };
 
 Sparkline.defaultProps = {
+	invertChangeColor: false,
 	loadSmall: true,
 	loadCompressed: true,
 	loadHeight: 46,

--- a/assets/js/components/sparkline.js
+++ b/assets/js/components/sparkline.js
@@ -33,7 +33,7 @@ class Sparkline extends Component {
 		const {
 			data,
 			change,
-			id,
+			instanceId,
 			invertChangeColor,
 			loadSmall,
 			loadCompressed,
@@ -80,7 +80,7 @@ class Sparkline extends Component {
 				<GoogleChart
 					data={ data }
 					options={ chartOptions }
-					id={ id }
+					id={ `googlesitekit-sparkline-${ instanceId }` }
 					loadSmall={ loadSmall }
 					loadCompressed={ loadCompressed }
 					loadHeight={ loadHeight }
@@ -92,6 +92,7 @@ class Sparkline extends Component {
 }
 
 Sparkline.propTypes = {
+	instanceId: PropTypes.string.isRequired,
 	invertChangeColor: PropTypes.bool,
 	loadSmall: PropTypes.bool,
 	loadCompressed: PropTypes.bool,

--- a/assets/js/modules/adsense/dashboard/dashboard-widget-main-summary.js
+++ b/assets/js/modules/adsense/dashboard/dashboard-widget-main-summary.js
@@ -136,7 +136,6 @@ class AdSenseDashboardMainSummary extends Component {
 											<Sparkline
 												data={ extractForSparkline( processedData.dataMap, 2 ) }
 												change={ 1 }
-												id="adsense-rpm-sparkline"
 												loadSmall={ false }
 											/>
 										}
@@ -161,7 +160,6 @@ class AdSenseDashboardMainSummary extends Component {
 											<Sparkline
 												data={ extractForSparkline( processedData.dataMap, 1 ) }
 												change={ 1 }
-												id="adsense-earnings-sparkline"
 												loadSmall={ false }
 											/>
 										}
@@ -184,7 +182,6 @@ class AdSenseDashboardMainSummary extends Component {
 											<Sparkline
 												data={ extractForSparkline( processedData.dataMap, 3 ) }
 												change={ 1 }
-												id="adsense-impressions-sparkline"
 												loadSmall={ false }
 											/>
 										}

--- a/assets/js/modules/analytics/dashboard/dashboard-widget-top-level.js
+++ b/assets/js/modules/analytics/dashboard/dashboard-widget-top-level.js
@@ -135,7 +135,6 @@ class AnalyticsDashboardWidgetTopLevel extends Component {
 								<Sparkline
 									data={ extractForSparkline( extractedAnalytics, 1 ) }
 									change={ totalUsersChange }
-									id="analytics-users-sparkline"
 								/>
 						}
 					/>
@@ -171,7 +170,6 @@ class AnalyticsDashboardWidgetTopLevel extends Component {
 										<Sparkline
 											data={ extractForSparkline( extractedAnalytics, 2 ) }
 											change={ averageBounceRateChange }
-											id="analytics-sessions-sparkline"
 										/>
 								}
 							/>
@@ -201,7 +199,6 @@ class AnalyticsDashboardWidgetTopLevel extends Component {
 								<Sparkline
 									data={ extractForSparkline( extractedAnalytics, 3 ) }
 									change={ goalCompletionsChange }
-									id="analytics-sessions-sparkline"
 								/>
 							}
 						/>

--- a/assets/js/modules/search-console/dashboard/dashboard-widget-top-level.js
+++ b/assets/js/modules/search-console/dashboard/dashboard-widget-top-level.js
@@ -130,7 +130,6 @@ class SearchConsoleDashboardWidgetTopLevel extends Component {
 							<Sparkline
 								data={ extractForSparkline( dataMap, 2 ) }
 								change={ totalImpressionsChange }
-								id="search-console-impressions-sparkline"
 							/>
 						}
 					/>
@@ -156,7 +155,6 @@ class SearchConsoleDashboardWidgetTopLevel extends Component {
 							<Sparkline
 								data={ extractForSparkline( dataMap, 1 ) }
 								change={ totalClicksChange }
-								id="search-console-clicks-sparkline"
 							/>
 						}
 					/>


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #1128.

## Relevant technical choices

Rather than a large refactor of many components proposed in the IB to fix this particular issue, I added the `invertChangeColor` prop to the `Sparkline` component (and a few lines to handle it), then conditionally added that prop to any `sparkline` prop in `data-block` that needed it. We can do the proposed refactor if still desired, but this is a more straightforward fix to me, and I didn't feel the existing `sparklines={ <Sparklines [...props] />}` code being changed from a component to an object of props was any better 😄

React lets us compose things like this, so I figured why not? 😄

### Before
<img width="339" alt="Screenshot 2020-02-25 18 02 20" src="https://user-images.githubusercontent.com/90871/75274620-104b4e80-57fb-11ea-96dd-f47b0a69eef2.png">

### After
<img width="334" alt="Screenshot 2020-02-25 18 00 08" src="https://user-images.githubusercontent.com/90871/75274614-0e818b00-57fb-11ea-991c-a618965fbfae.png">

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
