### PR TITLE
Reset dimensionColor when 'others' slice is selected.

### DIFF
--- a/assets/js/modules/analytics/components/dashboard/DashboardAllTrafficWidgetV2/UserDimensionsPieChart.js
+++ b/assets/js/modules/analytics/components/dashboard/DashboardAllTrafficWidgetV2/UserDimensionsPieChart.js
@@ -84,12 +84,13 @@ export default function UserDimensionsPieChart( { dimensionName, entityURL, sour
 					const { dataTable } = GoogleChart.charts.get( 'user-dimensions-pie-chart' ) || {};
 					if ( dataTable ) {
 						const dimensionValue = dataTable.getValue( row, 0 );
+						const isOthers = __( 'Others', 'google-site-kit' ) === dimensionValue;
 
 						setValues(
 							FORM_ALL_TRAFFIC_WIDGET,
 							{
-								dimensionValue: __( 'Others', 'google-site-kit' ) === dimensionValue ? '' : dimensionValue,
-								dimensionColor: slices[ row ]?.color,
+								dimensionValue: isOthers ? '' : dimensionValue,
+								dimensionColor: isOthers ? '' : slices[ row ]?.color,
 							}
 						);
 					}


### PR DESCRIPTION
## Summary
Selecting the 'others' slice should reset the color of the line on the userCountGraph. 

Addresses issue #2625

## Relevant technical choices

<!-- Please describe your changes. -->

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
