### PR TITLE
Fix E2E editor failure with WP 5.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -95,6 +95,7 @@ script:
 jobs:
   allow_failures:
     - php: nightly
+    - env: E2E=1 WP_VERSION=nightly
   include:
     - stage: test
       name: Lint
@@ -121,6 +122,9 @@ jobs:
     - stage: test
       name: E2E Tests (WordPress latest)
       env: E2E=1
+    - stage: test
+      name: E2E Tests (WordPress nightly)
+      env: E2E=1 WP_VERSION=nightly
     - stage: test
       name: E2E Tests (WordPress 4.7)
       env: E2E=1 WP_VERSION=4.7.13

--- a/tests/e2e/mu-plugins/e2e-rest-core-version.php
+++ b/tests/e2e/mu-plugins/e2e-rest-core-version.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Plugin Name: E2E WP Version REST Endpoint
+ * Description: REST Endpoint for providing information about the current core version.
+ *
+ * @package   Google\Site_Kit
+ * @copyright 2020 Google LLC
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
+ * @link      https://sitekit.withgoogle.com
+ */
+
+use Google\Site_Kit\Core\REST_API\REST_Routes;
+
+add_action(
+	'rest_api_init',
+	function () {
+		if ( ! defined( 'GOOGLESITEKIT_PLUGIN_MAIN_FILE' ) ) {
+			return;
+		}
+
+		register_rest_route(
+			REST_Routes::REST_ROOT,
+			'e2e/wp/version',
+			array(
+				'methods'  => 'GET',
+				'callback' => function () {
+					$version = get_bloginfo( 'version' );
+					list( $major, $minor ) = explode( '.', $version );
+
+					return array(
+						'version' => $version,
+						'major'   => (int) $major,
+						'minor'   => (int) $minor,
+					);
+				},
+			)
+		);
+	},
+	0
+);

