### PR TITLE
Add get_canonical_home_url() function to Context.

### DIFF
--- a/includes/Context.php
+++ b/includes/Context.php
@@ -166,6 +166,19 @@ class Context {
 	}
 
 	/**
+	 * Gets the cannonical "home" URL.
+	 *
+	 * Returns the value from the `"googlesitekit_canonical_home_url"` filter.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @return string Cannonical home URL.
+	 */
+	public function get_canonical_home_url() {
+		return apply_filters( 'googlesitekit_canonical_home_url', home_url() );
+	}
+
+	/**
 	 * Gets the site URL of the reference site to use for stats.
 	 *
 	 * @since 1.0.0
@@ -218,7 +231,7 @@ class Context {
 		// Ensure local URL is used for lookup.
 		$url = str_replace(
 			$this->get_reference_site_url(),
-			untrailingslashit( home_url() ),
+			untrailingslashit( $this->get_canonical_home_url() ),
 			$url
 		);
 
@@ -411,7 +424,7 @@ class Context {
 	 * @return string URL that starts with the reference site URL.
 	 */
 	private function filter_reference_url( $url = '' ) {
-		$site_url = untrailingslashit( home_url() );
+		$site_url = untrailingslashit( $this->get_canonical_home_url() );
 
 		/**
 		 * Filters the reference site URL to use for stats.

--- a/includes/Context.php
+++ b/includes/Context.php
@@ -175,6 +175,17 @@ class Context {
 	 * @return string Cannonical home URL.
 	 */
 	public function get_canonical_home_url() {
+		/**
+		 * Filters the canonical home URL considered by Site Kit.
+		 *
+		 * Typically this is okay to be the unmodified `home_url()`, but certain plugins (e.g. multilingual plugins)
+		 * that dynamically modify that value based on context can use this filter to ensure that the URL considered
+		 * by Site Kit remains stable.
+		 *
+		 * @since n.e.x.t
+		 *
+		 * @param string $home_url The value of `home_url()`.
+		 */
 		return apply_filters( 'googlesitekit_canonical_home_url', home_url() );
 	}
 

--- a/includes/Core/Assets/Assets.php
+++ b/includes/Core/Assets/Assets.php
@@ -650,7 +650,7 @@ final class Assets {
 		$current_user = wp_get_current_user();
 
 		$inline_data = array(
-			'homeURL'          => trailingslashit( home_url() ),
+			'homeURL'          => trailingslashit( $this->context->get_canonical_home_url() ),
 			'referenceSiteURL' => esc_url_raw( trailingslashit( $site_url ) ),
 			'userIDHash'       => md5( $site_url . $current_user->ID ),
 			'adminURL'         => esc_url_raw( trailingslashit( admin_url() ) ),
@@ -755,7 +755,7 @@ final class Assets {
 			'reAuth'           => $input->filter( INPUT_GET, 'reAuth', FILTER_VALIDATE_BOOLEAN ),
 			'ampEnabled'       => (bool) $this->context->get_amp_mode(),
 			'ampMode'          => $this->context->get_amp_mode(),
-			'homeURL'          => home_url(),
+			'homeURL'          => $this->context->get_canonical_home_url(),
 		);
 
 		$current_entity = $this->context->get_reference_entity();

--- a/includes/Core/Authentication/Authentication.php
+++ b/includes/Core/Authentication/Authentication.php
@@ -1019,7 +1019,7 @@ final class Authentication {
 	 * @since 1.17.0
 	 */
 	private function set_connected_proxy_url() {
-		$this->connected_proxy_url->set( home_url() );
+		$this->connected_proxy_url->set( $this->context->get_canonical_home_url() );
 	}
 
 	/**
@@ -1029,7 +1029,7 @@ final class Authentication {
 	 * @since 1.17.0
 	 */
 	private function check_connected_proxy_url() {
-		if ( $this->connected_proxy_url->matches_url( home_url() ) ) {
+		if ( $this->connected_proxy_url->matches_url( $this->context->get_canonical_home_url() ) ) {
 			return;
 		}
 

--- a/includes/Core/Authentication/Clients/OAuth_Client.php
+++ b/includes/Core/Authentication/Clients/OAuth_Client.php
@@ -926,7 +926,7 @@ final class OAuth_Client {
 	 * @return bool
 	 */
 	private function supports_file_verification() {
-		$home_path = wp_parse_url( home_url(), PHP_URL_PATH );
+		$home_path = wp_parse_url( $this->context->get_canonical_home_url(), PHP_URL_PATH );
 
 		return ( ! $home_path || '/' === $home_path );
 	}

--- a/includes/Core/Authentication/Google_Proxy.php
+++ b/includes/Core/Authentication/Google_Proxy.php
@@ -85,7 +85,7 @@ class Google_Proxy {
 	public function get_site_fields() {
 		return array(
 			'name'                   => wp_specialchars_decode( get_bloginfo( 'name' ) ),
-			'url'                    => home_url(),
+			'url'                    => $this->context->get_canonical_home_url(),
 			'redirect_uri'           => add_query_arg( 'oauth2callback', 1, admin_url( 'index.php' ) ),
 			'action_uri'             => admin_url( 'index.php' ),
 			'return_uri'             => $this->context->admin_url( 'splash' ),

--- a/includes/Modules/Analytics.php
+++ b/includes/Modules/Analytics.php
@@ -1544,7 +1544,7 @@ final class Analytics extends Module
 	 * @return string
 	 */
 	private function get_home_domain() {
-		return wp_parse_url( home_url(), PHP_URL_HOST );
+		return wp_parse_url( $this->context->get_canonical_home_url(), PHP_URL_HOST );
 	}
 
 	/**

--- a/tests/phpunit/integration/ContextTest.php
+++ b/tests/phpunit/integration/ContextTest.php
@@ -127,10 +127,36 @@ class ContextTest extends TestCase {
 		$this->assertEquals( $context->is_network_active(), $context->is_network_mode() );
 	}
 
-	public function test_get_reference_site_url() {
+	public function test_get_cannonical_home_url() {
 		$context = new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE );
 
 		$home_url = home_url();
+
+		// By default, the cannonical home URL should match `home_url()`.
+		$this->assertEquals( $home_url, $context->get_canonical_home_url() );
+
+		$url_filter = function () {
+			return 'https://test.com';
+		};
+
+		// Make sure that the filter is applied.
+		add_filter( 'googlesitekit_canonical_home_url', $url_filter );
+		$this->assertEquals( 'https://test.com', $context->get_canonical_home_url() );
+		remove_filter( 'googlesitekit_canonical_home_url', $url_filter );
+
+		$trailing_slash_url_filter = function () {
+			return 'https://test.com/';
+		};
+
+		// It returns a URL with a trailing slash, if the filter sets one.
+		add_filter( 'googlesitekit_canonical_home_url', $trailing_slash_url_filter );
+		$this->assertEquals( 'https://test.com/', $context->get_canonical_home_url() );
+	}
+
+	public function test_get_reference_site_url() {
+		$context = new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE );
+
+		$home_url = $context->get_canonical_home_url();
 
 		// By default, the reference site_url uses the home_url
 		$this->assertEquals( $home_url, $context->get_reference_site_url() );


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #2131.

## Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
