### PR TITLE
Update scope handling with unsatisfied scopes

### DIFF
--- a/assets/js/util/refresh-authentication.js
+++ b/assets/js/util/refresh-authentication.js
@@ -25,18 +25,23 @@ export const refreshAuthentication = async () => {
 	try {
 		// `timestamp` added to ensure this request is always made as it is preloaded
 		// using apiFetch's preloading middleware.
-		const response = await data.get( TYPE_CORE, 'user', 'authentication', { timestamp: Date.now() } );
-
-		const requiredAndGrantedScopes = response.grantedScopes.filter( ( scope ) => {
-			return -1 !== response.requiredScopes.indexOf( scope );
-		} );
+		const {
+			authenticated: isAuthenticated,
+			requiredScopes,
+			grantedScopes,
+			unsatisfiedScopes = [],
+		} = await data.get( TYPE_CORE, 'user', 'authentication', { timestamp: Date.now() } );
 
 		// We should really be using state management. This is terrible.
-		global.googlesitekit.setup = global.googlesitekit.setup || {};
-		global.googlesitekit.setup.isAuthenticated = response.authenticated;
-		global.googlesitekit.setup.requiredScopes = response.requiredScopes;
-		global.googlesitekit.setup.grantedScopes = response.grantedScopes;
-		global.googlesitekit.setup.needReauthenticate = requiredAndGrantedScopes.length < response.requiredScopes.length;
+		// Hang in there... we're getting to it ;)
+		global.googlesitekit.setup = {
+			...( global.googlesitekit.setup || {} ),
+			isAuthenticated,
+			requiredScopes,
+			grantedScopes,
+			unsatisfiedScopes,
+			needReauthenticate: 0 < unsatisfiedScopes.length,
+		};
 	} catch ( e ) { // eslint-disable-line no-empty
 	}
 };

--- a/includes/Core/Authentication/Authentication.php
+++ b/includes/Core/Authentication/Authentication.php
@@ -732,9 +732,10 @@ final class Authentication {
 							$access_token = $oauth_client->get_access_token();
 
 							$data = array(
-								'authenticated'  => ! empty( $access_token ),
-								'requiredScopes' => $oauth_client->get_required_scopes(),
-								'grantedScopes'  => ! empty( $access_token ) ? $oauth_client->get_granted_scopes() : array(),
+								'authenticated'     => ! empty( $access_token ),
+								'requiredScopes'    => $oauth_client->get_required_scopes(),
+								'grantedScopes'     => ! empty( $access_token ) ? $oauth_client->get_granted_scopes() : array(),
+								'unsatisfiedScopes' => ! empty( $access_token ) ? $oauth_client->get_unsatisfied_scopes() : array(),
 							);
 
 							return new WP_REST_Response( $data );

--- a/includes/Core/Authentication/Authentication.php
+++ b/includes/Core/Authentication/Authentication.php
@@ -633,7 +633,8 @@ final class Authentication {
 		$data['isAuthenticated']    = ! empty( $access_token );
 		$data['requiredScopes']     = $auth_client->get_required_scopes();
 		$data['grantedScopes']      = ! empty( $access_token ) ? $auth_client->get_granted_scopes() : array();
-		$data['needReauthenticate'] = $data['isAuthenticated'] && $auth_client->needs_reauthentication();
+		$data['unsatisfiedScopes']  = ! empty( $access_token ) ? $auth_client->get_unsatisfied_scopes() : array();
+		$data['needReauthenticate'] = $auth_client->needs_reauthentication();
 
 		if ( $this->credentials->using_proxy() ) {
 			$error_code = $this->user_options->get( OAuth_Client::OPTION_ERROR_CODE );

--- a/includes/Core/Authentication/Clients/OAuth_Client.php
+++ b/includes/Core/Authentication/Clients/OAuth_Client.php
@@ -459,14 +459,15 @@ final class OAuth_Client {
 			$scopes = $this->get_required_scopes();
 		}
 
-		$granted_scopes = $this->get_granted_scopes();
-
-		return array_filter(
+		$granted_scopes     = $this->get_granted_scopes();
+		$unsatisfied_scopes = array_filter(
 			$scopes,
 			function( $scope ) use ( $granted_scopes ) {
 				return ! Scopes::is_satisfied_by( $scope, $granted_scopes );
 			}
 		);
+
+		return array_values( $unsatisfied_scopes );
 	}
 
 	/**

--- a/includes/Core/Util/Debug_Data.php
+++ b/includes/Core/Util/Debug_Data.php
@@ -289,8 +289,8 @@ class Debug_Data {
 		$value           = array();
 
 		foreach ( $required_scopes as $scope ) {
-			$granted         = in_array( $scope, $granted_scopes, true );
-			$value[ $scope ] = $granted ? '✅' : '⭕';
+			$satisfied       = Scopes::is_satisfied_by( $scope, $granted_scopes );
+			$value[ $scope ] = $satisfied ? '✅' : '⭕';
 		}
 
 		return array(

--- a/tests/phpunit/integration/Core/Authentication/AuthenticationTest.php
+++ b/tests/phpunit/integration/Core/Authentication/AuthenticationTest.php
@@ -129,6 +129,7 @@ class AuthenticationTest extends TestCase {
 				'requiredScopes',
 				'showModuleSetupWizard',
 				'isResettable',
+				'unsatisfiedScopes',
 			),
 			array_keys( $data )
 		);


### PR DESCRIPTION
## Summary

Addresses issue #1566

## Relevant technical choices

* Updates scope granted status in Site Health using new scope-satisfaction logic
* Added `unsatisfiedScopes` to `googlesitekit.setup` data
* Added `unsatisfiedScopes` to `core/user/data/authentication` response
* Updated `refreshAuthentication` to include `unsatisfiedScopes`
* Updated `get_unsatisfied_scopes` to always return a list as `array_filter` preserves keys which causes the array to be encoded as an object otherwise

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
