### PR TITLE
Add React shim and webpack config changes.

### DIFF
--- a/assets/js/react-shim.js
+++ b/assets/js/react-shim.js
@@ -1,0 +1,122 @@
+/**
+ * React shim for ensuring all modules share the same instance of React.
+ *
+ * Site Kit by Google, Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, * as ReactExports from 'react__non-shim';
+
+if ( global.googlesitekit === undefined ) {
+	global.googlesitekit = {};
+}
+
+const {
+	default: defaultExport,
+	Children,
+	createRef,
+	Component,
+	PureComponent,
+	createContext,
+	forwardRef,
+	lazy,
+	memo,
+	useCallback,
+	useContext,
+	useEffect,
+	useImperativeHandle,
+	useDebugValue,
+	useLayoutEffect,
+	useMemo,
+	useReducer,
+	useRef,
+	useState,
+	Fragment,
+	Profiler,
+	StrictMode,
+	Suspense,
+	createElement,
+	cloneElement,
+	createFactory,
+	isValidElement,
+	version,
+	__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED,
+} = global.googlesitekit._react || { default: React, ...ReactExports };
+
+if ( global.googlesitekit._react === undefined ) {
+	global.googlesitekit._react = {
+		default: React,
+		Children,
+		createRef,
+		Component,
+		PureComponent,
+		createContext,
+		forwardRef,
+		lazy,
+		memo,
+		useCallback,
+		useContext,
+		useEffect,
+		useImperativeHandle,
+		useDebugValue,
+		useLayoutEffect,
+		useMemo,
+		useReducer,
+		useRef,
+		useState,
+		Fragment,
+		Profiler,
+		StrictMode,
+		Suspense,
+		createElement,
+		cloneElement,
+		createFactory,
+		isValidElement,
+		version,
+		__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED,
+	};
+}
+
+export default defaultExport;
+
+export {
+	Children,
+	createRef,
+	Component,
+	PureComponent,
+	createContext,
+	forwardRef,
+	lazy,
+	memo,
+	useCallback,
+	useContext,
+	useEffect,
+	useImperativeHandle,
+	useDebugValue,
+	useLayoutEffect,
+	useMemo,
+	useReducer,
+	useRef,
+	useState,
+	Fragment,
+	Profiler,
+	StrictMode,
+	Suspense,
+	createElement,
+	cloneElement,
+	createFactory,
+	isValidElement,
+	version,
+	__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED,
+};

--- a/assets/js/react-shim.test.js
+++ b/assets/js/react-shim.test.js
@@ -24,7 +24,7 @@ import reactDefault, * as react from 'react';
 /**
  * Internal dependencies
  */
-import reachShimDefault, * as reactShim from './react-shim';
+import reactShimDefault, * as reactShim from './react-shim';
 
 describe( 'react shim', () => {
 	it( 'mirrors all exports from the react package', () => {
@@ -35,6 +35,6 @@ describe( 'react shim', () => {
 	} );
 
 	it( 'mirrors the default export', () => {
-		expect( reactDefault ).toEqual( reachShimDefault );
+		expect( reactDefault ).toEqual( reactShimDefault );
 	} );
 } );

--- a/assets/js/react-shim.test.js
+++ b/assets/js/react-shim.test.js
@@ -19,12 +19,12 @@
 /**
  * External dependencies
  */
-import * as react from 'react';
+import reactDefault, * as react from 'react';
 
 /**
  * Internal dependencies
  */
-import * as reactShim from './react-shim';
+import reachShimDefault, * as reactShim from './react-shim';
 
 describe( 'react shim', () => {
 	it( 'mirrors all exports from the react package', () => {
@@ -32,5 +32,9 @@ describe( 'react shim', () => {
 		const shimExports = Object.keys( reactShim ).sort();
 
 		expect( shimExports ).toEqual( realExports );
+	} );
+
+	it( 'mirrors the default export', () => {
+		expect( reactDefault ).toEqual( reachShimDefault );
 	} );
 } );

--- a/assets/js/react-shim.test.js
+++ b/assets/js/react-shim.test.js
@@ -1,0 +1,36 @@
+/**
+ * React Shim tests.
+ *
+ * Site Kit by Google, Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import * as react from 'react';
+
+/**
+ * Internal dependencies
+ */
+import * as reactShim from './react-shim';
+
+describe( 'react shim', () => {
+	it( 'mirrors all exports from the react package', () => {
+		const realExports = Object.keys( react ).sort();
+		const shimExports = Object.keys( reactShim ).sort();
+
+		expect( shimExports ).toEqual( realExports );
+	} );
+} );

--- a/tests/js/jest.config.js
+++ b/tests/js/jest.config.js
@@ -41,6 +41,7 @@ module.exports = {
 	],
 	// Matches aliases in webpack.config.js.
 	moduleNameMapper: {
+		'react__non-shim': 'react',
 		'@wordpress/element__non-shim': '@wordpress/element',
 		// New (JSR) modules.
 		'^googlesitekit-(.+)$': '<rootDir>assets/js/googlesitekit-$1',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -86,6 +86,8 @@ const resolve = {
 		'@wordpress/element$': path.resolve( 'assets/js/element-shim.js' ),
 		'@wordpress/hooks__non-shim': require.resolve( '@wordpress/hooks' ),
 		'@wordpress/hooks$': path.resolve( 'assets/js/hooks-shim.js' ),
+		'react__non-shim': require.resolve( 'react' ),
+		react: path.resolve( 'assets/js/react-shim.js' ),
 	},
 	modules: [ projectPath( '.' ), 'node_modules' ],
 };


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #1888.

## Relevant technical choices

Adds a similar shim to element-shim to consolidate React and React hooks imports to prevent the dreaded "Invalid Hooks Error".

<!-- Please describe your changes. -->

## Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
