### PR TITLE
Update select fetch store actions with optional cache use

### DIFF
--- a/assets/js/googlesitekit/data/create-settings-store.js
+++ b/assets/js/googlesitekit/data/create-settings-store.js
@@ -76,9 +76,14 @@ export const createSettingsStore = ( type, identifier, datapoint, {
 
 	const fetchGetSettingsStore = createFetchStore( {
 		baseName: 'getSettings',
-		controlCallback: () => {
+		argsToParams: ( { useCache = true } = {} ) => {
+			return {
+				options: { useCache },
+			};
+		},
+		controlCallback: ( { options: { useCache } } ) => {
 			return API.get( type, identifier, datapoint, {}, {
-				useCache: false,
+				useCache,
 			} );
 		},
 		reducerCallback: ( state, values ) => {

--- a/assets/js/googlesitekit/data/create-settings-store.test.js
+++ b/assets/js/googlesitekit/data/create-settings-store.test.js
@@ -442,9 +442,12 @@ describe( 'createSettingsStore store', () => {
 					}
 				);
 
+				const params = {
+					options: { useCache: true },
+				};
 				const result = await storeDefinition.controls.FETCH_GET_SETTINGS( {
 					type: 'FETCH_GET_SETTINGS',
-					payload: { params: {} },
+					payload: { params },
 				} );
 				expect( result ).toEqual( response );
 				// Ensure `console.error()` wasn't called, which will happen if the API

--- a/assets/js/googlesitekit/datastore/site/connection.js
+++ b/assets/js/googlesitekit/datastore/site/connection.js
@@ -28,9 +28,14 @@ const { createRegistrySelector } = Data;
 
 const fetchGetConnectionStore = createFetchStore( {
 	baseName: 'getConnection',
-	controlCallback: () => {
+	argsToParams: ( { useCache = true } = {} ) => {
+		return {
+			options: { useCache },
+		};
+	},
+	controlCallback: ( { options: { useCache } } ) => {
 		return API.get( 'core', 'site', 'connection', undefined, {
-			useCache: false,
+			useCache,
 		} );
 	},
 	reducerCallback: ( state, connection ) => {

--- a/assets/js/googlesitekit/datastore/user/authentication.js
+++ b/assets/js/googlesitekit/datastore/user/authentication.js
@@ -28,9 +28,14 @@ const { createRegistrySelector } = Data;
 
 const fetchGetAuthenticationStore = createFetchStore( {
 	baseName: 'getAuthentication',
-	controlCallback: () => {
+	argsToParams: ( { useCache = true } = {} ) => {
+		return {
+			options: { useCache },
+		};
+	},
+	controlCallback: ( { options: { useCache } } ) => {
 		return API.get( 'core', 'user', 'authentication', undefined, {
-			useCache: false,
+			useCache,
 		} );
 	},
 	reducerCallback: ( state, authentication ) => {

--- a/assets/js/googlesitekit/modules/datastore/modules.js
+++ b/assets/js/googlesitekit/modules/datastore/modules.js
@@ -106,11 +106,6 @@ const baseActions = {
 	*activateModule( slug ) {
 		const { response, error } = yield baseActions.setModuleActivation( slug, true );
 
-		yield {
-			payload: {},
-			type: REFETCH_AUTHENICATION,
-		};
-
 		return { response, error };
 	},
 
@@ -126,11 +121,6 @@ const baseActions = {
 	 */
 	*deactivateModule( slug ) {
 		const { response, error } = yield baseActions.setModuleActivation( slug, false );
-
-		yield {
-			payload: {},
-			type: REFETCH_AUTHENICATION,
-		};
 
 		return { response, error };
 	},
@@ -156,6 +146,10 @@ const baseActions = {
 		if ( response?.success === true ) {
 			// Fetch (or re-fetch) all modules, with their updated status.
 			yield fetchGetModulesStore.actions.fetchGetModules( { useCache: false } );
+			yield {
+				payload: {},
+				type: REFETCH_AUTHENICATION,
+			};
 		}
 
 		return { response, error };

--- a/assets/js/googlesitekit/modules/datastore/modules.js
+++ b/assets/js/googlesitekit/modules/datastore/modules.js
@@ -27,9 +27,10 @@ import invariant from 'invariant';
 import API from 'googlesitekit-api';
 import Data from 'googlesitekit-data';
 import { STORE_NAME } from './constants';
+import { STORE_NAME as CORE_USER } from '../../datastore/user/constants';
 import { createFetchStore } from '../../data/create-fetch-store';
 
-const { createRegistrySelector } = Data;
+const { createRegistrySelector, createRegistryControl } = Data;
 
 // Actions.
 const REFETCH_AUTHENICATION = 'REFETCH_AUTHENICATION';
@@ -162,9 +163,9 @@ const baseActions = {
 };
 
 export const baseControls = {
-	[ REFETCH_AUTHENICATION ]: () => {
-		return API.get( 'core', 'user', 'authentication', {}, { useCache: false } );
-	},
+	[ REFETCH_AUTHENICATION ]: createRegistryControl( ( { dispatch } ) => () => {
+		return dispatch( CORE_USER ).fetchGetAuthentication( { useCache: false } );
+	} ),
 };
 
 const baseResolvers = {

--- a/assets/js/googlesitekit/modules/datastore/modules.js
+++ b/assets/js/googlesitekit/modules/datastore/modules.js
@@ -154,7 +154,7 @@ const baseActions = {
 		const { response, error } = yield fetchSetModuleActivationStore.actions.fetchSetModuleActivation( slug, active );
 		if ( response?.success === true ) {
 			// Fetch (or re-fetch) all modules, with their updated status.
-			yield fetchGetModulesStore.actions.fetchGetModules();
+			yield fetchGetModulesStore.actions.fetchGetModules( { useCache: false } );
 		}
 
 		return { response, error };

--- a/assets/js/googlesitekit/modules/datastore/modules.js
+++ b/assets/js/googlesitekit/modules/datastore/modules.js
@@ -36,9 +36,14 @@ const REFETCH_AUTHENICATION = 'REFETCH_AUTHENICATION';
 
 const fetchGetModulesStore = createFetchStore( {
 	baseName: 'getModules',
-	controlCallback: () => {
+	argsToParams: ( { useCache = true } = {} ) => {
+		return {
+			options: { useCache },
+		};
+	},
+	controlCallback: ( { options: { useCache } } ) => {
 		return API.get( 'core', 'modules', 'list', null, {
-			useCache: false,
+			useCache,
 		} );
 	},
 	reducerCallback: ( state, modules ) => {

--- a/assets/js/googlesitekit/modules/datastore/modules.test.js
+++ b/assets/js/googlesitekit/modules/datastore/modules.test.js
@@ -133,18 +133,8 @@ describe( 'core/modules modules', () => {
 			it( 'does not update status if the API encountered a failure', async () => {
 				// In our fixtures, optimize is off by default.
 				const slug = 'optimize';
-				fetchMock.getOnce(
-					/^\/google-site-kit\/v1\/core\/modules\/data\/list/,
-					{ body: FIXTURES, status: 200 }
-				);
+				registry.dispatch( STORE_NAME ).receiveGetModules( FIXTURES );
 
-				// Call a selector that triggers an HTTP request to get the modules.
-				registry.select( STORE_NAME ).isModuleActive( slug );
-				// Wait until the modules have been loaded.
-				await subscribeUntil( registry, () => registry
-					.select( STORE_NAME )
-					.hasFinishedResolution( 'getModules' )
-				);
 				const isActiveBefore = registry.select( STORE_NAME ).isModuleActive( slug );
 
 				expect( isActiveBefore ).toEqual( false );
@@ -159,10 +149,6 @@ describe( 'core/modules modules', () => {
 				fetchMock.postOnce(
 					/^\/google-site-kit\/v1\/core\/modules\/data\/activation/,
 					{ body: response, status: 500 }
-				);
-				fetchMock.getOnce(
-					/^\/google-site-kit\/v1\/core\/user\/data\/authentication/,
-					{ body: {}, status: 200 }
 				);
 
 				muteConsole( 'error' );
@@ -192,7 +178,7 @@ describe( 'core/modules modules', () => {
 
 				// The fourth request to update the modules shouldn't be called, because the
 				// activation request failed.
-				expect( fetchMock ).toHaveBeenCalledTimes( 3 );
+				expect( fetchMock ).toHaveBeenCalledTimes( 1 );
 				expect( isActiveAfter ).toEqual( false );
 			} );
 		} );
@@ -272,19 +258,8 @@ describe( 'core/modules modules', () => {
 			it( 'does not update status if the API encountered a failure', async () => {
 				// In our fixtures, analytics is on by default.
 				const slug = 'analytics';
+				registry.dispatch( STORE_NAME ).receiveGetModules( FIXTURES );
 
-				fetchMock.getOnce(
-					/^\/google-site-kit\/v1\/core\/modules\/data\/list/,
-					{ body: FIXTURES, status: 200 }
-				);
-
-				// Call a selector that triggers an HTTP request to get the modules.
-				registry.select( STORE_NAME ).isModuleActive( slug );
-				// Wait until the modules have been loaded.
-				await subscribeUntil( registry, () => registry
-					.select( STORE_NAME )
-					.hasFinishedResolution( 'getModules' )
-				);
 				const isActiveBefore = registry.select( STORE_NAME ).isModuleActive( slug );
 
 				expect( isActiveBefore ).toEqual( true );
@@ -299,11 +274,6 @@ describe( 'core/modules modules', () => {
 				fetchMock.postOnce(
 					/^\/google-site-kit\/v1\/core\/modules\/data\/activation/,
 					{ body: response, status: 500 }
-				);
-
-				fetchMock.getOnce(
-					/^\/google-site-kit\/v1\/core\/user\/data\/authentication/,
-					{ body: {}, status: 200 }
 				);
 
 				muteConsole( 'error' );
@@ -327,7 +297,7 @@ describe( 'core/modules modules', () => {
 
 				// The fourth request to update the modules shouldn't be called, because the
 				// deactivation request failed.
-				expect( fetchMock ).toHaveFetchedTimes( 3 );
+				expect( fetchMock ).toHaveFetchedTimes( 1 );
 				expect( isActiveAfter ).toEqual( true );
 			} );
 		} );

--- a/assets/js/googlesitekit/modules/datastore/modules.test.js
+++ b/assets/js/googlesitekit/modules/datastore/modules.test.js
@@ -42,10 +42,10 @@ describe( 'core/modules modules', () => {
 	let registry;
 	let store;
 
-	beforeEach( () => {
+	beforeEach( async () => {
 		// Invalidate the cache before every request, but keep it enabled to
 		// make sure we're opting-out of the cache for the correct requests.
-		API.invalidateCache();
+		await API.invalidateCache();
 
 		registry = createTestRegistry();
 		store = registry.stores[ STORE_NAME ].store;

--- a/includes/Core/Modules/Modules.php
+++ b/includes/Core/Modules/Modules.php
@@ -140,6 +140,17 @@ final class Modules {
 			}
 		);
 
+		add_filter(
+			'googlesitekit_apifetch_preload_paths',
+			function ( $paths ) {
+				$modules_routes = array(
+					'/' . REST_Routes::REST_ROOT . '/core/modules/data/list',
+				);
+
+				return array_merge( $paths, $modules_routes );
+			}
+		);
+
 		$available_modules = $this->get_available_modules();
 		array_walk(
 			$available_modules,

--- a/tests/phpunit/integration/Core/Modules/ModulesTest.php
+++ b/tests/phpunit/integration/Core/Modules/ModulesTest.php
@@ -12,6 +12,7 @@ namespace Google\Site_Kit\Tests\Core\Modules;
 
 use Google\Site_Kit\Context;
 use Google\Site_Kit\Core\Modules\Modules;
+use Google\Site_Kit\Core\REST_API\REST_Routes;
 use Google\Site_Kit\Tests\TestCase;
 
 /**
@@ -82,12 +83,19 @@ class ModulesTest extends TestCase {
 		$modules     = new Modules( new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE ) );
 		$fake_module = new FakeModule( new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE ) );
 		$fake_module->set_force_active( true );
+		remove_all_filters( 'googlesitekit_apifetch_preload_paths' );
 
 		$this->force_set_property( $modules, 'modules', array( 'fake-module' => $fake_module ) );
 
 		$this->assertFalse( $fake_module->is_registered() );
 		$modules->register();
 		$this->assertTrue( $fake_module->is_registered() );
+
+		$this->assertTrue( has_filter( 'googlesitekit_apifetch_preload_paths' ) );
+		$this->assertContains(
+			'/' . REST_Routes::REST_ROOT . '/core/modules/data/list',
+			apply_filters( 'googlesitekit_apifetch_preload_paths', array() )
+		);
 	}
 
 	public function test_get_module() {


### PR DESCRIPTION
## Summary

Addresses issue #1725 

## Relevant technical choices

* `modules.test.js` started failing after these changes for a few different reasons, but were easy and (mostly) expected
    - `API.invalidateCache` that was being called in `beforeEach` is `async` so it was causing cache to persist between tests in some cases (now that certain actions were not always being made with `useCache: false`)  
See https://github.com/google/site-kit-wp/commit/7f9eda627f83331a491d1829b8e229f28ad054b5
    - Moving the refetch authentication call to only happen when the activation request was successful caused a few fetch assertions to fail, which I simplified while updating as there was a some unnecessary fetch mocking going on.  
See https://github.com/google/site-kit-wp/commit/3083ea5c99c7a9c67a47224c7d86a0c4670fc5a1

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
