### PR TITLE
Set the header to sticky on tablet screens or larger.

### DIFF
--- a/assets/sass/components/global/_googlesitekit-header.scss
+++ b/assets/sass/components/global/_googlesitekit-header.scss
@@ -21,11 +21,15 @@
 	@include googlesitekit-inner-padding;
 	@include shadow;
 	background-color: $c-base;
-	left: 0;
-	position: sticky;
-	right: 0;
-	top: 46px;
 	z-index: 12;
+
+	// only become sticky when WordPress's #wpadminbar becomes sticky
+	@media (min-width: $bp-tablet) {
+		left: 0;
+		position: sticky;
+		right: 0;
+		top: 46px;
+	}
 
 	@media (min-width: $bp-wpAdminBarTablet) {
 		top: 32px;


### PR DESCRIPTION
## Summary

Based on QA feedback I've made the header absolutely positioned on mobile devices and fixed only from the tablet breakpoint upwards.
Addresses issue #2331

## Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
