### PR TITLE
Customize jsonpFunction in webpack.config to prevent conflicts

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -122,6 +122,13 @@ const webpackConfig = ( mode ) => {
 				path: __dirname + '/dist/assets/js',
 				chunkFilename: '[name]-[chunkhash].js',
 				publicPath: '',
+				/**
+				 * If multiple webpack runtimes (from different compilations) are used on the same webpage,
+				 * there is a risk of conflicts of on-demand chunks in the global namespace.
+				 *
+				 * @see (@link https://webpack.js.org/configuration/output/#outputjsonpfunction)
+				 */
+				jsonpFunction: '__googlesitekit_webpackJsonp',
 			},
 			performance: {
 				maxEntrypointSize: 175000,


### PR DESCRIPTION
## Summary

Addresses issue #1637

This PR fixes potential conflicts with other Webpack bundles loaded on the same page by customizing the `jsonpFunction` that webpack generates and sets on the global window object to be shared by all entrypoints of the same build. By using the default function name, it can lead to race condition like cryptic errors due to internal `moduleId` collisions. This PR prevents that by using a namespaced version of the generated function.

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
