### PR TITLE
Update default view name to be All Web Site Data.

### DIFF
--- a/assets/js/modules/analytics/common/account-create.js
+++ b/assets/js/modules/analytics/common/account-create.js
@@ -76,7 +76,7 @@ export default function AccountCreate() {
 			setValues( FORM_ACCOUNT_CREATE, {
 				accountName: siteName,
 				propertyName: hostname,
-				profileName: __( 'All website traffic', 'google-site-kit' ),
+				profileName: __( 'All Web Site Data', 'google-site-kit' ),
 				countryCode: countryCodesByTimezone[ timezone ],
 				timezone,
 			} );


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #716 

## Relevant technical choices

Updated default view name to be "All Web Site Data" when a new analytics account is created.

## Checklist

- [x] My code is tested and passes existing unit tests.
- [x]  My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
