### PR TITLE
Really fix adsenseLinked bug

### DIFF
--- a/includes/Modules/AdSense.php
+++ b/includes/Modules/AdSense.php
@@ -82,9 +82,18 @@ final class AdSense extends Module implements Module_With_Screen, Module_With_Sc
 			/**
 			 * Release filter forcing unlinked state.
 			 *
-			 * @see \Google\Site_Kit\Modules\Analytics\Settings::register
+			 * This is hooked into 'init' (default priority of 10), so that it
+			 * runs after the original filter is added.
+			 *
+			 * @see \Google\Site_Kit\Modules\Analytics::register()
+			 * @see \Google\Site_Kit\Modules\Analytics\Settings::register()
 			 */
-			remove_filter( 'googlesitekit_analytics_adsense_linked', '__return_false' );
+			add_action(
+				'init',
+				function () {
+					remove_filter( 'googlesitekit_analytics_adsense_linked', '__return_false' );
+				}
+			);
 		}
 	}
 

--- a/includes/Modules/AdSense.php
+++ b/includes/Modules/AdSense.php
@@ -89,7 +89,7 @@ final class AdSense extends Module implements Module_With_Screen, Module_With_Sc
 			 * @see \Google\Site_Kit\Modules\Analytics\Settings::register()
 			 */
 			add_action(
-				'init',
+				'googlesitekit_init',
 				function () {
 					remove_filter( 'googlesitekit_analytics_adsense_linked', '__return_false' );
 				}

--- a/includes/Modules/Analytics.php
+++ b/includes/Modules/Analytics.php
@@ -1232,7 +1232,8 @@ final class Analytics extends Module
 	 */
 	private function is_adsense_request( $data ) {
 		foreach ( (array) $data['metrics'] as $metric ) {
-			if ( isset( $metric->expression ) && 0 === strpos( $metric->expression, 'ga:adsense' ) ) {
+			$metric = (array) $metric;
+			if ( isset( $metric['expression'] ) && 0 === strpos( $metric['expression'], 'ga:adsense' ) ) {
 				return true;
 			}
 		}

--- a/includes/Modules/Analytics.php
+++ b/includes/Modules/Analytics.php
@@ -1066,10 +1066,9 @@ final class Analytics extends Module
 
 				return $response;
 			case 'GET:report':
-				/* @var Google_Service_AnalyticsReporting_GetReportsResponse $response Response object. */
+				// If AdSense metric successfully requested, set adsenseLinked to true.
 				if ( $this->is_adsense_request( $data ) ) {
-					$is_linked = empty( $response->error );
-					$this->get_settings()->merge( array( 'adsenseLinked' => $is_linked ) );
+					$this->get_settings()->merge( array( 'adsenseLinked' => true ) );
 				}
 
 				return $response->getReports();
@@ -1224,6 +1223,27 @@ final class Analytics extends Module
 	}
 
 	/**
+	 * Transforms an exception into a WP_Error object.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param Exception $e         Exception object.
+	 * @param string    $datapoint Datapoint originally requested.
+	 * @return WP_Error WordPress error object.
+	 */
+	protected function exception_to_error( Exception $e, $datapoint ) {
+		if ( 'report' === $datapoint && $e instanceof Google_Service_Exception ) {
+			$errors = $e->getErrors();
+			// If error is because of AdSense metric being requested, set adsenseLinked to false.
+			if ( isset( $errors[0]['message'] ) && $this->is_adsense_metric( substr( $errors[0]['message'], strlen( 'Restricted metric(s): ' ) ) ) ) {
+				$this->get_settings()->merge( array( 'adsenseLinked' => false ) );
+			}
+		}
+
+		return parent::exception_to_error( $e, $datapoint );
+	}
+
+	/**
 	 * Determines whether the given request is for an adsense request.
 	 *
 	 * @param Data_Request $data Data request object.
@@ -1233,12 +1253,24 @@ final class Analytics extends Module
 	private function is_adsense_request( $data ) {
 		foreach ( (array) $data['metrics'] as $metric ) {
 			$metric = (array) $metric;
-			if ( isset( $metric['expression'] ) && 0 === strpos( $metric['expression'], 'ga:adsense' ) ) {
+			if ( isset( $metric['expression'] ) && $this->is_adsense_metric( $metric['expression'] ) ) {
 				return true;
 			}
 		}
 
 		return false;
+	}
+
+	/**
+	 * Determines whether the given metric expression is for an AdSense metric.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param string $metric Metric expression.
+	 * @return bool True if AdSense metric, false otherwise.
+	 */
+	private function is_adsense_metric( $metric ) {
+		return 0 === strpos( $metric, 'ga:adsense' );
 	}
 
 	/**

--- a/tests/phpunit/integration/Modules/Analytics/SettingsTest.php
+++ b/tests/phpunit/integration/Modules/Analytics/SettingsTest.php
@@ -214,8 +214,7 @@ class SettingsTest extends SettingsTestCase {
 			'report',
 			array(
 				'metrics' => array(
-					// Metrics are expected to be objects (json_decode).
-					(object) array(
+					array(
 						'alias'      => 'Earnings',
 						'expression' => 'ga:adsenseRevenue',
 					),


### PR DESCRIPTION
## Summary

Addresses issue #1524

## Relevant technical choices

* Ensure adsenseLinked force filter is unhooked after it is hooked.
* Handle nested request parameters as arrays and cast them to make sure. This only applies to this one location causing the bug here. The original reason where this was introduced is https://github.com/google/site-kit-wp/pull/935/files#diff-1142b30534124ce88a43f90e0ba72e30L397 (parameters are cast to objects, but only top-level ones are, nested ones remain arrays).
* Ensure the `adsenseLinked` setting is modified for both successful and failing `ga:adsense...` requests (logic previously was in datapoint response handler which only is called on success).

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
