### PR TITLE
Simplify submitChanges in createSubmitChangesStore

### DIFF
--- a/assets/js/googlesitekit/modules/create-module-store.js
+++ b/assets/js/googlesitekit/modules/create-module-store.js
@@ -94,7 +94,7 @@ export const createModuleStore = ( slug, {
 		} );
 
 		// to prevent duplication errors during combining stores, we don't need to combine
-		// Data.commontStore here since settingsStore already uses commonActions and commonControls
+		// Data.commonStore here since settingsStore already uses commonActions and commonControls
 		// from the Data.commonStore.
 		combinedStore = Data.combineStores(
 			notificationsStore,

--- a/assets/js/googlesitekit/modules/create-module-store.js
+++ b/assets/js/googlesitekit/modules/create-module-store.js
@@ -89,7 +89,6 @@ export const createModuleStore = ( slug, {
 		} );
 
 		const submitChangesStore = createSubmitChangesStore( {
-			storeName,
 			submitChanges: submitChanges || makeDefaultSubmitChanges( slug, storeName ),
 			validateCanSubmitChanges: validateCanSubmitChanges || makeDefaultCanSubmitChanges( storeName ),
 		} );
@@ -111,7 +110,6 @@ export const createModuleStore = ( slug, {
 			infoStore,
 			createErrorStore(),
 			createSubmitChangesStore( {
-				storeName,
 				submitChanges,
 				validateCanSubmitChanges,
 			} ),

--- a/assets/js/googlesitekit/modules/create-module-store.test.js
+++ b/assets/js/googlesitekit/modules/create-module-store.test.js
@@ -71,7 +71,7 @@ describe( 'createModuleStore store', () => {
 		it.each( [
 			[ 'createNotificationsStore', createNotificationsStore( 'modules', MODULE_SLUG, 'notifications' ) ],
 			[ 'createSettingsStore', createSettingsStore( 'modules', MODULE_SLUG, 'settings', { settingSlugs, registry } ) ],
-			[ 'createSubmitChangesStore', createSubmitChangesStore( { storeName: MODULE_SLUG } ) ],
+			[ 'createSubmitChangesStore', createSubmitChangesStore() ],
 		] )( 'includes all actions from %s store', ( partialStoreName, partialStore ) => {
 			expect( Object.keys( storeDefinition.actions ) ).toEqual(
 				expect.arrayContaining( Object.keys( partialStore.actions ) )
@@ -84,7 +84,7 @@ describe( 'createModuleStore store', () => {
 			[ 'createInfoStore', createInfoStore() ],
 			[ 'createNotificationsStore', createNotificationsStore( 'modules', MODULE_SLUG, 'notifications' ) ],
 			[ 'createSettingsStore', createSettingsStore( 'modules', MODULE_SLUG, 'settings', { settingSlugs, registry } ) ],
-			[ 'createSubmitChangesStore', createSubmitChangesStore( { storeName: MODULE_SLUG } ) ],
+			[ 'createSubmitChangesStore', createSubmitChangesStore() ],
 		] )( 'includes all actions from %s store', ( partialStoreName, partialStore ) => {
 			expect( Object.keys( storeDefinition.selectors ) ).toEqual(
 				expect.arrayContaining( Object.keys( partialStore.selectors ) )

--- a/assets/js/googlesitekit/modules/create-submit-changes-store.js
+++ b/assets/js/googlesitekit/modules/create-submit-changes-store.js
@@ -17,16 +17,13 @@
  */
 
 /**
- * External dependencies
- */
-import invariant from 'invariant';
-
-/**
  * Internal dependencies
  */
 import Data from 'googlesitekit-data';
+import { actions as errorActions } from '../../googlesitekit/data/create-error-store';
 import { createValidationSelector } from '../data/utils';
 const { createRegistryControl } = Data;
+const { clearError, receiveError } = errorActions;
 
 // Actions
 const SUBMIT_CHANGES = 'SUBMIT_CHANGES';
@@ -39,18 +36,14 @@ const FINISH_SUBMIT_CHANGES = 'FINISH_SUBMIT_CHANGES';
  * @since n.e.x.t
  *
  * @param {Object}   args                            Arguments for creating the submitChanges store.
- * @param {string}   args.storeName                  Datastore slug.
  * @param {Function} [args.submitChanges]            Optional. Callback function to issue the submit changes request. Will be used inside the submit changes control.
  * @param {Function} [args.validateCanSubmitChanges] Optional. A helper function to validate that settings can be submitted.
  * @return {Object} Partial store object with properties 'actions', 'controls', 'reducer', 'resolvers', and 'selectors'.
  */
 export function createSubmitChangesStore( {
-	storeName,
 	submitChanges = () => ( {} ),
 	validateCanSubmitChanges = () => {},
 } = {} ) {
-	invariant( storeName, 'storeName is required.' );
-
 	const initialState = {
 		isDoingSubmitChanges: false,
 	};
@@ -64,12 +57,7 @@ export function createSubmitChangesStore( {
 		 * @return {Object} Empty object on success, object with `error` property on failure.
 		 */
 		*submitChanges() {
-			const { dispatch } = yield Data.commonActions.getRegistry();
-			const { clearError, receiveError } = dispatch( storeName );
-
-			if ( clearError ) {
-				clearError( 'submitChanges', [] );
-			}
+			yield clearError( 'submitChanges', [] );
 
 			yield {
 				type: START_SUBMIT_CHANGES,
@@ -81,8 +69,8 @@ export function createSubmitChangesStore( {
 				payload: {},
 			};
 
-			if ( result?.error && receiveError ) {
-				yield dispatch( storeName ).receiveError( result.error, 'submitChanges', [] );
+			if ( result?.error ) {
+				yield receiveError( result.error, 'submitChanges', [] );
 			}
 
 			yield {

--- a/assets/js/googlesitekit/modules/create-submit-changes-store.test.js
+++ b/assets/js/googlesitekit/modules/create-submit-changes-store.test.js
@@ -29,18 +29,18 @@ import { createErrorStore } from '../data/create-error-store';
 import { createSubmitChangesStore } from './create-submit-changes-store';
 
 describe( 'createSubmitChangesStore', () => {
-	const storeName = 'test store';
+	const storeName = 'test/store';
 
 	describe( 'actions', () => {
 		it( 'should be available in the returned object', () => {
-			const { actions } = createSubmitChangesStore( { storeName } );
+			const { actions } = createSubmitChangesStore();
 			expect( actions ).not.toBeUndefined();
 		} );
 
 		test.each( [
 			[ 'submitChanges' ],
 		] )( 'should have %s action', ( selector ) => {
-			const { actions } = createSubmitChangesStore( { storeName } );
+			const { actions } = createSubmitChangesStore();
 			expect( typeof actions[ selector ] ).toBe( 'function' );
 		} );
 
@@ -54,7 +54,7 @@ describe( 'createSubmitChangesStore', () => {
 					storeName,
 					Data.combineStores(
 						Data.commonStore,
-						createSubmitChangesStore( { storeName, submitChanges } ),
+						createSubmitChangesStore( { submitChanges } ),
 						createErrorStore(),
 					),
 				);
@@ -73,7 +73,7 @@ describe( 'createSubmitChangesStore', () => {
 					storeName,
 					Data.combineStores(
 						Data.commonStore,
-						createSubmitChangesStore( { storeName, submitChanges: async () => ( { error } ) } ),
+						createSubmitChangesStore( { submitChanges: async () => ( { error } ) } ),
 						createErrorStore(),
 					),
 				);
@@ -93,7 +93,7 @@ describe( 'createSubmitChangesStore', () => {
 					storeName,
 					Data.combineStores(
 						Data.commonStore,
-						createSubmitChangesStore( { storeName, submitChanges: async () => ( { error } ) } ),
+						createSubmitChangesStore( { submitChanges: async () => ( { error } ) } ),
 						createErrorStore(),
 					),
 				);
@@ -111,7 +111,7 @@ describe( 'createSubmitChangesStore', () => {
 
 	describe( 'selectors', () => {
 		it( 'should be available in the returned object', () => {
-			const { selectors } = createSubmitChangesStore( { storeName } );
+			const { selectors } = createSubmitChangesStore();
 			expect( selectors ).not.toBeUndefined();
 		} );
 
@@ -120,7 +120,7 @@ describe( 'createSubmitChangesStore', () => {
 			[ '__dangerousCanSubmitChanges' ],
 			[ 'isDoingSubmitChanges' ],
 		] )( 'should have %s selector', ( selector ) => {
-			const { selectors } = createSubmitChangesStore( { storeName } );
+			const { selectors } = createSubmitChangesStore();
 			expect( typeof selectors[ selector ] ).toBe( 'function' );
 		} );
 
@@ -130,7 +130,7 @@ describe( 'createSubmitChangesStore', () => {
 		] )( '%s', ( selector ) => {
 			it( 'should use provided validateCanSubmitChanges function', () => {
 				const validateCanSubmitChanges = jest.fn();
-				const { selectors } = createSubmitChangesStore( { storeName, validateCanSubmitChanges } );
+				const { selectors } = createSubmitChangesStore( { validateCanSubmitChanges } );
 
 				selectors[ selector ]();
 				expect( validateCanSubmitChanges ).toHaveBeenCalled();
@@ -140,7 +140,7 @@ describe( 'createSubmitChangesStore', () => {
 		describe( 'isDoingSubmitChanges', () => {
 			it( 'should be set to FALSE by default', () => {
 				const registry = createRegistry();
-				registry.registerStore( storeName, createSubmitChangesStore( { storeName } ) );
+				registry.registerStore( storeName, createSubmitChangesStore() );
 				expect( registry.select( storeName ).isDoingSubmitChanges() ).toBe( false );
 			} );
 
@@ -152,7 +152,7 @@ describe( 'createSubmitChangesStore', () => {
 					Data.combineStores(
 						Data.commonStore,
 						createErrorStore(),
-						createSubmitChangesStore( { storeName, submitChanges: async () => {
+						createSubmitChangesStore( { submitChanges: async () => {
 							expect( registry.select( storeName ).isDoingSubmitChanges() ).toBe( true );
 							return {};
 						} } ),
@@ -162,14 +162,14 @@ describe( 'createSubmitChangesStore', () => {
 				await registry.dispatch( storeName ).submitChanges();
 			} );
 
-			it( `should be set to FALSE after finishing submiting changes`, async () => {
+			it( `should be set to FALSE after finishing submitting changes`, async () => {
 				const registry = createRegistry();
 
 				registry.registerStore(
 					storeName,
 					Data.combineStores(
 						Data.commonStore,
-						createSubmitChangesStore( { storeName, submitChanges: async () => ( {} ) } ),
+						createSubmitChangesStore( { submitChanges: async () => ( {} ) } ),
 						createErrorStore(),
 					),
 				);

--- a/assets/js/googlesitekit/modules/create-submit-changes-store.test.js
+++ b/assets/js/googlesitekit/modules/create-submit-changes-store.test.js
@@ -31,10 +31,6 @@ import { createSubmitChangesStore } from './create-submit-changes-store';
 describe( 'createSubmitChangesStore', () => {
 	const storeName = 'test store';
 
-	it( 'should throw an error if storeName isnt provided', () => {
-		expect( () => createSubmitChangesStore() ).toThrow( 'storeName is required.' );
-	} );
-
 	describe( 'actions', () => {
 		it( 'should be available in the returned object', () => {
 			const { actions } = createSubmitChangesStore( { storeName } );


### PR DESCRIPTION
## Summary

Addresses issue #2136

## Relevant technical choices

<!-- Please describe your changes. -->

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
