### PR TITLE
Update PHP tests for WP nightly to use PHP 7.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -93,7 +93,7 @@ script:
 
 jobs:
   allow_failures:
-    - php: PHP=1 WP_VERSION=master
+    - env: WP_VERSION=master PHP=1
     - env: E2E=1 WP_VERSION=nightly
   include:
     - stage: test

--- a/.travis.yml
+++ b/.travis.yml
@@ -93,7 +93,7 @@ script:
 
 jobs:
   allow_failures:
-    - php: nightly
+    - php: PHP=1 WP_VERSION=master
     - env: E2E=1 WP_VERSION=nightly
   include:
     - stage: test
@@ -114,9 +114,9 @@ jobs:
       env: WP_VERSION=latest JS=1 PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
     - name: Visual Regression
       env: VRT=1
-    - name: PHP Tests (PHP nightly, WordPress trunk)
+    - name: PHP Tests (PHP 7.4, WordPress trunk)
       stage: test
-      php: nightly
+      php: 7.4
       env: WP_VERSION=master PHP=1
     - stage: test
       name: E2E Tests (WordPress latest)


### PR DESCRIPTION
## Summary

Addresses issue #1883

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
