### PR TITLE
Add full-stop to the module CTA descriptions based on QA feedback.

### DIFF
--- a/assets/js/components/ActivateModuleCTA.js
+++ b/assets/js/components/ActivateModuleCTA.js
@@ -77,7 +77,7 @@ const ActivateModuleCTA = ( { slug, title, description } ) => {
 			description={
 				description || sprintf(
 					/* translators: %s: Module name */
-					__( '%s module needs to be configured', 'google-site-kit' ),
+					__( '%s module needs to be configured.', 'google-site-kit' ),
 					module.name,
 				)
 			}

--- a/assets/js/components/CompleteModuleActivationCTA.js
+++ b/assets/js/components/CompleteModuleActivationCTA.js
@@ -61,7 +61,7 @@ const CompleteModuleActivationCTA = ( { slug, title, description } ) => {
 			description={
 				description || sprintf(
 					/* translators: %s: Module name */
-					__( '%s module setup needs to be completed', 'google-site-kit' ),
+					__( '%s module setup needs to be completed.', 'google-site-kit' ),
 					module.name,
 				)
 			}


### PR DESCRIPTION
Add full-stop to the ActivateModuleCTA and CompleteModuleActivationCTA descriptions based on [QA feedback](https://github.com/google/site-kit-wp/issues/2381#issuecomment-756178985).

## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #2381

## Relevant technical choices

I went ahead and updated the `ActivateModuleCTA` message also as it was missing the full stop there also.

## Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
