### PR TITLE
1386 Follow-up fix ability to select "set up a new container"

### DIFF
--- a/assets/js/modules/tagmanager/components/common/AMPContainerSelect.js
+++ b/assets/js/modules/tagmanager/components/common/AMPContainerSelect.js
@@ -19,6 +19,7 @@
 /**
  * WordPress dependencies
  */
+import { useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -28,7 +29,7 @@ import Data from 'googlesitekit-data';
 import ContainerSelect from './ContainerSelect';
 import { STORE_NAME } from '../../datastore/constants';
 import { STORE_NAME as CORE_SITE } from '../../../../googlesitekit/datastore/site/constants';
-const { useSelect } = Data;
+const { useSelect, useDispatch } = Data;
 
 export default function AMPContainerSelect() {
 	const accountID = useSelect( ( select ) => select( STORE_NAME ).getAccountID() );
@@ -36,6 +37,18 @@ export default function AMPContainerSelect() {
 	const ampContainers = useSelect( ( select ) => select( STORE_NAME ).getAMPContainers( accountID ) );
 	const isAMP = useSelect( ( select ) => select( CORE_SITE ).isAMP() );
 	const isSecondaryAMP = useSelect( ( select ) => select( CORE_SITE ).isSecondaryAMP() );
+
+	const { setAMPContainerID, setInternalAMPContainerID } = useDispatch( STORE_NAME );
+	const onSelect = useCallback( ( index, item ) => {
+		const {
+			value: newContainerID,
+			internalId: newInternalContainerID,
+		} = item.dataset;
+		if ( ampContainerID !== newContainerID ) {
+			setAMPContainerID( newContainerID );
+			setInternalAMPContainerID( newInternalContainerID || '' );
+		}
+	}, [ ampContainerID ] );
 
 	if ( ! isAMP ) {
 		return null;
@@ -51,6 +64,7 @@ export default function AMPContainerSelect() {
 			label={ label }
 			value={ ampContainerID }
 			containers={ ampContainers }
+			onEnhancedChange={ onSelect }
 		/>
 	);
 }

--- a/assets/js/modules/tagmanager/components/common/AMPContainerSelect.test.js
+++ b/assets/js/modules/tagmanager/components/common/AMPContainerSelect.test.js
@@ -64,7 +64,7 @@ describe( 'AMPContainerSelect', () => {
 
 	it( 'should have a "Set up a new container" item at the end of the list', () => {
 		const { account, containers } = factories.buildAccountWithContainers(
-			{ container: { usageContext: [ CONTEXT_WEB ] } }
+			{ container: { usageContext: [ CONTEXT_AMP ] } }
 		);
 		const accountID = account.accountId;
 		registry.dispatch( STORE_NAME ).setAccountID( accountID );
@@ -75,6 +75,23 @@ describe( 'AMPContainerSelect', () => {
 
 		const listItems = getAllByRole( 'menuitem', { hidden: true } );
 		expect( listItems.pop() ).toHaveTextContent( /set up a new container/i );
+	} );
+
+	it( 'can select the "Set up a new container" option', async () => {
+		const { account, containers } = factories.buildAccountWithContainers(
+			{ container: { usageContext: [ CONTEXT_AMP ] } }
+		);
+		const accountID = account.accountId;
+		registry.dispatch( STORE_NAME ).setAccountID( accountID );
+		registry.dispatch( STORE_NAME ).receiveGetAccounts( [ account ] );
+		registry.dispatch( STORE_NAME ).receiveGetContainers( containers, { accountID } );
+
+		const { container, getByText } = render( <AMPContainerSelect />, { registry } );
+
+		fireEvent.click( container.querySelector( '.mdc-select__selected-text' ) );
+		fireEvent.click( getByText( /set up a new container/i ) );
+
+		expect( container.querySelector( '.mdc-select__selected-text' ) ).toHaveTextContent( /set up a new container/i );
 	} );
 
 	it( 'should update the container ID and internal container ID when selected', async () => {

--- a/assets/js/modules/tagmanager/components/common/AMPContainerSelect.test.js
+++ b/assets/js/modules/tagmanager/components/common/AMPContainerSelect.test.js
@@ -177,6 +177,6 @@ describe( 'AMPContainerSelect', () => {
 
 		expect( queryByRole( 'progressbar' ) ).not.toBeInTheDocument();
 		expect( queryByRole( 'menu', { hidden: true } ) ).not.toBeInTheDocument();
-		expect( container ).toBeEmpty();
+		expect( container ).toBeEmptyDOMElement();
 	} );
 } );

--- a/assets/js/modules/tagmanager/components/common/ContainerSelect.js
+++ b/assets/js/modules/tagmanager/components/common/ContainerSelect.js
@@ -25,7 +25,6 @@ import PropTypes from 'prop-types';
 /**
  * WordPress dependencies
  */
-import { useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -36,7 +35,7 @@ import { Select, Option } from '../../../../material-components';
 import { STORE_NAME, CONTAINER_CREATE } from '../../datastore/constants';
 import ProgressBar from '../../../../components/progress-bar';
 import { isValidAccountID } from '../../util';
-const { useSelect, useDispatch } = Data;
+const { useSelect } = Data;
 
 export default function ContainerSelect( {
 	containers,
@@ -49,14 +48,6 @@ export default function ContainerSelect( {
 	const hasExistingTag = useSelect( ( select ) => select( STORE_NAME ).hasExistingTag() );
 	const isLoadingContainers = useSelect( ( select ) => select( STORE_NAME ).isDoingGetContainers( accountID ) );
 
-	const { selectContainer } = useDispatch( STORE_NAME );
-	const onSelect = useCallback( ( index, item ) => {
-		const newContainerID = item.dataset.value;
-		if ( value !== newContainerID ) {
-			selectContainer( newContainerID );
-		}
-	}, [ value ] );
-
 	if ( accounts === undefined || containers === undefined || isLoadingContainers ) {
 		return <ProgressBar small />;
 	}
@@ -65,7 +56,6 @@ export default function ContainerSelect( {
 		<Select
 			className={ classnames( 'googlesitekit-tagmanager__select-container', className ) }
 			disabled={ hasExistingTag || ! isValidAccountID( accountID ) }
-			onEnhancedChange={ onSelect }
 			value={ value }
 			enhanced
 			outlined

--- a/assets/js/modules/tagmanager/components/common/WebContainerSelect.js
+++ b/assets/js/modules/tagmanager/components/common/WebContainerSelect.js
@@ -19,6 +19,7 @@
 /**
  * WordPress dependencies
  */
+import { useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -28,7 +29,7 @@ import Data from 'googlesitekit-data';
 import { STORE_NAME } from '../../datastore/constants';
 import { STORE_NAME as CORE_SITE } from '../../../../googlesitekit/datastore/site/constants';
 import ContainerSelect from './ContainerSelect';
-const { useSelect } = Data;
+const { useSelect, useDispatch } = Data;
 
 export default function WebContainerSelect() {
 	const accountID = useSelect( ( select ) => select( STORE_NAME ).getAccountID() );
@@ -36,6 +37,18 @@ export default function WebContainerSelect() {
 	const containers = useSelect( ( select ) => select( STORE_NAME ).getWebContainers( accountID ) );
 	const isPrimaryAMP = useSelect( ( select ) => select( CORE_SITE ).isPrimaryAMP() );
 	const isSecondaryAMP = useSelect( ( select ) => select( CORE_SITE ).isSecondaryAMP() );
+
+	const { setContainerID, setInternalContainerID } = useDispatch( STORE_NAME );
+	const onSelect = useCallback( ( index, item ) => {
+		const {
+			value: newContainerID,
+			internalId: newInternalContainerID,
+		} = item.dataset;
+		if ( containerID !== newContainerID ) {
+			setContainerID( newContainerID );
+			setInternalContainerID( newInternalContainerID || '' );
+		}
+	}, [ containerID ] );
 
 	if ( isPrimaryAMP ) {
 		return null;
@@ -51,6 +64,7 @@ export default function WebContainerSelect() {
 			label={ label }
 			value={ containerID }
 			containers={ containers }
+			onEnhancedChange={ onSelect }
 		/>
 	);
 }

--- a/assets/js/modules/tagmanager/components/common/WebContainerSelect.test.js
+++ b/assets/js/modules/tagmanager/components/common/WebContainerSelect.test.js
@@ -178,6 +178,6 @@ describe( 'WebContainerSelect', () => {
 
 		expect( queryByRole( 'progressbar' ) ).not.toBeInTheDocument();
 		expect( queryByRole( 'menu', { hidden: true } ) ).not.toBeInTheDocument();
-		expect( container ).toBeEmpty();
+		expect( container ).toBeEmptyDOMElement();
 	} );
 } );

--- a/assets/js/modules/tagmanager/components/common/WebContainerSelect.test.js
+++ b/assets/js/modules/tagmanager/components/common/WebContainerSelect.test.js
@@ -77,6 +77,23 @@ describe( 'WebContainerSelect', () => {
 		expect( listItems.pop() ).toHaveTextContent( /set up a new container/i );
 	} );
 
+	it( 'can select the "Set up a new container" option', async () => {
+		const { account, containers } = factories.buildAccountWithContainers(
+			{ container: { usageContext: [ CONTEXT_WEB ] } }
+		);
+		const accountID = account.accountId;
+		registry.dispatch( STORE_NAME ).setAccountID( accountID );
+		registry.dispatch( STORE_NAME ).receiveGetAccounts( [ account ] );
+		registry.dispatch( STORE_NAME ).receiveGetContainers( containers, { accountID } );
+
+		const { container, getByText } = render( <WebContainerSelect />, { registry } );
+
+		fireEvent.click( container.querySelector( '.mdc-select__selected-text' ) );
+		fireEvent.click( getByText( /set up a new container/i ) );
+
+		expect( container.querySelector( '.mdc-select__selected-text' ) ).toHaveTextContent( /set up a new container/i );
+	} );
+
 	it( 'should update the container ID and internal container ID when selected', async () => {
 		const { account, containers } = factories.buildAccountWithContainers(
 			{ container: { usageContext: [ CONTEXT_WEB ] } }

--- a/assets/js/modules/tagmanager/datastore/containers.js
+++ b/assets/js/modules/tagmanager/datastore/containers.js
@@ -27,7 +27,7 @@ import invariant from 'invariant';
 import API from 'googlesitekit-api';
 import Data from 'googlesitekit-data';
 import { STORE_NAME, CONTEXT_WEB, CONTEXT_AMP } from './constants';
-import { isValidAccountID, isValidUsageContext, isValidContainerSelection } from '../util/validation';
+import { isValidAccountID, isValidContainerID, isValidUsageContext } from '../util/validation';
 import { createFetchStore } from '../../../googlesitekit/data/create-fetch-store';
 const { createRegistrySelector, createRegistryControl } = Data;
 
@@ -118,7 +118,10 @@ const baseActions = {
 	 * @param {string} containerID Tag Manager container `publicId` of container to select.
 	 */
 	*selectContainer( containerID ) {
-		invariant( isValidContainerSelection( containerID ), 'A valid container selection is required to select a container.' );
+		// This action relies on looking up the container in state to know what
+		// settings to set the container IDs for. For this reason we cannot use this
+		// for selecting the option to "set up a new container"
+		invariant( isValidContainerID( containerID ), 'A valid container ID is required to select a container.' );
 
 		const { select, dispatch } = yield Data.commonActions.getRegistry();
 		const accountID = select( STORE_NAME ).getAccountID();

--- a/assets/js/modules/tagmanager/datastore/containers.js
+++ b/assets/js/modules/tagmanager/datastore/containers.js
@@ -108,7 +108,7 @@ const baseActions = {
 	},
 
 	/**
-	 * Selects the given container, including its internal ID.
+	 * Sets selected container settings for the given container ID of the current account.
 	 *
 	 * Supports selecting a container that has not been received yet.
 	 *
@@ -117,11 +117,11 @@ const baseActions = {
 	 *
 	 * @param {string} containerID Tag Manager container `publicId` of container to select.
 	 */
-	*selectContainer( containerID ) {
+	*selectContainerByID( containerID ) {
 		// This action relies on looking up the container in state to know what
 		// settings to set the container IDs for. For this reason we cannot use this
 		// for selecting the option to "set up a new container"
-		invariant( isValidContainerID( containerID ), 'A valid container ID is required to select a container.' );
+		invariant( isValidContainerID( containerID ), 'A valid container ID is required to select a container by ID.' );
 
 		const { select, dispatch } = yield Data.commonActions.getRegistry();
 		const accountID = select( STORE_NAME ).getAccountID();

--- a/assets/js/modules/tagmanager/datastore/containers.test.js
+++ b/assets/js/modules/tagmanager/datastore/containers.test.js
@@ -132,7 +132,7 @@ describe( 'modules/tagmanager containers', () => {
 			} );
 		} );
 
-		describe( 'selectContainer', () => {
+		describe( 'selectContainerByID', () => {
 			it( 'sets the containerID and internalContainerID for a web container', async () => {
 				const { account, containers } = factories.buildAccountWithContainers( {
 					container: { usageContext: [ CONTEXT_WEB ] },
@@ -144,7 +144,7 @@ describe( 'modules/tagmanager containers', () => {
 				expect( registry.select( STORE_NAME ).getContainerID() ).toBe( '' );
 				expect( registry.select( STORE_NAME ).getInternalContainerID() ).toBe( '' );
 
-				await registry.dispatch( STORE_NAME ).selectContainer( container.publicId );
+				await registry.dispatch( STORE_NAME ).selectContainerByID( container.publicId );
 
 				expect( registry.select( STORE_NAME ).getContainerID() ).toBe( container.publicId );
 				expect( registry.select( STORE_NAME ).getInternalContainerID() ).toBe( container.containerId );
@@ -161,7 +161,7 @@ describe( 'modules/tagmanager containers', () => {
 				expect( registry.select( STORE_NAME ).getAMPContainerID() ).toBe( '' );
 				expect( registry.select( STORE_NAME ).getInternalAMPContainerID() ).toBe( '' );
 
-				await registry.dispatch( STORE_NAME ).selectContainer( container.publicId );
+				await registry.dispatch( STORE_NAME ).selectContainerByID( container.publicId );
 
 				expect( registry.select( STORE_NAME ).getAMPContainerID() ).toBe( container.publicId );
 				expect( registry.select( STORE_NAME ).getInternalAMPContainerID() ).toBe( container.containerId );
@@ -175,7 +175,7 @@ describe( 'modules/tagmanager containers', () => {
 				expect( registry.select( STORE_NAME ).getInternalAMPContainerID() ).toBe( '' );
 
 				muteFetch( 'path:/google-site-kit/v1/modules/tagmanager/data/containers', [] );
-				await registry.dispatch( STORE_NAME ).selectContainer( 'GTM-GXXXXGL3' );
+				await registry.dispatch( STORE_NAME ).selectContainerByID( 'GTM-GXXXXGL3' );
 
 				expect( registry.select( STORE_NAME ).getContainerID() ).toBe( '' );
 				expect( registry.select( STORE_NAME ).getInternalContainerID() ).toBe( '' );

--- a/assets/js/modules/tagmanager/hooks/useExistingTagEffect.js
+++ b/assets/js/modules/tagmanager/hooks/useExistingTagEffect.js
@@ -34,12 +34,12 @@ export default function useExistingTagEffect() {
 	const existingTagPermission = useSelect( ( select ) => select( STORE_NAME ).getTagPermission( existingTag ) );
 	const hasExistingTagPermission = useSelect( ( select ) => select( STORE_NAME ).hasExistingTagPermission() );
 	// Set the accountID and containerID if there is an existing tag.
-	const { selectAccount, selectContainer } = useDispatch( STORE_NAME );
+	const { selectAccount, selectContainerByID } = useDispatch( STORE_NAME );
 	useEffect( () => {
 		( async () => {
 			if ( hasExistingTag && hasExistingTagPermission ) {
 				await selectAccount( existingTagPermission.accountID );
-				await selectContainer( existingTag );
+				await selectContainerByID( existingTag );
 			}
 		} )();
 	}, [ hasExistingTag, existingTag, hasExistingTagPermission, existingTagPermission ] );


### PR DESCRIPTION
## Summary

Addresses issue #1386 (follow-up)

## Relevant technical choices

* Moves `onEnhancedChange` back into web/amp container select components because `selectContainer` can't support selecting `container_create` as it doesn't know which setting to set it for.
* More efficient and sets internal container ID at the same time as it was previously unused even though it is available on the option `item`
* Renames `selectContainer` to `selectContainerByID` per conversation with @felixarntz 

## Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
