### PR TITLE
Fix reauth notice when no Analytics account

### DIFF
--- a/includes/Modules/Analytics.php
+++ b/includes/Modules/Analytics.php
@@ -519,9 +519,9 @@ final class Analytics extends Module
 					return true;
 				};
 			case 'GET:accounts-properties-profiles':
-				$restore = $this->with_client_defer( false );
+				return function () use ( $data ) {
+					$restore_defer = $this->with_client_defer( false );
 
-				return function () use ( $data, $restore ) {
 					try {
 						return $this->get_service( 'analytics' )->management_accounts->listManagementAccounts();
 					} catch ( Google_Service_Exception $exception ) {
@@ -534,7 +534,7 @@ final class Analytics extends Module
 						// If any other exception was caught, re-throw it.
 						throw $exception;
 					} finally {
-						$restore(); // Will be called before returning in all cases.
+						$restore_defer(); // Will be called before returning in all cases.
 					}
 				};
 			case 'GET:anonymize-ip':

--- a/includes/Modules/Analytics.php
+++ b/includes/Modules/Analytics.php
@@ -43,6 +43,7 @@ use Google\Site_Kit_Dependencies\Google_Service_Analytics_Account;
 use Google\Site_Kit_Dependencies\Google_Service_Analytics_Webproperties;
 use Google\Site_Kit_Dependencies\Google_Service_Analytics_Webproperty;
 use Google\Site_Kit_Dependencies\Google_Service_Analytics_Profile;
+use Google\Site_Kit_Dependencies\Google_Service_Exception;
 use Google\Site_Kit_Dependencies\Psr\Http\Message\RequestInterface;
 use WP_Error;
 use Exception;
@@ -518,7 +519,24 @@ final class Analytics extends Module
 					return true;
 				};
 			case 'GET:accounts-properties-profiles':
-				return $this->get_service( 'analytics' )->management_accounts->listManagementAccounts();
+				$restore = $this->with_client_defer( false );
+
+				return function () use ( $data, $restore ) {
+					try {
+						return $this->get_service( 'analytics' )->management_accounts->listManagementAccounts();
+					} catch ( Google_Service_Exception $exception ) {
+						// The exception message is a JSON object of all errors, so we'll convert it to our WP Error first.
+						$wp_error = $this->exception_to_error( $exception, $data->datapoint );
+						// Unfortunately there isn't a better way to identify this without checking the message.
+						if ( 'User does not have any Google Analytics account.' === $wp_error->get_error_message() ) {
+							return new Google_Service_Analytics_Accounts();
+						}
+						// If any other exception was caught, re-throw it.
+						throw $exception;
+					} finally {
+						$restore(); // Will be called before returning in all cases.
+					}
+				};
 			case 'GET:anonymize-ip':
 				return function() {
 					$option = $this->get_settings()->get();
@@ -898,6 +916,10 @@ final class Analytics extends Module
 					'properties' => array(),
 					'profiles'   => array(),
 				);
+
+				if ( empty( $accounts ) ) {
+					return array_merge( compact( 'accounts' ), $properties_profiles );
+				}
 
 				if ( ! empty( $data['existingAccountID'] ) && ! empty( $data['existingPropertyID'] ) ) {
 					// If there is an existing tag, pass it through to ensure only the existing tag is matched.

--- a/tests/e2e/plugins/module-setup-analytics-no-account.php
+++ b/tests/e2e/plugins/module-setup-analytics-no-account.php
@@ -15,7 +15,6 @@
 namespace Google\Site_Kit\Tests\E2E\Modules\AnalyticsNoAccount;
 
 use Google\Site_Kit\Core\REST_API\REST_Routes;
-use WP_Error;
 
 add_action(
 	'rest_api_init',
@@ -27,16 +26,10 @@ add_action(
 			array(
 				'methods'  => 'GET',
 				'callback' => function () {
-					/**
-					 * Returned by \Google\Site_Kit\Core\Modules\Module::exception_to_error
-					 */
-					return new WP_Error(
-						403,
-						'User does not have any Google Analytics account.',
-						array(
-							'status' => 500,
-							'reason' => 'insufficientPermissions',
-						)
+					return array(
+						'accounts'   => array(),
+						'properties' => array(),
+						'profiles'   => array(),
 					);
 				},
 			),
@@ -60,5 +53,5 @@ add_action(
 		);
 
 	},
-	0 
+	0
 );


### PR DESCRIPTION
## Summary

Addresses issue #1368

## Relevant technical choices

* Updated datapoint to return successful response with empty arrays for each if no accounts
* No changes necessary in current Analytics `setup.js` component

![image](https://user-images.githubusercontent.com/1621608/79979249-e5534300-84a9-11ea-85a3-a8f68938b74d.png)

![image](https://user-images.githubusercontent.com/1621608/79979251-e7b59d00-84a9-11ea-9a15-ec5d51325e3f.png)

![image](https://user-images.githubusercontent.com/1621608/79979257-e8e6ca00-84a9-11ea-9ca1-1bba42602e52.png)


## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
