### PR TITLE
Restore CSS hack for keeping components mounted

### DIFF
--- a/assets/js/modules/analytics/components/dashboard/LegacyAnalyticsAllTraffic.js
+++ b/assets/js/modules/analytics/components/dashboard/LegacyAnalyticsAllTraffic.js
@@ -115,41 +115,42 @@ class LegacyAnalyticsAllTraffic extends Component {
 					/>
 				</div>
 
-				{ errorComponent || (
-					<div
-						className={ classnames(
-							'mdc-layout-grid__cell',
-							'mdc-layout-grid__cell--span-12',
-						) }
-					>
-						<Layout className="googlesitekit-dashboard-all-traffic">
-							<div className="mdc-layout-grid">
-								<div className="mdc-layout-grid__inner">
-									<div className="
-										mdc-layout-grid__cell
-										mdc-layout-grid__cell--span-4-desktop
-										mdc-layout-grid__cell--span-4-tablet
-										mdc-layout-grid__cell--span-4-phone
-									">
-										<LegacyDashboardAcquisitionPieChart
-											source
-											handleDataError={ this.handleDataError }
-											handleDataSuccess={ this.handleDataSuccess }
-										/>
-									</div>
-									<div className="
-										mdc-layout-grid__cell
-										mdc-layout-grid__cell--span-8-desktop
-										mdc-layout-grid__cell--span-4-tablet
-										mdc-layout-grid__cell--span-4-phone
-									">
-										<LegacyAnalyticsAllTrafficDashboardWidgetTopAcquisitionSources />
-									</div>
+				{ errorComponent }
+
+				<div
+					className={ classnames(
+						'mdc-layout-grid__cell',
+						'mdc-layout-grid__cell--span-12',
+						{ 'googlesitekit-nodata': errorComponent }
+					) }
+				>
+					<Layout className="googlesitekit-dashboard-all-traffic">
+						<div className="mdc-layout-grid">
+							<div className="mdc-layout-grid__inner">
+								<div className="
+									mdc-layout-grid__cell
+									mdc-layout-grid__cell--span-4-desktop
+									mdc-layout-grid__cell--span-4-tablet
+									mdc-layout-grid__cell--span-4-phone
+								">
+									<LegacyDashboardAcquisitionPieChart
+										source
+										handleDataError={ this.handleDataError }
+										handleDataSuccess={ this.handleDataSuccess }
+									/>
+								</div>
+								<div className="
+									mdc-layout-grid__cell
+									mdc-layout-grid__cell--span-8-desktop
+									mdc-layout-grid__cell--span-4-tablet
+									mdc-layout-grid__cell--span-4-phone
+								">
+									<LegacyAnalyticsAllTrafficDashboardWidgetTopAcquisitionSources />
 								</div>
 							</div>
-						</Layout>
-					</div>
-				) }
+						</div>
+					</Layout>
+				</div>
 			</Fragment>
 		);
 	}


### PR DESCRIPTION
## Summary

Addresses issue #2358

PR targets `master` for inclusion in the release. @cole10up and @adamsilverstein confirmed that this change fixed the original problem they found.

## Relevant technical choices

This PR undoes a change where inner `withData`-wrapped components in `LegacyAnalyticsAllTraffic` would be conditionally rendered. This caused a problem when an error component was caused to be rendered which would unmount the inner components. When the date range changed, and the error component related state was cleared, the inner `withData` connected components rendered an infinite loading state because they seem to have missed the timing for `withData` to hook into the batch request for the context if the requests for that batch are already cached. There may be a bit more nuance to it but that's the gist of it, and likely why this part was hidden with CSS previously.

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
