### PR TITLE
Add user notifications + option for client/server-only notifications

### DIFF
--- a/assets/js/googlesitekit/data/create-notifications-store.js
+++ b/assets/js/googlesitekit/data/create-notifications-store.js
@@ -41,15 +41,19 @@ const RECEIVE_NOTIFICATIONS_FAILED = 'RECEIVE_NOTIFICATIONS_FAILED';
  * @since 1.6.0
  * @private
  *
- * @param {string} type              The data to access. One of 'core' or 'modules'.
- * @param {string} identifier        The data identifier, eg. a module slug like 'search-console'.
- * @param {string} datapoint         The endpoint to request data from, e.g. 'notifications'.
- * @param {Object} options           Optional. Options to consider for the store.
- * @param {number} options.storeName Store name to use. Default is '{type}/{identifier}'.
+ * @param {string}  type              The data to access. One of 'core' or 'modules'.
+ * @param {string}  identifier        The data identifier, eg. a module slug like 'search-console'.
+ * @param {string}  datapoint         The endpoint to request data from, e.g. 'notifications'.
+ * @param {Object}  options           Optional. Options to consider for the store.
+ * @param {boolean} options.client    Enable client-only notifications. `true` by default.
+ * @param {boolean} options.server    Enable server notifications. `true` by default.
+ * @param {number}  options.storeName Store name to use. Default is '{type}/{identifier}'.
  * @return {Object} The notifications store object, with additional `STORE_NAME` and
  *                  `INITIAL_STATE` properties.
  */
 export const createNotificationsStore = ( type, identifier, datapoint, {
+	client = true,
+	server = true,
 	storeName = undefined,
 } = {} ) => {
 	invariant( type, 'type is required.' );
@@ -59,11 +63,11 @@ export const createNotificationsStore = ( type, identifier, datapoint, {
 	const STORE_NAME = storeName || `${ type }/${ identifier }`;
 
 	const INITIAL_STATE = {
-		serverNotifications: undefined,
+		serverNotifications: server ? undefined : null,
 		// Initialize clientNotifications as undefined rather than an empty
 		// object so we can know if a client notification was added and then
 		// removed from state.
-		clientNotifications: undefined,
+		clientNotifications: client ? undefined : null,
 		isFetchingNotifications: false,
 	};
 
@@ -237,14 +241,14 @@ export const createNotificationsStore = ( type, identifier, datapoint, {
 	};
 
 	const resolvers = {
-		*getNotifications() {
+		getNotifications: server ? function *() {
 			try {
 				const notifications = yield actions.fetchNotifications();
 				return actions.receiveNotifications( notifications );
 			} catch ( err ) {
 				return actions.receiveNotificationsFailed();
 			}
-		},
+		} : undefined,
 	};
 
 	const selectors = {


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #1174 and #1177.

## Relevant technical choices

<!-- Please describe your changes. -->

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
