### PR TITLE
Rename profile to view

### DIFF
--- a/includes/Modules/Analytics.php
+++ b/includes/Modules/Analytics.php
@@ -804,7 +804,7 @@ final class Analytics extends Module
 					$option = $this->get_settings()->get();
 
 					if ( empty( $option['profileID'] ) ) {
-						return new WP_Error( 'profile_id_not_set', __( 'Analytics profile ID not set.', 'google-site-kit' ), array( 'status' => 404 ) );
+						return new WP_Error( 'profile_id_not_set', __( 'Analytics view ID not set.', 'google-site-kit' ), array( 'status' => 404 ) );
 					}
 					return $option['profileID'];
 				};

--- a/includes/Modules/Analytics.php
+++ b/includes/Modules/Analytics.php
@@ -266,7 +266,7 @@ final class Analytics extends Module
 				'debug' => Debug_Data::redact_debug_value( $settings['propertyID'], 7 ),
 			),
 			'analytics_profile_id'  => array(
-				'label' => __( 'Analytics profile ID', 'google-site-kit' ),
+				'label' => __( 'Analytics view ID', 'google-site-kit' ),
 				'value' => $settings['profileID'],
 				'debug' => Debug_Data::redact_debug_value( $settings['profileID'] ),
 			),


### PR DESCRIPTION
## Summary

Addresses issue #1486 (follow-up)

## Relevant technical choices
* Updates label for `profileID` in Site Health to use "view" instead of "profile".  
Okay for "raw value" to still use `profile` as this is not intended to be user-facing
* Updates error message returned if profile ID is not set to use "view" instead of "profile".  


## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
