### PR TITLE
Add param doc for settings.wrapWidget in widgets API.

### DIFF
--- a/assets/js/googlesitekit/widgets/index.js
+++ b/assets/js/googlesitekit/widgets/index.js
@@ -69,12 +69,13 @@ const Widgets = {
 	 *
 	 * @since 1.9.0
 	 *
-	 * @param {string}          slug               Widget's slug.
-	 * @param {Object}          settings           Widget's settings.
-	 * @param {React.Component} settings.component React component used to display the contents of this widget.
-	 * @param {number}          settings.priority  Optional. Widget's priority for ordering (lower number is higher priority, like WordPress hooks). Default is: 10.
-	 * @param {string}          settings.width     Optional. Widget's maximum width to occupy. Default is: "quarter". One of: "quarter", "half", "full".
-	 * @param {(string|Array)}  [widgetAreaSlugs]  Optional. Widget area slug(s).
+	 * @param {string}          slug                Widget's slug.
+	 * @param {Object}          settings            Widget's settings.
+	 * @param {React.Component} settings.component  React component used to display the contents of this widget.
+	 * @param {number}          settings.priority   Optional. Widget's priority for ordering (lower number is higher priority, like WordPress hooks). Default is: 10.
+	 * @param {string}          settings.width      Optional. Widget's maximum width to occupy. Default is: "quarter". One of: "quarter", "half", "full".
+	 * @param {boolean}         settings.wrapWidget Optional. Whether to wrap the component with the <Widget> wrapper. Default is: true.
+	 * @param {(string|Array)}  [widgetAreaSlugs]   Optional. Widget area slug(s).
 	 */
 	registerWidget( slug, settings, widgetAreaSlugs ) {
 		dispatch( STORE_NAME ).registerWidget( slug, settings );


### PR DESCRIPTION
## Summary

Addresses issue #1724 

Adds `@param` jsdoc for `settings.wrapWidget` - all the other lines are only changed due to an added space needed to align the param descriptions as `settings.wrapWidget` is 1 character longer than the previous longest parameter 😆 

See https://github.com/google/site-kit-wp/issues/1724#issuecomment-658805417 for more details.

## Relevant technical choices

<!-- Please describe your changes. -->

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
