### PR TITLE
Fix translation strings that incorrectly combine 'last %s' and '%s days'

### DIFF
--- a/assets/js/modules/adsense/components/dashboard/AdSenseDashboardWidget.js
+++ b/assets/js/modules/adsense/components/dashboard/AdSenseDashboardWidget.js
@@ -130,7 +130,7 @@ class AdSenseDashboardWidget extends Component {
 
 		// Hide AdSense data display when we don't have data.
 		const wrapperClass = ( loading || ! receivingData || zeroData ) ? 'googlesitekit-nodata' : '';
-		const currentDateRange = getCurrentDateRangeDayCount( dateRange );
+		const currentDayCount = getCurrentDateRangeDayCount( dateRange );
 
 		let moduleStatus;
 		let moduleStatusText;
@@ -209,12 +209,9 @@ class AdSenseDashboardWidget extends Component {
 								<Layout
 									header
 									title={ sprintf(
-										/* translators: %s: date range */
-										_n(
-											'Performance over the last %s day',
-											'Performance over the last %s days',
-											currentDateRange, 'google-site-kit'
-										), currentDateRange
+										/* translators: %s: number of days */
+										_n( 'Performance over the last %s day', 'Performance over the last %s days', currentDayCount, 'google-site-kit' ),
+										currentDayCount
 									) }
 									headerCTALabel={ __( 'See full stats in AdSense', 'google-site-kit' ) }
 									headerCTALink={ homepage }

--- a/assets/js/modules/adsense/components/dashboard/AdSenseDashboardWidget.js
+++ b/assets/js/modules/adsense/components/dashboard/AdSenseDashboardWidget.js
@@ -26,7 +26,7 @@ import classnames from 'classnames';
  */
 import { withFilters } from '@wordpress/components';
 import { Component, Fragment } from '@wordpress/element';
-import { __, _x, sprintf } from '@wordpress/i18n';
+import { __, _x, _n, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -47,7 +47,7 @@ import PageHeader from '../../../../components/PageHeader';
 import PageHeaderDateRange from '../../../../components/PageHeaderDateRange';
 import Layout from '../../../../components/layout/layout';
 import { STORE_NAME as CORE_USER } from '../../../../googlesitekit/datastore/user/constants';
-import { getCurrentDateRange } from '../../../../util/date-range';
+import { getCurrentDateRangeDayCount } from '../../../../util/date-range';
 
 const { withSelect } = Data;
 
@@ -130,7 +130,7 @@ class AdSenseDashboardWidget extends Component {
 
 		// Hide AdSense data display when we don't have data.
 		const wrapperClass = ( loading || ! receivingData || zeroData ) ? 'googlesitekit-nodata' : '';
-		const currentDateRange = getCurrentDateRange( dateRange );
+		const currentDateRange = getCurrentDateRangeDayCount( dateRange );
 
 		let moduleStatus;
 		let moduleStatusText;
@@ -208,8 +208,14 @@ class AdSenseDashboardWidget extends Component {
 							) }>
 								<Layout
 									header
-									/* translators: %s: date range */
-									title={ sprintf( __( 'Performance over the last %s', 'google-site-kit' ), currentDateRange ) }
+									title={ sprintf(
+										/* translators: %s: date range */
+										_n(
+											'Performance over the last %s day',
+											'Performance over the last %s days',
+											currentDateRange, 'google-site-kit'
+										), currentDateRange
+									) }
 									headerCTALabel={ __( 'See full stats in AdSense', 'google-site-kit' ) }
 									headerCTALink={ homepage }
 								>

--- a/assets/js/modules/analytics/components/common/AcquisitionSources.js
+++ b/assets/js/modules/analytics/components/common/AcquisitionSources.js
@@ -24,7 +24,7 @@ import PropTypes from 'prop-types';
 /**
  * WordPress dependencies
  */
-import { __, sprintf } from '@wordpress/i18n';
+import { __, _n, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -32,7 +32,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import { getDataTableFromData, TableOverflowContainer } from '../../../../components/data-table';
 import MiniChart from '../../../../components/MiniChart';
 import { numberFormat } from '../../../../util/i18n';
-import { getCurrentDateRange } from '../../../../util/date-range';
+import { getCurrentDateRangeDayCount } from '../../../../util/date-range';
 
 function AcquisitionSources( { data, args } ) {
 	if ( ! data ) {
@@ -63,7 +63,7 @@ function AcquisitionSources( { data, args } ) {
 
 	const { dateRange, url } = args;
 	if ( url ) {
-		const currentRange = getCurrentDateRange( dateRange );
+		const currentRange = getCurrentDateRangeDayCount( dateRange );
 
 		keyColumnIndex = 1;
 		options.hideHeader = false;
@@ -80,13 +80,25 @@ function AcquisitionSources( { data, args } ) {
 			},
 			{
 				title: __( 'New Users', 'google-site-kit' ),
-				/* translators: %s: date range */
-				tooltip: sprintf( __( 'Number of new users to visit your page over last %s', 'google-site-kit' ), currentRange ),
+				tooltip: sprintf(
+					/* translators: %s: date range */
+					_n(
+						'Number of new users to visit your page over last %s day',
+						'Number of new users to visit your page over last %s days',
+						currentRange, 'google-site-kit',
+					), currentRange,
+				),
 			},
 			{
 				title: __( 'Sessions', 'google-site-kit' ),
-				/* translators: %s: date range */
-				tooltip: sprintf( __( 'Number of sessions users had on your website over last %s', 'google-site-kit' ), currentRange ),
+				tooltip: sprintf(
+					/* translators: %s: date range */
+					_n(
+						'Number of sessions users had on your website over last %s day',
+						'Number of sessions users had on your website over last %s days',
+						currentRange, 'google-site-kit',
+					), currentRange,
+				),
 			},
 			{
 				title: __( 'Percentage', 'google-site-kit' ),

--- a/assets/js/modules/analytics/components/common/AcquisitionSources.js
+++ b/assets/js/modules/analytics/components/common/AcquisitionSources.js
@@ -81,23 +81,17 @@ function AcquisitionSources( { data, args } ) {
 			{
 				title: __( 'New Users', 'google-site-kit' ),
 				tooltip: sprintf(
-					/* translators: %s: date range */
-					_n(
-						'Number of new users to visit your page over last %s day',
-						'Number of new users to visit your page over last %s days',
-						currentRange, 'google-site-kit',
-					), currentRange,
+					/* translators: %s: number of days */
+					_n( 'Number of new users to visit your page over last %s day', 'Number of new users to visit your page over last %s days', currentRange, 'google-site-kit', ),
+					currentRange,
 				),
 			},
 			{
 				title: __( 'Sessions', 'google-site-kit' ),
 				tooltip: sprintf(
-					/* translators: %s: date range */
-					_n(
-						'Number of sessions users had on your website over last %s day',
-						'Number of sessions users had on your website over last %s days',
-						currentRange, 'google-site-kit',
-					), currentRange,
+					/* translators: %s: number of days */
+					_n( 'Number of sessions users had on your website over last %s day', 'Number of sessions users had on your website over last %s days', currentRange, 'google-site-kit', ),
+					currentRange,
 				),
 			},
 			{

--- a/assets/js/modules/analytics/components/common/AcquisitionSources.js
+++ b/assets/js/modules/analytics/components/common/AcquisitionSources.js
@@ -63,7 +63,7 @@ function AcquisitionSources( { data, args } ) {
 
 	const { dateRange, url } = args;
 	if ( url ) {
-		const currentRange = getCurrentDateRangeDayCount( dateRange );
+		const currentDayCount = getCurrentDateRangeDayCount( dateRange );
 
 		keyColumnIndex = 1;
 		options.hideHeader = false;
@@ -82,16 +82,16 @@ function AcquisitionSources( { data, args } ) {
 				title: __( 'New Users', 'google-site-kit' ),
 				tooltip: sprintf(
 					/* translators: %s: number of days */
-					_n( 'Number of new users to visit your page over last %s day', 'Number of new users to visit your page over last %s days', currentRange, 'google-site-kit', ),
-					currentRange,
+					_n( 'Number of new users to visit your page over last %s day', 'Number of new users to visit your page over last %s days', currentDayCount, 'google-site-kit', ),
+					currentDayCount,
 				),
 			},
 			{
 				title: __( 'Sessions', 'google-site-kit' ),
 				tooltip: sprintf(
 					/* translators: %s: number of days */
-					_n( 'Number of sessions users had on your website over last %s day', 'Number of sessions users had on your website over last %s days', currentRange, 'google-site-kit', ),
-					currentRange,
+					_n( 'Number of sessions users had on your website over last %s day', 'Number of sessions users had on your website over last %s days', currentDayCount, 'google-site-kit', ),
+					currentDayCount,
 				),
 			},
 			{

--- a/assets/js/modules/analytics/components/dashboard/AnalyticsAdSenseDashboardWidgetLayout.js
+++ b/assets/js/modules/analytics/components/dashboard/AnalyticsAdSenseDashboardWidgetLayout.js
@@ -19,7 +19,7 @@
 /**
  * WordPress dependencies
  */
-import { __, sprintf } from '@wordpress/i18n';
+import { __, _n, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -28,19 +28,25 @@ import Data from 'googlesitekit-data';
 import { STORE_NAME as MODULES_ADSENSE } from '../../../adsense/datastore/constants';
 import { STORE_NAME as CORE_USER } from '../../../../googlesitekit/datastore/user/constants';
 import Layout from '../../../../components/layout/layout';
-import { getCurrentDateRange } from '../../../../util/date-range';
+import { getCurrentDateRangeDayCount } from '../../../../util/date-range';
 const { useSelect } = Data;
 
 const AnalyticsAdSenseDashboardWidgetLayout = ( { children } ) => {
 	const accountSiteURL = useSelect( ( select ) => select( MODULES_ADSENSE ).getServiceAccountSiteURL() );
 	const dateRange = useSelect( ( select ) => select( CORE_USER ).getDateRange() );
-	const currentDateRange = getCurrentDateRange( dateRange );
+	const currentDateRange = getCurrentDateRangeDayCount( dateRange );
 
 	return (
 		<Layout
 			header
-			/* translators: %s: date range */
-			title={ sprintf( __( 'Performance by page over the last %s', 'google-site-kit' ), currentDateRange ) }
+			title={ sprintf(
+				/* translators: %s: date range */
+				_n(
+					'Performance by page over the last %s day',
+					'Performance by page over the last %s days',
+					currentDateRange, 'google-site-kit',
+				), currentDateRange,
+			) }
 			headerCTALabel={ __( 'See full stats in AdSense', 'google-site-kit' ) }
 			headerCTALink={ accountSiteURL }>
 			{ children }

--- a/assets/js/modules/analytics/components/dashboard/AnalyticsAdSenseDashboardWidgetLayout.js
+++ b/assets/js/modules/analytics/components/dashboard/AnalyticsAdSenseDashboardWidgetLayout.js
@@ -34,18 +34,15 @@ const { useSelect } = Data;
 const AnalyticsAdSenseDashboardWidgetLayout = ( { children } ) => {
 	const accountSiteURL = useSelect( ( select ) => select( MODULES_ADSENSE ).getServiceAccountSiteURL() );
 	const dateRange = useSelect( ( select ) => select( CORE_USER ).getDateRange() );
-	const currentDateRange = getCurrentDateRangeDayCount( dateRange );
+	const currentDayCount = getCurrentDateRangeDayCount( dateRange );
 
 	return (
 		<Layout
 			header
 			title={ sprintf(
-				/* translators: %s: date range */
-				_n(
-					'Performance by page over the last %s day',
-					'Performance by page over the last %s days',
-					currentDateRange, 'google-site-kit',
-				), currentDateRange,
+				/* translators: %s: number of days */
+				_n( 'Performance by page over the last %s day', 'Performance by page over the last %s days', currentDayCount, 'google-site-kit', ),
+				currentDayCount,
 			) }
 			headerCTALabel={ __( 'See full stats in AdSense', 'google-site-kit' ) }
 			headerCTALink={ accountSiteURL }>

--- a/assets/js/modules/analytics/components/dashboard/AnalyticsDashboardWidget.js
+++ b/assets/js/modules/analytics/components/dashboard/AnalyticsDashboardWidget.js
@@ -142,7 +142,7 @@ export default function AnalyticsDashboardWidget() {
 
 	// Hide Analytics data display when we don't have data.
 	const wrapperClass = ! loading && receivingData ? '' : 'googlesitekit-nodata';
-	const currentDateRange = getCurrentDateRangeDayCount( dateRange );
+	const currentDayCount = getCurrentDateRangeDayCount( dateRange );
 
 	return (
 		<Fragment>
@@ -187,12 +187,9 @@ export default function AnalyticsDashboardWidget() {
 							<Layout
 								header
 								title={ sprintf(
-									/* translators: %s: date range */
-									_n(
-										'Audience overview for the last %s day',
-										'Audience overview for the last %s days',
-										currentDateRange, 'google-site-kit',
-									), currentDateRange,
+									/* translators: %s: number of days */
+									_n( 'Audience overview for the last %s day', 'Audience overview for the last %s days', currentDayCount, 'google-site-kit', ),
+									currentDayCount,
 								) }
 								headerCTALabel={ sprintf(
 									/* translators: %s: module name. */
@@ -224,12 +221,9 @@ export default function AnalyticsDashboardWidget() {
 								header
 								footer
 								title={ sprintf(
-									/* translators: %s: date range */
-									_n(
-										'Top content over the last %s day',
-										'Top content over the last %s days',
-										currentDateRange, 'google-site-kit',
-									), currentDateRange,
+									/* translators: %s: number of days */
+									_n( 'Top content over the last %s day', 'Top content over the last %s days', currentDayCount, 'google-site-kit', ),
+									currentDayCount,
 								) }
 								headerCTALink={ topContentServiceURL }
 								headerCTALabel={ sprintf(
@@ -252,12 +246,9 @@ export default function AnalyticsDashboardWidget() {
 								header
 								footer
 								title={ sprintf(
-									/* translators: %s: date range */
-									_n(
-										'Top acquisition channels over the last %s day',
-										'Top acquisition channels over the last %s days',
-										currentDateRange, 'google-site-kit',
-									), currentDateRange,
+									/* translators: %s: number of days */
+									_n( 'Top acquisition channels over the last %s day', 'Top acquisition channels over the last %s days', currentDayCount, 'google-site-kit', ),
+									currentDayCount,
 								) }
 								headerCTALink={ topAcquisitionServiceURL }
 								headerCTALabel={ sprintf(

--- a/assets/js/modules/analytics/components/dashboard/AnalyticsDashboardWidget.js
+++ b/assets/js/modules/analytics/components/dashboard/AnalyticsDashboardWidget.js
@@ -25,7 +25,7 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { Fragment, useState } from '@wordpress/element';
-import { __, _x, sprintf } from '@wordpress/i18n';
+import { __, _n, _x, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -45,8 +45,8 @@ import Alert from '../../../../components/alert';
 import ProgressBar from '../../../../components/ProgressBar';
 import getNoDataComponent from '../../../../components/notifications/nodata';
 import getDataErrorComponent from '../../../../components/notifications/data-error';
-import { getCurrentDateRange } from '../../../../util/date-range';
 import HelpLink from '../../../../components/HelpLink';
+import { getCurrentDateRangeDayCount } from '../../../../util/date-range';
 import { STORE_NAME as CORE_USER } from '../../../../googlesitekit/datastore/user/constants';
 import { STORE_NAME } from '../../datastore/constants';
 
@@ -142,7 +142,7 @@ export default function AnalyticsDashboardWidget() {
 
 	// Hide Analytics data display when we don't have data.
 	const wrapperClass = ! loading && receivingData ? '' : 'googlesitekit-nodata';
-	const currentDateRange = getCurrentDateRange( dateRange );
+	const currentDateRange = getCurrentDateRangeDayCount( dateRange );
 
 	return (
 		<Fragment>
@@ -186,8 +186,14 @@ export default function AnalyticsDashboardWidget() {
 						) }>
 							<Layout
 								header
-								/* translators: %s: date range */
-								title={ sprintf( __( 'Audience overview for the last %s', 'google-site-kit' ), currentDateRange ) }
+								title={ sprintf(
+									/* translators: %s: date range */
+									_n(
+										'Audience overview for the last %s day',
+										'Audience overview for the last %s days',
+										currentDateRange, 'google-site-kit',
+									), currentDateRange,
+								) }
 								headerCTALabel={ sprintf(
 									/* translators: %s: module name. */
 									__( 'See full stats in %s', 'google-site-kit' ),
@@ -217,8 +223,14 @@ export default function AnalyticsDashboardWidget() {
 							<Layout
 								header
 								footer
-								/* translators: %s: date range */
-								title={ sprintf( __( 'Top content over the last %s', 'google-site-kit' ), currentDateRange ) }
+								title={ sprintf(
+									/* translators: %s: date range */
+									_n(
+										'Top content over the last %s day',
+										'Top content over the last %s days',
+										currentDateRange, 'google-site-kit',
+									), currentDateRange,
+								) }
 								headerCTALink={ topContentServiceURL }
 								headerCTALabel={ sprintf(
 									/* translators: %s: module name. */
@@ -239,8 +251,14 @@ export default function AnalyticsDashboardWidget() {
 							<Layout
 								header
 								footer
-								/* translators: %s: date range */
-								title={ sprintf( __( 'Top acquisition channels over the last %s', 'google-site-kit' ), currentDateRange ) }
+								title={ sprintf(
+									/* translators: %s: date range */
+									_n(
+										'Top acquisition channels over the last %s day',
+										'Top acquisition channels over the last %s days',
+										currentDateRange, 'google-site-kit',
+									), currentDateRange,
+								) }
 								headerCTALink={ topAcquisitionServiceURL }
 								headerCTALabel={ sprintf(
 									/* translators: %s: module name. */

--- a/assets/js/modules/analytics/components/dashboard/LegacyAnalyticsDashboardWidgetTopAcquisitionSources.js
+++ b/assets/js/modules/analytics/components/dashboard/LegacyAnalyticsDashboardWidgetTopAcquisitionSources.js
@@ -19,7 +19,7 @@
 /**
  * WordPress dependencies
  */
-import { __, sprintf } from '@wordpress/i18n';
+import { __, _n, sprintf } from '@wordpress/i18n';
 import { Fragment } from '@wordpress/element';
 
 /**
@@ -30,7 +30,7 @@ import {
 	getTimeInSeconds,
 	numberFormat,
 } from '../../../../util';
-import { getCurrentDateRange } from '../../../../util/date-range';
+import { getCurrentDateRangeDayCount } from '../../../../util/date-range';
 import withData from '../../../../components/higherorder/withdata';
 import { TYPE_MODULES } from '../../../../components/data';
 import { getDataTableFromData, TableOverflowContainer } from '../../../../components/data-table';
@@ -53,7 +53,7 @@ function LegacyAnalyticsDashboardWidgetTopAcquisitionSources( { data } ) {
 		return null;
 	}
 
-	const currentRange = getCurrentDateRange( dateRange );
+	const currentRange = getCurrentDateRangeDayCount( dateRange );
 	const headers = [
 		{
 			title: __( 'Channel', 'google-site-kit' ),
@@ -65,13 +65,25 @@ function LegacyAnalyticsDashboardWidgetTopAcquisitionSources( { data } ) {
 		},
 		{
 			title: __( 'New Users', 'google-site-kit' ),
-			/* translators: %s: date range */
-			tooltip: sprintf( __( 'Number of new users to visit your page over last %s', 'google-site-kit' ), currentRange ),
+			tooltip: sprintf(
+				/* translators: %s: date range */
+				_n(
+					'Number of new users to visit your page over last %s day',
+					'Number of new users to visit your page over last %s days',
+					currentRange, 'google-site-kit',
+				), currentRange,
+			),
 		},
 		{
 			title: __( 'Sessions', 'google-site-kit' ),
-			/* translators: %s: date range */
-			tooltip: sprintf( __( 'Number of sessions users had on your website over last %s', 'google-site-kit' ), currentRange ),
+			tooltip: sprintf(
+				/* translators: %s: date range */
+				_n(
+					'Number of sessions users had on your website over last %s day',
+					'Number of sessions users had on your website over last %s days',
+					currentRange, 'google-site-kit',
+				), currentRange,
+			),
 		},
 		{
 			title: __( 'Percentage', 'google-site-kit' ),

--- a/assets/js/modules/analytics/components/dashboard/LegacyAnalyticsDashboardWidgetTopAcquisitionSources.js
+++ b/assets/js/modules/analytics/components/dashboard/LegacyAnalyticsDashboardWidgetTopAcquisitionSources.js
@@ -66,23 +66,17 @@ function LegacyAnalyticsDashboardWidgetTopAcquisitionSources( { data } ) {
 		{
 			title: __( 'New Users', 'google-site-kit' ),
 			tooltip: sprintf(
-				/* translators: %s: date range */
-				_n(
-					'Number of new users to visit your page over last %s day',
-					'Number of new users to visit your page over last %s days',
-					currentRange, 'google-site-kit',
-				), currentRange,
+				/* translators: %s: number of days */
+				_n( 'Number of new users to visit your page over last %s day', 'Number of new users to visit your page over last %s days', currentRange, 'google-site-kit', ),
+				currentRange,
 			),
 		},
 		{
 			title: __( 'Sessions', 'google-site-kit' ),
 			tooltip: sprintf(
-				/* translators: %s: date range */
-				_n(
-					'Number of sessions users had on your website over last %s day',
-					'Number of sessions users had on your website over last %s days',
-					currentRange, 'google-site-kit',
-				), currentRange,
+				/* translators: %s: number of days */
+				_n( 'Number of sessions users had on your website over last %s day', 'Number of sessions users had on your website over last %s days', currentRange, 'google-site-kit', ),
+				currentRange,
 			),
 		},
 		{

--- a/assets/js/modules/analytics/components/dashboard/LegacyAnalyticsDashboardWidgetTopAcquisitionSources.js
+++ b/assets/js/modules/analytics/components/dashboard/LegacyAnalyticsDashboardWidgetTopAcquisitionSources.js
@@ -53,7 +53,7 @@ function LegacyAnalyticsDashboardWidgetTopAcquisitionSources( { data } ) {
 		return null;
 	}
 
-	const currentRange = getCurrentDateRangeDayCount( dateRange );
+	const currentDayCount = getCurrentDateRangeDayCount( dateRange );
 	const headers = [
 		{
 			title: __( 'Channel', 'google-site-kit' ),
@@ -67,16 +67,16 @@ function LegacyAnalyticsDashboardWidgetTopAcquisitionSources( { data } ) {
 			title: __( 'New Users', 'google-site-kit' ),
 			tooltip: sprintf(
 				/* translators: %s: number of days */
-				_n( 'Number of new users to visit your page over last %s day', 'Number of new users to visit your page over last %s days', currentRange, 'google-site-kit', ),
-				currentRange,
+				_n( 'Number of new users to visit your page over last %s day', 'Number of new users to visit your page over last %s days', currentDayCount, 'google-site-kit', ),
+				currentDayCount,
 			),
 		},
 		{
 			title: __( 'Sessions', 'google-site-kit' ),
 			tooltip: sprintf(
 				/* translators: %s: number of days */
-				_n( 'Number of sessions users had on your website over last %s day', 'Number of sessions users had on your website over last %s days', currentRange, 'google-site-kit', ),
-				currentRange,
+				_n( 'Number of sessions users had on your website over last %s day', 'Number of sessions users had on your website over last %s days', currentDayCount, 'google-site-kit', ),
+				currentDayCount,
 			),
 		},
 		{

--- a/assets/js/modules/search-console/components/dashboard/GoogleSitekitSearchConsoleDashboardWidget.js
+++ b/assets/js/modules/search-console/components/dashboard/GoogleSitekitSearchConsoleDashboardWidget.js
@@ -161,7 +161,7 @@ const GoogleSitekitSearchConsoleDashboardWidget = () => {
 
 	// Hide AdSense data display when we don't have data.
 	const wrapperClass = ! loading && receivingData ? '' : 'googlesitekit-nodata';
-	const currentDateRange = getCurrentDateRangeDayCount( dateRange );
+	const currentDayCount = getCurrentDateRangeDayCount( dateRange );
 
 	return (
 		<Fragment>
@@ -206,12 +206,9 @@ const GoogleSitekitSearchConsoleDashboardWidget = () => {
 							<Layout
 								header
 								title={ sprintf(
-									/* translators: %s: date range */
-									_n(
-										'Overview for the last %s day',
-										'Overview for the last %s days',
-										currentDateRange, 'google-site-kit',
-									), currentDateRange,
+									/* translators: %s: number of days */
+									_n( 'Overview for the last %s day', 'Overview for the last %s days', currentDayCount, 'google-site-kit', ),
+									currentDayCount,
 								) }
 								headerCTALabel={ sprintf(
 									/* translators: %s: module name. */
@@ -235,14 +232,11 @@ const GoogleSitekitSearchConsoleDashboardWidget = () => {
 							wrapperClass
 						) }>
 							<Layout
-								/* translators: %s: date range */
+								/* translators: %s: number of days */
 								title={ sprintf(
-									/* translators: %s: date range */
-									_n(
-										'Top search queries over the last %s day',
-										'Top search queries over last %s days',
-										currentDateRange, 'google-site-kit',
-									), currentDateRange,
+									/* translators: %s: number of days */
+									_n( 'Top search queries over the last %s day', 'Top search queries over last %s days', currentDayCount, 'google-site-kit', ),
+									currentDayCount,
 								) }
 								header
 								footer

--- a/assets/js/modules/search-console/components/dashboard/GoogleSitekitSearchConsoleDashboardWidget.js
+++ b/assets/js/modules/search-console/components/dashboard/GoogleSitekitSearchConsoleDashboardWidget.js
@@ -25,7 +25,7 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { Fragment, useState } from '@wordpress/element';
-import { __, _x, sprintf } from '@wordpress/i18n';
+import { __, _n, _x, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -43,8 +43,8 @@ import Alert from '../../../../components/alert';
 import ProgressBar from '../../../../components/ProgressBar';
 import getNoDataComponent from '../../../../components/notifications/nodata';
 import getDataErrorComponent from '../../../../components/notifications/data-error';
-import { getCurrentDateRange, getCurrentDateRangeDayCount } from '../../../../util/date-range';
 import HelpLink from '../../../../components/HelpLink';
+import { getCurrentDateRangeDayCount } from '../../../../util/date-range';
 import { STORE_NAME } from '../../datastore/constants';
 import { STORE_NAME as CORE_USER } from '../../../../googlesitekit/datastore/user/constants';
 import { STORE_NAME as CORE_SITE } from '../../../../googlesitekit/datastore/site/constants';
@@ -161,7 +161,7 @@ const GoogleSitekitSearchConsoleDashboardWidget = () => {
 
 	// Hide AdSense data display when we don't have data.
 	const wrapperClass = ! loading && receivingData ? '' : 'googlesitekit-nodata';
-	const currentDateRange = getCurrentDateRange( dateRange );
+	const currentDateRange = getCurrentDateRangeDayCount( dateRange );
 
 	return (
 		<Fragment>
@@ -205,8 +205,14 @@ const GoogleSitekitSearchConsoleDashboardWidget = () => {
 						) }>
 							<Layout
 								header
-								/* translators: %s: date range */
-								title={ sprintf( __( 'Overview for the last %s', 'google-site-kit' ), currentDateRange ) }
+								title={ sprintf(
+									/* translators: %s: date range */
+									_n(
+										'Overview for the last %s day',
+										'Overview for the last %s days',
+										currentDateRange, 'google-site-kit',
+									), currentDateRange,
+								) }
 								headerCTALabel={ sprintf(
 									/* translators: %s: module name. */
 									__( 'See full stats in %s', 'google-site-kit' ),
@@ -230,7 +236,14 @@ const GoogleSitekitSearchConsoleDashboardWidget = () => {
 						) }>
 							<Layout
 								/* translators: %s: date range */
-								title={ sprintf( __( 'Top search queries over the last %s', 'google-site-kit' ), currentDateRange ) }
+								title={ sprintf(
+									/* translators: %s: date range */
+									_n(
+										'Top search queries over the last %s day',
+										'Top search queries over last %s days',
+										currentDateRange, 'google-site-kit',
+									), currentDateRange,
+								) }
 								header
 								footer
 								headerCTALabel={ sprintf(

--- a/assets/js/util/date-range.js
+++ b/assets/js/util/date-range.js
@@ -19,35 +19,13 @@
 /**
  * WordPress dependencies
  */
-import { __, _n, sprintf } from '@wordpress/i18n';
+import { _n, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
 import Data from 'googlesitekit-data';
 import { STORE_NAME as CORE_USER } from '../googlesitekit/datastore/user/constants';
-
-/**
- * Gets the current dateRange string.
- *
- * @since 1.8.0
- *
- * @param {string} [dateRange] Optional. The date range slug.
- * @return {string} The date range string.
- */
-export function getCurrentDateRange( dateRange = getCurrentDateRangeSlug() ) {
-	const daysMatch = dateRange.match( /last-(\d+)-days/ );
-
-	if ( daysMatch && daysMatch[ 1 ] ) {
-		return sprintf(
-			/* translators: %s: Number of days matched. */
-			_n( '%s day', '%s days', parseInt( daysMatch[ 1 ], 10 ), 'google-site-kit' ),
-			daysMatch[ 1 ]
-		);
-	}
-
-	throw new Error( 'Unrecognized date range slug.' );
-}
 
 /**
  * Gets the current dateRange day count.
@@ -86,25 +64,31 @@ export function getCurrentDateRangeSlug() {
  * @return {Object} The object hash where every key is a date range slug, and the value is an object with the date range slug and its translation.
  */
 export function getAvailableDateRanges() {
-	/* translators: %s: Number of days to request data. */
-	const format = __( 'Last %s days', 'google-site-kit' );
+	const label = ( days ) => sprintf(
+		/* translators: %s: Number of days to request data. */
+		_n(
+			'Last %s day',
+			'Last %s days',
+			days, 'google-site-kit',
+		), days,
+	);
 
 	return {
 		'last-7-days': {
 			slug: 'last-7-days',
-			label: sprintf( format, 7 ),
+			label: label( 7 ),
 		},
 		'last-14-days': {
 			slug: 'last-14-days',
-			label: sprintf( format, 14 ),
+			label: label( 14 ),
 		},
 		'last-28-days': {
 			slug: 'last-28-days',
-			label: sprintf( format, 28 ),
+			label: label( 28 ),
 		},
 		'last-90-days': {
 			slug: 'last-90-days',
-			label: sprintf( format, 90 ),
+			label: label( 90 ),
 		},
 	};
 }

--- a/assets/js/util/date-range.js
+++ b/assets/js/util/date-range.js
@@ -65,12 +65,9 @@ export function getCurrentDateRangeSlug() {
  */
 export function getAvailableDateRanges() {
 	const label = ( days ) => sprintf(
-		/* translators: %s: Number of days to request data. */
-		_n(
-			'Last %s day',
-			'Last %s days',
-			days, 'google-site-kit',
-		), days,
+		/* translators: %s: number of days */
+		_n( 'Last %s day', 'Last %s days', days, 'google-site-kit', ),
+		days,
 	);
 
 	return {


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #2146

## Relevant technical choices

<!-- Please describe your changes. -->
Fixes incorrect use of translation strings around `last n days`

## Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
