### PR TITLE
Fix typo in uninstall.php

### DIFF
--- a/uninstall.php
+++ b/uninstall.php
@@ -14,7 +14,7 @@ if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
 }
 
 // Load plugin main file to bootstrap infrastructure and add hooks.
-require_once dirname( __FILE ) . '/google-site-kit.php';
+require_once dirname( __FILE__ ) . '/google-site-kit.php';
 
 // Fire action to trigger uninstallation logic.
 do_action( 'googlesitekit_uninstallation' );


### PR DESCRIPTION
## Summary

Addresses issue #2311 

## Relevant technical choices

- Confirmed this fixes the error
- Updated QA brief on issue

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
