### PR TITLE
Fix/1517 Analytics settings rollback

### DIFF
--- a/assets/js/modules/analytics/settings/settings-edit.js
+++ b/assets/js/modules/analytics/settings/settings-edit.js
@@ -45,28 +45,7 @@ export default function SettingsEdit() {
 	const canSubmitChanges = useSelect( ( select ) => select( STORE_NAME ).canSubmitChanges() );
 	const isDoingGetAccounts = useSelect( ( select ) => select( STORE_NAME ).isDoingGetAccounts() );
 	const isDoingSubmitChanges = useSelect( ( select ) => select( STORE_NAME ).isDoingSubmitChanges() );
-	const haveSettingsChanged = useSelect( ( select ) => select( STORE_NAME ).haveSettingsChanged() );
 	const isCreateAccount = ACCOUNT_CREATE === accountID;
-
-	// Rollback any temporary selections to saved values on dismount.
-	// This is a bit of a hacky solution, as we'd prefer to rollback changes
-	// when the "cancel" button is clicked. But we don't yet have control over
-	// that section of the page, so if the component is unmounted, has changes,
-	// and is not submitting those changes: we rollback.
-	//
-	// Technically this means we rollback right before we receive new settings
-	// when they ARE saved, because the component is unmounted then and meets the
-	// `haveSettingsChanged && ! isDoingSubmitChanges` criteria below.
-	// But that's fine as the new settings are then immediately loaded into state
-	// and there aren't any visual glitches. 🤷🏻‍♂️
-	const { rollbackSettings } = useDispatch( STORE_NAME );
-	useEffect( () => {
-		return () => {
-			if ( haveSettingsChanged && ! isDoingSubmitChanges ) {
-				rollbackSettings();
-			}
-		};
-	}, [ haveSettingsChanged, isDoingSubmitChanges ] );
 
 	// Set the accountID and property if there is an existing tag.
 	// This only applies to the edit view, so we apply it here rather than in the datastore.

--- a/assets/js/modules/analytics/settings/settings-main.js
+++ b/assets/js/modules/analytics/settings/settings-main.js
@@ -17,12 +17,30 @@
  */
 
 /**
+ * WordPress dependencies
+ */
+import { useEffect } from '@wordpress/element';
+
+/**
  * Internal dependencies
  */
+import Data from 'googlesitekit-data';
 import SettingsEdit from './settings-edit';
 import SettingsView from './settings-view';
+import { STORE_NAME } from '../datastore/constants';
+const { useSelect, useDispatch } = Data;
 
 export default function SettingsMain( { isOpen, isEditing } ) {
+	const isDoingSubmitChanges = useSelect( ( select ) => select( STORE_NAME ).isDoingSubmitChanges() );
+	const haveSettingsChanged = useSelect( ( select ) => select( STORE_NAME ).haveSettingsChanged() );
+	// Rollback any temporary selections to saved values if settings have changed and no longer editing.
+	const { rollbackSettings } = useDispatch( STORE_NAME );
+	useEffect( () => {
+		if ( haveSettingsChanged && ! isDoingSubmitChanges && ! isEditing ) {
+			rollbackSettings();
+		}
+	}, [ haveSettingsChanged, isDoingSubmitChanges, isEditing ] );
+
 	if ( ! isOpen ) {
 		return null;
 	}

--- a/assets/js/modules/analytics/settings/settings-main.test.js
+++ b/assets/js/modules/analytics/settings/settings-main.test.js
@@ -83,7 +83,8 @@ describe( 'SettingsMain', () => {
 		fireEvent.click( container.querySelector( '.googlesitekit-analytics-usesnippet [role="switch"]' ) );
 		await wait( () => select( STORE_NAME ).haveSettingsChanged() === true );
 
-		// Rendering with isOpen: false and isEditing: true is not really possible but necessary to update.
+		// Rendering with isOpen: false and isEditing: true is possible by clicking the module header.
+		// Rerendering here manually for clarity.
 		rerender( <SettingsMain isOpen={ false } isEditing={ true } /> );
 
 		expect( select( STORE_NAME ).getSettings() ).toEqual( {

--- a/assets/js/modules/analytics/settings/settings-main.test.js
+++ b/assets/js/modules/analytics/settings/settings-main.test.js
@@ -1,0 +1,95 @@
+/**
+ * Analytics SettingsMain tests.
+ *
+ * Site Kit by Google, Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import { render, fireEvent, wait } from '../../../../../tests/js/test-utils';
+import { STORE_NAME } from '../datastore/constants';
+import { STORE_NAME as CORE_SITE } from '../../../googlesitekit/datastore/site/constants';
+import * as fixtures from '../datastore/__fixtures__';
+import SettingsMain from './settings-main';
+
+describe( 'SettingsMain', () => {
+	const initialSettings = {
+		accountID: fixtures.accountsPropertiesProfiles.profiles[ 0 ].accountId,
+		propertyID: fixtures.accountsPropertiesProfiles.profiles[ 0 ].webPropertyId,
+		internalWebPropertyID: fixtures.accountsPropertiesProfiles.profiles[ 0 ].internalWebPropertyId,
+		profileID: fixtures.accountsPropertiesProfiles.profiles[ 0 ].id,
+		useSnippet: true,
+		trackingDisabled: [],
+		anonymizeIP: true,
+	};
+
+	it( 'rolls back settings if settings have changed and is not editing', async () => {
+		fetch.doMockIf( /accounts-properties-profiles/ )
+			.mockResponse( JSON.stringify( fixtures.accountsPropertiesProfiles ) );
+
+		const setupRegistry = ( { dispatch } ) => {
+			dispatch( CORE_SITE ).receiveSiteInfo( {} );
+			dispatch( STORE_NAME ).receiveExistingTag( null );
+			dispatch( STORE_NAME ).receiveSettings( initialSettings );
+		};
+
+		const { rerender, registry, container } = render( <SettingsMain isOpen={ true } isEditing={ false } />, { setupRegistry } );
+		const { select } = registry;
+
+		expect( select( STORE_NAME ).getSettings() ).toEqual( initialSettings );
+
+		rerender( <SettingsMain isOpen={ true } isEditing={ true } /> );
+
+		await wait( () => container.querySelector( '.googlesitekit-analytics-usesnippet' ) );
+		fireEvent.click( container.querySelector( '.googlesitekit-analytics-usesnippet [role="switch"]' ) );
+		expect( select( STORE_NAME ).haveSettingsChanged() ).toBe( true );
+
+		rerender( <SettingsMain isOpen={ true } isEditing={ false } /> );
+
+		expect( select( STORE_NAME ).getSettings() ).toEqual( initialSettings );
+	} );
+
+	it( 'does not roll back settings if settings have changed and is editing', async () => {
+		fetch.doMockIf( /accounts-properties-profiles/ )
+			.mockResponse( JSON.stringify( fixtures.accountsPropertiesProfiles ) );
+
+		const setupRegistry = ( { dispatch } ) => {
+			dispatch( CORE_SITE ).receiveSiteInfo( {} );
+			dispatch( STORE_NAME ).receiveExistingTag( null );
+			dispatch( STORE_NAME ).receiveSettings( initialSettings );
+		};
+
+		const { rerender, registry, container } = render( <SettingsMain isOpen={ true } isEditing={ false } />, { setupRegistry } );
+		const { select } = registry;
+
+		expect( select( STORE_NAME ).getSettings() ).toEqual( initialSettings );
+
+		rerender( <SettingsMain isOpen={ true } isEditing={ true } /> );
+
+		await wait( () => container.querySelector( '.googlesitekit-analytics-usesnippet' ) );
+		const useSnippetEl = container.querySelector( '.googlesitekit-analytics-usesnippet' );
+		fireEvent.click( useSnippetEl.querySelector( '[role="switch"]' ) );
+		await wait( () => select( STORE_NAME ).haveSettingsChanged() === true );
+
+		// Rendering with isOpen: false and isEditing: true is not really possible but necessary to update.
+		rerender( <SettingsMain isOpen={ false } isEditing={ true } /> );
+
+		expect( select( STORE_NAME ).getSettings() ).toEqual( {
+			...initialSettings,
+			useSnippet: ! initialSettings.useSnippet, // toggled
+		} );
+	} );
+} );

--- a/assets/js/modules/analytics/settings/settings-main.test.js
+++ b/assets/js/modules/analytics/settings/settings-main.test.js
@@ -80,8 +80,7 @@ describe( 'SettingsMain', () => {
 		rerender( <SettingsMain isOpen={ true } isEditing={ true } /> );
 
 		await wait( () => container.querySelector( '.googlesitekit-analytics-usesnippet' ) );
-		const useSnippetEl = container.querySelector( '.googlesitekit-analytics-usesnippet' );
-		fireEvent.click( useSnippetEl.querySelector( '[role="switch"]' ) );
+		fireEvent.click( container.querySelector( '.googlesitekit-analytics-usesnippet [role="switch"]' ) );
 		await wait( () => select( STORE_NAME ).haveSettingsChanged() === true );
 
 		// Rendering with isOpen: false and isEditing: true is not really possible but necessary to update.


### PR DESCRIPTION
## Summary

Addresses issue #1517 

## Relevant technical choices

<!-- Please describe your changes. -->

## Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
