### PR TITLE
Set name-based ID in CreateAccountField.

### DIFF
--- a/assets/js/modules/analytics/common/account-create/create-account-field.js
+++ b/assets/js/modules/analytics/common/account-create/create-account-field.js
@@ -54,6 +54,7 @@ export default function CreateAccountField( {
 			<Input
 				name={ name }
 				value={ value }
+				id={ `googlesitekit_analytics_account_create_${ name }` }
 			/>
 		</TextField>
 	);


### PR DESCRIPTION
## Summary

Addresses issue #1211 (follow-up)

## Relevant technical choices

Fixes a duplicate ID warning due to empty `id` attributes set on `Input` components.

![image](https://user-images.githubusercontent.com/1621608/82078362-b4051600-96e9-11ea-8659-5ec1ace1f962.png)


## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
