### PR TITLE
Rollback Backstop to v4.4.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12133,6 +12133,16 @@
         "lodash": "^4.17.14"
       }
     },
+    "async-chain-proxy": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/async-chain-proxy/-/async-chain-proxy-0.1.6.tgz",
+      "integrity": "sha512-UeyYGtkMwxT9PRItz7AcIO2I/1TnjhIkq7DySLQJcdkHWCNYwZL8DZNpX7dh7tBdjnWYokjaBV771e5QVWpzEg==",
+      "dev": true,
+      "requires": {
+        "babel-polyfill": "^6.23.0",
+        "babel-runtime": "^6.23.0"
+      }
+    },
     "async-done": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/async-done/-/async-done-1.3.2.tgz",
@@ -13020,16 +13030,17 @@
       }
     },
     "backstopjs": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/backstopjs/-/backstopjs-5.0.6.tgz",
-      "integrity": "sha512-YNBiWDzgBqxW8UInxYIQlcdp0NQqJr2AeQ0JhTSL3p4DX+fZ7AVF60CX+NuJYekLN5gwGHS8YGgJtwGhQOTEpA==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/backstopjs/-/backstopjs-4.4.2.tgz",
+      "integrity": "sha512-O40QnbwYE0ynjeT0ZgpPk9Mug2XEidQouVdefnz3sdtp/tbMpN1Wu1ESK+pklcU8cqljnUa++0V6X0IdxQMcCA==",
       "dev": true,
       "requires": {
         "chalk": "^1.1.3",
+        "chromy": "0.5.11",
         "diverged": "^0.1.3",
         "fs-extra": "^0.30.0",
         "jump.js": "^1.0.2",
-        "junit-report-builder": "^1.3.3",
+        "junit-report-builder": "^1.3.1",
         "lodash": "^4.17.11",
         "merge-img": "^2.1.3",
         "minimist": "^1.2.0",
@@ -13040,18 +13051,12 @@
         "p-map": "^1.1.1",
         "path": "^0.12.7",
         "portfinder": "^1.0.17",
-        "puppeteer": "^2.0.0",
+        "puppeteer": "^1.15.0",
         "resolve": "^1.11.1",
         "super-simple-web-server": "^1.1.2",
         "temp": "^0.8.3"
       },
       "dependencies": {
-        "agent-base": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-5.1.1.tgz",
-          "integrity": "sha512-TMeqbNl2fMW0nMjTEPOwe3J/PRFP4vqeoNuQMG0HlMrtm5QxKqdvAkZ1pRBQ/ulIyDD5Yq0nJ7YbdD8ey0TO3g==",
-          "dev": true
-        },
         "ansi-styles": {
           "version": "2.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
@@ -13069,15 +13074,6 @@
             "has-ansi": "^2.0.0",
             "strip-ansi": "^3.0.0",
             "supports-color": "^2.0.0"
-          }
-        },
-        "debug": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
-          "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
-          "dev": true,
-          "requires": {
-            "ms": "2.1.2"
           }
         },
         "fs-extra": {
@@ -13107,47 +13103,10 @@
             "path-is-absolute": "^1.0.0"
           }
         },
