### PR TITLE
Fix missing spaces in autocomplete titles

### DIFF
--- a/assets/sass/components/global/_googlesitekit-autocomplete.scss
+++ b/assets/sass/components/global/_googlesitekit-autocomplete.scss
@@ -92,15 +92,11 @@
 }
 
 .autocomplete__option {
-	align-items: center;
 	color: $c-base;
-	display: flex;
 	font-weight: 400;
-	height: 48px;
-	justify-content: flex-start;
 	margin-bottom: 0;
 	overflow: hidden;
-	padding: 0 16px;
+	padding: 12px 16px;
 	position: relative;
 }
 


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #1761 (follow-up to #1890)

## Relevant technical choices

* Using `display: flex` on the autocomplete options causes [this problem](https://github.com/google/site-kit-wp/issues/1761#issuecomment-690778589) because the result values may be split into multiple `span` elements. If their content has trailing spaces, the flexbox styling will make it look like these spaces are not there.
* The same visual result can be achieved by specifying corresponding top and bottom padding for each autocomplete option instead of a fixed height - this way the text will still appear vertically centered.

## Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
