### PR TITLE
Remove analytics linker domain since we’re already on the same domain

### DIFF
--- a/includes/Modules/Analytics.php
+++ b/includes/Modules/Analytics.php
@@ -356,12 +356,6 @@ final class Analytics extends Module
 
 		$gtag_opt = array();
 
-		if ( $this->context->get_amp_mode() ) {
-			$gtag_opt['linker'] = array(
-				'domains' => array( $this->get_home_domain() ),
-			);
-		}
-
 		$anonymize_ip = $this->get_data( 'anonymize-ip' );
 		if ( ! is_wp_error( $anonymize_ip ) && $anonymize_ip ) {
 			// See https://developers.google.com/analytics/devguides/collection/gtagjs/ip-anonymization.
@@ -434,9 +428,6 @@ final class Analytics extends Module
 				'config'  => array(
 					$property_id => array(
 						'groups' => 'default',
-						'linker' => array(
-							'domains' => array( $this->get_home_domain() ),
-						),
 					),
 				),
 			),


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #2010.

## Relevant technical choices

The Google Analytics gtag linker is necessary only to [track user visits between different top level domains](https://developers.google.com/gtagjs/devguide/linker). Since the plugin is aware only of the site it is installed on, we should default to _not_ including the domain name of the current site.

> The domain linker functionality enables two or more related sites on separate domains to be measured as one.

On requests served from the AMP cache the linker is enabled by default and associated with the canonical URL of the response [per docs](https://developers.google.com/gtagjs/devguide/amp):

> The capability to link to your canonical domain from the AMP cache is enabled by default.

This changeset reverts some of the code introduced in #1203.

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