-        "https-proxy-agent": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-4.0.0.tgz",
-          "integrity": "sha512-zoDhWrkR3of1l9QAL8/scJZyLu8j/gBkcwcaQOZh7Gyh/+uJQzGVETdgT30akuwkpL8HTRfssqI3BZuV18teDg==",
-          "dev": true,
-          "requires": {
-            "agent-base": "5",
-            "debug": "4"
-          }
-        },
-        "mime": {
-          "version": "2.4.6",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.6.tgz",
-          "integrity": "sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA==",
-          "dev": true
-        },
-        "mime-db": {
-          "version": "1.44.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
-          "integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg==",
-          "dev": true
-        },
-        "mime-types": {
-          "version": "2.1.27",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.27.tgz",
-          "integrity": "sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==",
-          "dev": true,
-          "requires": {
-            "mime-db": "1.44.0"
-          }
-        },
         "minimist": {
           "version": "1.2.5",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
           "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-          "dev": true
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
         },
         "object-hash": {
@@ -13161,24 +13120,6 @@
           "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
           "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
           "dev": true
-        },
-        "puppeteer": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-2.1.1.tgz",
-          "integrity": "sha512-LWzaDVQkk1EPiuYeTOj+CZRIjda4k2s5w4MK4xoH2+kgWV/SDlkYHmxatDdtYrciHUKSXTsGgPgPP8ILVdBsxg==",
-          "dev": true,
-          "requires": {
-            "@types/mime-types": "^2.1.0",
-            "debug": "^4.1.0",
-            "extract-zip": "^1.6.6",
-            "https-proxy-agent": "^4.0.0",
-            "mime": "^2.0.3",
-            "mime-types": "^2.1.25",
-            "progress": "^2.0.1",
-            "proxy-from-env": "^1.0.0",
-            "rimraf": "^2.6.1",
-            "ws": "^6.1.0"
-          }
         },
         "resolve": {
           "version": "1.17.0",
@@ -13649,9 +13590,9 @@
       "dev": true
     },
     "bmp-js": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/bmp-js/-/bmp-js-0.0.1.tgz",
-      "integrity": "sha1-WtAUcJnROp84qnuZrx1ueGZu038=",
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/bmp-js/-/bmp-js-0.0.3.tgz",
+      "integrity": "sha1-ZBE+nHzxICs3btYHvzBibr5XsYo=",
       "dev": true
     },
     "bn.js": {
@@ -14532,12 +14473,101 @@
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",
       "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g=="
     },
