### PR TITLE
Pass user_roles query parameter in proxy setup URL

### DIFF
--- a/includes/Core/Authentication/Clients/OAuth_Client.php
+++ b/includes/Core/Authentication/Clients/OAuth_Client.php
@@ -829,7 +829,12 @@ final class OAuth_Client {
 			$site_fields  = array_map( 'rawurlencode', $this->google_proxy->get_site_fields() );
 			$query_params = array_merge( $query_params, $site_fields );
 		}
+
+		$user_fields  = array_map( 'rawurlencode', $this->google_proxy->get_user_fields() );
+		$query_params = array_merge( $query_params, $user_fields );
+
 		$query_params['application_name'] = rawurlencode( $this->get_application_name() );
+
 		return add_query_arg( $query_params, $this->google_proxy->url( Google_Proxy::SETUP_URI ) );
 	}
 

--- a/includes/Core/Authentication/Google_Proxy.php
+++ b/includes/Core/Authentication/Google_Proxy.php
@@ -79,7 +79,7 @@ class Google_Proxy {
 	 *
 	 * @since 1.5.0
 	 *
-	 * @return array
+	 * @return array Associative array of $query_arg => $value pairs.
 	 */
 	public function get_site_fields() {
 		$home_url_no_scheme = str_replace( array( 'http://', 'https://' ), '', home_url() );
@@ -93,6 +93,28 @@ class Google_Proxy {
 			// TODO: Remove admin_root once proxy is updated.
 			'admin_root'             => str_replace( array( 'http://', 'https://', $home_url_no_scheme ), '', admin_url() ),
 			'analytics_redirect_uri' => add_query_arg( 'gatoscallback', 1, admin_url( 'index.php' ) ),
+		);
+	}
+
+	/**
+	 * Gets user fields.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @return array Associative array of $query_arg => $value pairs.
+	 */
+	public function get_user_fields() {
+		$current_user = wp_get_current_user();
+
+		$user_roles = $current_user && $current_user->exists() && ! empty( $current_user->roles ) ? $current_user->roles : array();
+		// If multisite, also consider network administrators.
+		if ( is_multisite() && current_user_can( 'manage_network' ) ) {
+			$user_roles[] = 'network_administrator';
+		}
+		$user_roles = array_values( array_unique( $user_roles ) );
+
+		return array(
+			'user_roles' => implode( ',', $user_roles ),
 		);
 	}
 

--- a/tests/phpunit/integration/Core/Authentication/Clients/OAuth_ClientTest.php
+++ b/tests/phpunit/integration/Core/Authentication/Clients/OAuth_ClientTest.php
@@ -440,6 +440,7 @@ class OAuth_ClientTest extends TestCase {
 		$this->assertContains( 'nonce=', $url );
 		$this->assertContains( 'return_uri=', $url );
 		$this->assertContains( 'action_uri=', $url );
+		$this->assertContains( 'user_roles=', $url );
 		$this->assertContains( 'application_name=', $url );
 		$this->assertNotContains( 'site_id=', $url );
 
@@ -451,6 +452,7 @@ class OAuth_ClientTest extends TestCase {
 		$this->assertContains( 'code=temp-code', $url );
 		$this->assertContains( 'scope=', $url );
 		$this->assertContains( 'nonce=', $url );
+		$this->assertContains( 'user_roles=', $url );
 		$this->assertContains( 'application_name=', $url );
 		$this->assertNotContains( '&name=', $url );
 		$this->assertNotContains( 'url=', $url );


### PR DESCRIPTION
## Summary

Addresses issue #1639 

## Relevant technical choices

<!-- Please describe your changes. -->

## Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
