### PR TITLE
Filter modules to be shown in notifications.

### DIFF
--- a/assets/js/components/modules-list.js
+++ b/assets/js/components/modules-list.js
@@ -81,12 +81,15 @@ class ModulesList extends Component {
 		const { moduleSlugs } = this.props;
 		const modulesData = getModulesData();
 
-		// Filter out internal modules and specific ones via the moduleSlugs prop.
-		const modules = Object.values( modulesData ).filter(
-			( module ) =>
-				! module.internal &&
-				( Array.isArray( moduleSlugs ) && moduleSlugs.length > 0 ? moduleSlugs.includes( module.slug ) : true )
-		);
+		// Filter specific modules
+		const moduleObjects = Array.isArray( moduleSlugs ) && moduleSlugs.length
+			? moduleSlugs
+				.filter( ( slug ) => modulesData.hasOwnProperty( slug ) )
+				.reduce( ( acc, slug ) => ( { ...acc, [ slug ]: modulesData[ slug ] } ), {} )
+			: modulesData;
+
+		// Filter out internal modules.
+		const modules = Object.values( moduleObjects ).filter( ( module ) => ! module.internal );
 
 		// Map of slug => name for every module that is active and completely set up.
 		const completedModuleNames = modules

--- a/assets/js/components/modules-list.js
+++ b/assets/js/components/modules-list.js
@@ -78,10 +78,15 @@ class ModulesList extends Component {
 	}
 
 	render() {
+		const { moduleSlugs } = this.props;
 		const modulesData = getModulesData();
 
-		// Filter out internal modules.
-		const modules = Object.values( modulesData ).filter( ( module ) => ! module.internal );
+		// Filter out internal modules and specific ones via the moduleSlugs prop.
+		const modules = Object.values( modulesData ).filter(
+			( module ) =>
+				! module.internal &&
+				( Array.isArray( moduleSlugs ) && moduleSlugs.length > 0 ? moduleSlugs.includes( module.slug ) : true )
+		);
 
 		// Map of slug => name for every module that is active and completely set up.
 		const completedModuleNames = modules

--- a/assets/js/components/notifications/dashboard-setup-alerts.js
+++ b/assets/js/components/notifications/dashboard-setup-alerts.js
@@ -90,7 +90,9 @@ class DashboardSetupAlerts extends Component {
 							anchorLink={ 'pagespeed-insights' === slug ? '#googlesitekit-pagespeed-header' : '' }
 							anchorLinkLabel={ 'pagespeed-insights' === slug ? __( 'Jump to the bottom of the dashboard to see how fast your home page is.', 'google-site-kit' ) : '' }
 						>
-							<ModulesList />
+							<ModulesList
+								moduleSlugs={ [ 'search-console', 'adsense', 'analytics', 'pagespeed-insights' ] }
+							/>
 						</Notification>
 					</Fragment>
 				);


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #2025 

## Relevant technical choices
Adds a new moduleSlugs prop which is an array of module slugs which will be displayed in notifications. If moduleSlugs is undefined, all the modules will be displayed.

<!-- Please describe your changes. -->

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
