### PR TITLE
Fix trackEvent with value

### DIFF
--- a/assets/js/components/data/index.test.js
+++ b/assets/js/components/data/index.test.js
@@ -66,7 +66,7 @@ describe( 'dataAPI', () => {
 				expect( eventName ).toEqual( 'GET:test-type/test-identifier/data/test-datapoint' );
 				expect( eventData.event_category ).toEqual( 'api_error' );
 				expect( eventData.event_label ).toEqual( 'Internal server error (code: internal_server_error)' );
-				expect( eventData.event_value ).toEqual( 500 );
+				expect( eventData.value ).toEqual( 500 );
 			}
 		} );
 	} );
@@ -90,7 +90,7 @@ describe( 'dataAPI', () => {
 				expect( eventName ).toEqual( 'POST:test-type/test-identifier/data/test-datapoint' );
 				expect( eventData.event_category ).toEqual( 'api_error' );
 				expect( eventData.event_label ).toEqual( 'Internal server error (code: internal_server_error)' );
-				expect( eventData.event_value ).toEqual( 500 );
+				expect( eventData.value ).toEqual( 500 );
 			}
 		} );
 	} );
@@ -166,7 +166,7 @@ describe( 'dataAPI', () => {
 			expect( eventName ).toEqual( 'POST:test-type/test-identifier/data/test-datapoint' );
 			expect( eventData.event_category ).toEqual( 'api_error' );
 			expect( eventData.event_label ).toEqual( 'Internal server error (code: internal_server_error, reason: internal_server_error)' );
-			expect( eventData.event_value ).toEqual( 500 );
+			expect( eventData.value ).toEqual( 500 );
 		} );
 
 		it( 'should call trackEvent for each error in combinedGet with multiple errors', async () => {
@@ -207,13 +207,13 @@ describe( 'dataAPI', () => {
 			expect( eventName ).toEqual( 'POST:test-type/test-identifier/data/test-datapoint' );
 			expect( eventData.event_category ).toEqual( 'api_error' );
 			expect( eventData.event_label ).toEqual( 'Internal server error (code: internal_server_error, reason: internal_server_error)' );
-			expect( eventData.event_value ).toEqual( 500 );
+			expect( eventData.value ).toEqual( 500 );
 			[ event, eventName, eventData ] = dataLayerPushSpy.mock.calls[ 1 ][ 0 ];
 			expect( event ).toEqual( 'event' );
 			expect( eventName ).toEqual( 'POST:test-type/analytics/data/test-datapoint-3' );
 			expect( eventData.event_category ).toEqual( 'api_error' );
 			expect( eventData.event_label ).toEqual( 'Unknown error (code: unknown_error, reason: unknown_error)' );
-			expect( eventData.event_value ).toEqual( 503 );
+			expect( eventData.value ).toEqual( 503 );
 		} );
 	} );
 } );

--- a/assets/js/googlesitekit/api/index.test.js
+++ b/assets/js/googlesitekit/api/index.test.js
@@ -308,7 +308,7 @@ describe( 'googlesitekit.api', () => {
 				expect( eventName ).toEqual( 'GET:test-type/test-identifier/data/test-datapoint' );
 				expect( eventData.event_category ).toEqual( 'api_error' );
 				expect( eventData.event_label ).toEqual( 'Internal server error (code: internal_server_error)' );
-				expect( eventData.event_value ).toEqual( 500 );
+				expect( eventData.value ).toEqual( 500 );
 			}
 		} );
 	} );
@@ -491,7 +491,7 @@ describe( 'googlesitekit.api', () => {
 				expect( eventName ).toEqual( 'POST:test-type/test-identifier/data/test-datapoint' );
 				expect( eventData.event_category ).toEqual( 'api_error' );
 				expect( eventData.event_label ).toEqual( 'Internal server error (code: internal_server_error)' );
-				expect( eventData.event_value ).toEqual( 500 );
+				expect( eventData.value ).toEqual( 500 );
 			}
 		} );
 	} );

