### PR TITLE
Add missing placeholder for user input last question.

### DIFF
--- a/assets/js/components/user-input/UserInputKeywords.js
+++ b/assets/js/components/user-input/UserInputKeywords.js
@@ -75,7 +75,10 @@ export default function UserInputKeywords( { slug, max } ) {
 				) ) }
 
 				{ values.length !== max && (
-					<TextField>
+					<TextField
+						label={ __( 'Minimum one (1), maximum three (3) keywords', 'google-site-kit' ) }
+						noLabel
+					>
 						<Input
 							id={ `${ slug }-keywords` }
 							value={ keyword }


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #2302 

## Relevant technical choices
- Add missing placeholder `Minimum one (1), maximum three (3) keywords` for user input keywords.

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
