### PR TITLE
Enhancement/2180 get module dependency selectors

### DIFF
--- a/assets/js/googlesitekit/modules/datastore/modules.js
+++ b/assets/js/googlesitekit/modules/datastore/modules.js
@@ -416,7 +416,7 @@ const baseSelectors = {
 
 		// Module is found, return the names of the dependencies
 		const modules = select( STORE_NAME ).getModules();
-		return module.dependencies.map( ( dependencySlug ) => modules[ dependencySlug ].name );
+		return module.dependencies.map( ( dependencySlug ) => modules[ dependencySlug ].name || dependencySlug );
 	} ),
 
 	/**
@@ -445,7 +445,7 @@ const baseSelectors = {
 			return [];
 		}
 
-		// Module is found, return the names of the dependencies
+		// Module is found, return the names of the dependants
 		const modules = select( STORE_NAME ).getModules();
 		return module.dependants.map( ( dependantSlug ) => modules[ dependantSlug ].name );
 	} ),

--- a/assets/js/googlesitekit/modules/datastore/modules.js
+++ b/assets/js/googlesitekit/modules/datastore/modules.js
@@ -389,6 +389,68 @@ const baseSelectors = {
 	} ),
 
 	/**
+	 * Gets module dependency names by slug.
+	 *
+	 * Returns a list of modules that depend on this module.
+	 * Returns `undefined` if state is still loading or if said module doesn't exist.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param {Object} state Data store's state.
+	 * @param {string} slug  Module slug.
+	 * @return {(Array|undefined)} An array of dependency module names; `undefined` if state is still loading.
+	 */
+	getModuleDependencyNames: createRegistrySelector( ( select ) => ( state, slug ) => {
+		const module = select( STORE_NAME ).getModule( slug );
+
+		// Return `undefined` if module with this slug isn't loaded yet.
+		if ( module === undefined ) {
+			return undefined;
+		}
+
+		// A module with this slug couldn't be found; return `[]` to signify the
+		// "not found" state.
+		if ( module === null ) {
+			return [];
+		}
+
+		// Module is found, return the names of the dependencies
+		const modules = select( STORE_NAME ).getModules();
+		return module.dependencies.map( ( dependencySlug ) => modules[ dependencySlug ].name );
+	} ),
+
+	/**
+	 * Gets module dependant names by slug.
+	 *
+	 * Returns a list of modules on which this module depends.
+	 * Returns `undefined` if state is still loading or if said module doesn't exist.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param {Object} state Data store's state.
+	 * @param {string} slug  Module slug.
+	 * @return {(Array|undefined)} An array of dependant module names; `undefined` if state is still loading.
+	 */
+	getModuleDependantNames: createRegistrySelector( ( select ) => ( state, slug ) => {
+		const module = select( STORE_NAME ).getModule( slug );
+
+		// Return `undefined` if module with this slug isn't loaded yet.
+		if ( module === undefined ) {
+			return undefined;
+		}
+
+		// A module with this slug couldn't be found; return `[]` to signify the
+		// "not found" state.
+		if ( module === null ) {
+			return [];
+		}
+
+		// Module is found, return the names of the dependencies
+		const modules = select( STORE_NAME ).getModules();
+		return module.dependants.map( ( dependantSlug ) => modules[ dependantSlug ].name );
+	} ),
+
+	/**
 	 * Checks a module's activation status.
 	 *
 	 * Returns `true` if the module exists and is active.

--- a/assets/js/googlesitekit/modules/datastore/modules.js
+++ b/assets/js/googlesitekit/modules/datastore/modules.js
@@ -447,7 +447,7 @@ const baseSelectors = {
 
 		// Module is found, return the names of the dependants
 		const modules = select( STORE_NAME ).getModules();
-		return module.dependants.map( ( dependantSlug ) => modules[ dependantSlug ].name );
+		return module.dependants.map( ( dependantSlug ) => modules[ dependantSlug ].name || dependantSlug );
 	} ),
 
 	/**

--- a/assets/js/googlesitekit/modules/datastore/modules.js
+++ b/assets/js/googlesitekit/modules/datastore/modules.js
@@ -417,7 +417,7 @@ const baseSelectors = {
 		// Module is found, return the names of the dependencies
 		// Modules are already resolved after we getModule() so they can't be undefined.
 		const modules = select( STORE_NAME ).getModules();
-		return module.dependencies.map( ( dependencySlug ) => modules[ dependencySlug ].name || dependencySlug );
+		return module.dependencies.map( ( dependencySlug ) => modules[ dependencySlug ]?.name || dependencySlug );
 	} ),
 
 	/**
@@ -449,7 +449,7 @@ const baseSelectors = {
 		// Module is found, return the names of the dependants
 		// Modules are already resolved after we getModule() so they can't be undefined.
 		const modules = select( STORE_NAME ).getModules();
-		return module.dependants.map( ( dependantSlug ) => modules[ dependantSlug ].name || dependantSlug );
+		return module.dependants.map( ( dependantSlug ) => modules[ dependantSlug ]?.name || dependantSlug );
 	} ),
 
 	/**

--- a/assets/js/googlesitekit/modules/datastore/modules.js
+++ b/assets/js/googlesitekit/modules/datastore/modules.js
@@ -415,6 +415,7 @@ const baseSelectors = {
 		}
 
 		// Module is found, return the names of the dependencies
+		// Modules are already resolved after we getModule() so they can't be undefined.
 		const modules = select( STORE_NAME ).getModules();
 		return module.dependencies.map( ( dependencySlug ) => modules[ dependencySlug ].name || dependencySlug );
 	} ),

--- a/assets/js/googlesitekit/modules/datastore/modules.js
+++ b/assets/js/googlesitekit/modules/datastore/modules.js
@@ -447,6 +447,7 @@ const baseSelectors = {
 		}
 
 		// Module is found, return the names of the dependants
+		// Modules are already resolved after we getModule() so they can't be undefined.
 		const modules = select( STORE_NAME ).getModules();
 		return module.dependants.map( ( dependantSlug ) => modules[ dependantSlug ].name || dependantSlug );
 	} ),

--- a/assets/js/googlesitekit/modules/datastore/modules.test.js
+++ b/assets/js/googlesitekit/modules/datastore/modules.test.js
@@ -543,6 +543,102 @@ describe( 'core/modules modules', () => {
 			} );
 		} );
 
+		describe( 'getModuleDependencyNames', () => {
+			it( 'returns undefined when no modules are loaded', async () => {
+				fetchMock.getOnce(
+					/^\/google-site-kit\/v1\/core\/modules\/data\/list/,
+					{ body: FIXTURES, status: 200 }
+				);
+				const slug = 'optimize';
+				const dependencyNames = registry.select( STORE_NAME ).getModuleDependencyNames( slug );
+
+				// The modules will be undefined whilst loading.
+				expect( dependencyNames ).toBeUndefined();
+			} );
+
+			it( 'returns dependency module names when modules are loaded', async () => {
+				fetchMock.getOnce(
+					/^\/google-site-kit\/v1\/core\/modules\/data\/list/,
+					{ body: FIXTURES, status: 200 }
+				);
+				const slug = 'optimize';
+				registry.select( STORE_NAME ).getModuleDependencyNames( slug );
+
+				// Wait for loading to complete.
+				await untilResolved( registry, STORE_NAME ).getModules();
+
+				const dependencyNamesLoaded = registry.select( STORE_NAME ).getModuleDependencyNames( slug );
+
+				expect( fetchMock ).toHaveFetchedTimes( 1 );
+				expect( dependencyNamesLoaded ).toMatchObject( fixturesKeyValue[ slug ].dependencies.map( ( dependency ) => fixturesKeyValue[ dependency ].name ) );
+			} );
+
+			it( 'returns an empty array when requesting dependencies for a non-existent module', async () => {
+				fetchMock.getOnce(
+					/^\/google-site-kit\/v1\/core\/modules\/data\/list/,
+					{ body: FIXTURES, status: 200 }
+				);
+				const slug = 'non-existent-slug';
+				registry.select( STORE_NAME ).getModuleDependencyNames( slug );
+
+				// Wait for loading to complete.
+				await untilResolved( registry, STORE_NAME ).getModules();
+
+				const dependencyNamesLoaded = registry.select( STORE_NAME ).getModuleDependencyNames( slug );
+
+				expect( fetchMock ).toHaveFetchedTimes( 1 );
+				expect( dependencyNamesLoaded ).toMatchObject( {} );
+			} );
+		} );
+
+		describe( 'getModuleDependantNames', () => {
+			it( 'returns undefined when no modules are loaded', async () => {
+				fetchMock.getOnce(
+					/^\/google-site-kit\/v1\/core\/modules\/data\/list/,
+					{ body: FIXTURES, status: 200 }
+				);
+				const slug = 'optimize';
+				const dependantNames = registry.select( STORE_NAME ).getModuleDependantNames( slug );
+
+				// The modules will be undefined whilst loading.
+				expect( dependantNames ).toBeUndefined();
+			} );
+
+			it( 'returns dependant module names when modules are loaded', async () => {
+				fetchMock.getOnce(
+					/^\/google-site-kit\/v1\/core\/modules\/data\/list/,
+					{ body: FIXTURES, status: 200 }
+				);
+				const slug = 'analytics';
+				registry.select( STORE_NAME ).getModuleDependantNames( slug );
+
+				// Wait for loading to complete.
+				await untilResolved( registry, STORE_NAME ).getModules();
+
+				const dependantNamesLoaded = registry.select( STORE_NAME ).getModuleDependantNames( slug );
+
+				expect( fetchMock ).toHaveFetchedTimes( 1 );
+				expect( dependantNamesLoaded ).toMatchObject( fixturesKeyValue[ slug ].dependants.map( ( dependant ) => fixturesKeyValue[ dependant ].name ) );
+			} );
+
+			it( 'returns an empty array when requesting dependencies for a non-existent module', async () => {
+				fetchMock.getOnce(
+					/^\/google-site-kit\/v1\/core\/modules\/data\/list/,
+					{ body: FIXTURES, status: 200 }
+				);
+				const slug = 'non-existent-slug';
+				registry.select( STORE_NAME ).getModuleDependantNames( slug );
+
+				// Wait for loading to complete.
+				await untilResolved( registry, STORE_NAME ).getModules();
+
+				const dependantNamesLoaded = registry.select( STORE_NAME ).getModuleDependantNames( slug );
+
+				expect( fetchMock ).toHaveFetchedTimes( 1 );
+				expect( dependantNamesLoaded ).toMatchObject( {} );
+			} );
+		} );
+
 		describe( 'isModuleActive', () => {
 			beforeEach( () => {
 				fetchMock.getOnce(

--- a/assets/js/googlesitekit/modules/datastore/modules.test.js
+++ b/assets/js/googlesitekit/modules/datastore/modules.test.js
@@ -543,99 +543,54 @@ describe( 'core/modules modules', () => {
 			} );
 		} );
 
-		describe( 'getModuleDependencyNames', () => {
+		describe.each( [
+			[ 'getModuleDependencyNames', 'dependencies' ],
+			[ 'getModuleDependantNames', 'dependants' ],
+		] )( '%s', ( selector, collectionName ) => {
 			it( 'returns undefined when no modules are loaded', async () => {
 				fetchMock.getOnce(
 					/^\/google-site-kit\/v1\/core\/modules\/data\/list/,
 					{ body: FIXTURES, status: 200 }
 				);
 				const slug = 'optimize';
-				const dependencyNames = registry.select( STORE_NAME ).getModuleDependencyNames( slug );
+				const namesLoaded = registry.select( STORE_NAME )[ selector ]( slug );
 
 				// The modules will be undefined whilst loading.
-				expect( dependencyNames ).toBeUndefined();
+				expect( namesLoaded ).toBeUndefined();
 			} );
 
-			it( 'returns dependency module names when modules are loaded', async () => {
+			it( `returns ${ collectionName } module names when modules are loaded`, async () => {
 				fetchMock.getOnce(
 					/^\/google-site-kit\/v1\/core\/modules\/data\/list/,
 					{ body: FIXTURES, status: 200 }
 				);
 				const slug = 'optimize';
-				registry.select( STORE_NAME ).getModuleDependencyNames( slug );
+				registry.select( STORE_NAME )[ selector ]( slug );
 
 				// Wait for loading to complete.
 				await untilResolved( registry, STORE_NAME ).getModules();
 
-				const dependencyNamesLoaded = registry.select( STORE_NAME ).getModuleDependencyNames( slug );
+				const namesLoaded = registry.select( STORE_NAME )[ selector ]( slug );
 
 				expect( fetchMock ).toHaveFetchedTimes( 1 );
-				expect( dependencyNamesLoaded ).toMatchObject( fixturesKeyValue[ slug ].dependencies.map( ( dependency ) => fixturesKeyValue[ dependency ].name ) );
+				expect( namesLoaded ).toMatchObject( fixturesKeyValue[ slug ][ collectionName ].map( ( key ) => fixturesKeyValue[ key ].name ) );
 			} );
 
-			it( 'returns an empty array when requesting dependencies for a non-existent module', async () => {
+			it( `returns an empty array when requesting ${ collectionName } for a non-existent module`, async () => {
 				fetchMock.getOnce(
 					/^\/google-site-kit\/v1\/core\/modules\/data\/list/,
 					{ body: FIXTURES, status: 200 }
 				);
 				const slug = 'non-existent-slug';
-				registry.select( STORE_NAME ).getModuleDependencyNames( slug );
+				registry.select( STORE_NAME )[ selector ]( slug );
 
 				// Wait for loading to complete.
 				await untilResolved( registry, STORE_NAME ).getModules();
 
-				const dependencyNamesLoaded = registry.select( STORE_NAME ).getModuleDependencyNames( slug );
+				const namesLoaded = registry.select( STORE_NAME )[ selector ]( slug );
 
 				expect( fetchMock ).toHaveFetchedTimes( 1 );
-				expect( dependencyNamesLoaded ).toMatchObject( {} );
-			} );
-		} );
-
-		describe( 'getModuleDependantNames', () => {
-			it( 'returns undefined when no modules are loaded', async () => {
-				fetchMock.getOnce(
-					/^\/google-site-kit\/v1\/core\/modules\/data\/list/,
-					{ body: FIXTURES, status: 200 }
-				);
-				const slug = 'optimize';
-				const dependantNames = registry.select( STORE_NAME ).getModuleDependantNames( slug );
-
-				// The modules will be undefined whilst loading.
-				expect( dependantNames ).toBeUndefined();
-			} );
-
-			it( 'returns dependant module names when modules are loaded', async () => {
-				fetchMock.getOnce(
-					/^\/google-site-kit\/v1\/core\/modules\/data\/list/,
-					{ body: FIXTURES, status: 200 }
-				);
-				const slug = 'analytics';
-				registry.select( STORE_NAME ).getModuleDependantNames( slug );
-
-				// Wait for loading to complete.
-				await untilResolved( registry, STORE_NAME ).getModules();
-
-				const dependantNamesLoaded = registry.select( STORE_NAME ).getModuleDependantNames( slug );
-
-				expect( fetchMock ).toHaveFetchedTimes( 1 );
-				expect( dependantNamesLoaded ).toMatchObject( fixturesKeyValue[ slug ].dependants.map( ( dependant ) => fixturesKeyValue[ dependant ].name ) );
-			} );
-
-			it( 'returns an empty array when requesting dependencies for a non-existent module', async () => {
-				fetchMock.getOnce(
-					/^\/google-site-kit\/v1\/core\/modules\/data\/list/,
-					{ body: FIXTURES, status: 200 }
-				);
-				const slug = 'non-existent-slug';
-				registry.select( STORE_NAME ).getModuleDependantNames( slug );
-
-				// Wait for loading to complete.
-				await untilResolved( registry, STORE_NAME ).getModules();
-
-				const dependantNamesLoaded = registry.select( STORE_NAME ).getModuleDependantNames( slug );
-
-				expect( fetchMock ).toHaveFetchedTimes( 1 );
-				expect( dependantNamesLoaded ).toMatchObject( {} );
+				expect( namesLoaded ).toMatchObject( {} );
 			} );
 		} );
 


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #2180 

## Relevant technical choices
Went for a more KISS approach and less DRY. We could abstract both calls to call a function which takes a `slug` and a `key` where key would be one of dependency/dependant as they are almost identical in functionality.
Went with getModule per IB rather than getModules() and calculating everything based on that.

<!-- Please describe your changes. -->

## Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
