### PR TITLE
Bug/1279/addressing large number rounding issues

### DIFF
--- a/assets/js/util/index.js
+++ b/assets/js/util/index.js
@@ -135,23 +135,26 @@ export const readableLargeNumber = ( number, currencyCode = false ) => {
 	};
 
 	switch ( true ) {
-		case 1000000 < number :
+		// Numbers over 1,000,000 round normally and display a single decimal unless the decimal is 0.
+		case 1000000 <= number :
 			return sprintf(
 				// translators: %s: an abbreviated number in millions.
 				__( '%sM', 'google-site-kit' ),
-				numberFormat( number / 1000000, withSingleDecimal )
+				numberFormat( number / 1000000, number % 10 === 0 ? {} : withSingleDecimal )
 			);
-		case 99000 < number :
+		// Numbers between 10,000 and 1,000,000 round normally and have no decimals
+		case 10000 <= number :
 			return sprintf(
 				// translators: %s: an abbreviated number in thousands.
 				__( '%sK', 'google-site-kit' ),
 				numberFormat( Math.round( number / 1000 ) )
 			);
-		case 1000 < number :
+		// Numbers between 1000 and 10,000 round normally and display a single decimal unless the decimal is 0.
+		case 1000 <= number :
 			return sprintf(
 				// translators: %s: an abbreviated number in thousands.
 				__( '%sK', 'google-site-kit' ),
-				numberFormat( number / 1000, withSingleDecimal )
+				numberFormat( number / 1000, number % 10 === 0 ? {} : withSingleDecimal )
 			);
 		default:
 			return number.toString();

--- a/assets/js/util/test/readableLargeNumber.js
+++ b/assets/js/util/test/readableLargeNumber.js
@@ -30,7 +30,7 @@ const valuesToTest = [
 	],
 	[
 		12345,
-		'12.3K',
+		'12K',
 	],
 	[
 		123456,
@@ -58,8 +58,120 @@ const valuesToTest = [
 	],
 ];
 
+const numbersBelowOneThousand = [
+	[
+		1,
+		'1',
+	],
+	[
+		450,
+		'450',
+	],
+	[
+		550,
+		'550',
+	],
+	[
+		999,
+		'999',
+	],
+];
+
+const numbersBetweet1000And10000 = [
+	[
+		1000,
+		'1K',
+	],
+	[
+		3828,
+		'3.8K',
+	],
+	[
+		4656,
+		'4.7K',
+	],
+	[
+		9000,
+		'9K',
+	],
+];
+
+const numbersBetween10000And1000000 = [
+	[
+		10000,
+		'10K',
+	],
+	[
+		10970,
+		'11K',
+	],
+	[
+		18487,
+		'18K',
+	],
+	[
+		20922,
+		'21K',
+	],
+	[
+		114859,
+		'115K',
+	],
+	[
+		141309,
+		'141K',
+	],
+	[
+		611898,
+		'612K',
+	],
+];
+
+const numbersOver1000000 = [
+	[
+		1000000,
+		'1M',
+	],
+	[
+		1100000,
+		'1.1M',
+	],
+	[
+		2500623,
+		'2.5M',
+	],
+	[
+		100100000,
+		'100.1M',
+	],
+];
+
 describe( 'readableLargeNumber', () => {
 	it.each( valuesToTest )( 'for %d should return %s', ( value, expected ) => {
 		expect( readableLargeNumber( value ) ).toStrictEqual( expected );
+	} );
+
+	describe( 'Numbers below 1000 outout the same value that was passed.', () => {
+		it.each( numbersBelowOneThousand )( 'for %d should return %s', ( value, expected ) => {
+			expect( readableLargeNumber( value ) ).toStrictEqual( expected );
+		} );
+	} );
+
+	describe( 'Numbers between 1000 and 10,000 round normally with a single decimal unless the decimal is 0.', () => {
+		it.each( numbersBetweet1000And10000 )( 'for %d should return %s', ( value, expected ) => {
+			expect( readableLargeNumber( value ) ).toStrictEqual( expected );
+		} );
+	} );
+
+	describe( 'Numbers between 10,000 and 1,000,000 round normally with no decimals', () => {
+		it.each( numbersBetween10000And1000000 )( 'for %d should return %s', ( value, expected ) => {
+			expect( readableLargeNumber( value ) ).toStrictEqual( expected );
+		} );
+	} );
+
+	describe( 'Numbers over 1,000,000 round normally and display a single decimal unless the decimal is 0.', () => {
+		it.each( numbersOver1000000 )( 'for %d should return %s', ( value, expected ) => {
+			expect( readableLargeNumber( value ) ).toStrictEqual( expected );
+		} );
 	} );
 } );


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue # 1279

## Relevant technical choices
This PR addresses issues where the Site Kit UI doesn't match how large numbers are treated in the service UI.

Originally, the scope consisted of only managing how numbers were rounded but it was expanded to include the range of numbers that trigger certain conditions and the conditional rendering of trailing decimals based on if it was zero - i.e 9000 should render as 9K and not 9.0K


## Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
