### PR TITLE
Improve getAccountTicketTermsOfServiceURL URL logic.

### DIFF
--- a/assets/js/modules/analytics/datastore/accounts.js
+++ b/assets/js/modules/analytics/datastore/accounts.js
@@ -22,18 +22,12 @@
 import invariant from 'invariant';
 
 /**
- * WordPress dependencies
- */
-import { addQueryArgs } from '@wordpress/url';
-
-/**
  * Internal dependencies
  */
 import API from 'googlesitekit-api';
 import Data from 'googlesitekit-data';
 import { isValidAccountSelection } from '../util';
 import { STORE_NAME, ACCOUNT_CREATE, PROPERTY_CREATE, FORM_ACCOUNT_CREATE } from './constants';
-import { STORE_NAME as CORE_USER } from '../../../googlesitekit/datastore/user/constants';
 import { actions as tagActions } from './tags';
 const { createRegistrySelector, createRegistryControl } = Data;
 
@@ -418,23 +412,8 @@ export const selectors = {
 	 * @param {Object} state Data store's state.
 	 * @return {(string|undefined)} The terms of service URL.
 	 */
-	getAccountTicketTermsOfServiceURL: createRegistrySelector( ( select ) => ( state ) => {
-		const { accountTicketTermsOfServiceURL: url } = state;
-		if ( undefined === url ) {
-			return undefined;
-		}
-
-		const email = select( CORE_USER ).getEmail();
-		if ( undefined === email ) {
-			return undefined;
-		}
-
-		// While there should only be one anchor, let's make sure we get everything.
-		const [ baseURL, ...anchors ] = url.split( '#' );
-		const userBaseURL = addQueryArgs( baseURL, {
-			authuser: email,
-		} );
-		return `${ userBaseURL }#${ anchors.join( '#' ) }`;
+	getAccountTicketTermsOfServiceURL: createRegistrySelector( () => ( state ) => {
+		return state.accountTicketTermsOfServiceURL;
 	} ),
 
 	/**

--- a/assets/js/modules/analytics/datastore/accounts.js
+++ b/assets/js/modules/analytics/datastore/accounts.js
@@ -426,7 +426,7 @@ export const selectors = {
 
 		const email = select( CORE_USER ).getEmail();
 		if ( undefined === email ) {
-			return url;
+			return undefined;
 		}
 
 		// While there should only be one anchor, let's make sure we get everything.


### PR DESCRIPTION
Address URL construction bug discovered in QA on https://github.com/google/site-kit-wp/issues/1211.

## Summary

Ensure `getAccountTicketTermsOfServiceURL` returns undefined until email is available in the data store.

Before this change the original URL was returned without the user email and this was used as the redirect. This URL fails if the user is logged into a different Google account in their browser.


## Relevant technical choices

<!-- Please describe your changes. -->

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
