### PR TITLE
Hook user opt-out on wp_head.

### DIFF
--- a/includes/Modules/Analytics.php
+++ b/includes/Modules/Analytics.php
@@ -110,7 +110,7 @@ final class Analytics extends Module
 		);
 
 		add_action(
-			'wp_print_scripts',
+			'wp_head',
 			function () {
 				if ( $this->is_tracking_disabled() ) {
 					$this->print_tracking_opt_out();


### PR DESCRIPTION
## Summary

Addresses issue #944, Follow up to #1234 

## Relevant technical choices

Hooks the opt-out on `wp_head` instead of `wp_print_scripts` as this hook is fired by `print_head_scripts` during `admin_print_scripts`.

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
