### PR TITLE
Update AdSense to use account ID explicitly for urlchannels

### DIFF
--- a/assets/js/modules/adsense/components/setup/SetupMain.js
+++ b/assets/js/modules/adsense/components/setup/SetupMain.js
@@ -96,7 +96,7 @@ export default function SetupMain( { finishSetup } ) {
 
 	// Get additional information to determine account and site status.
 	const alerts = useSelect( ( select ) => select( STORE_NAME ).getAlerts( accountID ) );
-	const urlChannels = useSelect( ( select ) => select( STORE_NAME ).getURLChannels( clientID ) );
+	const urlChannels = useSelect( ( select ) => select( STORE_NAME ).getURLChannels( accountID, clientID ) );
 	const error = useSelect( ( select ) => select( STORE_NAME ).getError() );
 
 	// Determine account and site status.

--- a/assets/js/modules/adsense/datastore/urlchannels.js
+++ b/assets/js/modules/adsense/datastore/urlchannels.js
@@ -28,13 +28,11 @@ import { __ } from '@wordpress/i18n';
 import API from 'googlesitekit-api';
 import Data from 'googlesitekit-data';
 import { STORE_NAME } from './constants';
-import { parseAccountID } from '../util';
 import { createFetchStore } from '../../../googlesitekit/data/create-fetch-store';
 
 const fetchGetURLChannelsStore = createFetchStore( {
 	baseName: 'getURLChannels',
-	controlCallback: ( { clientID } ) => {
-		const accountID = parseAccountID( clientID );
+	controlCallback: ( { accountID, clientID } ) => {
 		if ( undefined === accountID ) {
 			// Mirror the API response that would happen for an invalid client ID.
 			return new Promise( () => {
@@ -49,18 +47,19 @@ const fetchGetURLChannelsStore = createFetchStore( {
 			useCache: false,
 		} );
 	},
-	reducerCallback: ( state, urlchannels, { clientID } ) => {
+	reducerCallback: ( state, urlchannels, { accountID, clientID } ) => {
 		return {
 			...state,
 			urlchannels: {
 				...state.urlchannels,
-				[ clientID ]: [ ...urlchannels ],
+				[ `${ accountID }::${ clientID }` ]: [ ...urlchannels ],
 			},
 		};
 	},
-	argsToParams: ( clientID ) => {
+	argsToParams: ( accountID, clientID ) => {
+		invariant( accountID, 'accountID is required.' );
 		invariant( clientID, 'clientID is required.' );
-		return { clientID };
+		return { accountID, clientID };
 	},
 } );
 
@@ -110,18 +109,18 @@ const baseReducer = ( state, { type } ) => {
 };
 
 const baseResolvers = {
-	*getURLChannels( clientID ) {
-		if ( undefined === clientID ) {
+	*getURLChannels( accountID, clientID ) {
+		if ( undefined === accountID || undefined === clientID ) {
 			return;
 		}
 
 		const registry = yield Data.commonActions.getRegistry();
-		const existingURLChannels = registry.select( STORE_NAME ).getURLChannels( clientID );
+		const existingURLChannels = registry.select( STORE_NAME ).getURLChannels( accountID, clientID );
 		if ( existingURLChannels ) {
 			return;
 		}
 
-		yield fetchGetURLChannelsStore.actions.fetchGetURLChannels( clientID );
+		yield fetchGetURLChannelsStore.actions.fetchGetURLChannels( accountID, clientID );
 	},
 };
 
@@ -131,18 +130,17 @@ const baseSelectors = {
 	 *
 	 * @since 1.9.0
 	 *
-	 * @param {Object} state    Data store's state.
-	 * @param {string} clientID The AdSense Client ID to fetch URL channels for.
+	 * @param {Object} state     Data store's state.
+	 * @param {string} accountID The AdSense Account ID to fetch URL channels for.
+	 * @param {string} clientID  The AdSense Client ID to fetch URL channels for.
 	 * @return {(Array.<Object>|undefined)} An array of AdSense URL channels; `undefined` if not loaded.
 	 */
-	getURLChannels( state, clientID ) {
-		if ( undefined === clientID ) {
+	getURLChannels( state, accountID, clientID ) {
+		if ( undefined === accountID || undefined === clientID ) {
 			return undefined;
 		}
 
-		const { urlchannels } = state;
-
-		return urlchannels[ clientID ];
+		return state.urlchannels[ `${ accountID }::${ clientID }` ];
 	},
 };
 

--- a/assets/js/modules/adsense/datastore/urlchannels.js
+++ b/assets/js/modules/adsense/datastore/urlchannels.js
@@ -20,7 +20,6 @@
  * External dependencies
  */
 import invariant from 'invariant';
-import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -33,16 +32,6 @@ import { createFetchStore } from '../../../googlesitekit/data/create-fetch-store
 const fetchGetURLChannelsStore = createFetchStore( {
 	baseName: 'getURLChannels',
 	controlCallback: ( { accountID, clientID } ) => {
-		if ( undefined === accountID ) {
-			// Mirror the API response that would happen for an invalid client ID.
-			return new Promise( () => {
-				throw {
-					code: 'invalid_param',
-					message: __( 'The clientID parameter is not a valid AdSense client ID.', 'google-site-kit' ),
-					data: { status: 400 },
-				};
-			} );
-		}
 		return API.get( 'modules', 'adsense', 'urlchannels', { accountID, clientID }, {
 			useCache: false,
 		} );

--- a/assets/js/modules/adsense/datastore/urlchannels.test.js
+++ b/assets/js/modules/adsense/datastore/urlchannels.test.js
@@ -60,7 +60,7 @@ describe( 'modules/adsense URL channels', () => {
 					{ body: fixtures.urlchannels, status: 200 }
 				);
 
-				const accountID = '12345';
+				const accountID = 'pub-12345';
 				const clientID = fixtures.clients[ 0 ].id;
 
 				const initialURLChannels = registry.select( STORE_NAME ).getURLChannels( accountID, clientID );
@@ -75,7 +75,7 @@ describe( 'modules/adsense URL channels', () => {
 			} );
 
 			it( 'does not make a network request if urlchannels for this account + client are already present', async () => {
-				const accountID = '12345';
+				const accountID = 'pub-12345';
 				const clientID = fixtures.clients[ 0 ].id;
 
 				// Load data into this store so there are matches for the data we're about to select,
@@ -101,7 +101,7 @@ describe( 'modules/adsense URL channels', () => {
 					{ body: response, status: 500 }
 				);
 
-				const fakeAccountID = '777888999';
+				const fakeAccountID = 'pub-777888999';
 				const fakeClientID = 'ca-pub-777888999';
 
 				muteConsole( 'error' );

--- a/includes/Modules/AdSense.php
+++ b/includes/Modules/AdSense.php
@@ -30,6 +30,7 @@ use Google\Site_Kit\Core\REST_API\Data_Request;
 use Google\Site_Kit\Core\Util\Debug_Data;
 use Google\Site_Kit\Modules\AdSense\Settings;
 use Google\Site_Kit_Dependencies\Google_Service_AdSense;
+use Google\Site_Kit_Dependencies\Google_Service_AdSense_Account;
 use Google\Site_Kit_Dependencies\Google_Service_AdSense_Alert;
 use Google\Site_Kit_Dependencies\Psr\Http\Message\RequestInterface;
 use WP_Error;
@@ -884,28 +885,68 @@ tag_partner: "site_kit"
 	 * @since 1.9.0
 	 *
 	 * @param string $client_id  Client found in the existing tag.
-	 * @param string $account_id Account ID the client belongs to.
-	 * @return bool True if the user has access, false otherwise.
+	 * @return array {
+	 *      AdSense account access data.
+	 *      @type string $account_id The AdSense account ID for the given client.
+	 *      @type bool   $permission Whether the user has access to this account and client.
+	 * }
 	 */
-	protected function has_access_to_client( $client_id, $account_id ) {
-		if ( empty( $client_id ) || empty( $account_id ) ) {
-			return false;
+	protected function has_access_to_client( $client_id ) {
+		if ( empty( $client_id ) ) {
+			return array(
+				'account_id' => '',
+				'permission' => false,
+			);
 		}
 
-		// Try to get clients for that account.
-		$clients = $this->get_data( 'clients', array( 'accountID' => $account_id ) );
-		if ( is_wp_error( $clients ) ) {
-			// No access to the account.
+		$account_has_client = function ( $account_id ) use ( $client_id ) {
+			// Try to get clients for that account.
+			$clients = $this->get_data( 'clients', array( 'accountID' => $account_id ) );
+			if ( is_wp_error( $clients ) ) {
+				// No access to the account.
+				return false;
+			}
+			// Ensure there is access to the client.
+			foreach ( $clients as $client ) {
+				if ( $client->getId() === $client_id ) {
+					return true;
+				}
+			}
+
 			return false;
+		};
+
+		$parsed_account_id = $this->parse_account_id( $client_id );
+
+		if ( $account_has_client( $parsed_account_id ) ) {
+			return array(
+				'account_id' => $parsed_account_id,
+				'permission' => true,
+			);
 		}
 
-		// Ensure there is access to the client.
-		foreach ( $clients as $client ) {
-			if ( $client->getId() === $client_id ) {
-				return true;
+		$accounts = $this->get_data( 'accounts' );
+		if ( is_wp_error( $accounts ) ) {
+			$accounts = array();
+		}
+
+		foreach ( $accounts as $account ) {
+			/* @var Google_Service_AdSense_Account $account AdSense account instance. */
+			if ( $account->getId() === $parsed_account_id ) {
+				continue;
+			}
+			if ( $account_has_client( $account->getId() ) ) {
+				return array(
+					'account_id' => $account->getId(),
+					'permission' => true,
+				);
 			}
 		}
-		return false;
+
+		return array(
+			'account_id' => $parsed_account_id,
+			'permission' => false,
+		);
 	}
 
 	/**

--- a/includes/Modules/AdSense.php
+++ b/includes/Modules/AdSense.php
@@ -560,19 +560,10 @@ tag_partner: "site_kit"
 							array( 'status' => 400 )
 						);
 					}
-					$client_id  = $data['clientID'];
-					$account_id = $this->parse_account_id( $client_id );
-					if ( empty( $account_id ) ) {
-						return new WP_Error(
-							'invalid_param',
-							__( 'The clientID parameter is not a valid AdSense client ID.', 'google-site-kit' ),
-							array( 'status' => 400 )
-						);
-					}
-					return array(
-						'accountID'  => $account_id,
-						'clientID'   => $client_id,
-						'permission' => $this->has_access_to_client( $client_id, $account_id ),
+
+					return array_merge(
+						array( 'clientID' => $data['clientID'] ),
+						$this->has_access_to_client( $data['clientID'] )
 					);
 				};
 			case 'GET:reports-url':

--- a/stories/module-adsense-setup.stories.js
+++ b/stories/module-adsense-setup.stories.js
@@ -97,7 +97,10 @@ storiesOf( 'AdSense Module/Setup', module )
 			registry.dispatch( STORE_NAME ).receiveGetAccounts( fixtures.accounts );
 			registry.dispatch( STORE_NAME ).receiveGetClients( fixtures.clients, { accountID: fixtures.accounts[ 0 ].id } );
 			registry.dispatch( STORE_NAME ).receiveGetAlerts( [], { accountID: fixtures.accounts[ 0 ].id } );
-			registry.dispatch( STORE_NAME ).receiveGetURLChannels( [], { clientID: fixtures.clients[ 0 ].id } );
+			registry.dispatch( STORE_NAME ).receiveGetURLChannels( [], {
+				accountID: fixtures.accounts[ 0 ].id,
+				clientID: fixtures.clients[ 0 ].id,
+			} );
 		};
 
 		return <Setup callback={ setupRegistry } />;
@@ -155,8 +158,14 @@ storiesOf( 'AdSense Module/Setup', module )
 			} ], { accountID: fixtures.accountsMultiple[ 1 ].id } );
 			registry.dispatch( STORE_NAME ).receiveGetAlerts( [], { accountID: fixtures.accountsMultiple[ 0 ].id } );
 			registry.dispatch( STORE_NAME ).receiveGetAlerts( [], { accountID: fixtures.accountsMultiple[ 1 ].id } );
-			registry.dispatch( STORE_NAME ).receiveGetURLChannels( [], { clientID: fixtures.clients[ 0 ].id } );
-			registry.dispatch( STORE_NAME ).receiveGetURLChannels( [], { clientID: `ca-${ fixtures.accountsMultiple[ 1 ].id }` } );
+			registry.dispatch( STORE_NAME ).receiveGetURLChannels( [], {
+				accountID: fixtures.accountsMultiple[ 0 ].id,
+				clientID: fixtures.clients[ 0 ].id,
+			} );
+			registry.dispatch( STORE_NAME ).receiveGetURLChannels( [], {
+				accountID: fixtures.accountsMultiple[ 1 ].id,
+				clientID: `ca-${ fixtures.accountsMultiple[ 1 ].id }`,
+			} );
 		};
 
 		return <Setup callback={ setupRegistry } />;
@@ -190,7 +199,10 @@ storiesOf( 'AdSense Module/Setup', module )
 			registry.dispatch( STORE_NAME ).receiveGetAccounts( fixtures.accounts );
 			registry.dispatch( STORE_NAME ).receiveGetClients( fixtures.clients, { accountID: fixtures.accounts[ 0 ].id } );
 			registry.dispatch( STORE_NAME ).receiveGetAlerts( fixtures.alertsGraylisted, { accountID: fixtures.accounts[ 0 ].id } );
-			registry.dispatch( STORE_NAME ).receiveGetURLChannels( [], { clientID: fixtures.clients[ 0 ].id } );
+			registry.dispatch( STORE_NAME ).receiveGetURLChannels( [], {
+				accountID: fixtures.accounts[ 0 ].id,
+				clientID: fixtures.clients[ 0 ].id,
+			} );
 		};
 
 		return <Setup callback={ setupRegistry } />;
@@ -212,7 +224,10 @@ storiesOf( 'AdSense Module/Setup', module )
 					reason: 'accountPendingReview',
 				},
 			} );
-			registry.dispatch( STORE_NAME ).receiveGetURLChannels( [], { clientID: fixtures.clients[ 0 ].id } );
+			registry.dispatch( STORE_NAME ).receiveGetURLChannels( [], {
+				accountID: fixtures.accounts[ 0 ].id,
+				clientID: fixtures.clients[ 0 ].id,
+			} );
 		};
 
 		return <Setup callback={ setupRegistry } />;
@@ -246,7 +261,10 @@ storiesOf( 'AdSense Module/Setup', module )
 			registry.dispatch( STORE_NAME ).receiveGetAccounts( fixtures.accounts );
 			registry.dispatch( STORE_NAME ).receiveGetClients( fixtures.clients, { accountID: fixtures.accounts[ 0 ].id } );
 			registry.dispatch( STORE_NAME ).receiveGetAlerts( fixtures.alerts, { accountID: fixtures.accounts[ 0 ].id } );
-			registry.dispatch( STORE_NAME ).receiveGetURLChannels( [], { clientID: fixtures.clients[ 0 ].id } );
+			registry.dispatch( STORE_NAME ).receiveGetURLChannels( [], {
+				accountID: fixtures.accounts[ 0 ].id,
+				clientID: fixtures.clients[ 0 ].id,
+			} );
 		};
 
 		return <Setup callback={ setupRegistry } />;
@@ -270,7 +288,10 @@ storiesOf( 'AdSense Module/Setup', module )
 			registry.dispatch( STORE_NAME ).receiveGetAccounts( fixtures.accounts );
 			registry.dispatch( STORE_NAME ).receiveGetClients( fixtures.clients, { accountID: fixtures.accounts[ 0 ].id } );
 			registry.dispatch( STORE_NAME ).receiveGetAlerts( fixtures.alerts, { accountID: fixtures.accounts[ 0 ].id } );
-			registry.dispatch( STORE_NAME ).receiveGetURLChannels( [], { clientID: fixtures.clients[ 0 ].id } );
+			registry.dispatch( STORE_NAME ).receiveGetURLChannels( [], {
+				accountID: fixtures.accounts[ 0 ].id,
+				clientID: fixtures.clients[ 0 ].id,
+			} );
 		};
 
 		return <Setup callback={ setupRegistry } />;
@@ -294,7 +315,10 @@ storiesOf( 'AdSense Module/Setup', module )
 			registry.dispatch( STORE_NAME ).receiveGetAccounts( fixtures.accounts );
 			registry.dispatch( STORE_NAME ).receiveGetClients( fixtures.clients, { accountID: fixtures.accounts[ 0 ].id } );
 			registry.dispatch( STORE_NAME ).receiveGetAlerts( fixtures.alerts, { accountID: fixtures.accounts[ 0 ].id } );
-			registry.dispatch( STORE_NAME ).receiveGetURLChannels( [], { clientID: fixtures.clients[ 0 ].id } );
+			registry.dispatch( STORE_NAME ).receiveGetURLChannels( [], {
+				accountID: fixtures.accounts[ 0 ].id,
+				clientID: fixtures.clients[ 0 ].id,
+			} );
 		};
 
 		return <Setup callback={ setupRegistry } />;
@@ -309,7 +333,10 @@ storiesOf( 'AdSense Module/Setup', module )
 			registry.dispatch( STORE_NAME ).receiveGetAccounts( fixtures.accounts );
 			registry.dispatch( STORE_NAME ).receiveGetClients( fixtures.clients, { accountID: fixtures.accounts[ 0 ].id } );
 			registry.dispatch( STORE_NAME ).receiveGetAlerts( fixtures.alerts, { accountID: fixtures.accounts[ 0 ].id } );
-			registry.dispatch( STORE_NAME ).receiveGetURLChannels( [], { clientID: fixtures.clients[ 0 ].id } );
+			registry.dispatch( STORE_NAME ).receiveGetURLChannels( [], {
+				accountID: fixtures.accounts[ 0 ].id,
+				clientID: fixtures.clients[ 0 ].id,
+			} );
 		};
 
 		return <Setup callback={ setupRegistry } />;
@@ -328,7 +355,10 @@ storiesOf( 'AdSense Module/Setup', module )
 			registry.dispatch( STORE_NAME ).receiveGetAccounts( fixtures.accounts );
 			registry.dispatch( STORE_NAME ).receiveGetClients( fixtures.clients, { accountID: fixtures.accounts[ 0 ].id } );
 			registry.dispatch( STORE_NAME ).receiveGetAlerts( fixtures.alerts, { accountID: fixtures.accounts[ 0 ].id } );
-			registry.dispatch( STORE_NAME ).receiveGetURLChannels( [], { clientID: fixtures.clients[ 0 ].id } );
+			registry.dispatch( STORE_NAME ).receiveGetURLChannels( [], {
+				accountID: fixtures.accounts[ 0 ].id,
+				clientID: fixtures.clients[ 0 ].id,
+			} );
 		};
 
 		return <Setup callback={ setupRegistry } />;
@@ -347,7 +377,10 @@ storiesOf( 'AdSense Module/Setup', module )
 			registry.dispatch( STORE_NAME ).receiveGetAccounts( fixtures.accounts );
 			registry.dispatch( STORE_NAME ).receiveGetClients( fixtures.clients, { accountID: fixtures.accounts[ 0 ].id } );
 			registry.dispatch( STORE_NAME ).receiveGetAlerts( fixtures.alerts, { accountID: fixtures.accounts[ 0 ].id } );
-			registry.dispatch( STORE_NAME ).receiveGetURLChannels( [], { clientID: fixtures.clients[ 0 ].id } );
+			registry.dispatch( STORE_NAME ).receiveGetURLChannels( [], {
+				accountID: fixtures.accounts[ 0 ].id,
+				clientID: fixtures.clients[ 0 ].id,
+			} );
 		};
 
 		return <Setup callback={ setupRegistry } />;
@@ -362,7 +395,10 @@ storiesOf( 'AdSense Module/Setup', module )
 			registry.dispatch( STORE_NAME ).receiveGetAccounts( fixtures.accounts );
 			registry.dispatch( STORE_NAME ).receiveGetClients( fixtures.clients, { accountID: fixtures.accounts[ 0 ].id } );
 			registry.dispatch( STORE_NAME ).receiveGetAlerts( fixtures.alerts, { accountID: fixtures.accounts[ 0 ].id } );
-			registry.dispatch( STORE_NAME ).receiveGetURLChannels( [], { clientID: fixtures.clients[ 0 ].id } );
+			registry.dispatch( STORE_NAME ).receiveGetURLChannels( [], {
+				accountID: fixtures.accounts[ 0 ].id,
+				clientID: fixtures.clients[ 0 ].id,
+			} );
 		};
 
 		return <Setup callback={ setupRegistry } />;
@@ -377,7 +413,13 @@ storiesOf( 'AdSense Module/Setup', module )
 			registry.dispatch( STORE_NAME ).receiveGetAccounts( fixtures.accounts );
 			registry.dispatch( STORE_NAME ).receiveGetClients( fixtures.clients, { accountID: fixtures.accounts[ 0 ].id } );
 			registry.dispatch( STORE_NAME ).receiveGetAlerts( fixtures.alerts, { accountID: fixtures.accounts[ 0 ].id } );
-			registry.dispatch( STORE_NAME ).receiveGetURLChannels( fixtures.urlchannels, { clientID: fixtures.clients[ 0 ].id } );
+			registry.dispatch( STORE_NAME ).receiveGetURLChannels(
+				fixtures.urlchannels,
+				{
+					accountID: fixtures.accounts[ 0 ].id,
+					clientID: fixtures.clients[ 0 ].id,
+				}
+			);
 		};
 
 		return <Setup callback={ setupRegistry } />;


### PR DESCRIPTION
## Summary

Addresses issue #1709

## Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
