### PR TITLE
Added filter to remove _gl paremeter from the url

### DIFF
--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -178,6 +178,15 @@ final class Plugin {
 			-999
 		);
 
+		// Register _gl parameter to be removed from the URL.
+		add_filter(
+			'removable_query_args',
+			function ( $args ) {
+				$args[] = '_gl';
+				return $args;
+			}
+		);
+
 		( new Core\Util\Activation( $this->context, $options, $assets ) )->register();
 		( new Core\Util\Migration_1_3_0( $this->context, $options ) )->register();
 		( new Core\Util\Reset( $this->context ) )->register();


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #1275 

## Relevant technical choices

<!-- Please describe your changes. -->

## Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
