### PR TITLE
Bug/2458 incorrect search console data threshold

### DIFF
--- a/assets/js/modules/search-console/components/dashboard/DashboardClicksWidget.js
+++ b/assets/js/modules/search-console/components/dashboard/DashboardClicksWidget.js
@@ -25,7 +25,7 @@ import { __, _x } from '@wordpress/i18n';
  * Internal dependencies
  */
 import Data from 'googlesitekit-data';
-import { STORE_NAME } from '../../datastore/constants';
+import { DATE_RANGE_OFFSET, STORE_NAME } from '../../datastore/constants';
 import { STORE_NAME as CORE_SITE } from '../../../../googlesitekit/datastore/site/constants';
 import { STORE_NAME as CORE_USER } from '../../../../googlesitekit/datastore/user/constants';
 import extractForSparkline from '../../../../util/extract-for-sparkline';
@@ -52,12 +52,12 @@ function DashboardClicksWidget() {
 		const isDomainProperty = select( STORE_NAME ).isDomainProperty();
 		const referenceSiteURL = untrailingslashit( select( CORE_SITE ).getReferenceSiteURL() );
 
-		const dateRange = select( CORE_USER ).getDateRangeDates( { compare: true, offsetDays: 1 } );
+		const { compareStartDate, endDate } = select( CORE_USER ).getDateRangeDates( { compare: true, offsetDays: DATE_RANGE_OFFSET } );
 		const args = {
 			dimensions: 'date',
 			// Combine both date ranges into one single date range.
-			startDate: dateRange.compareStartDate,
-			endDate: dateRange.endDate,
+			startDate: compareStartDate,
+			endDate,
 		};
 		const serviceBaseURLArgs = {
 			resource_id: propertyID,

--- a/assets/js/modules/search-console/components/dashboard/DashboardImpressionsWidget.js
+++ b/assets/js/modules/search-console/components/dashboard/DashboardImpressionsWidget.js
@@ -25,7 +25,7 @@ import { __, _x } from '@wordpress/i18n';
  * Internal dependencies
  */
 import Data from 'googlesitekit-data';
-import { STORE_NAME } from '../../datastore/constants';
+import { DATE_RANGE_OFFSET, STORE_NAME } from '../../datastore/constants';
 import { STORE_NAME as CORE_SITE } from '../../../../googlesitekit/datastore/site/constants';
 import { STORE_NAME as CORE_USER } from '../../../../googlesitekit/datastore/user/constants';
 import { isZeroReport } from '../../util';
@@ -52,12 +52,12 @@ function DashboardImpressionsWidget() {
 		const isDomainProperty = select( STORE_NAME ).isDomainProperty();
 		const referenceSiteURL = untrailingslashit( select( CORE_SITE ).getReferenceSiteURL() );
 
-		const dateRange = select( CORE_USER ).getDateRangeDates( { compare: true, offsetDays: 1 } );
+		const { compareStartDate, endDate } = select( CORE_USER ).getDateRangeDates( { compare: true, offsetDays: DATE_RANGE_OFFSET } );
 		const args = {
 			dimensions: 'date',
 			// Combine both date ranges into one single date range.
-			startDate: dateRange.compareStartDate,
-			endDate: dateRange.endDate,
+			startDate: compareStartDate,
+			endDate,
 		};
 
 		const serviceBaseURLArgs = {

--- a/assets/js/modules/search-console/components/dashboard/DashboardPopularKeywordsWidget.js
+++ b/assets/js/modules/search-console/components/dashboard/DashboardPopularKeywordsWidget.js
@@ -27,7 +27,7 @@ import { addQueryArgs } from '@wordpress/url';
  */
 import Data from 'googlesitekit-data';
 import Widgets from 'googlesitekit-widgets';
-import { STORE_NAME } from '../../datastore/constants';
+import { DATE_RANGE_OFFSET, STORE_NAME } from '../../datastore/constants';
 import { STORE_NAME as CORE_SITE } from '../../../../googlesitekit/datastore/site/constants';
 import { STORE_NAME as CORE_USER } from '../../../../googlesitekit/datastore/user/constants';
 import { numberFormat, untrailingslashit } from '../../../../util';
@@ -53,10 +53,10 @@ function DashboardPopularKeywordsWidget() {
 		const store = select( STORE_NAME );
 		const domain = store.getPropertyID();
 
-		const dateRange = select( CORE_USER ).getDateRangeDates( { offsetDays: 1 } );
+		const { startDate, endDate } = select( CORE_USER ).getDateRangeDates( { offsetDays: DATE_RANGE_OFFSET } );
 		const args = {
-			startDate: dateRange.startDate,
-			endDate: dateRange.endDate,
+			startDate,
+			endDate,
 			dimensions: 'query',
 			limit: 10,
 		};

--- a/assets/js/modules/search-console/datastore/constants.js
+++ b/assets/js/modules/search-console/datastore/constants.js
@@ -17,3 +17,4 @@
  */
 
 export const STORE_NAME = 'modules/search-console';
+export const DATE_RANGE_OFFSET = 2;

--- a/includes/Modules/Search_Console.php
+++ b/includes/Modules/Search_Console.php
@@ -200,7 +200,7 @@ final class Search_Console extends Module
 					list ( $start_date, $end_date ) = $this->parse_date_range(
 						$data['dateRange'] ?: 'last-28-days',
 						$data['compareDateRanges'] ? 2 : 1,
-						1
+						2 // Offset.
 					);
 				}
 


### PR DESCRIPTION
## Summary

I've corrected the Search Console data threshold (back) to 2 in `Search_Console::create_data_request` use of `parse_date_range`, added the DATE_RANGE_OFFSET constant and used it in each relevant getDateRangeDates selector function.

Addresses issue #2458

## Relevant technical choices

On top of the base changes in this task, I've changed each widget to destructure the getDateRangeDates selector..

## Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
