### PR TITLE
Use submitChange store in SettingsModule.

### DIFF
--- a/assets/js/components/settings/settings-module.js
+++ b/assets/js/components/settings/settings-module.js
@@ -222,6 +222,14 @@ class SettingsModule extends Component {
 			}
 		}
 
+		// Set button action based on state.
+		let buttonActionName = 'cancel';
+		let buttonAction;
+		if ( hasSettings && setupComplete ) {
+			buttonActionName = 'confirm';
+			buttonAction = submitChanges;
+		}
+
 		return (
 			<Fragment>
 				{ active ? (
@@ -366,7 +374,7 @@ class SettingsModule extends Component {
 											{ isEditing[ moduleKey ] || isSavingModule ? (
 												<Fragment>
 													<Button
-														onClick={ () => handleEdit( moduleKey, hasSettings && setupComplete ? 'confirm' : 'cancel', hasSettings && setupComplete ? submitChanges : null ) }
+														onClick={ () => handleEdit( moduleKey, buttonActionName, buttonAction ) }
 														disabled={ isSavingModule || ! canSubmitChanges }
 														id={ hasSettings && setupComplete ? `confirm-changes-${ slug }` : `close-${ slug }` }
 													>

--- a/assets/js/components/settings/settings-module.js
+++ b/assets/js/components/settings/settings-module.js
@@ -28,6 +28,7 @@ import classnames from 'classnames';
  */
 import { Component, Fragment } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
+import { compose } from '@wordpress/compose';
 import { applyFilters } from '@wordpress/hooks';
 
 /**
@@ -56,7 +57,7 @@ import ModuleSetupIncomplete from '../../components/settings/module-setup-incomp
 import { STORE_NAME as CORE_MODULES } from '../../googlesitekit/modules/datastore/constants';
 import SettingsRenderer from '../settings/SettingsRenderer';
 import VisuallyHidden from '../VisuallyHidden';
-const { withSelect } = Data;
+const { withSelect, withDispatch } = Data;
 
 /**
  * A single module. Keeps track of its own active state and settings.
@@ -185,6 +186,8 @@ class SettingsModule extends Component {
 			handleEdit,
 			description,
 			hasSettings,
+			canSubmitChanges,
+			submitChanges,
 			autoActivate,
 			provides,
 			isSaving,
@@ -363,8 +366,8 @@ class SettingsModule extends Component {
 											{ isEditing[ moduleKey ] || isSavingModule ? (
 												<Fragment>
 													<Button
-														onClick={ () => handleEdit( moduleKey, hasSettings && setupComplete ? 'confirm' : 'cancel' ) }
-														disabled={ isSavingModule }
+														onClick={ () => handleEdit( moduleKey, hasSettings && setupComplete ? 'confirm' : 'cancel', hasSettings && setupComplete ? submitChanges : null ) }
+														disabled={ isSavingModule || ! canSubmitChanges }
 														id={ hasSettings && setupComplete ? `confirm-changes-${ slug }` : `close-${ slug }` }
 													>
 														{ buttonText }
@@ -488,6 +491,8 @@ SettingsModule.propTypes = {
 	handleDialog: PropTypes.func,
 	autoActivate: PropTypes.bool,
 	hasSettings: PropTypes.bool,
+	canSubmitChanges: PropTypes.bool,
+	submitChanges: PropTypes.func,
 	required: PropTypes.array,
 	active: PropTypes.bool,
 	setupComplete: PropTypes.bool,
@@ -504,10 +509,21 @@ SettingsModule.defaultProps = {
 	setupComplete: false,
 };
 
-export default withSelect( ( select, { slug } ) => {
-	const module = select( CORE_MODULES ).getModule( slug );
+export default compose( [
+	withSelect( ( select, { slug } ) => {
+		const module = select( CORE_MODULES ).getModule( slug );
+		const canSubmitChanges = select( CORE_MODULES ).canSubmitChanges( slug );
 
-	return {
-		hasSettings: !! module?.settingsEditComponent,
-	};
-} )( SettingsModule );
+		return {
+			hasSettings: !! module?.settingsEditComponent,
+			canSubmitChanges,
+		};
+	} ),
+	withDispatch( ( dispatch, { slug } ) => {
+		const submitChanges = () => dispatch( CORE_MODULES ).submitChanges( slug );
+
+		return {
+			submitChanges,
+		};
+	} ),
+] )( SettingsModule );

--- a/assets/js/components/settings/settings-modules.js
+++ b/assets/js/components/settings/settings-modules.js
@@ -93,19 +93,18 @@ class SettingsModules extends Component {
 			if ( error ) {
 				if ( isPermissionScopeError( error ) ) {
 					this.setState( {
+						isSaving: false,
 						error: false,
 					} );
 				} else {
 					this.setState( {
+						isSaving: false,
 						error: {
 							errorCode: error.code,
 							errorMsg: error.message,
 						},
 					} );
 				}
-				this.setState( {
-					isSaving: false,
-				} );
 				return;
 			}
 

--- a/assets/js/components/settings/settings-modules.js
+++ b/assets/js/components/settings/settings-modules.js
@@ -88,21 +88,23 @@ class SettingsModules extends Component {
 	async handleButtonAction( module, action, submitChanges ) {
 		if ( 'confirm' === action ) {
 			this.setState( { isSaving: module } );
-			const { error: err } = await submitChanges( module );
+			const { error } = await submitChanges( module );
 
-			if ( err ) {
-				let error;
-				if ( isPermissionScopeError( err ) ) {
-					error = false;
+			if ( error ) {
+				if ( isPermissionScopeError( error ) ) {
+					this.setState( {
+						error: false,
+					} );
 				} else {
-					error = {
-						errorCode: err.code,
-						errorMsg: err.message,
-					};
+					this.setState( {
+						error: {
+							errorCode: error.code,
+							errorMsg: error.message,
+						},
+					} );
 				}
 				this.setState( {
 					isSaving: false,
-					error,
 				} );
 				return;
 			}

--- a/assets/js/googlesitekit/data/index.js
+++ b/assets/js/googlesitekit/data/index.js
@@ -27,6 +27,7 @@ import {
 	useDispatch,
 	useRegistry,
 	withSelect,
+	withDispatch,
 	RegistryProvider,
 } from '@wordpress/data';
 
@@ -54,6 +55,7 @@ Data.useSelect = useSelect;
 Data.useDispatch = useDispatch;
 Data.useRegistry = useRegistry;
 Data.withSelect = withSelect;
+Data.withDispatch = withDispatch;
 Data.RegistryProvider = RegistryProvider;
 
 export default Data;

--- a/assets/js/modules/tagmanager/components/settings/SettingsEdit.js
+++ b/assets/js/modules/tagmanager/components/settings/SettingsEdit.js
@@ -20,7 +20,6 @@
  * WordPress dependencies
  */
 import { useEffect } from '@wordpress/element';
-import { addFilter, removeFilter } from '@wordpress/hooks';
 
 /**
  * Internal dependencies
@@ -34,7 +33,7 @@ import {
 	ExistingTagError,
 } from '../common';
 import SettingsForm from './SettingsForm';
-const { useSelect, useDispatch } = Data;
+const { useSelect } = Data;
 
 export default function SettingsEdit() {
 	const accounts = useSelect( ( select ) => select( STORE_NAME ).getAccounts() ) || [];
@@ -56,31 +55,6 @@ export default function SettingsEdit() {
 			confirm.disabled = ! canSubmitChanges;
 		}
 	}, [ canSubmitChanges ] );
-
-	const { submitChanges } = useDispatch( STORE_NAME );
-	useEffect( () => {
-		addFilter(
-			'googlekit.SettingsConfirmed',
-			'googlekit.TagManagerSettingsConfirmed',
-			async ( chain, module ) => {
-				if ( 'tagmanager-module' === module ) {
-					const { error } = await submitChanges();
-					if ( error ) {
-						return Promise.reject( error );
-					}
-					return Promise.resolve();
-				}
-				return chain;
-			}
-		);
-
-		return () => {
-			removeFilter(
-				'googlekit.SettingsConfirmed',
-				'googlekit.TagManagerSettingsConfirmed',
-			);
-		};
-	}, [] );
 
 	let viewComponent;
 	// Here we also check for `hasResolvedAccounts` to prevent showing a different case below


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #2137

## Relevant technical choices

<!-- Please describe your changes. -->
* Use `withDispatch` in `SettingsModule`.
* Use Submit Changes store in Settings module.

## Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
