### PR TITLE
Update Backstop to wait for webfonts and images to load

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -3,14 +3,19 @@
 	  padding: 50px;
   }
 </style>
+<script src="https://unpkg.com/imagesloaded@4/imagesloaded.pkgd.min.js"></script>
 <script>
-
 	WebFontConfig = {
-		google: { families: ['Google+Sans:300,300i,400,400i,500,500i,700,700i','Roboto:300,300i,400,400i,500,500i,700,700i'] },
-		active: function() {
-			console.log( 'backstopjs_ready' );
+		google: {
+			families: [
+				'Google+Sans:300,300i,400,400i,500,500i,700,700i',
+				'Roboto:300,300i,400,400i,500,500i,700,700i'
+			]
 		},
 	};
+	const webFontsLoaded = new Promise( ( resolve ) => {
+		WebFontConfig.active = resolve;
+	} );
 
 	( function() {
 		let wf = document.createElement( 'script' );
@@ -20,4 +25,19 @@
 		let s = document.getElementsByTagName( 'script' )[0];
 		s.parentNode.insertBefore( wf, s );
 	} )();
+
+	const allImagesLoaded = new Promise( ( resolve ) => {
+		// Wait for the document to completely finish loading before checking for images.
+		window.addEventListener( 'load', () => {
+			imagesLoaded( '.googlesitekit-plugin-preview', { background: true }, resolve );
+		} );
+	} );
+
+	Promise.all( [
+		webFontsLoaded,
+		allImagesLoaded,
+	] ).then( () => {
+		// Signal Backstop that the environment is ready to go.
+		console.log( 'backstopjs_ready' );
+	} );
 </script>


### PR DESCRIPTION
## Summary

Addresses issue #2172 

* I opened this after having VRT fail 3 times in a row on an issue that didn't affect VRT at all.
* I've triggered the VRT job here to run and re-run multiple times, which has so far been successful every time

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
