### PR TITLE
Fix/php 5.4 references

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,4 +12,4 @@ Any kind of contributions to Site Kit by Google are welcome. Head over to the [C
 ## Requirements
 
 * WordPress >= 4.7
-* PHP >= 5.4
+* PHP >= 5.6

--- a/google-site-kit.php
+++ b/google-site-kit.php
@@ -31,7 +31,7 @@ define( 'GOOGLESITEKIT_PHP_MINIMUM', '5.6.0' );
 /**
  * Handles plugin activation.
  *
- * Throws an error if the plugin is activated on an older version than PHP 5.4.
+ * Throws an error if the plugin is activated with an insufficient version of PHP.
  *
  * @since 1.0.0
  * @since 1.3.0 Minimum required version of PHP raised to 5.6


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue # n/a

## Relevant technical choices

* Updates a few places where references to PHP 5.4 were missed when the minimum supported version was raised to 5.6

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
