### PR TITLE
Enhancement/1878 fix device size icons

### DIFF
--- a/assets/js/components/DeviceSizeTabBar.js
+++ b/assets/js/components/DeviceSizeTabBar.js
@@ -42,12 +42,12 @@ const DeviceSizeTabBar = ( {
 		{
 			slug: 'mobile',
 			label: __( 'Mobile', 'google-site-kit' ),
-			icon: <DeviceSizeMobileIcon />,
+			icon: <DeviceSizeMobileIcon width="15" height="22" />,
 		},
 		{
 			slug: 'desktop',
 			label: __( 'Desktop', 'google-site-kit' ),
-			icon: <DeviceSizeDesktopIcon />,
+			icon: <DeviceSizeDesktopIcon width="23" height="17" />,
 		},
 	],
 } ) => {


### PR DESCRIPTION
## Summary

Addresses issue [#1878](https://github.com/google/site-kit-wp/issues/1878)

## Relevant technical choices

Fixes a bug where device size icons do not show up by adding explicit height and width as these are stripped to allow manual setting.

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
