### PR TITLE
Add permission callbacks to E2E REST routes

### DIFF
--- a/tests/e2e/mu-plugins/e2e-core-notifications-mock.php
+++ b/tests/e2e/mu-plugins/e2e-core-notifications-mock.php
@@ -121,8 +121,8 @@ add_action(
 			REST_Routes::REST_ROOT,
 			'e2e/core/site/notifications',
 			array(
-				'methods'  => 'POST',
-				'callback' => function ( WP_REST_Request $request ) {
+				'methods'             => 'POST',
+				'callback'            => function ( WP_REST_Request $request ) {
 					$notifications = get_notifications();
 					$notification  = $request->get_json_params();
 					array_push( $notifications, $notification );
@@ -130,7 +130,8 @@ add_action(
 
 					return compact( 'success' );
 				},
-				'args'     => array(
+				'permission_callback' => '__return_true',
+				'args'                => array(
 					'id'      => array(
 						'type'     => 'string',
 						'required' => true,

--- a/tests/e2e/mu-plugins/e2e-rest-access-token.php
+++ b/tests/e2e/mu-plugins/e2e-rest-access-token.php
@@ -24,8 +24,8 @@ add_action(
 			REST_Routes::REST_ROOT,
 			'e2e/auth/access-token',
 			array(
-				'methods'  => WP_REST_Server::EDITABLE,
-				'callback' => function ( WP_REST_Request $request ) {
+				'methods'             => WP_REST_Server::EDITABLE,
+				'callback'            => function ( WP_REST_Request $request ) {
 					( new OAuth_Client( new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE ) ) )
 						->set_access_token( $request['token'], HOUR_IN_SECONDS );
 
@@ -34,8 +34,9 @@ add_action(
 						'token'   => $request['token'],
 					);
 				},
+				'permission_callback' => '__return_true',
 			)
 		);
 	},
-	0 
+	0
 );

--- a/tests/e2e/mu-plugins/e2e-rest-analytics-existing-property-id.php
+++ b/tests/e2e/mu-plugins/e2e-rest-analytics-existing-property-id.php
@@ -22,8 +22,8 @@ add_action(
 			REST_Routes::REST_ROOT,
 			'e2e/analytics/existing-property-id',
 			array(
-				'methods'  => WP_REST_Server::EDITABLE,
-				'callback' => function ( WP_REST_Request $request ) {
+				'methods'             => WP_REST_Server::EDITABLE,
+				'callback'            => function ( WP_REST_Request $request ) {
 					if ( $request['id'] ) {
 						update_option( 'googlesitekit_e2e_analytics_existing_property_id', $request['id'] );
 					} else {
@@ -35,9 +35,10 @@ add_action(
 						'id'      => $request['id'],
 					);
 				},
+				'permission_callback' => '__return_true',
 			)
 		);
 	},
-	0 
+	0
 );
 

--- a/tests/e2e/mu-plugins/e2e-rest-core-version.php
+++ b/tests/e2e/mu-plugins/e2e-rest-core-version.php
@@ -22,8 +22,8 @@ add_action(
 			REST_Routes::REST_ROOT,
 			'e2e/wp/version',
 			array(
-				'methods'  => 'GET',
-				'callback' => function () {
+				'methods'             => 'GET',
+				'callback'            => function () {
 					$version = get_bloginfo( 'version' );
 					list( $major, $minor ) = explode( '.', $version );
 
@@ -33,6 +33,7 @@ add_action(
 						'minor'   => (int) $minor,
 					);
 				},
+				'permission_callback' => '__return_true',
 			)
 		);
 	},

--- a/tests/e2e/mu-plugins/e2e-rest-credentials.php
+++ b/tests/e2e/mu-plugins/e2e-rest-credentials.php
@@ -23,8 +23,8 @@ add_action(
 			REST_Routes::REST_ROOT,
 			'e2e/auth/client-config',
 			array(
-				'methods'  => WP_REST_Server::EDITABLE,
-				'callback' => function ( WP_REST_Request $request ) {
+				'methods'             => WP_REST_Server::EDITABLE,
+				'callback'            => function ( WP_REST_Request $request ) {
 					$credentials = array(
 						'oauth2_client_id'     => sanitize_text_field( $request['clientID'] ),
 						'oauth2_client_secret' => sanitize_text_field( $request['clientSecret'] ),
@@ -37,6 +37,7 @@ add_action(
 
 					return array( 'success' => true );
 				},
+				'permission_callback' => '__return_true',
 			)
 		);
 	},

--- a/tests/e2e/mu-plugins/e2e-rest-search-console-property.php
+++ b/tests/e2e/mu-plugins/e2e-rest-search-console-property.php
@@ -23,14 +23,15 @@ add_action(
 			REST_Routes::REST_ROOT,
 			'e2e/setup/search-console-property',
 			array(
-				'methods'  => WP_REST_Server::EDITABLE,
-				'callback' => function ( WP_REST_Request $request ) {
-					$settings = get_option( Settings::OPTION );
+				'methods'             => WP_REST_Server::EDITABLE,
+				'callback'            => function ( WP_REST_Request $request ) {
+					$settings               = get_option( Settings::OPTION );
 					$settings['propertyID'] = $request['property'] ?: '';
 					update_option( Settings::OPTION, $settings );
 
 					return array( 'success' => true );
 				},
+				'permission_callback' => '__return_true',
 			)
 		);
 	},

--- a/tests/e2e/mu-plugins/e2e-rest-site-verification.php
+++ b/tests/e2e/mu-plugins/e2e-rest-site-verification.php
@@ -22,8 +22,8 @@ add_action(
 			REST_Routes::REST_ROOT,
 			'e2e/setup/site-verification',
 			array(
-				'methods'  => WP_REST_Server::EDITABLE,
-				'callback' => function ( WP_REST_Request $request ) {
+				'methods'             => WP_REST_Server::EDITABLE,
+				'callback'            => function ( WP_REST_Request $request ) {
 					if ( $request['verified'] ) {
 						update_user_option(
 							get_current_user_id(),
@@ -36,8 +36,9 @@ add_action(
 
 					return array( 'success' => true );
 				},
+				'permission_callback' => '__return_true',
 			)
 		);
 	},
-	0 
+	0
 );

--- a/tests/e2e/plugins/module-setup-analytics-no-account.php
+++ b/tests/e2e/plugins/module-setup-analytics-no-account.php
@@ -24,14 +24,15 @@ add_action(
 			REST_Routes::REST_ROOT,
 			'modules/analytics/data/accounts-properties-profiles',
 			array(
-				'methods'  => 'GET',
-				'callback' => function () {
+				'methods'             => 'GET',
+				'callback'            => function () {
 					return array(
 						'accounts'   => array(),
 						'properties' => array(),
 						'profiles'   => array(),
 					);
 				},
+				'permission_callback' => '__return_true',
 			),
 			true
 		);
@@ -40,8 +41,8 @@ add_action(
 			REST_Routes::REST_ROOT,
 			'e2e/setup/analytics/account-created',
 			array(
-				'methods'  => 'POST',
-				'callback' => function () {
+				'methods'             => 'POST',
+				'callback'            => function () {
 					require_once ABSPATH . 'wp-admin/includes/plugin.php';
 
 					deactivate_plugins( plugin_basename( __FILE__ ), true );
@@ -49,6 +50,7 @@ add_action(
 
 					return array( 'success' => true );
 				},
+				'permission_callback' => '__return_true',
 			)
 		);
 

--- a/tests/e2e/plugins/module-setup-analytics.php
+++ b/tests/e2e/plugins/module-setup-analytics.php
@@ -186,8 +186,8 @@ add_action(
 			REST_Routes::REST_ROOT,
 			'modules/analytics/data/accounts-properties-profiles',
 			array(
-				'methods'  => 'GET',
-				'callback' => function () use ( $accounts, $properties, $profiles ) {
+				'methods'             => 'GET',
+				'callback'            => function () use ( $accounts, $properties, $profiles ) {
 					$response = array(
 						'accounts'   => $accounts,
 						'properties' => filter_by_account_id( $properties, $accounts[0]['id'] ),
@@ -207,6 +207,7 @@ add_action(
 
 					return $response;
 				},
+				'permission_callback' => '__return_true',
 			),
 			true
 		);
@@ -216,8 +217,8 @@ add_action(
 			REST_Routes::REST_ROOT,
 			'modules/analytics/data/properties-profiles',
 			array(
-				'methods'  => 'GET',
-				'callback' => function ( \WP_REST_Request $request ) use ( $properties, $profiles ) {
+				'methods'             => 'GET',
+				'callback'            => function ( \WP_REST_Request $request ) use ( $properties, $profiles ) {
 					$filtered_properties = filter_by_account_id( $properties, $request->get_param( 'accountID' ) );
 
 					return array(
@@ -225,6 +226,7 @@ add_action(
 						'profiles'   => filter_by_property_id( $profiles, $filtered_properties[0]['id'] ),
 					);
 				},
+				'permission_callback' => '__return_true',
 			),
 			true
 		);
@@ -234,12 +236,13 @@ add_action(
 			REST_Routes::REST_ROOT,
 			'modules/analytics/data/profiles',
 			array(
-				'methods'  => 'GET',
-				'callback' => function ( \WP_REST_Request $request ) use ( $profiles ) {
+				'methods'             => 'GET',
+				'callback'            => function ( \WP_REST_Request $request ) use ( $profiles ) {
 					$profiles = filter_by_property_id( $profiles, $request->get_param( 'propertyID' ) );
 
 					return $profiles;
 				},
+				'permission_callback' => '__return_true',
 			),
 			true
 		);
@@ -248,8 +251,8 @@ add_action(
 			REST_Routes::REST_ROOT,
 			'e2e/reference-url',
 			array(
-				'methods'  => 'POST',
-				'callback' => function ( \WP_REST_Request $request ) {
+				'methods'             => 'POST',
+				'callback'            => function ( \WP_REST_Request $request ) {
 					$url = $request->get_param( 'url' );
 					update_option( 'googlesitekit_e2e_reference_url', $url );
 
@@ -258,6 +261,7 @@ add_action(
 						'url'     => $url,
 					);
 				},
+				'permission_callback' => '__return_true',
 			)
 		);
 	},

--- a/tests/e2e/plugins/module-setup-tagmanager-no-account.php
+++ b/tests/e2e/plugins/module-setup-tagmanager-no-account.php
@@ -22,10 +22,11 @@ add_action(
 			REST_Routes::REST_ROOT,
 			'modules/tagmanager/data/accounts',
 			array(
-				'methods'  => 'GET',
-				'callback' => function () {
+				'methods'             => 'GET',
+				'callback'            => function () {
 					return array();
 				},
+				'permission_callback' => '__return_true',
 			),
 			true
 		);
@@ -34,8 +35,8 @@ add_action(
 			REST_Routes::REST_ROOT,
 			'e2e/setup/tagmanager/account-created',
 			array(
-				'methods'  => 'POST',
-				'callback' => function () {
+				'methods'             => 'POST',
+				'callback'            => function () {
 					require_once ABSPATH . 'wp-admin/includes/plugin.php';
 
 					deactivate_plugins( plugin_basename( __FILE__ ), true );
@@ -46,6 +47,7 @@ add_action(
 						'result'  => 'account-created',
 					);
 				},
+				'permission_callback' => '__return_true',
 			)
 		);
 

--- a/tests/e2e/plugins/module-setup-tagmanager.php
+++ b/tests/e2e/plugins/module-setup-tagmanager.php
@@ -100,10 +100,11 @@ add_action(
 			REST_Routes::REST_ROOT,
 			'modules/tagmanager/data/accounts',
 			array(
-				'methods'  => 'GET',
-				'callback' => function () use ( $accounts ) {
+				'methods'             => 'GET',
+				'callback'            => function () use ( $accounts ) {
 					return $accounts;
 				},
+				'permission_callback' => '__return_true',
 			),
 			true
 		);
@@ -112,8 +113,8 @@ add_action(
 			REST_Routes::REST_ROOT,
 			'modules/tagmanager/data/accounts-containers',
 			array(
-				'methods'  => 'GET',
-				'callback' => function ( $request ) use ( $accounts, $containers ) {
+				'methods'             => 'GET',
+				'callback'            => function ( $request ) use ( $accounts, $containers ) {
 					$account_id = $request['accountID'] ?: $accounts[0]['accountId'];
 					$containers = filter_by_context( $containers, $request['usageContext'] );
 
@@ -122,6 +123,7 @@ add_action(
 						'containers' => filter_by_account_id( $containers, $account_id ),
 					);
 				},
+				'permission_callback' => '__return_true',
 			),
 			true
 		);
@@ -130,12 +132,13 @@ add_action(
 			REST_Routes::REST_ROOT,
 			'modules/tagmanager/data/containers',
 			array(
-				'methods'  => 'GET',
-				'callback' => function ( $request ) use ( $containers ) {
+				'methods'             => 'GET',
+				'callback'            => function ( $request ) use ( $containers ) {
 					$containers = filter_by_context( $containers, $request['usageContext'] );
 
 					return filter_by_account_id( $containers, $request['accountID'] );
 				},
+				'permission_callback' => '__return_true',
 			),
 			true
 		);

--- a/tests/e2e/plugins/site-verification-api-mock.php
+++ b/tests/e2e/plugins/site-verification-api-mock.php
@@ -39,18 +39,19 @@ add_action(
 			'modules/site-verification/data/verification',
 			array(
 				array(
-					'methods'  => WP_REST_Server::READABLE,
-					'callback' => function () {
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => function () {
 						return array(
 							'type'       => 'SITE',
 							'identifier' => home_url( '/' ),
 							'verified'   => (bool) get_transient( 'gsk_e2e_site_verified' ),
 						);
 					},
+					'permission_callback' => '__return_true',
 				),
 				array(
-					'methods'  => WP_REST_Server::CREATABLE,
-					'callback' => function ( WP_REST_Request $request ) {
+					'methods'             => WP_REST_Server::CREATABLE,
+					'callback'            => function ( WP_REST_Request $request ) {
 						$data = $request->get_param( 'data' );
 
 						update_user_option(
@@ -65,6 +66,7 @@ add_action(
 							'verified'   => true,
 						);
 					},
+					'permission_callback' => '__return_true',
 				),
 			),
 			true
@@ -74,8 +76,8 @@ add_action(
 			REST_Routes::REST_ROOT,
 			'modules/search-console/data/matched-sites',
 			array(
-				'methods'  => 'GET',
-				'callback' => function () {
+				'methods'             => 'GET',
+				'callback'            => function () {
 					return array(
 						array(
 							'siteURL'         => home_url( '/' ),
@@ -83,6 +85,7 @@ add_action(
 						),
 					);
 				},
+				'permission_callback' => '__return_true',
 			),
 			true
 		);
@@ -91,11 +94,11 @@ add_action(
 			REST_Routes::REST_ROOT,
 			'modules/search-console/data/site',
 			array(
-				'methods'  => 'POST',
-				'callback' => function ( WP_REST_Request $request ) {
+				'methods'             => 'POST',
+				'callback'            => function ( WP_REST_Request $request ) {
 					$data = $request->get_param( 'data' );
 
-					$settings = get_option( Settings::OPTION );
+					$settings               = get_option( Settings::OPTION );
 					$settings['propertyID'] = $data['siteURL'];
 					update_option( Settings::OPTION, $settings );
 
@@ -104,6 +107,7 @@ add_action(
 						'permissionLevel' => 'siteOwner',
 					);
 				},
+				'permission_callback' => '__return_true',
 			),
 			true
 		);
@@ -112,12 +116,13 @@ add_action(
 			REST_Routes::REST_ROOT,
 			'e2e/verify-site',
 			array(
-				'methods'  => 'POST',
-				'callback' => function () {
+				'methods'             => 'POST',
+				'callback'            => function () {
 					set_transient( 'gsk_e2e_site_verified', true );
 
 					return array( 'success' => true );
 				},
+				'permission_callback' => '__return_true',
 			)
 		);
 
@@ -125,12 +130,13 @@ add_action(
 			REST_Routes::REST_ROOT,
 			'e2e/sc-site-exists',
 			array(
-				'methods'  => 'POST',
-				'callback' => function () {
+				'methods'             => 'POST',
+				'callback'            => function () {
 					set_transient( 'gsk_e2e_sc_site_exists', true );
 
 					return array( 'success' => true );
 				},
+				'permission_callback' => '__return_true',
 			)
 		);
 


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #1882 

## Relevant technical choices

* Added `permission_callback` after `callback` for each route
* Used `__return_true` for permission callback for consistency with current definition
* Updated formatting as necessary for compliance with PHPCS rules

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
