### PR TITLE
Update element shim

### DIFF
--- a/assets/js/element-shim.js
+++ b/assets/js/element-shim.js
@@ -28,13 +28,13 @@ if ( global.googlesitekit === undefined ) {
 }
 
 const {
-	__experimentalCreateInterpolateElement,
 	Children,
 	cloneElement,
 	Component,
 	concatChildren,
 	createContext,
 	createElement,
+	createInterpolateElement,
 	createPortal,
 	createRef,
 	findDOMNode,
@@ -65,13 +65,13 @@ const {
 } = global.googlesitekit._element || element;
 
 export {
-	__experimentalCreateInterpolateElement,
 	Children,
 	cloneElement,
 	Component,
 	concatChildren,
 	createContext,
 	createElement,
+	createInterpolateElement,
 	createPortal,
 	createRef,
 	findDOMNode,
@@ -103,13 +103,13 @@ export {
 
 if ( global.googlesitekit._element === undefined ) {
 	global.googlesitekit._element = {
-		__experimentalCreateInterpolateElement,
 		Children,
 		cloneElement,
 		Component,
 		concatChildren,
 		createContext,
 		createElement,
+		createInterpolateElement,
 		createPortal,
 		createRef,
 		findDOMNode,

--- a/assets/js/element-shim.test.js
+++ b/assets/js/element-shim.test.js
@@ -1,0 +1,36 @@
+/**
+ * Element Shim tests.
+ *
+ * Site Kit by Google, Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import * as wordpressElement from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import * as elementShim from './element-shim';
+
+describe( '@wordpress/element shim', () => {
+	it( 'mirrors all exports from the @wordpress/element package', () => {
+		const realExports = Object.keys( wordpressElement ).sort();
+		const shimExports = Object.keys( elementShim ).sort();
+
+		expect( shimExports ).toEqual( realExports );
+	} );
+} );

--- a/tests/js/jest.config.js
+++ b/tests/js/jest.config.js
@@ -41,6 +41,7 @@ module.exports = {
 	],
 	// Matches aliases in webpack.config.js.
 	moduleNameMapper: {
+		'@wordpress/element__non-shim': '@wordpress/element',
 		// New (JSR) modules.
 		'^googlesitekit-(.+)$': '<rootDir>assets/js/googlesitekit-$1',
 	},


### PR DESCRIPTION
## Summary

Addresses issue #1356 (follow-up to PR #1762)

## Relevant technical choices

Updates our shim for `@wordpress/element` and adds a test to ensure it is always in sync going forward.

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
