### PR TITLE
Add registry access using controls and common actions

### DIFF
--- a/assets/js/googlesitekit/data/create-settings-store.js
+++ b/assets/js/googlesitekit/data/create-settings-store.js
@@ -28,6 +28,8 @@ import { isEqual } from 'lodash';
 import API from 'googlesitekit-api';
 import Data from 'googlesitekit-data';
 
+const { getRegistry } = Data.commonActions;
+
 // Actions
 const SET_SETTINGS = 'SET_SETTINGS';
 const FETCH_SETTINGS = 'FETCH_SETTINGS';
@@ -152,6 +154,7 @@ export const createSettingsStore = ( type, identifier, datapoint, {
 		 * @return {Object} Redux-style action.
 		 */
 		*saveSettings() {
+			const registry = yield getRegistry(); // eslint-disable-line no-shadow
 			const values = yield registry.select( STORE_NAME ).getSettings();
 
 			try {

--- a/assets/js/googlesitekit/data/create-settings-store.js
+++ b/assets/js/googlesitekit/data/create-settings-store.js
@@ -28,7 +28,7 @@ import { isEqual } from 'lodash';
 import API from 'googlesitekit-api';
 import Data from 'googlesitekit-data';
 
-const { commonActions, createRegistrySelector } = Data;
+const { commonActions, commonControls, createRegistrySelector } = Data;
 const { getRegistry } = commonActions;
 
 // Actions
@@ -79,6 +79,8 @@ export const createSettingsStore = ( type, identifier, datapoint, {
 	const settingReducers = {};
 
 	const actions = {
+		...commonActions,
+
 		/**
 		 * Sets settings for the given values.
 		 *
@@ -152,7 +154,7 @@ export const createSettingsStore = ( type, identifier, datapoint, {
 		 * @return {Object} Redux-style action.
 		 */
 		*saveSettings() {
-			const registry = yield getRegistry(); // eslint-disable-line no-shadow
+			const registry = yield getRegistry();
 			const values = yield registry.select( STORE_NAME ).getSettings();
 
 			try {
@@ -218,6 +220,7 @@ export const createSettingsStore = ( type, identifier, datapoint, {
 	};
 
 	const controls = {
+		...commonControls,
 		[ FETCH_SETTINGS ]: () => {
 			return API.get( type, identifier, datapoint );
 		},

--- a/assets/js/googlesitekit/data/create-settings-store.js
+++ b/assets/js/googlesitekit/data/create-settings-store.js
@@ -26,7 +26,7 @@ import { isEqual } from 'lodash';
  * Internal dependencies
  */
 import API from 'googlesitekit-api';
-import Data from 'googlesitekit-data';
+import Data, { createRegistrySelector } from 'googlesitekit-data';
 
 const { getRegistry } = Data.commonActions;
 
@@ -407,15 +407,15 @@ export const createSettingsStore = ( type, identifier, datapoint, {
 		 *
 		 * @return {*} Setting value, or undefined.
 		 */
-		selectors[ `get${ pascalCaseSlug }` ] = () => {
-			const settings = registry.select( STORE_NAME ).getSettings();
+		selectors[ `get${ pascalCaseSlug }` ] = createRegistrySelector( ( select ) => () => {
+			const settings = select( STORE_NAME ).getSettings();
 
 			if ( 'undefined' === typeof settings ) {
 				return settings;
 			}
 
 			return settings[ slug ];
-		};
+		} );
 	} );
 
 	return {

--- a/assets/js/googlesitekit/data/create-settings-store.js
+++ b/assets/js/googlesitekit/data/create-settings-store.js
@@ -26,9 +26,10 @@ import { isEqual } from 'lodash';
  * Internal dependencies
  */
 import API from 'googlesitekit-api';
-import Data, { createRegistrySelector } from 'googlesitekit-data';
+import Data from 'googlesitekit-data';
 
-const { getRegistry } = Data.commonActions;
+const { commonActions, createRegistrySelector } = Data;
+const { getRegistry } = commonActions;
 
 // Actions
 const SET_SETTINGS = 'SET_SETTINGS';

--- a/assets/js/googlesitekit/data/create-settings-store.js
+++ b/assets/js/googlesitekit/data/create-settings-store.js
@@ -54,15 +54,12 @@ const RECEIVE_SAVE_SETTINGS_FAILED = 'RECEIVE_SAVE_SETTINGS_FAILED';
  * @param {number} options.storeName    Store name to use. Default is '{type}/{identifier}'.
  * @param {Array}  options.settingSlugs List of the slugs that are part of the settings object
  *                                      handled by the respective API endpoint.
- * @param {Object} options.registry     Store registry that this store will be registered on. Default
- *                                      is the main Site Kit registry `googlesitekit.data`.
  * @return {Object} The settings store object, with additional `STORE_NAME` and
  *                  `INITIAL_STATE` properties.
  */
 export const createSettingsStore = ( type, identifier, datapoint, {
 	storeName = undefined,
 	settingSlugs = [],
-	registry = Data,
 } = {} ) => {
 	invariant( type, 'type is required.' );
 	invariant( identifier, 'identifier is required.' );

--- a/assets/js/googlesitekit/data/index.js
+++ b/assets/js/googlesitekit/data/index.js
@@ -20,6 +20,10 @@
  * WordPress dependencies
  */
 import { createRegistry } from '@wordpress/data';
+export {
+	createRegistryControl,
+	createRegistrySelector,
+} from '@wordpress/data';
 
 /**
  * Internal dependencies

--- a/assets/js/googlesitekit/data/index.js
+++ b/assets/js/googlesitekit/data/index.js
@@ -38,6 +38,8 @@ import {
 	collectSelectors,
 	collectState,
 	collectName,
+	commonActions,
+	commonControls,
 } from 'assets/js/googlesitekit/data/utils';
 
 const Data = createRegistry();
@@ -53,5 +55,7 @@ Data.collectResolvers = collectResolvers;
 Data.collectSelectors = collectSelectors;
 Data.collectState = collectState;
 Data.collectName = collectName;
+Data.commonActions = commonActions;
+Data.commonControls = commonControls;
 
 export default Data;

--- a/assets/js/googlesitekit/data/index.js
+++ b/assets/js/googlesitekit/data/index.js
@@ -17,10 +17,6 @@
  */
 
 /**
- * External dependencies
- */
-
-/**
  * WordPress dependencies
  */
 import { createRegistry } from '@wordpress/data';

--- a/assets/js/googlesitekit/data/index.js
+++ b/assets/js/googlesitekit/data/index.js
@@ -19,8 +19,8 @@
 /**
  * WordPress dependencies
  */
-import { createRegistry } from '@wordpress/data';
-export {
+import {
+	createRegistry,
 	createRegistryControl,
 	createRegistrySelector,
 } from '@wordpress/data';
@@ -57,5 +57,7 @@ Data.collectState = collectState;
 Data.collectName = collectName;
 Data.commonActions = commonActions;
 Data.commonControls = commonControls;
+Data.createRegistryControl = createRegistryControl;
+Data.createRegistrySelector = createRegistrySelector;
 
 export default Data;

--- a/assets/js/googlesitekit/data/utils.js
+++ b/assets/js/googlesitekit/data/utils.js
@@ -21,6 +21,12 @@
  */
 import invariant from 'invariant';
 
+/**
+ * WordPress dependencies
+ */
+import { createRegistryControl } from '@wordpress/data';
+
+const GET_REGISTRY = 'GET_REGISTRY';
 const INITIALIZE = 'INITIALIZE';
 
 /**
@@ -204,6 +210,51 @@ export const collectName = ( ...args ) => {
 	invariant( duplicates.length === names.length - 1, 'collectName() must not receive different names.' );
 
 	return names.shift();
+};
+
+/**
+ * An object of common actions most stores will use.
+ *
+ * @since n.e.x.t
+ *
+ * @return {Object} key/value list of common actions most stores will want.
+ */
+export const commonActions = {
+	/**
+	 * Dispatches an action and calls a control to get the current data registry.
+	 *
+	 * Useful for controls and resolvers that wish to dispatch actions/use selectors
+	 * on the current data registry.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @return {Object} FSA-compatible action.
+	 */
+	getRegistry() {
+		return { type: 'GET_REGISTRY' };
+	},
+	initialize: initializeAction,
+};
+
+/**
+ * An object of common controls most stores will use.
+ *
+ * @since n.e.x.t
+ *
+ * @return {Object} key/value list of common controls most stores will want.
+ */
+export const commonControls = {
+	/**
+	 * Returns the current registry.
+	 *
+	 * Useful for controls and resolvers that wish to dispatch actions/use selectors
+	 * on the current data registry.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @return {Object} FSA-compatible action.
+	 */
+	[ GET_REGISTRY ]: createRegistryControl( ( registry ) => () => registry ),
 };
 
 /**

--- a/assets/js/googlesitekit/data/utils.js
+++ b/assets/js/googlesitekit/data/utils.js
@@ -231,7 +231,7 @@ export const commonActions = {
 	 * @return {Object} FSA-compatible action.
 	 */
 	getRegistry() {
-		return { type: 'GET_REGISTRY' };
+		return { type: GET_REGISTRY };
 	},
 	initialize: initializeAction,
 };

--- a/assets/js/googlesitekit/data/utils.js
+++ b/assets/js/googlesitekit/data/utils.js
@@ -233,7 +233,6 @@ export const commonActions = {
 	getRegistry() {
 		return { type: GET_REGISTRY };
 	},
-	initialize: initializeAction,
 };
 
 /**

--- a/assets/js/googlesitekit/datastore/site/index.js
+++ b/assets/js/googlesitekit/datastore/site/index.js
@@ -34,10 +34,12 @@ export const INITIAL_STATE = Data.collectState(
 
 export const STORE_NAME = 'core/site';
 
-export const actions = Data.collectActions(
-	Data.commonActions,
-	connection.actions,
-	reset.actions,
+export const actions = Data.addInitializeAction(
+	Data.collectActions(
+		Data.commonActions,
+		connection.actions,
+		reset.actions,
+	)
 );
 
 export const controls = Data.collectControls(

--- a/assets/js/googlesitekit/datastore/site/index.js
+++ b/assets/js/googlesitekit/datastore/site/index.js
@@ -34,12 +34,14 @@ export const INITIAL_STATE = Data.collectState(
 
 export const STORE_NAME = 'core/site';
 
-export const actions = Data.addInitializeAction( Data.collectActions(
+export const actions = Data.collectActions(
+	Data.commonActions,
 	connection.actions,
 	reset.actions,
-) );
+);
 
 export const controls = Data.collectControls(
+	Data.commonControls,
 	connection.controls,
 	reset.controls,
 );

--- a/assets/js/googlesitekit/modules/create-module-store.js
+++ b/assets/js/googlesitekit/modules/create-module-store.js
@@ -59,13 +59,11 @@ import {
 export const createModuleStore = ( slug, {
 	storeName = undefined,
 	settingSlugs = undefined,
-	registry = Data,
 } = {} ) => {
 	invariant( slug, 'slug is required.' );
 
 	const notificationsStore = createNotificationsStore( 'modules', slug, 'notifications', {
 		storeName,
-		registry,
 	} );
 
 	const STORE_NAME = [ notificationsStore.STORE_NAME ];
@@ -81,7 +79,6 @@ export const createModuleStore = ( slug, {
 		const settingsStore = createSettingsStore( 'modules', slug, 'settings', {
 			storeName,
 			settingSlugs,
-			registry,
 		} );
 
 		STORE_NAME.push( settingsStore.STORE_NAME );

--- a/assets/js/modules/analytics/datastore/index.js
+++ b/assets/js/modules/analytics/datastore/index.js
@@ -52,17 +52,17 @@ export const INITIAL_STATE = Data.collectState(
 	tags.INITIAL_STATE,
 );
 
-export const actions = Data.addInitializeAction(
-	Data.collectActions(
-		baseModuleStore.actions,
-		accounts.actions,
-		properties.actions,
-		profiles.actions,
-		tags.actions,
-	)
+export const actions = Data.collectActions(
+	Data.commonActions,
+	baseModuleStore.actions,
+	accounts.actions,
+	properties.actions,
+	profiles.actions,
+	tags.actions,
 );
 
 export const controls = Data.collectControls(
+	Data.commonControls,
 	baseModuleStore.controls,
 	accounts.controls,
 	properties.controls,

--- a/assets/js/modules/analytics/datastore/index.js
+++ b/assets/js/modules/analytics/datastore/index.js
@@ -53,7 +53,6 @@ export const INITIAL_STATE = Data.collectState(
 );
 
 export const actions = Data.collectActions(
-	Data.commonActions,
 	baseModuleStore.actions,
 	accounts.actions,
 	properties.actions,
@@ -62,7 +61,6 @@ export const actions = Data.collectActions(
 );
 
 export const controls = Data.collectControls(
-	Data.commonControls,
 	baseModuleStore.controls,
 	accounts.controls,
 	properties.controls,

--- a/assets/js/modules/analytics/datastore/tags.js
+++ b/assets/js/modules/analytics/datastore/tags.js
@@ -25,11 +25,9 @@ import invariant from 'invariant';
  * Internal dependencies
  */
 import API from 'googlesitekit-api';
-import Data from 'googlesitekit-data';
+import { createRegistrySelector } from 'googlesitekit-data';
 import { getExistingTag } from 'assets/js/util';
 import { STORE_NAME } from './index';
-
-const { getRegistry } = Data.commonActions;
 
 // Actions
 const FETCH_EXISTING_TAG = 'FETCH_EXISTING_TAG';
@@ -194,16 +192,6 @@ export const reducer = ( state, { type, payload } ) => {
 };
 
 export const resolvers = {
-	*hasExistingTag() {
-		const registry = yield getRegistry();
-		yield registry.select( STORE_NAME ).getExistingTag();
-	},
-
-	*hasTagPermission( propertyID, accountID = '' ) {
-		const registry = yield getRegistry();
-		yield registry.select( STORE_NAME ).getTagPermission( propertyID, accountID );
-	},
-
 	*getExistingTag() {
 		try {
 			const registry = yield actions.getRegistry();
@@ -262,10 +250,11 @@ export const selectors = {
 	 * @param {Object} state Data store's state.
 	 * @return {?boolean} True if a tag exists, false if not; undefined if not loaded.
 	 */
-	hasExistingTag( state ) {
-		const existingTag = selectors.getExistingTag( state );
+	hasExistingTag: createRegistrySelector( ( select ) => () => {
+		const existingTag = select( STORE_NAME ).getExistingTag();
+
 		return existingTag !== undefined ? !! existingTag : undefined;
-	},
+	} ),
 
 	/**
 	 * Get an existing tag on the site, if present.
@@ -304,10 +293,11 @@ export const selectors = {
 	 * @param {string} accountID  Optional. The Analytics Account ID the property belongs to, if known.
 	 * @return {?boolean} True if the user has access, false if not; `undefined` if not loaded.
 	 */
-	hasTagPermission( state, propertyID, accountID = '' ) {
-		const response = selectors.getTagPermission( state, propertyID, accountID );
-		return response !== undefined ? response.permission : undefined;
-	},
+	hasTagPermission: createRegistrySelector( ( select ) => ( state, propertyID, accountID = '' ) => {
+		const { permission } = select( STORE_NAME ).getTagPermission( state, propertyID, accountID ) || {};
+
+		return permission;
+	} ),
 
 	/**
 	 * Checks permissions for an existing Google Analytics tag / property.

--- a/assets/js/modules/analytics/datastore/tags.js
+++ b/assets/js/modules/analytics/datastore/tags.js
@@ -25,9 +25,11 @@ import invariant from 'invariant';
  * Internal dependencies
  */
 import API from 'googlesitekit-api';
-import { createRegistrySelector } from 'googlesitekit-data';
+import Data from 'googlesitekit-data';
 import { getExistingTag } from 'assets/js/util';
 import { STORE_NAME } from './index';
+
+const { createRegistrySelector } = Data;
 
 // Actions
 const FETCH_EXISTING_TAG = 'FETCH_EXISTING_TAG';


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Part of issue #1101.

## Relevant technical choices

This introduces "common actions" and "common controls" for our stores. We'll need these to be able to get access to the _current_ registry rather than relying on `Data.select`/etc. for accessing selector data.

This also means we need to have resolvers for actions that rely on data from selectors that _also_ have resolvers. This is a bit more boilerplate code, but:

1. provides more explicit control flow
2. removes our usage of a global inside a data store, which was always a bit suspect (yes, I know it was my idea, but this is nicer 😅)

Tests still pass so I'll refactor any other data stores to use this approach.

We may want to extend all stores with this functionality as it's incredibly useful, but for now I've exported these features from `googlesitekit-data` because first-party and third-party code will benefit from them.

## Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
