### PR TITLE
Split Analytics module into its own asset

### DIFF
--- a/assets/js/googlesitekit-modules-analytics.js
+++ b/assets/js/googlesitekit-modules-analytics.js
@@ -19,4 +19,4 @@
 /**
  * Internal dependencies
  */
-import 'assets/js/modules/analytics';
+import './modules/analytics';

--- a/assets/js/googlesitekit-modules-analytics.js
+++ b/assets/js/googlesitekit-modules-analytics.js
@@ -1,5 +1,5 @@
 /**
- * Entrypoint for the "modules/analytics" data store.
+ * Analytics module entrypoint.
  *
  * Site Kit by Google, Copyright 2020 Google LLC
  *
@@ -19,4 +19,4 @@
 /**
  * Internal dependencies
  */
-import 'assets/js/modules/analytics/datastore';
+import 'assets/js/modules/analytics';

--- a/assets/js/modules/analytics/index.js
+++ b/assets/js/modules/analytics/index.js
@@ -1,7 +1,7 @@
 /**
  * Analytics module initialization.
  *
- * Site Kit by Google, Copyright 2019 Google LLC
+ * Site Kit by Google, Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,136 +17,6 @@
  */
 
 /**
- * External dependencies
- */
-import { fillFilterWithComponent, getSiteKitAdminURL } from 'GoogleUtil';
-import { createAddToFilter } from 'GoogleUtil/helpers';
-/**
  * Internal dependencies
  */
