### PR TITLE
Bug/1099 use view window mode

### DIFF
--- a/assets/js/modules/analytics/dashboard/dashboard-widget-sitestats.js
+++ b/assets/js/modules/analytics/dashboard/dashboard-widget-sitestats.js
@@ -73,6 +73,7 @@ class AnalyticsDashboardWidgetSiteStats extends Component {
 					color: '#616161',
 					fontSize: 12,
 				},
+				viewWindowMode: 'pretty',
 			},
 			vAxis: {
 				gridlines: {


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #1099 

## Relevant technical choices

This PR deviates from the IB to use the `viewWindowMode` instead of passing the `minValue`, `maxValue` properties.

## Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
