### PR TITLE
Fix AMP validation when tracking is disabled

### DIFF
--- a/assets/sass/components/global/_googlesitekit-noscript.scss
+++ b/assets/sass/components/global/_googlesitekit-noscript.scss
@@ -29,7 +29,7 @@
 	}
 }
 
-.no-js {
+.no-js:not([amp-version]) {
 
 	[id^="js-googlesitekit-"] {
 		display: none;

--- a/includes/Modules/Analytics.php
+++ b/includes/Modules/Analytics.php
@@ -380,6 +380,10 @@ final class Analytics extends Module
 			return;
 		}
 
+		if ( $this->is_tracking_disabled() ) {
+			return;
+		}
+
 		$gtag_amp_opt = array(
 			'vars' => array(
 				'gtag_id' => $tracking_id,

--- a/includes/Modules/Analytics.php
+++ b/includes/Modules/Analytics.php
@@ -388,12 +388,13 @@ final class Analytics extends Module
 			'vars' => array(
 				'gtag_id' => $tracking_id,
 				'config'  => array(
-					$tracking_id => array(
+					$tracking_id      => array(
 						'groups' => 'default',
 						'linker' => array(
 							'domains' => array( $this->get_home_domain() ),
 						),
 					),
+					'optoutElementId' => '__gaOptOutExtension',
 				),
 			),
 		);

--- a/includes/Modules/Analytics.php
+++ b/includes/Modules/Analytics.php
@@ -380,10 +380,6 @@ final class Analytics extends Module
 			return;
 		}
 
-		if ( $this->is_tracking_disabled() ) {
-			return;
-		}
-
 		$gtag_amp_opt = array(
 			'vars' => array(
 				'gtag_id' => $tracking_id,

--- a/includes/Modules/Analytics.php
+++ b/includes/Modules/Analytics.php
@@ -1274,8 +1274,8 @@ final class Analytics extends Module
 	private function print_tracking_opt_out() {
 		?>
 		<!-- <?php esc_html_e( 'Google Analytics user opt-out added via Site Kit by Google', 'google-site-kit' ); ?> -->
-		<?php if ( $this->context->is_amp() ) : ?>
-			<script type="text/plain" id="__gaOptOutExtension"></script>
+		<?php if ( $this->context->is_amp() ) : // TODO: update script type to `text/plain` when supported by AMP plugin. ?>
+			<script type="application/ld+json" id="__gaOptOutExtension"></script>
 		<?php else : ?>
 			<script type="text/javascript">window["_gaUserPrefs"] = { ioo : function() { return true; } }</script>
 		<?php endif; ?>

--- a/includes/Modules/Analytics.php
+++ b/includes/Modules/Analytics.php
@@ -1276,12 +1276,16 @@ final class Analytics extends Module
 	 * @link https://developers.google.com/analytics/devguides/collection/analyticsjs/user-opt-out
 	 */
 	private function print_tracking_opt_out() {
+		printf( '<!-- %s -->', esc_html__( 'Google Analytics user opt-out added via Site Kit by Google', 'google-site-kit' ) );
+
 		if ( $this->context->is_amp() ) {
-			// AMP does not support inline custom JS.
+			?>
+			<meta id="__gaOptOutExtension">
+			<?php
 			return;
 		}
+
 		?>
-		<!-- <?php esc_html_e( 'Google Analytics user opt-out added via Site Kit by Google', 'google-site-kit' ); ?> -->
 		<script type="text/javascript">window["_gaUserPrefs"] = { ioo : function() { return true; } }</script>
 		<?php
 	}

--- a/includes/Modules/Analytics.php
+++ b/includes/Modules/Analytics.php
@@ -1272,17 +1272,13 @@ final class Analytics extends Module
 	 * @link https://developers.google.com/analytics/devguides/collection/analyticsjs/user-opt-out
 	 */
 	private function print_tracking_opt_out() {
-		printf( '<!-- %s -->', esc_html__( 'Google Analytics user opt-out added via Site Kit by Google', 'google-site-kit' ) );
-
-		if ( $this->context->is_amp() ) {
-			?>
-			<script type="text/plain" id="__gaOptOutExtension"></script>
-			<?php
-			return;
-		}
-
 		?>
-		<script type="text/javascript">window["_gaUserPrefs"] = { ioo : function() { return true; } }</script>
+		<!-- <?php esc_html_e( 'Google Analytics user opt-out added via Site Kit by Google', 'google-site-kit' ); ?> -->
+		<?php if ( $this->context->is_amp() ) : ?>
+			<script type="text/plain" id="__gaOptOutExtension"></script>
+		<?php else : ?>
+			<script type="text/javascript">window["_gaUserPrefs"] = { ioo : function() { return true; } }</script>
+		<?php endif; ?>
 		<?php
 	}
 

--- a/includes/Modules/Analytics.php
+++ b/includes/Modules/Analytics.php
@@ -1275,6 +1275,10 @@ final class Analytics extends Module
 	 * @link https://developers.google.com/analytics/devguides/collection/analyticsjs/user-opt-out
 	 */
 	private function print_tracking_opt_out() {
+		if ( $this->context->is_amp() ) {
+			// AMP does not support inline custom JS.
+			return;
+		}
 		?>
 		<!-- <?php esc_html_e( 'Google Analytics user opt-out added via Site Kit by Google', 'google-site-kit' ); ?> -->
 		<script type="text/javascript">window["_gaUserPrefs"] = { ioo : function() { return true; } }</script>

--- a/includes/Modules/Analytics.php
+++ b/includes/Modules/Analytics.php
@@ -381,18 +381,18 @@ final class Analytics extends Module
 		}
 
 		$gtag_amp_opt = array(
-			'vars' => array(
+			'vars'            => array(
 				'gtag_id' => $tracking_id,
 				'config'  => array(
-					$tracking_id      => array(
+					$tracking_id => array(
 						'groups' => 'default',
 						'linker' => array(
 							'domains' => array( $this->get_home_domain() ),
 						),
 					),
-					'optoutElementId' => '__gaOptOutExtension',
 				),
 			),
+			'optoutElementId' => '__gaOptOutExtension',
 		);
 
 		/**

--- a/includes/Modules/Analytics.php
+++ b/includes/Modules/Analytics.php
@@ -1276,7 +1276,7 @@ final class Analytics extends Module
 
 		if ( $this->context->is_amp() ) {
 			?>
-			<meta id="__gaOptOutExtension">
+			<script type="text/plain" id="__gaOptOutExtension"></script>
 			<?php
 			return;
 		}

--- a/includes/Modules/Analytics.php
+++ b/includes/Modules/Analytics.php
@@ -1274,7 +1274,7 @@ final class Analytics extends Module
 	private function print_tracking_opt_out() {
 		?>
 		<!-- <?php esc_html_e( 'Google Analytics user opt-out added via Site Kit by Google', 'google-site-kit' ); ?> -->
-		<?php if ( $this->context->is_amp() ) : // TODO: update script type to `text/plain` when supported by AMP plugin. ?>
+		<?php if ( $this->context->is_amp() ) : ?>
 			<script type="application/ld+json" id="__gaOptOutExtension"></script>
 		<?php else : ?>
 			<script type="text/javascript">window["_gaUserPrefs"] = { ioo : function() { return true; } }</script>

--- a/includes/Modules/Tag_Manager.php
+++ b/includes/Modules/Tag_Manager.php
@@ -302,9 +302,20 @@ final class Tag_Manager extends Module implements Module_With_Scopes, Module_Wit
 			return;
 		}
 
+		// Add the optoutElementId for compatibility with our Analytics opt-out mechanism.
+		// This configuration object will be merged with the configuration object returned
+		// by the `config` attribute URL.
+		$gtm_amp_opt = array(
+			'optoutElementId' => '__gaOptOutExtension',
+		);
+
 		?>
 		<!-- Google Tag Manager added by Site Kit -->
-		<amp-analytics config="<?php echo esc_url( "https://www.googletagmanager.com/amp.json?id=$container_id" ); ?>" data-credentials="include"></amp-analytics>
+		<amp-analytics config="<?php echo esc_url( "https://www.googletagmanager.com/amp.json?id=$container_id" ); ?>" data-credentials="include">
+			<script type="application/json">
+				<?php echo wp_json_encode( $gtm_amp_opt ); ?>
+			</script>
+		</amp-analytics>
 		<!-- End Google Tag Manager -->
 		<?php
 	}


### PR DESCRIPTION
## Summary

Addresses issue #1251

## Relevant technical choices

* Targets `master` branch for merge
* Updates selector used to hide JS render targets for AMP.  
AMP render contexts will always have the `no-js` class on the `html` element, even if it isn't disabled in the browser. However, if it is disabled in the browser, additional attributes will not be present on the element such as `amp-version`. By ensuring that this attribute is not present, when hiding with if `no-js` we can prevent the Site Kit admin bar menu item from being hidden when it shouldn't (i.e. front end AMP render).
* Adds AMP opt-out using a script tag with type of `application/ld+json` (which is valid HTML for AMP).  
Ideally this would use `text/plain` (it's empty so it doesn't really matter) but this is done for compatibility with the AMP plugin which currently reports 2/3 of the valid script types as invalid and thus removes them.

**With JS enabled**
```html
<html class="no-js i-amphtml-singledoc i-amphtml-standalone" lang="en-US" amp data-ampdevmode amp-version="2003031842100" style="padding-top: 0px !important;">
```
![image](https://user-images.githubusercontent.com/1621608/76614995-ccaa5180-6529-11ea-8771-1472e3d87e7e.png)


**With JS disabled**
```html
<html class="no-js" lang="en-US" amp data-ampdevmode>
```
![image](https://user-images.githubusercontent.com/1621608/76615030-db910400-6529-11ea-99ed-6276af2954d9.png)

No AMP validation errors
![image](https://user-images.githubusercontent.com/1621608/76758001-6c1d4d80-6791-11ea-809a-53b07e796ebf.png)


## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
