### PR TITLE
Fixed minor bug variable profile_data being null checked twice.

### DIFF
--- a/includes/Core/Authentication/Authentication.php
+++ b/includes/Core/Authentication/Authentication.php
@@ -265,10 +265,8 @@ final class Authentication {
 			function( $user ) {
 				$profile_data = $this->profile->get();
 				if ( $profile_data ) {
-					if ( $profile_data ) {
-						$user['user']['email']   = $profile_data['email'];
-						$user['user']['picture'] = $profile_data['photo'];
-					}
+					$user['user']['email']   = $profile_data['email'];
+					$user['user']['picture'] = $profile_data['photo'];
 				}
 				$user['verified'] = $this->verification->has();
 				return $user;


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #1176 

## Relevant technical choices

<!-- Please describe your changes. -->

## Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
