### PR TITLE
Add serviceSetupV2 flag and apply to the setup-proxy.

### DIFF
--- a/assets/js/components/setup/setup-proxy.js
+++ b/assets/js/components/setup/setup-proxy.js
@@ -125,10 +125,10 @@ function SetupUsingProxy() {
 										<div className={ classnames(
 											'mdc-layout-grid__inner',
 											{
-												'googlesitekit-setup__content': featureFlags.userInput.enabled,
+												'googlesitekit-setup__content': featureFlags.serviceSetupV2.enabled,
 											}
 										) }>
-											{ featureFlags.userInput.enabled && (
+											{ featureFlags.serviceSetupV2.enabled && (
 												<div
 													className="
 															googlesitekit-setup__icon
@@ -146,8 +146,8 @@ function SetupUsingProxy() {
 													'mdc-layout-grid__cell',
 													'mdc-layout-grid__cell--span-12-tablet',
 													{
-														'mdc-layout-grid__cell--span-6-desktop': featureFlags.userInput.enabled,
-														'mdc-layout-grid__cell--span-12-desktop': ! featureFlags.userInput.enabled,
+														'mdc-layout-grid__cell--span-6-desktop': featureFlags.serviceSetupV2.enabled,
+														'mdc-layout-grid__cell--span-12-desktop': ! featureFlags.serviceSetupV2.enabled,
 													}
 												) }
 											>

--- a/webpack.feature-flags.config.js
+++ b/webpack.feature-flags.config.js
@@ -28,4 +28,7 @@ exports.featureFlags = {
 	userInput: {
 		enabled: 'development',
 	},
+	serviceSetupV2: {
+		enabled: 'development',
+	},
 };


### PR DESCRIPTION
## Summary

Addresses issue #2309

## Relevant technical choices

N/A

## Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