-import AnalyticsDashboardWidget from './dashboard/dashboard-widget';
-import AnalyticsAdminbarWidget from './adminbar/adminbar-widget';
-import AnalyticsAllTraffic from './dashboard/dashboard-widget-all-traffic';
-import AnalyticsDashboardWidgetTopLevel from './dashboard/dashboard-widget-top-level';
-import WPAnalyticsDashboardWidgetOverview from './wp-dashboard/wp-dashboard-widget-overview';
-import AnalyticsDashboardDetailsWidgetTopAcquisitionSources from './dashboard-details/dashboard-details-widget-top-acquisition-sources';
-import WPAnalyticsDashboardWidgetTopPagesTable from './wp-dashboard/wp-dashboard-widget-top-pages-table';
-import AnalyticsAdSenseDashboardWidgetTopPagesTable from './dashboard/dashboard-widget-analytics-adsense-top-pages';
-import AnalyticsDashboardWidgetPopularPagesTable from './dashboard/dashboard-widget-popular-pages-table';
-import AdSenseDashboardWidgetTopPagesTableSmall from './dashboard/dashboard-widget-top-earning-pages-small';
-import AnalyticsSetup from './setup';
-
-/**
- * WordPress dependencies
- */
-import { addFilter } from '@wordpress/hooks';
-const slug = 'analytics';
-
-const addAnalyticsAdminbarWidget = createAddToFilter( <AnalyticsAdminbarWidget /> );
-
-/**
- * Add components to the adminbar.
- */
-addFilter( 'googlesitekit.AdminbarModules',
-	'googlesitekit.Analytics',
-	addAnalyticsAdminbarWidget, 11 );
-
-// If setup is not complete, show the signup flow.
-if ( ! global.googlesitekit.modules[ slug ].setupComplete ) {
-	const {
-		reAuth,
-		currentScreen,
-	} = global.googlesitekit.admin;
-	const id = currentScreen ? currentScreen.id : null;
-	if ( ! reAuth && 'site-kit_page_googlesitekit-module-analytics' === id ) {
-		// Setup incomplete: redirect to the setup flow.
-		global.location = getSiteKitAdminURL(
-			`googlesitekit-module-${ slug }`,
-			{
-				reAuth: true,
-				slug,
-			}
-		);
-	}
-}
-
-if ( global.googlesitekit.modules.analytics.active ) {
-	const addAnalyticsDashboardWidget = createAddToFilter( <AnalyticsDashboardWidget /> );
-	const addAnalyticsAllTraffic = createAddToFilter( <AnalyticsAllTraffic /> );
-	const addWPAnalyticsDashboardWidgetOverview = createAddToFilter( <WPAnalyticsDashboardWidgetOverview /> );
-	const addWPAnalyticsDashboardWidgetTopPagesTable = createAddToFilter( <WPAnalyticsDashboardWidgetTopPagesTable /> );
-	const addAnalyticsDashboardWidgetTopLevel = createAddToFilter( <AnalyticsDashboardWidgetTopLevel /> );
-	const addAnalyticsDashboardDetailsWidget = createAddToFilter( <AnalyticsDashboardDetailsWidgetTopAcquisitionSources /> );
-	const addAnalyticsAdSenseTopPagesWidget = createAddToFilter( <AnalyticsAdSenseDashboardWidgetTopPagesTable /> );
-	const addAnalyticsDashboardWidgetPopularPagesTable = createAddToFilter( <AnalyticsDashboardWidgetPopularPagesTable /> );
-	const addAnalyticsDashboardWidgetPopularPagesTableSmall = createAddToFilter( <AdSenseDashboardWidgetTopPagesTableSmall /> );
-
-	/**
-	 * Add components to the Site Kit Dashboard.
-	 */
-	addFilter( 'googlesitekit.DashboardModule',
-		'googlesitekit.Analytics',
-		addAnalyticsAllTraffic, 9 );
-	addFilter( 'googlesitekit.DashboardSearchFunnel',
-		'googlesitekit.Analytics',
-		addAnalyticsDashboardWidgetTopLevel, 11 );
-	addFilter( 'googlesitekit.DashboardPopularity',
-		'googlesitekit.Analytics',
-		addAnalyticsDashboardWidgetPopularPagesTable, 20 );
-	addFilter( 'googlesitekit.AnalyticsAdSenseTopPagesTableSmall',
-		'googlesitekit.Analytics',
-		addAnalyticsDashboardWidgetPopularPagesTableSmall, 20 );
-
-	/**
-	 * Add components to the Site Kit URL Details Dashboard.
-	 */
-	addFilter( 'googlesitekit.DashboardDetailsModule',
-		'googlesitekit.Analytics',
-		addAnalyticsDashboardDetailsWidget, 20 );
-
-	/**
-	 * Add components to the WordPress Dashboard widget.
-	 */
-	addFilter( 'googlesitekit.WPDashboardHeader',
-		'googlesitekit.Analytics',
-		addWPAnalyticsDashboardWidgetOverview );
-	addFilter( 'googlesitekit.WPDashboardModule',
-		'googlesitekit.Analytics',
-		addWPAnalyticsDashboardWidgetTopPagesTable );
-
-	/**
-	 * Add components to the module detail page.
-	 */
-	addFilter( 'googlesitekit.ModuleApp-' + slug,
-		'googlesitekit.Analytics',
-		addAnalyticsDashboardWidget );
-
-	/**
-	 * Add components to the AdSense Dashboard.
-	 */
-	addFilter( 'googlesitekit.AnalyticsAdSenseTopPagesTable',
-		'googlesitekit.Analytics',
-		addAnalyticsAdSenseTopPagesWidget, 11 );
-
-	/**
-	 * Add components to the settings page.
-	 */
-	addFilter( `googlesitekit.ModuleSettingsDetails-${ slug }`,
-		'googlesitekit.AnalyticsModuleSettingsDetails',
-		fillFilterWithComponent( AnalyticsSetup, {
-			onSettingsPage: true,
-		} ) );
-
-	addFilter( `googlesitekit.showDateRangeSelector-${ slug }`,
-		'googlesitekit.analyticsShowDateRangeSelector',
-		() => true );
-
-	/**
-	 * Add component to the setup wizard
-	 */
-	addFilter( `googlesitekit.ModuleSetup-${ slug }`,
-		'googlesitekit.AnalyticsModuleSetupWizard',
-		fillFilterWithComponent( AnalyticsSetup, {
-			onSettingsPage: false,
-		} ) );
-}
+import './datastore';

