### PR TITLE
Only make API requests in resolvers if no data exists in state

### DIFF
--- a/assets/js/googlesitekit/datastore/site/connection.js
+++ b/assets/js/googlesitekit/datastore/site/connection.js
@@ -135,7 +135,7 @@ export const resolvers = {
 
 			const existingConnection = registry.select( STORE_NAME ).getConnection();
 
-			// If there are already accounts loaded in state, we don't want to make this request
+			// If there is already connection data loaded in state, don't make this request
 			// and consider this resolver fulfilled.
 			if ( existingConnection ) {
 				return;

--- a/assets/js/googlesitekit/datastore/site/connection.js
+++ b/assets/js/googlesitekit/datastore/site/connection.js
@@ -25,6 +25,8 @@ import invariant from 'invariant';
  * Internal dependencies
  */
 import API from 'googlesitekit-api';
+import Data from 'googlesitekit-data';
+import { STORE_NAME } from './index';
 
 // Actions
 const FETCH_CONNECTION = 'FETCH_CONNECTION';
@@ -129,6 +131,16 @@ export const reducer = ( state, { type, payload } ) => {
 export const resolvers = {
 	*getConnection() {
 		try {
+			const registry = yield Data.commonActions.getRegistry();
+
+			const existingConnection = registry.select( STORE_NAME ).getConnection();
+
+			// If there are already accounts loaded in state, we don't want to make this request
+			// and consider this resolver fulfilled.
+			if ( existingConnection ) {
+				return;
+			}
+
 			const connection = yield actions.fetchConnection();
 			return actions.receiveConnection( connection );
 		} catch ( err ) {

--- a/assets/js/googlesitekit/datastore/site/connection.test.js
+++ b/assets/js/googlesitekit/datastore/site/connection.test.js
@@ -122,6 +122,21 @@ describe( 'core/site connection', () => {
 				expect( connectionSelect ).toEqual( connection );
 			} );
 
+			it( 'does not make a network request if data is already in state', async () => {
+				const response = { connected: true, resettable: true };
+				registry.dispatch( STORE_NAME ).receiveConnection( response );
+
+				const connection = registry.select( STORE_NAME ).getConnection( );
+
+				await subscribeUntil( registry, () => registry
+					.select( STORE_NAME )
+					.hasFinishedResolution( 'getConnection' )
+				);
+
+				expect( fetch ).not.toHaveBeenCalled();
+				expect( connection ).toEqual( response );
+			} );
+
 			it( 'dispatches an error if the request fails', async () => {
 				const response = {
 					code: 'internal_server_error',

--- a/assets/js/googlesitekit/datastore/site/connection.test.js
+++ b/assets/js/googlesitekit/datastore/site/connection.test.js
@@ -126,7 +126,7 @@ describe( 'core/site connection', () => {
 				const response = { connected: true, resettable: true };
 				registry.dispatch( STORE_NAME ).receiveConnection( response );
 
-				const connection = registry.select( STORE_NAME ).getConnection( );
+				const connection = registry.select( STORE_NAME ).getConnection();
 
 				await subscribeUntil( registry, () => registry
 					.select( STORE_NAME )

--- a/assets/js/modules/analytics/datastore/accounts.test.js
+++ b/assets/js/modules/analytics/datastore/accounts.test.js
@@ -102,6 +102,20 @@ describe( 'modules/analytics accounts', () => {
 				expect( profiles ).toEqual( fixtures.accountsPropertiesProfiles.profiles );
 			} );
 
+			it( 'does not make a network request if accounts are already present', async () => {
+				registry.dispatch( STORE_NAME ).receiveAccounts( fixtures.accountsPropertiesProfiles.accounts );
+
+				const accounts = registry.select( STORE_NAME ).getAccounts();
+
+				await subscribeUntil( registry, () => registry
+					.select( STORE_NAME )
+					.hasFinishedResolution( 'getAccounts' )
+				);
+
+				expect( accounts ).toEqual( fixtures.accountsPropertiesProfiles.accounts );
+				expect( fetch ).not.toHaveBeenCalled();
+			} );
+
 			it( 'dispatches an error if the request fails', async () => {
 				const response = {
 					code: 'internal_server_error',

--- a/assets/js/modules/analytics/datastore/profiles.js
+++ b/assets/js/modules/analytics/datastore/profiles.js
@@ -287,6 +287,16 @@ export const reducer = ( state, { type, payload } ) => {
 export const resolvers = {
 	*getProfiles( accountID, propertyID ) {
 		try {
+			const registry = yield Data.commonActions.getRegistry();
+
+			const existingProfiles = registry.select( STORE_NAME ).getProfiles( accountID, propertyID );
+
+			// If there are already profiles loaded in state for this request; consider it fulfilled
+			// and don't make an API request.
+			if ( existingProfiles && existingProfiles.length ) {
+				return;
+			}
+
 			const profiles = yield actions.fetchProfiles( accountID, propertyID );
 
 			yield actions.receiveProfiles( profiles );

--- a/assets/js/modules/analytics/datastore/profiles.test.js
+++ b/assets/js/modules/analytics/datastore/profiles.test.js
@@ -188,6 +188,27 @@ describe( 'modules/analytics profiles', () => {
 
 				expect( fetch ).toHaveBeenCalledTimes( 1 );
 				expect( profiles ).toEqual( fixtures.profiles );
+				expect( profiles ).toHaveLength( 1 );
+			} );
+
+			it( 'does not make a network request if profiles for this account + property are already present', async () => {
+				const testAccountID = fixtures.profiles[ 0 ].accountId; // Capitalization rule exception: `accountId` is a property of an API returned value.
+				const testPropertyID = fixtures.profiles[ 0 ].webPropertyId; // Capitalization rule exception: `webPropertyId` is a property of an API returned value.
+
+				// Load data into this store so there are matches for the data we're about to select,
+				// even though the selector hasn't fulfilled yet.
+				registry.dispatch( STORE_NAME ).receiveProfiles( fixtures.profiles );
+
+				const profiles = registry.select( STORE_NAME ).getProfiles( testAccountID, testPropertyID );
+
+				await subscribeUntil( registry, () => registry
+					.select( STORE_NAME )
+					.hasFinishedResolution( 'getProfiles', [ testAccountID, testPropertyID ] )
+				);
+
+				expect( fetch ).not.toHaveBeenCalled();
+				expect( profiles ).toEqual( fixtures.profiles );
+				expect( profiles ).toHaveLength( 1 );
 			} );
 
 			it( 'dispatches an error if the request fails', async () => {

--- a/assets/js/modules/analytics/datastore/properties.js
+++ b/assets/js/modules/analytics/datastore/properties.js
@@ -315,6 +315,16 @@ export const reducer = ( state, { type, payload } ) => {
 export const resolvers = {
 	*getProperties( accountID ) {
 		try {
+			const registry = yield Data.commonActions.getRegistry();
+
+			const existingProperties = registry.select( STORE_NAME ).getProperties( accountID );
+
+			// If there are already properties loaded in state for this request; consider it fulfilled
+			// and don't make an API request.
+			if ( existingProperties && existingProperties.length ) {
+				return;
+			}
+
 			const { properties, profiles, matchedProperty } = yield actions.fetchPropertiesProfiles( accountID );
 
 			yield actions.receiveProperties( properties );

--- a/assets/js/modules/analytics/datastore/properties.test.js
+++ b/assets/js/modules/analytics/datastore/properties.test.js
@@ -173,7 +173,27 @@ describe( 'modules/analytics properties', () => {
 				const profiles = registry.select( STORE_NAME ).getProfiles( accountID, propertyID );
 
 				expect( properties ).toEqual( fixtures.propertiesProfiles.properties );
+				expect( properties ).toHaveLength( 17 );
 				expect( profiles ).toEqual( fixtures.propertiesProfiles.profiles );
+			} );
+
+			it( 'does not make a network request if properties for this account are already present', async () => {
+				const testAccountID = fixtures.profiles[ 0 ].accountId; // Capitalization rule exception: `accountId` is a property of an API returned value.
+
+				// Load data into this store so there are matches for the data we're about to select,
+				// even though the selector hasn't fulfilled yet.
+				registry.dispatch( STORE_NAME ).receiveProperties( fixtures.propertiesProfiles.properties );
+
+				const properties = registry.select( STORE_NAME ).getProperties( testAccountID );
+
+				await subscribeUntil( registry, () => registry
+					.select( STORE_NAME )
+					.hasFinishedResolution( 'getProperties', [ testAccountID ] )
+				);
+
+				expect( fetch ).not.toHaveBeenCalled();
+				expect( properties ).toEqual( fixtures.propertiesProfiles.properties );
+				expect( properties ).toHaveLength( 17 );
 			} );
 
 			it( 'dispatches an error if the request fails', async () => {


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #1286.

## Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
