### PR TITLE
Add line break to reset message.

### DIFF
--- a/assets/js/components/reset-button.js
+++ b/assets/js/components/reset-button.js
@@ -28,6 +28,7 @@ import { addQueryArgs } from '@wordpress/url';
  */
 import {
 	clearWebStorage,
+	sanitizeHTML,
 } from '../util';
 import data, { TYPE_CORE } from './data';
 import Dialog from './dialog';
@@ -88,6 +89,7 @@ export default class ResetButton extends Component {
 			dialogActive,
 		} = this.state;
 
+		const subtitle = __( `Resetting will disconnect all users and remove all Site Kit settings and data within WordPress. <br />You and any other users who wish to use Site Kit will need to reconnect to restore access.`, 'google-site-kit' );
 		return (
 			<Fragment>
 				<Link
@@ -103,7 +105,11 @@ export default class ResetButton extends Component {
 						handleConfirm={ this.handleUnlinkConfirm }
 						handleDialog={ this.handleDialog }
 						title={ __( 'Reset Site Kit', 'google-site-kit' ) }
-						subtitle={ __( 'Resetting will disconnect all users and remove all Site Kit settings and data within WordPress. You and any other users who wish to use Site Kit will need to reconnect to restore access.', 'google-site-kit' ) }
+						subtitle={ (
+							<span dangerouslySetInnerHTML={ sanitizeHTML( subtitle, {
+								ALLOWED_TAGS: [ 'br' ],
+							} ) } />
+						) }
 						confirmButton={ __( 'Reset', 'google-site-kit' ) }
 						provides={ [] }
 						danger


### PR DESCRIPTION
## Summary

Addresses issue #1825 

## Relevant technical choices
Adds a line break to the reset message.

## Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
