### PR TITLE
Fix internal GA event tracking loading

### DIFF
--- a/includes/Core/Admin/Screens.php
+++ b/includes/Core/Admin/Screens.php
@@ -157,6 +157,18 @@ final class Screens {
 	}
 
 	/**
+	 * Gets the Screen instance for a given hook suffix.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param string $hook_suffix The hook suffix associated with the screen to retrieve.
+	 * @return Screen|null Screen instance if available, otherwise null;
+	 */
+	public function get_screen( $hook_suffix ) {
+		return isset( $this->screens[ $hook_suffix ] ) ? $this->screens[ $hook_suffix ] : null;
+	}
+
+	/**
 	 * Adds all screens to the admin.
 	 *
 	 * @since 1.0.0

--- a/includes/Core/Util/Tracking.php
+++ b/includes/Core/Util/Tracking.php
@@ -11,7 +11,10 @@
 namespace Google\Site_Kit\Core\Util;
 
 use Google\Site_Kit\Context;
+use Google\Site_Kit\Core\Admin\Screen;
+use Google\Site_Kit\Core\Admin\Screens;
 use Google\Site_Kit\Core\Storage\User_Options;
+use WP_Screen;
 
 /**
  * Class managing admin tracking.
@@ -25,6 +28,15 @@ final class Tracking {
 	const TRACKING_ID = 'UA-130569087-3';
 
 	/**
+	 * Screens instance.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @var Screens
+	 */
+	protected $screens;
+
+	/**
 	 * Tracking_Consent instance.
 	 *
 	 * @var Tracking_Consent
@@ -35,11 +47,19 @@ final class Tracking {
 	 * Constructor.
 	 *
 	 * @since 1.4.0
+	 * @since n.e.x.t Added `Screens` instance.
+	 *
 	 * @param Context      $context      Context instance.
 	 * @param User_Options $user_options Optional. User_Options instance. Default is a new instance.
+	 * @param Screens      $screens      Optional. Screens instance. Default is a new instance.
 	 */
