### PR TITLE
Fix/entity detection 404 support

### DIFF
--- a/includes/Core/Util/Entity_Factory.php
+++ b/includes/Core/Util/Entity_Factory.php
@@ -81,7 +81,7 @@ final class Entity_Factory {
 			return null;
 		}
 
-		WP_Query_Factory::run_query( $query );
+		$query->get_posts();
 
 		return self::from_wp_query( $query );
 	}

--- a/includes/Core/Util/Entity_Factory.php
+++ b/includes/Core/Util/Entity_Factory.php
@@ -81,7 +81,7 @@ final class Entity_Factory {
 			return null;
 		}
 
-		$query->get_posts();
+		WP_Query_Factory::run_query( $query );
 
 		return self::from_wp_query( $query );
 	}

--- a/includes/Core/Util/Synthetic_WP_Query.php
+++ b/includes/Core/Util/Synthetic_WP_Query.php
@@ -1,0 +1,155 @@
+<?php
+/**
+ * Class Google\Site_Kit\Core\Util\Synthetic_WP_Query
+ *
+ * @package   Google\Site_Kit
+ * @copyright 2020 Google LLC
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
+ * @link      https://sitekit.withgoogle.com
+ */
+
+namespace Google\Site_Kit\Core\Util;
+
+use WP_Query;
+use WP_Post;
+
+/**
+ * Class extending WordPress core's `WP_Query` for more self-contained behavior.
+ *
+ * @since n.e.x.t
+ * @access private
+ * @ignore
+ */
+final class Synthetic_WP_Query extends WP_Query {
+
+	/**
+	 * The hash of the `$query` last parsed into `$query_vars`.
+	 *
+	 * @since n.e.x.t
+	 * @var string
+	 */
+	private $parsed_query_hash = '';
+
+	/**
+	 * Whether automatic 404 detection in `get_posts()` method is enabled.
+	 *
+	 * @since n.e.x.t
+	 * @var bool
+	 */
+	private $enable_404_detection = false;
+
+	/**
+	 * Sets whether 404 detection in `get_posts()` method should be enabled.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param bool $enable Whether or not to enable 404 detection.
+	 */
+	public function enable_404_detection( $enable ) {
+		$this->enable_404_detection = (bool) $enable;
+	}
+
+	/**
+	 * Initiates object properties and sets default values.
+	 *
+	 * @since n.e.x.t
+	 */
+	public function init() {
+		parent::init();
+
+		$this->parsed_query_hash = '';
+	}
+
+	/**
+	 * Extends `WP_Query::parse_query()` to ensure it is not unnecessarily run twice.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param string|array $query Optional. Array or string of query parameters. See `WP_Query::parse_query()`.
+	 */
+	public function parse_query( $query = '' ) {
+		if ( ! empty( $query ) ) {
+			$query_to_hash = wp_parse_args( $query );
+		} elseif ( ! isset( $this->query ) ) {
+			$query_to_hash = $this->query_vars;
+		} else {
+			$query_to_hash = $this->query;
+		}
+
+		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize
+		$query_hash = md5( serialize( $query_to_hash ) );
+
+		// If this query was parsed before, bail early.
+		if ( $query_hash === $this->parsed_query_hash ) {
+			return;
+		}
+
+		parent::parse_query( $query );
+
+		// Set query hash for current `$query` and `$query_vars` properties.
+		$this->parsed_query_hash = $query_hash;
+	}
+
+	/**
+	 * Extends `WP_Query::get_posts()` to include supplemental logic such as detecting a 404 state.
+	 *
+	 * The majority of the code is a copy of `WP::handle_404()`.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @return WP_Post[]|int[] Array of post objects or post IDs.
+	 */
+	public function get_posts() {
+		$results = parent::get_posts();
+
+		// If 404 detection is not enabled, just return the results.
+		if ( ! $this->enable_404_detection ) {
+			return $results;
+		}
+
+		// Check if this is a single paginated post query.
+		if ( $this->posts && $this->is_singular() && $this->post && ! empty( $this->query_vars['page'] ) ) {
+			// If the post is actually paged and the 'page' query var is within bounds, it's all good.
+			$next = '<!--nextpage-->';
+			if ( false !== strpos( $this->post->post_content, $next ) && (int) trim( $this->query_vars['page'], '/' ) <= ( substr_count( $this->post->post_content, $next ) + 1 ) ) {
+				return $results;
+			}
+
+			// Otherwise, this query is out of bounds, so set a 404.
+			$this->set_404();
+			return $results;
+		}
+
+		// If no posts were found, this is technically a 404.
+		if ( ! $this->posts ) {
+			// If this is a paginated query (i.e. out of bounds), always consider it a 404.
+			if ( $this->is_paged() ) {
+				$this->set_404();
+				return $results;
+			}
+
+			// If this is an author archive, don't consider it a 404 if the author exists.
+			if ( $this->is_author() ) {
+				$author = $this->get( 'author' );
+				if ( is_numeric( $author ) && $author > 0 && is_user_member_of_blog( $author ) ) {
+					return $results;
+				}
+			}
+
+			// If this is a valid taxonomy or post type archive, don't consider it a 404.
+			if ( ( $this->is_category() || $this->is_tag() || $this->is_tax() || $this->is_post_type_archive() ) && $this->get_queried_object() ) {
+				return $results;
+			}
+
+			// If this is a search results page or the home index, don't consider it a 404.
+			if ( $this->is_home() || $this->is_search() ) {
+				return $results;
+			}
+
+			// Otherwise, set a 404.
+			$this->set_404();
+		}
+
+		return $results;
+	}
+}

