### PR TITLE
Use correct imports for DATA_STOREs within stories.

### DIFF
--- a/stories/module-adsense-components.stories.js
+++ b/stories/module-adsense-components.stories.js
@@ -22,8 +22,8 @@
 import { generateReportBasedWidgetStories } from './utils/generate-widget-stories';
 import DashboardSummaryWidget from '../assets/js/modules/adsense/components/dashboard/DashboardSummaryWidget';
 import DashboardTopEarningPagesWidget from '../assets/js/modules/adsense/components/dashboard/DashboardTopEarningPagesWidget';
-import { STORE_NAME } from '../assets/js/modules/adsense/datastore';
-import { STORE_NAME as ANALYTICS_STORE } from '../assets/js/modules/analytics/datastore';
+import { STORE_NAME } from '../assets/js/modules/adsense/datastore/constants';
+import { STORE_NAME as ANALYTICS_STORE } from '../assets/js/modules/analytics/datastore/constants';
 import {
 	dashboardSummaryWidgetTodayData,
 	dashboardSummaryWidgetPeriodData,

--- a/stories/module-adsense-setup.stories.js
+++ b/stories/module-adsense-setup.stories.js
@@ -34,7 +34,7 @@ import { SetupMain as AdSenseSetup } from '../assets/js/modules/adsense/componen
 import { fillFilterWithComponent } from '../assets/js/util';
 import * as fixtures from '../assets/js/modules/adsense/datastore/__fixtures__';
 
-import { STORE_NAME } from '../assets/js/modules/adsense/datastore';
+import { STORE_NAME } from '../assets/js/modules/adsense/datastore/constants';
 import { WithTestRegistry } from '../tests/js/utils';
 
 function filterAdSenseSetup() {

--- a/stories/module-adsense.stories.js
+++ b/stories/module-adsense.stories.js
@@ -25,7 +25,7 @@ import {
 } from '../assets/js/modules/adsense/components/common';
 import { WithTestRegistry } from '../tests/js/utils';
 import * as fixtures from '../assets/js/modules/adsense/datastore/__fixtures__';
-import { STORE_NAME } from '../assets/js/modules/adsense/datastore';
+import { STORE_NAME } from '../assets/js/modules/adsense/datastore/constants';
 
 function SetupWrap( { children } ) {
 	return (

--- a/stories/module-analytics-components.stories.js
+++ b/stories/module-analytics-components.stories.js
@@ -25,7 +25,7 @@ import DashboardPopularPagesWidget from '../assets/js/modules/analytics/componen
 import DashboardBounceRateWidget from '../assets/js/modules/analytics/components/dashboard/DashboardBounceRateWidget';
 import DashboardGoalsWidget from '../assets/js/modules/analytics/components/dashboard/DashboardGoalsWidget';
 import DashboardUniqueVisitorsWidget from '../assets/js/modules/analytics/components/dashboard/DashboardUniqueVisitorsWidget';
-import { STORE_NAME } from '../assets/js/modules/analytics/datastore';
+import { STORE_NAME } from '../assets/js/modules/analytics/datastore/constants';
 import {
 	accountsPropertiesProfiles,
 	goals,

--- a/stories/module-analytics.stories.js
+++ b/stories/module-analytics.stories.js
@@ -29,7 +29,7 @@ import {
 import { WithTestRegistry } from '../tests/js/utils';
 
 import * as fixtures from '../assets/js/modules/analytics/datastore/__fixtures__';
-import { STORE_NAME } from '../assets/js/modules/analytics/datastore';
+import { STORE_NAME } from '../assets/js/modules/analytics/datastore/constants';
 
 function SetupWrap( { children } ) {
 	return (

--- a/stories/module-pagespeed-insights-components.stories.js
+++ b/stories/module-pagespeed-insights-components.stories.js
@@ -25,12 +25,11 @@ import { storiesOf } from '@storybook/react';
  * Internal dependencies
  */
 import DashboardPageSpeedWidget from '../assets/js/modules/pagespeed-insights/components/dashboard/DashboardPageSpeedWidget';
-import { STORE_NAME } from '../assets/js/modules/pagespeed-insights/datastore';
+import { STORE_NAME, STRATEGY_MOBILE, STRATEGY_DESKTOP } from '../assets/js/modules/pagespeed-insights/datastore/constants';
 import { STORE_NAME as CORE_SITE } from '../assets/js/googlesitekit/datastore/site/constants';
 import { STORE_NAME as CORE_USER, PERMISSION_MANAGE_OPTIONS } from '../assets/js/googlesitekit/datastore/user/constants';
 import { STORE_NAME as CORE_MODULES } from '../assets/js/googlesitekit/modules/datastore/constants';
 import * as fixtures from '../assets/js/modules/pagespeed-insights/datastore/__fixtures__';
-import { STRATEGY_MOBILE, STRATEGY_DESKTOP } from '../assets/js/modules/pagespeed-insights/datastore/constants';
 import { WithTestRegistry, freezeFetch } from '../tests/js/utils';
 
 storiesOf( 'PageSpeed Insights Module/Components', module )

--- a/stories/modules-tagmanager-setup.stories.js
+++ b/stories/modules-tagmanager-setup.stories.js
@@ -33,7 +33,7 @@ import { WithTestRegistry, createTestRegistry, freezeFetch } from '../tests/js/u
 import { fillFilterWithComponent } from '../assets/js/util';
 import SetupWrapper from '../assets/js/components/setup/setup-wrapper';
 import { STORE_NAME as CORE_SITE, AMP_MODE_PRIMARY, AMP_MODE_SECONDARY } from '../assets/js/googlesitekit/datastore/site/constants';
-import { STORE_NAME as CORE_USER } from '../assets/js/googlesitekit/datastore/user';
+import { STORE_NAME as CORE_USER } from '../assets/js/googlesitekit/datastore/user/constants';
 import { SetupMain as TagManagerSetup } from '../assets/js/modules/tagmanager/components/setup';
 import { STORE_NAME, ACCOUNT_CREATE } from '../assets/js/modules/tagmanager/datastore/constants';
 import { STORE_NAME as MODULES_ANALYTICS } from '../assets/js/modules/analytics/datastore/constants';

--- a/stories/modules-tagmanager.stories.js
+++ b/stories/modules-tagmanager.stories.js
@@ -25,7 +25,7 @@ import { storiesOf } from '@storybook/react';
  * Internal dependencies
  */
 import { WithTestRegistry } from '../tests/js/utils';
-import { STORE_NAME } from '../assets/js/modules/tagmanager/datastore';
+import { STORE_NAME } from '../assets/js/modules/tagmanager/datastore/constants';
 import { STORE_NAME as CORE_SITE, AMP_MODE_PRIMARY } from '../assets/js/googlesitekit/datastore/site/constants';
 import * as fixtures from '../assets/js/modules/tagmanager/datastore/__fixtures__';
 import AccountSelect from '../assets/js/modules/tagmanager/components/common/AccountSelect';


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #2145 

## Relevant technical choices

Removed all STORE_NAME exports from datastore index files so that stores are not registered twice.
Updated stories imports to use updated paths for STORE_NAME

## Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
