### PR TITLE
Restore previous isDataZeroAdSense logic

### DIFF
--- a/assets/js/modules/adsense/util/index.js
+++ b/assets/js/modules/adsense/util/index.js
@@ -64,9 +64,7 @@ export function reduceAdSenseData( rows ) {
 export const isDataZeroAdSense = ( adSenseData, datapoint, dataRequest ) => {
 	// We only check the last 28 days of earnings because it is the most reliable data point to identify new setups:
 	// only new accounts or accounts not showing ads would have zero earnings in the last 28 days.
-
-	// The 'prev-date-range-placeholder' is dynamically replaced with the previous date range based on the current date range so we need allow it here.
-	if ( ! dataRequest.data || ! dataRequest.data.dateRange || ( 'last-28-days' !== dataRequest.data.dateRange && 'prev-date-range-placeholder' !== dataRequest.data.dateRange ) ) {
+	if ( ! dataRequest.data || ! dataRequest.data.dateRange || 'last-28-days' !== dataRequest.data.dateRange ) {
 		return false;
 	}
 


### PR DESCRIPTION
This reverts commit e5bdb3d729fe7f2ddf05ef71ca5da171c99659d7.

## Summary

Addresses issue #317 (follow-up)

## Relevant technical choices

The previous logic only checked the `last-28-days` range specifically, so no change was necessary to allow for a different range.

**Example 90 view when _previous_ 90 days has no data after this change**

![image](https://user-images.githubusercontent.com/1621608/97158640-66a1d000-1782-11eb-9bc4-7cba9926b399.png)


## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
