### PR TITLE
Fix GitHub actions for wiki repo deployment

### DIFF
--- a/.github/workflows/build-zips.yml
+++ b/.github/workflows/build-zips.yml
@@ -67,6 +67,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           repository: ${{ github.repository }}.wiki
+          ref: master
           token: ${{ secrets.GITHUB_PERSONAL_ACCESS_TOKEN }}
       - name: Download artifacts
         uses: actions/download-artifact@v1

--- a/.github/workflows/remove-pr.yml
+++ b/.github/workflows/remove-pr.yml
@@ -10,6 +10,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           repository: ${{ github.repository }}.wiki
+          ref: master
           token: ${{ secrets.GITHUB_PERSONAL_ACCESS_TOKEN }}
       - name: Prune PR files
         run: |


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #1687

## Relevant technical choices

* Necessary due to `actions/checkout` bug introduced by https://github.com/actions/checkout/pull/278#pullrequestreview-432747285 - edge-case, but relevant to us.

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
