### PR TITLE
Ensure amp-auto-ads tag is not printed when checking for existing Site Kit tags

### DIFF
--- a/includes/Modules/AdSense.php
+++ b/includes/Modules/AdSense.php
@@ -305,6 +305,11 @@ tag_partner: "site_kit"
 			return $content;
 		}
 
+		// Bail early if we are checking for the tag presence from the back end.
+		if ( $this->context->input()->filter( INPUT_GET, 'tagverify', FILTER_VALIDATE_BOOLEAN ) ) {
+			return $content;
+		}
+
 		if ( ! $this->is_connected() ) {
 			return $content;
 		}

--- a/includes/Modules/AdSense.php
+++ b/includes/Modules/AdSense.php
@@ -274,6 +274,11 @@ tag_partner: "site_kit"
 	 * @return array Filtered $data.
 	 */
 	protected function amp_data_load_auto_ads_component( $data ) {
+		// Bail early if we are checking for the tag presence from the back end.
+		if ( $this->context->input()->filter( INPUT_GET, 'tagverify', FILTER_VALIDATE_BOOLEAN ) ) {
+			return $data;
+		}
+
 		if ( ! $this->is_connected() ) {
 			return $data;
 		}

--- a/includes/Modules/AdSense.php
+++ b/includes/Modules/AdSense.php
@@ -279,10 +279,6 @@ tag_partner: "site_kit"
 			return $data;
 		}
 
-		if ( ! $this->is_connected() ) {
-			return $data;
-		}
-
 		$tag_enabled = $this->get_data( 'use-snippet' );
 		if ( is_wp_error( $tag_enabled ) || ! $tag_enabled ) {
 			return $data;
@@ -312,10 +308,6 @@ tag_partner: "site_kit"
 
 		// Bail early if we are checking for the tag presence from the back end.
 		if ( $this->context->input()->filter( INPUT_GET, 'tagverify', FILTER_VALIDATE_BOOLEAN ) ) {
-			return $content;
-		}
-
-		if ( ! $this->is_connected() ) {
 			return $content;
 		}
 


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #1495 

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
