### PR TITLE
Refactor further instances of aliased STORE_NAME imports to use new exports

### DIFF
--- a/assets/js/components/setup/CompatibilityChecks/CompatibilityErrorNotice.js
+++ b/assets/js/components/setup/CompatibilityChecks/CompatibilityErrorNotice.js
@@ -28,7 +28,7 @@ import Data from 'googlesitekit-data';
 import { sanitizeHTML } from '../../../util/sanitize';
 import Link from '../../Link';
 const { useSelect } = Data;
-import { STORE_NAME as CORE_SITE } from '../../../googlesitekit/datastore/site/constants';
+import { CORE_SITE } from '../../../googlesitekit/datastore/site/constants';
 import {
 	ERROR_AMP_CDN_RESTRICTED,
 	ERROR_FETCH_FAIL,

--- a/assets/js/components/setup/CompatibilityChecks/checks.js
+++ b/assets/js/components/setup/CompatibilityChecks/checks.js
@@ -17,7 +17,7 @@
  */
 
 import API from 'googlesitekit-api';
-import { STORE_NAME as CORE_SITE } from '../../../googlesitekit/datastore/site/constants';
+import { CORE_SITE } from '../../../googlesitekit/datastore/site/constants';
 import {
 	AMP_PROJECT_TEST_URL,
 	ERROR_AMP_CDN_RESTRICTED,

--- a/assets/js/components/setup/CompatibilityChecks/index.js
+++ b/assets/js/components/setup/CompatibilityChecks/index.js
@@ -35,7 +35,7 @@ import Warning from '../../legacy-notifications/warning';
 import ProgressBar from '../../ProgressBar';
 import { useChecks } from '../../../hooks/useChecks';
 import CompatibilityErrorNotice from './CompatibilityErrorNotice';
-import { STORE_NAME as CORE_SITE } from '../../../googlesitekit/datastore/site/constants';
+import { CORE_SITE } from '../../../googlesitekit/datastore/site/constants';
 import { checkAMPConnectivity, checkHealthChecks, checkHostname, checkWPVersion, registryCheckSetupTag } from './checks';
 
 const createCompatibilityChecks = ( registry ) => {


### PR DESCRIPTION
## Summary

Hopefully the last instances in the codebase... 🤞
Addresses issue #2563

## Relevant technical choices

<!-- Please describe your changes. -->

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
