### PR TITLE
Add hl query parameter to proxy permissions URL.

### DIFF
--- a/includes/Core/Authentication/Clients/OAuth_Client.php
+++ b/includes/Core/Authentication/Clients/OAuth_Client.php
@@ -918,7 +918,7 @@ final class OAuth_Client {
 		}
 
 		$query_args['application_name'] = rawurlencode( $this->get_application_name() );
-		$query_params['hl']             = get_user_locale();
+		$query_args['hl']               = get_user_locale();
 
 		return add_query_arg( $query_args, $this->google_proxy->url( Google_Proxy::PERMISSIONS_URI ) );
 	}

--- a/includes/Core/Authentication/Clients/OAuth_Client.php
+++ b/includes/Core/Authentication/Clients/OAuth_Client.php
@@ -918,6 +918,7 @@ final class OAuth_Client {
 		}
 
 		$query_args['application_name'] = rawurlencode( $this->get_application_name() );
+		$query_params['hl']             = get_user_locale();
 
 		return add_query_arg( $query_args, $this->google_proxy->url( Google_Proxy::PERMISSIONS_URI ) );
 	}

--- a/tests/phpunit/integration/Core/Authentication/Clients/OAuth_ClientTest.php
+++ b/tests/phpunit/integration/Core/Authentication/Clients/OAuth_ClientTest.php
@@ -561,6 +561,9 @@ class OAuth_ClientTest extends TestCase {
 	public function test_get_proxy_permissions_url() {
 		$context = new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE );
 
+		$user_id = $this->factory()->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $user_id );
+
 		// If no access token, this does not work.
 		$client = new OAuth_Client( $context );
 		$url    = $client->get_proxy_permissions_url();

--- a/tests/phpunit/integration/Core/Authentication/Clients/OAuth_ClientTest.php
+++ b/tests/phpunit/integration/Core/Authentication/Clients/OAuth_ClientTest.php
@@ -572,6 +572,7 @@ class OAuth_ClientTest extends TestCase {
 		$url = $client->get_proxy_permissions_url();
 		$this->assertContains( 'token=test-access-token', $url );
 		$this->assertContains( 'application_name=', $url );
+		$this->assertContains( 'hl=', $url );
 
 		// If there is a site ID, it should also include that.
 		$fake_credentials = $this->fake_proxy_site_connection();
@@ -581,6 +582,7 @@ class OAuth_ClientTest extends TestCase {
 		$this->assertContains( 'token=test-access-token', $url );
 		$this->assertContains( 'site_id=' . $fake_credentials['client_id'], $url );
 		$this->assertContains( 'application_name=', $url );
+		$this->assertContains( 'hl=', $url );
 	}
 
 	public function test_get_error_message_unknown() {


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #1860

## Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
