### PR TITLE
Changed getauthentication to needsreauthentication in info store.

### DIFF
--- a/assets/js/googlesitekit/modules/create-info-store.js
+++ b/assets/js/googlesitekit/modules/create-info-store.js
@@ -76,10 +76,14 @@ export const createInfoStore = ( slug, {
 		 * @since n.e.x.t
 		 *
 		 * @param {boolean} reAuth The module activation status. Default is true.
-		 * @return {(string|undefined)} The admin reauthentication URL.
+		 * @return {(string|undefined)} The admin reauthentication URL, or
+		 *                              undefined if not loaded yet.
 		 */
 		getAdminReauthURL: createRegistrySelector( ( select ) => ( state, reAuth = true ) => {
-			const needsReauthentication = select( CORE_USER ).needsReauthentication() || false;
+			const needsReauthentication = select( CORE_USER ).needsReauthentication();
+			if ( needsReauthentication === undefined ) {
+				return undefined;
+			}
 
 			const noSetupQueryArgs = ! requiresSetup ? {
 				notification: 'authentication_success',
@@ -87,6 +91,9 @@ export const createInfoStore = ( slug, {
 			} : {};
 
 			const redirectURL = select( STORE_NAME ).getAdminScreenURL( { slug, reAuth, ...noSetupQueryArgs } );
+			if ( redirectURL === undefined ) {
+				return undefined;
+			}
 
 			if ( ! needsReauthentication ) {
 				return redirectURL;


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #1559 

## Relevant technical choices

<!-- Please describe your changes. -->

## Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
