### PR TITLE
Include /auth/analytics.provision scope in scopes to request for Analytics module

### DIFF
--- a/includes/Modules/Analytics.php
+++ b/includes/Modules/Analytics.php
@@ -153,6 +153,7 @@ final class Analytics extends Module
 			'https://www.googleapis.com/auth/analytics.readonly',
 			'https://www.googleapis.com/auth/analytics.manage.users',
 			'https://www.googleapis.com/auth/analytics.edit',
+			'https://www.googleapis.com/auth/analytics.provision',
 		);
 	}
 

--- a/tests/phpunit/integration/Modules/AnalyticsTest.php
+++ b/tests/phpunit/integration/Modules/AnalyticsTest.php
@@ -106,6 +106,7 @@ class AnalyticsTest extends TestCase {
 				'https://www.googleapis.com/auth/analytics.readonly',
 				'https://www.googleapis.com/auth/analytics.manage.users',
 				'https://www.googleapis.com/auth/analytics.edit',
+				'https://www.googleapis.com/auth/analytics.provision',
 			),
 			$analytics->get_scopes()
 		);


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #1209

## Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
