### PR TITLE
Remove console mocks in favour of using @wordpress/jest-console.

### DIFF
--- a/tests/js/jest.config.js
+++ b/tests/js/jest.config.js
@@ -22,7 +22,6 @@ module.exports = {
 	},
 	setupFiles: [
 		'<rootDir>/tests/js/setup-globals',
-		'<rootDir>/tests/js/setup-mocks',
 		'jest-localstorage-mock',
 	],
 	setupFilesAfterEnv: [

--- a/tests/js/setup-before-after.js
+++ b/tests/js/setup-before-after.js
@@ -6,12 +6,6 @@ import fetchMockJest from 'fetch-mock-jest';
 global.fetchMock = fetchMockJest;
 
 beforeEach( () => {
-	global.console.error.mockClear();
-	global.console.warn.mockClear();
-	global.console.log.mockClear();
-	global.console.info.mockClear();
-	global.console.debug.mockClear();
-
 	localStorage.clear();
 	sessionStorage.clear();
 

--- a/tests/js/setup-mocks.js
+++ b/tests/js/setup-mocks.js
@@ -1,5 +1,0 @@
-jest.spyOn( global.console, 'error' );
-jest.spyOn( global.console, 'warn' );
-jest.spyOn( global.console, 'log' );
-jest.spyOn( global.console, 'info' );
-jest.spyOn( global.console, 'debug' );


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #2231 

## Relevant technical choices
Remove manually mocked console functions which are no longer needed since we now have `@wordpress/jest-console` when `@wordpress/scripts` was upgraded.

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
