### PR TITLE
Remove all STORE_NAME from datastore exports to prevent stores being …

### DIFF
--- a/assets/js/components/permissions-modal/index.js
+++ b/assets/js/components/permissions-modal/index.js
@@ -26,7 +26,7 @@ import { useEffect, useCallback } from '@wordpress/element';
  * Internal dependencies
  */
 import Data from 'googlesitekit-data';
-import { STORE_NAME as CORE_USER } from '../../googlesitekit/datastore/user';
+import { STORE_NAME as CORE_USER } from '../../googlesitekit/datastore/user/constants';
 import Dialog from '../dialog';
 import Modal from '../modal';
 import { snapshotAllStores } from '../../googlesitekit/data/create-snapshot-store';

--- a/assets/js/googlesitekit/datastore/forms/index.js
+++ b/assets/js/googlesitekit/datastore/forms/index.js
@@ -25,8 +25,6 @@ import { createSnapshotStore } from '../../data/create-snapshot-store';
 import forms from './forms';
 import { STORE_NAME } from './constants';
 
-export { STORE_NAME };
-
 const store = Data.combineStores(
 	Data.commonStore,
 	forms,

--- a/assets/js/googlesitekit/datastore/site/index.js
+++ b/assets/js/googlesitekit/datastore/site/index.js
@@ -29,8 +29,6 @@ import notifications from './notifications';
 import registryKey from './registry-key';
 import { createErrorStore } from '../../data/create-error-store';
 
-export { STORE_NAME };
-
 const store = Data.combineStores(
 	Data.commonStore,
 	connection,

--- a/assets/js/googlesitekit/datastore/user/index.js
+++ b/assets/js/googlesitekit/datastore/user/index.js
@@ -29,8 +29,6 @@ import permissions from './permissions';
 import userInfo from './user-info';
 import { STORE_NAME } from './constants';
 
-export { STORE_NAME };
-
 const store = Data.combineStores(
 	Data.commonStore,
 	authentication,

--- a/assets/js/googlesitekit/modules/datastore/index.js
+++ b/assets/js/googlesitekit/modules/datastore/index.js
@@ -24,8 +24,6 @@ import modules from './modules';
 import { STORE_NAME } from './constants';
 import { createErrorStore } from '../../data/create-error-store';
 
-export { STORE_NAME };
-
 const store = Data.combineStores(
 	Data.commonStore,
 	modules,

--- a/assets/js/googlesitekit/modules/index.js
+++ b/assets/js/googlesitekit/modules/index.js
@@ -23,9 +23,10 @@
  */
 import Data from 'googlesitekit-data';
 import { createModuleStore } from './create-module-store';
+import { STORE_NAME } from './datastore/constants';
 // This import has a side-effect: it automatically registers the "core/modules"
 // store on `googlesitekit.data`.
-import { STORE_NAME } from './datastore';
+import './datastore';
 
 const Modules = {
 	createModuleStore,

--- a/assets/js/googlesitekit/widgets/components/WidgetContextRenderer.js
+++ b/assets/js/googlesitekit/widgets/components/WidgetContextRenderer.js
@@ -26,7 +26,7 @@ import PropTypes from 'prop-types';
  */
 import Data from 'googlesitekit-data';
 import WidgetAreaRenderer from './WidgetAreaRenderer';
-import { STORE_NAME } from '../datastore';
+import { STORE_NAME } from '../datastore/constants';
 
 const { useSelect } = Data;
 

--- a/assets/js/googlesitekit/widgets/components/WidgetRenderer.js
+++ b/assets/js/googlesitekit/widgets/components/WidgetRenderer.js
@@ -25,7 +25,7 @@ import PropTypes from 'prop-types';
  * Internal dependencies
  */
 import Data from 'googlesitekit-data';
-import { STORE_NAME } from '../datastore';
+import { STORE_NAME } from '../datastore/constants';
 import Widget from './Widget';
 
 const { useSelect } = Data;

--- a/assets/js/googlesitekit/widgets/datastore/index.js
+++ b/assets/js/googlesitekit/widgets/datastore/index.js
@@ -25,8 +25,6 @@ import { STORE_NAME } from './constants';
 import widgets from './widgets';
 import { createErrorStore } from '../../data/create-error-store';
 
-export { STORE_NAME };
-
 const store = Data.combineStores(
 	Data.commonStore,
 	areas,

--- a/assets/js/modules/adsense/components/common/AccountSelect.js
+++ b/assets/js/modules/adsense/components/common/AccountSelect.js
@@ -28,7 +28,7 @@ import { __ } from '@wordpress/i18n';
 import Data from 'googlesitekit-data';
 import { Select, Option } from '../../../../material-components';
 import ProgressBar from '../../../../components/progress-bar';
-import { STORE_NAME } from '../../datastore';
+import { STORE_NAME } from '../../datastore/constants';
 const { useSelect, useDispatch } = Data;
 
 export default function AccountSelect() {

--- a/assets/js/modules/adsense/components/common/AdBlockerWarning.js
+++ b/assets/js/modules/adsense/components/common/AdBlockerWarning.js
@@ -33,7 +33,7 @@ import { __ } from '@wordpress/i18n';
 import Data from 'googlesitekit-data';
 import ErrorIcon from '../../../../../svg/error.svg';
 
-import { STORE_NAME } from '../../datastore';
+import { STORE_NAME } from '../../datastore/constants';
 const { useSelect } = Data;
 
 export default function AdBlockerWarning( { context } ) {

--- a/assets/js/modules/adsense/components/common/SiteSteps.js
+++ b/assets/js/modules/adsense/components/common/SiteSteps.js
@@ -27,7 +27,7 @@ import { __ } from '@wordpress/i18n';
 import Data from 'googlesitekit-data';
 import Link from '../../../../components/link';
 import ProgressBar from '../../../../components/progress-bar';
-import { STORE_NAME } from '../../datastore';
+import { STORE_NAME } from '../../datastore/constants';
 const { useSelect } = Data;
 
 export default function SiteSteps() {

--- a/assets/js/modules/adsense/components/common/UseSnippetSwitch.js
+++ b/assets/js/modules/adsense/components/common/UseSnippetSwitch.js
@@ -34,7 +34,7 @@ import Data from 'googlesitekit-data';
 import Switch from '../../../../components/switch';
 import SettingsNotice from '../../../../components/settings-notice';
 import { trackEvent } from '../../../../util';
-import { STORE_NAME } from '../../datastore';
+import { STORE_NAME } from '../../datastore/constants';
 const { useSelect, useDispatch } = Data;
 
 export default function UseSnippetSwitch( props ) {

--- a/assets/js/modules/adsense/datastore/index.js
+++ b/assets/js/modules/adsense/datastore/index.js
@@ -32,8 +32,6 @@ import adblocker from './adblocker';
 import service from './service';
 import { STORE_NAME } from './constants';
 
-export { STORE_NAME };
-
 const baseModuleStore = Modules.createModuleStore( 'adsense', {
 	storeName: STORE_NAME,
 	settingSlugs: [

--- a/assets/js/modules/analytics/components/common/ProfileNameTextField.js
+++ b/assets/js/modules/analytics/components/common/ProfileNameTextField.js
@@ -26,7 +26,7 @@ import { __, _x } from '@wordpress/i18n';
  * Internal dependencies
  */
 import Data from 'googlesitekit-data';
-import { STORE_NAME as CORE_FORMS } from '../../../../googlesitekit/datastore/forms';
+import { STORE_NAME as CORE_FORMS } from '../../../../googlesitekit/datastore/forms/constants';
 import { TextField, HelperText, Input } from '../../../../material-components';
 import { STORE_NAME, PROFILE_CREATE, FORM_SETUP } from '../../datastore/constants';
 const { useSelect, useDispatch } = Data;

--- a/assets/js/modules/analytics/datastore/index.js
+++ b/assets/js/modules/analytics/datastore/index.js
@@ -33,8 +33,6 @@ import tags from './tags';
 import service from './service';
 import { STORE_NAME } from './constants';
 
-export { STORE_NAME };
-
 const baseModuleStore = Modules.createModuleStore( 'analytics', {
 	storeName: STORE_NAME,
 	settingSlugs: [

--- a/assets/js/modules/analytics/datastore/settings.js
+++ b/assets/js/modules/analytics/datastore/settings.js
@@ -21,7 +21,7 @@
  */
 import API from 'googlesitekit-api';
 import Data from 'googlesitekit-data';
-import { STORE_NAME as CORE_FORMS } from '../../../googlesitekit/datastore/forms';
+import { STORE_NAME as CORE_FORMS } from '../../../googlesitekit/datastore/forms/constants';
 import { STORE_NAME as CORE_MODULES } from '../../../googlesitekit/modules/datastore/constants';
 import { STORE_NAME as MODULES_TAGMANAGER } from '../../tagmanager/datastore/constants';
 import { TYPE_MODULES } from '../../../components/data/constants';

--- a/assets/js/modules/analytics/datastore/settings.test.js
+++ b/assets/js/modules/analytics/datastore/settings.test.js
@@ -21,7 +21,7 @@
  */
 import API from 'googlesitekit-api';
 import { STORE_NAME, FORM_SETUP, ACCOUNT_CREATE, PROPERTY_CREATE, PROFILE_CREATE } from './constants';
-import { STORE_NAME as CORE_FORMS } from '../../../googlesitekit/datastore/forms';
+import { STORE_NAME as CORE_FORMS } from '../../../googlesitekit/datastore/forms/constants';
 import { STORE_NAME as CORE_SITE, AMP_MODE_SECONDARY } from '../../../googlesitekit/datastore/site/constants';
 import { STORE_NAME as CORE_MODULES } from '../../../googlesitekit/modules/datastore/constants';
 import { withActive } from '../../../googlesitekit/modules/datastore/__fixtures__';

--- a/assets/js/modules/optimize/datastore/index.js
+++ b/assets/js/modules/optimize/datastore/index.js
@@ -25,8 +25,6 @@ import { STORE_NAME } from './constants';
 import settings from './settings';
 import service from './service';
 
-export { STORE_NAME };
-
 let baseModuleStore = Modules.createModuleStore( 'optimize', {
 	storeName: STORE_NAME,
 	settingSlugs: [

--- a/assets/js/modules/pagespeed-insights/datastore/index.js
+++ b/assets/js/modules/pagespeed-insights/datastore/index.js
@@ -25,8 +25,6 @@ import report from './report';
 import service from './service';
 import { STORE_NAME } from './constants';
 
-export { STORE_NAME };
-
 const baseModuleStore = Modules.createModuleStore( 'pagespeed-insights', {
 	storeName: STORE_NAME,
 	requiresSetup: false,

--- a/assets/js/modules/pagespeed-insights/datastore/report.test.js
+++ b/assets/js/modules/pagespeed-insights/datastore/report.test.js
@@ -20,7 +20,7 @@
  * Internal dependencies
  */
 import API from 'googlesitekit-api';
-import { STORE_NAME } from './index';
+import { STORE_NAME } from './constants';
 import {
 	createTestRegistry,
 	subscribeUntil,

--- a/assets/js/modules/search-console/datastore/index.js
+++ b/assets/js/modules/search-console/datastore/index.js
@@ -24,7 +24,6 @@ import Modules from 'googlesitekit-modules';
 import { STORE_NAME } from './constants';
 import report from './report';
 import service from './service';
-export { STORE_NAME };
 
 const baseModuleStore = Modules.createModuleStore( 'search-console', {
 	storeName: STORE_NAME,

--- a/assets/js/modules/tagmanager/components/common/AccountCreate.js
+++ b/assets/js/modules/tagmanager/components/common/AccountCreate.js
@@ -31,7 +31,7 @@ import Link from '../../../../components/link';
 import Button from '../../../../components/button';
 import ProgressBar from '../../../../components/progress-bar';
 import { STORE_NAME } from '../../datastore/constants';
-import { STORE_NAME as CORE_USER } from '../../../../googlesitekit/datastore/user';
+import { STORE_NAME as CORE_USER } from '../../../../googlesitekit/datastore/user/constants';
 const { useSelect, useDispatch } = Data;
 
 export default function AccountCreate() {

--- a/assets/js/modules/tagmanager/components/settings/SettingsView.js
+++ b/assets/js/modules/tagmanager/components/settings/SettingsView.js
@@ -27,8 +27,8 @@ import { __ } from '@wordpress/i18n';
  */
 import Data from 'googlesitekit-data';
 import DisplaySetting from '../../../../components/display-setting';
-import { STORE_NAME as CORE_SITE } from '../../../../googlesitekit/datastore/site';
-import { STORE_NAME } from '../../datastore';
+import { STORE_NAME as CORE_SITE } from '../../../../googlesitekit/datastore/site/constants';
+import { STORE_NAME } from '../../datastore/constants';
 import {
 	ExistingTagError,
 	ExistingTagNotice,

--- a/assets/js/modules/tagmanager/datastore/index.js
+++ b/assets/js/modules/tagmanager/datastore/index.js
@@ -30,8 +30,6 @@ import settings from './settings';
 import versions from './versions';
 import service from './service';
 
-export { STORE_NAME };
-
 let baseModuleStore = Modules.createModuleStore( 'tagmanager', {
 	storeName: STORE_NAME,
 	settingSlugs: [

--- a/tests/js/utils.js
+++ b/tests/js/utils.js
@@ -18,7 +18,7 @@ import { STORE_NAME as coreSiteStoreName } from '../../assets/js/googlesitekit/d
 import coreUserStore from '../../assets/js/googlesitekit/datastore/user';
 import { STORE_NAME as coreUserStoreName } from '../../assets/js/googlesitekit/datastore/user/constants';
 import coreFormsStore from '../../assets/js/googlesitekit/datastore/forms';
-import { STORE_NAME as coreFormsStoreName } from '../../assets/js/googlesitekit/datastore/forms/constants'
+import { STORE_NAME as coreFormsStoreName } from '../../assets/js/googlesitekit/datastore/forms/constants';
 import coreModulesStore from '../../assets/js/googlesitekit/modules/datastore';
 import { STORE_NAME as coreModulesStoreName } from '../../assets/js/googlesitekit/modules/datastore/constants';
 import coreWidgetsStore from '../../assets/js/googlesitekit/widgets/datastore';

--- a/tests/js/utils.js
+++ b/tests/js/utils.js
@@ -13,17 +13,28 @@ import { createRegistry, RegistryProvider } from '@wordpress/data';
 /**
  * Internal dependencies
  */
-import coreSiteStore, { STORE_NAME as coreSiteStoreName } from '../../assets/js/googlesitekit/datastore/site';
-import coreUserStore, { STORE_NAME as coreUserStoreName } from '../../assets/js/googlesitekit/datastore/user';
-import coreFormsStore, { STORE_NAME as coreFormsStoreName } from '../../assets/js/googlesitekit/datastore/forms';
-import coreModulesStore, { STORE_NAME as coreModulesStoreName } from '../../assets/js/googlesitekit/modules/datastore';
-import coreWidgetsStore, { STORE_NAME as coreWidgetsStoreName } from '../../assets/js/googlesitekit/widgets/datastore';
-import modulesAdSenseStore, { STORE_NAME as modulesAdSenseStoreName } from '../../assets/js/modules/adsense/datastore';
-import modulesAnalyticsStore, { STORE_NAME as modulesAnalyticsStoreName } from '../../assets/js/modules/analytics/datastore';
-import modulesPageSpeedInsightsStore, { STORE_NAME as modulesPageSpeedInsightsStoreName } from '../../assets/js/modules/pagespeed-insights/datastore';
-import modulesSearchConsoleStore, { STORE_NAME as modulesSearchConsoleStoreName } from '../../assets/js/modules/search-console/datastore';
-import modulesTagManagerStore, { STORE_NAME as modulesTagManagerStoreName } from '../../assets/js/modules/tagmanager/datastore';
-import modulesOptimizeStore, { STORE_NAME as modulesOptimizeStoreName } from '../../assets/js/modules/optimize/datastore';
+import coreSiteStore from '../../assets/js/googlesitekit/datastore/site';
+import { STORE_NAME as coreSiteStoreName } from '../../assets/js/googlesitekit/datastore/site/constants';
+import coreUserStore from '../../assets/js/googlesitekit/datastore/user';
+import { STORE_NAME as coreUserStoreName } from '../../assets/js/googlesitekit/datastore/user/constants';
+import coreFormsStore from '../../assets/js/googlesitekit/datastore/forms';
+import { STORE_NAME as coreFormsStoreName } from '../../assets/js/googlesitekit/datastore/forms/constants'
+import coreModulesStore from '../../assets/js/googlesitekit/modules/datastore';
+import { STORE_NAME as coreModulesStoreName } from '../../assets/js/googlesitekit/modules/datastore/constants';
+import coreWidgetsStore from '../../assets/js/googlesitekit/widgets/datastore';
+import { STORE_NAME as coreWidgetsStoreName } from '../../assets/js/googlesitekit/widgets/datastore/constants';
+import modulesAdSenseStore from '../../assets/js/modules/adsense/datastore';
+import { STORE_NAME as modulesAdSenseStoreName } from '../../assets/js/modules/adsense/datastore/constants';
+import modulesAnalyticsStore from '../../assets/js/modules/analytics/datastore';
+import { STORE_NAME as modulesAnalyticsStoreName } from '../../assets/js/modules/analytics/datastore/constants';
+import modulesPageSpeedInsightsStore from '../../assets/js/modules/pagespeed-insights/datastore';
+import { STORE_NAME as modulesPageSpeedInsightsStoreName } from '../../assets/js/modules/pagespeed-insights/datastore/constants';
+import modulesSearchConsoleStore from '../../assets/js/modules/search-console/datastore';
+import { STORE_NAME as modulesSearchConsoleStoreName } from '../../assets/js/modules/search-console/datastore/constants';
+import modulesTagManagerStore from '../../assets/js/modules/tagmanager/datastore';
+import { STORE_NAME as modulesTagManagerStoreName } from '../../assets/js/modules/tagmanager/datastore/constants';
+import modulesOptimizeStore from '../../assets/js/modules/optimize/datastore';
+import { STORE_NAME as modulesOptimizeStoreName } from '../../assets/js/modules/optimize/datastore/constants';
 import coreModulesFixture from '../../assets/js/googlesitekit/modules/datastore/fixtures.json';
 
 /**

--- a/tests/js/utils.js
+++ b/tests/js/utils.js
@@ -14,27 +14,27 @@ import { createRegistry, RegistryProvider } from '@wordpress/data';
  * Internal dependencies
  */
 import coreSiteStore from '../../assets/js/googlesitekit/datastore/site';
-import { STORE_NAME as coreSiteStoreName } from '../../assets/js/googlesitekit/datastore/site/constants';
+import { STORE_NAME as CORE_SITE } from '../../assets/js/googlesitekit/datastore/site/constants';
 import coreUserStore from '../../assets/js/googlesitekit/datastore/user';
-import { STORE_NAME as coreUserStoreName } from '../../assets/js/googlesitekit/datastore/user/constants';
+import { STORE_NAME as CORE_USER } from '../../assets/js/googlesitekit/datastore/user/constants';
 import coreFormsStore from '../../assets/js/googlesitekit/datastore/forms';
-import { STORE_NAME as coreFormsStoreName } from '../../assets/js/googlesitekit/datastore/forms/constants';
+import { STORE_NAME as CORE_FORMS } from '../../assets/js/googlesitekit/datastore/forms/constants';
 import coreModulesStore from '../../assets/js/googlesitekit/modules/datastore';
-import { STORE_NAME as coreModulesStoreName } from '../../assets/js/googlesitekit/modules/datastore/constants';
+import { STORE_NAME as CORE_MODULES } from '../../assets/js/googlesitekit/modules/datastore/constants';
 import coreWidgetsStore from '../../assets/js/googlesitekit/widgets/datastore';
-import { STORE_NAME as coreWidgetsStoreName } from '../../assets/js/googlesitekit/widgets/datastore/constants';
+import { STORE_NAME as CORE_WIDGETS } from '../../assets/js/googlesitekit/widgets/datastore/constants';
 import modulesAdSenseStore from '../../assets/js/modules/adsense/datastore';
-import { STORE_NAME as modulesAdSenseStoreName } from '../../assets/js/modules/adsense/datastore/constants';
+import { STORE_NAME as MODULES_ADSENSE } from '../../assets/js/modules/adsense/datastore/constants';
 import modulesAnalyticsStore from '../../assets/js/modules/analytics/datastore';
-import { STORE_NAME as modulesAnalyticsStoreName } from '../../assets/js/modules/analytics/datastore/constants';
+import { STORE_NAME as MODULES_ANALYTICS } from '../../assets/js/modules/analytics/datastore/constants';
 import modulesPageSpeedInsightsStore from '../../assets/js/modules/pagespeed-insights/datastore';
-import { STORE_NAME as modulesPageSpeedInsightsStoreName } from '../../assets/js/modules/pagespeed-insights/datastore/constants';
+import { STORE_NAME as MODULES_PAGESPEED_INSIGHTS } from '../../assets/js/modules/pagespeed-insights/datastore/constants';
 import modulesSearchConsoleStore from '../../assets/js/modules/search-console/datastore';
-import { STORE_NAME as modulesSearchConsoleStoreName } from '../../assets/js/modules/search-console/datastore/constants';
+import { STORE_NAME as MODULES_SEARCH_CONSOLE } from '../../assets/js/modules/search-console/datastore/constants';
 import modulesTagManagerStore from '../../assets/js/modules/tagmanager/datastore';
-import { STORE_NAME as modulesTagManagerStoreName } from '../../assets/js/modules/tagmanager/datastore/constants';
+import { STORE_NAME as MODULES_TAGMANAGER } from '../../assets/js/modules/tagmanager/datastore/constants';
 import modulesOptimizeStore from '../../assets/js/modules/optimize/datastore';
-import { STORE_NAME as modulesOptimizeStoreName } from '../../assets/js/modules/optimize/datastore/constants';
+import { STORE_NAME as MODULES_OPTIMIZE } from '../../assets/js/modules/optimize/datastore/constants';
 import coreModulesFixture from '../../assets/js/googlesitekit/modules/datastore/fixtures.json';
 
 /**
@@ -102,7 +102,7 @@ export const provideSiteConnection = ( registry, extraData = {} ) => {
 		ownerID: defaultConnected ? 1 : 0,
 	};
 
-	registry.dispatch( coreSiteStoreName ).receiveGetConnection( {
+	registry.dispatch( CORE_SITE ).receiveGetConnection( {
 		...defaults,
 		...extraData,
 	} );
@@ -129,10 +129,10 @@ export const provideUserAuthentication = ( registry, extraData = {} ) => {
 	};
 
 	const mergedData = { ...defaults, ...extraData };
-	registry.dispatch( coreUserStoreName ).receiveGetAuthentication( mergedData );
+	registry.dispatch( CORE_USER ).receiveGetAuthentication( mergedData );
 
 	// Also set verification info here based on authentication.
-	registry.dispatch( coreUserStoreName ).receiveUserIsVerified( mergedData.authenticated );
+	registry.dispatch( CORE_USER ).receiveUserIsVerified( mergedData.authenticated );
 };
 
 /**
@@ -161,7 +161,7 @@ export const provideSiteInfo = ( registry, extraData = {} ) => {
 		usingProxy: true,
 	};
 
-	registry.dispatch( coreSiteStoreName ).receiveSiteInfo( {
+	registry.dispatch( CORE_SITE ).receiveSiteInfo( {
 		...defaults,
 		...extraData,
 	} );
@@ -184,7 +184,7 @@ export const provideUserInfo = ( registry, extraData = {} ) => {
 		picture: 'https://wapu.us/wp-content/uploads/2017/11/WapuuFinal-100x138.png',
 	};
 
-	registry.dispatch( coreUserStoreName ).receiveUserInfo( {
+	registry.dispatch( CORE_USER ).receiveUserInfo( {
 		...defaults,
 		...extraData,
 	} );
@@ -211,7 +211,7 @@ export const provideModules = ( registry, extraData = [] ) => {
 		return { ...module };
 	} );
 
-	registry.dispatch( coreModulesStoreName ).receiveGetModules( modules );
+	registry.dispatch( CORE_MODULES ).receiveGetModules( modules );
 };
 
 /**
@@ -261,17 +261,17 @@ export const freezeFetch = ( matcher ) => {
  * @param {wp.data.registry} registry Registry to register each store on.
  */
 export const registerAllStoresOn = ( registry ) => {
-	registry.registerStore( coreSiteStoreName, coreSiteStore );
-	registry.registerStore( coreUserStoreName, coreUserStore );
-	registry.registerStore( coreFormsStoreName, coreFormsStore );
-	registry.registerStore( coreModulesStoreName, coreModulesStore );
-	registry.registerStore( coreWidgetsStoreName, coreWidgetsStore );
-	registry.registerStore( modulesAdSenseStoreName, modulesAdSenseStore );
-	registry.registerStore( modulesAnalyticsStoreName, modulesAnalyticsStore );
-	registry.registerStore( modulesPageSpeedInsightsStoreName, modulesPageSpeedInsightsStore );
-	registry.registerStore( modulesSearchConsoleStoreName, modulesSearchConsoleStore );
-	registry.registerStore( modulesTagManagerStoreName, modulesTagManagerStore );
-	registry.registerStore( modulesOptimizeStoreName, modulesOptimizeStore );
+	registry.registerStore( CORE_SITE, coreSiteStore );
+	registry.registerStore( CORE_USER, coreUserStore );
+	registry.registerStore( CORE_FORMS, coreFormsStore );
+	registry.registerStore( CORE_MODULES, coreModulesStore );
+	registry.registerStore( CORE_WIDGETS, coreWidgetsStore );
+	registry.registerStore( MODULES_ADSENSE, modulesAdSenseStore );
+	registry.registerStore( MODULES_ANALYTICS, modulesAnalyticsStore );
+	registry.registerStore( MODULES_PAGESPEED_INSIGHTS, modulesPageSpeedInsightsStore );
+	registry.registerStore( MODULES_SEARCH_CONSOLE, modulesSearchConsoleStore );
+	registry.registerStore( MODULES_TAGMANAGER, modulesTagManagerStore );
+	registry.registerStore( MODULES_OPTIMIZE, modulesOptimizeStore );
 };
 
 const unsubscribes = [];


### PR DESCRIPTION
…registered twice.

## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #2145 

## Relevant technical choices

- Removed all STORE_NAME exports from datastore index files so that stores are not registered twice.
- Updated Jest imports to use updated paths for STORE_NAME

## Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
