### PR TITLE
Add checks to ensure Array.map is not called on undefined

### DIFF
--- a/assets/js/modules/analytics/components/dashboard/AdSenseDashboardWidgetTopPagesTableSmall.js
+++ b/assets/js/modules/analytics/components/dashboard/AdSenseDashboardWidgetTopPagesTableSmall.js
@@ -65,6 +65,10 @@ class AdSenseDashboardWidgetTopPagesTableSmall extends Component {
 			return null;
 		}
 
+		if ( ! Array.isArray( data[ 0 ].data.rows ) ) {
+			return null;
+		}
+
 		const headers = [
 			{
 				title: __( 'Top Earning Pages', 'google-site-kit' ),

--- a/assets/js/modules/analytics/components/dashboard/AnalyticsAdSenseDashboardWidgetTopPagesTable.js
+++ b/assets/js/modules/analytics/components/dashboard/AnalyticsAdSenseDashboardWidgetTopPagesTable.js
@@ -52,6 +52,14 @@ const AnalyticsAdSenseDashboardWidgetTopPagesTable = ( { data } ) => {
 		return null;
 	}
 
+	if ( ! data || ! data.length ) {
+		return null;
+	}
+
+	if ( ! Array.isArray( data[ 0 ].data.rows ) ) {
+		return null;
+	}
+
 	const headers = [
 		{
 			title: __( 'Page Title', 'google-site-kit' ),

--- a/assets/js/modules/analytics/components/dashboard/AnalyticsAllTrafficDashboardWidgetTopAcquisitionSources.js
+++ b/assets/js/modules/analytics/components/dashboard/AnalyticsAllTrafficDashboardWidgetTopAcquisitionSources.js
@@ -39,10 +39,10 @@ class AnalyticsAllTrafficDashboardWidgetTopAcquisitionSources extends Component 
 		if ( ! data || ! data.length ) {
 			return null;
 		}
-		if ( ! data[ 0 ].data.totals || ! data[ 0 ].data.totals.length ) {
+		if ( ! Array.isArray( data[ 0 ].data.totals ) || ! data[ 0 ].data.totals.length ) {
 			return null;
 		}
-		if ( ! data[ 0 ].data.rows || ! data[ 0 ].data.rows.length ) {
+		if ( ! Array.isArray( data[ 0 ].data.rows ) || ! data[ 0 ].data.rows.length ) {
 			return null;
 		}
 

--- a/assets/js/modules/analytics/components/dashboard/AnalyticsAllTrafficDashboardWidgetTopAcquisitionSources.js
+++ b/assets/js/modules/analytics/components/dashboard/AnalyticsAllTrafficDashboardWidgetTopAcquisitionSources.js
@@ -39,6 +39,12 @@ class AnalyticsAllTrafficDashboardWidgetTopAcquisitionSources extends Component 
 		if ( ! data || ! data.length ) {
 			return null;
 		}
+		if ( ! data[ 0 ].data.totals || ! data[ 0 ].data.totals.length ) {
+			return null;
+		}
+		if ( ! data[ 0 ].data.rows || ! data[ 0 ].data.rows.length ) {
+			return null;
+		}
 
 		const headers = [
 			{

--- a/assets/js/modules/analytics/components/dashboard/AnalyticsDashboardWidgetPopularPagesTable.js
+++ b/assets/js/modules/analytics/components/dashboard/AnalyticsDashboardWidgetPopularPagesTable.js
@@ -61,6 +61,10 @@ class AnalyticsDashboardWidgetPopularPagesTable extends Component {
 			return null;
 		}
 
+		if ( ! Array.isArray( data[ 0 ].data.rows ) ) {
+			return null;
+		}
+
 		const headers = [
 			{
 				title: __( 'Most popular content', 'google-site-kit' ),

--- a/assets/js/modules/analytics/components/dashboard/AnalyticsDashboardWidgetTopAcquisitionSources.js
+++ b/assets/js/modules/analytics/components/dashboard/AnalyticsDashboardWidgetTopAcquisitionSources.js
@@ -46,6 +46,12 @@ function AnalyticsDashboardWidgetTopAcquisitionSources( { data } ) {
 	if ( ! data || ! data.length ) {
 		return null;
 	}
+	if ( ! Array.isArray( data[ 0 ].data.totals ) || ! data[ 0 ].data.totals.length ) {
+		return null;
+	}
+	if ( ! Array.isArray( data[ 0 ].data.rows ) || ! data[ 0 ].data.rows.length ) {
+		return null;
+	}
 
 	const currentRange = getCurrentDateRange( dateRange );
 	const headers = [

--- a/assets/js/modules/analytics/components/dashboard/AnalyticsDashboardWidgetTopPagesTable.js
+++ b/assets/js/modules/analytics/components/dashboard/AnalyticsDashboardWidgetTopPagesTable.js
@@ -53,6 +53,10 @@ const AnalyticsDashboardWidgetTopPagesTable = ( props ) => {
 		return null;
 	}
 
+	if ( ! Array.isArray( data[ 0 ].data.rows ) ) {
+		return null;
+	}
+
 	const headers = [
 		{
 			title: __( 'Title', 'google-site-kit' ),

--- a/assets/js/modules/analytics/components/wp-dashboard/WPAnalyticsDashboardWidgetTopPagesTable.js
+++ b/assets/js/modules/analytics/components/wp-dashboard/WPAnalyticsDashboardWidgetTopPagesTable.js
@@ -46,6 +46,14 @@ class WPAnalyticsDashboardWidgetTopPagesTable extends Component {
 			return null;
 		}
 
+		if ( ! data || ! data.length ) {
+			return null;
+		}
+
+		if ( ! Array.isArray( data[ 0 ].data.rows ) ) {
+			return null;
+		}
+
 		const links = [];
 		const dataMapped = data[ 0 ].data.rows.map( ( row, i ) => {
 			const [ title, url ] = row.dimensions;

--- a/assets/js/modules/search-console/components/dashboard/SearchConsoleDashboardWidgetKeywordTable.js
+++ b/assets/js/modules/search-console/components/dashboard/SearchConsoleDashboardWidgetKeywordTable.js
@@ -38,6 +38,11 @@ const SearchConsoleDashboardWidgetKeywordTable = ( props ) => {
 	const { data } = props;
 	const domain = useSelect( ( select ) => select( STORE_NAME ).getPropertyID() );
 	const baseServiceURL = useSelect( ( select ) => select( STORE_NAME ).getServiceURL( { path: '/performance/search-analytics', query: { resource_id: domain, num_of_days: 28 } } ) );
+
+	if ( ! data || ! data.length ) {
+		return null;
+	}
+
 	const headers = [
 		{
 			title: __( 'Keyword', 'google-site-kit' ),


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #1456 (follow-up to #1789)

## Relevant technical choices

* This happens due to the switch from lodash `map` to `Array.map`, but it's really more because we lacked a few checks before accessing properties.

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
