### PR TITLE
Fix auto scrolling from PSI widget

### DIFF
--- a/assets/js/components/DeviceSizeTabBar.js
+++ b/assets/js/components/DeviceSizeTabBar.js
@@ -73,6 +73,7 @@ const DeviceSizeTabBar = ( {
 					<Tab
 						key={ `google-sitekit-device-size-tab-key-${ i }` }
 						aria-label={ label }
+						focusOnActivate={ false }
 					>
 						{ icon }
 					</Tab>

--- a/assets/js/modules/pagespeed-insights/components/DashboardPageSpeed.js
+++ b/assets/js/modules/pagespeed-insights/components/DashboardPageSpeed.js
@@ -114,7 +114,10 @@ export default function DashboardPageSpeed() {
 						activeIndex={ [ DATA_SRC_LAB, DATA_SRC_FIELD ].indexOf( dataSrc ) }
 						handleActiveIndexUpdate={ updateActiveTab }
 					>
-						<Tab aria-labelledby={ `googlesitekit-pagespeed-widget__data-src-tab-${ DATA_SRC_LAB }` }>
+						<Tab
+							focusOnActivate={ false }
+							aria-labelledby={ `googlesitekit-pagespeed-widget__data-src-tab-${ DATA_SRC_LAB }` }
+						>
 							<span
 								id={ `googlesitekit-pagespeed-widget__data-src-tab-${ DATA_SRC_LAB }` }
 								className="mdc-tab__text-label"
@@ -122,7 +125,10 @@ export default function DashboardPageSpeed() {
 								{ __( 'In the Lab', 'google-site-kit' ) }
 							</span>
 						</Tab>
-						<Tab aria-labelledby={ `googlesitekit-pagespeed-widget__data-src-tab-${ DATA_SRC_FIELD }` }>
+						<Tab
+							focusOnActivate={ false }
+							aria-labelledby={ `googlesitekit-pagespeed-widget__data-src-tab-${ DATA_SRC_FIELD }` }
+						>
 							<span
 								id={ `googlesitekit-pagespeed-widget__data-src-tab-${ DATA_SRC_FIELD }` }
 								className="mdc-tab__text-label"

--- a/assets/js/modules/pagespeed-insights/components/DashboardPageSpeed.js
+++ b/assets/js/modules/pagespeed-insights/components/DashboardPageSpeed.js
@@ -55,7 +55,7 @@ export default function DashboardPageSpeed() {
 	const reportMobile = useSelect( ( select ) => select( STORE_NAME ).getReport( referenceURL, STRATEGY_MOBILE ) );
 	const reportDesktop = useSelect( ( select ) => select( STORE_NAME ).getReport( referenceURL, STRATEGY_DESKTOP ) );
 	const strategy = useSelect( ( select ) => select( CORE_FORMS ).getValue( FORM_DASH_WIDGET, 'strategy' ) ) || STRATEGY_MOBILE;
-	const dataSrc = useSelect( ( select ) => select( CORE_FORMS ).getValue( FORM_DASH_WIDGET, 'dataSrc' ) );
+	const dataSrc = useSelect( ( select ) => select( CORE_FORMS ).getValue( FORM_DASH_WIDGET, 'dataSrc' ) ) || DATA_SRC_LAB;
 
 	const { setValues } = useDispatch( CORE_FORMS );
 	const setStrategyMobile = useCallback( () => setValues( FORM_DASH_WIDGET, { strategy: STRATEGY_MOBILE } ), [] );
@@ -82,13 +82,8 @@ export default function DashboardPageSpeed() {
 
 	// Set the default data source based on report data.
 	useEffect( () => {
-		if ( ! reportMobile || ! reportDesktop ) {
-			return;
-		}
 		if ( reportMobile?.loadingExperience?.metrics && reportDesktop?.loadingExperience?.metrics ) {
 			setDataSrcField();
-		} else {
-			setDataSrcLab();
 		}
 	}, [ reportMobile, reportDesktop ] );
 


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #1649 (follow-up)

## Relevant technical choices

* Tests in Storybook showed that setting the `dataSrc` to a default value prevented the scrolling behavior but it didn't seem to have the same effect in WP
* Disabling the `focusOnActivate` for all `Tab` components in `TabBar`s fixes it without any substantial component changes

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
