### PR TITLE
Add Event List Registry for advanced GA event tracking

### DIFF
--- a/includes/Modules/Analytics/Advanced_Tracking.php
+++ b/includes/Modules/Analytics/Advanced_Tracking.php
@@ -19,6 +19,7 @@ use Google\Site_Kit\Modules\Analytics\Advanced_Tracking\Measurement_Events\WooCo
 use Google\Site_Kit\Modules\Analytics\Advanced_Tracking\Measurement_Events\WPForms_Event_List;
 use Google\Site_Kit\Modules\Analytics\Advanced_Tracking\Plugin_Detector;
 use Google\Site_Kit\Modules\Analytics\Advanced_Tracking\Measurement_Code_Injector;
+use Google\Site_Kit\Modules\Analytics\Advanced_Tracking\Event_List_Registry;
 
 // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 
@@ -64,6 +65,14 @@ final class Advanced_Tracking {
 	private $plugin_detector;
 
 	/**
+	 * Main class event list registry instance.
+	 *
+	 * @since n.e.x.t.
+	 * @var Event_List_Registry
+	 */
+	private $event_list_registry;
+
+	/**
 	 * Advanced_Tracking constructor.
 	 *
 	 * @since n.e.x.t.
@@ -76,6 +85,8 @@ final class Advanced_Tracking {
 		} else {
 			$this->plugin_detector = $plugin_detector;
 		}
+
+		$this->event_list_registry = new Event_List_Registry();
 	}
 
 	/**
@@ -157,6 +168,7 @@ final class Advanced_Tracking {
 			$plugin_event_list->register();
 			$this->plugin_event_lists[] = $plugin_event_list;
 		}
+		do_action( 'googlesitekit_analytics_register_event_list', $this->event_list_registry );
 	}
 
 	/**
@@ -171,6 +183,12 @@ final class Advanced_Tracking {
 				foreach ( $plugin_event_list->get_events() as $measurement_event ) {
 					$this->event_configurations[] = $measurement_event;
 				}
+			}
+		}
+
+		foreach ( $this->event_list_registry->get_active_event_lists() as $registry_event_list ) {
+			foreach ( $registry_event_list->get_events() as $measurement_event ) {
+				$this->event_configurations[] = $measurement_event;
 			}
 		}
 	}

--- a/includes/Modules/Analytics/Advanced_Tracking.php
+++ b/includes/Modules/Analytics/Advanced_Tracking.php
@@ -13,7 +13,6 @@ namespace Google\Site_Kit\Modules\Analytics;
 use Google\Site_Kit\Modules\Analytics\Advanced_Tracking\Measurement_Events\CF7_Event_List;
 use Google\Site_Kit\Modules\Analytics\Advanced_Tracking\Measurement_Events\FormidableForms_Event_List;
 use Google\Site_Kit\Modules\Analytics\Advanced_Tracking\Measurement_Events\Measurement_Event;
-use Google\Site_Kit\Modules\Analytics\Advanced_Tracking\Measurement_Events\Measurement_Event_List;
 use Google\Site_Kit\Modules\Analytics\Advanced_Tracking\Measurement_Events\NinjaForms_Event_List;
 use Google\Site_Kit\Modules\Analytics\Advanced_Tracking\Measurement_Events\WooCommerce_Event_List;
 use Google\Site_Kit\Modules\Analytics\Advanced_Tracking\Measurement_Events\WPForms_Event_List;
@@ -161,9 +160,9 @@ final class Advanced_Tracking {
 				'googlesitekit_analytics_register_event_lists',
 				function( $event_list_registry ) use ( $plugin_event_list ) {
 					$event_list_registry->register( $plugin_event_list );
-				});
+				}
+			);
 		}
-
 		do_action( 'googlesitekit_analytics_register_event_lists', $this->event_list_registry );
 	}
 
@@ -174,7 +173,6 @@ final class Advanced_Tracking {
 	 */
 	private function compile_events() {
 		$this->event_configurations = array();
-
 		foreach ( $this->event_list_registry->get_active_event_lists() as $registry_event_list ) {
 			foreach ( $registry_event_list->get_events() as $measurement_event ) {
 				$this->event_configurations[] = $measurement_event;

--- a/includes/Modules/Analytics/Advanced_Tracking.php
+++ b/includes/Modules/Analytics/Advanced_Tracking.php
@@ -168,7 +168,7 @@ final class Advanced_Tracking {
 			$plugin_event_list->register();
 			$this->plugin_event_lists[] = $plugin_event_list;
 		}
-		do_action( 'googlesitekit_analytics_register_event_list', $this->event_list_registry );
+		do_action( 'googlesitekit_analytics_register_event_lists', $this->event_list_registry );
 	}
 
 	/**

--- a/includes/Modules/Analytics/Advanced_Tracking.php
+++ b/includes/Modules/Analytics/Advanced_Tracking.php
@@ -40,13 +40,6 @@ final class Advanced_Tracking {
 	 */
 	private $supported_plugins;
 
-	/**
-	 * List of active plugin event lists.
-	 *
-	 * @since n.e.x.t.
-	 * @var Measurement_Event_List[]
-	 */
-	private $plugin_event_lists;
 
 	/**
 	 * List of event configurations to be tracked.
@@ -161,13 +154,16 @@ final class Advanced_Tracking {
 	 * @param array $active_plugin_configurations The list of active plugin configurations.
 	 */
 	private function register_event_lists( $active_plugin_configurations ) {
-		$this->plugin_event_lists = array();
 		foreach ( $active_plugin_configurations as $plugin_config ) {
 			$plugin_event_list_class = $plugin_config['event_list_class'];
 			$plugin_event_list       = new $plugin_event_list_class();
-			$plugin_event_list->register();
-			$this->plugin_event_lists[] = $plugin_event_list;
+			add_action(
+				'googlesitekit_analytics_register_event_lists',
+				function( $event_list_registry ) use ( $plugin_event_list ) {
+					$event_list_registry->register( $plugin_event_list );
+				});
 		}
+
 		do_action( 'googlesitekit_analytics_register_event_lists', $this->event_list_registry );
 	}
 
@@ -178,13 +174,6 @@ final class Advanced_Tracking {
 	 */
 	private function compile_events() {
 		$this->event_configurations = array();
-		foreach ( $this->plugin_event_lists as $plugin_event_list ) {
-			if ( null !== $plugin_event_list ) {
-				foreach ( $plugin_event_list->get_events() as $measurement_event ) {
-					$this->event_configurations[] = $measurement_event;
-				}
-			}
-		}
 
 		foreach ( $this->event_list_registry->get_active_event_lists() as $registry_event_list ) {
 			foreach ( $registry_event_list->get_events() as $measurement_event ) {

--- a/includes/Modules/Analytics/Advanced_Tracking/Event_List_Registry.php
+++ b/includes/Modules/Analytics/Advanced_Tracking/Event_List_Registry.php
@@ -34,7 +34,9 @@ class Event_List_Registry {
 	 *
 	 * @since n.e.x.t.
 	 */
-	public function __construct() {}
+	public function __construct() {
+		$this->active_event_lists = array();
+	}
 
 	/**
 	 * Registers a third party event lists.
@@ -42,7 +44,27 @@ class Event_List_Registry {
 	 * @since n.e.x.t.
 	 *
 	 * @param Measurement_Event_List $event_list The third party event list to be registered.
+	 * @throws \Exception Thrown when $event_list is not an instance of Measurement_Event_List.
 	 */
-	public function register( Measurement_Event_List $event_list ) {}
+	public function register( Measurement_Event_List $event_list ) {
+		if ( ! $event_list instanceof Measurement_Event_List ) {
+			throw new \Exception( 'Event list must extend Measurement_Event_List.' );
+		}
+
+		$event_list->register();
+		$this->active_event_lists[] = $event_list;
+	}
+
+	/**
+	 * Gets the list of active event lists.
+	 *
+	 * @since n.e.x.t.
+	 *
+	 * @return Measurement_Event_List[] The list of active event lists.
+	 */
+	public function get_active_event_lists() {
+		return $this->active_event_lists;
+	}
+
 
 }

--- a/includes/Modules/Analytics/Advanced_Tracking/Event_List_Registry.php
+++ b/includes/Modules/Analytics/Advanced_Tracking/Event_List_Registry.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Class Google\Site_Kit\Modules\Analytics\Advanced_Tracking\Event_List_Registry
+ *
+ * @package   Google\Site_Kit\Modules\Analytics
+ * @copyright 2020 Google LLC
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
+ * @link      https://sitekit.withgoogle.com
+ */
+
+namespace Google\Site_Kit\Modules\Analytics\Advanced_Tracking;
+
+use Google\Site_Kit\Modules\Analytics\Advanced_Tracking\Measurement_Events\Measurement_Event_List;
+
+/**
+ * Class for registering third party event lists.
+ *
+ * @since n.e.x.t.
+ * @access private
+ * @ignore
+ */
+class Event_List_Registry {
+
+	/**
+	 * The list of active event lists.
+	 *
+	 * @since n.e.x.t.
+	 * @var Measurement_Event_List[]
+	 */
+	private $active_event_lists;
+
+	/**
+	 * Event_List_Registry constructor.
+	 *
+	 * @since n.e.x.t.
+	 */
+	public function __construct() {}
+
+	/**
+	 * Registers a third party event lists.
+	 *
+	 * @since n.e.x.t.
+	 *
+	 * @param Measurement_Event_List $event_list The third party event list to be registered.
+	 */
+	public function register( Measurement_Event_List $event_list ) {}
+
+}


### PR DESCRIPTION
## Summary
Implements an `Event_List_Registry` class that handles 3P event list registration.
<!-- Please reference the issue this PR addresses. -->
Addresses issue #1728

## Relevant technical choices

<!-- Please describe your changes. -->
Introduces an action with the tag `googlesitekit_analytics_register_event_lists` that passes the registry instance. 3P can pass their event list instance to the `register` method of the registry to register their event list.

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
