### PR TITLE
Add `page` param to deep links for SC domain properties

### DIFF
--- a/assets/js/modules/search-console/components/dashboard-details/DashboardDetailsWidgetKeywordsTable.js
+++ b/assets/js/modules/search-console/components/dashboard-details/DashboardDetailsWidgetKeywordsTable.js
@@ -38,12 +38,20 @@ const { useSelect } = Data;
 const DashboardDetailsWidgetKeywordsTable = () => {
 	const propertyID = useSelect( ( select ) => select( STORE_NAME ).getPropertyID() );
 	const url = useSelect( ( select ) => select( CORE_SITE ).getCurrentEntityURL() );
+	const isDomainProperty = useSelect( ( select ) => select( STORE_NAME ).isDomainProperty() );
+	let referenceSiteURL = useSelect( ( select ) => select( CORE_SITE ).getReferenceSiteURL() );
+	if ( referenceSiteURL.endsWith( '/' ) ) {
+		// remove the trailing slash
+		referenceSiteURL = referenceSiteURL.slice( 0, -1 );
+	}
 	const footerCTALinkArgs = {
 		resource_id: propertyID,
 		num_of_days: getCurrentDateRangeDayCount(),
 	};
 	if ( url ) {
 		footerCTALinkArgs.page = `!${ url }`;
+	} else if ( isDomainProperty ) {
+		footerCTALinkArgs.page = `*${ referenceSiteURL }`;
 	}
 	const footerCTALink = useSelect( ( select ) => select( STORE_NAME ).getServiceURL( {
 		path: '/performance/search-analytics',

--- a/assets/js/modules/search-console/components/dashboard-details/DashboardDetailsWidgetKeywordsTable.js
+++ b/assets/js/modules/search-console/components/dashboard-details/DashboardDetailsWidgetKeywordsTable.js
@@ -32,6 +32,7 @@ import Layout from '../../../../components/layout/layout';
 import { STORE_NAME } from '../../datastore/constants';
 import { STORE_NAME as CORE_SITE } from '../../../../googlesitekit/datastore/site/constants';
 import { getCurrentDateRangeDayCount } from '../../../../util/date-range';
+import { unTrailingSlashIt } from '../../../../util';
 
 const { useSelect } = Data;
 
@@ -39,18 +40,14 @@ const DashboardDetailsWidgetKeywordsTable = () => {
 	const propertyID = useSelect( ( select ) => select( STORE_NAME ).getPropertyID() );
 	const url = useSelect( ( select ) => select( CORE_SITE ).getCurrentEntityURL() );
 	const isDomainProperty = useSelect( ( select ) => select( STORE_NAME ).isDomainProperty() );
-	let referenceSiteURL = useSelect( ( select ) => select( CORE_SITE ).getReferenceSiteURL() );
-	if ( referenceSiteURL.endsWith( '/' ) ) {
-		// remove the trailing slash
-		referenceSiteURL = referenceSiteURL.slice( 0, -1 );
-	}
+	const referenceSiteURL = useSelect( ( select ) => unTrailingSlashIt( select( CORE_SITE ).getReferenceSiteURL() ) );
 	const footerCTALinkArgs = {
 		resource_id: propertyID,
 		num_of_days: getCurrentDateRangeDayCount(),
 	};
 	if ( url ) {
 		footerCTALinkArgs.page = `!${ url }`;
-	} else if ( isDomainProperty ) {
+	} else if ( isDomainProperty && referenceSiteURL ) {
 		footerCTALinkArgs.page = `*${ referenceSiteURL }`;
 	}
 	const footerCTALink = useSelect( ( select ) => select( STORE_NAME ).getServiceURL( {

--- a/assets/js/modules/search-console/components/dashboard-details/DashboardDetailsWidgetKeywordsTable.js
+++ b/assets/js/modules/search-console/components/dashboard-details/DashboardDetailsWidgetKeywordsTable.js
@@ -32,6 +32,7 @@ import Layout from '../../../../components/layout/layout';
 import { STORE_NAME } from '../../datastore/constants';
 import { STORE_NAME as CORE_SITE } from '../../../../googlesitekit/datastore/site/constants';
 import { getCurrentDateRangeDayCount } from '../../../../util/date-range';
+import { untrailingslashit } from '../../../../util';
 
 const { useSelect } = Data;
 
@@ -42,8 +43,15 @@ const DashboardDetailsWidgetKeywordsTable = () => {
 		resource_id: propertyID,
 		num_of_days: getCurrentDateRangeDayCount(),
 	};
+	const isDomainProperty = useSelect( ( select ) => select( STORE_NAME ).isDomainProperty() );
+	const referenceSiteURL = useSelect( ( select ) => {
+		return untrailingslashit( select( CORE_SITE ).getReferenceSiteURL() );
+	} );
 	if ( url ) {
 		footerCTALinkArgs.page = `!${ url }`;
+	}
+	if ( isDomainProperty && referenceSiteURL ) {
+		footerCTALinkArgs.page = `*${ referenceSiteURL }`;
 	}
 	const footerCTALink = useSelect( ( select ) => select( STORE_NAME ).getServiceURL( {
 		path: '/performance/search-analytics',

--- a/assets/js/modules/search-console/components/dashboard-details/DashboardDetailsWidgetKeywordsTable.js
+++ b/assets/js/modules/search-console/components/dashboard-details/DashboardDetailsWidgetKeywordsTable.js
@@ -49,8 +49,7 @@ const DashboardDetailsWidgetKeywordsTable = () => {
 	} );
 	if ( url ) {
 		footerCTALinkArgs.page = `!${ url }`;
-	}
-	if ( isDomainProperty && referenceSiteURL ) {
+	} else if ( isDomainProperty && referenceSiteURL ) {
 		footerCTALinkArgs.page = `*${ referenceSiteURL }`;
 	}
 	const footerCTALink = useSelect( ( select ) => select( STORE_NAME ).getServiceURL( {

--- a/assets/js/modules/search-console/components/dashboard-details/DashboardDetailsWidgetKeywordsTable.js
+++ b/assets/js/modules/search-console/components/dashboard-details/DashboardDetailsWidgetKeywordsTable.js
@@ -32,23 +32,18 @@ import Layout from '../../../../components/layout/layout';
 import { STORE_NAME } from '../../datastore/constants';
 import { STORE_NAME as CORE_SITE } from '../../../../googlesitekit/datastore/site/constants';
 import { getCurrentDateRangeDayCount } from '../../../../util/date-range';
-import { unTrailingSlashIt } from '../../../../util';
 
 const { useSelect } = Data;
 
 const DashboardDetailsWidgetKeywordsTable = () => {
 	const propertyID = useSelect( ( select ) => select( STORE_NAME ).getPropertyID() );
 	const url = useSelect( ( select ) => select( CORE_SITE ).getCurrentEntityURL() );
-	const isDomainProperty = useSelect( ( select ) => select( STORE_NAME ).isDomainProperty() );
-	const referenceSiteURL = useSelect( ( select ) => unTrailingSlashIt( select( CORE_SITE ).getReferenceSiteURL() ) );
 	const footerCTALinkArgs = {
 		resource_id: propertyID,
 		num_of_days: getCurrentDateRangeDayCount(),
 	};
 	if ( url ) {
 		footerCTALinkArgs.page = `!${ url }`;
-	} else if ( isDomainProperty && referenceSiteURL ) {
-		footerCTALinkArgs.page = `*${ referenceSiteURL }`;
 	}
 	const footerCTALink = useSelect( ( select ) => select( STORE_NAME ).getServiceURL( {
 		path: '/performance/search-analytics',

--- a/assets/js/modules/search-console/components/dashboard/DashboardClicksWidget.js
+++ b/assets/js/modules/search-console/components/dashboard/DashboardClicksWidget.js
@@ -28,7 +28,7 @@ import Data from 'googlesitekit-data';
 import { STORE_NAME } from '../../datastore/constants';
 import { STORE_NAME as CORE_SITE } from '../../../../googlesitekit/datastore/site/constants';
 import { STORE_NAME as CORE_USER } from '../../../../googlesitekit/datastore/user/constants';
-import { extractForSparkline } from '../../../../util';
+import { extractForSparkline, untrailingslashit } from '../../../../util';
 import { trackEvent } from '../../../../util/tracking';
 import { extractSearchConsoleDashboardData } from '../../util';
 import whenActive from '../../../../util/when-active';
@@ -47,6 +47,8 @@ function DashboardClicksWidget() {
 
 		const propertyID = store.getPropertyID();
 		const url = select( CORE_SITE ).getCurrentEntityURL();
+		const isDomainProperty = select( STORE_NAME ).isDomainProperty();
+		const referenceSiteURL = untrailingslashit( select( CORE_SITE ).getReferenceSiteURL() );
 
 		const args = {
 			dimensions: 'date',
@@ -61,6 +63,9 @@ function DashboardClicksWidget() {
 		if ( url ) {
 			args.url = url;
 			serviceBaseURLArgs.page = `!${ url }`;
+		}
+		if ( isDomainProperty && referenceSiteURL ) {
+			serviceBaseURLArgs.page = `*${ referenceSiteURL }`;
 		}
 
 		return {

--- a/assets/js/modules/search-console/components/dashboard/DashboardClicksWidget.js
+++ b/assets/js/modules/search-console/components/dashboard/DashboardClicksWidget.js
@@ -63,8 +63,7 @@ function DashboardClicksWidget() {
 		if ( url ) {
 			args.url = url;
 			serviceBaseURLArgs.page = `!${ url }`;
-		}
-		if ( isDomainProperty && referenceSiteURL ) {
+		} else if ( isDomainProperty && referenceSiteURL ) {
 			serviceBaseURLArgs.page = `*${ referenceSiteURL }`;
 		}
 

--- a/assets/js/modules/search-console/components/dashboard/DashboardImpressionsWidget.js
+++ b/assets/js/modules/search-console/components/dashboard/DashboardImpressionsWidget.js
@@ -29,7 +29,7 @@ import { STORE_NAME } from '../../datastore/constants';
 import { STORE_NAME as CORE_SITE } from '../../../../googlesitekit/datastore/site/constants';
 import { STORE_NAME as CORE_USER } from '../../../../googlesitekit/datastore/user/constants';
 import { extractSearchConsoleDashboardData } from '../../util';
-import { extractForSparkline } from '../../../../util';
+import { extractForSparkline, untrailingslashit } from '../../../../util';
 import { trackEvent } from '../../../../util/tracking';
 import whenActive from '../../../../util/when-active';
 import DataBlock from '../../../../components/data-block';
@@ -47,6 +47,8 @@ function DashboardImpressionsWidget() {
 
 		const propertyID = store.getPropertyID();
 		const url = select( CORE_SITE ).getCurrentEntityURL();
+		const isDomainProperty = select( STORE_NAME ).isDomainProperty();
+		const referenceSiteURL = untrailingslashit( select( CORE_SITE ).getReferenceSiteURL() );
 
 		const args = {
 			dimensions: 'date',
@@ -61,6 +63,9 @@ function DashboardImpressionsWidget() {
 		if ( url ) {
 			args.url = url;
 			serviceBaseURLArgs.page = `!${ url }`;
+		}
+		if ( isDomainProperty && referenceSiteURL ) {
+			serviceBaseURLArgs.page = `*${ referenceSiteURL }`;
 		}
 
 		return {

--- a/assets/js/modules/search-console/components/dashboard/DashboardImpressionsWidget.js
+++ b/assets/js/modules/search-console/components/dashboard/DashboardImpressionsWidget.js
@@ -63,8 +63,7 @@ function DashboardImpressionsWidget() {
 		if ( url ) {
 			args.url = url;
 			serviceBaseURLArgs.page = `!${ url }`;
-		}
-		if ( isDomainProperty && referenceSiteURL ) {
+		} else if ( isDomainProperty && referenceSiteURL ) {
 			serviceBaseURLArgs.page = `*${ referenceSiteURL }`;
 		}
 

--- a/assets/js/modules/search-console/components/dashboard/DashboardPopularKeywordsWidget.js
+++ b/assets/js/modules/search-console/components/dashboard/DashboardPopularKeywordsWidget.js
@@ -30,7 +30,7 @@ import Widgets from 'googlesitekit-widgets';
 import { STORE_NAME } from '../../datastore/constants';
 import { STORE_NAME as CORE_SITE } from '../../../../googlesitekit/datastore/site/constants';
 import { STORE_NAME as CORE_USER } from '../../../../googlesitekit/datastore/user/constants';
-import { numberFormat } from '../../../../util';
+import { numberFormat, untrailingslashit } from '../../../../util';
 import { getDataTableFromData, TableOverflowContainer } from '../../../../components/data-table';
 import whenActive from '../../../../util/when-active';
 import PreviewTable from '../../../../components/PreviewTable';
@@ -62,9 +62,14 @@ function DashboardPopularKeywordsWidget() {
 		};
 
 		const url = select( CORE_SITE ).getCurrentEntityURL();
+		const isDomainProperty = select( STORE_NAME ).isDomainProperty();
+		const referenceSiteURL = untrailingslashit( select( CORE_SITE ).getReferenceSiteURL() );
 		if ( url ) {
 			args.url = url;
 			baseServiceURLArgs.page = `!${ url }`;
+		}
+		if ( isDomainProperty && referenceSiteURL ) {
+			baseServiceURLArgs.page = `*${ referenceSiteURL }`;
 		}
 
 		return {

--- a/assets/js/modules/search-console/components/dashboard/DashboardPopularKeywordsWidget.js
+++ b/assets/js/modules/search-console/components/dashboard/DashboardPopularKeywordsWidget.js
@@ -67,8 +67,7 @@ function DashboardPopularKeywordsWidget() {
 		if ( url ) {
 			args.url = url;
 			baseServiceURLArgs.page = `!${ url }`;
-		}
-		if ( isDomainProperty && referenceSiteURL ) {
+		} else if ( isDomainProperty && referenceSiteURL ) {
 			baseServiceURLArgs.page = `*${ referenceSiteURL }`;
 		}
 

--- a/assets/js/modules/search-console/components/dashboard/GoogleSitekitSearchConsoleDashboardWidget.js
+++ b/assets/js/modules/search-console/components/dashboard/GoogleSitekitSearchConsoleDashboardWidget.js
@@ -47,6 +47,7 @@ import { getCurrentDateRange, getCurrentDateRangeDayCount } from '../../../../ut
 import HelpLink from '../../../../components/help-link';
 import { STORE_NAME } from '../../datastore/constants';
 import { STORE_NAME as CORE_USER } from '../../../../googlesitekit/datastore/user/constants';
+import { STORE_NAME as CORE_SITE } from '../../../../googlesitekit/datastore/site/constants';
 
 const { useSelect } = Data;
 
@@ -58,13 +59,23 @@ const GoogleSitekitSearchConsoleDashboardWidget = () => {
 	const [ loading, setLoading ] = useState( true );
 	const dateRange = useSelect( ( select ) => select( CORE_USER ).getDateRange() );
 	const propertyID = useSelect( ( select ) => select( STORE_NAME ).getPropertyID() );
+	const isDomainProperty = useSelect( ( select ) => select( STORE_NAME ).isDomainProperty() );
+	let referenceSiteURL = useSelect( ( select ) => select( CORE_SITE ).getReferenceSiteURL() );
+	if ( referenceSiteURL.endsWith( '/' ) ) {
+		// remove the trailing slash
+		referenceSiteURL = referenceSiteURL.slice( 0, -1 );
+	}
+	const searchConsoleDeepArgs = {
+		resource_id: propertyID,
+		num_of_days: getCurrentDateRangeDayCount(),
+	};
+	if ( isDomainProperty ) {
+		searchConsoleDeepArgs.page = `*${ referenceSiteURL }`;
+	}
 	const searchConsoleDeepLink = useSelect( ( select ) => select( STORE_NAME ).getServiceURL(
 		{
 			path: '/performance/search-analytics',
-			query: {
-				resource_id: propertyID,
-				num_of_days: getCurrentDateRangeDayCount(),
-			},
+			query: searchConsoleDeepArgs,
 		} ) );
 
 	/**

--- a/assets/js/modules/search-console/components/dashboard/GoogleSitekitSearchConsoleDashboardWidget.js
+++ b/assets/js/modules/search-console/components/dashboard/GoogleSitekitSearchConsoleDashboardWidget.js
@@ -48,6 +48,7 @@ import HelpLink from '../../../../components/help-link';
 import { STORE_NAME } from '../../datastore/constants';
 import { STORE_NAME as CORE_USER } from '../../../../googlesitekit/datastore/user/constants';
 import { STORE_NAME as CORE_SITE } from '../../../../googlesitekit/datastore/site/constants';
+import { unTrailingSlashIt } from '../../../../util';
 
 const { useSelect } = Data;
 
@@ -60,16 +61,12 @@ const GoogleSitekitSearchConsoleDashboardWidget = () => {
 	const dateRange = useSelect( ( select ) => select( CORE_USER ).getDateRange() );
 	const propertyID = useSelect( ( select ) => select( STORE_NAME ).getPropertyID() );
 	const isDomainProperty = useSelect( ( select ) => select( STORE_NAME ).isDomainProperty() );
-	let referenceSiteURL = useSelect( ( select ) => select( CORE_SITE ).getReferenceSiteURL() );
-	if ( referenceSiteURL.endsWith( '/' ) ) {
-		// remove the trailing slash
-		referenceSiteURL = referenceSiteURL.slice( 0, -1 );
-	}
+	const referenceSiteURL = useSelect( ( select ) => unTrailingSlashIt( select( CORE_SITE ).getReferenceSiteURL() ) );
 	const searchConsoleDeepArgs = {
 		resource_id: propertyID,
 		num_of_days: getCurrentDateRangeDayCount(),
 	};
-	if ( isDomainProperty ) {
+	if ( isDomainProperty && referenceSiteURL ) {
 		searchConsoleDeepArgs.page = `*${ referenceSiteURL }`;
 	}
 	const searchConsoleDeepLink = useSelect( ( select ) => select( STORE_NAME ).getServiceURL(

--- a/assets/js/modules/search-console/components/dashboard/GoogleSitekitSearchConsoleDashboardWidget.js
+++ b/assets/js/modules/search-console/components/dashboard/GoogleSitekitSearchConsoleDashboardWidget.js
@@ -48,7 +48,7 @@ import HelpLink from '../../../../components/help-link';
 import { STORE_NAME } from '../../datastore/constants';
 import { STORE_NAME as CORE_USER } from '../../../../googlesitekit/datastore/user/constants';
 import { STORE_NAME as CORE_SITE } from '../../../../googlesitekit/datastore/site/constants';
-import { unTrailingSlashIt } from '../../../../util';
+import { untrailingslashit } from '../../../../util';
 
 const { useSelect } = Data;
 
@@ -62,7 +62,7 @@ const GoogleSitekitSearchConsoleDashboardWidget = () => {
 	const propertyID = useSelect( ( select ) => select( STORE_NAME ).getPropertyID() );
 	const isDomainProperty = useSelect( ( select ) => select( STORE_NAME ).isDomainProperty() );
 	const referenceSiteURL = useSelect( ( select ) => {
-		return unTrailingSlashIt( select( CORE_SITE ).getReferenceSiteURL() );
+		return untrailingslashit( select( CORE_SITE ).getReferenceSiteURL() );
 	} );
 	const searchConsoleDeepArgs = {
 		resource_id: propertyID,

--- a/assets/js/modules/search-console/components/dashboard/GoogleSitekitSearchConsoleDashboardWidget.js
+++ b/assets/js/modules/search-console/components/dashboard/GoogleSitekitSearchConsoleDashboardWidget.js
@@ -61,7 +61,9 @@ const GoogleSitekitSearchConsoleDashboardWidget = () => {
 	const dateRange = useSelect( ( select ) => select( CORE_USER ).getDateRange() );
 	const propertyID = useSelect( ( select ) => select( STORE_NAME ).getPropertyID() );
 	const isDomainProperty = useSelect( ( select ) => select( STORE_NAME ).isDomainProperty() );
-	const referenceSiteURL = useSelect( ( select ) => unTrailingSlashIt( select( CORE_SITE ).getReferenceSiteURL() ) );
+	const referenceSiteURL = useSelect( ( select ) => {
+		return unTrailingSlashIt( select( CORE_SITE ).getReferenceSiteURL() );
+	} );
 	const searchConsoleDeepArgs = {
 		resource_id: propertyID,
 		num_of_days: getCurrentDateRangeDayCount(),

--- a/assets/js/modules/search-console/components/dashboard/LegacyDashboardWidgetPopularKeywordsTable.js
+++ b/assets/js/modules/search-console/components/dashboard/LegacyDashboardWidgetPopularKeywordsTable.js
@@ -44,7 +44,9 @@ const LegacyDashboardWidgetPopularKeywordsTable = ( props ) => {
 	const { data } = props;
 	const domain = useSelect( ( select ) => select( STORE_NAME ).getPropertyID() );
 	const isDomainProperty = useSelect( ( select ) => select( STORE_NAME ).isDomainProperty() );
-	const referenceSiteURL = useSelect( ( select ) => unTrailingSlashIt( select( CORE_SITE ).getReferenceSiteURL() ) );
+	const referenceSiteURL = useSelect( ( select ) => {
+		return unTrailingSlashIt( select( CORE_SITE ).getReferenceSiteURL() );
+	} );
 	const baseServiceArgs = {
 		resource_id: domain,
 		num_of_days: getCurrentDateRangeDayCount(),

--- a/assets/js/modules/search-console/components/dashboard/LegacyDashboardWidgetPopularKeywordsTable.js
+++ b/assets/js/modules/search-console/components/dashboard/LegacyDashboardWidgetPopularKeywordsTable.js
@@ -26,7 +26,7 @@ import { addQueryArgs } from '@wordpress/url';
  * Internal dependencies
  */
 import Data from 'googlesitekit-data';
-import { getTimeInSeconds, numberFormat } from '../../../../util';
+import { getTimeInSeconds, numberFormat, unTrailingSlashIt } from '../../../../util';
 import withData from '../../../../components/higherorder/withdata';
 import { TYPE_MODULES } from '../../../../components/data';
 import { getDataTableFromData, TableOverflowContainer } from '../../../../components/data-table';
@@ -44,16 +44,12 @@ const LegacyDashboardWidgetPopularKeywordsTable = ( props ) => {
 	const { data } = props;
 	const domain = useSelect( ( select ) => select( STORE_NAME ).getPropertyID() );
 	const isDomainProperty = useSelect( ( select ) => select( STORE_NAME ).isDomainProperty() );
-	let referenceSiteURL = useSelect( ( select ) => select( CORE_SITE ).getReferenceSiteURL() );
-	if ( referenceSiteURL.endsWith( '/' ) ) {
-		// remove the trailing slash
-		referenceSiteURL = referenceSiteURL.slice( 0, -1 );
-	}
+	const referenceSiteURL = useSelect( ( select ) => unTrailingSlashIt( select( CORE_SITE ).getReferenceSiteURL() ) );
 	const baseServiceArgs = {
 		resource_id: domain,
 		num_of_days: getCurrentDateRangeDayCount(),
 	};
-	if ( isDomainProperty ) {
+	if ( isDomainProperty && referenceSiteURL ) {
 		baseServiceArgs.page = `*${ referenceSiteURL }`;
 	}
 	const baseServiceURL = useSelect( ( select ) => select( STORE_NAME ).getServiceURL(

--- a/assets/js/modules/search-console/components/dashboard/LegacyDashboardWidgetPopularKeywordsTable.js
+++ b/assets/js/modules/search-console/components/dashboard/LegacyDashboardWidgetPopularKeywordsTable.js
@@ -26,7 +26,7 @@ import { addQueryArgs } from '@wordpress/url';
  * Internal dependencies
  */
 import Data from 'googlesitekit-data';
-import { getTimeInSeconds, numberFormat, unTrailingSlashIt } from '../../../../util';
+import { getTimeInSeconds, numberFormat, untrailingslashit } from '../../../../util';
 import withData from '../../../../components/higherorder/withdata';
 import { TYPE_MODULES } from '../../../../components/data';
 import { getDataTableFromData, TableOverflowContainer } from '../../../../components/data-table';
@@ -45,7 +45,7 @@ const LegacyDashboardWidgetPopularKeywordsTable = ( props ) => {
 	const domain = useSelect( ( select ) => select( STORE_NAME ).getPropertyID() );
 	const isDomainProperty = useSelect( ( select ) => select( STORE_NAME ).isDomainProperty() );
 	const referenceSiteURL = useSelect( ( select ) => {
-		return unTrailingSlashIt( select( CORE_SITE ).getReferenceSiteURL() );
+		return untrailingslashit( select( CORE_SITE ).getReferenceSiteURL() );
 	} );
 	const baseServiceArgs = {
 		resource_id: domain,

--- a/assets/js/modules/search-console/components/dashboard/LegacyDashboardWidgetPopularKeywordsTable.js
+++ b/assets/js/modules/search-console/components/dashboard/LegacyDashboardWidgetPopularKeywordsTable.js
@@ -37,18 +37,29 @@ import {
 } from '../../util';
 import { getCurrentDateRangeDayCount } from '../../../../util/date-range';
 import { STORE_NAME } from '../../datastore/constants';
+import { STORE_NAME as CORE_SITE } from '../../../../googlesitekit/datastore/site';
 const { useSelect } = Data;
 
 const LegacyDashboardWidgetPopularKeywordsTable = ( props ) => {
 	const { data } = props;
 	const domain = useSelect( ( select ) => select( STORE_NAME ).getPropertyID() );
+	const isDomainProperty = useSelect( ( select ) => select( STORE_NAME ).isDomainProperty() );
+	let referenceSiteURL = useSelect( ( select ) => select( CORE_SITE ).getReferenceSiteURL() );
+	if ( referenceSiteURL.endsWith( '/' ) ) {
+		// remove the trailing slash
+		referenceSiteURL = referenceSiteURL.slice( 0, -1 );
+	}
+	const baseServiceArgs = {
+		resource_id: domain,
+		num_of_days: getCurrentDateRangeDayCount(),
+	};
+	if ( isDomainProperty ) {
+		baseServiceArgs.page = `*${ referenceSiteURL }`;
+	}
 	const baseServiceURL = useSelect( ( select ) => select( STORE_NAME ).getServiceURL(
 		{
 			path: '/performance/search-analytics',
-			query: {
-				resource_id: domain,
-				num_of_days: getCurrentDateRangeDayCount(),
-			},
+			query: baseServiceArgs,
 		} ) );
 
 	if ( ! data || ! data.length ) {

--- a/assets/js/modules/search-console/components/dashboard/LegacyDashboardWidgetPopularKeywordsTable.js
+++ b/assets/js/modules/search-console/components/dashboard/LegacyDashboardWidgetPopularKeywordsTable.js
@@ -37,7 +37,7 @@ import {
 } from '../../util';
 import { getCurrentDateRangeDayCount } from '../../../../util/date-range';
 import { STORE_NAME } from '../../datastore/constants';
-import { STORE_NAME as CORE_SITE } from '../../../../googlesitekit/datastore/site';
+import { STORE_NAME as CORE_SITE } from '../../../../googlesitekit/datastore/site/constants';
 const { useSelect } = Data;
 
 const LegacyDashboardWidgetPopularKeywordsTable = ( props ) => {

--- a/assets/js/modules/search-console/components/dashboard/LegacySearchConsoleDashboardWidgetKeywordTable.js
+++ b/assets/js/modules/search-console/components/dashboard/LegacySearchConsoleDashboardWidgetKeywordTable.js
@@ -26,7 +26,7 @@ import { addQueryArgs } from '@wordpress/url';
  * Internal dependencies
  */
 import Data from 'googlesitekit-data';
-import { getTimeInSeconds, numberFormat } from '../../../../util';
+import { getTimeInSeconds, numberFormat, untrailingslashit } from '../../../../util';
 import withData from '../../../../components/higherorder/withdata';
 import { TYPE_MODULES } from '../../../../components/data';
 import { getDataTableFromData, TableOverflowContainer } from '../../../../components/data-table';
@@ -40,12 +40,19 @@ const LegacySearchConsoleDashboardWidgetKeywordTable = ( props ) => {
 	const { data } = props;
 	const domain = useSelect( ( select ) => select( STORE_NAME ).getPropertyID() );
 	const url = useSelect( ( select ) => select( CORE_SITE ).getCurrentEntityURL() );
+	const isDomainProperty = useSelect( ( select ) => select( STORE_NAME ).isDomainProperty() );
+	const referenceSiteURL = useSelect( ( select ) => {
+		return untrailingslashit( select( CORE_SITE ).getReferenceSiteURL() );
+	} );
 	const baseServiceURLArgs = {
 		resource_id: domain,
 		num_of_days: getCurrentDateRangeDayCount(),
 	};
 	if ( url ) {
 		baseServiceURLArgs.page = `!${ url }`;
+	}
+	if ( isDomainProperty && referenceSiteURL ) {
+		baseServiceURLArgs.page = `*${ referenceSiteURL }`;
 	}
 	const baseServiceURL = useSelect( ( select ) => select( STORE_NAME ).getServiceURL(
 		{

--- a/assets/js/modules/search-console/components/dashboard/LegacySearchConsoleDashboardWidgetKeywordTable.js
+++ b/assets/js/modules/search-console/components/dashboard/LegacySearchConsoleDashboardWidgetKeywordTable.js
@@ -50,8 +50,7 @@ const LegacySearchConsoleDashboardWidgetKeywordTable = ( props ) => {
 	};
 	if ( url ) {
 		baseServiceURLArgs.page = `!${ url }`;
-	}
-	if ( isDomainProperty && referenceSiteURL ) {
+	} else if ( isDomainProperty && referenceSiteURL ) {
 		baseServiceURLArgs.page = `*${ referenceSiteURL }`;
 	}
 	const baseServiceURL = useSelect( ( select ) => select( STORE_NAME ).getServiceURL(

--- a/assets/js/modules/search-console/components/dashboard/LegacySearchConsoleDashboardWidgetTopLevel.js
+++ b/assets/js/modules/search-console/components/dashboard/LegacySearchConsoleDashboardWidgetTopLevel.js
@@ -66,8 +66,7 @@ function LegacySearchConsoleDashboardWidgetTopLevel( { data } ) {
 	};
 	if ( url ) {
 		serviceBaseURLArgs.page = `!${ url }`;
-	}
-	if ( isDomainProperty && referenceSiteURL ) {
+	} else if ( isDomainProperty && referenceSiteURL ) {
 		serviceBaseURLArgs.page = `*${ referenceSiteURL }`;
 	}
 

--- a/assets/js/modules/search-console/components/dashboard/LegacySearchConsoleDashboardWidgetTopLevel.js
+++ b/assets/js/modules/search-console/components/dashboard/LegacySearchConsoleDashboardWidgetTopLevel.js
@@ -38,7 +38,7 @@ import PreviewBlock from '../../../../components/PreviewBlock';
 import {
 	getTimeInSeconds,
 	extractForSparkline,
-	trackEvent,
+	trackEvent, untrailingslashit,
 } from '../../../../util';
 import CTA from '../../../../components/notifications/cta';
 import { STORE_NAME as CORE_SITE } from '../../../../googlesitekit/datastore/site/constants';
@@ -55,6 +55,10 @@ function LegacySearchConsoleDashboardWidgetTopLevel( { data } ) {
 	const url = useSelect( ( select ) => select( CORE_SITE ).getCurrentEntityURL() );
 	const propertyID = useSelect( ( select ) => select( STORE_NAME ).getPropertyID() );
 	const dateRange = useSelect( ( select ) => select( CORE_USER ).getDateRange() );
+	const isDomainProperty = useSelect( ( select ) => select( STORE_NAME ).isDomainProperty() );
+	const referenceSiteURL = useSelect( ( select ) => {
+		return untrailingslashit( select( CORE_SITE ).getReferenceSiteURL() );
+	} );
 
 	const serviceBaseURLArgs = {
 		resource_id: propertyID,
@@ -62,6 +66,9 @@ function LegacySearchConsoleDashboardWidgetTopLevel( { data } ) {
 	};
 	if ( url ) {
 		serviceBaseURLArgs.page = `!${ url }`;
+	}
+	if ( isDomainProperty && referenceSiteURL ) {
+		serviceBaseURLArgs.page = `*${ referenceSiteURL }`;
 	}
 
 	const serviceURL = useSelect( ( select ) => select( STORE_NAME ).getServiceURL(

--- a/assets/js/modules/search-console/datastore/service.js
+++ b/assets/js/modules/search-console/datastore/service.js
@@ -25,6 +25,7 @@ import { addQueryArgs } from '@wordpress/url';
  * Internal dependencies
  */
 import Data from 'googlesitekit-data';
+import { STORE_NAME } from './constants';
 import { STORE_NAME as CORE_USER } from '../../../googlesitekit/datastore/user/constants';
 const { createRegistrySelector } = Data;
 
@@ -52,6 +53,12 @@ export const selectors = {
 			return addQueryArgs( `${ baseURI }${ sanitizedPath }`, queryArgs );
 		}
 		return addQueryArgs( baseURI, queryArgs );
+	} ),
+
+	isDomainProperty: createRegistrySelector( ( select ) => () => {
+		const domain = select( STORE_NAME ).getPropertyID();
+
+		return domain && domain.startsWith( 'sc-domain:' );
 	} ),
 };
 

--- a/assets/js/modules/search-console/datastore/service.js
+++ b/assets/js/modules/search-console/datastore/service.js
@@ -57,7 +57,7 @@ export const selectors = {
 	} ),
 
 	/**
-	 * Checks whether the property is a Search Console Domain Property.
+	 * Checks whether the Search Console property is a domain property.
 	 *
 	 * @since n.e.x.t
 	 *

--- a/assets/js/modules/search-console/datastore/service.js
+++ b/assets/js/modules/search-console/datastore/service.js
@@ -27,6 +27,7 @@ import { addQueryArgs } from '@wordpress/url';
 import Data from 'googlesitekit-data';
 import { STORE_NAME } from './constants';
 import { STORE_NAME as CORE_USER } from '../../../googlesitekit/datastore/user/constants';
+
 const { createRegistrySelector } = Data;
 
 export const selectors = {
@@ -55,6 +56,13 @@ export const selectors = {
 		return addQueryArgs( baseURI, queryArgs );
 	} ),
 
+	/**
+	 * Checks whether the property is a Search Console Domain Property.
+	 *
+	 * @since 1.18.0
+	 *
+	 * @return {boolean} True if the propertyID is a search console domain property, otherwise false.
+	 */
 	isDomainProperty: createRegistrySelector( ( select ) => () => {
 		const domain = select( STORE_NAME ).getPropertyID();
 

--- a/assets/js/modules/search-console/datastore/service.js
+++ b/assets/js/modules/search-console/datastore/service.js
@@ -59,7 +59,7 @@ export const selectors = {
 	/**
 	 * Checks whether the property is a Search Console Domain Property.
 	 *
-	 * @since 1.18.0
+	 * @since n.e.x.t
 	 *
 	 * @return {boolean} True if the propertyID is a search console domain property, otherwise false.
 	 */

--- a/assets/js/modules/search-console/datastore/service.test.js
+++ b/assets/js/modules/search-console/datastore/service.test.js
@@ -80,7 +80,7 @@ describe( 'module/search-console service store', () => {
 			} );
 		} );
 		describe( 'isDomainProperty', () => {
-			it( 'identify if property is search console domain property', async () => {
+			it( 'should identify if property is search console domain property', async () => {
 				registry.dispatch( STORE_NAME ).setSettings( {
 					propertyID: 'http://sitekit.google.com',
 				} );

--- a/assets/js/modules/search-console/datastore/service.test.js
+++ b/assets/js/modules/search-console/datastore/service.test.js
@@ -79,5 +79,22 @@ describe( 'module/search-console service store', () => {
 				expect( serviceURL ).toMatchQueryParameters( query );
 			} );
 		} );
+		describe( 'isDomainProperty', () => {
+			it( 'identify if property is search console domain property', async () => {
+				registry.dispatch( STORE_NAME ).setSettings( {
+					propertyID: 'http://sitekit.google.com',
+				} );
+
+				let isDomainProperty = registry.select( STORE_NAME ).isDomainProperty();
+				expect( isDomainProperty ).toBe( false );
+
+				registry.dispatch( STORE_NAME ).setSettings( {
+					propertyID: 'sc-domain:sitekit.google.com',
+				} );
+
+				isDomainProperty = registry.select( STORE_NAME ).isDomainProperty();
+				expect( isDomainProperty ).toBe( true );
+			} );
+		} );
 	} );
 } );

--- a/assets/js/util/sanitize.js
+++ b/assets/js/util/sanitize.js
@@ -8,3 +8,25 @@ export const sanitizeHTML = ( unsafeHTML, domPurifyConfig = {} ) => {
 		__html: purify.sanitize( unsafeHTML, domPurifyConfig ),
 	};
 };
+
+/**
+ * Takes a URL string, removes the trailing stash if any and returns it.
+ *
+ * @since 1.18.0
+ * @private
+ *
+ * @param {string} url The URL with or without trailing slash.
+ * @return {string|null} The URL string after removing the trailing slash.
+ */
+export const unTrailingSlashIt = ( url ) => {
+	if ( typeof url !== 'string' ) {
+		return null;
+	}
+
+	if ( url.endsWith( '/' ) ) {
+		// remove the trailing slash
+		return url.slice( 0, -1 );
+	}
+
+	return url;
+};

--- a/assets/js/util/sanitize.js
+++ b/assets/js/util/sanitize.js
@@ -10,23 +10,12 @@ export const sanitizeHTML = ( unsafeHTML, domPurifyConfig = {} ) => {
 };
 
 /**
- * Takes a URL string, removes the trailing stash if any and returns it.
+ * Takes a string, removes the trailing stash if any and returns it.
  *
- * @since 1.18.0
+ * @since n.e.x.t
  * @private
  *
- * @param {string} url The URL with or without trailing slash.
- * @return {string|null} The URL string after removing the trailing slash.
+ * @param {string} string A string with or without trailing slash.
+ * @return {string|null} The string after removing the trailing slash.
  */
-export const unTrailingSlashIt = ( url ) => {
-	if ( typeof url !== 'string' ) {
-		return null;
-	}
-
-	if ( url.endsWith( '/' ) ) {
-		// remove the trailing slash
-		return url.slice( 0, -1 );
-	}
-
-	return url;
-};
+export const unTrailingSlashIt = ( string ) => string?.replace?.( /\/+$/, '' );

--- a/assets/js/util/sanitize.js
+++ b/assets/js/util/sanitize.js
@@ -18,4 +18,4 @@ export const sanitizeHTML = ( unsafeHTML, domPurifyConfig = {} ) => {
  * @param {string} string A string with or without trailing slash.
  * @return {string|null} The string after removing the trailing slash.
  */
-export const unTrailingSlashIt = ( string ) => string?.replace?.( /\/+$/, '' );
+export const untrailingslashit = ( string ) => string?.replace?.( /\/+$/, '' );

--- a/assets/js/util/sanitize.test.js
+++ b/assets/js/util/sanitize.test.js
@@ -31,17 +31,19 @@ describe( 'sanitizeHTML', () => {
 } );
 
 describe( 'unTrailingSlashIt', () => {
-	it( 'should not change a URL without trailing slash', () => {
-		const url = 'http://example.org';
-		expect( unTrailingSlashIt( url ) ).toEqual( 'http://example.org' );
+	it( 'should return the same string if there is no trailing slash', () => {
+		expect( unTrailingSlashIt( 'http://example.org' ) ).toEqual( 'http://example.org' );
 	} );
 
-	it( 'should change a URL with trailing slash', () => {
-		const url = 'http://example.org/';
-		expect( unTrailingSlashIt( url ) ).toEqual( 'http://example.org' );
+	it( 'should return string without trailing slash in a string with trailing slash', () => {
+		expect( unTrailingSlashIt( 'http://example.org/' ) ).toEqual( 'http://example.org' );
 	} );
 
-	it( 'should return null if the parameter is not a string', () => {
-		expect( unTrailingSlashIt( 1 ) ).toBeNull();
+	it( 'should return string without trailing slashes in a string with multiple trailing slash', () => {
+		expect( unTrailingSlashIt( 'http://example.org////' ) ).toEqual( 'http://example.org' );
+	} );
+
+	it( 'should return undefined if the parameter is not a string', () => {
+		expect( unTrailingSlashIt( 1 ) ).toBeUndefined();
 	} );
 } );

--- a/assets/js/util/sanitize.test.js
+++ b/assets/js/util/sanitize.test.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { sanitizeHTML } from './sanitize';
+import { sanitizeHTML, unTrailingSlashIt } from './sanitize';
 
 describe( 'sanitizeHTML', () => {
 	it( 'does not change links', () => {
@@ -27,5 +27,21 @@ describe( 'sanitizeHTML', () => {
 		} ) ).toEqual( {
 			__html: '<a target="_blank" href="http://example.org">link</a>',
 		} );
+	} );
+} );
+
+describe( 'unTrailingSlashIt', () => {
+	it( 'should not change a URL without trailing slash', () => {
+		const url = 'http://example.org';
+		expect( unTrailingSlashIt( url ) ).toEqual( 'http://example.org' );
+	} );
+
+	it( 'should change a URL with trailing slash', () => {
+		const url = 'http://example.org/';
+		expect( unTrailingSlashIt( url ) ).toEqual( 'http://example.org' );
+	} );
+
+	it( 'should return null if the parameter is not a string', () => {
+		expect( unTrailingSlashIt( 1 ) ).toBeNull();
 	} );
 } );

--- a/assets/js/util/sanitize.test.js
+++ b/assets/js/util/sanitize.test.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { sanitizeHTML, unTrailingSlashIt } from './sanitize';
+import { sanitizeHTML, untrailingslashit } from './sanitize';
 
 describe( 'sanitizeHTML', () => {
 	it( 'does not change links', () => {
@@ -32,18 +32,18 @@ describe( 'sanitizeHTML', () => {
 
 describe( 'unTrailingSlashIt', () => {
 	it( 'should return the same string if there is no trailing slash', () => {
-		expect( unTrailingSlashIt( 'http://example.org' ) ).toEqual( 'http://example.org' );
+		expect( untrailingslashit( 'http://example.org' ) ).toEqual( 'http://example.org' );
 	} );
 
 	it( 'should return string without trailing slash in a string with trailing slash', () => {
-		expect( unTrailingSlashIt( 'http://example.org/' ) ).toEqual( 'http://example.org' );
+		expect( untrailingslashit( 'http://example.org/' ) ).toEqual( 'http://example.org' );
 	} );
 
 	it( 'should return string without trailing slashes in a string with multiple trailing slash', () => {
-		expect( unTrailingSlashIt( 'http://example.org////' ) ).toEqual( 'http://example.org' );
+		expect( untrailingslashit( 'http://example.org////' ) ).toEqual( 'http://example.org' );
 	} );
 
 	it( 'should return undefined if the parameter is not a string', () => {
-		expect( unTrailingSlashIt( 1 ) ).toBeUndefined();
+		expect( untrailingslashit( 1 ) ).toBeUndefined();
 	} );
 } );


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #2110 

## Relevant technical choices

1. Adds a `isDomainProperty` selector to `search-console` module.  Relevant tests added also.
2. When the domain property is a Search Domain property, add `page` param to the Search Console deep link URL.

## Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
