### PR TITLE
Fix bugs with error/zero-data handling around Analytics/AdSense linked widgets

### DIFF
--- a/assets/js/components/higherorder/withdata.js
+++ b/assets/js/components/higherorder/withdata.js
@@ -124,6 +124,14 @@ const withData = (
 			}
 		}
 
+		// If error is the root of the response, ensure all expected parts are
+		// present, just to "be sure" that it is an error. All above error
+		// handlers are legacy and are likely never hit, but let's keep them
+		// because nobody will ever know.
+		if ( data.code && data.message && data.data && data.data.status ) {
+			return data.message;
+		}
+
 		// No error.
 		return false;
 	}

--- a/assets/js/modules/adsense/dashboard/dashboard-widget-performance.js
+++ b/assets/js/modules/adsense/dashboard/dashboard-widget-performance.js
@@ -169,7 +169,7 @@ export default withData(
 		},
 	],
 	<PreviewBlock width="100%" height="250px" />,
-	{},
+	{ createGrid: true },
 	isDataZeroAdSense
 );
 

--- a/assets/js/modules/analytics/common/adsense-link-cta.js
+++ b/assets/js/modules/analytics/common/adsense-link-cta.js
@@ -1,0 +1,36 @@
+/**
+ * Analytics AdSense Link CTA component.
+ *
+ * Site Kit by Google, Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import CTA from '../../../components/notifications/cta';
+
+export default function AdSenseLinkCTA() {
+	return (
+		<CTA
+			title={ __( 'Restricted metric(s)', 'google-site-kit' ) }
+			description={ __( 'You need to link Analytics and AdSense to get report for your top earning pages. Learn more: https://support.google.com/adsense/answer/6084409 ', 'google-site-kit' ) }
+		/>
+	);
+}

--- a/assets/js/modules/analytics/common/adsense-link-cta.js
+++ b/assets/js/modules/analytics/common/adsense-link-cta.js
@@ -29,8 +29,10 @@ import CTA from '../../../components/notifications/cta';
 export default function AdSenseLinkCTA() {
 	return (
 		<CTA
-			title={ __( 'Restricted metric(s)', 'google-site-kit' ) }
-			description={ __( 'You need to link Analytics and AdSense to get report for your top earning pages. Learn more: https://support.google.com/adsense/answer/6084409 ', 'google-site-kit' ) }
+			title={ __( 'Link Analytics and AdSense', 'google-site-kit' ) }
+			description={ __( 'You need to link Analytics and AdSense to get reports for your top earning pages.', 'google-site-kit' ) }
+			ctaLink="https://support.google.com/adsense/answer/6084409"
+			ctaLabel={ __( 'Learn more', 'google-site-kit' ) }
 		/>
 	);
 }

--- a/assets/js/modules/analytics/dashboard/dashboard-widget-analytics-adsense-top-pages.js
+++ b/assets/js/modules/analytics/dashboard/dashboard-widget-analytics-adsense-top-pages.js
@@ -36,6 +36,7 @@ import { TYPE_MODULES } from '../../../components/data';
 import { getDataTableFromData, TableOverflowContainer } from '../../../components/data-table';
 import Layout from '../../../components/layout/layout';
 import PreviewTable from '../../../components/preview-table';
+import ctaWrapper from '../../../components/notifications/cta-wrapper';
 import AdSenseLinkCTA from '../common/adsense-link-cta';
 import { analyticsAdsenseReportDataDefaults, isDataZeroForReporting } from '../util';
 
@@ -148,7 +149,7 @@ const getDataError = ( data ) => {
 		// Specifically looking for string "badRequest"
 		if ( 'badRequest' === data.data.reason ) {
 			return AnalyticsAdSenseDashboardWidgetTopPagesTable.renderLayout(
-				<AdSenseLinkCTA />
+				ctaWrapper( <AdSenseLinkCTA />, false, false, true )
 			);
 		}
 
@@ -192,11 +193,7 @@ export default withData(
 	AnalyticsAdSenseDashboardWidgetTopPagesTable.renderLayout(
 		<PreviewTable padding />
 	),
-	{
-		inGrid: true,
-		fullWidth: true,
-		createGrid: true,
-	},
+	{ createGrid: true },
 	// Force isDataZero to false since it is handled within the component.
 	() => false,
 	getDataError

--- a/assets/js/modules/analytics/dashboard/dashboard-widget-analytics-adsense-top-pages.js
+++ b/assets/js/modules/analytics/dashboard/dashboard-widget-analytics-adsense-top-pages.js
@@ -36,7 +36,7 @@ import { TYPE_MODULES } from '../../../components/data';
 import { getDataTableFromData, TableOverflowContainer } from '../../../components/data-table';
 import Layout from '../../../components/layout/layout';
 import PreviewTable from '../../../components/preview-table';
-import CTA from '../../../components/notifications/cta';
+import AdSenseLinkCTA from '../common/adsense-link-cta';
 import { analyticsAdsenseReportDataDefaults, isDataZeroForReporting } from '../util';
 
 class AnalyticsAdSenseDashboardWidgetTopPagesTable extends Component {
@@ -148,10 +148,7 @@ const getDataError = ( data ) => {
 		// Specifically looking for string "badRequest"
 		if ( data.data.reason && 'badRequest' === data.data.reason ) {
 			return AnalyticsAdSenseDashboardWidgetTopPagesTable.renderLayout(
-				<CTA
-					title={ __( 'Restricted metric(s)', 'google-site-kit' ) }
-					description={ __( 'You need to link Analytics and AdSense to get report for your top earning pages. Learn more: https://support.google.com/adsense/answer/6084409 ', 'google-site-kit' ) }
-				/>
+				<AdSenseLinkCTA />
 			);
 		}
 

--- a/assets/js/modules/analytics/dashboard/dashboard-widget-analytics-adsense-top-pages.js
+++ b/assets/js/modules/analytics/dashboard/dashboard-widget-analytics-adsense-top-pages.js
@@ -146,7 +146,7 @@ class AnalyticsAdSenseDashboardWidgetTopPagesTable extends Component {
 const getDataError = ( data ) => {
 	if ( data.code && data.message && data.data && data.data.status ) {
 		// Specifically looking for string "badRequest"
-		if ( data.data.reason && 'badRequest' === data.data.reason ) {
+		if ( 'badRequest' === data.data.reason ) {
 			return AnalyticsAdSenseDashboardWidgetTopPagesTable.renderLayout(
 				<AdSenseLinkCTA />
 			);

--- a/assets/js/modules/analytics/dashboard/dashboard-widget-top-earning-pages-small.js
+++ b/assets/js/modules/analytics/dashboard/dashboard-widget-top-earning-pages-small.js
@@ -36,7 +36,7 @@ import { TYPE_MODULES } from '../../../components/data';
 import { getDataTableFromData, TableOverflowContainer } from '../../../components/data-table';
 import PreviewTable from '../../../components/preview-table';
 import Layout from '../../../components/layout/layout';
-import CTA from '../../../components/notifications/cta';
+import AdSenseLinkCTA from '../common/adsense-link-cta';
 import { analyticsAdsenseReportDataDefaults, isDataZeroForReporting } from '../util';
 
 class AdSenseDashboardWidgetTopPagesTableSmall extends Component {
@@ -128,10 +128,7 @@ const getDataError = ( data ) => {
 						className="googlesitekit-top-earnings-pages"
 						fill
 					>
-						<CTA
-							title={ __( 'Restricted metric(s)', 'google-site-kit' ) }
-							description={ __( 'You need to link Analytics and AdSense to get report for your top earning pages. Learn more: https://support.google.com/adsense/answer/6084409 ', 'google-site-kit' ) }
-						/>
+						<AdSenseLinkCTA />
 					</Layout>
 				</div>
 			);

--- a/assets/js/modules/analytics/dashboard/dashboard-widget-top-earning-pages-small.js
+++ b/assets/js/modules/analytics/dashboard/dashboard-widget-top-earning-pages-small.js
@@ -117,7 +117,7 @@ class AdSenseDashboardWidgetTopPagesTableSmall extends Component {
 const getDataError = ( data ) => {
 	if ( data.code && data.message && data.data && data.data.status ) {
 		// Specifically looking for string "badRequest"
-		if ( data.data.reason && 'badRequest' === data.data.reason ) {
+		if ( 'badRequest' === data.data.reason ) {
 			return (
 				<div className="
 						mdc-layout-grid__cell

--- a/assets/js/modules/analytics/dashboard/dashboard-widget-top-earning-pages-small.js
+++ b/assets/js/modules/analytics/dashboard/dashboard-widget-top-earning-pages-small.js
@@ -37,7 +37,7 @@ import { getDataTableFromData, TableOverflowContainer } from '../../../component
 import PreviewTable from '../../../components/preview-table';
 import Layout from '../../../components/layout/layout';
 import CTA from '../../../components/notifications/cta';
-import { analyticsAdsenseReportDataDefaults } from '../util';
+import { analyticsAdsenseReportDataDefaults, isDataZeroForReporting } from '../util';
 
 class AdSenseDashboardWidgetTopPagesTableSmall extends Component {
 	static renderLayout( component ) {
@@ -107,23 +107,17 @@ class AdSenseDashboardWidgetTopPagesTableSmall extends Component {
 	}
 }
 
-const isDataZero = () => {
-	return false;
-};
-
 /**
  * Check error data response.
  *
- * @param {Object} data Response data.
+ * @param {Object} data Response error data.
  *
  * @return {(HTMLElement|null)} Returns HTML element markup with error message if it exists.
  */
 const getDataError = ( data ) => {
-	if ( data && data.error_data ) {
-		const errors = Object.values( data.error_data );
-
+	if ( data.code && data.message && data.data && data.data.status ) {
 		// Specifically looking for string "badRequest"
-		if ( errors[ 0 ] && 'badRequest' === errors[ 0 ].reason ) {
+		if ( data.data.reason && 'badRequest' === data.data.reason ) {
 			return (
 				<div className="
 						mdc-layout-grid__cell
@@ -142,8 +136,11 @@ const getDataError = ( data ) => {
 				</div>
 			);
 		}
+
+		return data.message;
 	}
 
+	// Legacy errors? Maybe this is never hit but better be safe than sorry.
 	if ( data && data.errors ) {
 		const errors = Object.values( data.errors );
 		if ( errors[ 0 ] && errors[ 0 ][ 0 ] ) {
@@ -175,6 +172,6 @@ export default withData(
 		inGrid: true,
 		createGrid: true,
 	},
-	isDataZero,
+	isDataZeroForReporting,
 	getDataError,
 );

--- a/assets/js/modules/analytics/util/index.js
+++ b/assets/js/modules/analytics/util/index.js
@@ -29,7 +29,6 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { getModulesData } from '../../../util';
 import calculateOverviewData from './calculateOverviewData';
 
 export { calculateOverviewData };
@@ -461,19 +460,6 @@ export const getTopPagesReportDataDefaults = () => {
 			alias: 'Bounce rate',
 		},
 	];
-
-	if ( getModulesData().analytics.settings.adsenseLinked ) {
-		metrics.push(
-			{
-				expression: 'ga:adsenseRevenue',
-				alias: 'AdSense Revenue',
-			},
-			{
-				expression: 'ga:adsenseECPM',
-				alias: 'AdSense ECPM',
-			}
-		);
-	}
 
 	return {
 		dimensions: [


### PR DESCRIPTION
## Summary

Addresses issue #1545

## Relevant technical choices

* Added some comments around the existing error conditions, which I maintained, since there could still be something that this somehow applies to. No need to deep dive and remove as much as possible since this code will all be removed in the long term.

## Screenshots

Here is what the two CTAs look like:
![Screenshot 2020-05-11 at 15 47 47](https://user-images.githubusercontent.com/3531426/81621637-c1e23080-93a3-11ea-9d8e-e620fa390356.png)

![Screenshot 2020-05-11 at 15 48 33](https://user-images.githubusercontent.com/3531426/81621643-c73f7b00-93a3-11ea-981e-ca99527171fa.png)

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
