### PR TITLE
Correct the sticky positioning of the header on mobile screen widths.

### DIFF
--- a/assets/sass/components/global/_googlesitekit-header.scss
+++ b/assets/sass/components/global/_googlesitekit-header.scss
@@ -21,18 +21,18 @@
 	@include googlesitekit-inner-padding;
 	@include shadow;
 	background-color: $c-base;
+	left: 0;
+	position: sticky;
+	right: 0;
+	top: 0;
 	z-index: 12;
-
-	// only become sticky when WordPress's #wpadminbar becomes sticky
-	@media (min-width: $bp-tablet) {
-		left: 0;
-		position: sticky;
-		right: 0;
-		top: 46px;
-	}
 
 	@media (min-width: $bp-wpAdminBarTablet) {
 		top: 32px;
+	}
+
+	@media (min-width: $bp-tablet) {
+		top: 46px;
 	}
 
 	.wp-responsive-open & {

--- a/assets/sass/components/global/_googlesitekit-header.scss
+++ b/assets/sass/components/global/_googlesitekit-header.scss
@@ -27,12 +27,12 @@
 	top: 0;
 	z-index: 12;
 
-	@media (min-width: $bp-wpAdminBarTablet) {
-		top: 32px;
-	}
-
 	@media (min-width: $bp-tablet) {
 		top: 46px;
+	}
+
+	@media (min-width: $bp-wpAdminBarTablet) {
+		top: 32px;
 	}
 
 	.wp-responsive-open & {


### PR DESCRIPTION
## Summary

Addresses issue #2331

## Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
