### PR TITLE
Fix PHP notice in AdSense constructor by removing additional unused datapoints

### DIFF
--- a/includes/Modules/AdSense.php
+++ b/includes/Modules/AdSense.php
@@ -359,26 +359,6 @@ final class AdSense extends Module
 	}
 
 	/**
-	 * Gets the service URL for the current account or signup if none.
-	 *
-	 * @since n.e.x.t
-	 *
-	 * @return string
-	 */
-	protected function get_account_url() {
-		$option = $this->get_settings()->get();
-
-		if ( ! empty( $option['accountID'] ) && $this->authentication->profile()->has() ) {
-			return add_query_arg(
-				array( 'authuser' => $this->authentication->profile()->get()['email'] ),
-				sprintf( 'https://www.google.com/adsense/new/%s/home', $option['accountID'] )
-			);
-		}
-
-		return 'https://www.google.com/adsense/signup/new';
-	}
-
-	/**
 	 * Parses a response for the given datapoint.
 	 *
 	 * @since 1.0.0
@@ -401,6 +381,36 @@ final class AdSense extends Module
 		}
 
 		return parent::parse_data_response( $data, $response );
+	}
+
+	/**
+	 * Gets the service URL for the current account or signup if none.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @return string
+	 */
+	protected function get_account_url() {
+		$profile = $this->authentication->profile();
+		$option  = $this->get_settings()->get();
+		$query   = array(
+			'source'     => 'site-kit',
+			'utm_source' => 'site-kit',
+			'utm_medium' => 'wordpress_signup',
+			'url'        => $this->context->get_reference_site_url(),
+		);
+
+		if ( ! empty( $option['accountID'] ) ) {
+			$url = sprintf( 'https://www.google.com/adsense/new/%s/home', $option['accountID'] );
+		} else {
+			$url = 'https://www.google.com/adsense/signup/new';
+		}
+
+		if ( $profile->has() ) {
+			$query['authuser'] = $profile->get()['email'];
+		}
+
+		return add_query_arg( $url, $query );
 	}
 
 	/**

--- a/includes/Modules/AdSense.php
+++ b/includes/Modules/AdSense.php
@@ -320,6 +320,26 @@ final class AdSense extends Module
 	}
 
 	/**
+	 * Gets the service URL for the current account or signup if none.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @return string
+	 */
+	protected function get_account_url() {
+		$option = $this->get_settings()->get();
+
+		if ( ! empty( $option['accountID'] ) && $this->authentication->profile()->has() ) {
+			return add_query_arg(
+				array( 'authuser' => $this->authentication->profile()->get()['email'] ),
+				sprintf( 'https://www.google.com/adsense/new/%s/home', $option['accountID'] )
+			);
+		}
+
+		return 'https://www.google.com/adsense/signup/new';
+	}
+
+	/**
 	 * Parses a response for the given datapoint.
 	 *
 	 * @since 1.0.0

--- a/includes/Modules/AdSense.php
+++ b/includes/Modules/AdSense.php
@@ -200,7 +200,6 @@ final class AdSense extends Module
 			'GET:alerts'         => array( 'service' => 'adsense' ),
 			'GET:clients'        => array( 'service' => 'adsense' ),
 			'GET:earnings'       => array( 'service' => 'adsense' ),
-			'GET:notifications'  => array( 'service' => '' ),
 			'GET:tag-permission' => array( 'service' => '' ),
 			'GET:urlchannels'    => array( 'service' => 'adsense' ),
 		);
@@ -280,44 +279,6 @@ final class AdSense extends Module
 				}
 
 				return $this->create_adsense_earning_data_request( array_filter( $args ) );
-			case 'GET:notifications':
-				return function() {
-					$alerts = $this->get_data( 'alerts' );
-					if ( is_wp_error( $alerts ) || empty( $alerts ) ) {
-						return array();
-					}
-					$alerts = array_filter(
-						$alerts,
-						function( Google_Service_AdSense_Alert $alert ) {
-							return 'SEVERE' === $alert->getSeverity();
-						}
-					);
-
-					// There is no SEVERE alert, return empty.
-					if ( empty( $alerts ) ) {
-						return array();
-					}
-
-					/**
-					 * First Alert
-					 *
-					 * @var Google_Service_AdSense_Alert $alert
-					 */
-					$alert = array_shift( $alerts );
-					return array(
-						array(
-							'id'            => 'adsense-notification',
-							'description'   => $alert->getMessage(),
-							'isDismissible' => true,
-							'winImage'      => 'sun-small.png',
-							'format'        => 'large',
-							'severity'      => 'win-info',
-							'ctaURL'        => $this->get_account_url(),
-							'ctaLabel'      => __( 'Go to AdSense', 'google-site-kit' ),
-							'ctaTarget'     => '_blank',
-						),
-					);
-				};
 			case 'GET:tag-permission':
 				return function() use ( $data ) {
 					if ( ! isset( $data['clientID'] ) ) {

--- a/includes/Modules/AdSense.php
+++ b/includes/Modules/AdSense.php
@@ -217,7 +217,6 @@ final class AdSense extends Module
 			'GET:clients'        => array( 'service' => 'adsense' ),
 			'GET:earnings'       => array( 'service' => 'adsense' ),
 			'GET:notifications'  => array( 'service' => '' ),
-			'GET:reports-url'    => array( 'service' => '' ),
 			'GET:tag-permission' => array( 'service' => '' ),
 			'GET:urlchannels'    => array( 'service' => 'adsense' ),
 		);
@@ -363,19 +362,6 @@ final class AdSense extends Module
 						array( 'clientID' => $data['clientID'] ),
 						$this->has_access_to_client( $data['clientID'] )
 					);
