### PR TITLE
Update default reducers to not copy state when not changed

### DIFF
--- a/assets/js/all-datastores.test.js
+++ b/assets/js/all-datastores.test.js
@@ -1,0 +1,45 @@
+/**
+ * Common tests for all data stores.
+ *
+ * Site Kit by Google, Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import omit from 'lodash/omit';
+
+/**
+ * Internal dependencies
+ */
+import { createTestRegistry } from '../../tests/js/utils';
+
+const registry = createTestRegistry();
+const firstPartyStores = omit( registry.stores, 'core/data' );
+
+describe( 'all data stores', () => {
+	describe.each( Object.keys( firstPartyStores ) )( '%s', ( storeName ) => {
+		describe( 'reducers', () => {
+			it( 'does not invoke subscribed listeners for unmatched actions', () => {
+				const listener = jest.fn();
+				registry.subscribe( listener );
+
+				registry.stores[ storeName ].store.dispatch( { type: '@@NON_EXISTENT_ACTION_TYPE@@' } );
+
+				expect( listener ).not.toHaveBeenCalled();
+			} );
+		} );
+	} );
+} );

--- a/assets/js/googlesitekit/data/create-error-store.js
+++ b/assets/js/googlesitekit/data/create-error-store.js
@@ -75,19 +75,19 @@ export function createErrorStore() {
 		switch ( type ) {
 			case RECEIVE_ERROR: {
 				const { baseName, args, error } = payload;
-				const newState = state;
 
 				if ( baseName ) {
-					newState.errors = {
-						...( state.errors || {} ),
-						[ generateErrorKey( baseName, args ) ]: error,
+					return {
+						...state,
+						errors: {
+							...( state.errors || {} ),
+							[ generateErrorKey( baseName, args ) ]: error,
+						},
 					};
-				} else {
-					// @TODO: remove it once all instances of the legacy behavior have been removed.
-					newState.error = error;
 				}
 
-				return newState;
+				// @TODO: remove once all instances of the legacy behavior have been removed.
+				return { ...state, error };
 			}
 
 			case CLEAR_ERROR: {

--- a/assets/js/googlesitekit/data/create-error-store.js
+++ b/assets/js/googlesitekit/data/create-error-store.js
@@ -75,7 +75,7 @@ export function createErrorStore() {
 		switch ( type ) {
 			case RECEIVE_ERROR: {
 				const { baseName, args, error } = payload;
-				const newState = { ...state };
+				const newState = state;
 
 				if ( baseName ) {
 					newState.errors = {
@@ -101,7 +101,7 @@ export function createErrorStore() {
 			}
 
 			default: {
-				return { ...state };
+				return state;
 			}
 		}
 	}

--- a/assets/js/googlesitekit/data/create-existing-tag-store.js
+++ b/assets/js/googlesitekit/data/create-existing-tag-store.js
@@ -132,7 +132,7 @@ export const createExistingTagStore = ( {
 			}
 
 			default: {
-				return { ...state };
+				return state;
 			}
 		}
 	};

--- a/assets/js/googlesitekit/data/create-fetch-store.js
+++ b/assets/js/googlesitekit/data/create-fetch-store.js
@@ -29,9 +29,7 @@ import { actions as errorStoreActions } from './create-error-store';
 import { camelCaseToPascalCase, camelCaseToConstantCase } from './transform-case';
 import { stringifyObject } from '../../util';
 
-const defaultReducerCallback = ( state ) => {
-	return { ...state };
-};
+const defaultReducerCallback = ( state ) => state;
 
 const defaultArgsToParams = () => {
 	return {};
@@ -250,7 +248,7 @@ export const createFetchStore = ( {
 			}
 
 			default: {
-				return { ...state };
+				return state;
 			}
 		}
 	};

--- a/assets/js/googlesitekit/data/create-fetch-store.test.js
+++ b/assets/js/googlesitekit/data/create-fetch-store.test.js
@@ -83,7 +83,8 @@ describe( 'createFetchStore store', () => {
 	beforeEach( () => {
 		registry = createRegistry();
 
-		storeDefinition = createFetchStore( STORE_PARAMS );
+		const { INITIAL_STATE: initialState, ...fetchStore } = createFetchStore( STORE_PARAMS );
+		storeDefinition = { initialState, ...fetchStore };
 		registry.registerStore( STORE_NAME, storeDefinition );
 		dispatch = registry.dispatch( STORE_NAME );
 		store = registry.stores[ STORE_NAME ].store;

--- a/assets/js/googlesitekit/data/create-notifications-store.js
+++ b/assets/js/googlesitekit/data/create-notifications-store.js
@@ -157,7 +157,7 @@ export const createNotificationsStore = ( type, identifier, datapoint, {
 						global.console.warn( `Cannot remove server-side notification with ID "${ id }"; this may be changed in a future release.` );
 					}
 
-					return { ...state };
+					return state;
 				}
 
 				const newNotifications = { ...state.clientNotifications };
@@ -170,7 +170,7 @@ export const createNotificationsStore = ( type, identifier, datapoint, {
 			}
 
 			default: {
-				return { ...state };
+				return state;
 			}
 		}
 	};

--- a/assets/js/googlesitekit/data/create-settings-store.js
+++ b/assets/js/googlesitekit/data/create-settings-store.js
@@ -210,7 +210,7 @@ export const createSettingsStore = ( type, identifier, datapoint, {
 					return settingReducers[ type ]( state, { type, payload } );
 				}
 
-				return { ...state };
+				return state;
 			}
 		}
 	};

--- a/assets/js/googlesitekit/data/create-snapshot-store.js
+++ b/assets/js/googlesitekit/data/create-snapshot-store.js
@@ -144,7 +144,7 @@ export const createSnapshotStore = ( storeName ) => {
 				// eslint-disable-next-line no-unused-vars
 				const { error, ...newState } = snapshot;
 
-				return { ...newState };
+				return newState;
 			}
 
 			default: {

--- a/assets/js/googlesitekit/data/create-snapshot-store.js
+++ b/assets/js/googlesitekit/data/create-snapshot-store.js
@@ -148,7 +148,7 @@ export const createSnapshotStore = ( storeName ) => {
 			}
 
 			default: {
-				return { ...state };
+				return state;
 			}
 		}
 	};

--- a/assets/js/googlesitekit/data/utils.js
+++ b/assets/js/googlesitekit/data/utils.js
@@ -161,9 +161,7 @@ export const collectName = ( ...args ) => {
  * @param {Object} state A store's state.
  * @return {Object} The same state data as passed in `state`.
  */
-const passthroughReducer = ( state ) => {
-	return { ...state };
-};
+const passthroughReducer = ( state ) => state;
 
 /**
  * Combines multiple stores.

--- a/assets/js/googlesitekit/data/utils.test.js
+++ b/assets/js/googlesitekit/data/utils.test.js
@@ -131,7 +131,7 @@ describe( 'data utils', () => {
 							case 'ACTION_ONE':
 								return { ...state, one: true };
 							default: {
-								return { ...state };
+								return state;
 							}
 						}
 					},
@@ -155,7 +155,7 @@ describe( 'data utils', () => {
 							case 'ACTION_TWO':
 								return { ...state, two: 2 };
 							default: {
-								return { ...state };
+								return state;
 							}
 						}
 					},
@@ -215,7 +215,7 @@ describe( 'data utils', () => {
 							case 'ACTION_ONE':
 								return { ...state, one: true };
 							default: {
-								return { ...state };
+								return state;
 							}
 						}
 					},
@@ -239,7 +239,7 @@ describe( 'data utils', () => {
 							case 'ACTION_TWO':
 								return { ...state, two: 2 };
 							default: {
-								return { ...state };
+								return state;
 							}
 						}
 					},
@@ -417,7 +417,7 @@ describe( 'data utils', () => {
 							case 'ACTION_ONE':
 								return { ...state, one: true };
 							default: {
-								return { ...state };
+								return state;
 							}
 						}
 					},
@@ -428,7 +428,7 @@ describe( 'data utils', () => {
 							case 'ACTION_TWO':
 								return { ...state, two: 2 };
 							default: {
-								return { ...state };
+								return state;
 							}
 						}
 					},
@@ -511,7 +511,7 @@ describe( 'data utils', () => {
 							case 'ACTION_ONE':
 								return { ...state, one: true };
 							default: {
-								return { ...state };
+								return state;
 							}
 						}
 					},
@@ -522,7 +522,7 @@ describe( 'data utils', () => {
 							case 'ACTION_TWO':
 								return { ...state, two: 'two' };
 							default: {
-								return { ...state };
+								return state;
 							}
 						}
 					},
@@ -659,7 +659,7 @@ describe( 'data utils', () => {
 				case 'ACTION_ONE':
 					return { ...state, one: true };
 				default: {
-					return { ...state };
+					return state;
 				}
 			}
 		};
@@ -668,7 +668,7 @@ describe( 'data utils', () => {
 				case 'ACTION_TWO':
 					return { ...state, two: 2 };
 				default: {
-					return { ...state };
+					return state;
 				}
 			}
 		};

--- a/assets/js/googlesitekit/datastore/forms/forms.js
+++ b/assets/js/googlesitekit/datastore/forms/forms.js
@@ -61,7 +61,7 @@ export const reducer = ( state, { type, payload } ) => {
 		}
 
 		default: {
-			return { ...state };
+			return state;
 		}
 	}
 };

--- a/assets/js/googlesitekit/datastore/site/html.js
+++ b/assets/js/googlesitekit/datastore/site/html.js
@@ -140,7 +140,7 @@ const baseReducer = ( state, { type, payload } ) => {
 		}
 
 		default: {
-			return { ...state };
+			return state;
 		}
 	}
 };

--- a/assets/js/googlesitekit/datastore/site/info.js
+++ b/assets/js/googlesitekit/datastore/site/info.js
@@ -111,7 +111,7 @@ export const reducer = ( state, { payload, type } ) => {
 		}
 
 		default: {
-			return { ...state };
+			return state;
 		}
 	}
 };

--- a/assets/js/googlesitekit/datastore/site/registry-key.js
+++ b/assets/js/googlesitekit/datastore/site/registry-key.js
@@ -63,7 +63,7 @@ export const reducer = ( state, { payload, type } ) => {
 			};
 		}
 		default: {
-			return { ...state };
+			return state;
 		}
 	}
 };

--- a/assets/js/googlesitekit/datastore/user/date-range.js
+++ b/assets/js/googlesitekit/datastore/user/date-range.js
@@ -59,7 +59,7 @@ export function reducer( state, { type, payload } ) {
 				dateRange: payload.slug,
 			};
 		default: {
-			return { ...state };
+			return state;
 		}
 	}
 }

--- a/assets/js/googlesitekit/datastore/user/permissions.js
+++ b/assets/js/googlesitekit/datastore/user/permissions.js
@@ -119,7 +119,7 @@ export const reducer = ( state, { type, payload } ) => {
 		}
 
 		default: {
-			return { ...state };
+			return state;
 		}
 	}
 };

--- a/assets/js/googlesitekit/datastore/user/user-info.js
+++ b/assets/js/googlesitekit/datastore/user/user-info.js
@@ -138,7 +138,7 @@ export const reducer = ( state, { type, payload } ) => {
 			};
 		}
 		default: {
-			return { ...state };
+			return state;
 		}
 	}
 };

--- a/assets/js/googlesitekit/modules/create-info-store.js
+++ b/assets/js/googlesitekit/modules/create-info-store.js
@@ -54,7 +54,7 @@ export const createInfoStore = ( slug, {
 	const actions = {};
 	const controls = {};
 	const reducer = ( state ) => {
-		return { ...state };
+		return state;
 	};
 	const resolvers = {};
 	const selectors = {

--- a/assets/js/googlesitekit/modules/datastore/modules.js
+++ b/assets/js/googlesitekit/modules/datastore/modules.js
@@ -284,7 +284,7 @@ const baseReducer = ( state, { type, payload } ) => {
 		}
 
 		default: {
-			return { ...state };
+			return state;
 		}
 	}
 };

--- a/assets/js/googlesitekit/widgets/datastore/areas.js
+++ b/assets/js/googlesitekit/widgets/datastore/areas.js
@@ -142,7 +142,7 @@ export const reducer = ( state, { type, payload } ) => {
 			if ( state.areas[ slug ] !== undefined ) {
 				global.console.warn( `Could not register widget area with slug "${ slug }". Widget area "${ slug }" is already registered.` );
 
-				return { ...state };
+				return state;
 			}
 
 			return {
@@ -155,7 +155,7 @@ export const reducer = ( state, { type, payload } ) => {
 		}
 
 		default: {
-			return { ...state };
+			return state;
 		}
 	}
 };

--- a/assets/js/googlesitekit/widgets/datastore/widgets.js
+++ b/assets/js/googlesitekit/widgets/datastore/widgets.js
@@ -152,7 +152,7 @@ export const reducer = ( state, { type, payload } ) => {
 			if ( state.widgets[ slug ] !== undefined ) {
 				global.console.warn( `Could not register widget with slug "${ slug }". Widget "${ slug }" is already registered.` );
 
-				return { ...state };
+				return state;
 			}
 
 			return {
@@ -165,7 +165,7 @@ export const reducer = ( state, { type, payload } ) => {
 		}
 
 		default: {
-			return { ...state };
+			return state;
 		}
 	}
 };

--- a/assets/js/modules/adsense/datastore/accounts.js
+++ b/assets/js/modules/adsense/datastore/accounts.js
@@ -87,7 +87,7 @@ const baseReducer = ( state, { type } ) => {
 		}
 
 		default: {
-			return { ...state };
+			return state;
 		}
 	}
 };

--- a/assets/js/modules/adsense/datastore/adblocker.js
+++ b/assets/js/modules/adsense/datastore/adblocker.js
@@ -58,7 +58,7 @@ export const reducer = ( state, { payload, type } ) => {
 		}
 
 		default: {
-			return { ...state };
+			return state;
 		}
 	}
 };

--- a/assets/js/modules/adsense/datastore/alerts.js
+++ b/assets/js/modules/adsense/datastore/alerts.js
@@ -98,7 +98,7 @@ const baseReducer = ( state, { type } ) => {
 		}
 
 		default: {
-			return { ...state };
+			return state;
 		}
 	}
 };

--- a/assets/js/modules/adsense/datastore/clients.js
+++ b/assets/js/modules/adsense/datastore/clients.js
@@ -100,7 +100,7 @@ const baseReducer = ( state, { type } ) => {
 		}
 
 		default: {
-			return { ...state };
+			return state;
 		}
 	}
 };

--- a/assets/js/modules/adsense/datastore/settings.js
+++ b/assets/js/modules/adsense/datastore/settings.js
@@ -284,11 +284,11 @@ const baseReducer = ( state, { type, payload } ) => {
 				};
 			}
 
-			return { ...state };
+			return state;
 		}
 
 		default: {
-			return { ...state };
+			return state;
 		}
 	}
 };

--- a/assets/js/modules/adsense/datastore/urlchannels.js
+++ b/assets/js/modules/adsense/datastore/urlchannels.js
@@ -94,7 +94,7 @@ const baseReducer = ( state, { type } ) => {
 		}
 
 		default: {
-			return { ...state };
+			return state;
 		}
 	}
 };

--- a/assets/js/modules/analytics/datastore/accounts.js
+++ b/assets/js/modules/analytics/datastore/accounts.js
@@ -199,7 +199,7 @@ const baseReducer = ( state, { type, payload } ) => {
 		}
 
 		default: {
-			return { ...state };
+			return state;
 		}
 	}
 };

--- a/assets/js/modules/analytics/datastore/adsense.js
+++ b/assets/js/modules/analytics/datastore/adsense.js
@@ -60,7 +60,7 @@ export const reducer = ( state, { type, payload } ) => {
 				adsenseLinked,
 			};
 		default:
-			return { ...state };
+			return state;
 	}
 };
 

--- a/assets/js/modules/analytics/datastore/properties.js
+++ b/assets/js/modules/analytics/datastore/properties.js
@@ -267,7 +267,7 @@ const baseReducer = ( state, { type, payload } ) => {
 		}
 
 		default: {
-			return { ...state };
+			return state;
 		}
 	}
 };

--- a/assets/js/modules/tagmanager/datastore/accounts.js
+++ b/assets/js/modules/tagmanager/datastore/accounts.js
@@ -141,7 +141,7 @@ export const baseReducer = ( state, { type } ) => {
 		}
 
 		default: {
-			return { ...state };
+			return state;
 		}
 	}
 };

--- a/assets/js/modules/tagmanager/datastore/settings.js
+++ b/assets/js/modules/tagmanager/datastore/settings.js
@@ -141,7 +141,7 @@ export const reducer = ( state, { type } ) => {
 		}
 
 		default:
-			return { ...state };
+			return state;
 	}
 };
 


### PR DESCRIPTION
## Summary

Addresses issue #2052

## Relevant technical choices

* Primarily replaces `return { ...state }` with `return state`
* Updated a few other similar cases to remove `{ ...state }` usage
* Surfaced another issue with store registration
* Added a test to automatically check all stores registered on the test registry to provide comprehensive future-proof coverage

## Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
