### PR TITLE
Fix redundant batch requests

### DIFF
--- a/assets/js/components/analytics-inactive-cta.js
+++ b/assets/js/components/analytics-inactive-cta.js
@@ -32,10 +32,10 @@ import { __ } from '@wordpress/i18n';
  */
 import {
 	activateOrDeactivateModule,
-	refreshAuthentication,
 	getReAuthURL,
 	showErrorNotification,
 } from '../util';
+import { refreshAuthentication } from '../util/refresh-authentication';
 import data from './data';
 import CTA from './notifications/cta';
 import GenericError from './notifications/generic-error';

--- a/assets/js/components/data/index.js
+++ b/assets/js/components/data/index.js
@@ -25,7 +25,7 @@ import { cloneDeep, each, intersection, isEqual, sortBy } from 'lodash';
  */
 import apiFetch from '@wordpress/api-fetch';
 import { addQueryArgs } from '@wordpress/url';
-import { addAction, applyFilters, doAction, addFilter, removeFilter } from '@wordpress/hooks';
+import { addAction, applyFilters, doAction, addFilter, removeFilter, hasAction } from '@wordpress/hooks';
 
 /**
  * Internal dependencies
@@ -78,14 +78,6 @@ const requestWithDateRange = ( originalRequest, dateRange ) => {
 const dataAPI = {
 
 	maxRequests: 10,
-
-	init() {
-		addAction(
-			'googlesitekit.moduleLoaded',
-			'googlesitekit.collectModuleListingData',
-			this.collectModuleData.bind( this )
-		);
-	},
 
 	/**
 	 * Gets data for multiple requests from the cache in a single batch process.
@@ -516,6 +508,12 @@ const dataAPI = {
 };
 
 // Init data module once.
-dataAPI.init();
+if ( ! hasAction( 'googlesitekit.moduleLoaded', 'googlesitekit.collectModuleData' ) ) {
+	addAction(
+		'googlesitekit.moduleLoaded',
+		'googlesitekit.collectModuleData',
+		dataAPI.collectModuleData.bind( dataAPI )
+	);
+}
 
 export default dataAPI;

--- a/assets/js/components/modules-list.js
+++ b/assets/js/components/modules-list.js
@@ -32,13 +32,13 @@ import { __, sprintf } from '@wordpress/i18n';
  * Internal dependencies
  */
 import {
-	refreshAuthentication,
 	getReAuthURL,
 	activateOrDeactivateModule,
 	showErrorNotification,
 	moduleIcon,
 	getModulesData,
 } from '../util';
+import { refreshAuthentication } from '../util/refresh-authentication';
 import Link from './link';
 import data from '../components/data';
 import GenericError from './notifications/generic-error';

--- a/assets/js/components/settings/settings-module.js
+++ b/assets/js/components/settings/settings-module.js
@@ -37,12 +37,12 @@ import { applyFilters } from '@wordpress/hooks';
 import SvgIcon from '../../util/svg-icon';
 import {
 	activateOrDeactivateModule,
-	refreshAuthentication,
 	getReAuthURL,
 	moduleIcon,
 	showErrorNotification,
 	getModulesData,
 } from '../../util';
+import { refreshAuthentication } from '../../util/refresh-authentication';
 import Link from '../../components/link';
 import Button from '../../components/button';
 import data, { TYPE_MODULES } from '../../components/data';

--- a/assets/js/components/setup-module.js
+++ b/assets/js/components/setup-module.js
@@ -34,11 +34,11 @@ import { applyFilters } from '@wordpress/hooks';
  */
 import {
 	activateOrDeactivateModule,
-	refreshAuthentication,
 	getReAuthURL,
 	showErrorNotification,
 	moduleIcon,
 } from '../util';
+import { refreshAuthentication } from '../util/refresh-authentication';
 import data from '../components/data';
 import Spinner from '../components/spinner';
 import Link from '../components/link';

--- a/assets/js/components/setup/compatibility-checks.js
+++ b/assets/js/components/setup/compatibility-checks.js
@@ -40,10 +40,6 @@ import { getExistingTag } from '../../util';
 import data, { TYPE_CORE } from '../data';
 import Link from '../link';
 
-export const tagMatchers = [
-	/<meta name="googlesitekit-setup" content="([a-z0-9-]+)"/,
-];
-
 const ERROR_INVALID_HOSTNAME = 'invalid_hostname';
 const ERROR_FETCH_FAIL = 'tag_fetch_failed';
 const ERROR_TOKEN_MISMATCH = 'setup_token_mismatch';

