### PR TITLE
Add site info data store/selectors

### DIFF
--- a/assets/js/googlesitekit/datastore/site/index.js
+++ b/assets/js/googlesitekit/datastore/site/index.js
@@ -36,11 +36,11 @@ export const INITIAL_STATE = Data.collectState(
 
 export const STORE_NAME = 'core/site';
 
-
 export const actions = Data.addInitializeAction(
 	Data.collectActions(
 		Data.commonActions,
 		connection.actions,
+		info.actions,
 		reset.actions,
 	)
 );

--- a/assets/js/googlesitekit/datastore/site/index.js
+++ b/assets/js/googlesitekit/datastore/site/index.js
@@ -30,6 +30,7 @@ import reset from './reset';
 
 export const INITIAL_STATE = Data.collectState(
 	connection.INITIAL_STATE,
+	info.INITIAL_STATE,
 	reset.INITIAL_STATE,
 );
 

--- a/assets/js/googlesitekit/datastore/site/index.js
+++ b/assets/js/googlesitekit/datastore/site/index.js
@@ -25,6 +25,7 @@
  */
 import Data from 'googlesitekit-data';
 import connection from './connection';
+import info from './info';
 import reset from './reset';
 
 export const INITIAL_STATE = Data.collectState(
@@ -36,11 +37,13 @@ export const STORE_NAME = 'core/site';
 
 export const actions = Data.addInitializeAction( Data.collectActions(
 	connection.actions,
+	info.actions,
 	reset.actions,
 ) );
 
 export const controls = Data.collectControls(
 	connection.controls,
+	info.controls,
 	reset.controls,
 );
 
@@ -48,17 +51,20 @@ export const reducer = Data.addInitializeReducer(
 	INITIAL_STATE,
 	Data.collectReducers(
 		connection.reducer,
+		info.reducer,
 		reset.reducer,
 	)
 );
 
 export const resolvers = Data.collectResolvers(
 	connection.resolvers,
+	info.resolvers,
 	reset.resolvers,
 );
 
 export const selectors = Data.collectSelectors(
 	connection.selectors,
+	info.selectors,
 	reset.selectors,
 );
 

--- a/assets/js/googlesitekit/datastore/site/info.js
+++ b/assets/js/googlesitekit/datastore/site/info.js
@@ -91,7 +91,7 @@ export const reducer = ( state, { payload, type } ) => {
 					adminURL,
 					ampMode,
 					currentEntityURL,
-					currentEntityID: parseFloat( currentEntityID, 10 ),
+					currentEntityID: parseInt( currentEntityID, 10 ),
 					currentEntityTitle,
 					currentEntityType,
 					homeURL,
@@ -182,7 +182,7 @@ export const selectors = {
 	 * @since n.e.x.t
 	 *
 	 * @param {Object} state Data store's state.
-	 * @return {string|undefined} This site's admin URL.
+	 * @return {?string} This site's admin URL.
 	 */
 	getAdminURL: createRegistrySelector( ( select ) => () => {
 		const { adminURL } = select( STORE_NAME ).getSiteInfo();
@@ -196,7 +196,7 @@ export const selectors = {
 	 * @since n.e.x.t
 	 *
 	 * @param {Object} state Data store's state.
-	 * @return {string|undefined} AMP Mode.
+	 * @return {?string} AMP Mode.
 	 */
 	getAMPMode: createRegistrySelector( ( select ) => () => {
 		const { ampMode } = select( STORE_NAME ).getSiteInfo();
@@ -210,7 +210,7 @@ export const selectors = {
 	 * @since n.e.x.t
 	 *
 	 * @param {Object} state Data store's state.
-	 * @return {number|undefined} Current entity's ID.
+	 * @return {?number} Current entity's ID.
 	 */
 	getCurrentEntityID: createRegistrySelector( ( select ) => () => {
 		const { currentEntityID } = select( STORE_NAME ).getSiteInfo();
@@ -224,7 +224,7 @@ export const selectors = {
 	 * @since n.e.x.t
 	 *
 	 * @param {Object} state Data store's state.
-	 * @return {string|undefined} Current entity's title.
+	 * @return {?string} Current entity's title.
 	 */
 	getCurrentEntityTitle: createRegistrySelector( ( select ) => () => {
 		const { currentEntityTitle } = select( STORE_NAME ).getSiteInfo();
@@ -238,7 +238,7 @@ export const selectors = {
 	 * @since n.e.x.t
 	 *
 	 * @param {Object} state Data store's state.
-	 * @return {string|undefined} Current entity's type.
+	 * @return {?string} Current entity's type.
 	 */
 	getCurrentEntityType: createRegistrySelector( ( select ) => () => {
 		const { currentEntityType } = select( STORE_NAME ).getSiteInfo();
@@ -252,7 +252,7 @@ export const selectors = {
 	 * @since n.e.x.t
 	 *
 	 * @param {Object} state Data store's state.
-	 * @return {string|undefined} Current entity's reference URL.
+	 * @return {?string} Current entity's reference URL.
 	 */
 	getCurrentEntityURL: createRegistrySelector( ( select ) => () => {
 		const { currentEntityURL } = select( STORE_NAME ).getSiteInfo();
@@ -266,7 +266,7 @@ export const selectors = {
 	 * @since n.e.x.t
 	 *
 	 * @param {Object} state Data store's state.
-	 * @return {string|undefined} This site's home URL.
+	 * @return {?string} This site's home URL.
 	 */
 	getHomeURL: createRegistrySelector( ( select ) => () => {
 		const { homeURL } = select( STORE_NAME ).getSiteInfo();
@@ -280,7 +280,7 @@ export const selectors = {
 	 * @since n.e.x.t
 	 *
 	 * @param {Object} state Data store's state.
-	 * @return {string|undefined} Thereference site URL.
+	 * @return {?string} The reference site URL.
 	 */
 	getReferenceSiteURL: createRegistrySelector( ( select ) => () => {
 		const { referenceSiteURL } = select( STORE_NAME ).getSiteInfo();
@@ -294,7 +294,7 @@ export const selectors = {
 	 * @since n.e.x.t
 	 *
 	 * @param {Object} state Data store's state.
-	 * @return {string|undefined} `true` if AMP support is enabled, `false` if not. Returns `undefined` if not loaded.
+	 * @return {?string} `true` if AMP support is enabled, `false` if not. Returns `undefined` if not loaded.
 	 */
 	isAmp: createRegistrySelector( ( select ) => () => {
 		const ampMode = select( STORE_NAME ).getAMPMode();

--- a/assets/js/googlesitekit/datastore/site/info.js
+++ b/assets/js/googlesitekit/datastore/site/info.js
@@ -39,14 +39,16 @@ import { STORE_NAME } from './index';
 const RECEIVE_SITE_INFO = 'RECEIVE_SITE_INFO';
 
 export const INITIAL_STATE = {
-	adminURL: undefined,
-	ampMode: undefined,
-	currentReferenceURL: undefined,
-	currentEntityID: undefined,
-	currentEntityTitle: undefined,
-	currentEntityType: undefined,
-	homeURL: undefined,
-	referenceSiteURL: undefined,
+	siteInfo: {
+		adminURL: undefined,
+		ampMode: undefined,
+		currentReferenceURL: undefined,
+		currentEntityID: undefined,
+		currentEntityTitle: undefined,
+		currentEntityType: undefined,
+		homeURL: undefined,
+		referenceSiteURL: undefined,
+	},
 };
 
 export const actions = {
@@ -91,14 +93,16 @@ export const reducer = ( state, { payload, type } ) => {
 
 			return {
 				...state,
-				adminURL,
-				ampMode,
-				currentReferenceURL,
-				currentEntityID: parseFloat( currentEntityID, 10 ),
-				currentEntityTitle,
-				currentEntityType,
-				homeURL,
-				referenceSiteURL,
+				siteInfo: {
+					adminURL,
+					ampMode,
+					currentReferenceURL,
+					currentEntityID: parseFloat( currentEntityID, 10 ),
+					currentEntityTitle,
+					currentEntityType,
+					homeURL,
+					referenceSiteURL,
+				},
 			};
 		}
 
@@ -110,11 +114,17 @@ export const reducer = ( state, { payload, type } ) => {
 
 export const resolvers = {
 	*getSiteInfo( siteInfo = global._googlesitekitSiteData ) {
-		yield actions.receiveSiteInfo( siteInfo );
+		if ( siteInfo ) {
+			yield actions.receiveSiteInfo( siteInfo );
 
-		if ( global._googlesitekitSiteData ) {
-			delete global._googlesitekitSiteData;
+			if ( global._googlesitekitSiteData ) {
+				delete global._googlesitekitSiteData;
+			}
+
+			return;
 		}
+
+		global.console.error( 'Could not load core/site info.' );
 	},
 };
 
@@ -141,7 +151,7 @@ export const selectors = {
 			currentEntityType,
 			homeURL,
 			referenceSiteURL,
-		} = state;
+		} = state.siteInfo || {};
 
 		return {
 			adminURL,

--- a/assets/js/googlesitekit/datastore/site/info.js
+++ b/assets/js/googlesitekit/datastore/site/info.js
@@ -22,18 +22,12 @@
 import invariant from 'invariant';
 
 /**
- * WordPress dependencies
- */
-// TODO: change this to use:
-// import Data from `googlesitekit-data`;
-// const { createRegistrySelector } = Data;
-// After https://github.com/google/site-kit-wp/pull/1278 is merged into `develop`.
-import { createRegistrySelector } from '@wordpress/data';
-
-/**
  * Internal dependencies
  */
+import Data from 'googlesitekit-data';
 import { STORE_NAME } from './index';
+
+const { createRegistrySelector } = Data;
 
 // Actions
 const RECEIVE_SITE_INFO = 'RECEIVE_SITE_INFO';

--- a/assets/js/googlesitekit/datastore/site/info.js
+++ b/assets/js/googlesitekit/datastore/site/info.js
@@ -42,7 +42,7 @@ export const INITIAL_STATE = {
 	siteInfo: {
 		adminURL: undefined,
 		ampMode: undefined,
-		currentReferenceURL: undefined,
+		currentEntityURL: undefined,
 		currentEntityID: undefined,
 		currentEntityTitle: undefined,
 		currentEntityType: undefined,
@@ -83,7 +83,7 @@ export const reducer = ( state, { payload, type } ) => {
 			const {
 				adminURL,
 				ampMode,
-				currentReferenceURL,
+				currentEntityURL,
 				currentEntityID,
 				currentEntityTitle,
 				currentEntityType,
@@ -96,7 +96,7 @@ export const reducer = ( state, { payload, type } ) => {
 				siteInfo: {
 					adminURL,
 					ampMode,
-					currentReferenceURL,
+					currentEntityURL,
 					currentEntityID: parseFloat( currentEntityID, 10 ),
 					currentEntityTitle,
 					currentEntityType,
@@ -145,7 +145,7 @@ export const selectors = {
 		const {
 			adminURL,
 			ampMode,
-			currentReferenceURL,
+			currentEntityURL,
 			currentEntityID,
 			currentEntityTitle,
 			currentEntityType,
@@ -156,7 +156,7 @@ export const selectors = {
 		return {
 			adminURL,
 			ampMode,
-			currentReferenceURL,
+			currentEntityURL,
 			currentEntityID,
 			currentEntityTitle,
 			currentEntityType,
@@ -243,10 +243,10 @@ export const selectors = {
 	 * @param {Object} state Data store's state.
 	 * @return {string|undefined} Current entity's reference URL.
 	 */
-	getCurrentReferenceURL: createRegistrySelector( ( select ) => () => {
-		const { currentReferenceURL } = select( STORE_NAME ).getSiteInfo();
+	getCurrentEntityURL: createRegistrySelector( ( select ) => () => {
+		const { currentEntityURL } = select( STORE_NAME ).getSiteInfo();
 
-		return currentReferenceURL;
+		return currentEntityURL;
 	} ),
 
 	/**

--- a/assets/js/googlesitekit/datastore/site/info.js
+++ b/assets/js/googlesitekit/datastore/site/info.js
@@ -1,0 +1,292 @@
+/**
+ * core/site data store: site info.
+ *
+ * Site Kit by Google, Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import invariant from 'invariant';
+
+/**
+ * WordPress dependencies
+ */
+// TODO: change this to use:
+// import Data from `googlesitekit-data`;
+// const { createRegistrySelector } = Data;
+// After https://github.com/google/site-kit-wp/pull/1278 is merged into `develop`.
+import { createRegistrySelector } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { STORE_NAME } from './index';
+
+// Actions
+const RECEIVE_SITE_INFO = 'RECEIVE_SITE_INFO';
+
+export const INITIAL_STATE = {
+	adminURL: undefined,
+	ampMode: undefined,
+	currentReferenceURL: undefined,
+	currentEntityID: undefined,
+	currentEntityTitle: undefined,
+	currentEntityType: undefined,
+	homeURL: undefined,
+	referenceSiteURL: undefined,
+};
+
+export const actions = {
+	/**
+	 * Stores site info in the datastore.
+	 *
+	 * Because this is frequently-accessed data, this is usually sourced
+	 * from a global variable (`_googlesitekitSiteData`), set by PHP
+	 * in the `before_print` callback for `googlesitekit-datastore-site`.
+	 *
+	 * @since n.e.x.t
+	 * @private
+	 *
+	 * @param {Object} siteInfo Site info, usually supplied via a global variable from PHP.
+	 * @return {Object} Redux-style action.
+	 */
+	receiveSiteInfo( siteInfo ) {
+		invariant( siteInfo, 'siteInfo is required.' );
+
+		return {
+			payload: { siteInfo },
+			type: RECEIVE_SITE_INFO,
+		};
+	},
+};
+
+export const controls = {};
+
+export const reducer = ( state, { payload, type } ) => {
+	switch ( type ) {
+		case RECEIVE_SITE_INFO: {
+			const {
+				adminURL,
+				ampMode,
+				currentReferenceURL,
+				currentEntityID,
+				currentEntityTitle,
+				currentEntityType,
+				homeURL,
+				referenceSiteURL,
+			} = payload.siteInfo;
+
+			return {
+				...state,
+				adminURL,
+				ampMode,
+				currentReferenceURL,
+				currentEntityID: parseFloat( currentEntityID, 10 ),
+				currentEntityTitle,
+				currentEntityType,
+				homeURL,
+				referenceSiteURL,
+			};
+		}
+
+		default: {
+			return { ...state };
+		}
+	}
+};
+
+export const resolvers = {
+	*getSiteInfo( siteInfo = global._googlesitekitSiteData ) {
+		yield actions.receiveSiteInfo( siteInfo );
+
+		if ( global._googlesitekitSiteData ) {
+			delete global._googlesitekitSiteData;
+		}
+	},
+};
+
+export const selectors = {
+	/**
+	 * Gets all site info from this data store.
+	 *
+	 * Not intended to be used publicly; this is largely here so other selectors can
+	 * request data using the selector/resolver pattern.
+	 *
+	 * @since n.e.x.t
+	 * @private
+	 *
+	 * @param {Object} state Data store's state.
+	 * @return {Object} Site connection info.
+	 */
+	getSiteInfo( state ) {
+		const {
+			adminURL,
+			ampMode,
+			currentReferenceURL,
+			currentEntityID,
+			currentEntityTitle,
+			currentEntityType,
+			homeURL,
+			referenceSiteURL,
+		} = state;
+
+		return {
+			adminURL,
+			ampMode,
+			currentReferenceURL,
+			currentEntityID,
+			currentEntityTitle,
+			currentEntityType,
+			homeURL,
+			referenceSiteURL,
+		};
+	},
+
+	/**
+	 * Gets a site's admin URL.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param {Object} state Data store's state.
+	 * @return {string|undefined} This site's admin URL.
+	 */
+	getAdminURL: createRegistrySelector( ( select ) => () => {
+		const { adminURL } = select( STORE_NAME ).getSiteInfo();
+
+		return adminURL;
+	} ),
+
+	/**
+	 * Gets a site's AMP mode.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param {Object} state Data store's state.
+	 * @return {string|undefined} AMP Mode.
+	 */
+	getAMPMode: createRegistrySelector( ( select ) => () => {
+		const { ampMode } = select( STORE_NAME ).getSiteInfo();
+
+		return ampMode;
+	} ),
+
+	/**
+	 * Gets the current entity's ID.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param {Object} state Data store's state.
+	 * @return {number|undefined} Current entity's ID.
+	 */
+	getCurrentEntityID: createRegistrySelector( ( select ) => () => {
+		const { currentEntityID } = select( STORE_NAME ).getSiteInfo();
+
+		return currentEntityID;
+	} ),
+
+	/**
+	 * Gets the current entity's title.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param {Object} state Data store's state.
+	 * @return {string|undefined} Current entity's title.
+	 */
+	getCurrentEntityTitle: createRegistrySelector( ( select ) => () => {
+		const { currentEntityTitle } = select( STORE_NAME ).getSiteInfo();
+
+		return currentEntityTitle;
+	} ),
+
+	/**
+	 * Gets the current entity's title.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param {Object} state Data store's state.
+	 * @return {string|undefined} Current entity's type.
+	 */
+	getCurrentEntityType: createRegistrySelector( ( select ) => () => {
+		const { currentEntityType } = select( STORE_NAME ).getSiteInfo();
+
+		return currentEntityType;
+	} ),
+
+	/**
+	 * Gets the current entity's reference URL.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param {Object} state Data store's state.
+	 * @return {string|undefined} Current entity's reference URL.
+	 */
+	getCurrentReferenceURL: createRegistrySelector( ( select ) => () => {
+		const { currentReferenceURL } = select( STORE_NAME ).getSiteInfo();
+
+		return currentReferenceURL;
+	} ),
+
+	/**
+	 * Gets a site's homepage URL.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param {Object} state Data store's state.
+	 * @return {string|undefined} This site's home URL.
+	 */
+	getHomeURL: createRegistrySelector( ( select ) => () => {
+		const { homeURL } = select( STORE_NAME ).getSiteInfo();
+
+		return homeURL;
+	} ),
+
+	/**
+	 * Gets a site's reference site URL.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param {Object} state Data store's state.
+	 * @return {string|undefined} Thereference site URL.
+	 */
+	getReferenceSiteURL: createRegistrySelector( ( select ) => () => {
+		const { referenceSiteURL } = select( STORE_NAME ).getSiteInfo();
+
+		return referenceSiteURL;
+	} ),
+
+	/**
+	 * Returns true if this site supports AMP.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param {Object} state Data store's state.
+	 * @return {string|undefined} `true` if AMP support is enabled, `false` if not. Returns `undefined` if not loaded.
+	 */
+	isAmp: createRegistrySelector( ( select ) => () => {
+		const ampMode = select( STORE_NAME ).getAMPMode();
+
+		return ampMode !== undefined ? !! ampMode : ampMode;
+	} ),
+};
+
+export default {
+	INITIAL_STATE,
+	actions,
+	controls,
+	reducer,
+	resolvers,
+	selectors,
+};

--- a/assets/js/googlesitekit/datastore/site/info.js
+++ b/assets/js/googlesitekit/datastore/site/info.js
@@ -113,18 +113,35 @@ export const reducer = ( state, { payload, type } ) => {
 };
 
 export const resolvers = {
-	*getSiteInfo( siteInfo = global._googlesitekitSiteData ) {
-		if ( siteInfo ) {
-			yield actions.receiveSiteInfo( siteInfo );
-
-			if ( global._googlesitekitSiteData ) {
-				delete global._googlesitekitSiteData;
-			}
-
+	*getSiteInfo() {
+		if ( ! global._googlesitekitBaseData || ! global._googlesitekitEntityData ) {
+			global.console.error( 'Could not load core/site info.' );
 			return;
 		}
 
-		global.console.error( 'Could not load core/site info.' );
+		const {
+			adminURL,
+			ampMode,
+			homeURL,
+			referenceSiteURL,
+		} = global._googlesitekitBaseData;
+		const {
+			currentEntityURL,
+			currentEntityID,
+			currentEntityTitle,
+			currentEntityType,
+		} = global._googlesitekitEntityData;
+
+		yield actions.receiveSiteInfo( {
+			adminURL,
+			ampMode,
+			currentEntityURL,
+			currentEntityID,
+			currentEntityTitle,
+			currentEntityType,
+			homeURL,
+			referenceSiteURL,
+		} );
 	},
 };
 

--- a/assets/js/googlesitekit/datastore/site/info.test.js
+++ b/assets/js/googlesitekit/datastore/site/info.test.js
@@ -17,10 +17,6 @@
  */
 
 /**
- * External dependencies
- */
-
-/**
  * Internal dependencies
  */
 import {

--- a/assets/js/googlesitekit/datastore/site/info.test.js
+++ b/assets/js/googlesitekit/datastore/site/info.test.js
@@ -107,7 +107,7 @@ describe( 'core/site site info', () => {
 			[ 'getCurrentEntityID' ],
 			[ 'getCurrentEntityTitle' ],
 			[ 'getCurrentEntityType' ],
-			[ 'getCurrentReferenceURL' ],
+			[ 'getCurrentEntityURL' ],
 			[ 'getHomeURL' ],
 			[ 'getReferenceSiteURL' ],
 		] )( `%i()`, ( selector ) => {

--- a/assets/js/googlesitekit/datastore/site/info.test.js
+++ b/assets/js/googlesitekit/datastore/site/info.test.js
@@ -1,0 +1,74 @@
+/**
+ * core/site data store: site info tests.
+ *
+ * Site Kit by Google, Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+
+/**
+ * Internal dependencies
+ */
+import {
+	createTestRegistry,
+	unsubscribeFromAll,
+} from 'tests/js/utils';
+import { STORE_NAME } from './index';
+
+describe( 'core/site site info', () => {
+	let registry;
+	let store;
+
+	beforeEach( () => {
+		registry = createTestRegistry();
+		store = registry.stores[ STORE_NAME ].store;
+	} );
+
+	afterEach( () => {
+		unsubscribeFromAll( registry );
+	} );
+
+	describe( 'actions', () => {
+		describe( 'receiveSiteInfo', () => {
+			it( 'requires the siteInfo param', () => {
+				expect( () => {
+					registry.dispatch( STORE_NAME ).receiveSiteInfo();
+				} ).toThrow( 'siteInfo is required.' );
+			} );
+
+			it( 'receives and sets site info ', async () => {
+				const siteInfo = {
+					adminURL: 'http://something.test/wp-admin',
+					ampMode: 'reader',
+					currentReferenceURL: 'http://something.test',
+					currentEntityID: '4',
+					currentEntityTitle: 'Something Witty',
+					currentEntityType: 'post',
+					homeURL: 'http://something.test/homepage',
+					referenceSiteURL: 'http://something.test',
+				};
+				await registry.dispatch( STORE_NAME ).receiveSiteInfo( siteInfo );
+
+				const state = store.getState();
+
+				expect(
+					registry.select( STORE_NAME ).getSiteInfo( state )
+				).toMatchObject( { ...siteInfo, currentEntityID: 4 } );
+			} );
+		} );
+	} );
+} );

--- a/includes/Context.php
+++ b/includes/Context.php
@@ -317,4 +317,25 @@ final class Context {
 
 		return $this->network_active;
 	}
+
+	/**
+	 * Gets the current entity (a post)
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @return WP_Post|bool The current post
+	 */
+	public function get_current_entity() {
+		if ( is_admin() ) {
+			$post = get_post();
+		} else {
+			$post = get_queried_object();
+		}
+
+		if ( ! $post instanceof \WP_Post ) {
+			return null;
+		}
+
+		return $post;
+	}
 }

--- a/includes/Context.php
+++ b/includes/Context.php
@@ -368,8 +368,7 @@ final class Context {
 	 * @return string URL that starts with the reference site URL.
 	 */
 	private function filter_reference_url( $url = '' ) {
-		$orig_site_url = untrailingslashit( home_url() );
-		$site_url      = $orig_site_url;
+		$site_url = untrailingslashit( home_url() );
 
 		/**
 		 * Filters the reference site URL to use for stats.
@@ -381,23 +380,22 @@ final class Context {
 		 *
 		 * @param string $site_url Reference site URL, typically the WordPress home URL.
 		 */
-		$site_url = apply_filters( 'googlesitekit_site_url', $site_url );
+		$reference_site_url = apply_filters( 'googlesitekit_site_url', $site_url );
+		$reference_site_url = untrailingslashit( $reference_site_url );
 
 		// Ensure this is not empty.
-		if ( empty( $site_url ) ) {
-			$site_url = $orig_site_url;
-		} else {
-			$site_url = untrailingslashit( $site_url );
+		if ( empty( $reference_site_url ) ) {
+			$reference_site_url = $site_url;
 		}
 
 		// If no URL given, just return the reference site URL.
 		if ( empty( $url ) ) {
-			return $site_url;
+			return $reference_site_url;
 		}
 
-		// Replace original site URL with the reference site URL.
-		if ( $orig_site_url !== $site_url ) {
-			$url = str_replace( $orig_site_url, $site_url, $url );
+		// Replace site URL with the reference site URL.
+		if ( $reference_site_url !== $site_url ) {
+			$url = str_replace( $site_url, $reference_site_url, $url );
 		}
 
 		return $url;

--- a/includes/Context.php
+++ b/includes/Context.php
@@ -223,7 +223,7 @@ final class Context {
 		if ( $post ) {
 			$permalink = get_permalink( $post );
 			if ( false === $permalink ) {
-				return $permalink;
+				return false;
 			}
 			return $this->filter_reference_url( $permalink );
 		}

--- a/includes/Context.php
+++ b/includes/Context.php
@@ -160,27 +160,7 @@ final class Context {
 	 * @return string Reference site URL.
 	 */
 	public function get_reference_site_url() {
-		$orig_site_url = home_url();
-		$site_url      = $orig_site_url;
-
-		/**
-		 * Filters the reference site URL to use for stats.
-		 *
-		 * This can be used to override the current site URL, for example when using the plugin on a non-public site,
-		 * such as in a staging environment.
-		 *
-		 * @since 1.0.0
-		 *
-		 * @param string $site_url Reference site URL, typically the WordPress home URL.
-		 */
-		$site_url = apply_filters( 'googlesitekit_site_url', $site_url );
-
-		// Ensure this is not empty.
-		if ( empty( $site_url ) ) {
-			$site_url = $orig_site_url;
-		}
-
-		return untrailingslashit( $site_url );
+		return untrailingslashit( $this->filter_reference_url() );
 	}
 
 	/**
@@ -384,15 +364,38 @@ final class Context {
 	 *
 	 * @since n.e.x.t
 	 *
-	 * @param string $url Input URL.
-	 * @return string URL that starts with the site reference URL.
+	 * @param string $url Optional. Input URL. If not provided, returns the plain reference site URL.
+	 * @return string URL that starts with the reference site URL.
 	 */
-	private function filter_reference_url( $url ) {
-		$reference_site_url = $this->get_reference_site_url();
-		$orig_site_url      = home_url();
+	private function filter_reference_url( $url = '' ) {
+		$orig_site_url = home_url();
+		$site_url      = $orig_site_url;
 
-		if ( $orig_site_url !== $reference_site_url ) {
-			$url = str_replace( $orig_site_url, $reference_site_url, $url );
+		/**
+		 * Filters the reference site URL to use for stats.
+		 *
+		 * This can be used to override the current site URL, for example when using the plugin on a non-public site,
+		 * such as in a staging environment.
+		 *
+		 * @since 1.0.0
+		 *
+		 * @param string $site_url Reference site URL, typically the WordPress home URL.
+		 */
+		$site_url = apply_filters( 'googlesitekit_site_url', $site_url );
+
+		// Ensure this is not empty.
+		if ( empty( $site_url ) ) {
+			$site_url = $orig_site_url;
+		}
+
+		// If no URL given, just return the reference site URL.
+		if ( empty( $url ) ) {
+			return $site_url;
+		}
+
+		// Replace original site URL with the reference site URL.
+		if ( $orig_site_url !== $site_url ) {
+			$url = str_replace( $orig_site_url, $site_url, $url );
 		}
 
 		return $url;

--- a/includes/Context.php
+++ b/includes/Context.php
@@ -160,7 +160,7 @@ final class Context {
 	 * @return string Reference site URL.
 	 */
 	public function get_reference_site_url() {
-		return untrailingslashit( $this->filter_reference_url() );
+		return $this->filter_reference_url();
 	}
 
 	/**
@@ -368,7 +368,7 @@ final class Context {
 	 * @return string URL that starts with the reference site URL.
 	 */
 	private function filter_reference_url( $url = '' ) {
-		$orig_site_url = home_url();
+		$orig_site_url = untrailingslashit( home_url() );
 		$site_url      = $orig_site_url;
 
 		/**
@@ -386,6 +386,8 @@ final class Context {
 		// Ensure this is not empty.
 		if ( empty( $site_url ) ) {
 			$site_url = $orig_site_url;
+		} else {
+			$site_url = untrailingslashit( $site_url );
 		}
 
 		// If no URL given, just return the reference site URL.

--- a/includes/Core/Assets/Assets.php
+++ b/includes/Core/Assets/Assets.php
@@ -414,19 +414,16 @@ final class Assets {
 						'googlesitekit-data',
 					),
 					'before_print' => function( $handle ) use ( $base_url ) {
-						$current_entity = $this->context->get_current_entity();
+						$current_entity = $this->context->get_reference_entity();
 						$inline_data = array(
-							'adminRootURL'        => esc_url_raw( get_admin_url() . 'admin.php' ),
-							'ampMode'             => $this->context->get_amp_mode(),
-							'currentEntityID'     => $current_entity ? $current_entity->ID : null,
-							'currentEntityTitle'  => $current_entity ? $current_entity->title : null,
-							// TODO: This seems like an incomplete approach to the suggestion in
-							// https://github.com/google/site-kit-wp/issues/1000
-							// It should possibly return `''` or `false`.
-							'currentEntityType'   => is_home() ? 'home' : 'post',
-							'currentReferenceURL' => $this->context->get_reference_canonical(),
-							'homeURL'             => home_url(),
-							'referenceSiteURL'    => esc_url_raw( $site_url ),
+							'adminRootURL'       => esc_url_raw( get_admin_url() . 'admin.php' ),
+							'ampMode'            => $this->context->get_amp_mode(),
+							'currentEntityURL'   => $current_entity ? $current_entity->get_url() : null,
+							'currentEntityType'  => $current_entity ? $current_entity->get_type() : null,
+							'currentEntityTitle' => $current_entity ? $current_entity->get_title() : null,
+							'currentEntityID'    => $current_entity ? $current_entity->get_id() : null,
+							'homeURL'            => home_url(),
+							'referenceSiteURL'   => esc_url_raw( $site_url ),
 						);
 						wp_add_inline_script(
 							$handle,

--- a/includes/Core/Assets/Assets.php
+++ b/includes/Core/Assets/Assets.php
@@ -409,14 +409,41 @@ final class Assets {
 				'googlesitekit-datastore-site',
 				array(
 					'src'          => $base_url . 'js/googlesitekit-datastore-site.js',
-					'dependencies' => array( 'googlesitekit-api', 'googlesitekit-data' ),
+					'dependencies' => array(
+						'googlesitekit-api',
+						'googlesitekit-data',
+					),
+					'before_print' => function( $handle ) use ( $base_url ) {
+						$current_entity = $this->context->get_current_entity();
+						$inline_data = array(
+							'adminRootURL'        => esc_url_raw( get_admin_url() . 'admin.php' ),
+							'ampMode'             => $this->context->get_amp_mode(),
+							'currentEntityID'     => $current_entity ? $current_entity->ID : null,
+							'currentEntityTitle'  => $current_entity ? $current_entity->title : null,
+							// TODO: This seems like an incomplete approach to the suggestion in
+							// https://github.com/google/site-kit-wp/issues/1000
+							// It should possibly return `''` or `false`.
+							'currentEntityType'   => is_home() ? 'home' : 'post',
+							'currentReferenceURL' => $this->context->get_reference_canonical(),
+							'homeURL'             => home_url(),
+							'referenceSiteURL'    => esc_url_raw( $site_url ),
+						);
+						wp_add_inline_script(
+							$handle,
+							'window._googlesitekitSiteData = ' . wp_json_encode( $inline_data ),
+							'before'
+						);
+					},
 				)
 			),
 			new Script(
 				'googlesitekit-modules',
 				array(
 					'src'          => $base_url . 'js/googlesitekit-modules.js',
-					'dependencies' => array( 'googlesitekit-api', 'googlesitekit-data' ),
+					'dependencies' => array(
+						'googlesitekit-api',
+						'googlesitekit-data',
+					),
 				)
 			),
 			// End JSR Assets.

--- a/includes/Core/Assets/Assets.php
+++ b/includes/Core/Assets/Assets.php
@@ -565,10 +565,10 @@ final class Assets {
 		$current_user = wp_get_current_user();
 
 		$inline_data = array(
-			'homeURL'          => home_url(),
-			'referenceSiteURL' => esc_url_raw( $site_url ),
+			'homeURL'          => trailingslashit( home_url() ),
+			'referenceSiteURL' => esc_url_raw( trailingslashit( $site_url ) ),
 			'userIDHash'       => md5( $site_url . $current_user->ID ),
-			'adminURL'         => esc_url_raw( get_admin_url() . 'admin.php' ),
+			'adminURL'         => esc_url_raw( trailingslashit( admin_url() ) ),
 			'assetsURL'        => esc_url_raw( $this->context->url( 'dist/assets/' ) ),
 			'blogPrefix'       => $wpdb->get_blog_prefix(),
 			'ampMode'          => $this->context->get_amp_mode(),

--- a/includes/Core/Assets/Assets.php
+++ b/includes/Core/Assets/Assets.php
@@ -362,6 +362,15 @@ final class Assets {
 				)
 			),
 			new Script_Data(
+				'googlesitekit-entity-data',
+				array(
+					'global'        => '_googlesitekitEntityData',
+					'data_callback' => function () {
+						return $this->get_inline_entity_data();
+					},
+				)
+			),
+			new Script_Data(
 				'googlesitekit-apifetch-data',
 				array(
 					'global'        => '_googlesitekitAPIFetchData',
@@ -412,25 +421,9 @@ final class Assets {
 					'dependencies' => array(
 						'googlesitekit-api',
 						'googlesitekit-data',
+						'googlesitekit-base-data',
+						'googlesitekit-entity-data',
 					),
-					'before_print' => function( $handle ) use ( $base_url ) {
-						$current_entity = $this->context->get_reference_entity();
-						$inline_data = array(
-							'adminRootURL'       => esc_url_raw( get_admin_url() . 'admin.php' ),
-							'ampMode'            => $this->context->get_amp_mode(),
-							'currentEntityURL'   => $current_entity ? $current_entity->get_url() : null,
-							'currentEntityType'  => $current_entity ? $current_entity->get_type() : null,
-							'currentEntityTitle' => $current_entity ? $current_entity->get_title() : null,
-							'currentEntityID'    => $current_entity ? $current_entity->get_id() : null,
-							'homeURL'            => home_url(),
-							'referenceSiteURL'   => esc_url_raw( $site_url ),
-						);
-						wp_add_inline_script(
-							$handle,
-							'window._googlesitekitSiteData = ' . wp_json_encode( $inline_data ),
-							'before'
-						);
-					},
 				)
 			),
 			new Script(
@@ -557,9 +550,10 @@ final class Assets {
 			'homeURL'          => home_url(),
 			'referenceSiteURL' => esc_url_raw( $site_url ),
 			'userIDHash'       => md5( $site_url . $current_user->ID ),
-			'adminRoot'        => esc_url_raw( get_admin_url() . 'admin.php' ),
-			'assetsRoot'       => esc_url_raw( $this->context->url( 'dist/assets/' ) ),
+			'adminURL'         => esc_url_raw( get_admin_url() . 'admin.php' ),
+			'assetsURL'        => esc_url_raw( $this->context->url( 'dist/assets/' ) ),
 			'blogPrefix'       => $wpdb->get_blog_prefix(),
+			'ampMode'          => $this->context->get_amp_mode(),
 			'isNetworkMode'    => $this->context->is_network_mode(),
 		);
 
@@ -573,6 +567,24 @@ final class Assets {
 		 * @param array $data Base data.
 		 */
 		return apply_filters( 'googlesitekit_inline_base_data', $inline_data );
+	}
+
+	/**
+	 * Gets the inline data specific to the current entity.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @return array The site inline data to be output.
+	 */
+	private function get_inline_entity_data() {
+		$current_entity = $this->context->get_reference_entity();
+
+		return array(
+			'currentEntityURL'   => $current_entity ? $current_entity->get_url() : null,
+			'currentEntityType'  => $current_entity ? $current_entity->get_type() : null,
+			'currentEntityTitle' => $current_entity ? $current_entity->get_title() : null,
+			'currentEntityID'    => $current_entity ? $current_entity->get_id() : null,
+		);
 	}
 
 	/**

--- a/includes/Core/Util/Entity.php
+++ b/includes/Core/Util/Entity.php
@@ -1,0 +1,137 @@
+<?php
+/**
+ * Class Google\Site_Kit\Core\Util\Entity
+ *
+ * @package   Google\Site_Kit
+ * @copyright 2020 Google LLC
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
+ * @link      https://sitekit.withgoogle.com
+ */
+
+namespace Google\Site_Kit\Core\Util;
+
+use Google\Site_Kit\Context;
+
+/**
+ * Class representing an entity.
+ *
+ * An entity in Site Kit terminology is based on a canonical URL, i.e. every
+ * canonical URL has an associated entity.
+ *
+ * An entity may also have a type, if it can be determined.
+ * Possible types are e.g. 'post' for a WordPress post (of any post type!),
+ * 'term' for a WordPress term (of any taxonomy!), 'home' for the blog archive,
+ * 'date' for a date-based archive etc.
+ *
+ * For specific entity types, the entity will also have a title, and it may
+ * even have an ID. For example:
+ * * For a type of 'post', the entity ID will be the post ID and the entity
+ *   title will be the post title.
+ * * For a type of 'term', the entity ID will be the term ID and the entity
+ *   title will be the term title.
+ * * For a type of 'date', there will be no entity ID, but the entity title
+ *   will be the title of the date-based archive.
+ *
+ * @since n.e.x.t
+ * @access private
+ * @ignore
+ */
+final class Entity {
+
+	/**
+	 * The entity URL.
+	 *
+	 * @since n.e.x.t
+	 * @var string
+	 */
+	private $url;
+
+	/**
+	 * The entity type.
+	 *
+	 * @since n.e.x.t
+	 * @var string
+	 */
+	private $type;
+
+	/**
+	 * The entity title.
+	 *
+	 * @since n.e.x.t
+	 * @var string
+	 */
+	private $title;
+
+	/**
+	 * The entity ID.
+	 *
+	 * @since n.e.x.t
+	 * @var int
+	 */
+	private $id;
+
+	/**
+	 * Constructor.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param string $url  The entity URL.
+	 * @param array  $args {
+	 *     Optional. Additional entity arguments.
+	 *
+	 *     @type string $type  The entity type.
+	 *     @type string $title The entity title.
+	 *     @type int    $id    The entity ID.
+	 * }
+	 */
+	public function __construct( $url, array $args = array() ) {
+		$this->url   = $url;
+		$this->type  = isset( $args['type'] ) ? (string) $args['type'] : '';
+		$this->title = isset( $args['title'] ) ? (string) $args['title'] : '';
+		$this->id    = isset( $args['id'] ) ? (int) $args['id'] : 0;
+	}
+
+	/**
+	 * Gets the entity URL.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @return string The entity URL.
+	 */
+	public function get_url() {
+		return $this->url;
+	}
+
+	/**
+	 * Gets the entity type.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @return string The entity type, or empty string if unknown.
+	 */
+	public function get_type() {
+		return $this->type;
+	}
+
+	/**
+	 * Gets the entity title.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @return string The entity title, or empty string if unknown.
+	 */
+	public function get_title() {
+		return $this->title;
+	}
+
+	/**
+	 * Gets the entity ID.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @return int The entity ID, or 0 if unknown.
+	 */
+	public function get_id() {
+		return $this->id;
+	}
+}

--- a/includes/Core/Util/Entity.php
+++ b/includes/Core/Util/Entity.php
@@ -16,7 +16,7 @@ use Google\Site_Kit\Context;
  * Class representing an entity.
  *
  * An entity in Site Kit terminology is based on a canonical URL, i.e. every
- * canonical URL has an associated entity.
+ * canonical frontend URL has an associated entity.
  *
  * An entity may also have a type, if it can be determined.
  * Possible types are e.g. 'post' for a WordPress post (of any post type!),
@@ -85,10 +85,19 @@ final class Entity {
 	 * }
 	 */
 	public function __construct( $url, array $args = array() ) {
+		$args = array_merge(
+			array(
+				'type'  => '',
+				'title' => '',
+				'id'    => 0,
+			),
+			$args
+		);
+
 		$this->url   = $url;
-		$this->type  = isset( $args['type'] ) ? (string) $args['type'] : '';
-		$this->title = isset( $args['title'] ) ? (string) $args['title'] : '';
-		$this->id    = isset( $args['id'] ) ? (int) $args['id'] : 0;
+		$this->type  = (string) $args['type'];
+		$this->title = (string) $args['title'];
+		$this->id    = (int) $args['id'];
 	}
 
 	/**

--- a/tests/phpunit/integration/ContextTest.php
+++ b/tests/phpunit/integration/ContextTest.php
@@ -231,7 +231,7 @@ class ContextTest extends TestCase {
 		$this->assertTrue( $context->is_network_active() );
 	}
 
-	public function test_get_current_entity() {
+	public function test_get_reference_entity() {
 		$this->markTestSkipped( 'Test not written yet.' );
 	}
 }

--- a/tests/phpunit/integration/ContextTest.php
+++ b/tests/phpunit/integration/ContextTest.php
@@ -230,8 +230,4 @@ class ContextTest extends TestCase {
 		$context = new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE );
 		$this->assertTrue( $context->is_network_active() );
 	}
-
-	public function test_get_reference_entity() {
-		$this->markTestSkipped( 'Test not written yet.' );
-	}
 }

--- a/tests/phpunit/integration/ContextTest.php
+++ b/tests/phpunit/integration/ContextTest.php
@@ -107,7 +107,7 @@ class ContextTest extends TestCase {
 			array(
 				'foo'  => 'bar',
 				'page' => 'different',
-			) 
+			)
 		);
 		$this->assertEqualSetsWithIndex(
 			array(
@@ -166,7 +166,7 @@ class ContextTest extends TestCase {
 			array(
 				'post_title' => 'homepage',
 				'post_type'  => 'page',
-			) 
+			)
 		);
 		self::factory()->category->create( array( 'slug' => 'postcategory' ) );
 
@@ -229,5 +229,9 @@ class ContextTest extends TestCase {
 		// Ensure re-checking evaluates as true.
 		$context = new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE );
 		$this->assertTrue( $context->is_network_active() );
+	}
+
+	public function test_get_current_entity() {
+		$this->markTestSkipped( 'Test not written yet.' );
 	}
 }


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #1000 

## Relevant technical choices

Added a `get_current_entity` method to the context class to allow getting the data required from #1000's IB.

<!-- Please describe your changes. -->

## Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
