### PR TITLE
Invalidate legacy cache groups on submit changes

### DIFF
--- a/assets/js/modules/adsense/datastore/settings.js
+++ b/assets/js/modules/adsense/datastore/settings.js
@@ -220,6 +220,7 @@ export const controls = {
 		}
 
 		await API.invalidateCache( 'modules', 'adsense' );
+		// TODO: Remove once legacy dataAPI is no longer used.
 		dataAPI.invalidateCacheGroup( TYPE_MODULES, 'adsense' );
 
 		return {};

--- a/assets/js/modules/adsense/datastore/settings.js
+++ b/assets/js/modules/adsense/datastore/settings.js
@@ -26,6 +26,7 @@ import invariant from 'invariant';
  */
 import API from 'googlesitekit-api';
 import Data from 'googlesitekit-data';
+import dataAPI, { TYPE_MODULES } from '../../../components/data';
 import {
 	isValidAccountID,
 	isValidClientID,
@@ -219,6 +220,8 @@ export const controls = {
 		}
 
 		await API.invalidateCache( 'modules', 'adsense' );
+		dataAPI.invalidateCacheGroup( TYPE_MODULES, 'adsense' );
+
 		return {};
 	} ),
 	// This is a control to allow for asynchronous logic using external action dispatchers.

--- a/assets/js/modules/analytics/datastore/settings.js
+++ b/assets/js/modules/analytics/datastore/settings.js
@@ -21,6 +21,7 @@
  */
 import API from 'googlesitekit-api';
 import Data from 'googlesitekit-data';
+import dataAPI, { TYPE_MODULES } from '../../../components/data';
 import {
 	isValidAccountID,
 	isValidInternalWebPropertyID,
@@ -101,6 +102,7 @@ export const controls = {
 		}
 
 		await API.invalidateCache( 'modules', 'analytics' );
+		dataAPI.invalidateCacheGroup( TYPE_MODULES, 'analytics' );
 
 		return {};
 	} ),

--- a/assets/js/modules/analytics/datastore/settings.js
+++ b/assets/js/modules/analytics/datastore/settings.js
@@ -102,6 +102,7 @@ export const controls = {
 		}
 
 		await API.invalidateCache( 'modules', 'analytics' );
+		// TODO: Remove once legacy dataAPI is no longer used.
 		dataAPI.invalidateCacheGroup( TYPE_MODULES, 'analytics' );
 
 		return {};


### PR DESCRIPTION
## Summary

Addresses issue #1593

## Relevant technical choices

* Kept `dataAPI` name in import for consistency

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