--- a/assets/js/components/setup/tag-matchers.js
+++ b/assets/js/components/setup/tag-matchers.js
@@ -1,0 +1,21 @@
+/**
+ * Setup Tag Matchers.
+ *
+ * Site Kit by Google, Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export default [
+	/<meta name="googlesitekit-setup" content="([a-z0-9-]+)"/,
+];

--- a/assets/js/util/index.js
+++ b/assets/js/util/index.js
@@ -46,7 +46,7 @@ import { addQueryArgs, getQueryString } from '@wordpress/url';
  * Internal dependencies
  */
 import SvgIcon from './svg-icon';
-import { tagMatchers as setupTagMatchers } from '../components/setup/compatibility-checks';
+import { default as setupTagMatchers } from '../components/setup/tag-matchers';
 import { default as adsenseTagMatchers } from '../modules/adsense/util/tagMatchers';
 import { default as analyticsTagMatchers } from '../modules/analytics/util/tagMatchers';
 import { tagMatchers as tagmanagerTagMatchers } from '../modules/tagmanager/util';

--- a/assets/js/util/index.js
+++ b/assets/js/util/index.js
@@ -51,7 +51,6 @@ import { default as adsenseTagMatchers } from '../modules/adsense/util/tagMatche
 import { default as analyticsTagMatchers } from '../modules/analytics/util/tagMatchers';
 import { tagMatchers as tagmanagerTagMatchers } from '../modules/tagmanager/util';
 import { trackEvent } from './tracking';
-import data, { TYPE_CORE } from '../components/data';
 export { trackEvent };
 export { SvgIcon };
 export * from './sanitize';
@@ -345,24 +344,6 @@ export const extractForSparkline = ( rowData, column ) => {
 			row[ column ] || ( 0 === i ? '' : 0 ), // the data for the sparkline.
 		];
 	} );
-};
-
-export const refreshAuthentication = async () => {
-	try {
-		const response = await data.get( TYPE_CORE, 'user', 'authentication' );
-
-		const requiredAndGrantedScopes = response.grantedScopes.filter( ( scope ) => {
-			return -1 !== response.requiredScopes.indexOf( scope );
-		} );
-
-		// We should really be using state management. This is terrible.
-		global.googlesitekit.setup = global.googlesitekit.setup || {};
-		global.googlesitekit.setup.isAuthenticated = response.isAuthenticated;
-		global.googlesitekit.setup.requiredScopes = response.requiredScopes;
-		global.googlesitekit.setup.grantedScopes = response.grantedScopes;
-		global.googlesitekit.setup.needReauthenticate = requiredAndGrantedScopes.length < response.requiredScopes.length;
-	} catch ( e ) { // eslint-disable-line no-empty
-	}
 };
 
 /**

--- a/assets/js/util/refresh-authentication.js
+++ b/assets/js/util/refresh-authentication.js
@@ -1,0 +1,40 @@
+/**
+ * Refresh Authentication utility.
+ *
+ * Site Kit by Google, Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import data, { TYPE_CORE } from '../components/data';
+
+export const refreshAuthentication = async () => {
+	try {
+		const response = await data.get( TYPE_CORE, 'user', 'authentication' );
+
+		const requiredAndGrantedScopes = response.grantedScopes.filter( ( scope ) => {
+			return -1 !== response.requiredScopes.indexOf( scope );
+		} );
+
+		// We should really be using state management. This is terrible.
+		global.googlesitekit.setup = global.googlesitekit.setup || {};
+		global.googlesitekit.setup.isAuthenticated = response.isAuthenticated;
+		global.googlesitekit.setup.requiredScopes = response.requiredScopes;
+		global.googlesitekit.setup.grantedScopes = response.grantedScopes;
+		global.googlesitekit.setup.needReauthenticate = requiredAndGrantedScopes.length < response.requiredScopes.length;
+	} catch ( e ) { // eslint-disable-line no-empty
+	}
+};


### PR DESCRIPTION
## Summary

Addresses issue #1406

## Relevant technical choices

* Moved `refreshAuthentication` out of main `util` as the only function that used `dataAPI`
* Moved setup tag matchers to dedicated module (like others) to decouple the `CompatibilityChecks` component from main `util` (also imports `data`)
* `dataAPI` is only enqueued from screen bundles now:
    - dashboard
    - dashboard-details
    - module
    - settings
    - adminbar
* NOT included in
    - datastore entrypoints
    - activation
    - splash
    - admin
    - modules-analytics
    - modules
    - ads

## Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
