### PR TITLE
Refactor import to use new STORE_NAME alias.

### DIFF
--- a/assets/js/modules/optimize/components/setup/SetupMain.js
+++ b/assets/js/modules/optimize/components/setup/SetupMain.js
@@ -34,7 +34,7 @@ import OptimizeIcon from '../../../../../svg/optimize.svg';
 import SetupForm from './SetupForm';
 import ProgressBar from '../../../../components/ProgressBar';
 import { STORE_NAME } from '../../datastore/constants';
-import { STORE_NAME as CORE_LOCATION } from '../../../../googlesitekit/datastore/location/constants';
+import { CORE_LOCATION } from '../../../../googlesitekit/datastore/location/constants';
 const { useSelect } = Data;
 
 export default function SetupMain( { finishSetup } ) {


### PR DESCRIPTION
## Summary
Another incorrect import...
Addresses issue #2563

## Relevant technical choices

<!-- Please describe your changes. -->

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [ ] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