--- a/assets/js/modules/analytics/index.legacy.js
+++ b/assets/js/modules/analytics/index.legacy.js
@@ -1,0 +1,152 @@
+/**
+ * Analytics module initialization.
+ *
+ * Site Kit by Google, Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import { fillFilterWithComponent, getSiteKitAdminURL } from 'GoogleUtil';
+import { createAddToFilter } from 'GoogleUtil/helpers';
+/**
+ * Internal dependencies
+ */
+import AnalyticsDashboardWidget from './dashboard/dashboard-widget';
+import AnalyticsAdminbarWidget from './adminbar/adminbar-widget';
+import AnalyticsAllTraffic from './dashboard/dashboard-widget-all-traffic';
+import AnalyticsDashboardWidgetTopLevel from './dashboard/dashboard-widget-top-level';
+import WPAnalyticsDashboardWidgetOverview from './wp-dashboard/wp-dashboard-widget-overview';
+import AnalyticsDashboardDetailsWidgetTopAcquisitionSources from './dashboard-details/dashboard-details-widget-top-acquisition-sources';
+import WPAnalyticsDashboardWidgetTopPagesTable from './wp-dashboard/wp-dashboard-widget-top-pages-table';
+import AnalyticsAdSenseDashboardWidgetTopPagesTable from './dashboard/dashboard-widget-analytics-adsense-top-pages';
+import AnalyticsDashboardWidgetPopularPagesTable from './dashboard/dashboard-widget-popular-pages-table';
+import AdSenseDashboardWidgetTopPagesTableSmall from './dashboard/dashboard-widget-top-earning-pages-small';
+import AnalyticsSetup from './setup';
+
+/**
+ * WordPress dependencies
+ */
+import { addFilter } from '@wordpress/hooks';
+const slug = 'analytics';
+
+const addAnalyticsAdminbarWidget = createAddToFilter( <AnalyticsAdminbarWidget /> );
+
+/**
+ * Add components to the adminbar.
+ */
+addFilter( 'googlesitekit.AdminbarModules',
+	'googlesitekit.Analytics',
+	addAnalyticsAdminbarWidget, 11 );
+
+// If setup is not complete, show the signup flow.
+if ( ! global.googlesitekit.modules[ slug ].setupComplete ) {
+	const {
+		reAuth,
+		currentScreen,
+	} = global.googlesitekit.admin;
+	const id = currentScreen ? currentScreen.id : null;
+	if ( ! reAuth && 'site-kit_page_googlesitekit-module-analytics' === id ) {
+		// Setup incomplete: redirect to the setup flow.
+		global.location = getSiteKitAdminURL(
+			`googlesitekit-module-${ slug }`,
+			{
+				reAuth: true,
+				slug,
+			}
+		);
+	}
+}
+
+if ( global.googlesitekit.modules.analytics.active ) {
+	const addAnalyticsDashboardWidget = createAddToFilter( <AnalyticsDashboardWidget /> );
+	const addAnalyticsAllTraffic = createAddToFilter( <AnalyticsAllTraffic /> );
+	const addWPAnalyticsDashboardWidgetOverview = createAddToFilter( <WPAnalyticsDashboardWidgetOverview /> );
+	const addWPAnalyticsDashboardWidgetTopPagesTable = createAddToFilter( <WPAnalyticsDashboardWidgetTopPagesTable /> );
+	const addAnalyticsDashboardWidgetTopLevel = createAddToFilter( <AnalyticsDashboardWidgetTopLevel /> );
+	const addAnalyticsDashboardDetailsWidget = createAddToFilter( <AnalyticsDashboardDetailsWidgetTopAcquisitionSources /> );
+	const addAnalyticsAdSenseTopPagesWidget = createAddToFilter( <AnalyticsAdSenseDashboardWidgetTopPagesTable /> );
+	const addAnalyticsDashboardWidgetPopularPagesTable = createAddToFilter( <AnalyticsDashboardWidgetPopularPagesTable /> );
+	const addAnalyticsDashboardWidgetPopularPagesTableSmall = createAddToFilter( <AdSenseDashboardWidgetTopPagesTableSmall /> );
+
+	/**
+	 * Add components to the Site Kit Dashboard.
+	 */
+	addFilter( 'googlesitekit.DashboardModule',
+		'googlesitekit.Analytics',
+		addAnalyticsAllTraffic, 9 );
+	addFilter( 'googlesitekit.DashboardSearchFunnel',
+		'googlesitekit.Analytics',
+		addAnalyticsDashboardWidgetTopLevel, 11 );
+	addFilter( 'googlesitekit.DashboardPopularity',
+		'googlesitekit.Analytics',
+		addAnalyticsDashboardWidgetPopularPagesTable, 20 );
+	addFilter( 'googlesitekit.AnalyticsAdSenseTopPagesTableSmall',
+		'googlesitekit.Analytics',
+		addAnalyticsDashboardWidgetPopularPagesTableSmall, 20 );
+
+	/**
+	 * Add components to the Site Kit URL Details Dashboard.
+	 */
+	addFilter( 'googlesitekit.DashboardDetailsModule',
+		'googlesitekit.Analytics',
+		addAnalyticsDashboardDetailsWidget, 20 );
+
+	/**
+	 * Add components to the WordPress Dashboard widget.
+	 */
+	addFilter( 'googlesitekit.WPDashboardHeader',
+		'googlesitekit.Analytics',
+		addWPAnalyticsDashboardWidgetOverview );
+	addFilter( 'googlesitekit.WPDashboardModule',
+		'googlesitekit.Analytics',
+		addWPAnalyticsDashboardWidgetTopPagesTable );
+
+	/**
+	 * Add components to the module detail page.
+	 */
+	addFilter( 'googlesitekit.ModuleApp-' + slug,
+		'googlesitekit.Analytics',
+		addAnalyticsDashboardWidget );
+
+	/**
+	 * Add components to the AdSense Dashboard.
+	 */
+	addFilter( 'googlesitekit.AnalyticsAdSenseTopPagesTable',
+		'googlesitekit.Analytics',
+		addAnalyticsAdSenseTopPagesWidget, 11 );
+
+	/**
+	 * Add components to the settings page.
+	 */
+	addFilter( `googlesitekit.ModuleSettingsDetails-${ slug }`,
+		'googlesitekit.AnalyticsModuleSettingsDetails',
+		fillFilterWithComponent( AnalyticsSetup, {
+			onSettingsPage: true,
+		} ) );
+
+	addFilter( `googlesitekit.showDateRangeSelector-${ slug }`,
+		'googlesitekit.analyticsShowDateRangeSelector',
+		() => true );
+
+	/**
+	 * Add component to the setup wizard
+	 */
+	addFilter( `googlesitekit.ModuleSetup-${ slug }`,
+		'googlesitekit.AnalyticsModuleSetupWizard',
+		fillFilterWithComponent( AnalyticsSetup, {
+			onSettingsPage: false,
+		} ) );
+}

