### PR TITLE
Add prepare-commit-msg hook to ament merge commit messages.

### DIFF
--- a/bin/prepare-commit-msg.php
+++ b/bin/prepare-commit-msg.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Script to prepare commit message
+ *
+ * @package   Google\Site_Kit
+ * @copyright 2020 Google LLC
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
+ * @link      https://sitekit.withgoogle.com
+ */
+
+// Checks if the current commit message is generated for a merge, then adds a dot at the end of the commit message.
+$message = explode( PHP_EOL, file_get_contents( $argv[1] ) ); // phpcs:ignore WordPressVIPMinimum.Performance.FetchingRemoteData.FileGetContentsUnknown
+if ( ! empty( $message[0] ) ) {
+	$tokens = preg_split( '/\s+/', trim( $message[0] ) );
+
+	$last_index = count( $tokens ) - 1;
+	if ( strtolower( $tokens[0] ) === 'merge' && ! preg_match( '/\.$/', $tokens[ $last_index ] ) ) {
+		$tokens[ $last_index ] .= '.';
+	}
+
+	$message[0] = implode( ' ', $tokens );
+
+	file_put_contents( $argv[1], implode( PHP_EOL, $message ) ); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_file_put_contents
+}

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
   "husky": {
     "hooks": {
       "pre-commit": "lint-staged",
+      "prepare-commit-msg": "php -f bin/prepare-commit-msg.php $HUSKY_GIT_PARAMS",
       "commit-msg": "php -f bin/check-commit-msg.php $HUSKY_GIT_PARAMS"
     }
   },


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #925

## Relevant technical choices

Added a new hook to check the commit message generated by `git merge` and add a dot at the end.

## Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
