### PR TITLE
Fix potential error with CompleteModuleActivationCTA with updates for consistency

### DIFF
--- a/assets/js/components/ActivateModuleCTA.js
+++ b/assets/js/components/ActivateModuleCTA.js
@@ -44,6 +44,7 @@ const ActivateModuleCTA = ( { slug, title, description } ) => {
 	const module = useSelect( ( select ) => select( CORE_MODULES ).getModule( slug ) );
 	const canManageOptions = useSelect( ( select ) => select( CORE_USER ).hasCapability( PERMISSION_MANAGE_OPTIONS ) );
 	const { activateModule } = useDispatch( CORE_MODULES );
+
 	const onCTAClick = useCallback( async () => {
 		const { error, response } = await activateModule( slug );
 
@@ -58,37 +59,36 @@ const ActivateModuleCTA = ( { slug, title, description } ) => {
 				type: 'win-error',
 			} );
 		}
-	} );
+	}, [ activateModule ] );
 
-	if ( ! module || ! canManageOptions ) {
+	if ( ! module?.name || ! canManageOptions ) {
 		return null;
 	}
-	const { name } = module;
-
-	const moduleTitle = title ||
-		sprintf(
-			/* translators: %s: Module name */
-			__( 'Activate %s', 'google-site-kit' ),
-			name,
-		);
-	const moduleDescription = description ||
-		sprintf(
-			/* translators: %s: Module name */
-			__( '%s module needs to be configured', 'google-site-kit' ),
-			name,
-		);
-	const moduleCTALabel = sprintf(
-		/* translators: %s: Module name */
-		__( 'Set up %s', 'google-site-kit' ),
-		name,
-	);
 
 	return (
 		<CTA
-			title={ moduleTitle }
-			description={ moduleDescription }
+			title={
+				title || sprintf(
+					/* translators: %s: Module name */
+					__( 'Activate %s', 'google-site-kit' ),
+					module.name,
+				)
+			}
+			description={
+				description || sprintf(
+					/* translators: %s: Module name */
+					__( '%s module needs to be configured', 'google-site-kit' ),
+					module.name,
+				)
+			}
+			ctaLabel={
+				sprintf(
+					/* translators: %s: Module name */
+					__( 'Set up %s', 'google-site-kit' ),
+					module.name,
+				)
+			}
 			onClick={ onCTAClick }
-			ctaLabel={ moduleCTALabel }
 		/>
 	);
 };

--- a/assets/js/components/CompleteModuleActivationCTA.js
+++ b/assets/js/components/CompleteModuleActivationCTA.js
@@ -40,43 +40,42 @@ const CompleteModuleActivationCTA = ( { slug, title, description } ) => {
 	const module = useSelect( ( select ) => select( MODULES_STORE ).getModule( slug ) );
 	const adminReauthURL = useSelect( ( select ) => select( `modules/${ slug }` )?.getAdminReauthURL() );
 	const canManageOptions = useSelect( ( select ) => select( CORE_USER ).hasCapability( PERMISSION_MANAGE_OPTIONS ) );
-	const { name } = module;
 
 	const onCTAClick = useCallback( async () => {
-		global.location = adminReauthURL;
-	} );
+		global.location.assign( adminReauthURL );
+	}, [ adminReauthURL ] );
 
-	if ( ! canManageOptions ) {
+	if ( ! module?.name || ! canManageOptions ) {
 		return null;
 	}
 
-	const moduleTitle = title ||
-		sprintf(
-			/* translators: %s: Module name */
-			__( 'Complete %s activation', 'google-site-kit' ),
-			name,
-		);
-	const moduleDescription = description ||
-		sprintf(
-			/* translators: %s: Module name */
-			__( '%s module setup needs to be completed', 'google-site-kit' ),
-			name,
-		);
-	const moduleCTA = __( 'Complete setup', 'google-site-kit' );
-
-	const moduleAriaLabel = sprintf(
-		/* translators: %s: Module name */
-		__( 'Complete %s setup', 'google-site-kit' ),
-		name,
-	);
-
 	return (
 		<CTA
-			title={ moduleTitle }
-			description={ moduleDescription }
+			title={
+				title || sprintf(
+					/* translators: %s: Module name */
+					__( 'Complete %s activation', 'google-site-kit' ),
+					module.name,
+				)
+			}
+			description={
+				description || sprintf(
+					/* translators: %s: Module name */
+					__( '%s module setup needs to be completed', 'google-site-kit' ),
+					module.name,
+				)
+			}
+			ctaLabel={
+				__( 'Complete setup', 'google-site-kit' )
+			}
+			aria-label={
+				sprintf(
+					/* translators: %s: Module name */
+					__( 'Complete %s setup', 'google-site-kit' ),
+					module.name,
+				)
+			}
 			onClick={ onCTAClick }
-			ctaLabel={ moduleCTA }
-			aria-label={ moduleAriaLabel }
 		/>
 	);
 };


### PR DESCRIPTION
## Summary

Addresses issue #2299

This PR fixes a potential fatal client side error when rendering `CompleteModuleActivationCTA` before the module has been fully loaded
![image](https://user-images.githubusercontent.com/1621608/102810928-3d41a100-43cd-11eb-8427-fa80f47da604.png)


## Relevant technical choices

* Targets `master` for inclusion in release
* Fixes potential "Cannot read property 'name' of undefined error" in `CompleteModuleActivationCTA` due to no guard for undefined `module`
* Inlined prop values for consistency with most other components
* Added missing dependencies to `useCallback` hooks
* Confirmed both components render without raising an error now in dev and production builds
![image](https://user-images.githubusercontent.com/1621608/102810853-200cd280-43cd-11eb-9863-da106fe7ab91.png)
![image](https://user-images.githubusercontent.com/1621608/102810857-213dff80-43cd-11eb-9ec6-232ffa2da752.png)


## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
