### PR TITLE
Add settings details for PageSpeed Insights

### DIFF
--- a/assets/js/modules/pagespeed-insights/index.js
+++ b/assets/js/modules/pagespeed-insights/index.js
@@ -32,6 +32,7 @@ import { addFilter } from '@wordpress/hooks';
 import DashboardSpeed from './dashboard/dashboard-widget-speed';
 import PageSpeedInsightsDashboardWidgetHomepageSpeed from './dashboard/dashboard-widget-homepage-speed';
 import PageSpeedInsightsCTA from './dashboard/dashboard-cta';
+import { settingsDetails as SettingsDetails } from './settings';
 
 const slug = 'pagespeed-insights';
 
@@ -62,3 +63,7 @@ if ( active && setupComplete ) {
 		'googlesitekit.PageSpeedInsights',
 		addPageSpeedInsightsCTA, 45 );
 }
+
+addFilter( `googlesitekit.ModuleSettingsDetails-${ slug }`,
+	'googlesitekit.PageSpeedInsightsModuleSettingsDetails',
+	createAddToFilter( <SettingsDetails /> ), 10 );

--- a/assets/js/modules/pagespeed-insights/settings/index.js
+++ b/assets/js/modules/pagespeed-insights/settings/index.js
@@ -1,0 +1,28 @@
+/**
+ * WordPress dependencies
+ */
+import { __, sprintf } from '@wordpress/i18n';
+
+/**
+ * External dependencies
+ */
+import { sanitizeHTML } from 'assets/js/util';
+
+export const settingsDetails = () => {
+	const { dashboardPermalink } = global.googlesitekit;
+
+	/* translators: %s is the URL to the Site Kit dashboard. */
+	const content = sprintf(
+		__( 'To view insights, <a href="%s">visit the dashboard</a>.', 'google-site-kit' ),
+		dashboardPermalink
+	);
+
+	return (
+		<p
+			dangerouslySetInnerHTML={ sanitizeHTML( content, {
+				ALLOWED_TAGS: [ 'a' ],
+				ALLOWED_ATTR: [ 'href' ],
+			} ) }
+		/>
+	);
+};

--- a/assets/js/modules/pagespeed-insights/settings/index.js
+++ b/assets/js/modules/pagespeed-insights/settings/index.js
@@ -11,8 +11,8 @@ import { sanitizeHTML } from 'assets/js/util';
 export const settingsDetails = () => {
 	const { dashboardPermalink } = global.googlesitekit;
 
-	/* translators: %s is the URL to the Site Kit dashboard. */
 	const content = sprintf(
+		/* translators: %s is the URL to the Site Kit dashboard. */
 		__( 'To view insights, <a href="%s">visit the dashboard</a>.', 'google-site-kit' ),
 		dashboardPermalink
 	);

--- a/assets/js/modules/pagespeed-insights/settings/index.js
+++ b/assets/js/modules/pagespeed-insights/settings/index.js
@@ -4,9 +4,9 @@
 import { __, sprintf } from '@wordpress/i18n';
 
 /**
- * External dependencies
+ * Internal dependencies
  */
-import { sanitizeHTML } from 'assets/js/util';
+import { sanitizeHTML } from '../../../util';
 
 export const settingsDetails = () => {
 	const { dashboardPermalink } = global.googlesitekit;

--- a/assets/js/util/index.js
+++ b/assets/js/util/index.js
@@ -54,6 +54,7 @@ import { default as analyticsTagMatchers } from '../modules/analytics/util/tagMa
 import { tagMatchers as tagmanagerTagMatchers } from '../modules/tagmanager/util';
 import { trackEvent } from './tracking';
 export { trackEvent };
+export * from './sanitize';
 export * from './standalone';
 export * from './storage';
 export * from './i18n';


### PR DESCRIPTION
## Summary

Addresses issue #1129 

* Also exports newly added `sanitize` utilities from the main `utils` index

![image](https://user-images.githubusercontent.com/1621608/75892491-11533000-5e3a-11ea-8589-bca1931d1e52.png)

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
