### PR TITLE
Unregister site on proxy on uninstallation of plugin

### DIFF
--- a/bin/release
+++ b/bin/release
@@ -112,6 +112,7 @@ async function makeRelease() {
 	await Promise.all( [
 		cp( 'readme.txt' ),
 		cp( 'google-site-kit.php' ),
+		cp( 'uninstall.php' ),
 		cp( 'dist/assets' ),
 		cp( 'includes' ),
 		cp( 'third-party' ),

--- a/google-site-kit.php
+++ b/google-site-kit.php
@@ -54,7 +54,6 @@ function googlesitekit_activate_plugin( $network_wide ) {
 
 	do_action( 'googlesitekit_activation', $network_wide );
 }
-
 register_activation_hook( __FILE__, 'googlesitekit_activate_plugin' );
 
 /**
@@ -76,8 +75,22 @@ function googlesitekit_deactivate_plugin( $network_wide ) {
 
 	do_action( 'googlesitekit_deactivation', $network_wide );
 }
-
 register_deactivation_hook( __FILE__, 'googlesitekit_deactivate_plugin' );
+
+/**
+ * Handles plugin uninstallation.
+ *
+ * @since n.e.x.t
+ * @access private
+ */
+function googlesitekit_uninstall_plugin() {
+	if ( version_compare( PHP_VERSION, GOOGLESITEKIT_PHP_MINIMUM, '<' ) ) {
+		return;
+	}
+
+	do_action( 'googlesitekit_uninstallation' );
+}
+register_uninstall_hook( __FILE__, 'googlesitekit_uninstall_plugin' );
 
 /**
  * Resets opcache if possible.

--- a/google-site-kit.php
+++ b/google-site-kit.php
@@ -78,21 +78,6 @@ function googlesitekit_deactivate_plugin( $network_wide ) {
 register_deactivation_hook( __FILE__, 'googlesitekit_deactivate_plugin' );
 
 /**
- * Handles plugin uninstallation.
- *
- * @since n.e.x.t
- * @access private
- */
-function googlesitekit_uninstall_plugin() {
-	if ( version_compare( PHP_VERSION, GOOGLESITEKIT_PHP_MINIMUM, '<' ) ) {
-		return;
-	}
-
-	do_action( 'googlesitekit_uninstallation' );
-}
-register_uninstall_hook( __FILE__, 'googlesitekit_uninstall_plugin' );
-
-/**
  * Resets opcache if possible.
  *
  * @since 1.3.0

--- a/includes/Core/Util/Uninstallation.php
+++ b/includes/Core/Util/Uninstallation.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * Class Google\Site_Kit\Core\Util\Uninstallation
+ *
+ * @package   Google\Site_Kit\Core\Util
+ * @copyright 2020 Google LLC
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
+ * @link      https://sitekit.withgoogle.com
+ */
+
+namespace Google\Site_Kit\Core\Util;
+
+use Google\Site_Kit\Context;
+use Google\Site_Kit\Core\Storage\Options;
+use Google\Site_Kit\Core\Storage\Encrypted_Options;
+use Google\Site_Kit\Core\Authentication\Credentials;
+use Google\Site_Kit\Core\Authentication\Google_Proxy;
+
+/**
+ * Utility class for handling uninstallation of the plugin.
+ *
+ * @since n.e.x.t
+ * @access private
+ * @ignore
+ */
+class Uninstallation {
+
+	/**
+	 * Plugin context.
+	 *
+	 * @since n.e.x.t
+	 * @var Context
+	 */
+	private $context;
+
+	/**
+	 * Options object.
+	 *
+	 * @since n.e.x.t
+	 * @var Options
+	 */
+	private $options = null;
+
+	/**
+	 * Constructor.
+	 *
+	 * This class and its logic must be instantiated early in the WordPress
+	 * bootstrap lifecycle because an uninstallation hook runs decoupled from
+	 * regular action hooks like 'init'.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param Context $context Plugin context.
+	 * @param Options $options Optional. Option API instance. Default is a new instance.
+	 */
+	public function __construct(
+		Context $context,
+		Options $options = null
+	) {
+		$this->context = $context;
+		$this->options = $options ?: new Options( $this->context );
+	}
+
+	/**
+	 * Registers functionality through WordPress hooks.
+	 *
+	 * @since n.e.x.t
+	 */
+	public function register() {
+		add_action(
+			'googlesitekit_uninstallation',
+			function() {
+				$this->uninstall();
+			}
+		);
+	}
+
+	/**
+	 * Runs necessary logic for uninstallation of the plugin.
+	 *
+	 * If connected to the proxy, it will issue a request to unregister the site.
+	 *
+	 * @since n.e.x.t
+	 */
+	private function uninstall() {
+		$credentials = new Credentials( new Encrypted_Options( $this->options ) );
+
+		if ( ! $credentials->has() || ! $credentials->using_proxy() ) {
+			return;
+		}
+
+		$google_proxy = new Google_Proxy( $this->context );
+		try {
+			$google_proxy->unregister_site( $credentials );
+		} catch ( Exception $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
+			// Just avoid this from being thrown.
+		}
+	}
+}

--- a/includes/Core/Util/Uninstallation.php
+++ b/includes/Core/Util/Uninstallation.php
@@ -15,6 +15,7 @@ use Google\Site_Kit\Core\Storage\Options;
 use Google\Site_Kit\Core\Storage\Encrypted_Options;
 use Google\Site_Kit\Core\Authentication\Credentials;
 use Google\Site_Kit\Core\Authentication\Google_Proxy;
+use Exception;
 
 /**
  * Utility class for handling uninstallation of the plugin.

--- a/includes/Core/Util/Uninstallation.php
+++ b/includes/Core/Util/Uninstallation.php
@@ -35,24 +35,24 @@ class Uninstallation {
 	private $context;
 
 	/**
-	 * Options object.
+	 * Options instance.
 	 *
 	 * @since n.e.x.t
 	 * @var Options
 	 */
-	private $options = null;
+	private $options;
 
 	/**
 	 * Constructor.
 	 *
 	 * This class and its logic must be instantiated early in the WordPress
-	 * bootstrap lifecycle because an uninstallation hook runs decoupled from
-	 * regular action hooks like 'init'.
+	 * bootstrap lifecycle because the 'uninstall.php' script runs decoupled
+	 * from regular action hooks like 'init'.
 	 *
 	 * @since n.e.x.t
 	 *
 	 * @param Context $context Plugin context.
-	 * @param Options $options Optional. Option API instance. Default is a new instance.
+	 * @param Options $options Optional. Options instance. Default is a new instance.
 	 */
 	public function __construct(
 		Context $context,

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -138,6 +138,11 @@ final class Plugin {
 		$activation_flag = new Core\Util\Activation_Flag( $this->context, $options );
 		$activation_flag->register();
 
+		// Register uninstallation logic outside of 'init' since it hooks into
+		// plugin uninstallation.
+		$uninstallation = new Core\Util\Uninstallation( $this->context, $options );
+		$uninstallation->register();
+
 		// Initiate the plugin on 'init' for relying on current user being set.
 		add_action(
 			'init',

--- a/tests/phpunit/integration/Core/Authentication/Google_ProxyTest.php
+++ b/tests/phpunit/integration/Core/Authentication/Google_ProxyTest.php
@@ -17,8 +17,14 @@ use Google\Site_Kit\Core\Storage\Options;
 use Google\Site_Kit\Tests\MethodSpy;
 use Google\Site_Kit\Tests\MutableInput;
 use Google\Site_Kit\Tests\TestCase;
+use Google\Site_Kit\Tests\Fake_Site_Connection_Trait;
+use Exception;
 
+/**
+ * @group Authentication
+ */
 class Google_ProxyTest extends TestCase {
+	use Fake_Site_Connection_Trait;
 
 	public function test_get_site_fields() {
 		$context      = new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE );
@@ -82,22 +88,71 @@ class Google_ProxyTest extends TestCase {
 		);
 	}
 
+	public function test_unregister_site() {
+		$context      = new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE );
+		$google_proxy = new Google_Proxy( $context );
+		$credentials  = new Credentials( new Options( $context ) );
+
+		$fake_creds = $this->fake_proxy_site_connection();
+
+		$pre_args = null;
+		$pre_url  = null;
+
+		add_filter(
+			'pre_http_request',
+			function ( $false, $args, $url ) use ( &$pre_args, &$pre_url ) {
+				$pre_args = $args;
+				$pre_url  = $url;
+
+				return $false;
+			},
+			10,
+			3
+		);
+
+		$expected_success_response = array( 'success' => true );
+		$this->expect_request_response(
+			$google_proxy->url( Google_Proxy::OAUTH2_DELETE_SITE_URI ),
+			$expected_success_response
+		);
+		$response_data = $google_proxy->unregister_site( $credentials );
+
+		// Ensure the request was made with the proper URL and body parameters.
+		$this->assertEquals( $google_proxy->url( Google_Proxy::OAUTH2_DELETE_SITE_URI ), $pre_url );
+		$this->assertEquals( 'POST', $pre_args['method'] );
+		$this->assertEqualSetsWithIndex(
+			array(
+				'site_id'     => $fake_creds['client_id'],
+				'site_secret' => $fake_creds['client_secret'],
+			),
+			$pre_args['body']
+		);
+
+		// Ensure success response data is correct.
+		$this->assertEquals( $expected_success_response, $response_data );
+
+		$expected_error_response = array( 'error' => "invalid 'site_id' or 'site_secret'" );
+		$this->expect_request_response(
+			$google_proxy->url( Google_Proxy::OAUTH2_DELETE_SITE_URI ),
+			$expected_error_response,
+			400
+		);
+
+		// Ensure exception with correct message is thrown for error response.
+		try {
+			$google_proxy->unregister_site( $credentials );
+			$this->assertEquals( $expected_error_response['error'], null );
+		} catch ( Exception $e ) {
+			$this->assertEquals( $expected_error_response['error'], $e->getMessage() );
+		}
+	}
+
 	public function test_sync_site_fields() {
 		$context      = new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE );
 		$google_proxy = new Google_Proxy( $context );
 		$credentials  = new Credentials( new Options( $context ) );
 
-		add_filter( // Fake "using proxy"
-			'googlesitekit_oauth_secret',
-			function () {
-				return array(
-					'web' => array(
-						'client_id'     => '12345678.apps.sitekit.withgoogle.com',
-						'client_secret' => 'test-client-secret',
-					),
-				);
-			}
-		);
+		$this->fake_proxy_site_connection();
 
 		$pre_args = null;
 		$pre_url  = null;
@@ -146,21 +201,40 @@ class Google_ProxyTest extends TestCase {
 		);
 
 		// Stub the response to the proxy oauth API.
+		$this->expect_request_response(
+			$google_proxy->url( Google_Proxy::OAUTH2_SITE_URI ),
+			$expected_credentials
+		);
+
+		$credentials = $google_proxy->exchange_site_code( 'test-site-code', 'test-undelegated-code' );
+		$this->assertEqualSetsWithIndex(
+			$expected_credentials,
+			$credentials
+		);
+	}
+
+	/**
+	 * Adds a 'pre_http_request' filter that will ensure the request for the
+	 * given URL will yield a specific response.
+	 *
+	 * @param string $request_url   Request URL to modify response for.
+	 * @param array  $response_data Response data to return for the request. Will be JSON-encoded.
+	 * @param int    $response_code Optional. Response status code to return. Default 200.
+	 */
+	private function expect_request_response( $request_url, array $response_data, $response_code = 200 ) {
 		add_filter(
 			'pre_http_request',
-			function ( $preempt, $args, $url ) use ( $google_proxy, $expected_credentials ) {
-				if ( $google_proxy->url( Google_Proxy::OAUTH2_SITE_URI ) !== $url ) {
+			function ( $preempt, $args, $url ) use ( $request_url, $response_data, $response_code ) {
+				if ( $request_url !== $url ) {
 					return $preempt;
 				}
 
 				return array(
 					'headers'       => array(),
-					'body'          => json_encode(
-						$expected_credentials
-					),
+					'body'          => json_encode( $response_data ),
 					'response'      => array(
-						'code'    => 200,
-						'message' => 'OK',
+						'code'    => $response_code,
+						'message' => get_status_header_desc( $response_code ),
 					),
 					'cookies'       => array(),
 					'http_response' => null,
@@ -168,12 +242,6 @@ class Google_ProxyTest extends TestCase {
 			},
 			10,
 			3
-		);
-
-		$credentials = $google_proxy->exchange_site_code( 'test-site-code', 'test-undelegated-code' );
-		$this->assertEqualSetsWithIndex(
-			$expected_credentials,
-			$credentials
 		);
 	}
 }

--- a/tests/phpunit/integration/Core/Authentication/Google_ProxyTest.php
+++ b/tests/phpunit/integration/Core/Authentication/Google_ProxyTest.php
@@ -111,7 +111,7 @@ class Google_ProxyTest extends TestCase {
 		);
 
 		$expected_success_response = array( 'success' => true );
-		$this->expect_request_response(
+		$this->mock_http_request(
 			$google_proxy->url( Google_Proxy::OAUTH2_DELETE_SITE_URI ),
 			$expected_success_response
 		);
@@ -132,7 +132,7 @@ class Google_ProxyTest extends TestCase {
 		$this->assertEquals( $expected_success_response, $response_data );
 
 		$expected_error_response = array( 'error' => "invalid 'site_id' or 'site_secret'" );
-		$this->expect_request_response(
+		$this->mock_http_request(
 			$google_proxy->url( Google_Proxy::OAUTH2_DELETE_SITE_URI ),
 			$expected_error_response,
 			400
@@ -141,7 +141,7 @@ class Google_ProxyTest extends TestCase {
 		// Ensure exception with correct message is thrown for error response.
 		try {
 			$google_proxy->unregister_site( $credentials );
-			$this->assertEquals( $expected_error_response['error'], null );
+			$this->fail( 'Expected an exception to be thrown when unregistering the site' );
 		} catch ( Exception $e ) {
 			$this->assertEquals( $expected_error_response['error'], $e->getMessage() );
 		}
@@ -201,7 +201,7 @@ class Google_ProxyTest extends TestCase {
 		);
 
 		// Stub the response to the proxy oauth API.
-		$this->expect_request_response(
+		$this->mock_http_request(
 			$google_proxy->url( Google_Proxy::OAUTH2_SITE_URI ),
 			$expected_credentials
 		);
@@ -221,7 +221,7 @@ class Google_ProxyTest extends TestCase {
 	 * @param array  $response_data Response data to return for the request. Will be JSON-encoded.
 	 * @param int    $response_code Optional. Response status code to return. Default 200.
 	 */
-	private function expect_request_response( $request_url, array $response_data, $response_code = 200 ) {
+	private function mock_http_request( $request_url, array $response_data, $response_code = 200 ) {
 		add_filter(
 			'pre_http_request',
 			function ( $preempt, $args, $url ) use ( $request_url, $response_data, $response_code ) {

--- a/tests/phpunit/integration/Core/Util/UninstallationTest.php
+++ b/tests/phpunit/integration/Core/Util/UninstallationTest.php
@@ -24,54 +24,54 @@ use WP_Error;
 class UninstallationTest extends TestCase {
 	use Fake_Site_Connection_Trait;
 
-	private $last_request_url;
+	private $google_proxy;
+	private $uninstallation;
+	private $issued_delete_site_request;
 
 	public function setUp() {
 		parent::setUp();
-		$this->last_request_url = null;
+
+		$context              = new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE );
+		$this->google_proxy   = new Google_Proxy( $context );
+		$this->uninstallation = new Uninstallation( $context );
+
+		$this->issued_delete_site_request = false;
 	}
 
 	public function test_register() {
-		$uninstallation = new Uninstallation( new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE ) );
-
 		remove_all_actions( 'googlesitekit_uninstallation' );
-		$uninstallation->register();
+		$this->uninstallation->register();
 		$this->assertTrue( has_action( 'googlesitekit_uninstallation' ) );
 	}
 
 	public function test_uninstall_using_proxy() {
-		$context        = new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE );
-		$uninstallation = new Uninstallation( $context );
 		remove_all_actions( 'googlesitekit_uninstallation' );
-		$uninstallation->register();
+		$this->uninstallation->register();
 
 		$this->fake_proxy_site_connection();
-		add_filter( 'pre_http_request', array( $this, 'record_request_url_and_cause_error' ), 10, 3 );
+		add_filter( 'pre_http_request', array( $this, 'check_proxy_delete_site_url' ), 10, 3 );
 		do_action( 'googlesitekit_uninstallation' );
 
 		// Assert HTTP request to proxy was made.
-		$this->assertEquals(
-			( new Google_Proxy( $context ) )->url( Google_Proxy::OAUTH2_DELETE_SITE_URI ),
-			$this->last_request_url
-		);
+		$this->assertTrue( $this->issued_delete_site_request );
 	}
 
 	public function test_uninstall_not_using_proxy() {
-		$context        = new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE );
-		$uninstallation = new Uninstallation( $context );
 		remove_all_actions( 'googlesitekit_uninstallation' );
-		$uninstallation->register();
+		$this->uninstallation->register();
 
 		$this->fake_site_connection();
-		add_filter( 'pre_http_request', array( $this, 'record_request_url_and_cause_error' ), 10, 3 );
+		add_filter( 'pre_http_request', array( $this, 'check_proxy_delete_site_url' ), 10, 3 );
 		do_action( 'googlesitekit_uninstallation' );
 
 		// Assert no HTTP request was made.
-		$this->assertNull( $this->last_request_url );
+		$this->assertFalse( $this->issued_delete_site_request );
 	}
 
-	public function record_request_url_and_cause_error( $preempt, $args, $url ) {
-		$this->last_request_url = $url;
-		return new WP_Error( 'outgoing_request_blocked', 'Outgoing request blocked for testing.' );
+	public function check_proxy_delete_site_url( $preempt, $args, $url ) {
+		if ( $this->google_proxy->url( Google_Proxy::OAUTH2_DELETE_SITE_URI ) === $url ) {
+			$this->issued_delete_site_request = true;
+		}
+		return $preempt;
 	}
 }

--- a/tests/phpunit/integration/Core/Util/UninstallationTest.php
+++ b/tests/phpunit/integration/Core/Util/UninstallationTest.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * UninstallationTest
+ *
+ * @package   Google\Site_Kit\Tests\Core\Util
+ * @copyright 2020 Google LLC
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
+ * @link      https://sitekit.withgoogle.com
+ */
+
+namespace Google\Site_Kit\Tests\Core\Util;
+
+use Google\Site_Kit\Context;
+use Google\Site_Kit\Core\Storage\Options;
+use Google\Site_Kit\Core\Util\Uninstallation;
+use Google\Site_Kit\Core\Authentication\Google_Proxy;
+use Google\Site_Kit\Tests\TestCase;
+use Google\Site_Kit\Tests\Fake_Site_Connection_Trait;
+use WP_Error;
+
+/**
+ * @group Util
+ */
+class UninstallationTest extends TestCase {
+	use Fake_Site_Connection_Trait;
+
+	private $last_request_url;
+
+	public function setUp() {
+		parent::setUp();
+		$this->last_request_url = null;
+	}
+
+	public function test_register() {
+		$uninstallation = new Uninstallation( new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE ) );
+
+		remove_all_actions( 'googlesitekit_uninstallation' );
+		$uninstallation->register();
+		$this->assertTrue( has_action( 'googlesitekit_uninstallation' ) );
+	}
+
+	public function test_uninstall_using_proxy() {
+		$context        = new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE );
+		$uninstallation = new Uninstallation( $context );
+		remove_all_actions( 'googlesitekit_uninstallation' );
+		$uninstallation->register();
+
+		$this->fake_proxy_site_connection();
+		add_filter( 'pre_http_request', array( $this, 'record_request_url_and_cause_error' ), 10, 3 );
+		do_action( 'googlesitekit_uninstallation' );
+
+		// Assert HTTP request to proxy was made.
+		$this->assertEquals(
+			( new Google_Proxy( $context ) )->url( Google_Proxy::OAUTH2_DELETE_SITE_URI ),
+			$this->last_request_url
+		);
+	}
+
+	public function test_uninstall_not_using_proxy() {
+		$context        = new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE );
+		$uninstallation = new Uninstallation( $context );
+		remove_all_actions( 'googlesitekit_uninstallation' );
+		$uninstallation->register();
+
+		$this->fake_site_connection();
+		add_filter( 'pre_http_request', array( $this, 'record_request_url_and_cause_error' ), 10, 3 );
+		do_action( 'googlesitekit_uninstallation' );
+
+		// Assert no HTTP request was made.
+		$this->assertNull( $this->last_request_url );
+	}
+
+	public function record_request_url_and_cause_error( $preempt, $args, $url ) {
+		$this->last_request_url = $url;
+		return new WP_Error( 'outgoing_request_blocked', 'Outgoing request blocked for testing.' );
+	}
+}

--- a/uninstall.php
+++ b/uninstall.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Uninstallation script for the plugin.
+ *
+ * @package   Google\Site_Kit
+ * @copyright 2020 Google LLC
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
+ * @link      https://sitekit.withgoogle.com
+ */
+
+// Prevent execution from directly accessing the file.
+if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
+	exit;
+}
+
+// Load plugin main file to bootstrap infrastructure and add hooks.
+require_once dirname( __FILE ) . '/google-site-kit.php';
+
+// Fire action to trigger uninstallation logic.
+do_action( 'googlesitekit_uninstallation' );


### PR DESCRIPTION
## Summary

Addresses issue #2311

## Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
