### PR TITLE
Remove duplicate refetch auth actions in module activation actions

### DIFF
--- a/assets/js/googlesitekit/modules/datastore/modules.js
+++ b/assets/js/googlesitekit/modules/datastore/modules.js
@@ -136,11 +136,6 @@ const baseActions = {
 	*activateModule( slug ) {
 		const { response, error } = yield baseActions.setModuleActivation( slug, true );
 
-		yield {
-			payload: {},
-			type: REFETCH_AUTHENTICATION,
-		};
-
 		return { response, error };
 	},
 
@@ -156,11 +151,6 @@ const baseActions = {
 	 */
 	*deactivateModule( slug ) {
 		const { response, error } = yield baseActions.setModuleActivation( slug, false );
-
-		yield {
-			payload: {},
-			type: REFETCH_AUTHENTICATION,
-		};
 
 		return { response, error };
 	},


### PR DESCRIPTION
## Summary

Addresses issue #1622 (follow-up)

This PR fixes a change in the modules datastore that caused a change introduced in #1785 to be lost when #1671 [was merged](https://github.com/google/site-kit-wp/commit/c3b46837ff10d9f8de82bb1f65641e991f7a97c1).

Specifically, the `REFETCH_AUTHENTICATION` action was moved from `activateModule` and `deactivateModule` actions to the shared `setModuleActivation` action (if successful) which is called by both former actions. Somehow (likely due to a merge conflict) both instances of the action were kept, instead of the single call in `setModuleActivation`.

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
