### PR TITLE
Separate collection from extending stores.

### DIFF
--- a/assets/js/googlesitekit/data/index.js
+++ b/assets/js/googlesitekit/data/index.js
@@ -29,6 +29,8 @@ import { createRegistry } from '@wordpress/data';
  * Internal dependencies
  */
 import {
+	addInitializeAction,
+	addInitializeReducer,
 	collectActions,
 	collectControls,
 	collectReducers,
@@ -41,6 +43,8 @@ const Data = createRegistry();
 
 // Attach some of our utility functions to the registry so third-party
 // developers can use them.
+Data.addInitializeAction = addInitializeAction;
+Data.addInitializeReducer = addInitializeReducer;
 Data.collectActions = collectActions;
 Data.collectControls = collectControls;
 Data.collectReducers = collectReducers;

--- a/assets/js/googlesitekit/data/utils.js
+++ b/assets/js/googlesitekit/data/utils.js
@@ -23,6 +23,44 @@ import invariant from 'invariant';
 
 const INITIALIZE = 'INITIALIZE';
 
+/**
+ * Add an initialize action to an existing object of actions.
+ *
+ * @param {Object} actions An object of actions.
+ * @return {Object} The combined action object, extended with an initialize() action.
+ */
+export const addInitializeAction = ( actions ) => {
+	return collect( actions, {
+		initialize: initializeAction,
+	} );
+};
+
+/**
+ * Add an initialize reducer handler to an existing reducer.
+ *
+ * Adds a reducer that resets the store to its initial state if the
+ * `initialize()` action is dispatched on it.
+ *
+ * @param {Object} initialState The store's default state (`INITIAL_STATE`).
+ * @param {Function} reducer A single reducer to extend with an initialize() handler.
+ * @return {Function} A Redux-style reducer.
+ */
+export const addInitializeReducer = ( initialState, reducer ) => {
+	const initializeReducer = ( state, action ) => {
+		switch ( action.type ) {
+			case INITIALIZE: {
+				return { ...initialState };
+			}
+
+			default: {
+				return { ...state };
+			}
+		}
+	};
+
+	return collectReducers( initialState, reducer, initializeReducer );
+};
+
 export const collect = ( ...items ) => {
 	const collectedObject = items.reduce( ( acc, item ) => {
 		return { ...acc, ...item };
@@ -38,36 +76,35 @@ export const collect = ( ...items ) => {
 	return collectedObject;
 };
 
-export const initializeAction = () => {
-	return {
-		payload: {},
-		type: INITIALIZE,
-	};
-};
-
 export const collectActions = ( ...args ) => {
-	return collect( ...args, {
-		initialize: initializeAction,
-	} );
+	return collect( ...args );
 };
 
 export const collectControls = collect;
 
-export const collectReducers = ( initialState, reducers ) => {
-	const initializeReducer = ( state, action ) => {
-		switch ( action.type ) {
-			case INITIALIZE: {
-				return { ...initialState };
-			}
+/**
+ * Collect all reducers and add an initialize reducer.
+ *
+ * This combines reducers and adds a reducer that resets the store to its
+ * initial state if the `initialize()` action is dispatched on it.
+ *
+ * If the first argument passed is not a function, it will be used as the
+ * combined reducer's `INITIAL_STATE`.
+ *
+ * @param {Object} initialState? The combined reducer's `INITIAL_STATE`. Only used when first argument is not a function.
+ * @param {Function} ...args A list of reducers, each containing their own controls.
+ * @return {Function} A Redux-style reducer.
+ */
+export const collectReducers = ( ...args ) => {
+	const reducers = [ ...args ];
+	let initialState;
 
-			default: {
-				return { ...state };
-			}
-		}
-	};
+	if ( typeof reducers[ 0 ] !== 'function' ) {
+		initialState = reducers.shift();
+	}
 
 	return ( state = initialState, action = {} ) => {
-		return [ ...reducers, initializeReducer ].reduce( ( newState, reducer ) => {
+		return reducers.reduce( ( newState, reducer ) => {
 			return reducer( newState, action );
 		}, state );
 	};
@@ -79,7 +116,7 @@ export const collectSelectors = collect;
 
 export const collectState = collect;
 
-function findDuplicates( array ) {
+const findDuplicates = ( array ) => {
 	const duplicates = [];
 	const counts = {};
 
@@ -92,4 +129,11 @@ function findDuplicates( array ) {
 	}
 
 	return duplicates;
-}
+};
+
+export const initializeAction = () => {
+	return {
+		payload: {},
+		type: INITIALIZE,
+	};
+};

--- a/assets/js/googlesitekit/data/utils.js
+++ b/assets/js/googlesitekit/data/utils.js
@@ -76,9 +76,13 @@ export const collect = ( ...items ) => {
 	return collectedObject;
 };
 
-export const collectActions = ( ...args ) => {
-	return collect( ...args );
-};
+/**
+ * Collect all actions.
+ *
+ * @param {Object} ...args A list of objects, each containing their own actions.
+ * @return {Object} The combined object.
+ */
+export const collectActions = collect;
 
 export const collectControls = collect;
 

--- a/assets/js/googlesitekit/data/utils.test.js
+++ b/assets/js/googlesitekit/data/utils.test.js
@@ -2,6 +2,8 @@
  * Internal dependencies
  */
 import {
+	addInitializeAction,
+	addInitializeReducer,
 	collect,
 	collectActions,
 	collectReducers,
@@ -84,23 +86,7 @@ describe( 'data utils', () => {
 		} );
 	} );
 
-	describe( 'collectActions()', () => {
-		it( 'should collect multiple actions and combine them into one object', () => {
-			const objectOne = {
-				bar: () => {},
-				foo: () => {},
-			};
-			const objectTwo = {
-				cat: () => {},
-				dog: () => {},
-			};
-
-			expect( collectActions( objectOne, objectTwo ) ).toMatchObject( {
-				...objectOne,
-				...objectTwo,
-			} );
-		} );
-
+	describe( 'addInitializeAction()', () => {
 		it( 'should include an initialize action that dispatches an INITIALIZE action type', () => {
 			const objectOne = {
 				bar: () => {},
@@ -111,35 +97,86 @@ describe( 'data utils', () => {
 				dog: () => {},
 			};
 
-			expect( collectActions( objectOne, objectTwo ) ).toMatchObject( {
+			expect(
+				addInitializeAction( collectActions( objectOne, objectTwo ) )
+			).toMatchObject( {
 				initialize: initializeAction,
 			} );
 		} );
 	} );
 
-	describe( 'collectReducers()', () => {
-		it( 'should respond to an INITIALIZE action because it extends the reducers to include one', () => {
-			const reducer = ( state, action ) => {
-				switch ( action.type ) {
-					default: {
-						return { ...state };
-					}
+	describe( 'reducer utility functions', () => {
+		const fakeAction = () => {
+			return { type: 'ACTION_ONE', payload: {} };
+		};
+		const anotherFakeAction = () => {
+			return { type: 'ACTION_TWO', payload: {} };
+		};
+
+		const fakeReducer = ( state, action ) => {
+			switch ( action.type ) {
+				case 'ACTION_ONE':
+					return { ...state, one: true };
+				default: {
+					return { ...state };
 				}
-			};
-			const initialState = { count: 0 };
-			const combinedReducer = collectReducers( initialState, [ reducer ] );
+			}
+		};
+		const fakeReducerTwo = ( state, action ) => {
+			switch ( action.type ) {
+				case 'ACTION_TWO':
+					return { ...state, two: 2 };
+				default: {
+					return { ...state };
+				}
+			}
+		};
 
-			let state = combinedReducer();
-			expect( state ).toEqual( { count: 0 } );
+		describe( 'collectReducers()', () => {
+			it( 'should return modified state based on the reducers supplied', () => {
+				const initialState = { count: 0 };
+				const combinedReducer = collectReducers( initialState, fakeReducer, fakeReducerTwo );
 
-			// Normally we'd be dispatching an action to change state, but for our
-			// testing purposes this is fine 😅
-			state.count = 5;
-			expect( state ).toEqual( { count: 5 } );
+				let state = combinedReducer();
+				expect( state ).toEqual( { count: 0 } );
+				expect( state.one ).toEqual( undefined );
 
-			state = combinedReducer( state, initializeAction() );
+				state = combinedReducer( state, fakeAction() );
+				expect( state ).toEqual( { count: 0, one: true } );
 
-			expect( state ).toEqual( { count: 0 } );
+				state = combinedReducer( state, anotherFakeAction() );
+				expect( state ).toEqual( { count: 0, one: true, two: 2 } );
+
+				// Should not respond to the initializeAction as this reducer is not
+				// extended with `addInitializeReducer()`. This will return state as-is.
+				const newState = combinedReducer( state, initializeAction() );
+
+				expect( state ).toEqual( newState );
+			} );
+		} );
+
+		describe( 'addInitializeReducer()', () => {
+			it( 'should respond to an INITIALIZE action because it extends the reducers to include one', () => {
+				const initialState = { count: 0 };
+				const combinedReducer = addInitializeReducer(
+					initialState,
+					collectReducers( fakeReducer, fakeReducerTwo )
+				);
+
+				let state = combinedReducer();
+				expect( state ).toEqual( { count: 0 } );
+
+				// It should still respond to the original actions.
+				state = combinedReducer( state, fakeAction() );
+				expect( state ).toEqual( { count: 0, one: true } );
+
+				state = combinedReducer( state, anotherFakeAction() );
+				expect( state ).toEqual( { count: 0, one: true, two: 2 } );
+
+				//
+				state = combinedReducer( state, initializeAction() );
+				expect( state ).toEqual( initialState );
+			} );
 		} );
 	} );
 } );

--- a/assets/js/googlesitekit/datastore/site/index.js
+++ b/assets/js/googlesitekit/datastore/site/index.js
@@ -34,20 +34,23 @@ export const INITIAL_STATE = Data.collectState(
 
 export const STORE_NAME = 'core/site';
 
-export const actions = Data.collectActions(
+export const actions = Data.addInitializeAction( Data.collectActions(
 	connection.actions,
 	reset.actions,
-);
+) );
 
 export const controls = Data.collectControls(
 	connection.controls,
 	reset.controls,
 );
 
-export const reducer = Data.collectReducers( INITIAL_STATE, [
-	connection.reducer,
-	reset.reducer,
-] );
+export const reducer = Data.addInitializeReducer(
+	INITIAL_STATE,
+	Data.collectReducers(
+		connection.reducer,
+		reset.reducer,
+	)
+);
 
 export const resolvers = Data.collectResolvers(
 	connection.resolvers,


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #1225.

## Relevant technical choices

I made `collectReducers` similar to other `collect*` functions and allowed for unlimited arguments rather than the atypical `array`-as-second-argument approach. If an object (any non-`function`-value) is passed as the first argument it's used as the `INITIAL_STATE` instead of a reducer, which is also handy because it means we don't have to pass `INITIAL_STATE` to `collectReducers` when using `addInitializeReducer()`.

This only adds docs for changed methods—the rest of the docs are in #1215.

## Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