--- a/assets/js/modules/index.js
+++ b/assets/js/modules/index.js
@@ -20,7 +20,7 @@
  * Internal dependencies
  */
 import './adsense';
-import './analytics';
+import './analytics/index.legacy';
 import './optimize';
 import './pagespeed-insights';
 import './search-console';

--- a/includes/Core/Assets/Assets.php
+++ b/includes/Core/Assets/Assets.php
@@ -438,10 +438,10 @@ final class Assets {
 				)
 			),
 			new Script(
-				'googlesitekit-datastore-modules-analytics',
+				'googlesitekit-modules-analytics',
 				array(
-					'src'          => $base_url . 'js/googlesitekit-datastore-modules-analytics.js',
-					'dependencies' => array( 'googlesitekit-modules' ),
+					'src'          => $base_url . 'js/googlesitekit-modules-analytics.js',
+					'dependencies' => array( 'googlesitekit-api', 'googlesitekit-data', 'googlesitekit-modules' ),
 				)
 			),
 			// End JSR Assets.

--- a/includes/Core/Assets/Assets.php
+++ b/includes/Core/Assets/Assets.php
@@ -437,13 +437,6 @@ final class Assets {
 					'dependencies' => array( 'googlesitekit-api', 'googlesitekit-data' ),
 				)
 			),
-			new Script(
-				'googlesitekit-modules-analytics',
-				array(
-					'src'          => $base_url . 'js/googlesitekit-modules-analytics.js',
-					'dependencies' => array( 'googlesitekit-api', 'googlesitekit-data', 'googlesitekit-modules' ),
-				)
-			),
 			// End JSR Assets.
 			new Script(
 				'googlesitekit-ads-detect',

--- a/includes/Modules/Analytics.php
+++ b/includes/Modules/Analytics.php
@@ -1314,7 +1314,12 @@ final class Analytics extends Module
 				'googlesitekit-modules-analytics',
 				array(
 					'src'          => $base_url . 'js/googlesitekit-modules-analytics.js',
-					'dependencies' => array( 'googlesitekit-api', 'googlesitekit-data', 'googlesitekit-modules' ),
+					'dependencies' => array(
+						'googlesitekit-api',
+						'googlesitekit-data',
+						'googlesitekit-modules',
+						'googlesitekit-datastore-site',
+					),
 				)
 			),
 		);