--- a/includes/Core/Util/WP_Query_Factory.php
+++ b/includes/Core/Util/WP_Query_Factory.php
@@ -25,7 +25,7 @@ final class WP_Query_Factory {
 	 * Creates a `WP_Query` instance to use for a given URL.
 	 *
 	 * The `WP_Query` instance returned is initialized with the correct query arguments, but the actual query will not
-	 * have run yet. The {@see WP_Query_Factory::run_query()} method should be used to do that.
+	 * have run yet. The `WP_Query::get_posts()` method should be used to do that.
 	 *
 	 * This is an expensive function that works similarly to WordPress core's `url_to_postid()` function, however also
 	 * covering non-post URLs. It follows logic used in `WP::parse_request()` to cover the other kinds of URLs. The
@@ -47,69 +47,12 @@ final class WP_Query_Factory {
 
 		$query_args = self::parse_wp_query_args( $url_path_vars, $url_query_vars );
 
-		$query = new WP_Query();
+		// Return extended version of `WP_Query` with self-contained 404 detection.
+		$query = new Synthetic_WP_Query();
 		$query->parse_query( $query_args );
+		$query->enable_404_detection( true );
 
 		return $query;
-	}
-
-	/**
-	 * Runs the query for the given `WP_Query` instance.
-	 *
-	 * This method should be used in favor of calling `WP_Query::get_posts()` on custom `WP_Query` instances, to ensure
-	 * that supplemental logic such as detecting a 404 state is run as well.
-	 *
-	 * The majority of the code is a copy of `WP::handle_404()`.
-	 *
-	 * @since n.e.x.t
-	 *
-	 * @param WP_Query $query WordPress query instance to run the query on.
-	 */
-	public static function run_query( WP_Query $query ) {
-		$query->get_posts();
-
-		// Check if this is a single paginated post query.
-		if ( $query->posts && $query->is_singular() && $query->post && ! empty( $query->query_vars['page'] ) ) {
-			// If the post is actually paged and the 'page' query var is within bounds, it's all good.
-			$next = '<!--nextpage-->';
-			if ( false !== strpos( $query->post->post_content, $next ) && (int) trim( $query->query_vars['page'], '/' ) <= ( substr_count( $query->post->post_content, $next ) + 1 ) ) {
-				return;
-			}
-
-			// Otherwise, this query is out of bounds, so set a 404.
-			$query->set_404();
-			return;
-		}
-
-		// If no posts were found, this is technically a 404.
-		if ( ! $query->posts ) {
-			// If this is a paginated query (i.e. out of bounds), always consider it a 404.
-			if ( $query->is_paged() ) {
-				$query->set_404();
-				return;
-			}
-
-			// If this is an author archive, don't consider it a 404 if the author exists.
-			if ( $query->is_author() ) {
-				$author = $query->get( 'author' );
-				if ( is_numeric( $author ) && $author > 0 && is_user_member_of_blog( $author ) ) {
-					return;
-				}
-			}
-
-			// If this is a valid taxonomy or post type archive, don't consider it a 404.
-			if ( ( $query->is_category() || $query->is_tag() || $query->is_tax() || $query->is_post_type_archive() ) && $query->get_queried_object() ) {
-				return;
-			}
-
-			// If this is a search results page or the home index, don't consider it a 404.
-			if ( $query->is_home() || $query->is_search() ) {
-				return;
-			}
-
-			// Otherwise, set a 404.
-			$query->set_404();
-		}
 	}
 
 	/**

--- a/includes/Core/Util/WP_Query_Factory.php
+++ b/includes/Core/Util/WP_Query_Factory.php
@@ -72,7 +72,7 @@ final class WP_Query_Factory {
 		if ( $query->posts && $query->is_singular() && $query->post && ! empty( $query->query_vars['page'] ) ) {
 			// If the post is actually paged and the 'page' query var is within bounds, it's all good.
 			$next = '<!--nextpage-->';
-			if ( false !== strpos( $query->post->post_content, $next ) || (int) trim( $query->query_vars['page'], '/' ) <= ( substr_count( $query->post->post_content, $next ) + 1 ) ) {
+			if ( false !== strpos( $query->post->post_content, $next ) && (int) trim( $query->query_vars['page'], '/' ) <= ( substr_count( $query->post->post_content, $next ) + 1 ) ) {
 				return;
 			}
 

--- a/includes/Core/Util/WP_Query_Factory.php
+++ b/includes/Core/Util/WP_Query_Factory.php
@@ -25,7 +25,7 @@ final class WP_Query_Factory {
 	 * Creates a `WP_Query` instance to use for a given URL.
 	 *
 	 * The `WP_Query` instance returned is initialized with the correct query arguments, but the actual query will not
-	 * have run yet. The `WP_Query::get_posts()` method can be used to do that.
+	 * have run yet. The {@see WP_Query_Factory::run_query()} method should be used to do that.
 	 *
 	 * This is an expensive function that works similarly to WordPress core's `url_to_postid()` function, however also
 	 * covering non-post URLs. It follows logic used in `WP::parse_request()` to cover the other kinds of URLs. The
@@ -51,6 +51,65 @@ final class WP_Query_Factory {
 		$query->parse_query( $query_args );
 
 		return $query;
+	}
+
+	/**
+	 * Runs the query for the given `WP_Query` instance.
+	 *
+	 * This method should be used in favor of calling `WP_Query::get_posts()` on custom `WP_Query` instances, to ensure
+	 * that supplemental logic such as detecting a 404 state is run as well.
+	 *
+	 * The majority of the code is a copy of `WP::handle_404()`.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param WP_Query $query WordPress query instance to run the query on.
+	 */
+	public static function run_query( WP_Query $query ) {
+		$query->get_posts();
+
+		// Check if this is a single paginated post query.
+		if ( $query->posts && $query->is_singular() && $query->post && ! empty( $query->query_vars['page'] ) ) {
+			// If the post is actually paged and the 'page' query var is within bounds, it's all good.
+			$next = '<!--nextpage-->';
+			if ( false !== strpos( $query->post->post_content, $next ) || (int) trim( $query->query_vars['page'], '/' ) <= ( substr_count( $query->post->post_content, $next ) + 1 ) ) {
+				return;
+			}
+
+			// Otherwise, this query is out of bounds, so set a 404.
+			$query->set_404();
+			return;
+		}
+
+		// If no posts were found, this is technically a 404.
+		if ( ! $query->posts ) {
+			// If this is a paginated query (i.e. out of bounds), always consider it a 404.
+			if ( $query->is_paged() ) {
+				$query->set_404();
+				return;
+			}
+
+			// If this is an author archive, don't consider it a 404 if the author exists.
+			if ( $query->is_author() ) {
+				$author = $query->get( 'author' );
+				if ( is_numeric( $author ) && $author > 0 && is_user_member_of_blog( $author ) ) {
+					return;
+				}
+			}
+
+			// If this is a valid taxonomy or post type archive, don't consider it a 404.
+			if ( ( $query->is_category() || $query->is_tag() || $query->is_tax() || $query->is_post_type_archive() ) && $query->get_queried_object() ) {
+				return;
+			}
+
+			// If this is a search results page or the home index, don't consider it a 404.
+			if ( $query->is_home() || $query->is_search() ) {
+				return;
+			}
+
+			// Otherwise, set a 404.
+			$query->set_404();
+		}
 	}
 
 	/**

--- a/tests/phpunit/integration/Core/Util/Entity_FactoryTest.php
+++ b/tests/phpunit/integration/Core/Util/Entity_FactoryTest.php
@@ -280,6 +280,10 @@ class Entity_FactoryTest extends TestCase {
 			),
 			Entity_Factory::from_url( home_url() )
 		);
+
+		// High-level assertion to ensure 404s are considered as expected.
+		// In this example, it is a valid taxonomy term archive, but the pagination is out of bounds.
+		$this->assertNull( Entity_Factory::from_url( trailingslashit( get_term_link( self::$term_names_to_ids['Food'] ) ) . 'page/2/' ) );
 	}
 
 	/**

--- a/tests/phpunit/integration/Core/Util/Synthetic_WP_QueryTest.php
+++ b/tests/phpunit/integration/Core/Util/Synthetic_WP_QueryTest.php
@@ -1,0 +1,276 @@
+<?php
+/**
+ * Class Google\Site_Kit\Tests\Core\Util\Synthetic_WP_QueryTest
+ *
+ * @package   Google\Site_Kit\Tests\Core\Util
+ * @copyright 2020 Google LLC
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
+ * @link      https://sitekit.withgoogle.com
+ */
+
+namespace Google\Site_Kit\Tests\Core\Util;
+
+use Google\Site_Kit\Core\Util\Synthetic_WP_Query;
+use Google\Site_Kit\Tests\TestCase;
+
+/**
+ * @group Util
+ */
+class Synthetic_WP_QueryTest extends TestCase {
+
+	public function test_parse_query() {
+		$query_args = array(
+			'post_type'      => 'page',
+			'post_status'    => 'publish',
+			'posts_per_page' => 3,
+		);
+
+		$query = new Synthetic_WP_Query();
+
+		// After parsing initial query, query vars should be populated.
+		$query->parse_query( $query_args );
+		$this->assertNotEmpty( $query->query_vars );
+
+		// Set query vars to empty array to check below that it's not re-populated.
+		$query->query_vars = array();
+
+		// When parsing query again (by relying on `$query` property), the logic shouldn't run.
+		$query->parse_query();
+		$this->assertEmpty( $query->query_vars );
+
+		// When providing the same query again, the logic shouldn't run.
+		$query->parse_query( $query_args );
+		$this->assertEmpty( $query->query_vars );
+
+		// When setting a different `$query` property and parsing query, the logic should run.
+		$query->query = array( 'post_type' => 'attachment' );
+		$query->parse_query();
+		$this->assertNotEmpty( $query->query_vars );
+	}
+
+	public function test_get_posts_no_404() {
+		// Set up query without 404 detection enabled (default).
+		$query = new Synthetic_WP_Query();
+
+		// Non-existing page should not be a 404.
+		$query->parse_query( array( 'pagename' => 'invalid-page-slug' ) );
+		$query->get_posts();
+		$this->assertTrue( $query->is_page() );
+		$this->assertFalse( $query->is_404() );
+	}
+
+	public function test_get_posts_404_singular() {
+		// Create regular non-paginated page.
+		self::factory()->post->create(
+			array(
+				'post_title' => 'Non-Paginated Page',
+				'post_name'  => 'non-paginated-page',
+				'post_type'  => 'page',
+			)
+		);
+
+		// Create paginated page.
+		self::factory()->post->create(
+			array(
+				'post_title'   => 'Paginated Page',
+				'post_name'    => 'paginated-page',
+				'post_type'    => 'page',
+				'post_content' => "Page 1\n<!--nextpage-->\nPage 2\n<!--nextpage-->\nPage 3",
+			)
+		);
+
+		// Set up query with 404 detection enabled.
+		$query = new Synthetic_WP_Query();
+		$query->enable_404_detection( true );
+
+		// Existing regular page.
+		$query->parse_query( array( 'pagename' => 'non-paginated-page' ) );
+		$query->get_posts();
+		$this->assertTrue( $query->is_page() );
+		$this->assertFalse( $query->is_404() );
+
+		// Non-existing page.
+		$query->parse_query( array( 'pagename' => 'invalid-page-slug' ) );
+		$query->get_posts();
+		$this->assertFalse( $query->is_page() );
+		$this->assertTrue( $query->is_404() );
+
+		// Paginated content queried without pagination.
+		$query->parse_query( array( 'pagename' => 'paginated-page' ) );
+		$query->get_posts();
+		$this->assertTrue( $query->is_page() );
+		$this->assertFalse( $query->is_404() );
+
+		// Paginated content queried with pagination within bounds.
+		$query->parse_query(
+			array(
+				'pagename' => 'paginated-page',
+				'page'     => '3',
+			)
+		);
+		$query->get_posts();
+		$this->assertTrue( $query->is_page() );
+		$this->assertFalse( $query->is_404() );
+
+		// Paginated content queried with pagination out of bounds.
+		$query->parse_query(
+			array(
+				'pagename' => 'paginated-page',
+				'page'     => '4',
+			)
+		);
+		$query->get_posts();
+		$this->assertFalse( $query->is_page() );
+		$this->assertTrue( $query->is_404() );
+
+		// Paginated content queried with pagination when the content is not paginated at all.
+		$query->parse_query(
+			array(
+				'pagename' => 'home',
+				'page'     => '2',
+			)
+		);
+		$query->get_posts();
+		$this->assertFalse( $query->is_page() );
+		$this->assertTrue( $query->is_404() );
+	}
+
+	public function test_get_posts_404_home() {
+		// Create blog page and assign it.
+		$blog_id = self::factory()->post->create(
+			array(
+				'post_title' => 'Blog',
+				'post_name'  => 'blog',
+				'post_type'  => 'page',
+			)
+		);
+		update_option( 'show_on_front', 'page' );
+		update_option( 'page_for_posts', $blog_id );
+
+		// Set up query with 404 detection enabled.
+		$query = new Synthetic_WP_Query();
+		$query->enable_404_detection( true );
+
+		// Blog page without pagination.
+		$query->parse_query( array( 'pagename' => 'blog' ) );
+		$query->get_posts();
+		$this->assertTrue( $query->is_home() );
+		$this->assertFalse( $query->is_404() );
+
+		// Blog page with pagination out of bounds.
+		$query->parse_query(
+			array(
+				'pagename' => 'blog',
+				'paged'    => '2', // This would only work if there were more than 10 posts.
+			)
+		);
+		$query->get_posts();
+		$this->assertFalse( $query->is_home() );
+		$this->assertTrue( $query->is_404() );
+	}
+
+	public function test_get_posts_404_taxonomy_archive() {
+		// Create post in default category.
+		self::factory()->post->create(
+			array(
+				'post_title' => 'Uncategorized Post',
+				'post_name'  => 'uncategorized-post',
+			)
+		);
+
+		// Create empty category.
+		self::factory()->category->create(
+			array(
+				'name' => 'Empty category',
+				'slug' => 'empty-category',
+			)
+		);
+
+		// Set up query with 404 detection enabled.
+		$query = new Synthetic_WP_Query();
+		$query->enable_404_detection( true );
+
+		// Category with content, without pagination.
+		$query->parse_query( array( 'category_name' => 'uncategorized' ) );
+		$query->get_posts();
+		$this->assertTrue( $query->is_category() );
+		$this->assertFalse( $query->is_404() );
+
+		// Category without content, without pagination.
+		$query->parse_query( array( 'category_name' => 'empty-category' ) );
+		$query->get_posts();
+		$this->assertTrue( $query->is_category() );
+		$this->assertFalse( $query->is_404() );
+
+		// Non-existing category, without pagination.
+		$query->parse_query( array( 'category_name' => 'invalid-category-slug' ) );
+		$query->get_posts();
+		$this->assertFalse( $query->is_category() );
+		$this->assertTrue( $query->is_404() );
+
+		// Category with content, with pagination out of bounds.
+		$query->parse_query(
+			array(
+				'category_name' => 'uncategorized',
+				'paged'         => '2',
+			)
+		);
+		$query->get_posts();
+		$this->assertFalse( $query->is_category() );
+		$this->assertTrue( $query->is_404() );
+	}
+
+	public function test_get_posts_404_author_archive() {
+		// Create user with posts.
+		$posts_user_id = self::factory()->user->create(
+			array(
+				'role'         => 'editor',
+				'display_name' => 'Johnny Withposts',
+				'user_login'   => 'johnnywithposts',
+			)
+		);
+		self::factory()->post->create( array( 'post_author' => $posts_user_id ) );
+
+		// Create user without posts.
+		$noposts_user_id = self::factory()->user->create(
+			array(
+				'role'         => 'editor',
+				'display_name' => 'Johnny Noposts',
+				'user_login'   => 'johnnynoposts',
+			)
+		);
+
+		// Set up query with 404 detection enabled.
+		$query = new Synthetic_WP_Query();
+		$query->enable_404_detection( true );
+
+		// User with content, without pagination.
+		$query->parse_query( array( 'author' => $posts_user_id ) );
+		$query->get_posts();
+		$this->assertTrue( $query->is_author() );
+		$this->assertFalse( $query->is_404() );
+
+		// User without content, without pagination.
+		$query->parse_query( array( 'author' => $noposts_user_id ) );
+		$query->get_posts();
+		$this->assertTrue( $query->is_author() );
+		$this->assertFalse( $query->is_404() );
+
+		// Non-existing user, without pagination.
+		$query->parse_query( array( 'author' => 6789 ) );
+		$query->get_posts();
+		$this->assertFalse( $query->is_author() );
+		$this->assertTrue( $query->is_404() );
+
+		// User with content, with pagination out of bounds.
+		$query->parse_query(
+			array(
+				'author' => $posts_user_id,
+				'paged'  => '2',
+			)
+		);
+		$query->get_posts();
+		$this->assertFalse( $query->is_author() );
+		$this->assertTrue( $query->is_404() );
+	}
+}

--- a/tests/phpunit/integration/Core/Util/WP_Query_FactoryTest.php
+++ b/tests/phpunit/integration/Core/Util/WP_Query_FactoryTest.php
@@ -110,6 +110,8 @@ class WP_Query_FactoryTest extends TestCase {
 		}
 
 		$query = WP_Query_Factory::from_url( $url );
+		// This test focuses on correct query flags being set, hence disable 404 detection.
+		$query->enable_404_detection( false );
 		$query->get_posts();
 
 		$this->assertEqualSetsWithIndex( $expected_args, $query->query );
@@ -613,6 +615,8 @@ class WP_Query_FactoryTest extends TestCase {
 		flush_rewrite_rules();
 
 		$query = WP_Query_Factory::from_url( $url );
+		// This test focuses on correct query flags being set, hence disable 404 detection.
+		$query->enable_404_detection( false );
 		$query->get_posts();
 
 		$this->assertEqualSetsWithIndex( $expected_args, $query->query );
@@ -1044,6 +1048,8 @@ class WP_Query_FactoryTest extends TestCase {
 		flush_rewrite_rules();
 
 		$query = WP_Query_Factory::from_url( $url );
+		// This test focuses on correct query flags being set, hence disable 404 detection.
+		$query->enable_404_detection( false );
 		$query->get_posts();
 
 		$this->assertEqualSetsWithIndex( $expected_args, $query->query );
@@ -1110,192 +1116,5 @@ class WP_Query_FactoryTest extends TestCase {
 				array(),
 			),
 		);
-	}
-
-	public function test_run_query_singular() {
-		// Existing page.
-		$query = new WP_Query();
-		$query->parse_query( array( 'pagename' => 'home' ) );
-		WP_Query_Factory::run_query( $query );
-		$this->assertTrue( $query->is_page() );
-		$this->assertFalse( $query->is_404() );
-
-		// Non-existing page.
-		$query = new WP_Query();
-		$query->parse_query( array( 'pagename' => 'invalid-page-slug' ) );
-		WP_Query_Factory::run_query( $query );
-		$this->assertFalse( $query->is_page() );
-		$this->assertTrue( $query->is_404() );
-
-		// Create paginated page.
-		self::factory()->post->create(
-			array(
-				'post_title'   => 'Paginated Page',
-				'post_name'    => 'paginated-page',
-				'post_type'    => 'page',
-				'post_content' => "Page 1\n<!--nextpage-->\nPage 2\n<!--nextpage-->\nPage 3",
-			)
-		);
-
-		// Paginated content queried without pagination.
-		$query = new WP_Query();
-		$query->parse_query( array( 'pagename' => 'paginated-page' ) );
-		WP_Query_Factory::run_query( $query );
-		$this->assertTrue( $query->is_page() );
-		$this->assertFalse( $query->is_404() );
-
-		// Paginated content queried with pagination within bounds.
-		$query = new WP_Query();
-		$query->parse_query(
-			array(
-				'pagename' => 'paginated-page',
-				'page'     => '3',
-			)
-		);
-		WP_Query_Factory::run_query( $query );
-		$this->assertTrue( $query->is_page() );
-		$this->assertFalse( $query->is_404() );
-
-		// Paginated content queried with pagination out of bounds.
-		$query = new WP_Query();
-		$query->parse_query(
-			array(
-				'pagename' => 'paginated-page',
-				'page'     => '4',
-			)
-		);
-		WP_Query_Factory::run_query( $query );
-		$this->assertFalse( $query->is_page() );
-		$this->assertTrue( $query->is_404() );
-
-		// Paginated content queried with pagination when the content is not paginated at all.
-		$query = new WP_Query();
-		$query->parse_query(
-			array(
-				'pagename' => 'home',
-				'page'     => '2',
-			)
-		);
-		WP_Query_Factory::run_query( $query );
-		$this->assertFalse( $query->is_page() );
-		$this->assertTrue( $query->is_404() );
-	}
-
-	public function test_run_query_home() {
-		// Blog page without pagination.
-		$query = new WP_Query();
-		$query->parse_query( array( 'pagename' => 'blog' ) );
-		WP_Query_Factory::run_query( $query );
-		$this->assertTrue( $query->is_home() );
-		$this->assertFalse( $query->is_404() );
-
-		// Blog page with pagination out of bounds.
-		$query = new WP_Query();
-		$query->parse_query(
-			array(
-				'pagename' => 'blog',
-				'paged'    => '2', // This would only work if there were more than 10 posts.
-			)
-		);
-		WP_Query_Factory::run_query( $query );
-		$this->assertFalse( $query->is_home() );
-		$this->assertTrue( $query->is_404() );
-	}
-
-	public function test_run_query_taxonomy_archive() {
-		// Create empty category.
-		self::factory()->category->create(
-			array(
-				'name' => 'Empty category',
-				'slug' => 'empty-category',
-			)
-		);
-
-		// Category with content, without pagination.
-		$query = new WP_Query();
-		$query->parse_query( array( 'category_name' => 'uncategorized' ) );
-		WP_Query_Factory::run_query( $query );
-		$this->assertTrue( $query->is_category() );
-		$this->assertFalse( $query->is_404() );
-
-		// Category without content, without pagination.
-		$query = new WP_Query();
-		$query->parse_query( array( 'category_name' => 'empty-category' ) );
-		WP_Query_Factory::run_query( $query );
-		$this->assertTrue( $query->is_category() );
-		$this->assertFalse( $query->is_404() );
-
-		// Non-existing category, without pagination.
-		$query = new WP_Query();
-		$query->parse_query( array( 'category_name' => 'invalid-category-slug' ) );
-		WP_Query_Factory::run_query( $query );
-		$this->assertFalse( $query->is_category() );
-		$this->assertTrue( $query->is_404() );
-
-		// Category with content, with pagination out of bounds.
-		$query = new WP_Query();
-		$query->parse_query(
-			array(
-				'category_name' => 'uncategorized',
-				'paged'         => '2',
-			)
-		);
-		WP_Query_Factory::run_query( $query );
-		$this->assertFalse( $query->is_category() );
-		$this->assertTrue( $query->is_404() );
-	}
-
-	public function test_run_query_author_archive() {
-		// Create user with posts.
-		$posts_user_id = self::factory()->user->create(
-			array(
-				'role'         => 'editor',
-				'display_name' => 'Johnny Withposts',
-				'user_login'   => 'johnnywithposts',
-			)
-		);
-		self::factory()->post->create( array( 'post_author' => $posts_user_id ) );
-
-		// Create user without posts.
-		$noposts_user_id = self::factory()->user->create(
-			array(
-				'role'         => 'editor',
-				'display_name' => 'Johnny Noposts',
-				'user_login'   => 'johnnynoposts',
-			)
-		);
-
-		// User with content, without pagination.
-		$query = new WP_Query();
-		$query->parse_query( array( 'author' => $posts_user_id ) );
-		WP_Query_Factory::run_query( $query );
-		$this->assertTrue( $query->is_author() );
-		$this->assertFalse( $query->is_404() );
-
-		// User without content, without pagination.
-		$query = new WP_Query();
-		$query->parse_query( array( 'author' => $noposts_user_id ) );
-		WP_Query_Factory::run_query( $query );
-		$this->assertTrue( $query->is_author() );
-		$this->assertFalse( $query->is_404() );
-
-		// Non-existing user, without pagination.
-		$query = new WP_Query();
-		$query->parse_query( array( 'author' => 6789 ) );
-		WP_Query_Factory::run_query( $query );
-		$this->assertFalse( $query->is_author() );
-		$this->assertTrue( $query->is_404() );
-
-		// User with content, with pagination out of bounds.
-		$query = new WP_Query();
-		$query->parse_query(
-			array(
-				'author' => $posts_user_id,
-				'paged'  => '2',
-			)
-		);
-		WP_Query_Factory::run_query( $query );
-		$this->assertFalse( $query->is_author() );
-		$this->assertTrue( $query->is_404() );
 	}
 }

