### PR TITLE
Enhancement/1607 integrate commonstore into createmodulestore

### DIFF
--- a/assets/js/googlesitekit/modules/create-module-store.js
+++ b/assets/js/googlesitekit/modules/create-module-store.js
@@ -76,6 +76,7 @@ export const createModuleStore = ( slug, {
 		: {};
 
 	const combinedStore = Data.combineStores(
+		Data.commonStore,
 		notificationsStore,
 		settingsStore,
 	);

--- a/assets/js/googlesitekit/modules/create-module-store.js
+++ b/assets/js/googlesitekit/modules/create-module-store.js
@@ -68,18 +68,26 @@ export const createModuleStore = ( slug, {
 		storeName,
 	} );
 
-	const settingsStore = ( 'undefined' !== typeof settingSlugs )
-		? createSettingsStore( 'modules', slug, 'settings', {
+	let combinedStore = {};
+	if ( 'undefined' !== typeof settingSlugs ) {
+		const settingsStore = createSettingsStore( 'modules', slug, 'settings', {
 			storeName,
 			settingSlugs,
-		} )
-		: {};
+		} );
 
-	const combinedStore = Data.combineStores(
-		Data.commonStore,
-		notificationsStore,
-		settingsStore,
-	);
+		// to prevent duplication errors during combining stores, we don't need to combine
+		// Data.commontStore here since settingsStore already uses commonActions and commonControls
+		// from the Data.commonStore.
+		combinedStore = Data.combineStores(
+			notificationsStore,
+			settingsStore,
+		);
+	} else {
+		combinedStore = Data.combineStores(
+			Data.commonStore,
+			notificationsStore,
+		);
+	}
 
 	combinedStore.STORE_NAME = storeName;
 

--- a/assets/js/modules/pagespeed-insights/datastore/index.js
+++ b/assets/js/modules/pagespeed-insights/datastore/index.js
@@ -25,14 +25,9 @@ import { STORE_NAME } from './constants';
 
 export { STORE_NAME };
 
-const baseModuleStore = Modules.createModuleStore( 'pagespeed-insights', {
+const store = Modules.createModuleStore( 'pagespeed-insights', {
 	storeName: STORE_NAME,
 } );
-
-const store = Data.combineStores(
-	Data.commonStore,
-	baseModuleStore,
-);
 
 // Register this store on the global registry.
 Data.registerStore( STORE_NAME, store );


### PR DESCRIPTION
## Summary

Addresses issue #1607 

## Relevant technical choices

Updated createModuleStore function to combine commonStore by default.

## Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
