### PR TITLE
Enable fast_finish for Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -89,6 +89,7 @@ script:
     fi
 
 jobs:
+  fast_finish: true
   allow_failures:
     - env: PHP=1 WP_VERSION=nightly
     - env: E2E=1 WP_VERSION=nightly


### PR DESCRIPTION
## Summary

Addresses issue #1986

The build shows successful completion even though one of the allowed failure jobs was cancelled:

![image](https://user-images.githubusercontent.com/1621608/92104967-cadf8d80-edea-11ea-8aae-682604eae344.png)

https://travis-ci.com/github/google/site-kit-wp/builds/182575634

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