--- a/tests/phpunit/integration/Core/Util/WP_Query_FactoryTest.php
+++ b/tests/phpunit/integration/Core/Util/WP_Query_FactoryTest.php
@@ -152,6 +152,7 @@ class WP_Query_FactoryTest extends TestCase {
 					'is_singular'   => false,
 				),
 			),
+			// This is technically a 404, but irrelevant for this test.
 			'blog page, page 3'                  => array(
 				'https://example.com/?pagename=blog&paged=3',
 				array(
@@ -175,6 +176,7 @@ class WP_Query_FactoryTest extends TestCase {
 					'is_singular' => true,
 				),
 			),
+			// This is technically a 404, but irrelevant for this test.
 			'single post, by ID, paginated'      => array(
 				'https://example.com/?p=42&page=2',
 				array(
@@ -196,11 +198,23 @@ class WP_Query_FactoryTest extends TestCase {
 					'is_singular' => true,
 				),
 			),
+			// This is technically a 404, but irrelevant for this test.
 			'single post, by slug, paginated'    => array(
 				'https://example.com/?name=some-post&page=2',
 				array(
 					'name' => 'some-post',
 					'page' => '2',
+				),
+				array(
+					'is_single'   => true,
+					'is_singular' => true,
+				),
+			),
+			// This is technically a 404, but irrelevant for this test.
+			'non-existing post'                  => array(
+				'https://example.com/?name=non-existing-post',
+				array(
+					'name' => 'non-existing-post',
 				),
 				array(
 					'is_single'   => true,
@@ -218,6 +232,7 @@ class WP_Query_FactoryTest extends TestCase {
 					'is_singular' => false,
 				),
 			),
+			// This is technically a 404, but irrelevant for this test.
 			'category archives, by ID, page 3'   => array(
 				'https://example.com/?cat=23&paged=3',
 				array(
@@ -252,6 +267,7 @@ class WP_Query_FactoryTest extends TestCase {
 					'is_singular' => false,
 				),
 			),
+			// This is technically a 404, but irrelevant for this test.
 			'category archives, by slug, page 3' => array(
 				'https://example.com/?category_name=uncategorized&paged=3',
 				array(
@@ -275,6 +291,7 @@ class WP_Query_FactoryTest extends TestCase {
 					'is_singular' => false,
 				),
 			),
+			// This is technically a 404, but irrelevant for this test.
 			'tag archives, page 3'               => array(
 				'https://example.com/?tag=food&paged=3',
 				array(
@@ -299,6 +316,7 @@ class WP_Query_FactoryTest extends TestCase {
 					'is_singular' => false,
 				),
 			),
+			// This is technically a 404, but irrelevant for this test.
 			'post format archives, page 2'       => array(
 				'https://example.com/?post_format=image&paged=2',
 				array(
@@ -323,6 +341,7 @@ class WP_Query_FactoryTest extends TestCase {
 					'is_singular' => false,
 				),
 			),
+			// This is technically a 404, but irrelevant for this test.
 			'author archives, by ID, page 2'     => array(
 				'https://example.com/?author=1&paged=2',
 				array(
@@ -346,6 +365,7 @@ class WP_Query_FactoryTest extends TestCase {
 					'is_singular' => false,
 				),
 			),
+			// This is technically a 404, but irrelevant for this test.
 			'author archives, by slug, page 2'   => array(
 				'https://example.com/?author_name=johndoe&paged=2',
 				array(
@@ -370,6 +390,7 @@ class WP_Query_FactoryTest extends TestCase {
 					'is_singular' => false,
 				),
 			),
+			// This is technically a 404, but irrelevant for this test.
 			'year archives, page 3'              => array(
 				'https://example.com/?year=2020&paged=3',
 				array(
@@ -397,6 +418,7 @@ class WP_Query_FactoryTest extends TestCase {
 					'is_singular' => false,
 				),
 			),
+			// This is technically a 404, but irrelevant for this test.
 			'month archives, page 3'             => array(
 				'https://example.com/?year=2020&monthnum=08&paged=3',
 				array(
@@ -428,6 +450,7 @@ class WP_Query_FactoryTest extends TestCase {
 					'is_singular' => false,
 				),
 			),
+			// This is technically a 404, but irrelevant for this test.
 			'day archives, page 3'               => array(
 				'https://example.com/?year=2020&monthnum=08&day=04&paged=3',
 				array(
@@ -463,6 +486,7 @@ class WP_Query_FactoryTest extends TestCase {
 					'is_singular' => false,
 				),
 			),
+			// This is technically a 404, but irrelevant for this test.
 			'time archives, page 3'              => array(
 				'https://example.com/?year=2020&monthnum=08&day=04&hour=11&paged=3',
 				array(
@@ -505,6 +529,7 @@ class WP_Query_FactoryTest extends TestCase {
 					'is_singular'          => false,
 				),
 			),
+			// This is technically a 404, but irrelevant for this test.
 			'post type archives, page 3'         => array(
 				'https://example.com/?post_type=customposttype&paged=3',
 				array(
@@ -528,6 +553,7 @@ class WP_Query_FactoryTest extends TestCase {
 					'is_singular' => false,
 				),
 			),
+			// This is technically a 404, but irrelevant for this test.
 			'taxonomy archives, page 3'          => array(
 				'https://example.com/?customtaxonomy=coffee&paged=3',
 				array(
@@ -630,6 +656,7 @@ class WP_Query_FactoryTest extends TestCase {
 					'is_singular'   => false,
 				),
 			),
+			// This is technically a 404, but irrelevant for this test.
 			'blog page, page 3'            => array(
 				'https://example.com/blog/page/3/',
 				array(
@@ -654,11 +681,24 @@ class WP_Query_FactoryTest extends TestCase {
 					'is_singular' => true,
 				),
 			),
+			// This is technically a 404, but irrelevant for this test.
 			'single post, paginated'       => array(
 				'https://example.com/some-post/2/',
 				array(
 					'name' => 'some-post',
 					'page' => '2',
+				),
+				array(
+					'is_single'   => true,
+					'is_singular' => true,
+				),
+			),
+			// This is technically a 404, but irrelevant for this test.
+			'non-existing post'            => array(
+				'https://example.com/non-existing-post/',
+				array(
+					'name' => 'non-existing-post',
+					'page' => '',
 				),
 				array(
 					'is_single'   => true,
@@ -687,6 +727,7 @@ class WP_Query_FactoryTest extends TestCase {
 					'is_singular' => false,
 				),
 			),
+			// This is technically a 404, but irrelevant for this test.
 			'category archives, page 3'    => array(
 				'https://example.com/category/uncategorized/page/3/',
 				array(
@@ -710,6 +751,7 @@ class WP_Query_FactoryTest extends TestCase {
 					'is_singular' => false,
 				),
 			),
+			// This is technically a 404, but irrelevant for this test.
 			'tag archives, page 3'         => array(
 				'https://example.com/tag/food/page/3/',
 				array(
@@ -734,6 +776,7 @@ class WP_Query_FactoryTest extends TestCase {
 					'is_singular' => false,
 				),
 			),
+			// This is technically a 404, but irrelevant for this test.
 			'post format archives, page 2' => array(
 				'https://example.com/type/image/page/2/',
 				array(
@@ -758,6 +801,7 @@ class WP_Query_FactoryTest extends TestCase {
 					'is_singular' => false,
 				),
 			),
+			// This is technically a 404, but irrelevant for this test.
 			'author archives, page 2'      => array(
 				'https://example.com/author/johndoe/page/2/',
 				array(
@@ -782,6 +826,7 @@ class WP_Query_FactoryTest extends TestCase {
 					'is_singular' => false,
 				),
 			),
+			// This is technically a 404, but irrelevant for this test.
 			'year archives, page 3'        => array(
 				'https://example.com/2020/page/3/',
 				array(
@@ -809,6 +854,7 @@ class WP_Query_FactoryTest extends TestCase {
 					'is_singular' => false,
 				),
 			),
+			// This is technically a 404, but irrelevant for this test.
 			'month archives, page 3'       => array(
 				'https://example.com/2020/08/page/3/',
 				array(
@@ -840,6 +886,7 @@ class WP_Query_FactoryTest extends TestCase {
 					'is_singular' => false,
 				),
 			),
+			// This is technically a 404, but irrelevant for this test.
 			'day archives, page 3'         => array(
 				'https://example.com/2020/08/04/page/3/',
 				array(
@@ -876,6 +923,7 @@ class WP_Query_FactoryTest extends TestCase {
 					'is_singular' => false,
 				),
 			),
+			// This is technically a 404, but irrelevant for this test.
 			'time archives, page 3'        => array(
 				// Time archives don't have any rewrite rules.
 				'https://example.com/2020/08/04/page/3/?hour=11',
@@ -920,6 +968,7 @@ class WP_Query_FactoryTest extends TestCase {
 					'is_singular'          => false,
 				),
 			),
+			// This is technically a 404, but irrelevant for this test.
 			'post type archives, page 3'   => array(
 				'https://example.com/customposttype/page/3/',
 				array(
@@ -943,6 +992,7 @@ class WP_Query_FactoryTest extends TestCase {
 					'is_singular' => false,
 				),
 			),
+			// This is technically a 404, but irrelevant for this test.
 			'taxonomy archives, page 3'    => array(
 				'https://example.com/customtaxonomy/coffee/page/3/',
 				array(

--- a/tests/phpunit/integration/Core/Util/WP_Query_FactoryTest.php
+++ b/tests/phpunit/integration/Core/Util/WP_Query_FactoryTest.php
@@ -13,6 +13,7 @@ namespace Google\Site_Kit\Tests\Core\Util;
 use Google\Site_Kit\Core\Util\WP_Query_Factory;
 use Google\Site_Kit\Tests\TestCase;
 use Google\Site_Kit\Tests\FixWPCoreEntityRewriteTrait;
+use WP_Query;
 
 /**
  * @group Util
@@ -1109,5 +1110,192 @@ class WP_Query_FactoryTest extends TestCase {
 				array(),
 			),
 		);
+	}
+
+	public function test_run_query_singular() {
+		// Existing page.
+		$query = new WP_Query();
+		$query->parse_query( array( 'pagename' => 'home' ) );
+		WP_Query_Factory::run_query( $query );
+		$this->assertTrue( $query->is_page() );
+		$this->assertFalse( $query->is_404() );
+
+		// Non-existing page.
+		$query = new WP_Query();
+		$query->parse_query( array( 'pagename' => 'invalid-page-slug' ) );
+		WP_Query_Factory::run_query( $query );
+		$this->assertFalse( $query->is_page() );
+		$this->assertTrue( $query->is_404() );
+
+		// Create paginated page.
+		self::factory()->post->create(
+			array(
+				'post_title'   => 'Paginated Page',
+				'post_name'    => 'paginated-page',
+				'post_type'    => 'page',
+				'post_content' => "Page 1\n<!--nextpage-->\nPage 2\n<!--nextpage-->\nPage 3",
+			)
+		);
+
+		// Paginated content queried without pagination.
+		$query = new WP_Query();
+		$query->parse_query( array( 'pagename' => 'paginated-page' ) );
+		WP_Query_Factory::run_query( $query );
+		$this->assertTrue( $query->is_page() );
+		$this->assertFalse( $query->is_404() );
+
+		// Paginated content queried with pagination within bounds.
+		$query = new WP_Query();
+		$query->parse_query(
+			array(
+				'pagename' => 'paginated-page',
+				'page'     => '3',
+			)
+		);
+		WP_Query_Factory::run_query( $query );
+		$this->assertTrue( $query->is_page() );
+		$this->assertFalse( $query->is_404() );
+
+		// Paginated content queried with pagination out of bounds.
+		$query = new WP_Query();
+		$query->parse_query(
+			array(
+				'pagename' => 'paginated-page',
+				'page'     => '4',
+			)
+		);
+		WP_Query_Factory::run_query( $query );
+		$this->assertFalse( $query->is_page() );
+		$this->assertTrue( $query->is_404() );
+
+		// Paginated content queried with pagination when the content is not paginated at all.
+		$query = new WP_Query();
+		$query->parse_query(
+			array(
+				'pagename' => 'home',
+				'page'     => '2',
+			)
+		);
+		WP_Query_Factory::run_query( $query );
+		$this->assertFalse( $query->is_page() );
+		$this->assertTrue( $query->is_404() );
+	}
+
+	public function test_run_query_home() {
+		// Blog page without pagination.
+		$query = new WP_Query();
+		$query->parse_query( array( 'pagename' => 'blog' ) );
+		WP_Query_Factory::run_query( $query );
+		$this->assertTrue( $query->is_home() );
+		$this->assertFalse( $query->is_404() );
+
+		// Blog page with pagination out of bounds.
+		$query = new WP_Query();
+		$query->parse_query(
+			array(
+				'pagename' => 'blog',
+				'paged'    => '2', // This would only work if there were more than 10 posts.
+			)
+		);
+		WP_Query_Factory::run_query( $query );
+		$this->assertFalse( $query->is_home() );
+		$this->assertTrue( $query->is_404() );
+	}
+
+	public function test_run_query_taxonomy_archive() {
+		// Create empty category.
+		self::factory()->category->create(
+			array(
+				'name' => 'Empty category',
+				'slug' => 'empty-category',
+			)
+		);
+
+		// Category with content, without pagination.
+		$query = new WP_Query();
+		$query->parse_query( array( 'category_name' => 'uncategorized' ) );
+		WP_Query_Factory::run_query( $query );
+		$this->assertTrue( $query->is_category() );
+		$this->assertFalse( $query->is_404() );
+
+		// Category without content, without pagination.
+		$query = new WP_Query();
+		$query->parse_query( array( 'category_name' => 'empty-category' ) );
+		WP_Query_Factory::run_query( $query );
+		$this->assertTrue( $query->is_category() );
+		$this->assertFalse( $query->is_404() );
+
+		// Non-existing category, without pagination.
+		$query = new WP_Query();
+		$query->parse_query( array( 'category_name' => 'invalid-category-slug' ) );
+		WP_Query_Factory::run_query( $query );
+		$this->assertFalse( $query->is_category() );
+		$this->assertTrue( $query->is_404() );
+
+		// Category with content, with pagination out of bounds.
+		$query = new WP_Query();
+		$query->parse_query(
+			array(
+				'category_name' => 'uncategorized',
+				'paged'         => '2',
+			)
+		);
+		WP_Query_Factory::run_query( $query );
+		$this->assertFalse( $query->is_category() );
+		$this->assertTrue( $query->is_404() );
+	}
+
+	public function test_run_query_author_archive() {
+		// Create user with posts.
+		$posts_user_id = self::factory()->user->create(
+			array(
+				'role'         => 'editor',
+				'display_name' => 'Johnny Withposts',
+				'user_login'   => 'johnnywithposts',
+			)
+		);
+		self::factory()->post->create( array( 'post_author' => $posts_user_id ) );
+
+		// Create user without posts.
+		$noposts_user_id = self::factory()->user->create(
+			array(
+				'role'         => 'editor',
+				'display_name' => 'Johnny Noposts',
+				'user_login'   => 'johnnynoposts',
+			)
+		);
+
+		// User with content, without pagination.
+		$query = new WP_Query();
+		$query->parse_query( array( 'author' => $posts_user_id ) );
+		WP_Query_Factory::run_query( $query );
+		$this->assertTrue( $query->is_author() );
+		$this->assertFalse( $query->is_404() );
+
+		// User without content, without pagination.
+		$query = new WP_Query();
+		$query->parse_query( array( 'author' => $noposts_user_id ) );
+		WP_Query_Factory::run_query( $query );
+		$this->assertTrue( $query->is_author() );
+		$this->assertFalse( $query->is_404() );
+
+		// Non-existing user, without pagination.
+		$query = new WP_Query();
+		$query->parse_query( array( 'author' => 6789 ) );
+		WP_Query_Factory::run_query( $query );
+		$this->assertFalse( $query->is_author() );
+		$this->assertTrue( $query->is_404() );
+
+		// User with content, with pagination out of bounds.
+		$query = new WP_Query();
+		$query->parse_query(
+			array(
+				'author' => $posts_user_id,
+				'paged'  => '2',
+			)
+		);
+		WP_Query_Factory::run_query( $query );
+		$this->assertFalse( $query->is_author() );
+		$this->assertTrue( $query->is_404() );
 	}
 }


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #1980 

## Relevant technical choices

* Annotates test cases in `WP_Query_FactoryTest` where these would technically end up as 404s, but aren't actually handled like that in the respective test because the method tested is not supposed to include 404 coverage.

## Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
