### PR TITLE
Update proxy authentication to be set via proxy request option rather than header

### DIFF
--- a/includes/Core/Authentication/Clients/OAuth_Client.php
+++ b/includes/Core/Authentication/Clients/OAuth_Client.php
@@ -237,15 +237,9 @@ final class OAuth_Client {
 
 		// Configure the Google_Client's HTTP client to use to use the same HTTP proxy as WordPress HTTP, if set.
 		if ( $this->http_proxy->is_enabled() ) {
-			if ( $this->http_proxy->use_authentication() ) {
-				// The "Authorization" header is used to authenticate the end request; use the dedicated proxy header.
-				$http_client->setDefaultOption(
-					'headers/Proxy-Authorization',
-					'Basic ' . base64_encode( $this->http_proxy->authentication() )
-				);
-			}
-
-			$http_client->setDefaultOption( 'proxy', $this->http_proxy->host() . ':' . $this->http_proxy->port() );
+			// See http://docs.guzzlephp.org/en/5.3/clients.html#proxy for reference.
+			$auth = $this->http_proxy->use_authentication() ? "{$this->http_proxy->authentication()}@" : '';
+			$http_client->setDefaultOption( 'proxy', "{$auth}{$this->http_proxy->host()}:{$this->http_proxy->port()}" );
 			$ssl_verify = $http_client->getDefaultOption( 'verify' );
 			// Allow SSL verification to be filtered, as is often necessary with HTTP proxies.
 			$http_client->setDefaultOption(


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #1976 

## Relevant technical choices

<!-- Please describe your changes. -->

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
