### PR TITLE
Update dataLayerPush to use arguments

### DIFF
--- a/assets/js/util/tracking/createDataLayerPush.js
+++ b/assets/js/util/tracking/createDataLayerPush.js
@@ -13,7 +13,9 @@ import { DATA_LAYER } from './index.private';
 export default function createDataLayerPush( target ) {
 	/**
 	 * Pushes data onto the data layer.
-	 * Must use `arguments` internally.
+	 * Must push an instance of Arguments to the target.
+	 * Using an ES6 spread operator (i.e. `...args`) will cause tracking events to _silently_ fail.
+	 * @link https://github.com/google/site-kit-wp/issues/1181
 	 */
 	return function dataLayerPush() {
 		target[ DATA_LAYER ] = target[ DATA_LAYER ] || [];

--- a/assets/js/util/tracking/createDataLayerPush.js
+++ b/assets/js/util/tracking/createDataLayerPush.js
@@ -13,11 +13,10 @@ import { DATA_LAYER } from './index.private';
 export default function createDataLayerPush( target ) {
 	/**
 	 * Pushes data onto the data layer.
-	 *
-	 * @param {...any} args Arguments to push onto the data layer.
+	 * Must use `arguments` internally.
 	 */
-	return function dataLayerPush( ...args ) {
+	return function dataLayerPush() {
 		target[ DATA_LAYER ] = target[ DATA_LAYER ] || [];
-		target[ DATA_LAYER ].push( args );
+		target[ DATA_LAYER ].push( arguments );
 	};
 }

--- a/assets/js/util/tracking/index.test.js
+++ b/assets/js/util/tracking/index.test.js
@@ -81,7 +81,10 @@ describe( 'trackEvent', () => {
 		function makeArguments() {
 			return arguments;
 		}
-		// dataLayerPush must push `arguments` onto the data layer.
+		// dataLayerPush must push an instance of `Arguments` onto the data layer.
+		// Because `arguments` is a special, `Array`-like object (but not an actual `Array`),
+		// we can only create it using the magic `arguments` variable
+		// made available to normal, non-arrow functions.
 		expect( push ).toHaveBeenCalledWith(
 			makeArguments(
 				'event',

--- a/assets/js/util/tracking/index.test.js
+++ b/assets/js/util/tracking/index.test.js
@@ -78,18 +78,24 @@ describe( 'trackEvent', () => {
 
 		trackEvent( 'category', 'name', 'label', 'value' );
 
-		expect( push ).toHaveBeenCalledWith( [
-			'event',
-			'name',
-			{
-				send_to: config.trackingID,
-				event_category: 'category',
-				event_label: 'label',
-				event_value: 'value',
-				dimension1: 'https://www.example.com',
-				dimension2: 'true',
-				dimension3: config.userIDHash,
-			},
-		] );
+		function makeArguments() {
+			return arguments;
+		}
+		// dataLayerPush must push `arguments` onto the data layer.
+		expect( push ).toHaveBeenCalledWith(
+			makeArguments(
+				'event',
+				'name',
+				{
+					send_to: config.trackingID,
+					event_category: 'category',
+					event_label: 'label',
+					event_value: 'value',
+					dimension1: 'https://www.example.com',
+					dimension2: 'true',
+					dimension3: config.userIDHash,
+				}
+			)
+		);
 	} );
 } );


### PR DESCRIPTION
## Summary

Addresses issue #1181 

![image](https://user-images.githubusercontent.com/1621608/75368787-ed886b00-58ca-11ea-9e5c-fe35406210ae.png)
![image](https://user-images.githubusercontent.com/1621608/75368796-f0835b80-58ca-11ea-8374-e7e3a7285f1a.png)


## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
