### PR TITLE
Ensure that the new googlesitekit.modules API works together with the old googlesitekit.modules PHP data

### DIFF
--- a/assets/js/googlesitekit-modules.js
+++ b/assets/js/googlesitekit-modules.js
@@ -29,7 +29,7 @@ if ( typeof global.googlesitekit === 'undefined' ) {
 
 if ( typeof global.googlesitekit.modules === 'undefined' ) {
 	global.googlesitekit.modules = Modules;
-} else { // TODO: Remove this once the old googlesitekit.modules has been faded out.
+} else { // TODO: Remove this once the old googlesitekit.modules has been phased out.
 	global.googlesitekit.modules = {
 		...global.googlesitekit.modules,
 		...Modules,

--- a/assets/js/googlesitekit-modules.js
+++ b/assets/js/googlesitekit-modules.js
@@ -29,6 +29,11 @@ if ( typeof global.googlesitekit === 'undefined' ) {
 
 if ( typeof global.googlesitekit.modules === 'undefined' ) {
 	global.googlesitekit.modules = Modules;
+} else { // TODO: Remove this once the old googlesitekit.modules has been faded out.
+	global.googlesitekit.modules = {
+		...global.googlesitekit.modules,
+		...Modules,
+	};
 }
 
 export default Modules;


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #1335

You can copy-paste this change into e.g. #1248, `npm run build` and then activate the AdSense module, to make sure that it works :)

## Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
