### PR TITLE
Simplify module registration

### DIFF
--- a/assets/js/googlesitekit/modules/datastore/modules.js
+++ b/assets/js/googlesitekit/modules/datastore/modules.js
@@ -257,10 +257,7 @@ const baseReducer = ( state, { type, payload } ) => {
 				...state,
 				clientDefinitions: {
 					...state.clientDefinitions,
-					[ slug ]: {
-						...( state.clientDefinitions[ slug ] || {} ),
-						...settings,
-					},
+					[ slug ]: settings,
 				},
 			};
 		}

--- a/assets/js/googlesitekit/modules/datastore/modules.js
+++ b/assets/js/googlesitekit/modules/datastore/modules.js
@@ -45,13 +45,17 @@ const REFETCH_AUTHENTICATION = 'REFETCH_AUTHENTICATION';
 const REGISTER_MODULE = 'REGISTER_MODULE';
 
 const moduleDefaults = {
+	slug: '',
 	name: '',
 	description: '',
-	icon: null,
-	order: 10,
 	homepage: null,
+	internal: false,
 	active: false,
 	connected: false,
+	dependencies: [],
+	dependants: [],
+	order: 10,
+	icon: null,
 	settingsComponent: DefaultModuleSettings,
 };
 

--- a/assets/js/googlesitekit/modules/datastore/modules.js
+++ b/assets/js/googlesitekit/modules/datastore/modules.js
@@ -248,6 +248,11 @@ const baseReducer = ( state, { type, payload } ) => {
 		case REGISTER_MODULE: {
 			const { slug, settings } = payload;
 
+			if ( state.clientDefinitions[ slug ] ) {
+				global.console.warn( `Could not register module with slug "${ slug }". Module "${ slug }" is already registered.` );
+				return state;
+			}
+
 			return {
 				...state,
 				clientDefinitions: {

--- a/assets/js/googlesitekit/modules/datastore/modules.js
+++ b/assets/js/googlesitekit/modules/datastore/modules.js
@@ -43,7 +43,6 @@ const { createRegistrySelector, createRegistryControl } = Data;
 // Actions.
 const REFETCH_AUTHENTICATION = 'REFETCH_AUTHENTICATION';
 const REGISTER_MODULE = 'REGISTER_MODULE';
-const WAIT_FOR_MODULES = 'WAIT_FOR_MODULES';
 
 const moduleDefaults = {
 	name: '',
@@ -112,19 +111,6 @@ const BASE_INITIAL_STATE = {
 };
 
 const baseActions = {
-	/**
-	 * Wait for the modules to be loaded
-	 *
-	 * @since 1.13.0
-	 *
-	 * @return {Object} Redux-style action.
-	 */
-	waitForModules() {
-		return {
-			payload: {},
-			type: WAIT_FOR_MODULES,
-		};
-	},
 	/**
 	 * Activates a module on the server.
 	 *
@@ -234,23 +220,6 @@ const baseActions = {
 export const baseControls = {
 	[ REFETCH_AUTHENTICATION ]: createRegistryControl( ( { dispatch } ) => () => {
 		return dispatch( CORE_USER ).fetchGetAuthentication();
-	} ),
-	[ WAIT_FOR_MODULES ]: createRegistryControl( ( registry ) => ( { payload: {} } ) => {
-		// Select first to ensure resolution is always triggered.
-		const { getModules, hasFinishedResolution } = registry.select( STORE_NAME );
-		getModules();
-		const modulesAreLoaded = () => hasFinishedResolution( 'getModules', [] );
-		if ( modulesAreLoaded() ) {
-			return;
-		}
-		return new Promise( ( resolve ) => {
-			const unsubscribe = registry.subscribe( () => {
-				if ( modulesAreLoaded() ) {
-					unsubscribe();
-					resolve();
-				}
-			} );
-		} );
 	} ),
 };
 

--- a/assets/js/googlesitekit/modules/datastore/modules.js
+++ b/assets/js/googlesitekit/modules/datastore/modules.js
@@ -19,7 +19,6 @@
 /**
  * External dependencies
  */
-import mapValues from 'lodash/mapValues';
 import merge from 'lodash/merge';
 import invariant from 'invariant';
 
@@ -302,14 +301,20 @@ const baseSelectors = {
 		// but only for keys whose values are not `undefined`.
 		const modules = merge( {}, serverDefinitions, clientDefinitions );
 
-		return mapValues( modules, ( module, slug ) => {
-			return {
-				...moduleDefaults,
-				name: slug, // Ensure `name` is not empty.
-				...module,
-				slug,
-			};
-		} );
+		return Object.keys( modules )
+			.map( ( slug ) => {
+				return {
+					...moduleDefaults,
+					name: slug, // Ensure `name` is not empty.
+					...modules[ slug ],
+					slug,
+				};
+			} )
+			.sort( ( a, b ) => a.order - b.order )
+			.reduce( ( acc, module ) => {
+				return { ...acc, [ module.slug ]: module };
+			}, {} )
+		;
 	},
 
 	/**

--- a/assets/js/googlesitekit/modules/datastore/modules.test.js
+++ b/assets/js/googlesitekit/modules/datastore/modules.test.js
@@ -384,6 +384,41 @@ describe( 'core/modules modules', () => {
 				expect( fetchMock ).toHaveFetchedTimes( 1 );
 				expect( modules ).toBeUndefined();
 			} );
+
+			it( 'combines `serverDefinitions` with `clientDefinitions`', () => {
+				registry.dispatch( STORE_NAME ).receiveGetModules( [
+					{ slug: 'server-module' },
+				] );
+				registry.dispatch( STORE_NAME ).registerModule( 'client-module' );
+
+				const modules = registry.select( STORE_NAME ).getModules();
+
+				expect( Object.keys( modules ) ).toEqual(
+					expect.arrayContaining( [ 'server-module', 'client-module' ] )
+				);
+			} );
+
+			it( 'merges `serverDefinitions` of the same module with `clientDefinitions`', () => {
+				registry.dispatch( STORE_NAME ).receiveGetModules( [
+					{ slug: 'test-module', name: 'Server Name' },
+				] );
+				registry.dispatch( STORE_NAME ).registerModule( 'test-module', { name: 'Client Name' } );
+
+				const modules = registry.select( STORE_NAME ).getModules();
+
+				expect( modules[ 'test-module' ] ).toMatchObject( { name: 'Client Name' } );
+			} );
+
+			it( 'does not overwrite `serverDefinitions` of the same module with undefined settings from client registration', () => {
+				registry.dispatch( STORE_NAME ).receiveGetModules( [
+					{ slug: 'test-module', name: 'Server Name', description: 'Server description' },
+				] );
+				registry.dispatch( STORE_NAME ).registerModule( 'test-module', { description: 'Client description' } );
+
+				const modules = registry.select( STORE_NAME ).getModules();
+
+				expect( modules[ 'test-module' ] ).toMatchObject( { name: 'Server Name', description: 'Client description' } );
+			} );
 		} );
 
 		describe( 'getModule', () => {

--- a/assets/js/googlesitekit/modules/datastore/modules.test.js
+++ b/assets/js/googlesitekit/modules/datastore/modules.test.js
@@ -343,7 +343,7 @@ describe( 'core/modules modules', () => {
 				const initialModules = registry.select( STORE_NAME ).getModules();
 				// The modules info will be its initial value while the modules
 				// info is fetched.
-				expect( initialModules ).toEqual( undefined );
+				expect( initialModules ).toBeUndefined();
 				await untilResolved( registry, STORE_NAME ).getModules();
 
 				const modules = registry.select( STORE_NAME ).getModules();
@@ -396,7 +396,7 @@ describe( 'core/modules modules', () => {
 				const module = registry.select( STORE_NAME ).getModule( slug );
 
 				// The modules will be undefined whilst loading.
-				expect( module ).toEqual( undefined );
+				expect( module ).toBeUndefined();
 
 				// Wait for loading to complete.
 				await untilResolved( registry, STORE_NAME ).getModules();
@@ -428,7 +428,7 @@ describe( 'core/modules modules', () => {
 				const module = registry.select( STORE_NAME ).getModule( slug );
 
 				expect( fetchMock ).toHaveFetchedTimes( 1 );
-				expect( module ).toEqual( undefined );
+				expect( module ).toBeUndefined();
 			} );
 
 			it( 'returns undefined if modules is not yet available', async () => {
@@ -437,7 +437,7 @@ describe( 'core/modules modules', () => {
 
 				const module = registry.select( STORE_NAME ).getModule( 'analytics' );
 
-				expect( module ).toEqual( undefined );
+				expect( module ).toBeUndefined();
 			} );
 
 			it( 'returns null if the module does not exist', async () => {
@@ -449,7 +449,7 @@ describe( 'core/modules modules', () => {
 				const slug = 'analytics';
 				const module = registry.select( STORE_NAME ).getModule( slug );
 				// The modules will be undefined whilst loading.
-				expect( module ).toEqual( undefined );
+				expect( module ).toBeUndefined();
 
 				// Wait for loading to complete.
 				await untilResolved( registry, STORE_NAME ).getModules();
@@ -474,7 +474,7 @@ describe( 'core/modules modules', () => {
 				const slug = 'search-console';
 				const isActive = registry.select( STORE_NAME ).isModuleActive( slug );
 				// The modules will be undefined whilst loading, so this will return `undefined`.
-				expect( isActive ).toEqual( undefined );
+				expect( isActive ).toBeUndefined();
 
 				// Wait for loading to complete.
 				await untilResolved( registry, STORE_NAME ).getModules();
@@ -489,7 +489,7 @@ describe( 'core/modules modules', () => {
 				const slug = 'optimize';
 				const isActive = registry.select( STORE_NAME ).isModuleActive( slug );
 				// The modules will be undefined whilst loading, so this will return `undefined`.
-				expect( isActive ).toEqual( undefined );
+				expect( isActive ).toBeUndefined();
 
 				// Wait for loading to complete.
 				await untilResolved( registry, STORE_NAME ).getModules();
@@ -504,7 +504,7 @@ describe( 'core/modules modules', () => {
 				const slug = 'not-a-real-module';
 				const isActive = registry.select( STORE_NAME ).isModuleActive( slug );
 				// The modules will be undefined whilst loading, so this will return `undefined`.
-				expect( isActive ).toEqual( undefined );
+				expect( isActive ).toBeUndefined();
 
 				// Wait for loading to complete.
 				await untilResolved( registry, STORE_NAME ).getModules();
@@ -520,7 +520,7 @@ describe( 'core/modules modules', () => {
 
 				const isActive = registry.select( STORE_NAME ).isModuleActive( 'analytics' );
 
-				expect( isActive ).toEqual( undefined );
+				expect( isActive ).toBeUndefined();
 			} );
 		} );
 
@@ -598,7 +598,7 @@ describe( 'core/modules modules', () => {
 
 				const isConnected = registry.select( STORE_NAME ).isModuleConnected( 'analytics' );
 
-				expect( isConnected ).toEqual( undefined );
+				expect( isConnected ).toBeUndefined();
 			} );
 		} );
 	} );

--- a/assets/js/googlesitekit/modules/datastore/modules.test.js
+++ b/assets/js/googlesitekit/modules/datastore/modules.test.js
@@ -419,6 +419,17 @@ describe( 'core/modules modules', () => {
 
 				expect( modules[ 'test-module' ] ).toMatchObject( { name: 'Server Name', description: 'Client description' } );
 			} );
+
+			it( 'returns an object with keys set in module order', () => {
+				registry.dispatch( STORE_NAME ).receiveGetModules( [] );
+				registry.dispatch( STORE_NAME ).registerModule( 'second-module', { order: 2 } );
+				registry.dispatch( STORE_NAME ).registerModule( 'first-module', { order: 1 } );
+				registry.dispatch( STORE_NAME ).registerModule( 'third-module', { order: 3 } );
+
+				const modules = registry.select( STORE_NAME ).getModules();
+
+				expect( Object.keys( modules ) ).toEqual( [ 'first-module', 'second-module', 'third-module' ] );
+			} );
 		} );
 
 		describe( 'getModule', () => {

--- a/assets/js/googlesitekit/modules/datastore/modules.test.js
+++ b/assets/js/googlesitekit/modules/datastore/modules.test.js
@@ -302,6 +302,19 @@ describe( 'core/modules modules', () => {
 					registry.dispatch( STORE_NAME ).registerModule();
 				} ).toThrow( 'module slug is required' );
 			} );
+
+			it( 'does not allow the same module to be registered more than once on the client', () => {
+				registry.dispatch( STORE_NAME ).receiveGetModules( [] );
+
+				registry.dispatch( STORE_NAME ).registerModule( 'test-module', { name: 'Original Name' } );
+
+				expect( console ).not.toHaveWarned();
+
+				registry.dispatch( STORE_NAME ).registerModule( 'test-module', { name: 'New Name' } );
+
+				expect( store.getState().clientDefinitions[ 'test-module' ].name ).toBe( 'Original Name' );
+				expect( console ).toHaveWarned();
+			} );
 		} );
 
 		describe( 'fetchGetModules', () => {

--- a/assets/js/googlesitekit/modules/datastore/modules.test.js
+++ b/assets/js/googlesitekit/modules/datastore/modules.test.js
@@ -24,7 +24,6 @@ import {
 	createTestRegistry,
 	muteConsole,
 	muteFetch,
-	subscribeUntil,
 	unsubscribeFromAll,
 	untilResolved,
 } from '../../../../../tests/js/utils';
@@ -72,10 +71,7 @@ describe( 'core/modules modules', () => {
 				// Call a selector that triggers an HTTP request to get the modules.
 				registry.select( STORE_NAME ).isModuleActive( slug );
 				// Wait until the modules have been loaded.
-				await subscribeUntil( registry, () => registry
-					.select( STORE_NAME )
-					.hasFinishedResolution( 'getModules' )
-				);
+				await untilResolved( registry, STORE_NAME ).getModules();
 				const isActiveBefore = registry.select( STORE_NAME ).isModuleActive( slug );
 
 				expect( isActiveBefore ).toEqual( false );
@@ -94,13 +90,7 @@ describe( 'core/modules modules', () => {
 					{ body: {}, status: 200 }
 				);
 
-				registry.dispatch( STORE_NAME ).activateModule( slug );
-
-				// Wait until this activation action has completed.
-				await subscribeUntil( registry, () => registry
-					.select( STORE_NAME )
-					.isDoingSetModuleActivation( slug ) === false
-				);
+				await registry.dispatch( STORE_NAME ).activateModule( slug );
 
 				// Ensure the proper body parameters were sent.
 				expect( fetchMock ).toHaveFetched(
@@ -144,13 +134,7 @@ describe( 'core/modules modules', () => {
 				);
 
 				muteConsole( 'error' );
-				registry.dispatch( STORE_NAME ).activateModule( slug );
-
-				// Wait until this activation action has completed.
-				await subscribeUntil( registry, () => registry
-					.select( STORE_NAME )
-					.isDoingSetModuleActivation( slug ) === false
-				);
+				await registry.dispatch( STORE_NAME ).activateModule( slug );
 
 				// Ensure the proper body parameters were sent.
 				expect( fetchMock ).toHaveFetched(
@@ -196,10 +180,7 @@ describe( 'core/modules modules', () => {
 				registry.select( STORE_NAME ).getModules();
 
 				// Wait until the modules have been loaded.
-				await subscribeUntil( registry, () => registry
-					.select( STORE_NAME )
-					.hasFinishedResolution( 'getModules' )
-				);
+				await untilResolved( registry, STORE_NAME ).getModules();
 
 				const isActiveBefore = registry.select( STORE_NAME ).isModuleActive( slug );
 
@@ -376,10 +357,7 @@ describe( 'core/modules modules', () => {
 
 				const modules = registry.select( STORE_NAME ).getModules();
 
-				await subscribeUntil( registry, () => registry
-					.select( STORE_NAME )
-					.hasFinishedResolution( 'getModules' )
-				);
+				await untilResolved( registry, STORE_NAME ).getModules();
 
 				expect( fetchMock ).not.toHaveFetched();
 				expect( modules ).toMatchObject( fixturesKeyValue );
@@ -399,10 +377,7 @@ describe( 'core/modules modules', () => {
 				muteConsole( 'error' );
 				registry.select( STORE_NAME ).getModules();
 
-				await subscribeUntil( registry, () => registry
-					.select( STORE_NAME )
-					.hasFinishedResolution( 'getModules' )
-				);
+				await untilResolved( registry, STORE_NAME ).getModules();
 
 				const modules = registry.select( STORE_NAME ).getModules();
 
@@ -424,10 +399,7 @@ describe( 'core/modules modules', () => {
 				expect( module ).toEqual( undefined );
 
 				// Wait for loading to complete.
-				await subscribeUntil( registry, () => registry
-					.select( STORE_NAME )
-					.hasFinishedResolution( 'getModules' )
-				);
+				await untilResolved( registry, STORE_NAME ).getModules();
 
 				const moduleLoaded = registry.select( STORE_NAME ).getModule( slug );
 
@@ -451,10 +423,7 @@ describe( 'core/modules modules', () => {
 				muteConsole( 'error' );
 				registry.select( STORE_NAME ).getModule( slug );
 
-				await subscribeUntil( registry, () => registry
-					.select( STORE_NAME )
-					.hasFinishedResolution( 'getModules' )
-				);
+				await untilResolved( registry, STORE_NAME ).getModules();
 
 				const module = registry.select( STORE_NAME ).getModule( slug );
 
@@ -483,10 +452,7 @@ describe( 'core/modules modules', () => {
 				expect( module ).toEqual( undefined );
 
 				// Wait for loading to complete.
-				await subscribeUntil( registry, () => registry
-					.select( STORE_NAME )
-					.hasFinishedResolution( 'getModules' )
-				);
+				await untilResolved( registry, STORE_NAME ).getModules();
 
 				const moduleLoaded = registry.select( STORE_NAME ).getModule( 'not-a-real-module' );
 
@@ -511,10 +477,7 @@ describe( 'core/modules modules', () => {
 				expect( isActive ).toEqual( undefined );
 
 				// Wait for loading to complete.
-				await subscribeUntil( registry, () => registry
-					.select( STORE_NAME )
-					.hasFinishedResolution( 'getModules' )
-				);
+				await untilResolved( registry, STORE_NAME ).getModules();
 
 				const isActiveLoaded = registry.select( STORE_NAME ).isModuleActive( slug );
 				expect( fetchMock ).toHaveFetchedTimes( 1 );
@@ -529,10 +492,7 @@ describe( 'core/modules modules', () => {
 				expect( isActive ).toEqual( undefined );
 
 				// Wait for loading to complete.
-				await subscribeUntil( registry, () => registry
-					.select( STORE_NAME )
-					.hasFinishedResolution( 'getModules' )
-				);
+				await untilResolved( registry, STORE_NAME ).getModules();
 
 				const isActiveLoaded = registry.select( STORE_NAME ).isModuleActive( slug );
 
@@ -547,10 +507,7 @@ describe( 'core/modules modules', () => {
 				expect( isActive ).toEqual( undefined );
 
 				// Wait for loading to complete.
-				await subscribeUntil( registry, () => registry
-					.select( STORE_NAME )
-					.hasFinishedResolution( 'getModules' )
-				);
+				await untilResolved( registry, STORE_NAME ).getModules();
 
 				const isActiveLoaded = registry.select( STORE_NAME ).isModuleActive( slug );
 
@@ -582,10 +539,7 @@ describe( 'core/modules modules', () => {
 				expect( isConnected ).toBeUndefined();
 
 				// Wait for loading to complete.
-				await subscribeUntil( registry, () => registry
-					.select( STORE_NAME )
-					.hasFinishedResolution( 'getModules' )
-				);
+				await untilResolved( registry, STORE_NAME ).getModules();
 
 				const isConnectedLoaded = registry.select( STORE_NAME ).isModuleConnected( slug );
 				expect( fetchMock ).toHaveFetchedTimes( 1 );
@@ -600,10 +554,7 @@ describe( 'core/modules modules', () => {
 				expect( isConnected ).toBeUndefined();
 
 				// Wait for loading to complete.
-				await subscribeUntil( registry, () => registry
-					.select( STORE_NAME )
-					.hasFinishedResolution( 'getModules' )
-				);
+				await untilResolved( registry, STORE_NAME ).getModules();
 
 				const isConnectedLoaded = registry.select( STORE_NAME ).isModuleConnected( slug );
 
@@ -619,10 +570,7 @@ describe( 'core/modules modules', () => {
 				expect( isConnected ).toBeUndefined();
 
 				// Wait for loading to complete.
-				await subscribeUntil( registry, () => registry
-					.select( STORE_NAME )
-					.hasFinishedResolution( 'getModules' )
-				);
+				await untilResolved( registry, STORE_NAME ).getModules();
 
 				const isConnectedLoaded = registry.select( STORE_NAME ).isModuleConnected( slug );
 
@@ -637,10 +585,7 @@ describe( 'core/modules modules', () => {
 				expect( isConnected ).toBeUndefined();
 
 				// Wait for loading to complete.
-				await subscribeUntil( registry, () => registry
-					.select( STORE_NAME )
-					.hasFinishedResolution( 'getModules' )
-				);
+				await untilResolved( registry, STORE_NAME ).getModules();
 
 				const isConnectedLoaded = registry.select( STORE_NAME ).isModuleConnected( slug );
 

--- a/assets/js/googlesitekit/modules/datastore/modules.test.js
+++ b/assets/js/googlesitekit/modules/datastore/modules.test.js
@@ -377,6 +377,8 @@ describe( 'core/modules modules', () => {
 
 				await untilResolved( registry, STORE_NAME ).getModules();
 
+				expect( console ).toHaveErrored();
+
 				const modules = registry.select( STORE_NAME ).getModules();
 
 				expect( fetchMock ).toHaveFetchedTimes( 1 );

--- a/assets/js/googlesitekit/modules/datastore/modules.test.js
+++ b/assets/js/googlesitekit/modules/datastore/modules.test.js
@@ -336,7 +336,6 @@ describe( 'core/modules modules', () => {
 		describe( 'receiveGetModules', () => {
 			it( 'requires the response param', () => {
 				expect( () => {
-					muteConsole( 'error' );
 					registry.dispatch( STORE_NAME ).receiveGetModules();
 				} ).toThrow( 'response is required.' );
 			} );


### PR DESCRIPTION
## Summary

Addresses issue #2024

## Relevant technical choices

* Removed sorting from return value of `getModules` – [see comment below](https://github.com/google/site-kit-wp/pull/2026#discussion_r488457023)
* Cleans up the tests a bit to be more consistent with others using `untilResolved` and awaiting async actions rather than using a selector

## Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
