### PR TITLE
Fix broken data store controls and update action syntax in reducers and controls

### DIFF
--- a/assets/js/googlesitekit/data/create-notifications-store.js
+++ b/assets/js/googlesitekit/data/create-notifications-store.js
@@ -157,10 +157,10 @@ export const createNotificationsStore = ( type, identifier, datapoint, {
 		},
 	};
 
-	const reducer = ( state = INITIAL_STATE, action ) => {
-		switch ( action.type ) {
+	const reducer = ( state = INITIAL_STATE, { type, payload } ) => { // eslint-disable-line no-shadow
+		switch ( type ) {
 			case ADD_NOTIFICATION: {
-				const { notification } = action.payload;
+				const { notification } = payload;
 
 				return {
 					...state,
@@ -172,7 +172,7 @@ export const createNotificationsStore = ( type, identifier, datapoint, {
 			}
 
 			case REMOVE_NOTIFICATION: {
-				const { id } = action.payload;
+				const { id } = payload;
 
 				// At this point, only client-side notifications can be removed.
 				if (
@@ -206,7 +206,7 @@ export const createNotificationsStore = ( type, identifier, datapoint, {
 			}
 
 			case RECEIVE_NOTIFICATIONS: {
-				const { notifications } = action.payload;
+				const { notifications } = payload;
 
 				return {
 					...state,

--- a/assets/js/googlesitekit/data/create-settings-store.js
+++ b/assets/js/googlesitekit/data/create-settings-store.js
@@ -220,15 +220,16 @@ export const createSettingsStore = ( type, identifier, datapoint, {
 		[ FETCH_SETTINGS ]: () => {
 			return API.get( type, identifier, datapoint );
 		},
-		[ FETCH_SAVE_SETTINGS ]: ( values ) => {
+		[ FETCH_SAVE_SETTINGS ]: ( { payload } ) => {
+			const { values } = payload;
 			return API.set( type, identifier, datapoint, values );
 		},
 	};
 
-	const reducer = ( state = INITIAL_STATE, action ) => {
-		switch ( action.type ) {
+	const reducer = ( state = INITIAL_STATE, { type, payload } ) => { // eslint-disable-line no-shadow
+		switch ( type ) {
 			case SET_SETTINGS: {
-				const { values } = action.payload;
+				const { values } = payload;
 
 				return {
 					...state,
@@ -247,7 +248,7 @@ export const createSettingsStore = ( type, identifier, datapoint, {
 			}
 
 			case RECEIVE_SETTINGS: {
-				const { values } = action.payload;
+				const { values } = payload;
 
 				return {
 					...state,
@@ -278,7 +279,7 @@ export const createSettingsStore = ( type, identifier, datapoint, {
 			}
 
 			case RECEIVE_SAVE_SETTINGS: {
-				const { values } = action.payload;
+				const { values } = payload;
 
 				return {
 					...state,
@@ -301,8 +302,8 @@ export const createSettingsStore = ( type, identifier, datapoint, {
 
 			default: {
 				// Check if this action is for a reducer for an individual setting.
-				if ( 'undefined' !== typeof settingReducers[ action.type ] ) {
-					return settingReducers[ action.type ]( state, action );
+				if ( 'undefined' !== typeof settingReducers[ type ] ) {
+					return settingReducers[ type ]( state, { type, payload } );
 				}
 
 				return { ...state };
@@ -385,8 +386,8 @@ export const createSettingsStore = ( type, identifier, datapoint, {
 			};
 		};
 
-		settingReducers[ `SET_${ constantSlug }` ] = ( state, action ) => {
-			const { value } = action.payload;
+		settingReducers[ `SET_${ constantSlug }` ] = ( state, { payload } ) => {
+			const { value } = payload;
 
 			return {
 				...state,

--- a/assets/js/googlesitekit/data/create-settings-store.test.js
+++ b/assets/js/googlesitekit/data/create-settings-store.test.js
@@ -439,7 +439,10 @@ describe( 'createSettingsStore store', () => {
 						};
 					} );
 
-				const result = await storeDefinition.controls.FETCH_SAVE_SETTINGS( {} );
+				const result = await storeDefinition.controls.FETCH_SAVE_SETTINGS( {
+					type: 'FETCH_SAVE_SETTINGS',
+					payload: { values: {} },
+				} );
 				expect( result ).toEqual( response );
 				// Ensure `console.error()` wasn't called, which will happen if the API
 				// request fails.

--- a/assets/js/googlesitekit/datastore/site/connection.js
+++ b/assets/js/googlesitekit/datastore/site/connection.js
@@ -94,8 +94,8 @@ export const controls = {
 	},
 };
 
-export const reducer = ( state, action ) => {
-	switch ( action.type ) {
+export const reducer = ( state, { type, payload } ) => {
+	switch ( type ) {
 		case FETCH_CONNECTION: {
 			return {
 				...state,
@@ -104,7 +104,7 @@ export const reducer = ( state, action ) => {
 		}
 
 		case RECEIVE_CONNECTION: {
-			const { connection } = action.payload;
+			const { connection } = payload;
 
 			return {
 				...state,

--- a/assets/js/googlesitekit/datastore/site/reset.js
+++ b/assets/js/googlesitekit/datastore/site/reset.js
@@ -32,7 +32,7 @@ const RECEIVE_RESET = 'RECEIVE_RESET';
 const RECEIVE_RESET_FAILURE = 'RECEIVE_RESET_FAILURE';
 
 export const INITIAL_STATE = {
-	isDoingReset: false,
+	isFetchingReset: false,
 };
 
 export const actions = {
@@ -118,14 +118,14 @@ export const reducer = ( state, { type } ) => {
 		case FETCH_RESET: {
 			return {
 				...state,
-				isDoingReset: true,
+				isFetchingReset: true,
 			};
 		}
 
 		case RECEIVE_RESET_FAILURE: {
 			return {
 				...state,
-				isDoingReset: false,
+				isFetchingReset: false,
 			};
 		}
 
@@ -151,9 +151,9 @@ export const selectors = {
 	 * @return {boolean} `true` if resetting is in-flight; `false` if not.
 	 */
 	isDoingReset: ( state ) => {
-		const { isDoingReset } = state;
+		const { isFetchingReset } = state;
 
-		return isDoingReset;
+		return isFetchingReset;
 	},
 };
 

--- a/assets/js/googlesitekit/datastore/site/reset.js
+++ b/assets/js/googlesitekit/datastore/site/reset.js
@@ -113,8 +113,8 @@ export const controls = {
 	},
 };
 
-export const reducer = ( state, action ) => {
-	switch ( action.type ) {
+export const reducer = ( state, { type } ) => {
+	switch ( type ) {
 		case FETCH_RESET: {
 			return {
 				...state,


### PR DESCRIPTION
## Summary

Just this one time, without a related issue, since this is about fixing existing code.

## Relevant technical choices

* Controls receive the action object as parameters, while we were so far assuming it receives the same values as the action function. There was only one case so far where that was relevant. See [Gutenberg docs here](https://github.com/WordPress/gutenberg/tree/master/packages/data).
* As discussed, our way to write reducers should always destructure the action object passed to `{ type, payload }` (or whatever of the two is needed).
* All state properties that indicate whether an API request is happening right now should start with `isFetching...` - that applies also to actions where we add a public selector that would have the name `isDoing...`. `isFetching...` is the internal thing that actually happens, while `isDoing...` is our generic "abstraction" to have a reusable public name that works for anything.

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
