### PR TITLE
Add registry select to datastore

### DIFF
--- a/assets/js/googlesitekit/data/create-settings-store.js
+++ b/assets/js/googlesitekit/data/create-settings-store.js
@@ -28,6 +28,8 @@ import { isEqual } from 'lodash';
 import API from 'googlesitekit-api';
 import Data from 'googlesitekit-data';
 
+const { getRegistry } = Data.commonActions;
+
 // Actions
 const SET_SETTINGS = 'SET_SETTINGS';
 const FETCH_SETTINGS = 'FETCH_SETTINGS';
@@ -152,6 +154,7 @@ export const createSettingsStore = ( type, identifier, datapoint, {
 		 * @return {Object} Redux-style action.
 		 */
 		*saveSettings() {
+			const registry = yield getRegistry(); // eslint-disable-line no-shadow
 			const values = yield registry.select( STORE_NAME ).getSettings();
 
 			try {

--- a/assets/js/googlesitekit/data/create-settings-store.js
+++ b/assets/js/googlesitekit/data/create-settings-store.js
@@ -26,7 +26,7 @@ import { isEqual } from 'lodash';
  * Internal dependencies
  */
 import API from 'googlesitekit-api';
-import Data from 'googlesitekit-data';
+import Data, { createRegistrySelector } from 'googlesitekit-data';
 
 const { getRegistry } = Data.commonActions;
 
@@ -408,15 +408,15 @@ export const createSettingsStore = ( type, identifier, datapoint, {
 		 *
 		 * @return {*} Setting value, or undefined.
 		 */
-		selectors[ `get${ pascalCaseSlug }` ] = () => {
-			const settings = registry.select( STORE_NAME ).getSettings();
+		selectors[ `get${ pascalCaseSlug }` ] = createRegistrySelector( ( select ) => () => {
+			const settings = select( STORE_NAME ).getSettings();
 
 			if ( 'undefined' === typeof settings ) {
 				return settings;
 			}
 
 			return settings[ slug ];
-		};
+		} );
 	} );
 
 	return {

--- a/assets/js/googlesitekit/data/create-settings-store.js
+++ b/assets/js/googlesitekit/data/create-settings-store.js
@@ -28,7 +28,7 @@ import { isEqual } from 'lodash';
 import API from 'googlesitekit-api';
 import Data from 'googlesitekit-data';
 
-const { commonActions, createRegistrySelector } = Data;
+const { commonActions, commonControls, createRegistrySelector } = Data;
 const { getRegistry } = commonActions;
 
 // Actions
@@ -79,6 +79,8 @@ export const createSettingsStore = ( type, identifier, datapoint, {
 	const settingReducers = {};
 
 	const actions = {
+		...commonActions,
+
 		/**
 		 * Sets settings for the given values.
 		 *
@@ -152,7 +154,7 @@ export const createSettingsStore = ( type, identifier, datapoint, {
 		 * @return {Object} Redux-style action.
 		 */
 		*saveSettings() {
-			const registry = yield getRegistry(); // eslint-disable-line no-shadow
+			const registry = yield getRegistry();
 			const values = yield registry.select( STORE_NAME ).getSettings();
 
 			try {
@@ -218,6 +220,7 @@ export const createSettingsStore = ( type, identifier, datapoint, {
 	};
 
 	const controls = {
+		...commonControls,
 		[ FETCH_SETTINGS ]: () => {
 			return API.get( type, identifier, datapoint );
 		},

--- a/assets/js/googlesitekit/data/create-settings-store.js
+++ b/assets/js/googlesitekit/data/create-settings-store.js
@@ -26,9 +26,10 @@ import { isEqual } from 'lodash';
  * Internal dependencies
  */
 import API from 'googlesitekit-api';
-import Data, { createRegistrySelector } from 'googlesitekit-data';
+import Data from 'googlesitekit-data';
 
-const { getRegistry } = Data.commonActions;
+const { commonActions, createRegistrySelector } = Data;
+const { getRegistry } = commonActions;
 
 // Actions
 const SET_SETTINGS = 'SET_SETTINGS';

--- a/assets/js/googlesitekit/data/create-settings-store.js
+++ b/assets/js/googlesitekit/data/create-settings-store.js
@@ -54,15 +54,12 @@ const RECEIVE_SAVE_SETTINGS_FAILED = 'RECEIVE_SAVE_SETTINGS_FAILED';
  * @param {number} options.storeName    Store name to use. Default is '{type}/{identifier}'.
  * @param {Array}  options.settingSlugs List of the slugs that are part of the settings object
  *                                      handled by the respective API endpoint.
- * @param {Object} options.registry     Store registry that this store will be registered on. Default
- *                                      is the main Site Kit registry `googlesitekit.data`.
  * @return {Object} The settings store object, with additional `STORE_NAME` and
  *                  `INITIAL_STATE` properties.
  */
 export const createSettingsStore = ( type, identifier, datapoint, {
 	storeName = undefined,
 	settingSlugs = [],
-	registry = Data,
 } = {} ) => {
 	invariant( type, 'type is required.' );
 	invariant( identifier, 'identifier is required.' );

--- a/assets/js/googlesitekit/data/index.js
+++ b/assets/js/googlesitekit/data/index.js
@@ -20,6 +20,10 @@
  * WordPress dependencies
  */
 import { createRegistry } from '@wordpress/data';
+export {
+	createRegistryControl,
+	createRegistrySelector,
+} from '@wordpress/data';
 
 /**
  * Internal dependencies

--- a/assets/js/googlesitekit/data/index.js
+++ b/assets/js/googlesitekit/data/index.js
@@ -38,6 +38,8 @@ import {
 	collectSelectors,
 	collectState,
 	collectName,
+	commonActions,
+	commonControls,
 } from 'assets/js/googlesitekit/data/utils';
 
 const Data = createRegistry();
@@ -53,5 +55,7 @@ Data.collectResolvers = collectResolvers;
 Data.collectSelectors = collectSelectors;
 Data.collectState = collectState;
 Data.collectName = collectName;
+Data.commonActions = commonActions;
+Data.commonControls = commonControls;
 
 export default Data;

--- a/assets/js/googlesitekit/data/index.js
+++ b/assets/js/googlesitekit/data/index.js
@@ -17,10 +17,6 @@
  */
 
 /**
- * External dependencies
- */
-
-/**
  * WordPress dependencies
  */
 import { createRegistry } from '@wordpress/data';

--- a/assets/js/googlesitekit/data/index.js
+++ b/assets/js/googlesitekit/data/index.js
@@ -19,8 +19,8 @@
 /**
  * WordPress dependencies
  */
-import { createRegistry } from '@wordpress/data';
-export {
+import {
+	createRegistry,
 	createRegistryControl,
 	createRegistrySelector,
 } from '@wordpress/data';
@@ -57,5 +57,7 @@ Data.collectState = collectState;
 Data.collectName = collectName;
 Data.commonActions = commonActions;
 Data.commonControls = commonControls;
+Data.createRegistryControl = createRegistryControl;
+Data.createRegistrySelector = createRegistrySelector;
 
 export default Data;

--- a/assets/js/googlesitekit/data/utils.js
+++ b/assets/js/googlesitekit/data/utils.js
@@ -21,6 +21,12 @@
  */
 import invariant from 'invariant';
 
+/**
+ * WordPress dependencies
+ */
+import { createRegistryControl } from '@wordpress/data';
+
+const GET_REGISTRY = 'GET_REGISTRY';
 const INITIALIZE = 'INITIALIZE';
 
 /**
@@ -204,6 +210,51 @@ export const collectName = ( ...args ) => {
 	invariant( duplicates.length === names.length - 1, 'collectName() must not receive different names.' );
 
 	return names.shift();
+};
+
+/**
+ * An object of common actions most stores will use.
+ *
+ * @since n.e.x.t
+ *
+ * @return {Object} key/value list of common actions most stores will want.
+ */
+export const commonActions = {
+	/**
+	 * Dispatches an action and calls a control to get the current data registry.
+	 *
+	 * Useful for controls and resolvers that wish to dispatch actions/use selectors
+	 * on the current data registry.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @return {Object} FSA-compatible action.
+	 */
+	getRegistry() {
+		return { type: 'GET_REGISTRY' };
+	},
+	initialize: initializeAction,
+};
+
+/**
+ * An object of common controls most stores will use.
+ *
+ * @since n.e.x.t
+ *
+ * @return {Object} key/value list of common controls most stores will want.
+ */
+export const commonControls = {
+	/**
+	 * Returns the current registry.
+	 *
+	 * Useful for controls and resolvers that wish to dispatch actions/use selectors
+	 * on the current data registry.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @return {Object} FSA-compatible action.
+	 */
+	[ GET_REGISTRY ]: createRegistryControl( ( registry ) => () => registry ),
 };
 
 /**

--- a/assets/js/googlesitekit/data/utils.js
+++ b/assets/js/googlesitekit/data/utils.js
@@ -231,7 +231,7 @@ export const commonActions = {
 	 * @return {Object} FSA-compatible action.
 	 */
 	getRegistry() {
-		return { type: 'GET_REGISTRY' };
+		return { type: GET_REGISTRY };
 	},
 	initialize: initializeAction,
 };

--- a/assets/js/googlesitekit/data/utils.js
+++ b/assets/js/googlesitekit/data/utils.js
@@ -233,7 +233,6 @@ export const commonActions = {
 	getRegistry() {
 		return { type: GET_REGISTRY };
 	},
-	initialize: initializeAction,
 };
 
 /**

--- a/assets/js/googlesitekit/datastore/site/index.js
+++ b/assets/js/googlesitekit/datastore/site/index.js
@@ -34,10 +34,12 @@ export const INITIAL_STATE = Data.collectState(
 
 export const STORE_NAME = 'core/site';
 
-export const actions = Data.collectActions(
-	Data.commonActions,
-	connection.actions,
-	reset.actions,
+export const actions = Data.addInitializeAction(
+	Data.collectActions(
+		Data.commonActions,
+		connection.actions,
+		reset.actions,
+	)
 );
 
 export const controls = Data.collectControls(

--- a/assets/js/googlesitekit/datastore/site/index.js
+++ b/assets/js/googlesitekit/datastore/site/index.js
@@ -34,12 +34,14 @@ export const INITIAL_STATE = Data.collectState(
 
 export const STORE_NAME = 'core/site';
 
-export const actions = Data.addInitializeAction( Data.collectActions(
+export const actions = Data.collectActions(
+	Data.commonActions,
 	connection.actions,
 	reset.actions,
-) );
+);
 
 export const controls = Data.collectControls(
+	Data.commonControls,
 	connection.controls,
 	reset.controls,
 );

--- a/assets/js/googlesitekit/modules/create-module-store.js
+++ b/assets/js/googlesitekit/modules/create-module-store.js
@@ -59,13 +59,11 @@ import {
 export const createModuleStore = ( slug, {
 	storeName = undefined,
 	settingSlugs = undefined,
-	registry = Data,
 } = {} ) => {
 	invariant( slug, 'slug is required.' );
 
 	const notificationsStore = createNotificationsStore( 'modules', slug, 'notifications', {
 		storeName,
-		registry,
 	} );
 
 	const STORE_NAME = [ notificationsStore.STORE_NAME ];
@@ -81,7 +79,6 @@ export const createModuleStore = ( slug, {
 		const settingsStore = createSettingsStore( 'modules', slug, 'settings', {
 			storeName,
 			settingSlugs,
-			registry,
 		} );
 
 		STORE_NAME.push( settingsStore.STORE_NAME );


### PR DESCRIPTION
## Summary

This merges the datastore selector refactors from #1101 into `develop` so we have them available. Since this was already merged in #1278 it should be good; this is just those commits, cherry-picked, with the analytics module changes removed 🙂 

Addresses issue #1287.

## Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
