### PR TITLE
Make API requests on when needed in resolvers, for develop

### DIFF
--- a/assets/js/googlesitekit/datastore/site/connection.js
+++ b/assets/js/googlesitekit/datastore/site/connection.js
@@ -135,7 +135,7 @@ export const resolvers = {
 
 			const existingConnection = registry.select( STORE_NAME ).getConnection();
 
-			// If there are already accounts loaded in state, we don't want to make this request
+			// If there is already connection data loaded in state, don't make this request
 			// and consider this resolver fulfilled.
 			if ( existingConnection ) {
 				return;

--- a/assets/js/googlesitekit/datastore/site/connection.js
+++ b/assets/js/googlesitekit/datastore/site/connection.js
@@ -25,6 +25,8 @@ import invariant from 'invariant';
  * Internal dependencies
  */
 import API from 'googlesitekit-api';
+import Data from 'googlesitekit-data';
+import { STORE_NAME } from './index';
 
 // Actions
 const FETCH_CONNECTION = 'FETCH_CONNECTION';
@@ -129,6 +131,16 @@ export const reducer = ( state, { type, payload } ) => {
 export const resolvers = {
 	*getConnection() {
 		try {
+			const registry = yield Data.commonActions.getRegistry();
+
+			const existingConnection = registry.select( STORE_NAME ).getConnection();
+
+			// If there are already accounts loaded in state, we don't want to make this request
+			// and consider this resolver fulfilled.
+			if ( existingConnection ) {
+				return;
+			}
+
 			const connection = yield actions.fetchConnection();
 			return actions.receiveConnection( connection );
 		} catch ( err ) {

--- a/assets/js/googlesitekit/datastore/site/connection.test.js
+++ b/assets/js/googlesitekit/datastore/site/connection.test.js
@@ -122,6 +122,21 @@ describe( 'core/site connection', () => {
 				expect( connectionSelect ).toEqual( connection );
 			} );
 
+			it( 'does not make a network request if data is already in state', async () => {
+				const response = { connected: true, resettable: true };
+				registry.dispatch( STORE_NAME ).receiveConnection( response );
+
+				const connection = registry.select( STORE_NAME ).getConnection( );
+
+				await subscribeUntil( registry, () => registry
+					.select( STORE_NAME )
+					.hasFinishedResolution( 'getConnection' )
+				);
+
+				expect( fetch ).not.toHaveBeenCalled();
+				expect( connection ).toEqual( response );
+			} );
+
 			it( 'dispatches an error if the request fails', async () => {
 				const response = {
 					code: 'internal_server_error',

--- a/assets/js/googlesitekit/datastore/site/connection.test.js
+++ b/assets/js/googlesitekit/datastore/site/connection.test.js
@@ -126,7 +126,7 @@ describe( 'core/site connection', () => {
 				const response = { connected: true, resettable: true };
 				registry.dispatch( STORE_NAME ).receiveConnection( response );
 
-				const connection = registry.select( STORE_NAME ).getConnection( );
+				const connection = registry.select( STORE_NAME ).getConnection();
 
 				await subscribeUntil( registry, () => registry
 					.select( STORE_NAME )


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #1286, (this is #1290 but without the analytics code, so `develop` can benefit from it right away).

## Relevant technical choices

Same as in #1290.

## Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
