### PR TITLE
Fix conditional running of remove-pr action

### DIFF
--- a/.github/workflows/build-storybook.yml
+++ b/.github/workflows/build-storybook.yml
@@ -88,8 +88,8 @@ jobs:
           git add .
           git status
           git diff --staged --quiet && echo 'No changes to commit; exiting!' && exit 0
-          git commit -m "Deploy storybook for ${TARGET_DIR}."
           git pull --no-edit --quiet
+          git commit -m "Deploy storybook for ${TARGET_DIR}."
           git push origin gh-pages
         env:
           GIT_AUTHOR_EMAIL: ${{ github.actor }}@users.noreply.github.com
@@ -115,6 +115,6 @@ jobs:
           git rm -rf storybook/pull/${PULL_REQUEST_NUMBER}
           git status
           git diff --staged --quiet && echo 'No changes to commit; exiting!' && exit 0
-          git commit -m "Remove storybook for pull/${PULL_REQUEST_NUMBER}."
           git pull --no-edit --quiet
+          git commit -m "Remove storybook for pull/${PULL_REQUEST_NUMBER}."
           git push origin gh-pages

--- a/.github/workflows/build-zips.yml
+++ b/.github/workflows/build-zips.yml
@@ -79,8 +79,8 @@ jobs:
           git add .
           git status
           git diff --staged --quiet && echo 'No changes to commit; exiting!' && exit 0
-          git commit -m "Build and publish ${{ github.ref }}"
           git pull --no-edit --quiet
+          git commit -m "Build and publish ${{ github.ref }}"
           git push origin master
         env:
           GIT_AUTHOR_EMAIL: ${{ github.actor }}@users.noreply.github.com

--- a/.github/workflows/remove-pr.yml
+++ b/.github/workflows/remove-pr.yml
@@ -19,6 +19,7 @@ jobs:
           git add .
           git status
           git diff --staged --quiet && echo 'No changes to commit; exiting!' && exit 0
+          git pull --no-edit --quiet
           git commit -m "Prune refs/pull/${{ github.event.pull_request.number }}"
           git push origin master
         env:

--- a/.github/workflows/remove-pr.yml
+++ b/.github/workflows/remove-pr.yml
@@ -5,6 +5,7 @@ on:
     types: [closed]
 jobs:
   remove-pr:
+    if: ${{ always() }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #1590

## Relevant technical choices

* Updates `remove-pr` job to run always, rather than only on success (default)
* Updates git deploy to wiki to `pull` before committing and pushing rather than after committing

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
