### PR TITLE
Fix additional conflict with googlesitekit.modules global

### DIFF
--- a/assets/js/components/higherorder/withdata.js
+++ b/assets/js/components/higherorder/withdata.js
@@ -32,6 +32,11 @@ import { Component } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 /**
+ * Internal dependencies
+ */
+import { getModulesData } from 'GoogleUtil';
+
+/**
  * A Higher order Component that provides data functionality to Components.
  *
  * This function takes a React Component that is data dependent, resolving via the data API.
@@ -242,10 +247,11 @@ const withData = (
 				return loadingComponent;
 			}
 
-			const moduleName = module ? global.googlesitekit.modules[ module ].name : __( 'Site Kit', 'google-site-kit' );
+			const modulesData = getModulesData();
+			const moduleName = module ? modulesData[ module ].name : __( 'Site Kit', 'google-site-kit' );
 
 			// If module is active but setup not complete.
-			if ( module && global.googlesitekit.modules[ module ].active && ! global.googlesitekit.modules[ module ].setupComplete ) {
+			if ( module && modulesData[ module ].active && ! modulesData[ module ].setupComplete ) {
 				return getSetupIncompleteComponent( module, layoutOptions.inGrid, layoutOptions.fullWidth, layoutOptions.createGrid );
 			}
 

--- a/assets/js/components/modules-list.js
+++ b/assets/js/components/modules-list.js
@@ -27,6 +27,7 @@ import {
 	activateOrDeactivateModule,
 	showErrorNotification,
 	moduleIcon,
+	getModulesData,
 } from 'GoogleUtil';
 import GenericError from 'GoogleComponents/notifications/generic-error';
 import ModuleSettingsWarning from 'GoogleComponents/notifications/module-settings-warning';
@@ -77,8 +78,10 @@ class ModulesList extends Component {
 	}
 
 	render() {
+		const modulesData = getModulesData();
+
 		// Filter out internal modules.
-		const modules = Object.values( global.googlesitekit.modules || {} ).filter( ( module ) => ! module.internal );
+		const modules = Object.values( modulesData ).filter( ( module ) => ! module.internal );
 
 		// Map of slug => name for every module that is active and completely set up.
 		const completedModuleNames = modules

--- a/assets/js/components/notifications/dashboard-modules-alerts.js
+++ b/assets/js/components/notifications/dashboard-modules-alerts.js
@@ -29,6 +29,11 @@ import { each } from 'lodash';
 import { Component, Fragment } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
+/**
+ * Internal dependencies
+ */
+import { getModulesData } from 'GoogleUtil';
+
 class DashboardModulesAlerts extends Component {
 	constructor( props ) {
 		super( props );
@@ -57,6 +62,7 @@ class DashboardModulesAlerts extends Component {
 			return null;
 		}
 
+		const modulesData = getModulesData();
 		const notifications = [];
 
 		Object.keys( data ).forEach( ( key ) => {
@@ -81,7 +87,7 @@ class DashboardModulesAlerts extends Component {
 						isDismissable={ notification.isDismissable || true }
 						logo={ notification.logo || true }
 						module={ key }
-						moduleName={ global.googlesitekit.modules[ key ].name }
+						moduleName={ modulesData[ key ].name }
 						pageIndex={ notification.pageIndex || '' }
 						dismissExpires={ notification.dismissExpires || 0 }
 						showOnce={ notification.showOnce || false }

--- a/assets/js/components/notifications/dashboard-setup-alerts.js
+++ b/assets/js/components/notifications/dashboard-setup-alerts.js
@@ -19,7 +19,7 @@
 /**
  * External dependencies
  */
-import { getQueryParameter } from 'GoogleUtil';
+import { getQueryParameter, getModulesData } from 'GoogleUtil';
 import Notification from 'GoogleComponents/notifications/notification';
 import ModulesList from 'GoogleComponents/modules-list';
 
@@ -57,15 +57,16 @@ class DashboardSetupAlerts extends Component {
 					return null;
 				}
 
+				const modulesData = getModulesData();
 				const slug = getQueryParameter( 'slug' );
 
-				if ( slug && global.googlesitekit.modules[ slug ] && ! global.googlesitekit.modules[ slug ].active ) {
+				if ( slug && modulesData[ slug ] && ! modulesData[ slug ].active ) {
 					return null;
 				}
 
-				if ( slug && global.googlesitekit.modules[ slug ] ) {
+				if ( slug && modulesData[ slug ] ) {
 					winData.id = `${ winData.id }-${ slug }`;
-					winData.setupTitle = global.googlesitekit.modules[ slug ].name;
+					winData.setupTitle = modulesData[ slug ].name;
 					winData.description = __( 'Here are some other services you can connect to see even more stats:', 'google-site-kit' );
 
 					winData = applyFilters( ` global.googlesitekit.SetupWinNotification-${ slug }`, winData );

--- a/assets/js/components/notifications/setup-incomplete.js
+++ b/assets/js/components/notifications/setup-incomplete.js
@@ -22,7 +22,7 @@
  */
 import CTA from 'GoogleComponents/notifications/cta';
 import ctaWrapper from 'GoogleComponents/notifications/cta-wrapper';
-import { getReAuthURL } from 'GoogleUtil';
+import { getReAuthURL, getModulesData } from 'GoogleUtil';
 
 /**
  * WordPress dependencies
@@ -40,7 +40,7 @@ import { __, sprintf } from '@wordpress/i18n';
  * @return {WPElement} Returns CTA component with configuration CTA.
  */
 const getSetupIncompleteComponent = ( module, inGrid = false, fullWidth = false, createGrid = false ) => {
-	const { name } = global.googlesitekit.modules[ module ];
+	const { name } = getModulesData()[ module ];
 	const cta = <CTA
 
 		/* translators: %s: Module name */

--- a/assets/js/components/publisher-wins/index.js
+++ b/assets/js/components/publisher-wins/index.js
@@ -19,7 +19,7 @@
 /**
  * External dependencies
  */
-import { getTimeInSeconds, getQueryParameter } from 'GoogleUtil';
+import { getTimeInSeconds, getQueryParameter, getModulesData } from 'GoogleUtil';
 import { TYPE_MODULES } from 'GoogleComponents/data';
 import * as publisherWinCallbacks from 'GoogleComponents/publisher-wins/callbacks';
 /**
@@ -97,7 +97,8 @@ if ( 'authentication_success' !== notification && 'authentication_failure' !== n
 			return wins;
 		}, 2 );
 
-	if ( global.googlesitekit.modules.analytics.active ) {
+	const modulesData = getModulesData();
+	if ( modulesData.analytics.active ) {
 		addFilter( 'googlesitekit.WinsNotificationsRequest',
 			'googlesitekit.PublisherWinsNotification',
 			( wins ) => {

--- a/assets/js/components/publisher-wins/pageview-increase.js
+++ b/assets/js/components/publisher-wins/pageview-increase.js
@@ -19,7 +19,7 @@
 /**
  * External dependencies
  */
-import { numberFormat, getTimeInSeconds } from 'GoogleUtil';
+import { numberFormat, getTimeInSeconds, getModulesData } from 'GoogleUtil';
 import { calculateOverviewData } from 'GoogleModules/analytics/util';
 
 /**
@@ -28,7 +28,9 @@ import { calculateOverviewData } from 'GoogleModules/analytics/util';
 import { __ } from '@wordpress/i18n';
 
 const pageviewIncrease = ( data, id ) => {
-	if ( ! global.googlesitekit.modules.analytics || ! global.googlesitekit.modules.analytics.active ) {
+	const modulesData = getModulesData();
+
+	if ( ! modulesData.analytics || ! modulesData.analytics.active ) {
 		return false;
 	}
 

--- a/assets/js/components/publisher-wins/publishing-win.js
+++ b/assets/js/components/publisher-wins/publishing-win.js
@@ -20,7 +20,7 @@
  * External dependencies
  */
 import { extractSearchConsoleDashboardData } from 'GoogleModules/search-console/dashboard/util';
-import { readableLargeNumber } from 'GoogleUtil';
+import { readableLargeNumber, getModulesData } from 'GoogleUtil';
 
 /**
  * WordPress dependencies
@@ -37,7 +37,8 @@ const publishingWin = ( data, id ) => {
 	let message = __( 'That’s out of this world.', 'google-site-kit' );
 	let dataBlocks = [];
 
-	if ( global.googlesitekit.modules[ 'search-console' ] && global.googlesitekit.modules[ 'search-console' ].active && data ) {
+	const modulesData = getModulesData();
+	if ( modulesData[ 'search-console' ] && modulesData[ 'search-console' ].active && data ) {
 		const processedData = extractSearchConsoleDashboardData( data );
 
 		const {

--- a/assets/js/components/publisher-wins/traffic-increase.js
+++ b/assets/js/components/publisher-wins/traffic-increase.js
@@ -19,7 +19,7 @@
 /**
  * External dependencies
  */
-import { getTimeInSeconds, readableLargeNumber } from 'GoogleUtil';
+import { getTimeInSeconds, readableLargeNumber, getModulesData } from 'GoogleUtil';
 import { calculateOverviewData } from 'GoogleModules/analytics/util';
 
 /**
@@ -28,7 +28,9 @@ import { calculateOverviewData } from 'GoogleModules/analytics/util';
 import { __ } from '@wordpress/i18n';
 
 const trafficIncrease = ( data, id ) => {
-	if ( ! global.googlesitekit.modules.analytics || ! global.googlesitekit.modules.analytics.active ) {
+	const modulesData = getModulesData();
+
+	if ( ! modulesData.analytics || ! modulesData.analytics.active ) {
 		return false;
 	}
 

--- a/assets/js/components/settings/settings-module.js
+++ b/assets/js/components/settings/settings-module.js
@@ -34,6 +34,7 @@ import {
 	getReAuthURL,
 	moduleIcon,
 	showErrorNotification,
+	getModulesData,
 } from 'GoogleUtil';
 import Spinner from 'GoogleComponents/spinner';
 import SettingsOverlay from 'GoogleComponents/settings/settings-overlay';
@@ -56,7 +57,7 @@ class SettingsModule extends Component {
 	constructor( props ) {
 		super( props );
 		const { slug } = props;
-		const { setupComplete } = global.googlesitekit.modules[ slug ];
+		const { setupComplete } = getModulesData()[ slug ];
 		this.state = {
 			isSaving: false,
 			active: props.active,

--- a/assets/js/components/settings/settings-modules.js
+++ b/assets/js/components/settings/settings-modules.js
@@ -21,7 +21,7 @@
  */
 import Layout from 'GoogleComponents/layout/layout';
 import Notification from 'GoogleComponents/notifications/notification';
-import { clearWebStorage } from 'GoogleUtil/index';
+import { clearWebStorage, getModulesData } from 'GoogleUtil';
 import { map, filter, sortBy } from 'lodash';
 
 /**
@@ -55,7 +55,8 @@ class SettingsModules extends Component {
 	}
 
 	componentDidMount() {
-		if ( global.googlesitekit.editmodule && global.googlesitekit.modules[ global.googlesitekit.editmodule ].active ) {
+		const modulesData = getModulesData();
+		if ( global.googlesitekit.editmodule && modulesData[ global.googlesitekit.editmodule ].active ) {
 			this.handleButtonAction( `${ global.googlesitekit.editmodule }-module`, 'edit' );
 		}
 	}
@@ -131,7 +132,9 @@ class SettingsModules extends Component {
 	}
 
 	settingsModuleComponent( module, isSaving ) {
-		const { provides } = global.googlesitekit.modules[ module.slug ];
+		const modulesData = getModulesData();
+
+		const { provides } = modulesData[ module.slug ];
 		const { isEditing, openModules, error } = this.state;
 		const isOpen = openModules[ module.slug ] || false;
 
@@ -196,16 +199,18 @@ class SettingsModules extends Component {
 	}
 
 	render() {
+		const modulesData = getModulesData();
+
 		const { isEditing } = this.state;
 		const { activeTab } = this.props;
 		const modulesBeingEdited = filter( isEditing, ( module ) => module );
 		const editActive = 0 < modulesBeingEdited.length;
-		if ( ! global.googlesitekit || ! global.googlesitekit.modules ) {
+		if ( ! Object.values( modulesData ).length ) {
 			return null;
 		}
 
 		// Filter out internal modules.
-		const modules = filter( global.googlesitekit.modules, ( module ) => ! module.internal );
+		const modules = filter( modulesData, ( module ) => ! module.internal );
 
 		const activeModules = this.mapToModule(
 			sortBy(

--- a/assets/js/components/wp-dashboard/wp-dashboard-modules.js
+++ b/assets/js/components/wp-dashboard/wp-dashboard-modules.js
@@ -17,11 +17,6 @@
  */
 
 /**
- * Internal dependencies
- */
-import WPDashboardModule from './wp-dashboard-module';
-import WPDashboardHeader from './wp-dashboard-header';
-/**
  * External dependencies
  */
 import AnalyticsInactiveCTA from 'GoogleComponents/analytics-inactive-cta';
@@ -33,19 +28,28 @@ import classnames from 'classnames';
 import { Component, Fragment } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
+/**
+ * Internal dependencies
+ */
+import { getModulesData } from 'GoogleUtil';
+import WPDashboardModule from './wp-dashboard-module';
+import WPDashboardHeader from './wp-dashboard-header';
+
 class WPDashboardModules extends Component {
 	render() {
+		const modulesData = getModulesData();
+
 		return (
 			<Fragment>
 				<div className={ classnames(
 					'googlesitekit-wp-dashboard-stats',
-					{ 'googlesitekit-wp-dashboard-stats--fourup': global.googlesitekit.modules.analytics.active }
+					{ 'googlesitekit-wp-dashboard-stats--fourup': modulesData.analytics.active }
 				) }>
 					<WPDashboardHeader
 						key={ 'googlesitekit-wp-dashboard-header' }
 					/>
 					{ // Show the Analytics CTA if analytics is not enabled.
-						( ! global.googlesitekit.modules.analytics.active ) &&
+						( ! modulesData.analytics.active ) &&
 						<div className="googlesitekit-wp-dashboard-stats__cta">
 							<AnalyticsInactiveCTA
 								title={ __( 'See unique vistors, goal completions, top pages and more.', 'google-site-kit' ) }

--- a/assets/js/modules/adsense/dashboard/adsense-module-status.js
+++ b/assets/js/modules/adsense/dashboard/adsense-module-status.js
@@ -33,7 +33,7 @@ import { __, _x } from '@wordpress/i18n';
  */
 import AdSenseSetupInstructions from '../setup/adsense-setup-instructions';
 import AdSenseInProcessStatus from './adsense-in-process-status';
-import { getExistingTag } from 'GoogleUtil';
+import { getExistingTag, getModulesData } from 'GoogleUtil';
 import { getAdSenseAccountStatus, propsFromAccountStatus } from '../util';
 
 class AdSenseModuleStatus extends Component {
@@ -97,9 +97,10 @@ class AdSenseModuleStatus extends Component {
 	}
 
 	render() {
+		const modulesData = getModulesData();
 		const { accountStatus, clientID, loadingMessage, instructionProps } = this.state;
 
-		const showInProcess = ! accountStatus || ! global.googlesitekit.modules.adsense.setupComplete || [
+		const showInProcess = ! accountStatus || ! modulesData.adsense.setupComplete || [
 			'ads-display-pending',
 			'account-pending-review',
 			'account-required-action',
@@ -119,7 +120,7 @@ class AdSenseModuleStatus extends Component {
 					</h2>
 				</div>
 				<div className="googlesitekit-setup-module__step">
-					{ ! global.googlesitekit.canAdsRun && ! global.googlesitekit.modules.adsense.setupComplete && (
+					{ ! global.googlesitekit.canAdsRun && ! modulesData.adsense.setupComplete && (
 						<div className="googlesitekit-settings-module-warning">
 							<SvgIcon id="error" height="20" width="23" />
 							{ __( 'Ad blocker detected, you need to disable it in order to setup AdSense.', 'google-site-kit' ) }
@@ -138,7 +139,7 @@ class AdSenseModuleStatus extends Component {
 						/>
 					) }
 
-					{ global.googlesitekit.canAdsRun && accountStatus && ( global.googlesitekit.modules.adsense.setupComplete || 'account-connected' === accountStatus ) && (
+					{ global.googlesitekit.canAdsRun && accountStatus && ( modulesData.adsense.setupComplete || 'account-connected' === accountStatus ) && (
 						<AdSenseSetupInstructions
 							{ ...instructionProps }
 							accountStatus={ accountStatus }

--- a/assets/js/modules/adsense/dashboard/dashboard-outro.js
+++ b/assets/js/modules/adsense/dashboard/dashboard-outro.js
@@ -28,9 +28,14 @@ import Button from 'GoogleComponents/button';
 import { Component } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
+/**
+ * Internal dependencies
+ */
+import { getModulesData } from 'GoogleUtil';
+
 class AdSenseDashboardOutro extends Component {
 	render() {
-		const { accountURL } = global.googlesitekit.modules.adsense;
+		const { accountURL } = getModulesData().adsense;
 
 		return (
 			<section className="googlesitekit-module-outro">

--- a/assets/js/modules/adsense/dashboard/dashboard-widget.js
+++ b/assets/js/modules/adsense/dashboard/dashboard-widget.js
@@ -45,6 +45,7 @@ import { isAdsenseConnectedAnalytics, propsFromAccountStatus } from '../util';
 import ModuleSettingsWarning from 'GoogleComponents/notifications/module-settings-warning';
 import AdSenseInProcessStatus from './adsense-in-process-status';
 import HelpLink from 'GoogleComponents/help-link';
+import { getModulesData } from 'GoogleUtil';
 
 class AdSenseDashboardWidget extends Component {
 	constructor( props ) {
@@ -124,6 +125,8 @@ class AdSenseDashboardWidget extends Component {
 	}
 
 	render() {
+		const modulesData = getModulesData();
+
 		const {
 			receivingData,
 			error,
@@ -132,7 +135,7 @@ class AdSenseDashboardWidget extends Component {
 			zeroData,
 			instructionProps,
 		} = this.state;
-		const { homepage } = global.googlesitekit.modules.adsense;
+		const { homepage } = modulesData.adsense;
 
 		// Hide AdSense data display when we don't have data.
 		const wrapperClass = ( loading || ! receivingData || zeroData ) ? 'googlesitekit-nodata' : '';
@@ -152,7 +155,7 @@ class AdSenseDashboardWidget extends Component {
 								mdc-layout-grid__cell--span-12
 							">
 								{
-									( ! error && global.googlesitekit.modules.adsense.setupComplete )
+									( ! error && modulesData.adsense.setupComplete )
 										? <PageHeader title={ _x( 'AdSense', 'Service name', 'google-site-kit' ) } icon iconWidth="30" iconHeight="26" iconID="adsense" status="connected" statusText={ __( 'AdSense is connected', 'google-site-kit' ) } />
 										: <PageHeader title={ _x( 'AdSense', 'Service name', 'google-site-kit' ) } icon iconWidth="30" iconHeight="26" iconID="adsense" status="not-connected" statusText={ __( 'AdSense is not connected', 'google-site-kit' ) } />
 								}

--- a/assets/js/modules/adsense/index.js
+++ b/assets/js/modules/adsense/index.js
@@ -20,7 +20,13 @@
  * External dependencies
  */
 import { createAddToFilter } from 'GoogleUtil/helpers';
-import { fillFilterWithComponent, getSiteKitAdminURL } from 'GoogleUtil';
+import { fillFilterWithComponent, getSiteKitAdminURL, getModulesData } from 'GoogleUtil';
+
+/**
+ * WordPress dependencies
+ */
+import { addFilter } from '@wordpress/hooks';
+
 /**
  * Internal dependencies
  */
@@ -31,10 +37,6 @@ import AdSenseModuleStatus from './dashboard/adsense-module-status';
 import AdSenseSettingsStatus from './settings/adsense-settings-status';
 import AdSenseSettingsWarning from './settings/adsense-settings-warning';
 
-/**
- * WordPress dependencies
- */
-import { addFilter } from '@wordpress/hooks';
 const slug = 'adsense';
 
 /**
@@ -52,12 +54,13 @@ addFilter( 'googlesitekit.SetupModuleShowLink',
 		return showLink;
 	} );
 
-if ( global.googlesitekit.modules.adsense.active ) {
+const modulesData = getModulesData();
+if ( modulesData.adsense.active ) {
 	const addAdSenseDashboardWidget = createAddToFilter( <AdSenseDashboardWidget /> );
 	const addDashboardEarnings = createAddToFilter( <DashboardEarnings /> );
 
 	// If setup is complete, show the AdSense data.
-	if ( global.googlesitekit.modules[ slug ].setupComplete ) {
+	if ( modulesData[ slug ].setupComplete ) {
 		/**
 		 * Action triggered when the settings App is loaded.
 		 */
@@ -89,7 +92,7 @@ if ( global.googlesitekit.modules.adsense.active ) {
 		// Show module as connected in the settings when status is pending review.
 		addFilter( `googlesitekit.Connected-${ slug }`,
 			'googlesitekit.AdSenseModuleConnected', ( isConnected ) => {
-				const { settings } = global.googlesitekit.modules[ slug ];
+				const { settings } = modulesData[ slug ];
 				if ( ! isConnected && undefined !== settings && ( 'account-pending-review' === settings.accountStatus || 'ads-display-pending' === settings.accountStatus ) ) {
 					return true;
 				}
@@ -124,8 +127,8 @@ if ( global.googlesitekit.modules.adsense.active ) {
 				identifier: 'adsense',
 				toRefresh: () => {
 					let status = '';
-					if ( global.googlesitekit.modules.adsense && global.googlesitekit.modules.adsense[ 'account-status' ] ) {
-						status = global.googlesitekit.modules.adsense[ 'account-status' ].accountStatus;
+					if ( modulesData.adsense && modulesData.adsense[ 'account-status' ] ) {
+						status = modulesData.adsense[ 'account-status' ].accountStatus;
 					}
 
 					if ( status && -1 < status.indexOf( 'account-connected' ) ) {

--- a/assets/js/modules/adsense/settings/adsense-settings-status.js
+++ b/assets/js/modules/adsense/settings/adsense-settings-status.js
@@ -21,6 +21,7 @@
  */
 import {
 	getSiteKitAdminURL,
+	getModulesData,
 } from 'GoogleUtil';
 import Link from 'GoogleComponents/link';
 
@@ -38,7 +39,7 @@ class AdSenseSettingsStatus extends Component {
 			OriginalComponent,
 		} = this.props;
 
-		const { accountStatus } = global.googlesitekit.modules.adsense.settings;
+		const { accountStatus } = getModulesData().adsense.settings;
 
 		if ( ! accountStatus || 'adsense' !== slug ) {
 			return <OriginalComponent { ...this.props } />;

--- a/assets/js/modules/adsense/settings/adsense-settings-warning.js
+++ b/assets/js/modules/adsense/settings/adsense-settings-warning.js
@@ -9,6 +9,11 @@ import SvgIcon from 'GoogleUtil/svg-icon';
 import { Component } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
+/**
+ * Internal dependencies
+ */
+import { getModulesData } from 'GoogleUtil';
+
 class AdSenseSettingsWarning extends Component {
 	render() {
 		const {
@@ -21,7 +26,7 @@ class AdSenseSettingsWarning extends Component {
 			return <OriginalComponent { ...this.props } />;
 		}
 
-		const { active, setupComplete } = global.googlesitekit.modules.adsense;
+		const { active, setupComplete } = getModulesData().adsense;
 		let message = __( 'Ad blocker detected, you need to disable it in order to setup AdSense.', 'google-site-kit' );
 		if ( active && setupComplete ) {
 			message = __( 'Ad blocker detected, You need to disable it to get the AdSense latest data.', 'google-site-kit' );

--- a/assets/js/modules/adsense/settings/adsense-settings.js
+++ b/assets/js/modules/adsense/settings/adsense-settings.js
@@ -25,6 +25,7 @@ import PropTypes from 'prop-types';
 import {
 	trackEvent,
 	toggleConfirmModuleSettings,
+	getModulesData,
 } from 'GoogleUtil';
 
 /**
@@ -37,7 +38,7 @@ import { addFilter, removeFilter } from '@wordpress/hooks';
 class AdSenseSettings extends Component {
 	constructor( props ) {
 		super( props );
-		const { useSnippet = true } = global.googlesitekit.modules.adsense.settings;
+		const { useSnippet = true } = getModulesData().adsense.settings;
 
 		this.state = {
 			useSnippet: !! useSnippet,
@@ -76,6 +77,8 @@ class AdSenseSettings extends Component {
 	}
 
 	save() {
+		const modulesData = getModulesData();
+
 		const { useSnippet } = this.state;
 		if ( this._isMounted ) {
 			this.setState( {
@@ -88,8 +91,8 @@ class AdSenseSettings extends Component {
 		};
 
 		// Reset the localized variable.
-		if ( global.googlesitekit.modules.adsense.settings ) {
-			global.googlesitekit.modules.adsense.settings.useSnippet = useSnippet;
+		if ( modulesData.adsense.settings ) {
+			modulesData.adsense.settings.useSnippet = useSnippet;
 		}
 
 		return data.set( TYPE_MODULES, 'adsense', 'use-snippet', toSave ).then( ( res ) => res ).catch( ( e ) => e );

--- a/assets/js/modules/adsense/setup/setup-auth-flow-widget.js
+++ b/assets/js/modules/adsense/setup/setup-auth-flow-widget.js
@@ -27,6 +27,11 @@ import Button from 'GoogleComponents/button';
 import { Component, Fragment } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
+/**
+ * Internal dependencies
+ */
+import { getModulesData } from 'GoogleUtil';
+
 class AdSenseSetupAuthFlowWidget extends Component {
 	constructor( props ) {
 		super( props );
@@ -37,7 +42,7 @@ class AdSenseSetupAuthFlowWidget extends Component {
 	static createNewAccount( e ) {
 		e.preventDefault();
 
-		const { signupURL } = global.googlesitekit.modules.adsense;
+		const { signupURL } = getModulesData().adsense;
 
 		global.open( signupURL, '_blank' );
 	}

--- a/assets/js/modules/adsense/util/index.js
+++ b/assets/js/modules/adsense/util/index.js
@@ -21,7 +21,7 @@
  */
 import { parse as pslParse } from 'psl';
 import data, { TYPE_MODULES } from 'GoogleComponents/data';
-import { trackEvent, getReAuthURL, getSiteKitAdminURL } from 'GoogleUtil';
+import { trackEvent, getReAuthURL, getSiteKitAdminURL, getModulesData } from 'GoogleUtil';
 import { each, find, filter } from 'lodash';
 
 /**
@@ -84,7 +84,7 @@ export const propsFromAccountStatus = ( accountStatus, existingTag ) => {
 	let switchOnMessage;
 	let tracking = false;
 
-	const { accountURL, signupURL } = global.googlesitekit.modules.adsense;
+	const { accountURL, signupURL } = getModulesData().adsense;
 	const moduleURL = getSiteKitAdminURL(
 		'googlesitekit-module-adsense',
 		{}
@@ -321,7 +321,7 @@ export const getAdSenseAccountStatus = async ( existingTag = false, statusUpdate
 			}
 		} else {
 			// Set AdSense account link with account found.
-			global.googlesitekit.modules.adsense.accountURL = sprintf( 'https://www.google.com/adsense/new/%s/home', id );
+			getModulesData().adsense.accountURL = sprintf( 'https://www.google.com/adsense/new/%s/home', id );
 
 			statusUpdateCallback( __( 'Account found, checking account status…', 'google-site-kit' ) );
 
@@ -462,8 +462,10 @@ export const getAdSenseAccountStatus = async ( existingTag = false, statusUpdate
  * @return {Promise} Resolves to a boolean, whether or not AdSense is connected.
  */
 export const isAdsenseConnectedAnalytics = async () => {
-	const { active: adsenseActive } = global.googlesitekit.modules.adsense;
-	const { active: analyticsActive } = global.googlesitekit.modules.analytics;
+	const modulesData = getModulesData();
+
+	const { active: adsenseActive } = modulesData.adsense;
+	const { active: analyticsActive } = modulesData.analytics;
 
 	let adsenseConnect = true;
 

--- a/assets/js/modules/analytics/adminbar/adminbar-widget.js
+++ b/assets/js/modules/analytics/adminbar/adminbar-widget.js
@@ -17,10 +17,6 @@
  */
 
 /**
- * Internal dependencies
- */
-import AnalyticsAdminbarWidgetOverview from './adminbar-widget-overview';
-/**
  * External dependencies
  */
 import AnalyticsInactiveCTA from 'GoogleComponents/analytics-inactive-cta';
@@ -30,13 +26,19 @@ import AnalyticsInactiveCTA from 'GoogleComponents/analytics-inactive-cta';
  */
 import { Component, Fragment } from '@wordpress/element';
 
+/**
+ * Internal dependencies
+ */
+import AnalyticsAdminbarWidgetOverview from './adminbar-widget-overview';
+import { getModulesData } from 'GoogleUtil';
+
 class AnalyticsAdminbarWidget extends Component {
 	render() {
 		if ( typeof global.googlesitekit.permaLink !== typeof undefined && '' === global.googlesitekit.permaLink ) {
 			return null;
 		}
 
-		if ( ! global.googlesitekit.modules.analytics.active ) {
+		if ( ! getModulesData().analytics.active ) {
 			return (
 				<Fragment>
 					<div className="

--- a/assets/js/modules/analytics/dashboard/dashboard-widget-all-traffic.js
+++ b/assets/js/modules/analytics/dashboard/dashboard-widget-all-traffic.js
@@ -17,12 +17,6 @@
  */
 
 /**
- * Internal dependencies
- */
-import DashboardAcquisitionPieChart from './dashboard-widget-acquisition-piechart';
-import AnalyticsAllTrafficDashboardWidgetTopAcquisitionSources from './dashboard-alltraffic-widget-top-acquisition-sources-table';
-
-/**
  * WordPress dependencies
  */
 import { Component, Fragment } from '@wordpress/element';
@@ -37,6 +31,13 @@ import getNoDataComponent from 'GoogleComponents/notifications/nodata';
 import getDataErrorComponent from 'GoogleComponents/notifications/data-error';
 import getSetupIncompleteComponent from 'GoogleComponents/notifications/setup-incomplete';
 import classnames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+import DashboardAcquisitionPieChart from './dashboard-widget-acquisition-piechart';
+import AnalyticsAllTrafficDashboardWidgetTopAcquisitionSources from './dashboard-alltraffic-widget-top-acquisition-sources-table';
+import { getModulesData } from 'GoogleUtil';
 
 class AnalyticsAllTraffic extends Component {
 	constructor( props ) {
@@ -76,7 +77,7 @@ class AnalyticsAllTraffic extends Component {
 		const {
 			active,
 			setupComplete,
-		} = global.googlesitekit.modules.analytics;
+		} = getModulesData().analytics;
 
 		const {
 			error,

--- a/assets/js/modules/analytics/dashboard/dashboard-widget-analytics-adsense-top-pages.js
+++ b/assets/js/modules/analytics/dashboard/dashboard-widget-analytics-adsense-top-pages.js
@@ -21,7 +21,7 @@
  */
 import withData from 'GoogleComponents/higherorder/withdata';
 import { TYPE_MODULES } from 'GoogleComponents/data';
-import { getTimeInSeconds, numberFormat } from 'GoogleUtil';
+import { getTimeInSeconds, numberFormat, getModulesData } from 'GoogleUtil';
 import { getDataTableFromData, TableOverflowContainer } from 'GoogleComponents/data-table';
 import Layout from 'GoogleComponents/layout/layout';
 import PreviewTable from 'GoogleComponents/preview-table';
@@ -40,7 +40,7 @@ import { analyticsAdsenseReportDataDefaults } from '../util';
 
 class AnalyticsAdSenseDashboardWidgetTopPagesTable extends Component {
 	static renderLayout( component ) {
-		const { accountURL } = global.googlesitekit.modules.adsense;
+		const { accountURL } = getModulesData().adsense;
 		return (
 			<Layout
 				header
@@ -101,7 +101,7 @@ class AnalyticsAdSenseDashboardWidgetTopPagesTable extends Component {
 			accountID,
 			internalWebPropertyID,
 			profileID,
-		} = global.googlesitekit.modules.analytics.settings;
+		} = getModulesData().analytics.settings;
 
 		// Construct a deep link.
 		const adsenseDeepLink = `https://analytics.google.com/analytics/web/?pli=1#/report/content-pages/a${ accountID }w${ internalWebPropertyID }p${ profileID }/explorer-table.plotKeys=%5B%5D&_r.drilldown=analytics.pagePath:~2F`;
@@ -151,7 +151,7 @@ const getDataError = ( data ) => {
 	}
 
 	// We don't want to show error as AdsenseDashboardOutro will be rendered for this case.
-	if ( 400 === data.error.code && 'INVALID_ARGUMENT' === data.error.status && global.googlesitekit.modules.analytics.active ) {
+	if ( 400 === data.error.code && 'INVALID_ARGUMENT' === data.error.status && getModulesData().analytics.active ) {
 		return null;
 	}
 

--- a/assets/js/modules/analytics/dashboard/dashboard-widget-popular-pages-table.js
+++ b/assets/js/modules/analytics/dashboard/dashboard-widget-popular-pages-table.js
@@ -21,7 +21,7 @@
  */
 import withData from 'GoogleComponents/higherorder/withdata';
 import { TYPE_MODULES } from 'GoogleComponents/data';
-import { getTimeInSeconds, numberFormat } from 'GoogleUtil';
+import { getTimeInSeconds, numberFormat, getModulesData } from 'GoogleUtil';
 import { getDataTableFromData, TableOverflowContainer } from 'GoogleComponents/data-table';
 import PreviewTable from 'GoogleComponents/preview-table';
 import Layout from 'GoogleComponents/layout/layout';
@@ -50,7 +50,7 @@ class AnalyticsDashboardWidgetPopularPagesTable extends Component {
 					className="googlesitekit-popular-content"
 					footer
 					footerCtaLabel={ _x( 'Analytics', 'Service name', 'google-site-kit' ) }
-					footerCtaLink={ global.googlesitekit.modules.analytics.homepage }
+					footerCtaLink={ getModulesData().analytics.homepage }
 					fill
 				>
 					{ component }

--- a/assets/js/modules/analytics/dashboard/dashboard-widget-top-pages-table.js
+++ b/assets/js/modules/analytics/dashboard/dashboard-widget-top-pages-table.js
@@ -22,7 +22,7 @@
 import classnames from 'classnames';
 import withData from 'GoogleComponents/higherorder/withdata';
 import { TYPE_MODULES } from 'GoogleComponents/data';
-import { getTimeInSeconds, numberFormat } from 'GoogleUtil';
+import { getTimeInSeconds, numberFormat, getModulesData } from 'GoogleUtil';
 import { getDataTableFromData, TableOverflowContainer } from 'GoogleComponents/data-table';
 import PreviewTable from 'GoogleComponents/preview-table';
 import { map } from 'lodash';
@@ -52,7 +52,7 @@ class AnalyticsDashboardWidgetTopPagesTable extends Component {
 			accountID,
 			internalWebPropertyID,
 			profileID,
-		} = global.googlesitekit.modules.analytics.settings;
+		} = getModulesData().analytics.settings;
 
 		if ( ! accountID ) {
 			return 'https://analytics.google.com/analytics/web/';

--- a/assets/js/modules/analytics/index.js
+++ b/assets/js/modules/analytics/index.js
@@ -19,7 +19,7 @@
 /**
  * External dependencies
  */
-import { fillFilterWithComponent, getSiteKitAdminURL } from 'GoogleUtil';
+import { fillFilterWithComponent, getSiteKitAdminURL, getModulesData } from 'GoogleUtil';
 import { createAddToFilter } from 'GoogleUtil/helpers';
 /**
  * Internal dependencies
@@ -51,8 +51,10 @@ addFilter( 'googlesitekit.AdminbarModules',
 	'googlesitekit.Analytics',
 	addAnalyticsAdminbarWidget, 11 );
 
+const modulesData = getModulesData();
+
 // If setup is not complete, show the signup flow.
-if ( ! global.googlesitekit.modules[ slug ].setupComplete ) {
+if ( ! modulesData[ slug ].setupComplete ) {
 	const {
 		reAuth,
 		currentScreen,
@@ -70,7 +72,7 @@ if ( ! global.googlesitekit.modules[ slug ].setupComplete ) {
 	}
 }
 
-if ( global.googlesitekit.modules.analytics.active ) {
+if ( modulesData.analytics.active ) {
 	const addAnalyticsDashboardWidget = createAddToFilter( <AnalyticsDashboardWidget /> );
 	const addAnalyticsAllTraffic = createAddToFilter( <AnalyticsAllTraffic /> );
 	const addWPAnalyticsDashboardWidgetOverview = createAddToFilter( <WPAnalyticsDashboardWidgetOverview /> );

--- a/assets/js/modules/analytics/setup.js
+++ b/assets/js/modules/analytics/setup.js
@@ -32,6 +32,7 @@ import {
 	trackEvent,
 	getExistingTag,
 	toggleConfirmModuleSettings,
+	getModulesData,
 } from 'GoogleUtil';
 import classnames from 'classnames';
 
@@ -59,7 +60,7 @@ class AnalyticsSetup extends Component {
 			propertyID,
 			useSnippet,
 			trackingDisabled,
-		} = global.googlesitekit.modules.analytics.settings;
+		} = getModulesData().analytics.settings;
 
 		this.state = {
 			anonymizeIP,
@@ -527,7 +528,7 @@ class AnalyticsSetup extends Component {
 			data.invalidateCacheGroup( TYPE_MODULES, 'analytics', 'accounts-properties-profiles' );
 			await this.getAccounts();
 
-			global.googlesitekit.modules.analytics.settings = savedSettings;
+			getModulesData().analytics.settings = savedSettings;
 
 			trackEvent( 'analytics_setup', 'analytics_configured' );
 
@@ -627,7 +628,7 @@ class AnalyticsSetup extends Component {
 		} = this.props;
 		const disabled = ! isEditing;
 		const { ampMode } = global.googlesitekit.admin;
-		const useSnippetSettings = global.googlesitekit.modules.analytics.settings.useSnippet;
+		const useSnippetSettings = getModulesData().analytics.settings.useSnippet;
 
 		return (
 			<div className="googlesitekit-setup-module__inputs googlesitekit-setup-module__inputs--multiline">
@@ -781,7 +782,7 @@ class AnalyticsSetup extends Component {
 		const enableProfileSelect = !! /^UA-/.test( selectedProperty.toString() );
 
 		const { ampMode } = global.googlesitekit.admin;
-		const { setupComplete } = global.googlesitekit.modules.analytics;
+		const { setupComplete } = getModulesData().analytics;
 
 		if ( isLoading ) {
 			return <ProgressBar />;

--- a/assets/js/modules/analytics/util/index.js
+++ b/assets/js/modules/analytics/util/index.js
@@ -19,7 +19,7 @@
 /**
  * External dependencies
  */
-import { changeToPercent } from 'GoogleUtil';
+import { changeToPercent, getModulesData } from 'GoogleUtil';
 import { each } from 'lodash';
 
 /**
@@ -476,7 +476,7 @@ export const getTopPagesReportDataDefaults = () => {
 		},
 	];
 
-	if ( global.googlesitekit.modules.analytics.settings.adsenseLinked ) {
+	if ( getModulesData().analytics.settings.adsenseLinked ) {
 		metrics.push(
 			{
 				expression: 'ga:adsenseRevenue',

--- a/assets/js/modules/optimize/index.js
+++ b/assets/js/modules/optimize/index.js
@@ -19,7 +19,7 @@
 /**
  * External dependencies
  */
-import { fillFilterWithComponent } from 'GoogleUtil';
+import { fillFilterWithComponent, getModulesData } from 'GoogleUtil';
 import OptimizeSetup from 'GoogleModules/optimize/setup';
 /**
  * WordPress dependencies
@@ -28,7 +28,8 @@ import { addFilter } from '@wordpress/hooks';
 import { __ } from '@wordpress/i18n';
 const slug = 'optimize';
 
-if ( global.googlesitekit.modules.optimize.active ) {
+const modulesData = getModulesData();
+if ( modulesData.optimize.active ) {
 	/**
 	 * Add components to the settings page.
 	 */

--- a/assets/js/modules/optimize/setup.js
+++ b/assets/js/modules/optimize/setup.js
@@ -29,6 +29,7 @@ import {
 	validateJSON,
 	validateOptimizeID,
 	toggleConfirmModuleSettings,
+	getModulesData,
 } from 'GoogleUtil';
 import classnames from 'classnames';
 
@@ -43,19 +44,21 @@ class OptimizeSetup extends Component {
 	constructor( props ) {
 		super( props );
 
+		const modulesData = getModulesData();
+
 		const {
 			optimizeID,
 			ampExperimentJSON,
-		} = global.googlesitekit.modules.optimize.settings;
+		} = modulesData.optimize.settings;
 
 		const {
 			settings: analyticsSettings,
-		} = global.googlesitekit.modules.analytics || {};
+		} = modulesData.analytics || {};
 
 		const {
 			active: gtmActive,
 			settings: gtmSettings,
-		} = global.googlesitekit.modules.tagmanager || {};
+		} = modulesData.tagmanager || {};
 
 		const analyticsUseSnippet = analyticsSettings ? analyticsSettings.useSnippet : false;
 		const gtmUseSnippet = gtmActive && gtmSettings ? gtmSettings.useSnippet : false;
@@ -144,7 +147,7 @@ class OptimizeSetup extends Component {
 				finishSetup();
 			}
 
-			global.googlesitekit.modules.optimize.settings.optimizeID = optimizeID;
+			getModulesData().optimize.settings.optimizeID = optimizeID;
 
 			if ( this._isMounted ) {
 				this.setState( {

--- a/assets/js/modules/pagespeed-insights/dashboard/dashboard-cta.js
+++ b/assets/js/modules/pagespeed-insights/dashboard/dashboard-cta.js
@@ -8,6 +8,7 @@ import {
 	activateOrDeactivateModule,
 	getReAuthURL,
 	showErrorNotification,
+	getModulesData,
 } from 'GoogleUtil';
 
 /**
@@ -19,7 +20,7 @@ const PageSpeedInsightsCTA = () => {
 	const {
 		active,
 		setupComplete,
-	} = global.googlesitekit.modules[ 'pagespeed-insights' ];
+	} = getModulesData()[ 'pagespeed-insights' ];
 
 	const { canManageOptions } = global.googlesitekit.permissions;
 

--- a/assets/js/modules/pagespeed-insights/index.js
+++ b/assets/js/modules/pagespeed-insights/index.js
@@ -33,13 +33,14 @@ import DashboardSpeed from './dashboard/dashboard-widget-speed';
 import PageSpeedInsightsDashboardWidgetHomepageSpeed from './dashboard/dashboard-widget-homepage-speed';
 import PageSpeedInsightsCTA from './dashboard/dashboard-cta';
 import { settingsDetails as SettingsDetails } from './settings';
+import { getModulesData } from 'GoogleUtil';
 
 const slug = 'pagespeed-insights';
 
 const {
 	active,
 	setupComplete,
-} = global.googlesitekit.modules[ slug ];
+} = getModulesData()[ slug ];
 
 if ( active && setupComplete ) {
 	const addDashboardSpeed = createAddToFilter( <DashboardSpeed /> );

--- a/assets/js/modules/search-console/dashboard-details/dashboard-details-widget-search-funnel.js
+++ b/assets/js/modules/search-console/dashboard-details/dashboard-details-widget-search-funnel.js
@@ -33,6 +33,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import DashboardSearchFunnelInner from '../dashboard/dashboard-widget-search-funnel-inner';
+import { getModulesData } from 'GoogleUtil';
 
 class DashboardDetailsSearchFunnel extends Component {
 	render() {
@@ -53,7 +54,7 @@ class DashboardDetailsSearchFunnel extends Component {
 							<div className="mdc-layout-grid__inner">
 								<DashboardSearchFunnelInner />
 								{ // Show the Analytics CTA if analytics is not enabled.
-									( ! global.googlesitekit.modules.analytics.active ) &&
+									( ! getModulesData().analytics.active ) &&
 									<div className="
 										mdc-layout-grid__cell
 										mdc-layout-grid__cell--span-4-phone

--- a/assets/js/modules/search-console/dashboard/dashboard-widget-search-funnel.js
+++ b/assets/js/modules/search-console/dashboard/dashboard-widget-search-funnel.js
@@ -17,10 +17,6 @@
  */
 
 /**
- * Internal dependencies
- */
-import DashboardSearchFunnelInner from './dashboard-widget-search-funnel-inner';
-/**
  * External dependencies
  */
 import Layout from 'GoogleComponents/layout/layout';
@@ -34,12 +30,19 @@ import classnames from 'classnames';
 import { Component, Fragment } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
+/**
+ * Internal dependencies
+ */
+import DashboardSearchFunnelInner from './dashboard-widget-search-funnel-inner';
+import { getModulesData } from 'GoogleUtil';
+
 class DashboardSearchFunnel extends Component {
 	render() {
+		const modulesData = getModulesData();
 		const { canManageOptions } = global.googlesitekit.permissions;
 
 		// Users without manage options capability will not see Setup CTA.
-		const wrapperCols = ! global.googlesitekit.modules.analytics.active && ! canManageOptions ? 6 : 12;
+		const wrapperCols = ! modulesData.analytics.active && ! canManageOptions ? 6 : 12;
 
 		return (
 			<Fragment>
@@ -61,7 +64,7 @@ class DashboardSearchFunnel extends Component {
 							<div className="mdc-layout-grid__inner">
 								<DashboardSearchFunnelInner />
 								{ // Show the Analytics CTA if analytics is not enabled.
-									( ! global.googlesitekit.modules.analytics.active ) &&
+									( ! modulesData.analytics.active ) &&
 									<div className="
 										mdc-layout-grid__cell
 										mdc-layout-grid__cell--span-4-phone

--- a/assets/js/modules/tagmanager/index.js
+++ b/assets/js/modules/tagmanager/index.js
@@ -19,7 +19,7 @@
 /**
  * External dependencies
  */
-import { fillFilterWithComponent } from 'GoogleUtil';
+import { fillFilterWithComponent, getModulesData } from 'GoogleUtil';
 import TagmanagerSetup from 'GoogleModules/tagmanager/setup';
 /**
  * WordPress dependencies
@@ -27,7 +27,7 @@ import TagmanagerSetup from 'GoogleModules/tagmanager/setup';
 import { addFilter } from '@wordpress/hooks';
 const slug = 'tagmanager';
 
-if ( global.googlesitekit.modules.tagmanager.active ) {
+if ( getModulesData().tagmanager.active ) {
 	/**
 	 * Add components to the settings page.
 	 */

--- a/assets/js/modules/tagmanager/setup.js
+++ b/assets/js/modules/tagmanager/setup.js
@@ -27,7 +27,7 @@ import ProgressBar from 'GoogleComponents/progress-bar';
 import { Select, Option } from 'SiteKitCore/material-components';
 import SvgIcon from 'GoogleUtil/svg-icon';
 import PropTypes from 'prop-types';
-import { getExistingTag, toggleConfirmModuleSettings } from 'GoogleUtil';
+import { getExistingTag, toggleConfirmModuleSettings, getModulesData } from 'GoogleUtil';
 import { get } from 'lodash';
 import classnames from 'classnames';
 /**
@@ -56,7 +56,7 @@ class TagmanagerSetup extends Component {
 		super( props );
 
 		const { ampEnabled, ampMode } = global.googlesitekit.admin;
-		const { settings } = global.googlesitekit.modules.tagmanager;
+		const { settings } = getModulesData().tagmanager;
 		const ampUsageContext = ampMode === 'primary' ? USAGE_CONTEXT_AMP : [ USAGE_CONTEXT_WEB, USAGE_CONTEXT_AMP ];
 
 		this.state = {
@@ -363,7 +363,7 @@ class TagmanagerSetup extends Component {
 				finishSetup();
 			}
 
-			global.googlesitekit.modules.tagmanager.settings = savedSettings;
+			getModulesData().tagmanager.settings = savedSettings;
 
 			this.setState( {
 				isSaving: false,
@@ -424,7 +424,7 @@ class TagmanagerSetup extends Component {
 	}
 
 	renderSettingsInfo() {
-		const { settings } = global.googlesitekit.modules.tagmanager;
+		const { settings } = getModulesData().tagmanager;
 		const {
 			ampEnabled,
 			isSecondaryAMP,

--- a/assets/js/util/index.js
+++ b/assets/js/util/index.js
@@ -353,22 +353,19 @@ export const getModulesData = ( _googlesitekit = global.googlesitekit ) => {
 		return {};
 	}
 
-	const modules = {};
-	Object.keys( modulesObj ).forEach( ( slug ) => {
+	return Object.keys( modulesObj ).reduce( ( acc, slug ) => {
 		if ( 'object' !== typeof modulesObj[ slug ] ) {
-			return;
+			return acc;
 		}
 		if (
 			'undefined' === typeof modulesObj[ slug ].slug ||
 			'undefined' === typeof modulesObj[ slug ].name ||
 			modulesObj[ slug ].slug !== slug
 		) {
-			return;
+			return acc;
 		}
-		modules[ slug ] = modulesObj[ slug ];
-	} );
-
-	return modules;
+		return { ...acc, [ slug ]: modulesObj[ slug ] };
+	}, {} );
 };
 
 /**

--- a/assets/js/util/index.test.js
+++ b/assets/js/util/index.test.js
@@ -1,0 +1,71 @@
+/**
+ * Utility functions tests.
+ *
+ * Site Kit by Google, Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import { getModulesData } from './index';
+
+describe( 'getModulesData', () => {
+	it( 'returns only properties that are module data', () => {
+		const _googlesitekit = {
+			modules: {
+				module1: {
+					slug: 'module1',
+					name: 'Module 1',
+					description: 'Module 1 description.',
+					active: false,
+				},
+				anotherModule: {
+					slug: 'anotherModule',
+					name: 'Another Module',
+					description: 'Another Module description.',
+					active: false,
+				},
+				anAPIFunction: () => true,
+			},
+		};
+		expect( getModulesData( _googlesitekit ) ).toEqual( {
+			module1: _googlesitekit.modules.module1,
+			anotherModule: _googlesitekit.modules.anotherModule,
+		} );
+	} );
+
+	it( 'passes through module data to directly modify module objects', () => {
+		const _googlesitekit = {
+			modules: {
+				module1: {
+					slug: 'module1',
+					name: 'Module 1',
+					description: 'Module 1 description.',
+					active: false,
+				},
+				anotherModule: {
+					slug: 'anotherModule',
+					name: 'Another Module',
+					description: 'Another Module description.',
+					active: false,
+				},
+				anAPIFunction: () => true,
+			},
+		};
+		const modulesData = getModulesData( _googlesitekit );
+		modulesData.module1.active = true;
+		expect( _googlesitekit.modules.module1.active ).toEqual( true );
+	} );
+} );

--- a/assets/js/util/test/getReAuthUrl.js
+++ b/assets/js/util/test/getReAuthUrl.js
@@ -11,9 +11,13 @@ const createSiteKit = () => {
 		},
 		modules: {
 			'search-console': {
+				slug: 'search-console',
+				name: 'Search Console',
 				screenID: 'googlesitekit-module-search-console',
 			},
 			'pagespeed-insights': {
+				slug: 'pagespeed-insights',
+				name: 'PageSpeed Insights',
 				screenID: 'googlesitekit-module-pagespeed-insights',
 			},
 		},

--- a/assets/js/util/test/toggleConfirmModuleSettings.js
+++ b/assets/js/util/test/toggleConfirmModuleSettings.js
@@ -8,6 +8,8 @@ describe( 'toggleConfirmModuleSettings', () => {
 		const googlesitekit = {
 			modules: {
 				analytics: {
+					slug: 'analytics',
+					name: 'Analytics',
 					settings: { accountID: '12345678' },
 					setupComplete: true,
 					confirm: true,
@@ -34,6 +36,8 @@ describe( 'toggleConfirmModuleSettings', () => {
 		const googlesitekit = {
 			modules: {
 				analytics: {
+					slug: 'analytics',
+					name: 'Analytics',
 					settings: { accountID: '12345678' },
 					setupComplete: true,
 					confirm: true,
@@ -60,11 +64,15 @@ describe( 'toggleConfirmModuleSettings', () => {
 		const googlesitekit = {
 			modules: {
 				adsense: {
+					slug: 'adsense',
+					name: 'AdSense',
 					settings: { accountID: '99999999' },
 					setupComplete: false,
 					confirm: true,
 				},
 				analytics: {
+					slug: 'analytics',
+					name: 'Analytics',
 					settings: { accountID: '12345678' },
 					setupComplete: true,
 					confirm: true,


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #1335

## Relevant technical choices

* In some places the `googlesitekit.modules` object is assumed to be a list of only the (legacy) module objects, so running module-specific functions on the new API functions would result in an error.
* This PR abstracts access away into a `getModulesData()` utility function.
* In that function it only exposes the parts of `googlesitekit.modules` that are actually module objects.
* Module objects are still passed through directly (i.e. not as `module = { ...module }`), which is necessary because we set some properties on the global... which yeah is terrible, but we'll need to maintain these bad parts, knowing they'll be phased out.
* This PR also paves a way for us to at some point sooner than later actually rename the global properties for legacy data, to at least distinguish them further (e.g. the legacy `googlesitekit.modules` could become `googlesitekit._modulesData`).

## Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
