### PR TITLE
Introduce central mechanism for modules to register and enqueue assets

### DIFF
--- a/assets/js/googlesitekit/data/index.js
+++ b/assets/js/googlesitekit/data/index.js
@@ -23,6 +23,10 @@ import {
 	createRegistry,
 	createRegistryControl,
 	createRegistrySelector,
+	useSelect,
+	useDispatch,
+	useRegistry,
+	RegistryProvider,
 } from '@wordpress/data';
 
 /**
@@ -59,5 +63,9 @@ Data.commonActions = commonActions;
 Data.commonControls = commonControls;
 Data.createRegistryControl = createRegistryControl;
 Data.createRegistrySelector = createRegistrySelector;
+Data.useSelect = useSelect;
+Data.useDispatch = useDispatch;
+Data.useRegistry = useRegistry;
+Data.RegistryProvider = RegistryProvider;
 
 export default Data;

--- a/includes/Core/Admin/Dashboard.php
+++ b/includes/Core/Admin/Dashboard.php
@@ -43,6 +43,14 @@ final class Dashboard {
 	private $assets;
 
 	/**
+	 * Modules instance.
+	 *
+	 * @since n.e.x.t
+	 * @var Modules
+	 */
+	private $modules;
+
+	/**
 	 * Constructor.
 	 *
 	 * @since 1.0.0

--- a/includes/Core/Admin/Dashboard.php
+++ b/includes/Core/Admin/Dashboard.php
@@ -12,6 +12,7 @@ namespace Google\Site_Kit\Core\Admin;
 
 use Google\Site_Kit\Context;
 use Google\Site_Kit\Core\Assets\Assets;
+use Google\Site_Kit\Core\Modules\Modules;
 use Google\Site_Kit\Core\Permissions\Permissions;
 use Google\Site_Kit\Core\Util\Requires_Javascript_Trait;
 
@@ -48,14 +49,16 @@ final class Dashboard {
 	 *
 	 * @param Context $context Plugin context.
 	 * @param Assets  $assets  Optional. Assets API instance. Default is a new instance.
+	 * @param Modules $modules Optional. Modules instance. Default is a new instance.
 	 */
