### PR TITLE
Fix warning icon in View Name text field

### DIFF
--- a/assets/js/modules/analytics/common/ProfileNameTextField.js
+++ b/assets/js/modules/analytics/common/ProfileNameTextField.js
@@ -65,7 +65,7 @@ export default function ProfileNameTextField() {
 		);
 
 		trailingIcon = (
-			<span className="googlesitekit-settings-module__status-icon googlesitekit-settings-module__status-icon--warning">
+			<span className="googlesitekit-text-field-icon--warning">
 				<span className="screen-reader-text">
 					{ __( 'Warning', 'google-site-kit' ) }
 				</span>

--- a/assets/sass/admin.scss
+++ b/assets/sass/admin.scss
@@ -91,6 +91,7 @@
 @import "components/global/googlesitekit-module-outro";
 @import "components/global/googlesitekit-module-page";
 @import "components/global/googlesitekit-modules-list";
+@import "components/global/googlesitekit-noscript";
 @import "components/global/googlesitekit-notifications-counter";
 @import "components/global/googlesitekit-opt-in";
 @import "components/global/googlesitekit-overlay";
@@ -106,7 +107,7 @@
 @import "components/global/googlesitekit-source-link";
 @import "components/global/googlesitekit-table";
 @import "components/global/googlesitekit-table-overflow";
-@import "components/global/googlesitekit-noscript";
+@import "components/global/googlesitekit-text-field-icon";
 
 // Dashboard
 @import "components/dashboard/googlesitekit-signin-box";

--- a/assets/sass/components/global/_googlesitekit-text-field-icon.scss
+++ b/assets/sass/components/global/_googlesitekit-text-field-icon.scss
@@ -1,0 +1,34 @@
+/**
+ * Text Field Icon styles.
+ *
+ * Site Kit by Google, Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+.googlesitekit-plugin .googlesitekit-text-field-icon {
+
+	&--warning::before {
+		background-color: $c-warning;
+		background-image: url("data:image/svg+xml;charset=UTF-8,%3Csvg%20width%3D%2222%22%20height%3D%2219%22%20viewBox%3D%220%200%2022%2019%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20d%3D%22M0%2019h22L11%200%200%2019zm12-3h-2v-2h2v2zm0-4h-2V8h2v4z%22%20fill%3D%22%23FFF%22%20fill-rule%3D%22nonzero%22%2F%3E%3C%2Fsvg%3E");
+		background-position: center 4px;
+		background-repeat: no-repeat;
+		background-size: 14px 12px;
+		border-radius: 50%;
+		content: "";
+		display: inline-block;
+		height: 22px;
+		vertical-align: middle;
+		width: 22px;
+	}
+}

--- a/stories/module-analytics-settings.stories.js
+++ b/stories/module-analytics-settings.stories.js
@@ -33,8 +33,7 @@ import SettingsModule from '../assets/js/components/settings/settings-module';
 import { SettingsMain as AnalyticsSettings } from '../assets/js/modules/analytics/settings';
 import { fillFilterWithComponent } from '../assets/js/util';
 import * as fixtures from '../assets/js/modules/analytics/datastore/__fixtures__';
-
-import { STORE_NAME } from '../assets/js/modules/analytics/datastore';
+import { STORE_NAME, PROFILE_CREATE } from '../assets/js/modules/analytics/datastore/constants';
 import { WithTestRegistry } from '../tests/js/utils';
 
 function filterAnalyticsSettings() {
@@ -164,6 +163,28 @@ storiesOf( 'Analytics Module/Settings', module )
 				accountID: accountId,
 				propertyID: webPropertyId,
 				profileID,
+				anonymizeIP: true,
+				useSnippet: true,
+				trackingDisabled: [ 'loggedinUsers' ],
+			} );
+		};
+
+		return <Settings isEditing={ true } module={ completeModuleData } callback={ setupRegistry } />;
+	} )
+	.add( 'Edit, open when creating new view', () => {
+		filterAnalyticsSettings();
+
+		const { accounts, properties, profiles } = fixtures.accountsPropertiesProfiles;
+		const { accountId, webPropertyId } = profiles[ 0 ];
+		const setupRegistry = ( { dispatch } ) => {
+			dispatch( STORE_NAME ).receiveGetExistingTag( null );
+			dispatch( STORE_NAME ).receiveGetAccounts( accounts );
+			dispatch( STORE_NAME ).receiveGetProperties( properties, { accountID: accountId } );
+			dispatch( STORE_NAME ).receiveGetProfiles( profiles, { propertyID: webPropertyId } );
+			dispatch( STORE_NAME ).receiveGetSettings( {
+				accountID: accountId,
+				propertyID: webPropertyId,
+				profileID: PROFILE_CREATE,
 				anonymizeIP: true,
 				useSnippet: true,
 				trackingDisabled: [ 'loggedinUsers' ],

--- a/stories/module-analytics-settings.stories.js
+++ b/stories/module-analytics-settings.stories.js
@@ -119,6 +119,7 @@ storiesOf( 'Analytics Module/Settings', module )
 			dispatch( STORE_NAME ).receiveGetSettings( {
 				accountID: '1234567890',
 				propertyID: 'UA-1234567890-1',
+				internalWebPropertyID: '135791113',
 				profileID: '9999999',
 				anonymizeIP: true,
 				useSnippet: true,
@@ -140,6 +141,7 @@ storiesOf( 'Analytics Module/Settings', module )
 			dispatch( STORE_NAME ).receiveGetSettings( {
 				accountID: '1234567890',
 				propertyID: 'UA-1234567890-1',
+				internalWebPropertyID: '135791113',
 				profileID: '9999999',
 				anonymizeIP: true,
 				useSnippet: false,
@@ -154,6 +156,7 @@ storiesOf( 'Analytics Module/Settings', module )
 
 		const { accounts, properties, profiles } = fixtures.accountsPropertiesProfiles;
 		const { accountId, webPropertyId, id: profileID } = profiles[ 0 ];
+		const { internalWebPropertyId } = properties.find( ( property ) => webPropertyId === property.id );
 		const setupRegistry = ( { dispatch } ) => {
 			dispatch( STORE_NAME ).receiveGetExistingTag( null );
 			dispatch( STORE_NAME ).receiveGetAccounts( accounts );
@@ -162,6 +165,7 @@ storiesOf( 'Analytics Module/Settings', module )
 			dispatch( STORE_NAME ).receiveGetSettings( {
 				accountID: accountId,
 				propertyID: webPropertyId,
+				internalWebPropertyID: internalWebPropertyId,
 				profileID,
 				anonymizeIP: true,
 				useSnippet: true,
@@ -175,7 +179,8 @@ storiesOf( 'Analytics Module/Settings', module )
 		filterAnalyticsSettings();
 
 		const { accounts, properties, profiles } = fixtures.accountsPropertiesProfiles;
-		const { accountId, webPropertyId } = profiles[ 0 ];
+		const { accountId, webPropertyId, id: profileID } = profiles[ 0 ];
+		const { internalWebPropertyId } = properties.find( ( property ) => webPropertyId === property.id );
 		const setupRegistry = ( { dispatch } ) => {
 			dispatch( STORE_NAME ).receiveGetExistingTag( null );
 			dispatch( STORE_NAME ).receiveGetAccounts( accounts );
@@ -184,10 +189,15 @@ storiesOf( 'Analytics Module/Settings', module )
 			dispatch( STORE_NAME ).receiveGetSettings( {
 				accountID: accountId,
 				propertyID: webPropertyId,
-				profileID: PROFILE_CREATE,
+				internalWebPropertyID: internalWebPropertyId,
+				profileID,
 				anonymizeIP: true,
 				useSnippet: true,
 				trackingDisabled: [ 'loggedinUsers' ],
+			} );
+			// This is chosen by the user, not received from API.
+			dispatch( STORE_NAME ).setSettings( {
+				profileID: PROFILE_CREATE,
 			} );
 		};
 
@@ -217,10 +227,11 @@ storiesOf( 'Analytics Module/Settings', module )
 			dispatch( STORE_NAME ).receiveGetAccounts( accounts );
 			dispatch( STORE_NAME ).receiveGetProperties( properties, { accountID: properties[ 0 ].accountId } );
 			dispatch( STORE_NAME ).receiveGetProfiles( profiles, { propertyID: profiles[ 0 ].webPropertyId } );
-			dispatch( STORE_NAME ).setSettings( {
+			dispatch( STORE_NAME ).receiveGetSettings( {
 				accountID: '',
 				propertyID: '',
 				profileID: '',
+				internalWebPropertyID: '',
 				anonymizeIP: true,
 				useSnippet: true,
 				trackingDisabled: [ 'loggedinUsers' ],
@@ -247,7 +258,7 @@ storiesOf( 'Analytics Module/Settings', module )
 				accountID: existingTag.accountID,
 				permission: false,
 			}, { propertyID: existingTag.propertyID } );
-			dispatch( STORE_NAME ).setSettings( {} );
+			dispatch( STORE_NAME ).receiveGetSettings( {} );
 			dispatch( STORE_NAME ).receiveGetAccounts( accounts );
 			dispatch( STORE_NAME ).receiveGetProperties( properties, { accountID: properties[ 0 ].accountId } );
 			dispatch( STORE_NAME ).receiveGetProfiles( profiles, { propertyID: profiles[ 0 ].webPropertyId } );

--- a/stories/module-analytics-setup.stories.js
+++ b/stories/module-analytics-setup.stories.js
@@ -34,7 +34,7 @@ import { SetupMain as AnalyticsSetup } from '../assets/js/modules/analytics/setu
 import { fillFilterWithComponent } from '../assets/js/util';
 import * as fixtures from '../assets/js/modules/analytics/datastore/__fixtures__';
 
-import { STORE_NAME, ACCOUNT_CREATE, PROVISIONING_SCOPE } from '../assets/js/modules/analytics/datastore/constants';
+import { STORE_NAME, ACCOUNT_CREATE, PROFILE_CREATE, PROVISIONING_SCOPE } from '../assets/js/modules/analytics/datastore/constants';
 import { STORE_NAME as CORE_SITE } from '../assets/js/googlesitekit/datastore/site/constants';
 import { STORE_NAME as CORE_USER } from '../assets/js/googlesitekit/datastore/user/constants';
 import { WithTestRegistry } from '../tests/js/utils';
@@ -94,6 +94,28 @@ storiesOf( 'Analytics Module/Setup', module )
 			dispatch( STORE_NAME ).receiveGetProfiles( profiles, { propertyID: profiles[ 0 ].webPropertyId } );
 			dispatch( STORE_NAME ).receiveGetExistingTag( null );
 			dispatch( STORE_NAME ).receiveMatchedProperty( matchedProperty );
+		};
+
+		return <Setup callback={ setupRegistry } />;
+	} )
+	.add( 'Create new view', () => {
+		filterAnalyticsSetup();
+
+		const { accounts, properties, profiles } = fixtures.accountsPropertiesProfiles;
+		const { accountId, webPropertyId } = profiles[ 0 ];
+		const setupRegistry = ( { dispatch } ) => {
+			dispatch( STORE_NAME ).setSettings({
+				accountID: accountId,
+				propertyID: webPropertyId,
+				profileID: PROFILE_CREATE,
+				anonymizeIP: true,
+				useSnippet: true,
+				trackingDisabled: [ 'loggedinUsers' ],
+			});
+			dispatch( STORE_NAME ).receiveGetAccounts( accounts );
+			dispatch( STORE_NAME ).receiveGetProperties( properties, { accountID: accountId } );
+			dispatch( STORE_NAME ).receiveGetProfiles( profiles, { propertyID: webPropertyId } );
+			dispatch( STORE_NAME ).receiveGetExistingTag( null );
 		};
 
 		return <Setup callback={ setupRegistry } />;

--- a/stories/module-analytics-setup.stories.js
+++ b/stories/module-analytics-setup.stories.js
@@ -63,7 +63,7 @@ storiesOf( 'Analytics Module/Setup', module )
 		filterAnalyticsSetup();
 
 		const setupRegistry = ( registry ) => {
-			registry.dispatch( STORE_NAME ).setSettings( {} );
+			registry.dispatch( STORE_NAME ).receiveGetSettings( {} );
 			registry.dispatch( STORE_NAME ).receiveGetExistingTag( null );
 		};
 
@@ -74,7 +74,7 @@ storiesOf( 'Analytics Module/Setup', module )
 
 		const { accounts, properties, profiles } = fixtures.accountsPropertiesProfiles;
 		const setupRegistry = ( { dispatch } ) => {
-			dispatch( STORE_NAME ).setSettings( {} );
+			dispatch( STORE_NAME ).receiveGetSettings( {} );
 			dispatch( STORE_NAME ).receiveGetAccounts( accounts );
 			dispatch( STORE_NAME ).receiveGetProperties( properties, { accountID: properties[ 0 ].accountId } );
 			dispatch( STORE_NAME ).receiveGetProfiles( profiles, { propertyID: profiles[ 0 ].webPropertyId } );
@@ -88,7 +88,7 @@ storiesOf( 'Analytics Module/Setup', module )
 
 		const { accounts, properties, profiles, matchedProperty } = fixtures.accountsPropertiesProfiles;
 		const setupRegistry = ( { dispatch } ) => {
-			dispatch( STORE_NAME ).setSettings( {} );
+			dispatch( STORE_NAME ).receiveGetSettings( {} );
 			dispatch( STORE_NAME ).receiveGetAccounts( accounts );
 			dispatch( STORE_NAME ).receiveGetProperties( properties, { accountID: properties[ 0 ].accountId } );
 			dispatch( STORE_NAME ).receiveGetProfiles( profiles, { propertyID: profiles[ 0 ].webPropertyId } );
@@ -103,19 +103,22 @@ storiesOf( 'Analytics Module/Setup', module )
 
 		const { accounts, properties, profiles } = fixtures.accountsPropertiesProfiles;
 		const { accountId, webPropertyId } = profiles[ 0 ];
+		const { internalWebPropertyId } = properties.find( ( property ) => webPropertyId === property.id );
 		const setupRegistry = ( { dispatch } ) => {
-			dispatch( STORE_NAME ).setSettings({
-				accountID: accountId,
-				propertyID: webPropertyId,
-				profileID: PROFILE_CREATE,
-				anonymizeIP: true,
-				useSnippet: true,
-				trackingDisabled: [ 'loggedinUsers' ],
-			});
+			dispatch( STORE_NAME ).receiveGetSettings( {} );
 			dispatch( STORE_NAME ).receiveGetAccounts( accounts );
 			dispatch( STORE_NAME ).receiveGetProperties( properties, { accountID: accountId } );
 			dispatch( STORE_NAME ).receiveGetProfiles( profiles, { propertyID: webPropertyId } );
 			dispatch( STORE_NAME ).receiveGetExistingTag( null );
+			dispatch( STORE_NAME ).setSettings( {
+				accountID: accountId,
+				propertyID: webPropertyId,
+				internalWebPropertyID: internalWebPropertyId,
+				profileID: PROFILE_CREATE,
+				anonymizeIP: true,
+				useSnippet: true,
+				trackingDisabled: [ 'loggedinUsers' ],
+			} );
 		};
 
 		return <Setup callback={ setupRegistry } />;
@@ -124,7 +127,7 @@ storiesOf( 'Analytics Module/Setup', module )
 		filterAnalyticsSetup();
 
 		const setupRegistry = ( { dispatch } ) => {
-			dispatch( STORE_NAME ).setSettings( {} );
+			dispatch( STORE_NAME ).receiveGetSettings( {} );
 			dispatch( STORE_NAME ).receiveGetAccounts( [] );
 			dispatch( STORE_NAME ).receiveGetExistingTag( null );
 		};
@@ -140,7 +143,7 @@ storiesOf( 'Analytics Module/Setup', module )
 			dispatch( STORE_NAME ).receiveGetAccounts( accounts );
 			dispatch( STORE_NAME ).receiveGetProperties( properties, { accountID: properties[ 0 ].accountId } );
 			dispatch( STORE_NAME ).receiveGetProfiles( profiles, { propertyID: profiles[ 0 ].webPropertyId } );
-			dispatch( STORE_NAME ).setSettings( {
+			dispatch( STORE_NAME ).receiveGetSettings( {
 				accountID: ACCOUNT_CREATE,
 			} );
 		};
@@ -167,7 +170,7 @@ storiesOf( 'Analytics Module/Setup', module )
 			dispatch( STORE_NAME ).receiveGetAccounts( accounts );
 			dispatch( STORE_NAME ).receiveGetProperties( properties, { accountID: properties[ 0 ].accountId } );
 			dispatch( STORE_NAME ).receiveGetProfiles( profiles, { propertyID: profiles[ 0 ].webPropertyId } );
-			dispatch( STORE_NAME ).setSettings( {
+			dispatch( STORE_NAME ).receiveGetSettings( {
 				accountID: ACCOUNT_CREATE,
 			} );
 		};
@@ -194,7 +197,7 @@ storiesOf( 'Analytics Module/Setup', module )
 			dispatch( STORE_NAME ).receiveGetAccounts( accounts );
 			dispatch( STORE_NAME ).receiveGetProperties( properties, { accountID: properties[ 0 ].accountId } );
 			dispatch( STORE_NAME ).receiveGetProfiles( profiles, { propertyID: profiles[ 0 ].webPropertyId } );
-			dispatch( STORE_NAME ).setSettings( {
+			dispatch( STORE_NAME ).receiveGetSettings( {
 				accountID: ACCOUNT_CREATE,
 			} );
 		};
@@ -211,7 +214,7 @@ storiesOf( 'Analytics Module/Setup', module )
 		};
 
 		const setupRegistry = ( { dispatch } ) => {
-			dispatch( STORE_NAME ).setSettings( {} );
+			dispatch( STORE_NAME ).receiveGetSettings( {} );
 			dispatch( STORE_NAME ).receiveGetAccounts( accounts );
 			dispatch( STORE_NAME ).receiveGetProperties( properties, { accountID: properties[ 0 ].accountId } );
 			dispatch( STORE_NAME ).receiveGetProfiles( profiles, { propertyID: profiles[ 0 ].webPropertyId } );
@@ -233,7 +236,7 @@ storiesOf( 'Analytics Module/Setup', module )
 		};
 		const { accounts, properties, profiles } = fixtures.accountsPropertiesProfiles;
 		const setupRegistry = ( { dispatch } ) => {
-			dispatch( STORE_NAME ).setSettings( {} );
+			dispatch( STORE_NAME ).receiveGetSettings( {} );
 			dispatch( STORE_NAME ).receiveGetAccounts( accounts );
 			dispatch( STORE_NAME ).receiveGetProperties( properties, { accountID: properties[ 0 ].accountId } );
 			dispatch( STORE_NAME ).receiveGetProfiles( profiles, { propertyID: profiles[ 0 ].webPropertyId } );


### PR DESCRIPTION
## Summary

Addresses issue #1754 (follow-up)

This PR fixes the missing warning icon for the Profile Name Text Field when displayed in a module Setup context due to the settings-specific css selectors that were used for it.

## Relevant technical choices

* Created a new stylesheet for global text-field icon styles
* Originally attempted to extract the svg to a new component but it's a bit more complicated than that as the yellow circle is applied with CSS and the icon is a bit smaller inside of it, so using the same CSS is a simpler approach for now
* The original styles used were added by extending an existing selector, so there are no unused styles to remove (the added selector is okay to keep)

**Settings**
![image](https://user-images.githubusercontent.com/1621608/87011397-85c72280-c1d0-11ea-9e9b-009a351892ca.png)

**Setup**
![image](https://user-images.githubusercontent.com/1621608/87011401-8790e600-c1d0-11ea-8f92-d80d1895ff32.png)


## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