--- a/tests/e2e/specs/modules/search-console/admin-bar.test.js
+++ b/tests/e2e/specs/modules/search-console/admin-bar.test.js
@@ -7,6 +7,7 @@ import { activatePlugin, createURL } from '@wordpress/e2e-test-utils';
  * Internal dependencies
  */
 import {
+	setEditPostFeature,
 	setSiteVerification,
 	setSearchConsoleProperty,
 	useRequestInterception,
@@ -14,6 +15,18 @@ import {
 import * as adminBarMockResponses from './fixtures/admin-bar';
 
 let mockBatchResponse;
+
+// Editor utilities are no-op if WP is pre v5.
+async function exitFullscreenEditor() {
+	const bodyClasses = await page.evaluate( () => Array.from( document.body.classList ) );
+	if ( bodyClasses.includes( 'is-fullscreen-mode' ) ) {
+		await setEditPostFeature( 'fullscreenMode', false );
+	}
+}
+
+async function dismissEditorWelcome() {
+	await setEditPostFeature( 'welcomeGuide', false );
+}
 
 describe( 'Site Kit admin bar component display', () => {
 	beforeAll( async () => {
@@ -73,6 +86,8 @@ describe( 'Site Kit admin bar component display', () => {
 		] );
 
 		// We're now in Gutenberg.
+		await dismissEditorWelcome();
+		await exitFullscreenEditor();
 
 		await Promise.all( [
 			page.hover( '#wp-admin-bar-google-site-kit' ),

--- a/tests/e2e/utils/eval-with-wp-data.js
+++ b/tests/e2e/utils/eval-with-wp-data.js
@@ -1,0 +1,23 @@
+/**
+ * Internal dependencies
+ */
+import { getWPVersion } from './get-wp-version';
+
+/**
+ * Evaluates a function if wp.data is available.
+ *
+ * @param {Function} callback Function to call in browser context, if wp.data is available.
+ * @param {...*} args Arguments to pass to the callback in browser context.
+ */
+export async function evalWithWPData( callback, ...args ) {
+	const { major } = await getWPVersion();
+
+	if ( major < 5 ) {
+		return;
+	}
+
+	await page.waitForFunction( () => window.wp !== undefined );
+	await page.waitForFunction( () => window.wp.data !== undefined );
+
+	return await page.evaluate( callback, ...args );
+}

--- a/tests/e2e/utils/eval-with-wp-data.js
+++ b/tests/e2e/utils/eval-with-wp-data.js
@@ -6,6 +6,9 @@ import { getWPVersion } from './get-wp-version';
 /**
  * Evaluates a function if wp.data is available.
  *
+ * For older versions of WP, the callback will not be invoked
+ * making this safe to use in all environments.
+ *
  * @param {Function} callback Function to call in browser context, if wp.data is available.
  * @param {...*} args Arguments to pass to the callback in browser context.
  */

--- a/tests/e2e/utils/get-wp-version.js
+++ b/tests/e2e/utils/get-wp-version.js
@@ -1,0 +1,21 @@
+/**
+ * External dependencies
+ */
+import { memoize } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { wpApiFetch } from './wp-api-fetch';
+
+/**
+ * Gets information about the current WP Version.
+ *
+ * @return {Object} Version info. { major, minor, version }
+ */
+export const getWPVersion = memoize( async () => {
+	return await wpApiFetch( {
+		path: 'google-site-kit/v1/e2e/wp/version',
+		method: 'get',
+	} );
+} );

--- a/tests/e2e/utils/index.js
+++ b/tests/e2e/utils/index.js
@@ -1,5 +1,6 @@
 export { clearSessionStorage } from './clear-session-storage';
 export { deactivateUtilityPlugins } from './deactivate-utility-plugins';
+export { evalWithWPData } from './eval-with-wp-data';
 export { getWPVersion } from './get-wp-version';
 export { logoutUser } from './logout-user';
 export { pasteText } from './paste-text';

--- a/tests/e2e/utils/index.js
+++ b/tests/e2e/utils/index.js
@@ -9,6 +9,7 @@ export { safeLoginUser } from './safe-login-user';
 export { setAnalyticsExistingPropertyID } from './set-analytics-existing-property-id';
 export { setAuthToken } from './set-auth-token';
 export { setClientConfig } from './set-client-config';
+export { setEditPostFeature } from './set-edit-post-feature';
 export { setSiteVerification } from './set-site-verification';
 export { setSearchConsoleProperty } from './set-search-console-property';
 export { setupAnalytics } from './setup-analytics';

--- a/tests/e2e/utils/index.js
+++ b/tests/e2e/utils/index.js
@@ -1,5 +1,6 @@
 export { clearSessionStorage } from './clear-session-storage';
 export { deactivateUtilityPlugins } from './deactivate-utility-plugins';
+export { getWPVersion } from './get-wp-version';
 export { logoutUser } from './logout-user';
 export { pasteText } from './paste-text';
 export { resetSiteKit } from './reset';

--- a/tests/e2e/utils/set-edit-post-feature.js
+++ b/tests/e2e/utils/set-edit-post-feature.js
@@ -1,0 +1,23 @@
+/**
+ * Internal dependencies
+ */
+import { evalWithWPData } from './eval-with-wp-data';
+
+/**
+ * Sets feature activation for a core/edit-post feature.
+ *
+ * @param {string} feature Feature ID/name.
+ * @param {boolean} setActivation Activation to set.
+ */
+export async function setEditPostFeature( feature, setActivation ) {
+	return await evalWithWPData(
+		( featureName, activation ) => {
+			const isActive = wp.data.select( 'core/edit-post' ).isFeatureActive( featureName );
+			if ( ( isActive && ! activation ) || ( ! isActive && activation ) ) {
+				return wp.data.dispatch( 'core/edit-post' ).toggleFeature( featureName );
+			}
+		},
+		feature,
+		setActivation
+	);
+}


### PR DESCRIPTION
## Summary

Addresses issue #1322

## Relevant technical choices

The added code here is mostly utilities to allow for safely calling `wp.data` in environments where it may not exist yet.

* Added REST endpoint for `e2e/wp/version` which returns an object of version data
* Added an e2e utility to get the version data from the API, which is memoized so it will only call it once per e2e run
* Added e2e utility for evaluating a function in browser context if `wp.data` is available (introduced in WP 5) - safe to use in all environments (no-op for older WP)
* Added an e2e utility for toggling a `core/edit-post` feature (only controlled via client and persisted in browser so not possible to force from PHP)
* Added a new E2E job to the Travis matrix for testing against the latest unreleased WP (nightly)  
This is of course allowed to fail, but at least we'll see it coming

## Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
