### PR TITLE
Override get_sanitize_callback function for user input state class.

### DIFF
--- a/includes/Core/Authentication/User_Input_State.php
+++ b/includes/Core/Authentication/User_Input_State.php
@@ -54,7 +54,7 @@ final class User_Input_State extends User_Setting {
 				return false;
 			}
 
-			return true;
+			return $value;
 		};
 	}
 }

--- a/includes/Core/Authentication/User_Input_State.php
+++ b/includes/Core/Authentication/User_Input_State.php
@@ -54,7 +54,7 @@ final class User_Input_State extends User_Setting {
 				return false;
 			}
 
-			return $value;
+			return true;
 		};
 	}
 }

--- a/includes/Core/Authentication/User_Input_State.php
+++ b/includes/Core/Authentication/User_Input_State.php
@@ -42,17 +42,19 @@ final class User_Input_State extends User_Setting {
 	const VALUE_MISSING = 'missing';
 
 	/**
-	 * Sets the value of the setting with the given value.
+	 * Gets the callback for sanitizing the setting's value before saving.
 	 *
-	 * @since 1.20.0
+	 * @since n.e.x.t
 	 *
-	 * @param string $value Setting value. One of 'required', 'missing', 'completed' or ''.
-	 * @return bool True on success, false on failure or if value is not a valid string.
+	 * @return callable|null
 	 */
-	public function set( $value ) {
-		if ( ! in_array( $value, array( self::VALUE_COMPLETED, self::VALUE_MISSING, self::VALUE_REQUIRED, '' ), true ) ) {
-			return false;
-		}
-		return parent::set( $value );
+	protected function get_sanitize_callback() {
+		return function( $value ) {
+			if ( ! in_array( $value, array( self::VALUE_COMPLETED, self::VALUE_MISSING, self::VALUE_REQUIRED, '' ), true ) ) {
+				return false;
+			}
+
+			return $value;
+		};
 	}
 }

--- a/tests/phpunit/integration/Core/Authentication/User_Input_StateTest.php
+++ b/tests/phpunit/integration/Core/Authentication/User_Input_StateTest.php
@@ -70,7 +70,7 @@ class User_Input_StateTest extends TestCase {
 			array( 'required', true, 'required' ),
 			array( 'missing', true, 'missing' ),
 			array( '', true, '' ),
-			array( 'invalid-value', false, '' ),
+			array( 'invalid-value', true, '' ),
 		);
 	}
 }

--- a/tests/phpunit/integration/Core/Storage/Encrypted_User_OptionsTest.php
+++ b/tests/phpunit/integration/Core/Storage/Encrypted_User_OptionsTest.php
@@ -53,6 +53,18 @@ class Encrypted_User_OptionsTest extends TestCase {
 		$this->assertEquals( base64_encode( serialize( array( 'test-value' ) ) ), get_user_option( 'test-serialized-option', $user_id ) );
 	}
 
+	public function test_user_input_state_value() {
+		$user_id = $this->factory()->user->create();
+		wp_set_current_user( $user_id );
+		$encrypted_user_options = $this->new_encrypted_user_options();
+
+		update_user_option( $user_id, 'googlesitekit_user_input_state', base64_encode( 'completed' ) );
+		$this->assertEquals( 'completed', $encrypted_user_options->get( 'googlesitekit_user_input_state' ) );
+
+		update_user_option( $user_id, 'googlesitekit_user_input_state', base64_encode( 'invalid' ) );
+		$this->assertEquals( '', $encrypted_user_options->get( 'googlesitekit_user_input_state' ) );
+	}
+
 	public function test_delete() {
 		$user_id = $this->factory()->user->create();
 		wp_set_current_user( $user_id );

--- a/tests/phpunit/integration/Core/Storage/Encrypted_User_OptionsTest.php
+++ b/tests/phpunit/integration/Core/Storage/Encrypted_User_OptionsTest.php
@@ -53,18 +53,6 @@ class Encrypted_User_OptionsTest extends TestCase {
 		$this->assertEquals( base64_encode( serialize( array( 'test-value' ) ) ), get_user_option( 'test-serialized-option', $user_id ) );
 	}
 
-	public function test_user_input_state_value() {
-		$user_id = $this->factory()->user->create();
-		wp_set_current_user( $user_id );
-		$encrypted_user_options = $this->new_encrypted_user_options();
-
-		update_user_option( $user_id, 'googlesitekit_user_input_state', base64_encode( 'completed' ) );
-		$this->assertEquals( 'completed', $encrypted_user_options->get( 'googlesitekit_user_input_state' ) );
-
-		update_user_option( $user_id, 'googlesitekit_user_input_state', base64_encode( 'invalid' ) );
-		$this->assertEquals( false, $encrypted_user_options->get( 'googlesitekit_user_input_state' ) );
-	}
-
 	public function test_delete() {
 		$user_id = $this->factory()->user->create();
 		wp_set_current_user( $user_id );

--- a/tests/phpunit/integration/Core/Storage/Encrypted_User_OptionsTest.php
+++ b/tests/phpunit/integration/Core/Storage/Encrypted_User_OptionsTest.php
@@ -62,7 +62,7 @@ class Encrypted_User_OptionsTest extends TestCase {
 		$this->assertEquals( 'completed', $encrypted_user_options->get( 'googlesitekit_user_input_state' ) );
 
 		update_user_option( $user_id, 'googlesitekit_user_input_state', base64_encode( 'invalid' ) );
-		$this->assertEquals( '', $encrypted_user_options->get( 'googlesitekit_user_input_state' ) );
+		$this->assertEquals( false, $encrypted_user_options->get( 'googlesitekit_user_input_state' ) );
 	}
 
 	public function test_delete() {

--- a/tests/phpunit/integration/Core/Storage/User_OptionsTest.php
+++ b/tests/phpunit/integration/Core/Storage/User_OptionsTest.php
@@ -108,6 +108,17 @@ class User_OptionsTest extends TestCase {
 		$this->assertFalse( metadata_exists( 'user', $user_id, 'test-key' ) );
 	}
 
+	public function test_user_input_state_value() {
+		$user_id = $this->factory()->user->create();
+		wp_set_current_user( $user_id );
+
+		update_user_option( $user_id, 'googlesitekit_user_input_state', 'completed' );
+		$this->assertEquals( 'completed', get_user_option( 'googlesitekit_user_input_state', $user_id ) );
+
+		update_user_option( $user_id, 'googlesitekit_user_input_state', 'invalid' );
+		$this->assertEquals( false, get_user_option( 'googlesitekit_user_input_state', $user_id ) );
+	}
+
 	protected function create_user_aware_instance() {
 		$user_id      = $this->factory()->user->create();
 		$user_options = new User_Options(


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #2323 

## Relevant technical choices

<!-- Please describe your changes. -->

## Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
