### PR TITLE
Add DisplaySetting component.

### DIFF
--- a/assets/js/components/display-setting.js
+++ b/assets/js/components/display-setting.js
@@ -1,0 +1,29 @@
+/**
+ * DisplaySetting component.
+ *
+ * Google Site Kit, Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import PropTypes from 'prop-types';
+
+const DisplaySetting = ( { value } ) => {
+	return value || '\u00A0';
+};
+
+DisplaySetting.propTypes = {
+	value: PropTypes.oneOfType( [ PropTypes.string, PropTypes.bool, PropTypes.number ] ),
+};
+
+export default DisplaySetting;

--- a/assets/js/components/display-setting.test.js
+++ b/assets/js/components/display-setting.test.js
@@ -1,0 +1,55 @@
+/**
+ * DisplaySetting tests.
+ *
+ * Site Kit by Google, Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import DisplaySetting from './display-setting';
+import { render } from '../../../tests/js/test-utils';
+
+describe( 'DisplaySetting', () => {
+	it( 'returns non-empty string unchanged', () => {
+		const { container } = render( <DisplaySetting value="Test Value" /> );
+		expect( container.textContent ).toBe( 'Test Value' );
+	} );
+
+	it( 'returns unicode value for &nbsp; if no value prop provided', () => {
+		const { container } = render( <DisplaySetting /> );
+		expect( container.textContent ).toBe( '\u00A0' );
+	} );
+
+	it( 'returns unicode value for &nbsp; if value prop is undefined', () => {
+		const { container } = render( <DisplaySetting value={ undefined } /> );
+		expect( container.textContent ).toBe( '\u00A0' );
+	} );
+
+	it( 'returns unicode value for &nbsp; if value prop is null', () => {
+		const { container } = render( <DisplaySetting value={ null } /> );
+		expect( container.textContent ).toBe( '\u00A0' );
+	} );
+
+	it( 'returns unicode value for &nbsp; if value prop is false', () => {
+		const { container } = render( <DisplaySetting value={ false } /> );
+		expect( container.textContent ).toBe( '\u00A0' );
+	} );
+
+	it( 'returns unicode value for &nbsp; if value prop is empty string', () => {
+		const { container } = render( <DisplaySetting value={ '' } /> );
+		expect( container.textContent ).toBe( '\u00A0' );
+	} );
+} );

--- a/assets/js/components/display-setting.test.js
+++ b/assets/js/components/display-setting.test.js
@@ -25,31 +25,31 @@ import { render } from '../../../tests/js/test-utils';
 describe( 'DisplaySetting', () => {
 	it( 'returns non-empty string unchanged', () => {
 		const { container } = render( <DisplaySetting value="Test Value" /> );
-		expect( container.textContent ).toBe( 'Test Value' );
+		expect( container ).toHaveTextContent( 'Test Value' );
 	} );
 
 	it( 'returns unicode value for &nbsp; if no value prop provided', () => {
 		const { container } = render( <DisplaySetting /> );
-		expect( container.textContent ).toBe( '\u00A0' );
+		expect( container.textContent ).toBe( '\u00A0' ); // Use toBe() matcher instead of toHaveTextContent() to preserve &nbsp;
 	} );
 
 	it( 'returns unicode value for &nbsp; if value prop is undefined', () => {
 		const { container } = render( <DisplaySetting value={ undefined } /> );
-		expect( container.textContent ).toBe( '\u00A0' );
+		expect( container.textContent ).toBe( '\u00A0' ); // Use toBe() matcher instead of toHaveTextContent() to preserve &nbsp;
 	} );
 
 	it( 'returns unicode value for &nbsp; if value prop is null', () => {
 		const { container } = render( <DisplaySetting value={ null } /> );
-		expect( container.textContent ).toBe( '\u00A0' );
+		expect( container.textContent ).toBe( '\u00A0' ); // Use toBe() matcher instead of toHaveTextContent() to preserve &nbsp;
 	} );
 
 	it( 'returns unicode value for &nbsp; if value prop is false', () => {
 		const { container } = render( <DisplaySetting value={ false } /> );
-		expect( container.textContent ).toBe( '\u00A0' );
+		expect( container.textContent ).toBe( '\u00A0' ); // Use toBe() matcher instead of toHaveTextContent() to preserve &nbsp;
 	} );
 
 	it( 'returns unicode value for &nbsp; if value prop is empty string', () => {
 		const { container } = render( <DisplaySetting value={ '' } /> );
-		expect( container.textContent ).toBe( '\u00A0' );
+		expect( container.textContent ).toBe( '\u00A0' ); // Use toBe() matcher instead of toHaveTextContent() to preserve &nbsp;
 	} );
 } );

--- a/assets/js/modules/tagmanager/setup.js
+++ b/assets/js/modules/tagmanager/setup.js
@@ -42,6 +42,7 @@ import {
 } from './util';
 import { Select, Option } from '../../material-components';
 import Button from '../../components/button';
+import DisplaySetting from '../../components/display-setting';
 import Link from '../../components/link';
 import Switch from '../../components/switch';
 import data, { TYPE_MODULES } from '../../components/data';
@@ -449,7 +450,7 @@ class TagmanagerSetup extends Component {
 							{ __( 'Account', 'google-site-kit' ) }
 						</p>
 						<h5 className="googlesitekit-settings-module__meta-item-data">
-							{ accountID || false }
+							<DisplaySetting value={ accountID } />
 						</h5>
 					</div>
 
@@ -460,7 +461,7 @@ class TagmanagerSetup extends Component {
 								{ ! ampEnabled && __( 'Container ID', 'google-site-kit' ) }
 							</p>
 							<h5 className="googlesitekit-settings-module__meta-item-data">
-								{ settings.containerID || false }
+								<DisplaySetting value={ settings.containerID } />
 							</h5>
 						</div>
 					) }
@@ -472,7 +473,7 @@ class TagmanagerSetup extends Component {
 								{ ! isSecondaryAMP && __( 'Container ID', 'google-site-kit' ) }
 							</p>
 							<h5 className="googlesitekit-settings-module__meta-item-data">
-								{ settings.ampContainerID || false }
+								<DisplaySetting value={ settings.ampContainerID } />
 							</h5>
 						</div>
 					) }


### PR DESCRIPTION
## Summary

Addresses issue [#1296](https://github.com/google/site-kit-wp/issues/1296)

## Relevant technical choices

Adds a DisplaySetting component which takes `value` as a prop, returning the value if it is valid, or `"\u00A0"` if it is falsy. The component is used in `TagmanagerSetup` to display setting values.

## Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
