### PR TITLE
Add import detection to camelcase rules.

### DIFF
--- a/packages/eslint-plugin/rules/camelcase-acronyms.js
+++ b/packages/eslint-plugin/rules/camelcase-acronyms.js
@@ -16,10 +16,16 @@
  * limitations under the License.
  */
 
+/**
+ * Internal dependencies
+ */
+const { isImported } = require( '../utils' );
+
 module.exports = {
 	create( context ) {
 		const options = context.options[ 0 ] || {};
 		let properties = options.properties || '';
+		const importedNames = [];
 
 		if ( properties !== 'always' && properties !== 'never' ) {
 			properties = 'always';
@@ -66,14 +72,8 @@ module.exports = {
 				const name = node.name;
 
 				// Ignore imports, because they may not respect our rules.
-				if ( node.parent && (
-					node.parent.type === 'ImportDefaultSpecifier' ||
-							node.parent.type === 'ImportSpecifier' ||
-							( node.parent.parent && (
-								node.parent.parent.type === 'ExportDefaultDeclaration' ||
-								node.parent.parent.type === 'ExportDeclaration'
-							) )
-				) ) {
+				if ( isImported( node ) ) {
+					importedNames.push( node.name );
 					return;
 				}
 
@@ -136,6 +136,11 @@ module.exports = {
 							acronymMatches.input[ acronymMatches.index + acronym.length ] &&
 									acronymMatches.input[ acronymMatches.index + acronym.length ].match( /[a-z]/ )
 						) {
+							return;
+						}
+
+						// Ignore known imported names.
+						if ( importedNames.includes( name ) ) {
 							return;
 						}
 

--- a/packages/eslint-plugin/rules/camelcase-acronyms.test.js
+++ b/packages/eslint-plugin/rules/camelcase-acronyms.test.js
@@ -1,0 +1,103 @@
+/**
+ * ESLint rules: capitalization tests.
+ *
+ * Site Kit by Google, Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import { RuleTester } from 'eslint';
+
+/**
+ * Internal dependencies
+ */
+import rule from './camelcase-acronyms';
+
+const ruleTester = new RuleTester( {
+	parserOptions: {
+		sourceType: 'module',
+		ecmaVersion: 6,
+	},
+} );
+
+ruleTester.run( 'camelcase-acronyms', rule, {
+	valid: [
+		{
+			code: `
+		export function myCoolHTMLParser() {
+			return 'test';
+		}
+		      `,
+		},
+		{
+			code: `
+import { useInstanceId } from '@wordpress/compose;'
+
+export function FancyComponent() {
+	const instanceID = useInstanceId();
+
+	return \`myId-\${instanceID}\`;
+}
+			`,
+		},
+	],
+	invalid: [
+		{
+			code: `
+		const useInstanceId = () => {
+			return 'random-id';
+		}
+
+		export function FancyComponent() {
+			const instanceID = useInstanceId();
+
+			return \`myId-\${instanceID}\`;
+		}
+		      `,
+			errors: [
+				{
+					message:
+								'`useInstanceId` violates naming rules.',
+				},
+				{
+					message:
+								'`useInstanceId` violates naming rules.',
+				},
+			],
+		},
+		{
+			code: `
+const { useInstanceId } = { myCoolObject: true };
+
+export function FancyComponent() {
+	const instanceID = useInstanceId();
+
+	return \`myId-\${instanceID}\`;
+}
+`,
+			errors: [
+				{
+					message:
+								'`useInstanceId` violates naming rules.',
+				},
+				{
+					message:
+								'`useInstanceId` violates naming rules.',
+				},
+			],
+		},
+	],
+} );

--- a/packages/eslint-plugin/utils.js
+++ b/packages/eslint-plugin/utils.js
@@ -40,6 +40,51 @@ function isDependencyBlock( jsdoc ) {
 	);
 }
 
+function isImported( node ) {
+	if ( ! node || ! node.type ) {
+		return false;
+	}
+
+	const importTypes = [
+		'ImportDefaultSpecifier',
+		'ImportSpecifier',
+		'ExportDefaultDeclaration',
+		'ExportDeclaration',
+		'ImportDeclaration',
+	];
+
+	if ( importTypes.includes( node.type ) || importTypes.includes( node?.parent?.type ) ) {
+		return true;
+	}
+
+	for ( const attribute in [ 'parent', 'init', 'imported' ] ) {
+		if ( node[ attribute ] ) {
+			return isImported( node[ attribute ] );
+		}
+	}
+
+	if (
+		node.declarations &&
+		node.declarations.length
+	) {
+		const hasImportedDeclarations = node.specifiers.some( ( importedNode ) => {
+			return isImported( importedNode );
+		} );
+
+		if ( hasImportedDeclarations ) {
+			return true;
+		}
+	}
+
+	if (
+		node.declaration
+	) {
+		return isImported( node.declaration );
+	}
+
+	return false;
+}
+
 function isFunction( node ) {
 	if ( ! node ) {
 		return false;
@@ -85,4 +130,5 @@ module.exports = {
 	findTagInGroup,
 	isDependencyBlock,
 	isFunction,
+	isImported,
 };


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #2346.

## Relevant technical choices

<!-- Please describe your changes. -->

## Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