--- a/includes/Modules/Analytics.php
+++ b/includes/Modules/Analytics.php
@@ -20,6 +20,10 @@ use Google\Site_Kit\Core\Modules\Module_With_Scopes;
 use Google\Site_Kit\Core\Modules\Module_With_Scopes_Trait;
 use Google\Site_Kit\Core\Modules\Module_With_Settings;
 use Google\Site_Kit\Core\Modules\Module_With_Settings_Trait;
+use Google\Site_Kit\Core\Modules\Module_With_Assets;
+use Google\Site_Kit\Core\Modules\Module_With_Assets_Trait;
+use Google\Site_Kit\Core\Assets\Asset;
+use Google\Site_Kit\Core\Assets\Script;
 use Google\Site_Kit\Core\Authentication\Clients\Google_Site_Kit_Client;
 use Google\Site_Kit\Core\REST_API\Data_Request;
 use Google\Site_Kit\Core\Util\Debug_Data;
@@ -55,8 +59,8 @@ use Exception;
  * @ignore
  */
 final class Analytics extends Module
-	implements Module_With_Screen, Module_With_Scopes, Module_With_Settings, Module_With_Admin_Bar, Module_With_Debug_Fields {
-	use Module_With_Screen_Trait, Module_With_Scopes_Trait, Module_With_Settings_Trait;
+	implements Module_With_Screen, Module_With_Scopes, Module_With_Settings, Module_With_Assets, Module_With_Admin_Bar, Module_With_Debug_Fields {
+	use Module_With_Screen_Trait, Module_With_Scopes_Trait, Module_With_Settings_Trait, Module_With_Assets_Trait;
 
 	/**
 	 * Registers functionality through WordPress hooks.
@@ -1293,6 +1297,27 @@ final class Analytics extends Module
 	 */
 	protected function setup_settings() {
 		return new Settings( $this->options );
+	}
+
+	/**
+	 * Sets up the module's assets to register.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @return array List of Asset objects.
+	 */
+	protected function setup_assets() {
+		$base_url = $this->context->url( 'dist/assets/' );
+
+		return array(
+			new Script(
+				'googlesitekit-modules-analytics',
+				array(
+					'src'          => $base_url . 'js/googlesitekit-modules-analytics.js',
+					'dependencies' => array( 'googlesitekit-api', 'googlesitekit-data', 'googlesitekit-modules' ),
+				)
+			),
+		);
 	}
 
 	/**

--- a/includes/Modules/Analytics.php
+++ b/includes/Modules/Analytics.php
@@ -1304,7 +1304,7 @@ final class Analytics extends Module
 	 *
 	 * @since n.e.x.t
 	 *
-	 * @return array List of Asset objects.
+	 * @return Asset[] List of Asset objects.
 	 */
 	protected function setup_assets() {
 		$base_url = $this->context->url( 'dist/assets/' );

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -92,7 +92,7 @@ const webpackConfig = ( mode ) => {
 				'googlesitekit-api': './assets/js/googlesitekit-api.js',
 				'googlesitekit-data': './assets/js/googlesitekit-data.js',
 				'googlesitekit-datastore-site': './assets/js/googlesitekit-datastore-site.js',
-				'googlesitekit-datastore-modules-analytics': './assets/js/googlesitekit-datastore-modules-analytics.js',
+				'googlesitekit-modules-analytics': './assets/js/googlesitekit-modules-analytics.js',
 				'googlesitekit-modules': './assets/js/googlesitekit-modules.js', // TODO: Add external following 1162.
 				// Old Modules
 				'googlesitekit-activation': './assets/js/googlesitekit-activation.js',


### PR DESCRIPTION
## Summary

Follow-up to #1224 / #1259 

This splits the Analytics module into its own entrypoint. The old `index.js` file becomes `index.legacy.js`. This is how we should proceed with future modules as well.

## Relevant technical choices

The new module asset is currently not enqueued anywhere, this will be fixed via #1319 which should be able to get merged quickly.

## Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
