### PR TITLE
Adds analytics_redirect_uri field to site fields

### DIFF
--- a/includes/Core/Authentication/Google_Proxy.php
+++ b/includes/Core/Authentication/Google_Proxy.php
@@ -85,12 +85,13 @@ class Google_Proxy {
 		$home_url_no_scheme = str_replace( array( 'http://', 'https://' ), '', home_url() );
 
 		return array(
-			'name'       => wp_specialchars_decode( get_bloginfo( 'name' ) ),
-			'url'        => home_url(),
-			'action_uri' => admin_url( 'index.php' ),
-			'return_uri' => $this->context->admin_url( 'splash' ),
+			'name'                   => wp_specialchars_decode( get_bloginfo( 'name' ) ),
+			'url'                    => home_url(),
+			'action_uri'             => admin_url( 'index.php' ),
+			'return_uri'             => $this->context->admin_url( 'splash' ),
 			// TODO: Remove admin_root once proxy is updated.
-			'admin_root' => str_replace( array( 'http://', 'https://', $home_url_no_scheme ), '', admin_url() ),
+			'admin_root'             => str_replace( array( 'http://', 'https://', $home_url_no_scheme ), '', admin_url() ),
+			'analytics_redirect_uri' => add_query_arg( 'gatoscallback', 1, home_url() ),
 		);
 	}
 

--- a/includes/Core/Authentication/Google_Proxy.php
+++ b/includes/Core/Authentication/Google_Proxy.php
@@ -91,7 +91,7 @@ class Google_Proxy {
 			'return_uri'             => $this->context->admin_url( 'splash' ),
 			// TODO: Remove admin_root once proxy is updated.
 			'admin_root'             => str_replace( array( 'http://', 'https://', $home_url_no_scheme ), '', admin_url() ),
-			'analytics_redirect_uri' => add_query_arg( 'gatoscallback', 1, home_url() ),
+			'analytics_redirect_uri' => add_query_arg( 'gatoscallback', 1, untrailingslashit( home_url() ) ),
 		);
 	}
 

--- a/tests/phpunit/integration/Core/Authentication/Google_ProxyTest.php
+++ b/tests/phpunit/integration/Core/Authentication/Google_ProxyTest.php
@@ -31,7 +31,7 @@ class Google_ProxyTest extends TestCase {
 				'name'                   => get_bloginfo( 'name' ),
 				'return_uri'             => $context->admin_url( 'splash' ),
 				'admin_root'             => parse_url( admin_url( '/' ), PHP_URL_PATH ),
-				'analytics_redirect_uri' => add_query_arg( 'gatoscallback', 1, home_url() ),
+				'analytics_redirect_uri' => add_query_arg( 'gatoscallback', 1, untrailingslashit( home_url() ) ),
 			),
 			$google_proxy->get_site_fields()
 		);

--- a/tests/phpunit/integration/Core/Authentication/Google_ProxyTest.php
+++ b/tests/phpunit/integration/Core/Authentication/Google_ProxyTest.php
@@ -26,11 +26,12 @@ class Google_ProxyTest extends TestCase {
 
 		$this->assertEqualSetsWithIndex(
 			array(
-				'url'        => home_url(),
-				'action_uri' => admin_url( 'index.php' ),
-				'name'       => get_bloginfo( 'name' ),
-				'return_uri' => $context->admin_url( 'splash' ),
-				'admin_root' => parse_url( admin_url( '/' ), PHP_URL_PATH ),
+				'url'                    => home_url(),
+				'action_uri'             => admin_url( 'index.php' ),
+				'name'                   => get_bloginfo( 'name' ),
+				'return_uri'             => $context->admin_url( 'splash' ),
+				'admin_root'             => parse_url( admin_url( '/' ), PHP_URL_PATH ),
+				'analytics_redirect_uri' => add_query_arg( 'gatoscallback', 1, home_url() ),
 			),
 			$google_proxy->get_site_fields()
 		);
@@ -76,6 +77,7 @@ class Google_ProxyTest extends TestCase {
 				'admin_root',
 				'return_uri',
 				'action_uri',
+				'analytics_redirect_uri',
 			),
 			array_keys( $args['body'] )
 		);


### PR DESCRIPTION
## Summary
This PR replaces #1312. It is against the correct base branch.

Addresses issue #1254 

## Relevant technical choices

<!-- Please describe your changes. -->

## Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
