### PR TITLE
Update CompleteModuleActivationCTA to select module store name

### DIFF
--- a/assets/js/components/CompleteModuleActivationCTA.js
+++ b/assets/js/components/CompleteModuleActivationCTA.js
@@ -38,14 +38,15 @@ const { useSelect } = Data;
 
 const CompleteModuleActivationCTA = ( { slug, title, description } ) => {
 	const module = useSelect( ( select ) => select( MODULES_STORE ).getModule( slug ) );
-	const adminReauthURL = useSelect( ( select ) => select( `modules/${ slug }` )?.getAdminReauthURL() );
+	const moduleStoreName = useSelect( ( select ) => select( MODULES_STORE ).getModuleStoreName( slug ) );
+	const adminReauthURL = useSelect( ( select ) => select( moduleStoreName )?.getAdminReauthURL() );
 	const canManageOptions = useSelect( ( select ) => select( CORE_USER ).hasCapability( PERMISSION_MANAGE_OPTIONS ) );
 
 	const onCTAClick = useCallback( async () => {
 		global.location.assign( adminReauthURL );
 	}, [ adminReauthURL ] );
 
-	if ( ! module?.name || ! canManageOptions ) {
+	if ( ! module?.name || ! adminReauthURL || ! canManageOptions ) {
 		return null;
 	}
 

--- a/assets/js/components/higherorder/withdata.test.js
+++ b/assets/js/components/higherorder/withdata.test.js
@@ -28,8 +28,10 @@ import withData from './withData';
 import { render, act } from '../../../../tests/js/test-utils';
 import dataAPI, { TYPE_MODULES } from '../data';
 import { getCacheKey } from '../data/cache';
-import { provideModules, provideUserAuthentication } from '../../../../tests/js/utils';
+import { provideModules, provideSiteInfo, provideUserAuthentication } from '../../../../tests/js/utils';
 import { STORE_NAME as CORE_USER, PERMISSION_MANAGE_OPTIONS } from '../../googlesitekit/datastore/user/constants';
+import { STORE_NAME as CORE_MODULES } from '../../googlesitekit/modules/datastore/constants';
+import { createModuleStore } from '../../googlesitekit/modules/create-module-store';
 
 const collectModuleData = dataAPI.collectModuleData.bind( dataAPI );
 
@@ -59,6 +61,16 @@ describe( 'withData', () => {
 	const setupRegistry = ( registry ) => {
 		provideModules( registry, [ testModule ] );
 		provideUserAuthentication( registry );
+		provideSiteInfo( registry );
+		// Module registration is now required by CompleteModuleActivationCTA to display.
+		const registerModule = ( slug ) => {
+			const storeName = `test/${ slug }`;
+			const store = createModuleStore( slug, { storeName } );
+			registry.registerStore( storeName, store );
+			registry.dispatch( CORE_MODULES ).registerModule( slug, { storeName } );
+		};
+		registerModule( testModule.slug );
+		registerModule( testModuleAlt.slug );
 		registry.dispatch( CORE_USER ).receiveCapabilities( { [ PERMISSION_MANAGE_OPTIONS ]: true } );
 	};
 

--- a/tests/js/utils.js
+++ b/tests/js/utils.js
@@ -161,7 +161,7 @@ export const provideUserAuthentication = ( registry, extraData = {} ) => {
 		requiredScopes: [],
 		grantedScopes: [],
 		unsatisfiedScopes: [],
-		needsReauthentication: [],
+		needsReauthentication: false,
 	};
 
 	const mergedData = { ...defaults, ...extraData };


### PR DESCRIPTION
## Summary

Addresses issue #2271 

Fixes one remaining instance where this was missed in the original PR likely due to this component being introduced after the 2271 was already defined.

* Note that `adminReauthURL` was added as a condition for rendering the component because the purpose of the component is a CTA for the user to navigate to that.

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
