### PR TITLE
Bug/1817 wrong settings validation

### DIFF
--- a/assets/js/modules/tagmanager/datastore/settings.js
+++ b/assets/js/modules/tagmanager/datastore/settings.js
@@ -219,7 +219,6 @@ const {
 	const { getPropertyID } = strictSelect( MODULES_ANALYTICS );
 
 	const accountID = getAccountID();
-	const ampContainerID = getAMPContainerID();
 
 	// Note: these error messages are referenced in test assertions.
 	invariant( ! isDoingSubmitChanges(), INVARIANT_DOING_SUBMIT_CHANGES );
@@ -236,21 +235,23 @@ const {
 		invariant( isUniqueContainerName( containerName, containers ), `a container with "${ normalizedContainerName }" name already exists` );
 	}
 
-	if ( ampContainerID === CONTAINER_CREATE ) {
-		const ampContainerName = strictSelect( CORE_FORMS ).getValue( FORM_SETUP, 'ampContainerName' );
-		invariant( isValidContainerName( ampContainerName ), INVARIANT_INVALID_CONTAINER_NAME );
-
-		const containers = getContainers( accountID );
-		const normalizedContainerName = getNormalizedContainerName( ampContainerName );
-		invariant( isUniqueContainerName( ampContainerName, containers ), `an AMP container with "${ normalizedContainerName }" name already exists` );
-	}
-
 	if ( isAMP() ) {
+		const ampContainerID = getAMPContainerID();
+
 		// If AMP is active, the AMP container ID must be valid, regardless of mode.
 		invariant( isValidContainerSelection( ampContainerID ), INVARIANT_INVALID_AMP_CONTAINER_SELECTION );
 		// If AMP is active, and a valid AMP container ID is selected, the internal ID must also be valid.
 		if ( isValidContainerID( ampContainerID ) ) {
 			invariant( isValidInternalContainerID( getInternalAMPContainerID() ), INVARIANT_INVALID_AMP_INTERNAL_CONTAINER_ID );
+		}
+
+		if ( ampContainerID === CONTAINER_CREATE ) {
+			const ampContainerName = strictSelect( CORE_FORMS ).getValue( FORM_SETUP, 'ampContainerName' );
+			invariant( isValidContainerName( ampContainerName ), INVARIANT_INVALID_CONTAINER_NAME );
+
+			const containers = getContainers( accountID );
+			const normalizedContainerName = getNormalizedContainerName( ampContainerName );
+			invariant( isUniqueContainerName( ampContainerName, containers ), `an AMP container with "${ normalizedContainerName }" name already exists` );
 		}
 	}
 

--- a/assets/js/modules/tagmanager/datastore/settings.js
+++ b/assets/js/modules/tagmanager/datastore/settings.js
@@ -227,7 +227,7 @@ const {
 
 	const containerID = getContainerID();
 	if ( containerID === CONTAINER_CREATE ) {
-		const containerName = strictSelect( CORE_FORMS ).getValue( FORM_SETUP, 'containerName' );
+		const containerName = select( CORE_FORMS ).getValue( FORM_SETUP, 'containerName' );
 		invariant( isValidContainerName( containerName ), INVARIANT_INVALID_CONTAINER_NAME );
 
 		const containers = getContainers( accountID );
@@ -246,7 +246,7 @@ const {
 		}
 
 		if ( ampContainerID === CONTAINER_CREATE ) {
-			const ampContainerName = strictSelect( CORE_FORMS ).getValue( FORM_SETUP, 'ampContainerName' );
+			const ampContainerName = select( CORE_FORMS ).getValue( FORM_SETUP, 'ampContainerName' );
 			invariant( isValidContainerName( ampContainerName ), INVARIANT_INVALID_CONTAINER_NAME );
 
 			const containers = getContainers( accountID );


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #1817

## Relevant technical choices

* Revert usage of `strictSelect` for the form datastore in favor of using just regular `select` because there is no need to use `strictSelect` to get form data since that datastore doesn't use resolvers.

## Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