+    "chrome-launcher": {
+      "version": "0.10.7",
+      "resolved": "https://registry.npmjs.org/chrome-launcher/-/chrome-launcher-0.10.7.tgz",
+      "integrity": "sha512-IoQLp64s2n8OQuvKZwt77CscVj3UlV2Dj7yZtd1EBMld9mSdGcsGy9fN5hd/r4vJuWZR09it78n1+A17gB+AIQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "is-wsl": "^1.1.0",
+        "lighthouse-logger": "^1.0.0",
+        "mkdirp": "0.5.1",
+        "rimraf": "^2.6.1"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.1.6",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
+      }
+    },
+    "chrome-remote-interface": {
+      "version": "0.25.7",
+      "resolved": "https://registry.npmjs.org/chrome-remote-interface/-/chrome-remote-interface-0.25.7.tgz",
+      "integrity": "sha512-6zI6LbR2IiGmduFZededaerEr9hHXabxT/L+fRrdq65a0CfyLMzpq0BKuZiqN0Upqcacsb6q2POj7fmobwBsEA==",
+      "dev": true,
+      "requires": {
+        "commander": "2.11.x",
+        "ws": "3.3.x"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.11.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+          "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+          "dev": true
+        },
+        "ws": {
+          "version": "3.3.3",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
+          "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
+          "dev": true,
+          "requires": {
+            "async-limiter": "~1.0.0",
+            "safe-buffer": "~5.1.0",
+            "ultron": "~1.1.0"
+          }
+        }
+      }
+    },
     "chrome-trace-event": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.2.tgz",
       "integrity": "sha512-9e/zx1jw7B4CO+c/RXoCsfg/x1AfUBioy4owYH0bJprEYAx5hRFLRhWBqHAG57D0ZM4H7vxbP7bPe0VwhQRYDQ==",
       "requires": {
         "tslib": "^1.9.0"
+      }
+    },
+    "chromy": {
+      "version": "0.5.11",
+      "resolved": "https://registry.npmjs.org/chromy/-/chromy-0.5.11.tgz",
+      "integrity": "sha512-SBz5/xPYgeQiwFGMixPNQcbgnzsRHGCJnZKNJ5S0SmauSUY77/mqA8NjotQa12SZ3tZy0NX2gyGP41BAUWI6Rg==",
+      "dev": true,
+      "requires": {
+        "async-chain-proxy": "^0.1.5",
+        "babel-runtime": "^6.26.0",
+        "chrome-launcher": "^0.10.2",
+        "chrome-remote-interface": "^0.25.5",
+        "jimp": "^0.2.28",
+        "uuid": "^3.2.1"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+          "dev": true
+        }
       }
     },
     "ci-env": {
@@ -25382,19 +25412,20 @@
       }
     },
     "jimp": {
-      "version": "0.2.27",
-      "resolved": "https://registry.npmjs.org/jimp/-/jimp-0.2.27.tgz",
-      "integrity": "sha1-Qe9Qgti2MgHVR0fgT+i8rLryVHQ=",
+      "version": "0.2.28",
+      "resolved": "https://registry.npmjs.org/jimp/-/jimp-0.2.28.tgz",
+      "integrity": "sha1-3VKak3GQ9ClXp5N9Gsw6d2KZbqI=",
       "dev": true,
       "requires": {
         "bignumber.js": "^2.1.0",
-        "bmp-js": "0.0.1",
+        "bmp-js": "0.0.3",
         "es6-promise": "^3.0.2",
         "exif-parser": "^0.1.9",
         "file-type": "^3.1.0",
         "jpeg-js": "^0.2.0",
         "load-bmfont": "^1.2.3",
         "mime": "^1.3.4",
+        "mkdirp": "0.5.1",
         "pixelmatch": "^4.0.0",
         "pngjs": "^3.0.0",
         "read-chunk": "^1.0.1",
@@ -25729,6 +25760,14 @@
         "lodash": "^4.17.15",
         "mkdirp": "^0.5.0",
         "xmlbuilder": "^10.0.0"
+      },
+      "dependencies": {
+        "xmlbuilder": {
+          "version": "10.1.1",
+          "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-10.1.1.tgz",
+          "integrity": "sha512-OyzrcFLL/nb6fMGHbiRDuPup9ljBycsdCypwuyg5AAHvyWzGfChJpCXMG88AGTIMFhGZ9RccFN1e6lhg3hkwKg==",
+          "dev": true
+        }
       }
     },
     "junk": {
@@ -25907,6 +25946,27 @@
             "is-glob": "^4.0.0",
             "micromatch": "^3.0.4",
             "resolve-dir": "^1.0.1"
+          }
+        }
+      }
+    },
+    "lighthouse-logger": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/lighthouse-logger/-/lighthouse-logger-1.2.0.tgz",
+      "integrity": "sha512-wzUvdIeJZhRsG6gpZfmSCfysaxNEr43i+QT+Hie94wvHDKFLi4n7C2GqZ4sTC+PH5b5iktmXJvU87rWvhP3lHw==",
+      "dev": true,
+      "requires": {
+        "debug": "^2.6.8",
+        "marky": "^1.2.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
           }
         }
       }
@@ -27043,6 +27103,12 @@
       "resolved": "https://registry.npmjs.org/markdownlint-rule-helpers/-/markdownlint-rule-helpers-0.6.0.tgz",
       "integrity": "sha512-LiZVAbg9/cqkBHtLNNqHV3xuy4Y2L/KuGU6+ZXqCT9NnCdEkIoxeI5/96t+ExquBY0iHy2CVWxPH16nG1RKQVQ=="
     },
+    "marky": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/marky/-/marky-1.2.1.tgz",
+      "integrity": "sha512-md9k+Gxa3qLH6sUKpeC2CNkJK/Ld+bEz5X96nYwloqphQE0CKCVEKco/6jxEZixinqNdz5RFi/KaCyfbMDMAXQ==",
+      "dev": true
+    },
     "matchdep": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/matchdep/-/matchdep-2.0.0.tgz",
