### PR TITLE
Write and read features config from config.json

### DIFF
--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -247,9 +247,7 @@ final class Plugin {
 
 		$config = new JSON_File( GOOGLESITEKIT_PLUGIN_DIR_PATH . 'dist/config.json' );
 		Feature_Flags::set_mode( $config['flagMode'] );
-		Feature_Flags::set_features(
-			new JSON_File( GOOGLESITEKIT_PLUGIN_DIR_PATH . 'feature-flags.json' )
-		);
+		Feature_Flags::set_features( (array) $config['features'] );
 
 		static::$instance = new static( $main_file );
 		static::$instance->register();

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -33,6 +33,7 @@ const { DefinePlugin, ProvidePlugin } = require( 'webpack' );
 const CreateFileWebpack = require( 'create-file-webpack' );
 const ManifestPlugin = require( 'webpack-manifest-plugin' );
 const ImageminPlugin = require( 'imagemin-webpack' );
+const features = require( './feature-flags.json' );
 
 const projectPath = ( relativePath ) => {
 	return path.resolve( fs.realpathSync( process.cwd() ), relativePath );
@@ -236,7 +237,7 @@ const webpackConfig = ( env, argv ) => {
 				new CreateFileWebpack( {
 					path: './dist',
 					fileName: 'config.json',
-					content: JSON.stringify( { flagMode } ),
+					content: JSON.stringify( { flagMode, features } ),
 				} ),
 				new ManifestPlugin( {
 					fileName: path.resolve( __dirname, 'includes/Core/Assets/Manifest.php' ),


### PR DESCRIPTION
## Summary

Addresses issue #2452

## Relevant technical choices

* Writes feature config to the `dist/config.json` file since `feature-flags.json` isn't included in the release zip, and doesn't make sense to include separately
* Results in the expected behavior since this file is not included in a production build and in such cases this will be an empty array passed to `Feature_Flags::set_features`
* Also, 1 less JSON file to read from the file system as we're already loading `config.json` for the build mode

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
