### PR TITLE
Bug/1541 plugin menu order

### DIFF
--- a/includes/Core/Admin/Screens.php
+++ b/includes/Core/Admin/Screens.php
@@ -154,12 +154,20 @@ final class Screens {
 			function( array $menu_order ) {
 				// Move the Site Kit dashboard menu item to be one after the index.php item if it exists.
 				$dashboard_index = array_search( 'index.php', $menu_order, true );
-				$sitekit_index   = array_search( self::PREFIX . 'dashboard', $menu_order, true );
+
+				$sitekit_index = false;
+				foreach ( $menu_order as $key => $value ) {
+					if ( substr( $value, 0, strlen( self::PREFIX ) ) === self::PREFIX ) {
+						$sitekit_index = $key;
+						$sitekit_value = $value;
+					}
+				}
+
 				if ( false === $dashboard_index || false === $sitekit_index ) {
 					return $menu_order;
 				}
 				unset( $menu_order[ $sitekit_index ] );
-				array_splice( $menu_order, $dashboard_index + 1, 0, self::PREFIX . 'dashboard' );
+				array_splice( $menu_order, $dashboard_index + 1, 0, $sitekit_value );
 				return $menu_order;
 			}
 		);

--- a/includes/Core/Admin/Screens.php
+++ b/includes/Core/Admin/Screens.php
@@ -152,14 +152,15 @@ final class Screens {
 		add_filter(
 			'menu_order',
 			function( array $menu_order ) {
-				$new_order = array();
-				foreach ( $menu_order as $index => $item ) {
-					if ( 'index.php' === $item || 0 === strpos( $item, self::PREFIX ) ) {
-						$new_order[] = $item;
-						unset( $menu_order[ $index ] );
-					}
+				// Move the sitekit-dashboard menu item to be one after the index.php item if it exists.
+				$dashboard_index = array_search( 'index.php', $menu_order, true );
+				$sitekit_index   = array_search( self::PREFIX . 'dashboard', $menu_order, true );
+				if ( false === $dashboard_index || false === $sitekit_index ) {
+					return $menu_order;
 				}
-				return array_values( array_merge( $new_order, $menu_order ) );
+				unset( $menu_order[ $sitekit_index ] );
+				array_splice( $menu_order, ++$dashboard_index, 0, self::PREFIX . 'dashboard' );
+				return $menu_order;
 			}
 		);
 	}

--- a/includes/Core/Admin/Screens.php
+++ b/includes/Core/Admin/Screens.php
@@ -152,14 +152,14 @@ final class Screens {
 		add_filter(
 			'menu_order',
 			function( array $menu_order ) {
-				// Move the sitekit-dashboard menu item to be one after the index.php item if it exists.
+				// Move the Site Kit dashboard menu item to be one after the index.php item if it exists.
 				$dashboard_index = array_search( 'index.php', $menu_order, true );
 				$sitekit_index   = array_search( self::PREFIX . 'dashboard', $menu_order, true );
 				if ( false === $dashboard_index || false === $sitekit_index ) {
 					return $menu_order;
 				}
 				unset( $menu_order[ $sitekit_index ] );
-				array_splice( $menu_order, ++$dashboard_index, 0, self::PREFIX . 'dashboard' );
+				array_splice( $menu_order, $dashboard_index + 1, 0, self::PREFIX . 'dashboard' );
 				return $menu_order;
 			}
 		);

--- a/includes/Core/Admin/Screens.php
+++ b/includes/Core/Admin/Screens.php
@@ -157,9 +157,10 @@ final class Screens {
 
 				$sitekit_index = false;
 				foreach ( $menu_order as $key => $value ) {
-					if ( substr( $value, 0, strlen( self::PREFIX ) ) === self::PREFIX ) {
+					if ( strpos( $value, self::PREFIX ) === 0 ) {
 						$sitekit_index = $key;
 						$sitekit_value = $value;
+						break;
 					}
 				}
 

--- a/tests/phpunit/integration/Core/Admin/ScreensTest.php
+++ b/tests/phpunit/integration/Core/Admin/ScreensTest.php
@@ -102,8 +102,7 @@ class ScreensTest extends TestCase {
 
 	public function menu_order_provider() {
 		return array(
-			// Typical plugin scenario
-			array(
+			'typical plugin scenario'             => array(
 				array(
 					'index.php',
 					'third-party-plugin',
@@ -119,8 +118,7 @@ class ScreensTest extends TestCase {
 					'options-general.php',
 				),
 			),
-			// Hosting provider has a custom menu item prior to the Dashboard menu item
-			array(
+			'custom menu item before Dashboard'   => array(
 				array(
 					'third-party-host',
 					'index.php',
@@ -138,8 +136,7 @@ class ScreensTest extends TestCase {
 					'options-general.php',
 				),
 			),
-			// For some reason our plugin is above the Dashboard
-			array(
+			'edge case: dashboard after Site Kit' => array(
 				array(
 					'googlesitekit-dashboard',
 					'third-party-plugin',

--- a/tests/phpunit/integration/Core/Admin/ScreensTest.php
+++ b/tests/phpunit/integration/Core/Admin/ScreensTest.php
@@ -100,7 +100,7 @@ class ScreensTest extends TestCase {
 	}
 
 
-	public function menu_order_provider() {
+	public function data_menu_order() {
 		return array(
 			'typical plugin scenario'             => array(
 				array(
@@ -113,6 +113,22 @@ class ScreensTest extends TestCase {
 				array(
 					'index.php',
 					'googlesitekit-dashboard',
+					'third-party-plugin',
+					'edit.php',
+					'options-general.php',
+				),
+			),
+			'different plugin slug'               => array(
+				array(
+					'index.php',
+					'third-party-plugin',
+					'edit.php',
+					'options-general.php',
+					'googlesitekit-dashboard-splash',
+				),
+				array(
+					'index.php',
+					'googlesitekit-dashboard-splash',
 					'third-party-plugin',
 					'edit.php',
 					'options-general.php',
@@ -156,7 +172,7 @@ class ScreensTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider menu_order_provider
+	 * @dataProvider data_menu_order
 	 */
 	public function test_menu_order( $given_menu_order, $expected_order ) {
 		$this->screens->register();

--- a/tests/phpunit/integration/Core/Admin/ScreensTest.php
+++ b/tests/phpunit/integration/Core/Admin/ScreensTest.php
@@ -99,46 +99,76 @@ class ScreensTest extends TestCase {
 		$this->assertNotEmpty( ob_get_clean() );
 	}
 
-	public function test_menu_order() {
-		$menu_order = array(
-			'index.php',
-			'third-party-plugin',
-			'edit.php',
-			'options-general.php',
-			'googlesitekit-dashboard',
-		);
 
-		$overridden_menu_order = array_merge(
+	public function menu_order() {
+		return array(
+			// Typical plugin scenario
 			array(
-				'third-party-host',
+				array(
+					'index.php',
+					'third-party-plugin',
+					'edit.php',
+					'options-general.php',
+					'googlesitekit-dashboard',
+				),
+				array(
+					'index.php',
+					'googlesitekit-dashboard',
+					'third-party-plugin',
+					'edit.php',
+					'options-general.php',
+				),
 			),
-			$menu_order
+			// Hosting provider has a custom menu item prior to the Dashboard menu item
+			array(
+				array(
+					'third-party-host',
+					'index.php',
+					'third-party-plugin',
+					'edit.php',
+					'options-general.php',
+					'googlesitekit-dashboard',
+				),
+				array(
+					'third-party-host',
+					'index.php',
+					'googlesitekit-dashboard',
+					'third-party-plugin',
+					'edit.php',
+					'options-general.php',
+				),
+			),
+			// For some reason our plugin is above the Dashboard
+			array(
+				array(
+					'googlesitekit-dashboard',
+					'third-party-plugin',
+					'index.php',
+					'edit.php',
+					'options-general.php',
+				),
+				array(
+					'third-party-plugin',
+					'index.php',
+					'googlesitekit-dashboard',
+					'edit.php',
+					'options-general.php',
+				),
+			),
 		);
+	}
 
+	/**
+	 * @dataProvider menu_order
+	 */
+	public function test_menu_order( $given_menu_order, $expected_order ) {
 		$this->screens->register();
 
 		// Imitate WordPress core running these filters.
 		if ( apply_filters( 'custom_menu_order', false ) ) {
-			$menu_order            = apply_filters( 'menu_order', $menu_order );
-			$overridden_menu_order = apply_filters( 'menu_order', $overridden_menu_order );
+			$menu_order = apply_filters( 'menu_order', $given_menu_order );
 		}
 
-		$expected_order = array(
-			'index.php',
-			'googlesitekit-dashboard',
-			'third-party-plugin',
-			'edit.php',
-			'options-general.php',
-		);
-
-		$overridden_expected_order = array_merge(
-			array(
-				'third-party-host',
-			),
-			$expected_order
-		);
-
 		$this->assertEquals( $expected_order, $menu_order );
-		$this->assertEquals( $overridden_expected_order, $overridden_menu_order );
 	}
 }

--- a/tests/phpunit/integration/Core/Admin/ScreensTest.php
+++ b/tests/phpunit/integration/Core/Admin/ScreensTest.php
@@ -100,7 +100,7 @@ class ScreensTest extends TestCase {
 	}
 
 
-	public function menu_order() {
+	public function menu_order_provider() {
 		return array(
 			// Typical plugin scenario
 			array(
@@ -159,7 +159,7 @@ class ScreensTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider menu_order
+	 * @dataProvider menu_order_provider
 	 */
 	public function test_menu_order( $given_menu_order, $expected_order ) {
 		$this->screens->register();

--- a/tests/phpunit/integration/Core/Admin/ScreensTest.php
+++ b/tests/phpunit/integration/Core/Admin/ScreensTest.php
@@ -108,11 +108,19 @@ class ScreensTest extends TestCase {
 			'googlesitekit-dashboard',
 		);
 
+		$overridden_menu_order = array_merge(
+			array(
+				'third-party-host',
+			),
+			$menu_order
+		);
+
 		$this->screens->register();
 
 		// Imitate WordPress core running these filters.
 		if ( apply_filters( 'custom_menu_order', false ) ) {
-			$menu_order = apply_filters( 'menu_order', $menu_order );
+			$menu_order            = apply_filters( 'menu_order', $menu_order );
+			$overridden_menu_order = apply_filters( 'menu_order', $overridden_menu_order );
 		}
 
 		$expected_order = array(
@@ -123,6 +131,14 @@ class ScreensTest extends TestCase {
 			'options-general.php',
 		);
 
+		$overridden_expected_order = array_merge(
+			array(
+				'third-party-host',
+			),
+			$expected_order
+		);
+
 		$this->assertEquals( $expected_order, $menu_order );
+		$this->assertEquals( $overridden_expected_order, $overridden_menu_order );
 	}
 }


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #1541 

## Relevant technical choices


## Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
