### PR TITLE
Always make request in refreshAuthentication

### DIFF
--- a/assets/js/util/refresh-authentication.js
+++ b/assets/js/util/refresh-authentication.js
@@ -23,7 +23,9 @@ import data, { TYPE_CORE } from '../components/data';
 
 export const refreshAuthentication = async () => {
 	try {
-		const response = await data.get( TYPE_CORE, 'user', 'authentication' );
+		// `timestamp` added to ensure this request is always made as it is preloaded
+		// using apiFetch's preloading middleware.
+		const response = await data.get( TYPE_CORE, 'user', 'authentication', { timestamp: Date.now() } );
 
 		const requiredAndGrantedScopes = response.grantedScopes.filter( ( scope ) => {
 			return -1 !== response.requiredScopes.indexOf( scope );


### PR DESCRIPTION
## Summary

Addresses issue #1478 (follow-up)

## Relevant technical choices

* Adds timestamp to `core/user/data/authentication` called in `refreshAuthentication` to bypass stale preloaded response.

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
