### PR TITLE
Build action: pull immediately before pushing.

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -77,6 +77,7 @@ jobs:
           git add .
           git status
           git commit -m "Build and publish ${{ github.ref }}"
+          git pull --no-edit --quiet
           git push origin master
         env:
           GIT_AUTHOR_EMAIL: ${{ github.actor }}@users.noreply.github.com


### PR DESCRIPTION
## Summary

In the build action, add a pull command immediately before pushing.

Fix an race condition where the push would fail if the wiki repository had changed since the checkout (for example because another build completed)

Addresses issue #1351

## Relevant technical choices

* Includes `-no-edit` to avoid opening a confirmation editor.
* Includes `--quiet` to avoid warnings about `--no-edit`.

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
