### PR TITLE
Add an application_name query parameter in request URLs.

### DIFF
--- a/includes/Core/Authentication/Clients/OAuth_Client.php
+++ b/includes/Core/Authentication/Clients/OAuth_Client.php
@@ -808,6 +808,8 @@ final class OAuth_Client {
 			$query_args['site_id'] = $credentials->web->client_id;
 		}
 
+		$query_args['application_name'] = rawurlencode( 'wordpress/google-site-kit/' . GOOGLESITEKIT_VERSION );
+
 		return add_query_arg( $query_args, $this->google_proxy->url( Google_Proxy::PERMISSIONS_URI ) );
 	}
 

--- a/includes/Core/Authentication/Clients/OAuth_Client.php
+++ b/includes/Core/Authentication/Clients/OAuth_Client.php
@@ -746,7 +746,7 @@ final class OAuth_Client {
 			$site_fields  = array_map( 'rawurlencode', $this->google_proxy->get_site_fields() );
 			$query_params = array_merge( $query_params, $site_fields );
 		}
-
+		$query_params['application_name'] = rawurlencode( 'wordpress/google-site-kit/' . GOOGLESITEKIT_VERSION );
 		return add_query_arg( $query_params, $this->google_proxy->url( Google_Proxy::SETUP_URI ) );
 	}
 

--- a/includes/Core/Authentication/Clients/OAuth_Client.php
+++ b/includes/Core/Authentication/Clients/OAuth_Client.php
@@ -213,7 +213,7 @@ final class OAuth_Client {
 			$client = new Google_Site_Kit_Client();
 		}
 
-		$application_name = 'wordpress/google-site-kit/' . GOOGLESITEKIT_VERSION;
+		$application_name = $this->get_application_name();
 		// The application name is included in the Google client's user-agent for requests to Google APIs.
 		$client->setApplicationName( $application_name );
 		// Override the default user-agent for the Guzzle client. This is used for oauth/token requests.
@@ -746,7 +746,7 @@ final class OAuth_Client {
 			$site_fields  = array_map( 'rawurlencode', $this->google_proxy->get_site_fields() );
 			$query_params = array_merge( $query_params, $site_fields );
 		}
-		$query_params['application_name'] = rawurlencode( 'wordpress/google-site-kit/' . GOOGLESITEKIT_VERSION );
+		$query_params['application_name'] = rawurlencode( $this->get_application_name() );
 		return add_query_arg( $query_params, $this->google_proxy->url( Google_Proxy::SETUP_URI ) );
 	}
 
@@ -808,9 +808,20 @@ final class OAuth_Client {
 			$query_args['site_id'] = $credentials->web->client_id;
 		}
 
-		$query_args['application_name'] = rawurlencode( 'wordpress/google-site-kit/' . GOOGLESITEKIT_VERSION );
+		$query_args['application_name'] = rawurlencode( $this->get_application_name() );
 
 		return add_query_arg( $query_args, $this->google_proxy->url( Google_Proxy::PERMISSIONS_URI ) );
+	}
+
+	/**
+	 * Returns the application name: a combination of the namespace and version.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @return string The application name.
+	 */
+	private function get_application_name() {
+		return 'wordpress/google-site-kit/' . GOOGLESITEKIT_VERSION;
 	}
 
 	/**

--- a/tests/phpunit/integration/Core/Authentication/Clients/OAuth_ClientTest.php
+++ b/tests/phpunit/integration/Core/Authentication/Clients/OAuth_ClientTest.php
@@ -348,6 +348,7 @@ class OAuth_ClientTest extends TestCase {
 		$this->assertContains( 'code=temp-code', $url );
 		$this->assertContains( 'scope=', $url );
 		$this->assertContains( 'nonce=', $url );
+		$this->assertContains( 'application_name=', $url );
 		$this->assertNotContains( '&name=', $url );
 		$this->assertNotContains( 'url=', $url );
 		$this->assertNotContains( 'admin_root=', $url );
@@ -368,6 +369,7 @@ class OAuth_ClientTest extends TestCase {
 		$client->set_access_token( 'test-access-token', 3600 );
 		$url = $client->get_proxy_permissions_url();
 		$this->assertContains( 'token=test-access-token', $url );
+		$this->assertContains( 'application_name=', $url );
 
 		// If there is a site ID, it should also include that.
 		$this->fake_proxy_authentication();
@@ -376,8 +378,6 @@ class OAuth_ClientTest extends TestCase {
 		$url = $client->get_proxy_permissions_url();
 		$this->assertContains( 'token=test-access-token', $url );
 		$this->assertContains( 'site_id=' . self::SITE_ID, $url );
-
-		// The URL should include the application name.
 		$this->assertContains( 'application_name=', $url );
 	}
 

--- a/tests/phpunit/integration/Core/Authentication/Clients/OAuth_ClientTest.php
+++ b/tests/phpunit/integration/Core/Authentication/Clients/OAuth_ClientTest.php
@@ -337,6 +337,7 @@ class OAuth_ClientTest extends TestCase {
 		$this->assertContains( 'nonce=', $url );
 		$this->assertContains( 'return_uri=', $url );
 		$this->assertContains( 'action_uri=', $url );
+		$this->assertContains( 'application_name=', $url );
 		$this->assertNotContains( 'site_id=', $url );
 
 		// Otherwise, pass site ID and given temporary access code.
@@ -347,7 +348,7 @@ class OAuth_ClientTest extends TestCase {
 		$this->assertContains( 'code=temp-code', $url );
 		$this->assertContains( 'scope=', $url );
 		$this->assertContains( 'nonce=', $url );
-		$this->assertNotContains( 'name=', $url );
+		$this->assertNotContains( '&name=', $url );
 		$this->assertNotContains( 'url=', $url );
 		$this->assertNotContains( 'admin_root=', $url );
 		$this->assertNotContains( 'return_uri=', $url );

--- a/tests/phpunit/integration/Core/Authentication/Clients/OAuth_ClientTest.php
+++ b/tests/phpunit/integration/Core/Authentication/Clients/OAuth_ClientTest.php
@@ -376,6 +376,9 @@ class OAuth_ClientTest extends TestCase {
 		$url = $client->get_proxy_permissions_url();
 		$this->assertContains( 'token=test-access-token', $url );
 		$this->assertContains( 'site_id=' . self::SITE_ID, $url );
+
+		// The URL should include the application name.
+		$this->assertContains( 'application_name=', $url );
 	}
 
 	public function test_get_error_message_unknown() {


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue https://github.com/google/site-kit-wp/issues/1571

## Relevant technical choices

<!-- Please describe your changes. -->

## Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