@@ -27315,6 +27381,49 @@
       "requires": {
         "is-plain-obj": "^1.1.0",
         "jimp": "0.2.27"
+      },
+      "dependencies": {
+        "bmp-js": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/bmp-js/-/bmp-js-0.0.1.tgz",
+          "integrity": "sha1-WtAUcJnROp84qnuZrx1ueGZu038=",
+          "dev": true
+        },
+        "es6-promise": {
+          "version": "3.3.1",
+          "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.3.1.tgz",
+          "integrity": "sha1-oIzd6EzNvzTQJ6FFG8kdS80ophM=",
+          "dev": true
+        },
+        "file-type": {
+          "version": "3.9.0",
+          "resolved": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
+          "integrity": "sha1-JXoHg4TR24CHvESdEH1SpSZyuek=",
+          "dev": true
+        },
+        "jimp": {
+          "version": "0.2.27",
+          "resolved": "https://registry.npmjs.org/jimp/-/jimp-0.2.27.tgz",
+          "integrity": "sha1-Qe9Qgti2MgHVR0fgT+i8rLryVHQ=",
+          "dev": true,
+          "requires": {
+            "bignumber.js": "^2.1.0",
+            "bmp-js": "0.0.1",
+            "es6-promise": "^3.0.2",
+            "exif-parser": "^0.1.9",
+            "file-type": "^3.1.0",
+            "jpeg-js": "^0.2.0",
+            "load-bmfont": "^1.2.3",
+            "mime": "^1.3.4",
+            "pixelmatch": "^4.0.0",
+            "pngjs": "^3.0.0",
+            "read-chunk": "^1.0.1",
+            "request": "^2.65.0",
+            "stream-to-buffer": "^0.1.0",
+            "tinycolor2": "^1.1.2",
+            "url-regex": "^3.0.0"
+          }
+        }
       }
     },
     "merge-stream": {
@@ -38625,6 +38734,12 @@
       "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
       "optional": true
     },
+    "ultron": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
+      "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og==",
+      "dev": true
+    },
     "unbzip2-stream": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz",
@@ -40959,20 +41074,12 @@
       "requires": {
         "sax": ">=0.6.0",
         "xmlbuilder": "~11.0.0"
-      },
-      "dependencies": {
-        "xmlbuilder": {
-          "version": "11.0.1",
-          "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
-          "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
-          "dev": true
-        }
       }
     },
     "xmlbuilder": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-10.1.1.tgz",
-      "integrity": "sha512-OyzrcFLL/nb6fMGHbiRDuPup9ljBycsdCypwuyg5AAHvyWzGfChJpCXMG88AGTIMFhGZ9RccFN1e6lhg3hkwKg==",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
       "dev": true
     },
     "xmlchars": {

--- a/package.json
+++ b/package.json
@@ -159,7 +159,7 @@
     "amphtml-validator": "^1.0.31",
     "babel-loader": "^8.1.0",
     "babel-plugin-lodash": "^3.3.4",
-    "backstopjs": "^5.0.6",
+    "backstopjs": "~4.4.0",
     "bundlesize": "^0.18.0",
     "circular-dependency-plugin": "^5.2.0",
     "css-loader": "^3.6.0",


### PR DESCRIPTION
## Summary

Addresses issue #2172 

**This PR is a follow-up to https://github.com/google/site-kit-wp/pull/2173 (merged) which didn't completely address the issue.**

In #1865 we moved VRT to run on GitHub Actions. As part of this work, it was necessary to customize the Docker command that is used to run the tests, due to TTY complications on the Actions platform.

As a result, Backstop was upgraded to the latest version (5.x), however the necessary `dockerCommandTemplate` config argument has been available [since v3.9.6](https://github.com/garris/BackstopJS/commit/db8bdba52bbe7f380b26808d53628a737247fe0d)

After digging into this a bit more on the Backstop issues, I found a few issues of users having similar problems with newer versions of Backstop.
See https://github.com/garris/BackstopJS/issues/1156 (I also saw this locally) 
<details>
<summary>Screenshot</summary>

![image](https://user-images.githubusercontent.com/1621608/96157824-7831df00-0f1b-11eb-9c39-917c898b9aee.png)

</details>

Anecdotally, stability of Backstop JS seems to have become problematic starting around v4.5, hence this PR rolls it back to the latest version which seems to be more stable for most people).

## Relevant technical choices

<!-- Please describe your changes. -->

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