--- a/assets/js/util/api.test.js
+++ b/assets/js/util/api.test.js
@@ -52,7 +52,7 @@ describe( 'trackAPIError', () => {
 		expect( eventName ).toEqual( 'test-method:test-type/test-identifier/data/test-datapoint' );
 		expect( eventData.event_category ).toEqual( 'api_error' );
 		expect( eventData.event_label ).toEqual( 'test-error-message (code: test-error-code, reason: test-error-reason)' );
-		expect( eventData.event_value ).toEqual( 'test-error-code' );
+		expect( eventData.value ).toEqual( 'test-error-code' );
 	} );
 
 	it( 'tracks API error message & code with no reason', () => {
@@ -74,7 +74,7 @@ describe( 'trackAPIError', () => {
 		expect( eventName ).toEqual( 'test-method:test-type/test-identifier/data/test-datapoint' );
 		expect( eventData.event_category ).toEqual( 'api_error' );
 		expect( eventData.event_label ).toEqual( 'test-error-message (code: test-error-code)' );
-		expect( eventData.event_value ).toEqual( 'test-error-code' );
+		expect( eventData.value ).toEqual( 'test-error-code' );
 	} );
 
 	it( 'tracks API error message & code with no data', () => {
@@ -94,7 +94,7 @@ describe( 'trackAPIError', () => {
 		expect( eventName ).toEqual( 'test-method:test-type/test-identifier/data/test-datapoint' );
 		expect( eventData.event_category ).toEqual( 'api_error' );
 		expect( eventData.event_label ).toEqual( 'test-error-message (code: test-error-code)' );
-		expect( eventData.event_value ).toEqual( 'test-error-code' );
+		expect( eventData.value ).toEqual( 'test-error-code' );
 	} );
 
 	it( "doesn't track excluded error codes", () => {

--- a/assets/js/util/tracking/createTrackEvent.js
+++ b/assets/js/util/tracking/createTrackEvent.js
@@ -22,13 +22,13 @@ export default function createTrackEvent( config, dataLayerTarget, _global ) {
 	 *
 	 * @since 1.3.0
 	 *
-	 * @param {string} eventCategory The event category. Required.
-	 * @param {string} eventName     The event category. Required.
-	 * @param {string} eventLabel    The event category. Optional.
-	 * @param {string} eventValue    The event category. Optional.
+	 * @param {string} category The category of the event.
+	 * @param {string} action   The value that will appear as the event action in Google Analytics Event reports.
+	 * @param {string} [label]  The label of the event. Optional.
+	 * @param {number} [value]  A non-negative integer that will appear as the event value. Optional.
 	 * @return {Promise} Promise that always resolves.
 	 */
-	return async function trackEvent( eventCategory, eventName, eventLabel = '', eventValue = '' ) {
+	return async function trackEvent( category, action, label, value ) {
 		const {
 			isFirstAdmin,
 			referenceSiteURL,
@@ -48,9 +48,9 @@ export default function createTrackEvent( config, dataLayerTarget, _global ) {
 
 		const eventData = {
 			send_to: trackingID,
-			event_category: eventCategory,
-			event_label: eventLabel,
-			value: eventValue,
+			event_category: category,
+			event_label: label,
+			value,
 			dimension1: referenceSiteURL,
 			dimension2: isFirstAdmin ? 'true' : 'false',
 			dimension3: userIDHash,
@@ -63,11 +63,11 @@ export default function createTrackEvent( config, dataLayerTarget, _global ) {
 			// tracking should not result in user-facing errors. It will just
 			// trigger a console warning.
 			const failTimeout = setTimeout( () => {
-				global.console.warn( `Tracking event "${ eventName }" (category "${ eventCategory }") took too long to fire.` );
+				global.console.warn( `Tracking event "${ action }" (category "${ category }") took too long to fire.` );
 				resolve();
 			}, 1000 );
 
-			dataLayerPush( 'event', eventName, {
+			dataLayerPush( 'event', action, {
 				...eventData,
 				event_callback: () => {
 					clearTimeout( failTimeout );

--- a/assets/js/util/tracking/createTrackEvent.js
+++ b/assets/js/util/tracking/createTrackEvent.js
@@ -50,7 +50,7 @@ export default function createTrackEvent( config, dataLayerTarget, _global ) {
 			send_to: trackingID,
 			event_category: eventCategory,
 			event_label: eventLabel,
-			event_value: eventValue,
+			value: eventValue,
 			dimension1: referenceSiteURL,
 			dimension2: isFirstAdmin ? 'true' : 'false',
 			dimension3: userIDHash,

--- a/assets/js/util/tracking/createTrackEvent.js
+++ b/assets/js/util/tracking/createTrackEvent.js
@@ -23,9 +23,9 @@ export default function createTrackEvent( config, dataLayerTarget, _global ) {
 	 * @since 1.3.0
 	 *
 	 * @param {string} category The category of the event.
-	 * @param {string} action   The value that will appear as the event action in Google Analytics Event reports.
-	 * @param {string} [label]  The label of the event. Optional.
-	 * @param {number} [value]  A non-negative integer that will appear as the event value. Optional.
+	 * @param {string} action   The action name of the event.
+	 * @param {string} [label]  Optional. The label of the event.
+	 * @param {number} [value]  Optional. A non-negative integer that will appear as the event value.
 	 * @return {Promise} Promise that always resolves.
 	 */
 	return async function trackEvent( category, action, label, value ) {

--- a/assets/js/util/tracking/index.test.js
+++ b/assets/js/util/tracking/index.test.js
@@ -101,7 +101,7 @@ describe( 'trackEvent', () => {
 			send_to: config.trackingID,
 			event_category: 'category',
 			event_label: 'label',
-			event_value: 'value',
+			value: 'value',
 			dimension1: 'https://www.example.com',
 			dimension2: 'true',
 			dimension3: config.userIDHash,


### PR DESCRIPTION
## Summary

Addresses issue #1999 (follow-up)

## Relevant technical choices

* Updated parameter names and docs (which were incorrect) to more closely match the [docs for `gtag.js`](https://developers.google.com/analytics/devguides/collection/gtagjs/events#send_events)

## Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
