### PR TITLE
Fix/1101 use snippet view

### DIFF
--- a/assets/js/modules/analytics/settings/settings-view.js
+++ b/assets/js/modules/analytics/settings/settings-view.js
@@ -84,7 +84,8 @@ export default function SettingsView() {
 					</p>
 					<h5 className="googlesitekit-settings-module__meta-item-data">
 						{ useSnippet && __( 'Snippet is inserted', 'google-site-kit' ) }
-						{ ! useSnippet && __( 'Snippet is not inserted', 'google-site-kit' ) }
+						{ ( ! useSnippet && ! hasExistingTag ) && __( 'Snippet is not inserted', 'google-site-kit' ) }
+						{ ( ! useSnippet && hasExistingTag ) && __( 'Inserted by another plugin or theme', 'google-site-kit' ) }
 					</h5>
 				</div>
 			</div>

--- a/stories/module-analytics-settings.stories.js
+++ b/stories/module-analytics-settings.stories.js
@@ -122,6 +122,28 @@ storiesOf( 'Analytics Module/Settings', module )
 
 		return <Settings callback={ setupRegistry } />;
 	} )
+	.add( 'View, open with all settings, no snippet with existing tag', () => {
+		filterAnalyticsSettings();
+
+		const setupRegistry = ( { dispatch } ) => {
+			dispatch( STORE_NAME ).receiveExistingTag( 'UA-1234567890-1' );
+			dispatch( STORE_NAME ).receiveTagPermission( {
+				accountID: '1234567890',
+				propertyID: 'UA-1234567890-1',
+				permission: true,
+			} );
+			dispatch( STORE_NAME ).receiveSettings( {
+				accountID: '1234567890',
+				propertyID: 'UA-1234567890-1',
+				profileID: '9999999',
+				anonymizeIP: true,
+				useSnippet: false,
+				trackingDisabled: [ 'loggedinUsers' ],
+			} );
+		};
+
+		return <Settings callback={ setupRegistry } />;
+	} )
 	.add( 'Edit, open with all settings', () => {
 		filterAnalyticsSettings();
 


### PR DESCRIPTION
## Summary

Addresses issue #1101

Addresses [QA feedback](https://github.com/google/site-kit-wp/issues/1101#issuecomment-623598267) regarding `useSnippet` display when `useSnippet` is set to false with an existing tag

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
