### PR TITLE
Fix settings app

### DIFF
--- a/assets/js/components/settings/SettingsApp.js
+++ b/assets/js/components/settings/SettingsApp.js
@@ -21,12 +21,12 @@
  */
 import Tab from '@material/react-tab';
 import TabBar from '@material/react-tab-bar';
-import { useHash } from 'react-use';
+import { useFirstMountState, useHash } from 'react-use';
 
 /**
  * WordPress dependencies
  */
-import { Fragment, useEffect } from '@wordpress/element';
+import { Fragment, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -44,61 +44,56 @@ import { Cell, Grid, Row } from '../../material-components';
 
 const { useSelect, useDispatch } = Data;
 
+const hashFrom = ( tabID, slug, state ) => {
+	const fragments = [ tabID ];
+
+	if ( tabID === 'settings' && slug && state !== 'closed' ) {
+		fragments.push( slug );
+		if ( state ) {
+			fragments.push( state );
+		}
+	}
+
+	return fragments.join( '/' );
+};
+
+const parseHash = ( hashToParse ) => hashToParse.replace( '#', '' ).split( /\// );
+
 export default function SettingsApp() {
 	const [ hash, setHash ] = useHash();
-
-	const parseHash = ( hashToParse ) => hashToParse.replace( '#', '' ).split( /\// );
-
-	let [ activeTabID, moduleSlug, moduleState ] = parseHash( hash );
-	if ( ! activeTabID ) {
-		activeTabID = 'settings';
-	}
-
-	const isModuleActive = useSelect( ( select ) => moduleSlug ? select( CORE_MODULES ).isModuleActive( moduleSlug ) : null );
-
-	moduleSlug = isModuleActive && moduleSlug;
-	moduleState = useSelect( ( select ) => moduleSlug ? select( CORE_MODULES ).getModuleSettingsPanelState( moduleSlug ) : null );
-
+	const isFirstMount = useFirstMountState();
 	const { setModuleSettingsPanelState } = useDispatch( CORE_MODULES );
-
-	if ( moduleSlug && ! moduleState ) {
-		moduleState = 'view';
-	}
-
+	const [ initialActiveTabID, initialModuleSlug, initialModuleState ] = parseHash( hash );
+	const [ activeTabID, setActiveTabID ] = useState( initialActiveTabID || 'settings' );
+	const [ moduleSlug, setModuleSlug ] = useState( initialModuleSlug );
 	const activeTab = SettingsApp.tabToIndex[ activeTabID ];
 
-	const hashFrom = ( tabID, slug = moduleSlug, state = moduleState ) => {
-		const fragments = [ tabID ];
-
-		if ( tabID === 'settings' && slug && state !== 'closed' ) {
-			fragments.push( slug );
-			if ( state ) {
-				fragments.push( state );
-			}
+	if ( isFirstMount ) {
+		if ( initialModuleSlug ) {
+			setModuleSettingsPanelState( initialModuleSlug, initialModuleState );
 		}
+		if ( ! hash ) {
+			setHash( 'settings' );
+		}
+	}
 
-		return fragments.join( '/' );
-	};
+	const moduleState = useSelect( ( select ) => moduleSlug ? select( CORE_MODULES ).getModuleSettingsPanelState( moduleSlug ) : null );
 
 	const setModuleState = ( slug, state ) => {
+		if ( state === 'edit' || state === 'view' ) {
+			setModuleSlug( slug );
+		} else {
+			setModuleSlug( null );
+		}
 		setModuleSettingsPanelState( slug, state );
 		setHash( hashFrom( activeTabID, slug, state ) );
 	};
 
 	const handleTabUpdate = ( tabIndex ) => {
 		const newActiveTabID = SettingsApp.tabIDsByIndex[ tabIndex ];
+		setActiveTabID( newActiveTabID );
 		setHash( hashFrom( newActiveTabID ) );
 	};
-
-	useEffect( () => {
-		if ( isModuleActive && ! hash ) {
-			setHash( hashFrom( activeTabID ) );
-		} else if ( isModuleActive && moduleSlug && moduleState ) {
-			const hashParts = parseHash( hash );
-			// The 2nd index contains the current module state.
-			setModuleSettingsPanelState( moduleSlug, hashParts[ 2 ] || 'view' );
-		}
-	}, [ isModuleActive ] );
 
 	return (
 		<Fragment>

--- a/assets/js/components/settings/SettingsApp.test.js
+++ b/assets/js/components/settings/SettingsApp.test.js
@@ -59,7 +59,7 @@ describe( 'SettingsApp', () => {
 		};
 	} );
 
-	it( 'should change location hash & DOM correctly when module accordian clicked and opened', async () => {
+	it( 'should change location hash & DOM correctly when module accordion clicked and opened', async () => {
 		fetchMock.getOnce(
 			/^\/google-site-kit\/v1\/modules\/analytics\/data\/settings/,
 			{ body: validResponse, status: 200 }
@@ -74,7 +74,7 @@ describe( 'SettingsApp', () => {
 		expect( analyticsPanel ).toHaveAttribute( 'id', 'googlesitekit-settings-module__content--analytics' );
 	} );
 
-	it( 'should change location hash & DOM correctly when module accordian clicked and closed', async () => {
+	it( 'should change location hash & DOM correctly when module accordion clicked and closed', async () => {
 		const { getByRole, findByRole, queryByRole } = render( <SettingsApp />, { registry } );
 
 		fireEvent.click( getByRole( 'tab', { name: /analytics/i } ) );


### PR DESCRIPTION
## Summary

Addresses issue #2187 (follow-up), #2627

Targets `master` branch

## Relevant technical choices

* Fixes unwanted side-effects (settings rollback) due to settings panel state not being initialized on initial render

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