-				};
-			case 'GET:reports-url':
-				return function() {
-					$option     = $this->get_settings()->get();
-					$account_id = $option['accountID'];
-					if ( $account_id && $this->authentication->profile()->has() ) {
-						$profile_email = $this->authentication->profile()->get()['email'];
-						return add_query_arg(
-							array( 'authuser' => $profile_email ),
-							sprintf( 'https://www.google.com/adsense/new/%s/main/viewreports', $account_id )
-						);
-					}
-					return 'https://www.google.com/adsense/start';
 				};
 			case 'GET:urlchannels':
 				if ( ! isset( $data['accountID'] ) ) {

--- a/includes/Modules/AdSense.php
+++ b/includes/Modules/AdSense.php
@@ -397,7 +397,7 @@ final class AdSense extends Module
 			'source'     => 'site-kit',
 			'utm_source' => 'site-kit',
 			'utm_medium' => 'wordpress_signup',
-			'url'        => $this->context->get_reference_site_url(),
+			'url'        => rawurlencode( $this->context->get_reference_site_url() ),
 		);
 
 		if ( ! empty( $option['accountID'] ) ) {

--- a/includes/Modules/AdSense.php
+++ b/includes/Modules/AdSense.php
@@ -320,26 +320,6 @@ final class AdSense extends Module
 	}
 
 	/**
-	 * Gets the service URL for the current account or signup if none.
-	 *
-	 * @since n.e.x.t
-	 *
-	 * @return string
-	 */
-	protected function get_account_url() {
-		$option = $this->get_settings()->get();
-
-		if ( ! empty( $option['accountID'] ) && $this->authentication->profile()->has() ) {
-			return add_query_arg(
-				array( 'authuser' => $this->authentication->profile()->get()['email'] ),
-				sprintf( 'https://www.google.com/adsense/new/%s/home', $option['accountID'] )
-			);
-		}
-
-		return 'https://www.google.com/adsense/signup/new';
-	}
-
-	/**
 	 * Parses a response for the given datapoint.
 	 *
 	 * @since 1.0.0

--- a/includes/Modules/AdSense.php
+++ b/includes/Modules/AdSense.php
@@ -604,7 +604,7 @@ final class AdSense extends Module
 			'description' => __( 'Earn money by placing ads on your website. It’s free and easy.', 'google-site-kit' ),
 			'cta'         => __( 'Monetize Your Site.', 'google-site-kit' ),
 			'order'       => 2,
-			'homepage'    => add_query_arg( $idenfifier_args, $this->get_data( 'reports-url' ) ),
+			'homepage'    => add_query_arg( $idenfifier_args, 'https://www.google.com/adsense/start' ),
 			'learn_more'  => __( 'https://www.google.com/intl/en_us/adsense/start/', 'google-site-kit' ),
 		);
 	}

--- a/includes/Modules/AdSense.php
+++ b/includes/Modules/AdSense.php
@@ -410,7 +410,7 @@ final class AdSense extends Module
 			$query['authuser'] = $profile->get()['email'];
 		}
 
-		return add_query_arg( $url, $query );
+		return add_query_arg( $query, $url );
 	}
 
 	/**

--- a/includes/Modules/AdSense.php
+++ b/includes/Modules/AdSense.php
@@ -123,21 +123,6 @@ final class AdSense extends Module
 			__( 'Intelligent, automatic ad placement', 'google-site-kit' ),
 		);
 
-		// Clear datapoints that don't need to be localized.
-		$idenfifier_args = array(
-			'source' => 'site-kit',
-			'url'    => rawurlencode( $this->context->get_reference_site_url() ),
-		);
-
-		$signup_args = array(
-			'utm_source' => 'site-kit',
-			'utm_medium' => 'wordpress_signup',
-		);
-
-		$info['accountURL'] = add_query_arg( $idenfifier_args, $this->get_account_url() );
-		$info['signupURL']  = add_query_arg( $signup_args, $info['accountURL'] );
-		$info['rootURL']    = add_query_arg( $idenfifier_args, 'https://www.google.com/adsense/' );
-
 		return $info;
 	}
 

--- a/tests/phpunit/integration/Modules/AdSenseTest.php
+++ b/tests/phpunit/integration/Modules/AdSenseTest.php
@@ -371,7 +371,6 @@ class AdSenseTest extends TestCase {
 		$this->assertEqualSets(
 			array(
 				'account-url',
-				'reports-url',
 				'notifications',
 				'tag-permission',
 				'accounts',

--- a/tests/phpunit/integration/Modules/AdSenseTest.php
+++ b/tests/phpunit/integration/Modules/AdSenseTest.php
@@ -370,7 +370,6 @@ class AdSenseTest extends TestCase {
 
 		$this->assertEqualSets(
 			array(
-				'account-url',
 				'notifications',
 				'tag-permission',
 				'accounts',

--- a/tests/phpunit/integration/Modules/AdSenseTest.php
+++ b/tests/phpunit/integration/Modules/AdSenseTest.php
@@ -321,17 +321,11 @@ class AdSenseTest extends TestCase {
 				'screenID',
 				'settings',
 				'provides',
-				'accountURL',
-				'signupURL',
-				'rootURL',
 			),
 			array_keys( $info )
 		);
 
 		$this->assertEquals( 'adsense', $info['slug'] );
-		$this->assertStringStartsWith( 'https://www.google.com/adsense/', $info['accountURL'] );
-		$this->assertStringStartsWith( 'https://www.google.com/adsense/', $info['signupURL'] );
-		$this->assertStringStartsWith( 'https://www.google.com/adsense/', $info['rootURL'] );
 	}
 
 	public function test_is_connected() {

--- a/tests/phpunit/integration/Modules/AdSenseTest.php
+++ b/tests/phpunit/integration/Modules/AdSenseTest.php
@@ -364,6 +364,7 @@ class AdSenseTest extends TestCase {
 
 		$this->assertEqualSets(
 			array(
+				'notifications',
 				'tag-permission',
 				'accounts',
 				'alerts',

--- a/tests/phpunit/integration/Modules/AdSenseTest.php
+++ b/tests/phpunit/integration/Modules/AdSenseTest.php
@@ -370,7 +370,6 @@ class AdSenseTest extends TestCase {
 
 		$this->assertEqualSets(
 			array(
-				'notifications',
 				'tag-permission',
 				'accounts',
 				'alerts',


### PR DESCRIPTION
## Summary

Addresses issue #2507

## Relevant technical choices

* Fixes initial follow-up issue related to PHP notice raised during `setup_info` call by inlining the fallback case that we were already using for the module's `homeurl`
* `GET:reports-url` datapoint is no longer used and removed
* Initially extracted `GET:account-url` datapoint to a method for it to be used in `GET:notifications` so the now unused `GET:account-url` could be removed
* ~~Found that AdSense's `GET:notifications` datapoint is also unused and removed this as well, which allowed for the added method for `get_account_url` to also be removed as it was now unused as well~~
    - ~~I was a bit surprised about this but after looking through the code, the AdSense module uses `getAlerts`, never `getNotifications` and all references to the notifications datapoint are all for site notifications, no module notifications are ever requested. Even the datapoint for AdSense's `GET:notifications` used `get_data( 'alerts' )` internally so it makes sense that this would no longer be used. This should simplify the changes needed in #2468 as well.~~

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
