### PR TITLE
Separate out invalidateCacheGroup from main data.

### DIFF
--- a/assets/js/components/data/constants.js
+++ b/assets/js/components/data/constants.js
@@ -1,0 +1,20 @@
+/**
+ * Data API: Constants.
+ *
+ * Site Kit by Google, Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export const TYPE_CORE = 'core';
+export const TYPE_MODULES = 'modules';

--- a/assets/js/components/data/index.js
+++ b/assets/js/components/data/index.js
@@ -15,6 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 /**
  * External dependencies
  */
@@ -30,16 +31,16 @@ import { addAction, applyFilters, doAction, addFilter, removeFilter, hasAction }
 /**
  * Internal dependencies
  */
-import { getStorage } from '../../util/storage';
 import { getCurrentDateRangeSlug } from '../../util/date-range';
 import { fillFilterWithComponent } from '../../util/helpers';
 import { getQueryParameter } from '../../util/standalone';
 import DashboardAuthAlert from '../notifications/dashboard-auth-alert';
 import DashboardPermissionAlert from '../notifications/dashboard-permission-alert';
-import { getCacheKey, getCache, lazilySetupLocalCache, setCache } from './cache';
+import { getCacheKey, getCache, setCache } from './cache';
+import { TYPE_CORE, TYPE_MODULES } from './constants';
+import { invalidateCacheGroup } from './invalidate-cache-group';
 
-export const TYPE_CORE = 'core';
-export const TYPE_MODULES = 'modules';
+export { TYPE_CORE, TYPE_MODULES };
 
 /**
  * Gets a copy of the given data request object with the data.dateRange populated via filter, if not set.
@@ -259,30 +260,7 @@ const dataAPI = {
 		}
 	},
 
-	/**
-	 * Invalidates all caches associated with a specific cache group.
-	 *
-	 * @param {string} type       The data to access. One of 'core' or 'modules'.
-	 * @param {string} identifier The data identifier, for example a module slug.
-	 * @param {string} datapoint  The datapoint.
-	 */
-	invalidateCacheGroup( type, identifier, datapoint ) {
-		const groupPrefix = getCacheKey( type, identifier, datapoint );
-
-		lazilySetupLocalCache();
-
-		Object.keys( global._googlesitekitLegacyData.admin.datacache ).forEach( ( key ) => {
-			if ( 0 === key.indexOf( groupPrefix + '::' ) || key === groupPrefix ) {
-				delete global._googlesitekitLegacyData.admin.datacache[ key ];
-			}
-		} );
-
-		Object.keys( getStorage() ).forEach( ( key ) => {
-			if ( 0 === key.indexOf( `googlesitekit_${ groupPrefix }::` ) || key === `googlesitekit_${ groupPrefix }` ) {
-				getStorage().removeItem( key );
-			}
-		} );
-	},
+	invalidateCacheGroup,
 
 	/**
 	 * Collects the initial module data request.

--- a/assets/js/components/data/invalidate-cache-group.js
+++ b/assets/js/components/data/invalidate-cache-group.js
@@ -1,0 +1,48 @@
+/**
+ * Data API: Cache group invalidation.
+ *
+ * Site Kit by Google, Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import { getStorage } from '../../util/storage';
+import { getCacheKey, lazilySetupLocalCache } from './cache';
+
+/**
+ * Invalidates all caches associated with a specific cache group.
+ *
+ * @param {string} type       The data to access. One of 'core' or 'modules'.
+ * @param {string} identifier The data identifier, for example a module slug.
+ * @param {string} datapoint  The datapoint.
+ */
+export const invalidateCacheGroup = ( type, identifier, datapoint ) => {
+	const groupPrefix = getCacheKey( type, identifier, datapoint );
+
+	lazilySetupLocalCache();
+
+	Object.keys( global._googlesitekitLegacyData.admin.datacache ).forEach( ( key ) => {
+		if ( 0 === key.indexOf( groupPrefix + '::' ) || key === groupPrefix ) {
+			delete global._googlesitekitLegacyData.admin.datacache[ key ];
+		}
+	} );
+
+	Object.keys( getStorage() ).forEach( ( key ) => {
+		if ( 0 === key.indexOf( `googlesitekit_${ groupPrefix }::` ) || key === `googlesitekit_${ groupPrefix }` ) {
+			getStorage().removeItem( key );
+		}
+	} );
+};

--- a/assets/js/modules/adsense/datastore/settings.js
+++ b/assets/js/modules/adsense/datastore/settings.js
@@ -26,7 +26,8 @@ import invariant from 'invariant';
  */
 import API from 'googlesitekit-api';
 import Data from 'googlesitekit-data';
-import dataAPI, { TYPE_MODULES } from '../../../components/data';
+import { TYPE_MODULES } from '../../../components/data/constants';
+import { invalidateCacheGroup } from '../../../components/data/invalidate-cache-group';
 import {
 	isValidAccountID,
 	isValidClientID,
@@ -191,7 +192,7 @@ const baseControls = {
 
 		await API.invalidateCache( 'modules', 'adsense' );
 		// TODO: Remove once legacy dataAPI is no longer used.
-		dataAPI.invalidateCacheGroup( TYPE_MODULES, 'adsense' );
+		invalidateCacheGroup( TYPE_MODULES, 'adsense' );
 
 		return {};
 	} ),

--- a/assets/js/modules/analytics/datastore/settings.js
+++ b/assets/js/modules/analytics/datastore/settings.js
@@ -21,7 +21,8 @@
  */
 import API from 'googlesitekit-api';
 import Data from 'googlesitekit-data';
-import dataAPI, { TYPE_MODULES } from '../../../components/data';
+import { TYPE_MODULES } from '../../../components/data/constants';
+import { invalidateCacheGroup } from '../../../components/data/invalidate-cache-group';
 import {
 	isValidAccountID,
 	isValidInternalWebPropertyID,
@@ -110,7 +111,7 @@ export const controls = {
 
 		await API.invalidateCache( 'modules', 'analytics' );
 		// TODO: Remove once legacy dataAPI is no longer used.
-		dataAPI.invalidateCacheGroup( TYPE_MODULES, 'analytics' );
+		invalidateCacheGroup( TYPE_MODULES, 'analytics' );
 
 		return {};
 	} ),

--- a/assets/js/modules/optimize/datastore/settings.js
+++ b/assets/js/modules/optimize/datastore/settings.js
@@ -21,7 +21,8 @@
  */
 import API from 'googlesitekit-api';
 import Data from 'googlesitekit-data';
-import dataAPI, { TYPE_MODULES } from '../../../components/data';
+import { TYPE_MODULES } from '../../../components/data/constants';
+import { invalidateCacheGroup } from '../../../components/data/invalidate-cache-group';
 import {
 	isValidOptimizeID,
 	isValidAMPExperimentJSON,
@@ -81,7 +82,7 @@ export const controls = {
 
 		await API.invalidateCache( 'modules', 'optimize' );
 		// TODO: Remove once legacy dataAPI is no longer used.
-		dataAPI.invalidateCacheGroup( TYPE_MODULES, 'optimize' );
+		invalidateCacheGroup( TYPE_MODULES, 'optimize' );
 
 		return {};
 	} ),


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #1661.

## Relevant technical choices

This also separates out the constants for the DataAPI into their own file, as mentioned in https://github.com/google/site-kit-wp/issues/1661#issuecomment-642882658. They're still exported in the main DataAPI module though, so it's not a breaking change.

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
