### PR TITLE
Fix validation in receiveGetExistingTag

### DIFF
--- a/assets/js/googlesitekit/data/create-existing-tag-store.js
+++ b/assets/js/googlesitekit/data/create-existing-tag-store.js
@@ -69,13 +69,12 @@ export const createExistingTagStore = ( {
 			};
 		},
 		receiveGetExistingTag( existingTag ) {
-			invariant(
-				existingTag !== undefined && ( existingTag === null || isValidTag( existingTag ) ),
-				'existingTag must be a valid tag or null.'
-			);
+			invariant( existingTag === null || 'string' === typeof existingTag, 'existingTag must be a tag string or null.' );
 
 			return {
-				payload: { existingTag },
+				payload: {
+					existingTag: isValidTag( existingTag ) ? existingTag : null,
+				},
 				type: RECEIVE_GET_EXISTING_TAG,
 			};
 		},

--- a/assets/js/googlesitekit/data/create-existing-tag-store.test.js
+++ b/assets/js/googlesitekit/data/create-existing-tag-store.test.js
@@ -81,40 +81,32 @@ describe( 'createExistingTagStore store', () => {
 				expect( () => {
 					muteConsole( 'error' );
 					registry.dispatch( STORE_NAME ).receiveGetExistingTag();
-				} ).toThrow( 'existingTag must be a valid tag or null.' );
+				} ).toThrow( 'existingTag must be a tag string or null.' );
 			} );
 
-			it( 'requires a non-zero length string tag by default', () => {
-				expect( () => {
-					muteConsole( 'error' );
-					registry.dispatch( STORE_NAME ).receiveGetExistingTag( '' );
-				} ).toThrow( 'existingTag must be a valid tag or null.' );
-
-				expect( () => {
-					registry.dispatch( STORE_NAME ).receiveGetExistingTag( 'a' );
-				} ).not.toThrow();
+			it( 'receives an empty string tag as null', () => {
+				registry.dispatch( STORE_NAME ).receiveGetExistingTag( '' );
+				expect( store.getState().existingTag ).toBe( null );
 			} );
 
-			it( 'allows custom validation for tags', () => {
+			it( 'allows custom validation for tags, and receives invalid tags as null', () => {
 				const storeName = 'is-valid-tag/store';
 				const isValidTag = ( tag ) => tag === 'valid-tag';
 				const storeDefinition = createExistingTagStore( {
 					storeName,
-					tagMatchers: [ /(\w+)/ ],
+					tagMatchers: [],
 					isValidTag,
 				} );
-				registry.registerStore( storeName, storeDefinition );
+				store = registry.registerStore( storeName, storeDefinition );
 
 				expect( isValidTag( 'invalid-tag' ) ).toBe( false );
-				expect( () => {
-					muteConsole( 'error' );
-					registry.dispatch( storeName ).receiveGetExistingTag( 'invalid-tag' );
-				} ).toThrow( 'existingTag must be a valid tag or null.' );
+
+				registry.dispatch( storeName ).receiveGetExistingTag( 'invalid-tag' );
+				expect( store.getState().existingTag ).toBe( null );
 
 				expect( isValidTag( 'valid-tag' ) ).toBe( true );
-				expect( () => {
-					registry.dispatch( storeName ).receiveGetExistingTag( 'valid-tag' );
-				} ).not.toThrow();
+				registry.dispatch( storeName ).receiveGetExistingTag( 'valid-tag' );
+				expect( store.getState().existingTag ).toBe( 'valid-tag' );
 			} );
 
 			it( 'receives and sets value', () => {

--- a/assets/js/modules/adsense/util/validation.js
+++ b/assets/js/modules/adsense/util/validation.js
@@ -25,7 +25,7 @@
  * @return {boolean} True if the given account ID is valid, false otherwise.
  */
 export function isValidAccountID( accountID ) {
-	return typeof accountID === 'string' && !! accountID.match( /^pub-\d+$/ );
+	return typeof accountID === 'string' && /^pub-\d+$/.test( accountID );
 }
 
 /**
@@ -37,5 +37,5 @@ export function isValidAccountID( accountID ) {
  * @return {boolean} True if the given client ID is valid, false otherwise.
  */
 export function isValidClientID( clientID ) {
-	return typeof clientID === 'string' && !! clientID.match( /^ca-pub-\d+$/ );
+	return typeof clientID === 'string' && /^ca-pub-\d+$/.test( clientID );
 }

--- a/assets/js/modules/analytics/util/validation.js
+++ b/assets/js/modules/analytics/util/validation.js
@@ -62,7 +62,7 @@ export function isValidAccountSelection( value ) {
  * @return {boolean} Whether or not the given property ID is valid.
  */
 export function isValidPropertyID( propertyID ) {
-	return typeof propertyID === 'string' && propertyID.match( /^UA-\d+-\d+$/ );
+	return !! ( typeof propertyID === 'string' && propertyID.match( /^UA-\d+-\d+$/ ) );
 }
 
 /**

--- a/assets/js/modules/analytics/util/validation.js
+++ b/assets/js/modules/analytics/util/validation.js
@@ -62,7 +62,7 @@ export function isValidAccountSelection( value ) {
  * @return {boolean} Whether or not the given property ID is valid.
  */
 export function isValidPropertyID( propertyID ) {
-	return !! ( typeof propertyID === 'string' && propertyID.match( /^UA-\d+-\d+$/ ) );
+	return typeof propertyID === 'string' && /^UA-\d+-\d+$/.test( propertyID );
 }
 
 /**

--- a/assets/js/modules/optimize/util/validation.js
+++ b/assets/js/modules/optimize/util/validation.js
@@ -25,7 +25,7 @@
  * @return {boolean} True if the given optimize ID is valid, false otherwise.
  */
 export function isValidOptimizeID( optimizeID ) {
-	return typeof optimizeID === 'string' && !! optimizeID.match( /^(GTM|OPT)-[A-Z0-9]+$/ );
+	return typeof optimizeID === 'string' && /^(GTM|OPT)-[A-Z0-9]+$/.test( optimizeID );
 }
 
 /**

--- a/assets/js/modules/tagmanager/util/validation.js
+++ b/assets/js/modules/tagmanager/util/validation.js
@@ -72,7 +72,7 @@ export function isValidAccountSelection( value ) {
  * @return {boolean} Whether or not the given container ID is valid.
  */
 export function isValidContainerID( containerID ) {
-	return !! containerID?.toString?.()?.match?.( /^GTM-[A-Z0-9]+$/ );
+	return typeof containerID === 'string' && /^GTM-[A-Z0-9]+$/.test( containerID );
 }
 
 /**


### PR DESCRIPTION
## Summary

Addresses issue #1328

## Relevant technical choices

* Updates `receiveGetExistingTag` action to only throw an error if a non-string, non-null value is passed
* Updates `receiveGetExistingTag` to receive `null` for otherwise invalid tags (as determined by `isValidTag`)
* Updates validation utilities for consistency and ensure they're always returning a boolean
* Targeting `master` for inclusion in the release

## Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
