### PR TITLE
Remove initialize functionality from commonStore.

### DIFF
--- a/assets/js/googlesitekit/data/utils.js
+++ b/assets/js/googlesitekit/data/utils.js
@@ -338,7 +338,7 @@ const findDuplicates = ( array ) => {
  * @return {Object} Object with common actions, controls and reducer.
  */
 export const commonStore = {
-	actions: addInitializeAction( commonActions ),
+	actions: commonActions,
 	controls: commonControls,
-	reducer: addInitializeReducer( {}, passthroughReducer ),
+	reducer: passthroughReducer,
 };


### PR DESCRIPTION
## Summary

Remove initialization functionality from `combineStores()` to prepare for release.

## Relevant technical choices

Removes  `addInitializeReducer()` and `addInitializeAction()` from `Data.commonStore`.
Addresses issue #1400.

## Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