-	public function __construct( Context $context, User_Options $user_options = null ) {
+	public function __construct(
+		Context $context,
+		User_Options $user_options = null,
+		Screens $screens = null
+	) {
 		$user_options  = $user_options ?: new User_Options( $context );
+		$this->screens = $screens ?: new Screens( $context );
 		$this->consent = new Tracking_Consent( $user_options );
 	}
 

--- a/includes/Core/Util/Tracking.php
+++ b/includes/Core/Util/Tracking.php
@@ -101,8 +101,7 @@ final class Tracking {
 	 */
 	private function inline_js_base_data( $data ) {
 		global $hook_suffix;
-		
-		$data['trackingAllowed'] = 0 === strpos( $hook_suffix, 'googlesitekit-' );
+		$data['trackingAllowed'] = $this->screens->get_screen( $hook_suffix ) instanceof Screen;
 		$data['trackingEnabled'] = $this->is_active();
 		$data['trackingID']      = self::TRACKING_ID;
 

--- a/includes/Core/Util/Tracking.php
+++ b/includes/Core/Util/Tracking.php
@@ -14,7 +14,6 @@ use Google\Site_Kit\Context;
 use Google\Site_Kit\Core\Admin\Screen;
 use Google\Site_Kit\Core\Admin\Screens;
 use Google\Site_Kit\Core\Storage\User_Options;
-use WP_Screen;
 
 /**
  * Class managing admin tracking.

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -157,12 +157,14 @@ final class Plugin {
 				$assets = new Core\Assets\Assets( $this->context );
 				$assets->register();
 
+				$screens = new Core\Admin\Screens( $this->context, $assets, $modules );
+				$screens->register();
+
 				( new Core\Util\Reset( $this->context ) )->register();
 				( new Core\Util\Developer_Plugin_Installer( $this->context ) )->register();
-				( new Core\Util\Tracking( $this->context, $user_options ) )->register();
+				( new Core\Util\Tracking( $this->context, $user_options, $screens ) )->register();
 				( new Core\REST_API\REST_Routes( $this->context, $authentication, $modules ) )->register();
 				( new Core\Admin_Bar\Admin_Bar( $this->context, $assets, $modules ) )->register();
-				( new Core\Admin\Screens( $this->context, $assets, $modules ) )->register();
 				( new Core\Admin\Notices() )->register();
 				( new Core\Admin\Dashboard( $this->context, $assets, $modules ) )->register();
 				( new Core\Notifications\Notifications( $this->context, $options, $authentication ) )->register();

--- a/tests/e2e/config/bootstrap.js
+++ b/tests/e2e/config/bootstrap.js
@@ -21,12 +21,7 @@ import {
 	deactivateUtilityPlugins,
 	resetSiteKit,
 } from '../utils';
-import {
-	toHaveAdSenseTag,
-	toHaveValidAMPForUser,
-	toHaveValidAMPForVisitor,
-	toHaveValue,
-} from '../matchers';
+import * as customMatchers from '../matchers';
 
 /**
  * Environment variables
@@ -61,12 +56,7 @@ jest.setTimeout( PUPPETEER_TIMEOUT || 100000 );
 setDefaultOptions( { timeout: EXPECT_PUPPETEER_TIMEOUT || 500 } );
 
 // Add custom matchers specific to Site Kit.
-expect.extend( {
-	toHaveAdSenseTag,
-	toHaveValidAMPForUser,
-	toHaveValidAMPForVisitor,
-	toHaveValue,
-} );
+expect.extend( customMatchers );
 
 /**
  * Adds an event listener to the page to handle additions of page event

--- a/tests/e2e/matchers/index.js
+++ b/tests/e2e/matchers/index.js
@@ -1,4 +1,25 @@
+/**
+ * Jest custom matchers for use in E2E tests.
+ *
+ * Site Kit by Google, Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Jest will be extended with all exports from this module automatically.
+export { toBeChecked } from './to-be-checked';
 export { toHaveAdSenseTag } from './to-have-adsense-tag';
+export { toHaveTracking } from './to-have-tracking';
 export { toHaveValidAMPForUser } from './to-have-valid-amp-for-user';
 export { toHaveValidAMPForVisitor } from './to-have-valid-amp-for-visitor';
 export { toHaveValue } from './to-have-value';

--- a/tests/e2e/matchers/to-be-checked.js
+++ b/tests/e2e/matchers/to-be-checked.js
@@ -1,0 +1,49 @@
+/**
+ * Custom matcher for testing if a checkbox is checked or not.
+ *
+ * Site Kit by Google, Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import { getDefaultOptions } from 'expect-puppeteer';
+
+/**
+ * Asserts the given selector is checked.
+ *
+ * @since n.e.x.t
+ *
+ * @param {string} selector          Selector for element with value.
+ * @param {Object} [options]         Matcher options.
+ * @param {number} [options.timeout] Maximum time to wait for selector in milliseconds.
+ * @return {Object} Object with `pass` and `message` keys.
+ */
+export async function toBeChecked( selector, { timeout } = getDefaultOptions() ) {
+	let pass, message;
+
+	await page.waitForSelector( selector, { timeout } );
+	const actualValue = await page.$eval( selector, ( { checked } ) => checked );
+
+	if ( this.equals( true, actualValue ) ) {
+		pass = true;
+		message = `Expected "${ selector }" to be checked.`;
+	} else {
+		pass = false;
+		message = `Expected ${ selector } not to be checked.`;
+	}
+
+	return { pass, message };
+}

--- a/tests/e2e/matchers/to-have-tracking.js
+++ b/tests/e2e/matchers/to-have-tracking.js
@@ -1,0 +1,48 @@
+/**
+ * Custom matcher for checking the presence of Site Kit event tracking.
+ *
+ * Site Kit by Google, Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import { getDefaultOptions } from 'expect-puppeteer';
+import { Page, ElementHandle } from 'puppeteer';
+
+/**
+ * Jest matcher for asserting the given instance has tracking loaded or not.
+ *
+ * @since n.e.x.t
+ *
+ * @param {(Page|ElementHandle)} instance Page or element handle instance.
+ * @param {Object} [options]              Matcher options.
+ * @param {number} [options.timeout]      Maximum time to wait for selector in milliseconds.
+ * @return {Object} Object with `pass` and `message` keys.
+ */
+export async function toHaveTracking( instance, { timeout } = getDefaultOptions() ) {
+	let pass, message;
+
+	try {
+		await expect( instance ).toMatchElement( 'script[data-googlesitekit-gtag]', { timeout } );
+		pass = true;
+		message = () => `Expected tracking not to be loaded`;
+	} catch {
+		pass = false;
+		message = () => `Expected tracking to be loaded`;
+	}
+
+	return { pass, message };
+}

--- a/tests/e2e/specs/admin-tracking.test.js
+++ b/tests/e2e/specs/admin-tracking.test.js
@@ -124,3 +124,126 @@ describe( 'management of tracking opt-in/out via settings page', () => {
 		await expect( page ).not.toMatchElement( 'script[src^="https://www.googletagmanager.com/gtag/js?id=UA-130569087-3"]' );
 	} );
 } );
+
+describe( 'initialization on load for Site Kit screens', () => {
+	describe( 'splash page', () => {
+		afterEach( async () => await resetSiteKit() );
+
+		it( 'does not load tracking if not opted-in', async () => {
+			await visitAdminPage( 'admin.php', 'page=googlesitekit-splash' );
+
+			await expect( page ).not.toHaveTracking();
+		} );
+
+		it( 'loads tracking when opted-in', async () => {
+			await visitAdminPage( 'admin.php', 'page=googlesitekit-splash' );
+			await toggleOptIn();
+			await page.reload();
+
+			await expect( page ).toHaveTracking();
+		} );
+	} );
+
+	describe( 'settings page', () => {
+		beforeEach( async () => await setupSiteKit() );
+		afterEach( async () => await resetSiteKit() );
+
+		it( 'does not load tracking if not opted-in', async () => {
+			await visitAdminPage( 'admin.php', 'page=googlesitekit-settings' );
+
+			await expect( page ).not.toHaveTracking();
+		} );
+
+		it( 'loads tracking when opted-in', async () => {
+			await visitAdminPage( 'admin.php', 'page=googlesitekit-splash' );
+			await toggleOptIn();
+			await visitAdminPage( 'admin.php', 'page=googlesitekit-settings' );
+
+			await expect( page ).toHaveTracking();
+		} );
+	} );
+
+	describe( 'Site Kit dashboard', () => {
+		beforeEach( async () => await setupSiteKit() );
+
+		afterEach( async () => {
+			await resetSiteKit();
+			await deactivateUtilityPlugins();
+		} );
+
+		it( 'does not load tracking if not opted-in', async () => {
+			await visitAdminPage( 'admin.php', 'page=googlesitekit-dashboard' );
+
+			await expect( page ).not.toHaveTracking();
+		} );
+
+		it( 'loads tracking when opted-in', async () => {
+			await visitAdminPage( 'admin.php', 'page=googlesitekit-splash' );
+			await toggleOptIn();
+			await visitAdminPage( 'admin.php', 'page=googlesitekit-dashboard' );
+
+			await expect( page ).toHaveTracking();
+		} );
+	} );
+
+	describe( 'module pages', () => {
+		beforeEach( async () => await setupSiteKit() );
+
+		afterEach( async () => {
+			await resetSiteKit();
+			await deactivateUtilityPlugins();
+		} );
+
+		it( 'does not load tracking if not opted-in', async () => {
+			await visitAdminPage( 'admin.php', 'page=googlesitekit-module-search-console' );
+
+			await expect( page ).not.toHaveTracking();
+		} );
+
+		it( 'loads tracking when opted-in', async () => {
+			await visitAdminPage( 'admin.php', 'page=googlesitekit-splash' );
+			await toggleOptIn();
+			await visitAdminPage( 'admin.php', 'page=googlesitekit-module-search-console' );
+
+			await expect( page ).toHaveTracking();
+		} );
+	} );
+} );
+
+describe( 'initialization on load for non-Site Kit screens', () => {
+	describe( 'plugins page', () => {
+		afterEach( async () => await resetSiteKit() );
+
+		it( 'does not load tracking if not opted-in', async () => {
+			await visitAdminPage( 'plugins.php' );
+
+			await expect( page ).not.toHaveTracking();
+		} );
+
+		it( 'does not load tracking if opted-in', async () => {
+			await visitAdminPage( 'admin.php', 'page=googlesitekit-splash' );
+			await toggleOptIn();
+			await visitAdminPage( 'plugins.php' );
+
+			await expect( page ).not.toHaveTracking();
+		} );
+	} );
+
+	describe( 'WordPress dashboard', () => {
+		afterEach( async () => await resetSiteKit() );
+
+		it( 'does not load tracking if not opted-in', async () => {
+			await visitAdminPage( 'index.php' );
+
+			await expect( page ).not.toHaveTracking();
+		} );
+
+		it( 'does not load tracking if opted-in', async () => {
+			await visitAdminPage( 'admin.php', 'page=googlesitekit-splash' );
+			await toggleOptIn();
+			await visitAdminPage( 'index.php' );
+
+			await expect( page ).not.toHaveTracking();
+		} );
+	} );
+} );

--- a/tests/e2e/specs/admin-tracking.test.js
+++ b/tests/e2e/specs/admin-tracking.test.js
@@ -24,7 +24,13 @@ import { activatePlugin, visitAdminPage } from '@wordpress/e2e-test-utils';
 /**
  * Internal dependencies
  */
-import { resetSiteKit, setSearchConsoleProperty, deactivateUtilityPlugins, pageWait } from '../utils';
+import {
+	deactivateUtilityPlugins,
+	pageWait,
+	resetSiteKit,
+	setSearchConsoleProperty,
+	setupSiteKit,
+} from '../utils';
 
 async function toggleOptIn() {
 	await Promise.all( [
@@ -58,10 +64,13 @@ describe( 'management of tracking opt-in/out via settings page', () => {
 	} );
 
 	it( 'should be opted-out by default', async () => {
+		await expect( page ).not.toHaveTracking();
 		expect( await page.$eval( '#googlesitekit-opt-in', ( el ) => el.checked ) ).toBe( false );
 	} );
 
 	it( 'should have tracking code when opted in', async () => {
+		await expect( page ).not.toHaveTracking();
+
 		// Make sure the script tags are not yet loaded on the page.
 		await expect( page ).not.toMatchElement( 'script[src^="https://www.googletagmanager.com/gtag/js?id=UA-130569087-3"]' );
 
@@ -70,6 +79,7 @@ describe( 'management of tracking opt-in/out via settings page', () => {
 
 		expect( await page.$eval( '#googlesitekit-opt-in', ( el ) => el.checked ) ).toBe( true );
 
+		await expect( page ).toHaveTracking();
 		// Ensure the script tags are injected into the page if they weren't
 		// loaded already.
 		await page.waitForSelector( 'script[src^="https://www.googletagmanager.com/gtag/js?id=UA-130569087-3"]' );
@@ -109,6 +119,7 @@ describe( 'management of tracking opt-in/out via settings page', () => {
 		// Ensure no analytics script tag exists.
 		await expect( page ).not.toMatchElement( 'script[src^="https://www.google-analytics.com/analytics.js"]' );
 
+		await expect( page ).not.toHaveTracking();
 		// Ensure no tag manager script exists.
 		await expect( page ).not.toMatchElement( 'script[src^="https://www.googletagmanager.com/gtag/js?id=UA-130569087-3"]' );
 	} );


### PR DESCRIPTION
## Summary

Addresses issue #1717

## Relevant technical choices

Added E2E tests against `develop` demonstrate the bug

```
  initialization on load for Site Kit screens
    splash page
      ✓ does not load tracking if not opted-in (878ms)
      ✕ loads tracking when opted-in (1226ms)
    settings page
      ✓ does not load tracking if not opted-in (2054ms)
      ✕ loads tracking when opted-in (2224ms)
    Site Kit dashboard
      ✓ does not load tracking if not opted-in (2543ms)
      ✕ loads tracking when opted-in (2342ms)
    module pages
      ✓ does not load tracking if not opted-in (2470ms)
      ✕ loads tracking when opted-in (2344ms)
```

## Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
