### PR TITLE
Bug/2013 popular keywords loading state

### DIFF
--- a/assets/js/modules/search-console/components/dashboard/LegacyDashboardWidgetPopularKeywordsTable.js
+++ b/assets/js/modules/search-console/components/dashboard/LegacyDashboardWidgetPopularKeywordsTable.js
@@ -120,7 +120,11 @@ export default withData(
 			context: [ 'Dashboard' ],
 		},
 	],
-	<PreviewTable padding />,
+	<div className="mdc-layout-grid__cell mdc-layout-grid__cell--span-6-desktop mdc-layout-grid__cell--span-4-tablet">
+		<Layout className="googlesitekit-popular-content" fill>
+			<PreviewTable padding />
+		</Layout>
+	</div>,
 	{
 		inGrid: true,
 		createGrid: true,


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #2013

## Relevant technical choices

Updated only legacy widget because new ones are already fixed.

## Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
