### PR TITLE
Add support for Web Stories plugin, specifically integrate Analytics snippet

### DIFF
--- a/includes/Context.php
+++ b/includes/Context.php
@@ -273,6 +273,10 @@ final class Context {
 	 * @return bool True if an AMP request, false otherwise.
 	 */
 	public function is_amp() {
+		if ( is_singular( 'web-story' ) ) {
+			return true;
+		}
+
 		return function_exists( 'is_amp_endpoint' ) && is_amp_endpoint();
 	}
 

--- a/includes/Modules/AdSense.php
+++ b/includes/Modules/AdSense.php
@@ -207,7 +207,7 @@ final class AdSense extends Module implements Module_With_Screen, Module_With_Sc
 		// On AMP, preferably use the new 'wp_body_open' hook, falling back to 'the_content' below.
 		if ( $this->context->is_amp() ) {
 			// TODO: 'amp_story' support can be phased out in the long term.
-			if ( is_singular( 'web-story' ) || is_singular( 'amp_story' ) ) {
+			if ( is_singular( array( 'web-story', 'amp_story' ) ) ) {
 				return;
 			}
 			add_action(
@@ -319,7 +319,7 @@ tag_partner: "site_kit"
 	 */
 	protected function amp_content_add_auto_ads( $content ) {
 		// TODO: 'amp_story' support can be phased out in the long term.
-		if ( ! $this->context->is_amp() || is_singular( 'web-story' ) || is_singular( 'amp_story' ) ) {
+		if ( ! $this->context->is_amp() || is_singular( array( 'web-story', 'amp_story' ) ) ) {
 			return $content;
 		}
 

--- a/includes/Modules/AdSense.php
+++ b/includes/Modules/AdSense.php
@@ -204,7 +204,8 @@ final class AdSense extends Module implements Module_With_Screen, Module_With_Sc
 
 		// On AMP, preferably use the new 'wp_body_open' hook, falling back to 'the_content' below.
 		if ( $this->context->is_amp() ) {
-			if ( is_singular( 'amp_story' ) ) {
+			// TODO: 'amp_story' support can be phased out in the long term.
+			if ( is_singular( 'web-story' ) || is_singular( 'amp_story' ) ) {
 				return;
 			}
 			add_action(
@@ -315,7 +316,8 @@ tag_partner: "site_kit"
 	 * @return string Filtered $content.
 	 */
 	protected function amp_content_add_auto_ads( $content ) {
-		if ( ! $this->context->is_amp() || is_singular( 'amp_story' ) ) {
+		// TODO: 'amp_story' support can be phased out in the long term.
+		if ( ! $this->context->is_amp() || is_singular( 'web-story' ) || is_singular( 'amp_story' ) ) {
 			return $content;
 		}
 

--- a/includes/Modules/Analytics.php
+++ b/includes/Modules/Analytics.php
@@ -112,6 +112,8 @@ final class Analytics extends Module
 		add_action( 'wp_footer', $print_amp_gtag, 20 );
 		// For AMP Reader, AMP plugin version <1.3.
 		add_action( 'amp_post_template_footer', $print_amp_gtag, 20 );
+		// For Web Stories plugin.
+		add_action( 'web_stories_print_analytics', $print_amp_gtag );
 
 		add_filter( // Load amp-analytics component for AMP Reader.
 			'amp_post_template_data',


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #1506

## Relevant technical choices

The Web Stories plugin will have to be updated:
* All the Site Kit duplicate logic needs to be removed, otherwise it will end up including two Analytics snippets.
* It needs to hook into Site Kit's `googlesitekit_amp_gtag_opt` filter to conditionally (if `is_singular( 'web-story' )`) include all its extra configuration.
* See https://github.com/google/web-stories-wp/issues/1168. cc @swissspidy @miina

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
