### PR TITLE
Fix/1101 submit changes error handling and tests

### DIFF
--- a/assets/js/modules/analytics/datastore/accounts.test.js
+++ b/assets/js/modules/analytics/datastore/accounts.test.js
@@ -46,8 +46,9 @@ describe( 'modules/analytics accounts', () => {
 	beforeEach( () => {
 		registry = createTestRegistry();
 		store = registry.stores[ STORE_NAME ].store;
-
 		apiFetchSpy = jest.spyOn( { apiFetch }, 'apiFetch' );
+		// Receive empty settings to prevent unexpected fetch by resolver.
+		registry.dispatch( STORE_NAME ).receiveSettings( {} );
 	} );
 
 	afterAll( () => {
@@ -108,7 +109,6 @@ describe( 'modules/analytics accounts', () => {
 	describe( 'selectors', () => {
 		describe( 'getAccounts', () => {
 			it( 'uses a resolver to make a network request', async () => {
-				registry.dispatch( STORE_NAME ).setSettings( {} );
 				registry.dispatch( STORE_NAME ).receiveExistingTag( null );
 				fetch
 					.doMockOnceIf(
@@ -146,7 +146,6 @@ describe( 'modules/analytics accounts', () => {
 			} );
 
 			it( 'does not make a network request if accounts are already present', async () => {
-				registry.dispatch( STORE_NAME ).setSettings( {} );
 				registry.dispatch( STORE_NAME ).receiveAccounts( fixtures.accountsPropertiesProfiles.accounts );
 
 				const accounts = registry.select( STORE_NAME ).getAccounts();
@@ -161,7 +160,6 @@ describe( 'modules/analytics accounts', () => {
 			} );
 
 			it( 'does not make a network request if accounts exist but are empty (this is a valid state)', async () => {
-				registry.dispatch( STORE_NAME ).setSettings( {} );
 				registry.dispatch( STORE_NAME ).receiveAccounts( [] );
 
 				const accounts = registry.select( STORE_NAME ).getAccounts();
@@ -191,7 +189,7 @@ describe( 'modules/analytics accounts', () => {
 					);
 
 				registry.dispatch( STORE_NAME ).receiveExistingTag( null );
-				registry.dispatch( STORE_NAME ).setSettings( {} );
+
 				muteConsole( 'error' );
 				registry.select( STORE_NAME ).getAccounts();
 				await subscribeUntil( registry,
@@ -215,7 +213,6 @@ describe( 'modules/analytics accounts', () => {
 					propertyID: existingPropertyID,
 					permission: true,
 				} );
-				registry.dispatch( STORE_NAME ).setSettings( {} );
 
 				fetch
 					.doMockOnceIf(
@@ -260,7 +257,6 @@ describe( 'modules/analytics accounts', () => {
 					matchedProperty,
 				};
 
-				registry.dispatch( STORE_NAME ).setSettings( {} );
 				registry.dispatch( STORE_NAME ).receiveExistingTag( null );
 
 				fetch

--- a/assets/js/modules/analytics/datastore/accounts.test.js
+++ b/assets/js/modules/analytics/datastore/accounts.test.js
@@ -78,11 +78,20 @@ describe( 'modules/analytics accounts', () => {
 
 				registry.dispatch( STORE_NAME ).resetAccounts();
 
+				// getAccounts() will trigger a request again.
+				fetch
+					.doMockOnceIf(
+						/^\/google-site-kit\/v1\/modules\/analytics\/data\/accounts-properties-profiles/
+					)
+					.mockResponse(
+						JSON.stringify( fixtures.accountsPropertiesProfiles ),
+						{ status: 200 }
+					);
+
 				expect( registry.select( STORE_NAME ).getAccountID() ).toStrictEqual( undefined );
 				expect( registry.select( STORE_NAME ).getPropertyID() ).toStrictEqual( undefined );
 				expect( registry.select( STORE_NAME ).getInternalWebPropertyID() ).toStrictEqual( undefined );
 				expect( registry.select( STORE_NAME ).getProfileID() ).toStrictEqual( undefined );
-				muteConsole( 'error' ); // getAccounts() will trigger a request again.
 				expect( registry.select( STORE_NAME ).getAccounts() ).toStrictEqual( undefined );
 				// Other settings are left untouched.
 				expect( registry.select( STORE_NAME ).getUseSnippet() ).toStrictEqual( true );
@@ -136,7 +145,6 @@ describe( 'modules/analytics accounts', () => {
 
 				// Properties and profiles should also have been received by
 				// this action.
-				muteConsole( 'error', 2 );
 				const properties = registry.select( STORE_NAME ).getProperties( accountID );
 				const profiles = registry.select( STORE_NAME ).getProfiles( propertyID );
 

--- a/assets/js/modules/analytics/datastore/profiles.test.js
+++ b/assets/js/modules/analytics/datastore/profiles.test.js
@@ -86,7 +86,6 @@ describe( 'modules/analytics profiles', () => {
 					}
 				);
 
-				muteConsole( 'error' );
 				await subscribeUntil( registry,
 					() => (
 						registry.select( STORE_NAME ).getProfiles( propertyID )

--- a/assets/js/modules/analytics/datastore/profiles.test.js
+++ b/assets/js/modules/analytics/datastore/profiles.test.js
@@ -48,6 +48,8 @@ describe( 'modules/analytics profiles', () => {
 		store = registry.stores[ STORE_NAME ].store;
 
 		apiFetchSpy = jest.spyOn( { apiFetch }, 'apiFetch' );
+		// Receive empty settings to prevent unexpected fetch by resolver.
+		registry.dispatch( STORE_NAME ).receiveSettings( {} );
 	} );
 
 	afterAll( () => {
@@ -142,10 +144,15 @@ describe( 'modules/analytics profiles', () => {
 				expect( registry.select( STORE_NAME ).getError() ).toMatchObject( response );
 
 				// Ignore the request fired by the `getProperties` selector.
-				muteConsole( 'error' );
+				fetch
+					.doMockIf(
+						/^\/google-site-kit\/v1\/modules\/analytics\/data\/properties-profiles/
+					)
+					.mockResponse( JSON.stringify( {} ) );
+
 				const properties = registry.select( STORE_NAME ).getProperties( accountID );
-				// No properties should have been added yet, as the property creation
-				// failed.
+
+				// No properties should have been added yet, as the property creation failed.
 				expect( properties ).toEqual( undefined );
 			} );
 		} );

--- a/assets/js/modules/analytics/datastore/profiles.test.js
+++ b/assets/js/modules/analytics/datastore/profiles.test.js
@@ -161,7 +161,6 @@ describe( 'modules/analytics profiles', () => {
 	describe( 'selectors', () => {
 		describe( 'getProfiles', () => {
 			it( 'uses a resolver to make a network request', async () => {
-				registry.dispatch( STORE_NAME ).setSettings( {} );
 				fetch
 					.doMockOnceIf(
 						/^\/google-site-kit\/v1\/modules\/analytics\/data\/profiles/
@@ -199,7 +198,6 @@ describe( 'modules/analytics profiles', () => {
 			} );
 
 			it( 'does not make a network request if profiles for this account + property are already present', async () => {
-				registry.dispatch( STORE_NAME ).setSettings( {} );
 				const testPropertyID = fixtures.profiles[ 0 ].webPropertyId; // Capitalization rule exception: `webPropertyId` is a property of an API returned value.
 
 				// Load data into this store so there are matches for the data we're about to select,
@@ -219,7 +217,6 @@ describe( 'modules/analytics profiles', () => {
 			} );
 
 			it( 'dispatches an error if the request fails', async () => {
-				registry.dispatch( STORE_NAME ).setSettings( {} );
 				const response = {
 					code: 'internal_server_error',
 					message: 'Internal server error',

--- a/assets/js/modules/analytics/datastore/properties.js
+++ b/assets/js/modules/analytics/datastore/properties.js
@@ -415,9 +415,12 @@ export const resolvers = {
 
 		// Only fetch properties if there are none in the store for the given account.
 		if ( ! properties ) {
-			const { response } = yield actions.fetchPropertiesProfiles( accountID );
+			const { response, error } = yield actions.fetchPropertiesProfiles( accountID );
 			if ( response && response.properties ) {
 				( { properties } = response );
+			}
+			if ( error ) {
+				return;
 			}
 		}
 

--- a/assets/js/modules/analytics/datastore/properties.test.js
+++ b/assets/js/modules/analytics/datastore/properties.test.js
@@ -46,8 +46,9 @@ describe( 'modules/analytics properties', () => {
 	beforeEach( () => {
 		registry = createTestRegistry();
 		store = registry.stores[ STORE_NAME ].store;
-
 		apiFetchSpy = jest.spyOn( { apiFetch }, 'apiFetch' );
+		// Receive empty settings to prevent unexpected fetch by resolver.
+		registry.dispatch( STORE_NAME ).receiveSettings( {} );
 	} );
 
 	afterAll( () => {
@@ -89,6 +90,14 @@ describe( 'modules/analytics properties', () => {
 
 			it( 'sets isDoingCreateProperty ', async () => {
 				const accountID = fixtures.createProperty.accountId; // Capitalization rule exception: `accountId` is a property of an API returned value.
+				fetch
+					.doMockIf(
+						/^\/google-site-kit\/v1\/modules\/analytics\/data\/create-property/
+					)
+					.mockResponse(
+						JSON.stringify( fixtures.createProperty ),
+						{ status: 200 }
+					);
 
 				registry.dispatch( STORE_NAME ).createProperty( accountID );
 				expect( registry.select( STORE_NAME ).isDoingCreateProperty( accountID ) ).toEqual( true );
@@ -122,8 +131,12 @@ describe( 'modules/analytics properties', () => {
 
 				expect( registry.select( STORE_NAME ).getError() ).toMatchObject( response );
 
-				// Ignore the request fired by the `getProperties` selector.
-				muteConsole( 'error' );
+				fetch
+					.doMockIf(
+						/^\/google-site-kit\/v1\/modules\/analytics\/data\/properties-profiles/
+					)
+					.mockResponse( JSON.stringify( fixtures.propertiesProfiles ) );
+
 				const properties = registry.select( STORE_NAME ).getProperties( accountID );
 				// No properties should have been added yet, as the property creation
 				// failed.
@@ -146,7 +159,7 @@ describe( 'modules/analytics properties', () => {
 
 				const accountID = fixtures.propertiesProfiles.properties[ 0 ].accountId; // Capitalization rule exception: `accountId` is a property of an API returned value.
 				const propertyID = fixtures.propertiesProfiles.profiles[ 0 ].webPropertyId; // Capitalization rule exception: `webPropertyId` is a property of an API returned value.
-				registry.dispatch( STORE_NAME ).setSettings( {} );
+
 				const initialProperties = registry.select( STORE_NAME ).getProperties( accountID );
 
 				// Ensure the proper parameters were passed.
@@ -166,7 +179,6 @@ describe( 'modules/analytics properties', () => {
 				expect( fetch ).toHaveBeenCalledTimes( 1 );
 
 				// Profiles should also have been received by this action.
-				muteConsole( 'error' );
 				const profiles = registry.select( STORE_NAME ).getProfiles( propertyID );
 
 				expect( properties ).toEqual( fixtures.propertiesProfiles.properties );
@@ -199,7 +211,6 @@ describe( 'modules/analytics properties', () => {
 			} );
 
 			it( 'dispatches an error if the request fails', async () => {
-				registry.dispatch( STORE_NAME ).setSettings( {} );
 				const response = {
 					code: 'internal_server_error',
 					message: 'Internal server error',

--- a/assets/js/modules/analytics/datastore/settings.js
+++ b/assets/js/modules/analytics/datastore/settings.js
@@ -101,6 +101,8 @@ export const controls = {
 		}
 
 		await API.invalidateCache( 'modules', 'analytics' );
+
+		return {};
 	} ),
 };
 

--- a/assets/js/modules/analytics/datastore/settings.js
+++ b/assets/js/modules/analytics/datastore/settings.js
@@ -48,7 +48,7 @@ export const actions = {
 			type: START_SUBMIT_CHANGES,
 		};
 
-		yield {
+		const result = yield {
 			payload: {},
 			type: SUBMIT_CHANGES,
 		};
@@ -57,6 +57,8 @@ export const actions = {
 			payload: {},
 			type: FINISH_SUBMIT_CHANGES,
 		};
+
+		return result;
 	},
 };
 

--- a/assets/js/modules/analytics/datastore/settings.test.js
+++ b/assets/js/modules/analytics/datastore/settings.test.js
@@ -301,15 +301,12 @@ describe( 'modules/analytics settings', () => {
 
 	describe( 'selectors', () => {
 		describe( 'isDoingSubmitChanges', () => {
-			it( 'sets internal state while submitting changes', () => {
+			it( 'sets internal state while submitting changes', async () => {
+				registry.dispatch( STORE_NAME ).receiveSettings( validSettings );
+				expect( registry.select( STORE_NAME ).haveSettingsChanged() ).toBe( false );
+
 				expect( registry.select( STORE_NAME ).isDoingSubmitChanges() ).toBe( false );
 
-				registry.dispatch( STORE_NAME ).submitChanges();
-
-				expect( registry.select( STORE_NAME ).isDoingSubmitChanges() ).toBe( true );
-			} );
-
-			it( 'toggles the internal state again once submission is completed', async () => {
 				registry.dispatch( STORE_NAME ).submitChanges();
 
 				expect( registry.select( STORE_NAME ).isDoingSubmitChanges() ).toBe( true );

--- a/assets/js/modules/analytics/datastore/settings.test.js
+++ b/assets/js/modules/analytics/datastore/settings.test.js
@@ -106,12 +106,13 @@ describe( 'modules/analytics settings', () => {
 						{ status: 200 }
 					);
 
-				await registry.dispatch( STORE_NAME ).submitChanges();
+				const result = await registry.dispatch( STORE_NAME ).submitChanges();
 
 				expect( JSON.parse( fetch.mock.calls[ 0 ][ 1 ].body ) ).toMatchObject( {
 					data: { accountID: '12345' },
 				} );
 
+				expect( result.error ).toBeFalsy();
 				expect( registry.select( STORE_NAME ).getPropertyID() ).toBe( createdProperty.id );
 				expect( registry.select( STORE_NAME ).getInternalWebPropertyID() ).toBe( createdProperty.internalWebPropertyId );
 			} );

--- a/assets/js/modules/analytics/datastore/settings.test.js
+++ b/assets/js/modules/analytics/datastore/settings.test.js
@@ -127,6 +127,7 @@ describe( 'modules/analytics settings', () => {
 						{ status: 500 }
 					);
 
+				muteConsole( 'error' );
 				await registry.dispatch( STORE_NAME ).submitChanges();
 
 				expect( JSON.parse( fetch.mock.calls[ 0 ][ 1 ].body ) ).toMatchObject(

--- a/assets/js/modules/analytics/datastore/settings.test.js
+++ b/assets/js/modules/analytics/datastore/settings.test.js
@@ -79,6 +79,11 @@ describe( 'modules/analytics settings', () => {
 	} );
 
 	describe( 'actions', () => {
+		beforeEach( () => {
+			// Receive empty settings to prevent unexpected fetch by resolver.
+			registry.dispatch( STORE_NAME ).receiveSettings( {} );
+		} );
+
 		describe( 'submitChanges', () => {
 			it( 'dispatches createProperty if the "set up a new property" option is chosen', async () => {
 				registry.dispatch( STORE_NAME ).setSettings( {

--- a/assets/js/modules/analytics/datastore/settings.test.js
+++ b/assets/js/modules/analytics/datastore/settings.test.js
@@ -104,7 +104,14 @@ describe( 'modules/analytics settings', () => {
 					.mockResponseOnce(
 						JSON.stringify( createdProperty ),
 						{ status: 200 }
-					);
+					)
+					.doMockOnceIf( /^\/google-site-kit\/v1\/modules\/analytics\/data\/settings/ )
+					.mockResponseOnce( async ( req ) => {
+						const { data } = await req.json();
+						// Return the same settings passed to the API.
+						return JSON.stringify( data );
+					} )
+				;
 
 				const result = await registry.dispatch( STORE_NAME ).submitChanges();
 
@@ -167,7 +174,14 @@ describe( 'modules/analytics settings', () => {
 					.mockResponseOnce(
 						JSON.stringify( createdProfile ),
 						{ status: 200 }
-					);
+					)
+					.doMockOnceIf( /^\/google-site-kit\/v1\/modules\/analytics\/data\/settings/ )
+					.mockResponseOnce( async ( req ) => {
+						const { data } = await req.json();
+						// Return the same settings passed to the API.
+						return JSON.stringify( data );
+					} )
+				;
 
 				await registry.dispatch( STORE_NAME ).submitChanges();
 
@@ -236,7 +250,14 @@ describe( 'modules/analytics settings', () => {
 					.doMockOnceIf( /^\/google-site-kit\/v1\/modules\/analytics\/data\/create-property/ )
 					.mockResponseOnce( JSON.stringify( createdProperty ), { status: 200 } )
 					.doMockOnceIf( /^\/google-site-kit\/v1\/modules\/analytics\/data\/create-profile/ )
-					.mockResponseOnce( JSON.stringify( createdProfile ), { status: 200 } );
+					.mockResponseOnce( JSON.stringify( createdProfile ), { status: 200 } )
+					.doMockOnceIf( /^\/google-site-kit\/v1\/modules\/analytics\/data\/settings/ )
+					.mockResponseOnce( async ( req ) => {
+						const { data } = await req.json();
+						// Return the same settings passed to the API.
+						return JSON.stringify( data );
+					} )
+				;
 
 				await registry.dispatch( STORE_NAME ).submitChanges();
 

--- a/assets/js/modules/analytics/datastore/tags.test.js
+++ b/assets/js/modules/analytics/datastore/tags.test.js
@@ -283,7 +283,14 @@ describe( 'modules/analytics tags', () => {
 			} );
 
 			it( 'returns undefined if existing tag has not been loaded yet', async () => {
-				muteConsole( 'error' );
+				fetch
+					.doMockOnceIf(
+						/^\/google-site-kit\/v1\/modules\/analytics\/data\/tag-permission/
+					)
+					.mockResponseOnce(
+						JSON.stringify( fixtures.getTagPermissionsAccess ),
+						{ status: 200 }
+					);
 				const hasPermission = registry.select( STORE_NAME ).hasTagPermission( fixtures.getTagPermissionsNoAccess.propertyID );
 
 				expect( hasPermission ).toEqual( undefined );

--- a/assets/js/modules/analytics/settings/settings-edit.js
+++ b/assets/js/modules/analytics/settings/settings-edit.js
@@ -95,7 +95,7 @@ export default function SettingsEdit() {
 			'googlekit.AnalyticsSettingsConfirmed',
 			async ( chain, module ) => {
 				if ( 'analytics-module' === module ) {
-					const { error } = await submitChanges() || {};
+					const { error } = await submitChanges();
 					if ( error ) {
 						return Promise.reject( error );
 					}

--- a/assets/js/modules/analytics/setup/setup-form.js
+++ b/assets/js/modules/analytics/setup/setup-form.js
@@ -46,7 +46,7 @@ export default function SetupForm( { finishSetup } ) {
 	const { submitChanges } = useDispatch( STORE_NAME );
 	const submitForm = useCallback( async ( event ) => {
 		event.preventDefault();
-		const { error } = await submitChanges() || {};
+		const { error } = await submitChanges();
 		if ( ! error ) {
 			finishSetup();
 			trackEvent( 'analytics_setup', 'analytics_configured' );


### PR DESCRIPTION
## Summary

Addresses issue #1101

## Relevant technical choices
* Added tests to ensure `submitChanges` behaves as expected during failures
* Updated calls to `submitChanges` to no longer use a `|| {}` fallback
* Fixes all console errors from all Analytics datastore/ tests  
These did not cause the tests to fail previously but is not something we should normalize
* Removes `muteConsole` use for any mutes other than expected errors (such as a test that produces a failing request)
    - Using `muteConsole` for silencing legitimate requests should not be done as it can lead to silencing legitimate errors
* Fixed a bug in `getProperties` resolver if `fetchPropertiesProfiles` fails
* Added a call to `receiveSettings` (not set) to the test set up for most files as requests to `settings` was the most frequent offender of causing errors
    - One exception is in `settings.test` where `canSubmitChanges` is more sensitive to this so in this test the settings setup is scoped to actions only


## Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
