### PR TITLE
Bug/2210 errors should require args

### DIFF
--- a/assets/js/googlesitekit/data/create-error-store.js
+++ b/assets/js/googlesitekit/data/create-error-store.js
@@ -45,7 +45,9 @@ export function generateErrorKey( baseName, args ) {
 export const actions = {
 	receiveError( error, baseName, args ) {
 		invariant( error, 'error is required.' );
-		invariant( ! baseName || ( args && Array.isArray( args ) ), 'args is required (and must be an array) when baseName is specified.' );
+		if ( baseName ) {
+			invariant( args && Array.isArray( args ), 'args is required (and must be an array) when baseName is specified.' );
+		}
 
 		return {
 			type: RECEIVE_ERROR,
@@ -57,7 +59,9 @@ export const actions = {
 		};
 	},
 	clearError( baseName, args ) {
-		invariant( ! baseName || ( args && Array.isArray( args ) ), 'args is required (and must be an array) when baseName is specified.' );
+		if ( baseName ) {
+			invariant( args && Array.isArray( args ), 'args is required (and must be an array) when baseName is specified.' );
+		}
 
 		return {
 			type: CLEAR_ERROR,

--- a/assets/js/googlesitekit/data/create-error-store.js
+++ b/assets/js/googlesitekit/data/create-error-store.js
@@ -45,6 +45,7 @@ export function generateErrorKey( baseName, args ) {
 export const actions = {
 	receiveError( error, baseName, args ) {
 		invariant( error, 'error is required.' );
+		invariant( ! baseName || ( args && Array.isArray( args ) ), 'args is required (and must be an array) when baseName is specified.' );
 
 		return {
 			type: RECEIVE_ERROR,
@@ -56,6 +57,8 @@ export const actions = {
 		};
 	},
 	clearError( baseName, args ) {
+		invariant( ! baseName || ( args && Array.isArray( args ) ), 'args is required (and must be an array) when baseName is specified.' );
+
 		return {
 			type: CLEAR_ERROR,
 			payload: {

--- a/assets/js/googlesitekit/data/create-error-store.test.js
+++ b/assets/js/googlesitekit/data/create-error-store.test.js
@@ -75,8 +75,8 @@ describe( 'createErrorStore store', () => {
 			} );
 
 			it( 'receives and sets value for an error with `baseName` only', () => {
-				dispatch.receiveError( errorNotFound, baseName );
-				expect( store.getState().errors[ baseName ] ).toEqual( errorNotFound );
+				dispatch.receiveError( errorNotFound, baseName, [] );
+				expect( store.getState().errors[ generateErrorKey( baseName, [] ) ] ).toEqual( errorNotFound );
 			} );
 
 			it( 'receives and sets value for an error with `baseName` and `args`', () => {
@@ -102,7 +102,7 @@ describe( 'createErrorStore store', () => {
 			it( 'requires the same `baseName` and `args` an error was received with to clear it', () => {
 				dispatch.receiveError( errorForbidden, baseName, args );
 
-				dispatch.clearError( baseName );
+				dispatch.clearError( baseName, [] );
 
 				expect( store.getState().errors ).toHaveProperty(
 					generateErrorKey( baseName, args ),
@@ -120,7 +120,7 @@ describe( 'createErrorStore store', () => {
 		describe( 'clearErrors', () => {
 			it( 'clears all received errors when called with no arguments', () => {
 				dispatch.receiveError( errorNotFound );
-				dispatch.receiveError( errorForbidden, baseName );
+				dispatch.receiveError( errorForbidden, baseName, [] );
 				dispatch.receiveError( errorForbidden, baseName, args );
 
 				dispatch.clearErrors();
@@ -131,7 +131,7 @@ describe( 'createErrorStore store', () => {
 
 			it( 'clears all received errors for a given `baseName`', () => {
 				dispatch.receiveError( errorNotFound );
-				dispatch.receiveError( errorForbidden, baseName );
+				dispatch.receiveError( errorForbidden, baseName, [] );
 				dispatch.receiveError( errorForbidden, baseName, args );
 				dispatch.receiveError( errorNotFound, 'otherBaseName', args );
 
@@ -173,7 +173,7 @@ describe( 'createErrorStore store', () => {
 			} );
 
 			it( `returns the error received for the given \`${ baseNameParam }\` and \`args\``, () => {
-				dispatch.receiveError( errorNotFound, baseName );
+				dispatch.receiveError( errorNotFound, baseName, [] );
 				dispatch.receiveError( errorForbidden, baseName, args );
 
 				expect( select[ selectorName ]( baseName, args ) ).toEqual( errorForbidden );
@@ -188,7 +188,7 @@ describe( 'createErrorStore store', () => {
 				} );
 
 				it( 'returns the error which was received without any `baseName` or `args`', () => {
-					dispatch.receiveError( errorNotFound, baseName );
+					dispatch.receiveError( errorNotFound, baseName, [] );
 
 					expect( select.getError() ).toBeUndefined();
 
@@ -209,10 +209,10 @@ describe( 'createErrorStore store', () => {
 			} );
 
 			it( 'returns the error received with the same given `baseName` and `args`', () => {
-				dispatch.receiveError( errorNotFound, baseName );
+				dispatch.receiveError( errorNotFound, baseName, [] );
 				dispatch.receiveError( errorForbidden, baseName, args );
 
-				expect( select.getError( baseName ) ).toEqual( errorNotFound );
+				expect( select.getError( baseName, [] ) ).toEqual( errorNotFound );
 				expect( select.getError( baseName, args ) ).toEqual( errorForbidden );
 			} );
 		} );
@@ -233,8 +233,8 @@ describe( 'createErrorStore store', () => {
 
 			it( 'returns a list of unique errors, regardless of `baseName` or `args`', () => {
 				dispatch.receiveError( errorNotFound );
-				dispatch.receiveError( errorNotFound, baseName );
-				dispatch.receiveError( errorNotFound, 'otherBaseName' );
+				dispatch.receiveError( errorNotFound, baseName, [] );
+				dispatch.receiveError( errorNotFound, 'otherBaseName', [] );
 				dispatch.receiveError( errorNotFound, baseName, [ 'foo' ] );
 				dispatch.receiveError( errorNotFound, baseName, [ 'bar' ] );
 

--- a/assets/js/googlesitekit/data/create-settings-store.js
+++ b/assets/js/googlesitekit/data/create-settings-store.js
@@ -169,13 +169,17 @@ export const createSettingsStore = ( type, identifier, datapoint, {
 		 */
 		*saveSettings() {
 			const registry = yield Data.commonActions.getRegistry();
-			registry.dispatch( STORE_NAME ).clearError( 'saveSettings', [] );
+
+			const { clearError, receiveError } = registry.dispatch( STORE_NAME );
+			if ( clearError ) {
+				clearError( 'saveSettings', [] );
+			}
 
 			const values = registry.select( STORE_NAME ).getSettings();
 			const { response, error } = yield fetchSaveSettingsStore.actions.fetchSaveSettings( values );
-			if ( error ) {
+			if ( error && receiveError ) {
 				// Store error manually since saveSettings signature differs from fetchSaveSettings.
-				registry.dispatch( STORE_NAME ).receiveError( error, 'saveSettings', [] );
+				receiveError( error, 'saveSettings', [] );
 			}
 
 			return { response, error };

--- a/assets/js/googlesitekit/data/create-settings-store.js
+++ b/assets/js/googlesitekit/data/create-settings-store.js
@@ -169,12 +169,13 @@ export const createSettingsStore = ( type, identifier, datapoint, {
 		 */
 		*saveSettings() {
 			const registry = yield Data.commonActions.getRegistry();
-			const values = registry.select( STORE_NAME ).getSettings();
+			registry.dispatch( STORE_NAME ).clearError( 'saveSettings', [] );
 
+			const values = registry.select( STORE_NAME ).getSettings();
 			const { response, error } = yield fetchSaveSettingsStore.actions.fetchSaveSettings( values );
 			if ( error ) {
 				// Store error manually since saveSettings signature differs from fetchSaveSettings.
-				registry.dispatch( STORE_NAME ).receiveError( error, 'saveSettings' );
+				registry.dispatch( STORE_NAME ).receiveError( error, 'saveSettings', [] );
 			}
 
 			return { response, error };

--- a/assets/js/googlesitekit/data/create-settings-store.test.js
+++ b/assets/js/googlesitekit/data/create-settings-store.test.js
@@ -24,12 +24,14 @@ import { createRegistry } from '@wordpress/data';
 /**
  * Internal dependencies
  */
+import Data from 'googlesitekit-data';
 import API from 'googlesitekit-api';
 import {
 	muteFetch,
 	subscribeUntil,
 	unsubscribeFromAll,
 } from '../../../../tests/js/utils';
+import { createErrorStore } from './create-error-store';
 import { createSettingsStore } from './create-settings-store';
 
 const STORE_ARGS = [ 'core', 'site', 'settings' ];
@@ -52,7 +54,12 @@ describe( 'createSettingsStore store', () => {
 			settingSlugs: [ 'isSkyBlue' ],
 			registry,
 		} );
-		registry.registerStore( storeDefinition.STORE_NAME, storeDefinition );
+
+		registry.registerStore( storeDefinition.STORE_NAME, Data.combineStores(
+			storeDefinition,
+			createErrorStore(),
+		) );
+
 		dispatch = registry.dispatch( storeDefinition.STORE_NAME );
 		store = registry.stores[ storeDefinition.STORE_NAME ].store;
 		select = registry.select( storeDefinition.STORE_NAME );

--- a/assets/js/googlesitekit/data/create-settings-store.test.js
+++ b/assets/js/googlesitekit/data/create-settings-store.test.js
@@ -24,14 +24,12 @@ import { createRegistry } from '@wordpress/data';
 /**
  * Internal dependencies
  */
-import Data from 'googlesitekit-data';
 import API from 'googlesitekit-api';
 import {
 	muteFetch,
 	subscribeUntil,
 	unsubscribeFromAll,
 } from '../../../../tests/js/utils';
-import { createErrorStore } from './create-error-store';
 import { createSettingsStore } from './create-settings-store';
 
 const STORE_ARGS = [ 'core', 'site', 'settings' ];
@@ -54,12 +52,7 @@ describe( 'createSettingsStore store', () => {
 			settingSlugs: [ 'isSkyBlue' ],
 			registry,
 		} );
-
-		registry.registerStore( storeDefinition.STORE_NAME, Data.combineStores(
-			storeDefinition,
-			createErrorStore(),
-		) );
-
+		registry.registerStore( storeDefinition.STORE_NAME, storeDefinition );
 		dispatch = registry.dispatch( storeDefinition.STORE_NAME );
 		store = registry.stores[ storeDefinition.STORE_NAME ].store;
 		select = registry.select( storeDefinition.STORE_NAME );

--- a/assets/js/modules/adsense/datastore/settings.js
+++ b/assets/js/modules/adsense/datastore/settings.js
@@ -123,6 +123,7 @@ const baseActions = {
 	 */
 	*submitChanges() {
 		const registry = yield Data.commonActions.getRegistry();
+		registry.dispatch( STORE_NAME ).clearError( 'submitChanges', [] );
 
 		yield {
 			payload: {},

--- a/assets/js/modules/analytics/datastore/accounts.js
+++ b/assets/js/modules/analytics/datastore/accounts.js
@@ -148,8 +148,9 @@ const baseActions = {
 	 */
 	*createAccount() {
 		const registry = yield Data.commonActions.getRegistry();
-		const { getValue } = registry.select( CORE_FORMS );
+		registry.dispatch( STORE_NAME ).clearError( 'createAccount', [] );
 
+		const { getValue } = registry.select( CORE_FORMS );
 		const data = {
 			accountName: getValue( FORM_ACCOUNT_CREATE, 'accountName' ),
 			propertyName: getValue( FORM_ACCOUNT_CREATE, 'propertyName' ),
@@ -207,6 +208,8 @@ const baseReducer = ( state, { type, payload } ) => {
 const baseResolvers = {
 	*getAccounts() {
 		const registry = yield Data.commonActions.getRegistry();
+		registry.dispatch( STORE_NAME ).clearError( 'getAccounts', [] );
+
 		const existingAccounts = registry.select( STORE_NAME ).getAccounts();
 		let matchedProperty = registry.select( STORE_NAME ).getMatchedProperty();
 		// Only fetch accounts if there are none in the store.

--- a/assets/js/modules/analytics/datastore/properties.js
+++ b/assets/js/modules/analytics/datastore/properties.js
@@ -279,9 +279,10 @@ const baseResolvers = {
 		}
 
 		const registry = yield Data.commonActions.getRegistry();
-		let properties = registry.select( STORE_NAME ).getProperties( accountID );
+		registry.dispatch( STORE_NAME ).clearError( 'getProperties', [ accountID ] );
 
 		// Only fetch properties if there are none in the store for the given account.
+		let properties = registry.select( STORE_NAME ).getProperties( accountID );
 		if ( properties === undefined ) {
 			const { response, error } = yield fetchGetPropertiesProfilesStore.actions.fetchGetPropertiesProfiles( accountID );
 			const { dispatch } = registry;

--- a/assets/js/modules/analytics/datastore/settings.js
+++ b/assets/js/modules/analytics/datastore/settings.js
@@ -74,6 +74,7 @@ export const actions = {
 	 */
 	*submitChanges() {
 		const registry = yield Data.commonActions.getRegistry();
+		registry.dispatch( STORE_NAME ).clearError( 'submitChanges', [] );
 
 		yield {
 			payload: {},

--- a/assets/js/modules/optimize/datastore/settings.js
+++ b/assets/js/modules/optimize/datastore/settings.js
@@ -62,6 +62,7 @@ export const actions = {
 	 */
 	*submitChanges() {
 		const registry = yield Data.commonActions.getRegistry();
+		registry.dispatch( STORE_NAME ).clearError( 'submitChanges', [] );
 
 		yield {
 			payload: {},

--- a/assets/js/modules/tagmanager/datastore/settings.js
+++ b/assets/js/modules/tagmanager/datastore/settings.js
@@ -78,6 +78,7 @@ export const actions = {
 	 */
 	*submitChanges() {
 		const registry = yield Data.commonActions.getRegistry();
+		registry.dispatch( STORE_NAME ).clearError( 'submitChanges', [] );
 
 		yield {
 			payload: {},


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #2210

## Relevant technical choices

<!-- Please describe your changes. -->

## Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