-	public function __construct( Context $context, Assets $assets = null ) {
+	public function __construct(
+		Context $context,
+		Assets $assets = null,
+		Modules $modules = null
+	) {
 		$this->context = $context;
-
-		if ( ! $assets ) {
-			$assets = new Assets( $this->context );
-		}
-		$this->assets = $assets;
+		$this->assets  = $assets ?: new Assets( $this->context );
+		$this->modules = $modules ?: new Modules( $this->context );
 	}
 
 	/**
@@ -81,6 +84,7 @@ final class Dashboard {
 
 				// Enqueue scripts.
 				$this->assets->enqueue_asset( 'googlesitekit-wp-dashboard' );
+				$this->modules->enqueue_assets();
 			}
 		};
 

--- a/includes/Core/Admin/Screens.php
+++ b/includes/Core/Admin/Screens.php
@@ -44,6 +44,14 @@ final class Screens {
 	private $assets;
 
 	/**
+	 * Modules instance.
+	 *
+	 * @since n.e.x.t
+	 * @var Modules
+	 */
+	private $modules;
+
+	/**
 	 * Associative array of $hook_suffix => $screen pairs.
 	 *
 	 * @since 1.0.0
@@ -66,11 +74,8 @@ final class Screens {
 		Modules $modules = null
 	) {
 		$this->context = $context;
-
-		if ( ! $assets ) {
-			$assets = new Assets( $this->context );
-		}
-		$this->assets = $assets;
+		$this->assets  = $assets ?: new Assets( $this->context );
+		$this->modules = $modules ?: new Modules( $this->context );
 	}
 
 	/**

--- a/includes/Core/Admin/Screens.php
+++ b/includes/Core/Admin/Screens.php
@@ -11,9 +11,10 @@
 namespace Google\Site_Kit\Core\Admin;
 
 use Google\Site_Kit\Context;
-use Google\Site_Kit\Core\Authentication\Authentication;
-use Google\Site_Kit\Core\Permissions\Permissions;
 use Google\Site_Kit\Core\Assets\Assets;
+use Google\Site_Kit\Core\Authentication\Authentication;
+use Google\Site_Kit\Core\Modules\Modules;
+use Google\Site_Kit\Core\Permissions\Permissions;
 
 /**
  * Class managing admin screens.
@@ -57,8 +58,13 @@ final class Screens {
 	 *
 	 * @param Context $context Plugin context.
 	 * @param Assets  $assets  Optional. Assets API instance. Default is a new instance.
+	 * @param Modules $modules Optional. Modules instance. Default is a new instance.
 	 */
-	public function __construct( Context $context, Assets $assets = null ) {
+	public function __construct(
+		Context $context,
+		Assets $assets = null,
+		Modules $modules = null
+	) {
 		$this->context = $context;
 
 		if ( ! $assets ) {
@@ -192,13 +198,7 @@ final class Screens {
 		}
 
 		$this->screens[ $hook_suffix ]->enqueue_assets( $this->assets );
-
-		/**
-		 * Fires when assets are enqueued for a Site Kit admin screen.
-		 *
-		 * @since 1.0.0
-		 */
-		do_action( 'googlesitekit_enqueue_screen_assets' );
+		$this->modules->enqueue_assets();
 	}
 
 	/**

--- a/includes/Core/Admin_Bar/Admin_Bar.php
+++ b/includes/Core/Admin_Bar/Admin_Bar.php
@@ -105,6 +105,7 @@ final class Admin_Bar {
 
 			// Enqueue scripts.
 			$this->assets->enqueue_asset( 'googlesitekit-adminbar-loader' );
+			$this->modules->enqueue_assets();
 		};
 		add_action( 'admin_enqueue_scripts', $admin_bar_callback, 40 );
 		add_action( 'wp_enqueue_scripts', $admin_bar_callback, 40 );

--- a/includes/Core/Assets/Assets.php
+++ b/includes/Core/Assets/Assets.php
@@ -525,6 +525,17 @@ final class Assets {
 			),
 		);
 
+		/**
+		 * Filters the list of assets that Site Kit should register.
+		 *
+		 * This filter covers both scripts and stylesheets.
+		 *
+		 * @since n.e.x.t
+		 *
+		 * @param array $routes List of Asset objects.
+		 */
+		$assets = apply_filters( 'googlesitekit_assets', $assets );
+
 		$this->assets = array();
 		foreach ( $assets as $asset ) {
 			$this->assets[ $asset->get_handle() ] = $asset;

--- a/includes/Core/Assets/Assets.php
+++ b/includes/Core/Assets/Assets.php
@@ -532,7 +532,7 @@ final class Assets {
 		 *
 		 * @since n.e.x.t
 		 *
-		 * @param array $routes List of Asset objects.
+		 * @param Asset[] $assets List of Asset objects.
 		 */
 		$assets = apply_filters( 'googlesitekit_assets', $assets );
 

--- a/includes/Core/Modules/Module_With_Assets.php
+++ b/includes/Core/Modules/Module_With_Assets.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Interface Google\Site_Kit\Core\Modules\Module_With_Assets
+ *
+ * @package   Google\Site_Kit
+ * @copyright 2020 Google LLC
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
+ * @link      https://sitekit.withgoogle.com
+ */
+
+namespace Google\Site_Kit\Core\Modules;
+
+use Google\Site_Kit\Core\Assets\Asset;
+
+/**
+ * Interface for a module that includes assets.
+ *
+ * @since n.e.x.t
+ * @access private
+ * @ignore
+ */
+interface Module_With_Assets {
+
+	/**
+	 * Gets the assets to register for the module.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @return array List of Asset objects.
+	 */
+	public function get_assets();
+
+	/**
+	 * Enqueues all assets necessary for the module.
+	 *
+	 * @since n.e.x.t
+	 */
+	public function enqueue_assets();
+}

--- a/includes/Core/Modules/Module_With_Assets.php
+++ b/includes/Core/Modules/Module_With_Assets.php
@@ -26,7 +26,7 @@ interface Module_With_Assets {
 	 *
 	 * @since n.e.x.t
 	 *
-	 * @return array List of Asset objects.
+	 * @return Asset[] List of Asset objects.
 	 */
 	public function get_assets();
 

--- a/includes/Core/Modules/Module_With_Assets_Trait.php
+++ b/includes/Core/Modules/Module_With_Assets_Trait.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Trait Google\Site_Kit\Core\Modules\Module_With_Assets_Trait
+ *
+ * @package   Google\Site_Kit
+ * @copyright 2020 Google LLC
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
+ * @link      https://sitekit.withgoogle.com
+ */
+
+namespace Google\Site_Kit\Core\Modules;
+
+use Google\Site_Kit\Core\Assets\Asset;
+
+/**
+ * Trait for a module that includes assets.
+ *
+ * @since n.e.x.t
+ * @access private
+ * @ignore
+ */
+trait Module_With_Assets_Trait {
+
+	/**
+	 * List of the module's Asset objects to register.
+	 *
+	 * @since n.e.x.t
+	 * @var array
+	 */
+	protected $registerable_assets;
+
+	/**
+	 * Gets the assets to register for the module.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @return array List of Asset objects.
+	 */
+	public function get_assets() {
+		if ( null === $this->registerable_assets ) {
+			$this->registerable_assets = $this->setup_assets();
+		}
+
+		return $this->registerable_assets;
+	}
+
+	/**
+	 * Enqueues all assets necessary for the module.
+	 *
+	 * This default implementation simply enqueues all assets that the module
+	 * has registered.
+	 *
+	 * @since n.e.x.t
+	 */
+	public function enqueue_assets() {
+		$assets = $this->get_assets();
+		array_walk(
+			$assets,
+			function( Asset $asset ) {
+				$asset->enqueue();
+			}
+		);
+	}
+}

--- a/includes/Core/Modules/Module_With_Assets_Trait.php
+++ b/includes/Core/Modules/Module_With_Assets_Trait.php
@@ -61,4 +61,13 @@ trait Module_With_Assets_Trait {
 			}
 		);
 	}
+
+	/**
+	 * Sets up the module's assets to register.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @return array List of Asset objects.
+	 */
+	abstract protected function setup_assets();
 }

--- a/includes/Core/Modules/Module_With_Assets_Trait.php
+++ b/includes/Core/Modules/Module_With_Assets_Trait.php
@@ -34,7 +34,7 @@ trait Module_With_Assets_Trait {
 	 *
 	 * @since n.e.x.t
 	 *
-	 * @return array List of Asset objects.
+	 * @return Asset[] List of Asset objects.
 	 */
 	public function get_assets() {
 		if ( null === $this->registerable_assets ) {
@@ -67,7 +67,7 @@ trait Module_With_Assets_Trait {
 	 *
 	 * @since n.e.x.t
 	 *
-	 * @return array List of Asset objects.
+	 * @return Asset[] List of Asset objects.
 	 */
 	abstract protected function setup_assets();
 }

--- a/includes/Core/Modules/Modules.php
+++ b/includes/Core/Modules/Modules.php
@@ -429,6 +429,23 @@ final class Modules {
 	}
 
 	/**
+	 * Enqueues all module-specific assets.
+	 *
+	 * @since n.e.x.t
+	 */
+	public function enqueue_assets() {
+		$available_modules = $this->get_available_modules();
+		array_walk(
+			$available_modules,
+			function( Module $module ) {
+				if ( $module instanceof Module_With_Assets ) {
+					$module->enqueue_assets();
+				}
+			}
+		);
+	}
+
+	/**
 	 * Gets related REST routes.
 	 *
 	 * @since 1.3.0

--- a/includes/Core/Modules/Modules.php
+++ b/includes/Core/Modules/Modules.php
@@ -149,6 +149,18 @@ final class Modules {
 			}
 		);
 
+		add_filter(
+			'googlesitekit_assets',
+			function( $assets ) use ( $available_modules ) {
+				foreach ( $available_modules as $module ) {
+					if ( $module instanceof Module_With_Assets ) {
+						$assets = array_merge( $assets, $module->get_assets() );
+					}
+				}
+				return $assets;
+			}
+		);
+
 		$active_modules = $this->get_active_modules();
 		array_walk(
 			$active_modules,

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -152,9 +152,9 @@ final class Plugin {
 				( new Core\Util\Tracking( $this->context, $user_options ) )->register();
 				( new Core\REST_API\REST_Routes( $this->context, $authentication, $modules ) )->register();
 				( new Core\Admin_Bar\Admin_Bar( $this->context, $assets, $modules ) )->register();
-				( new Core\Admin\Screens( $this->context, $assets ) )->register();
+				( new Core\Admin\Screens( $this->context, $assets, $modules ) )->register();
 				( new Core\Admin\Notices() )->register();
-				( new Core\Admin\Dashboard( $this->context, $assets ) )->register();
+				( new Core\Admin\Dashboard( $this->context, $assets, $modules ) )->register();
 				( new Core\Notifications\Notifications( $this->context, $options ) )->register();
 				( new Core\Util\Debug_Data( $this->context, $options, $user_options, $authentication, $modules ) )->register();
 


### PR DESCRIPTION
## Summary

Addresses issue #1319 

## Relevant technical choices

* In addition to the ACs and IB, this removes an unused `googlesitekit_enqueue_screen_assets` action (that I believe we actually used to have for module assets a while back).

## Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
