### PR TITLE
Fix console warnings in widgets tests and add googlesitekit.widgets as missing external

### DIFF
--- a/assets/js/googlesitekit/widgets/datastore/areas.test.js
+++ b/assets/js/googlesitekit/widgets/datastore/areas.test.js
@@ -22,6 +22,7 @@
 import {
 	createTestRegistry,
 	unsubscribeFromAll,
+	muteConsole,
 } from '../../../../../tests/js/utils';
 import { STORE_NAME } from './constants';
 
@@ -117,6 +118,9 @@ describe( 'core/widgets Widget areas', () => {
 			} );
 
 			it( 'requires a title and subtitle in settings', () => {
+				// Mute warning about duplicate slug registrations for this test.
+				muteConsole( 'warn' );
+
 				expect( () => {
 					registry.dispatch( STORE_NAME ).registerWidgetArea( 'header', {} );
 				} ).toThrow( 'settings.title is required.' );
@@ -211,7 +215,16 @@ describe( 'core/widgets Widget areas', () => {
 					style: 'composite',
 				};
 				registry.dispatch( STORE_NAME ).registerWidgetArea( slug, settings );
+
+				// Mute warning about duplicate slug since we expect it below anyway.
+				muteConsole( 'warn' );
+
+				// Expect console warning about duplicate slug.
+				const consoleWarnSpy = jest.spyOn( global.console, 'warn' );
 				registry.dispatch( STORE_NAME ).registerWidgetArea( slug, differentSettings );
+				expect( consoleWarnSpy ).toHaveBeenCalledWith( `Could not register widget area with slug "${ slug }". Widget area "${ slug }" is already registered.` );
+				consoleWarnSpy.mockClear();
+
 				const state = store.getState();
 
 				// Ensure the original settings are registered.

--- a/assets/js/googlesitekit/widgets/datastore/widgets.test.js
+++ b/assets/js/googlesitekit/widgets/datastore/widgets.test.js
@@ -22,6 +22,7 @@
 import {
 	createTestRegistry,
 	unsubscribeFromAll,
+	muteConsole,
 } from '../../../../../tests/js/utils';
 import { render } from '../../../../../tests/js/test-utils';
 import { STORE_NAME } from './constants';
@@ -188,11 +189,21 @@ describe( 'core/widgets Widgets', () => {
 				registry.dispatch( STORE_NAME ).registerWidget( slug, {
 					component: WidgetOne,
 				} );
+
+				// Mute warning about duplicate slug since we expect it below anyway.
+				muteConsole( 'warn' );
+
+				// Expect console warning about duplicate slug.
+				const consoleWarnSpy = jest.spyOn( global.console, 'warn' );
 				registry.dispatch( STORE_NAME ).registerWidget( slug, {
 					component: WidgetOneRedone,
 				} );
+				expect( consoleWarnSpy ).toHaveBeenCalledWith( `Could not register widget with slug "${ slug }". Widget "${ slug }" is already registered.` );
+				consoleWarnSpy.mockClear();
+
 				const registryKey = registry.select( STORE_NAME ).getWidgetRegistryKey();
 
+				// Ensure original widget's component is registered.
 				expect( Object.keys( WidgetComponents[ registryKey ] ) ).toHaveLength( 1 );
 				expect( WidgetComponents[ registryKey ][ slug ] ).toEqual( WidgetOne );
 			} );

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -41,6 +41,7 @@ const siteKitExternals = {
 	'googlesitekit-api': [ 'googlesitekit', 'api' ],
 	'googlesitekit-data': [ 'googlesitekit', 'data' ],
 	'googlesitekit-modules': [ 'googlesitekit', 'modules' ],
+	'googlesitekit-widgets': [ 'googlesitekit', 'widgets' ],
 };
 
 const externals = { ...siteKitExternals };
@@ -96,11 +97,11 @@ const webpackConfig = ( mode ) => {
 				'googlesitekit-datastore-user': './assets/js/googlesitekit-datastore-user.js',
 				'googlesitekit-datastore-forms': './assets/js/googlesitekit-datastore-forms.js',
 				'googlesitekit-modules': './assets/js/googlesitekit-modules.js',
+				'googlesitekit-widgets': './assets/js/googlesitekit-widgets.js',
 				'googlesitekit-modules-adsense': './assets/js/googlesitekit-modules-adsense.js',
 				'googlesitekit-modules-analytics': './assets/js/googlesitekit-modules-analytics.js',
 				'googlesitekit-modules-pagespeed-insights': 'assets/js/googlesitekit-modules-pagespeed-insights.js',
 				'googlesitekit-modules-search-console': './assets/js/googlesitekit-modules-search-console.js',
-				'googlesitekit-widgets': './assets/js/googlesitekit-widgets.js',
 				// Old Modules
 				'googlesitekit-activation': './assets/js/googlesitekit-activation.js',
 				'googlesitekit-settings': './assets/js/googlesitekit-settings.js',


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #1298 (QA follow-up)

## Relevant technical choices

* Fixes tests to explicitly check for `console.warn` calls where they are expected to occur.
* Mute all of these `console.warn` calls since they are expected to occur in every case.
* Adds external for `googlesitekit.widgets` which was also missing.

## Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
