### PR TITLE
Disable Jest coverage collection by default

### DIFF
--- a/tests/js/jest.config.js
+++ b/tests/js/jest.config.js
@@ -2,7 +2,7 @@ const { preset } = require( '@wordpress/scripts/config/jest-unit.config' );
 
 module.exports = {
 	preset,
-	collectCoverage: true,
+	collectCoverage: false, // Enable with `--coverage=true` flag.
 	collectCoverageFrom: [
 		'assets/**/**.js',
 	],


### PR DESCRIPTION
## Summary

Addresses issue #1974 

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
