### PR TITLE
Enhance/1211 back button

### DIFF
--- a/assets/js/modules/analytics/common/account-create.js
+++ b/assets/js/modules/analytics/common/account-create.js
@@ -91,7 +91,7 @@ export default function AccountCreate() {
 	const { rollbackSettings } = useDispatch( STORE_NAME );
 	const handleBack = useCallback( () => rollbackSettings() );
 
-	if ( isDoingCreateAccount || isNavigating ) {
+	if ( isDoingCreateAccount || isNavigating || accounts === undefined ) {
 		return <ProgressBar />;
 	}
 

--- a/assets/js/modules/analytics/common/account-create.js
+++ b/assets/js/modules/analytics/common/account-create.js
@@ -26,6 +26,7 @@ import { useCallback, useState, useEffect } from '@wordpress/element';
  * Internal dependencies
  */
 import Button from '../../../components/button';
+import Link from '../../../components/link';
 import ProgressBar from '../../../components/progress-bar';
 import { trackEvent } from '../../../util';
 import TimezoneSelect from './account-create/timezone-select';
@@ -85,6 +86,10 @@ export default function AccountCreate() {
 		[ createAccount, setIsNavigating ]
 	);
 
+	// If the user clicks "Back", rollback settings to restore saved values, if any.
+	const { rollbackSettings } = useDispatch( STORE_NAME );
+	const handleBack = useCallback( () => rollbackSettings() );
+
 	if ( isDoingCreateAccount || isNavigating ) {
 		return <ProgressBar />;
 	}
@@ -123,12 +128,21 @@ export default function AccountCreate() {
 				{ __( 'You will be redirected to Google Analytics to accept the Terms of Service and create your new account.', 'google-site-kit' ) }
 			</p>
 
-			<Button
-				disabled={ ! canSubmitAccountCreate }
-				onClick={ handleSubmit }
-			>
-				{ __( 'Create Account', 'google-site-kit' ) }
-			</Button>
+			<div className="googlesitekit-setup-module__action">
+				<Button
+					disabled={ ! canSubmitAccountCreate }
+					onClick={ handleSubmit }
+				>
+					{ __( 'Create Account', 'google-site-kit' ) }
+				</Button>
+
+				<Link
+					className="googlesitekit-setup-module__sub-action"
+					onClick={ handleBack }
+				>
+					{ __( 'Back', 'google-site-kit' ) }
+				</Link>
+			</div>
 		</div>
 	);
 }

--- a/assets/js/modules/analytics/common/account-create.js
+++ b/assets/js/modules/analytics/common/account-create.js
@@ -46,6 +46,7 @@ export default function AccountCreate() {
 	const accountTicketTermsOfServiceURL = useSelect( ( select ) => select( STORE_NAME ).getAccountTicketTermsOfServiceURL() );
 	const canSubmitAccountCreate = useSelect( ( select ) => select( STORE_NAME ).canSubmitAccountCreate() );
 	const isDoingCreateAccount = useSelect( ( select ) => select( STORE_NAME ).isDoingCreateAccount() );
+	const accounts = useSelect( ( select ) => select( STORE_NAME ).getAccounts() );
 	const siteURL = useSelect( ( select ) => select( CORE_SITE ).getReferenceSiteURL() );
 	const siteName = useSelect( ( select ) => select( CORE_SITE ).getSiteName() );
 	let timezone = useSelect( ( select ) => select( CORE_SITE ).getTimezone() );
@@ -136,12 +137,14 @@ export default function AccountCreate() {
 					{ __( 'Create Account', 'google-site-kit' ) }
 				</Button>
 
-				<Link
-					className="googlesitekit-setup-module__sub-action"
-					onClick={ handleBack }
-				>
-					{ __( 'Back', 'google-site-kit' ) }
-				</Link>
+				{ ( accounts && !! accounts.length ) && (
+					<Link
+						className="googlesitekit-setup-module__sub-action"
+						onClick={ handleBack }
+					>
+						{ __( 'Back', 'google-site-kit' ) }
+					</Link>
+				) }
 			</div>
 		</div>
 	);

--- a/stories/module-analytics-setup.stories.js
+++ b/stories/module-analytics-setup.stories.js
@@ -100,10 +100,27 @@ storiesOf( 'Analytics Module/Setup', module )
 
 		return <Setup callback={ setupRegistry } />;
 	} )
+	.add( 'No Accounts (legacy)', () => {
+		filterAnalyticsSetup();
+
+		const setupRegistry = ( { dispatch } ) => {
+			dispatch( STORE_NAME ).setSettings( {} );
+			dispatch( STORE_NAME ).receiveAccounts( [] );
+			dispatch( STORE_NAME ).receiveExistingTag( null );
+		};
+
+		return <Setup callback={ setupRegistry } />;
+	} )
 	.add( 'No Accounts', () => {
 		filterAnalyticsSetup();
 
 		const setupRegistry = ( { dispatch } ) => {
+			dispatch( CORE_SITE ).receiveSiteInfo( {
+				usingProxy: true,
+				referenceSiteURL: 'http://example.com',
+				timezone: 'America/Detroit',
+				siteName: 'My Site Name',
+			} );
 			dispatch( STORE_NAME ).setSettings( {} );
 			dispatch( STORE_NAME ).receiveAccounts( [] );
 			dispatch( STORE_NAME ).receiveExistingTag( null );


### PR DESCRIPTION
## Summary

Addresses issue #1211 (follow-up)

![image](https://user-images.githubusercontent.com/1621608/82825407-dcdc9680-9eb3-11ea-9c4f-280b8ed9e2ef.png)

## Relevant technical choices

* Adds a "Back" button to the new Account Create screen  
This prevents a user from being stuck in this view by selecting the "Set up a new account" option.
    - Only adds this link if the user has any accounts, otherwise the Account Create view is the only one available to them anyways
* Adds a story to storybook for "No Accounts" using new component

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
