### PR TITLE
Fix/2674 e2e fetch stability

### DIFF
--- a/tests/e2e/specs/dashboard/dashboard-noscript.test.js
+++ b/tests/e2e/specs/dashboard/dashboard-noscript.test.js
@@ -1,4 +1,22 @@
 /**
+ * Dashboard noscript tests.
+ *
+ * Site Kit by Google, Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
  * WordPress dependencies
  */
 import { visitAdminPage } from '@wordpress/e2e-test-utils';

--- a/tests/e2e/specs/dashboard/dashboard-noscript.test.js
+++ b/tests/e2e/specs/dashboard/dashboard-noscript.test.js
@@ -4,7 +4,7 @@
 import { visitAdminPage } from '@wordpress/e2e-test-utils';
 import { createWaitForFetchRequests } from '../../utils';
 
-describe( 'Site Kit noscript notice', () => {
+describe( 'dashboard noscript notice', () => {
 	let waitForFetchRequests;
 	beforeEach( async () => {
 		waitForFetchRequests = createWaitForFetchRequests();
@@ -13,14 +13,14 @@ describe( 'Site Kit noscript notice', () => {
 
 	afterEach( () => waitForFetchRequests() ); // Clean up request listeners.
 
-	describe( 'When Javascript is enabled', () => {
+	describe( 'with Javascript enabled', () => {
 		it( 'Should not display noscript notice', async () => {
 			await expect( page ).not.toMatchElement( '.googlesitekit-noscript' );
 			await waitForFetchRequests(); // Wait for compatibility checks to finish.
 		} );
 	} );
 
-	describe( 'When Javascript is disabled', () => {
+	describe( 'with Javascript disabled', () => {
 		beforeAll( async () => {
 			await page.setJavaScriptEnabled( false );
 		} );
@@ -29,13 +29,13 @@ describe( 'Site Kit noscript notice', () => {
 			await page.setJavaScriptEnabled( true );
 		} );
 
-		it( 'Should not display plugin html', async () => {
+		it( 'should not display plugin html', async () => {
 			await expect( page ).toMatchElement( '[id^=js-googlesitekit-]', { visible: false } );
 			await expect( page ).not.toMatchElement( '.googlesitekit-header' );
 			await expect( page ).not.toMatchElement( '.googlesitekit-module-page' );
 		} );
 
-		it( 'Should display noscript notice', async () => {
+		it( 'should display noscript notice', async () => {
 			await expect( page ).toMatchElement(
 				'.googlesitekit-noscript__text',
 				{ text: /The Site Kit by Google plugin requires JavaScript to be enabled in your browser/i },

--- a/tests/e2e/specs/dashboard/dashboard-noscript.test.js
+++ b/tests/e2e/specs/dashboard/dashboard-noscript.test.js
@@ -2,15 +2,21 @@
  * WordPress dependencies
  */
 import { visitAdminPage } from '@wordpress/e2e-test-utils';
+import { createWaitForFetchRequests } from '../../utils';
 
 describe( 'Site Kit noscript notice', () => {
+	let waitForFetchRequests;
 	beforeEach( async () => {
+		waitForFetchRequests = createWaitForFetchRequests();
 		await visitAdminPage( 'admin.php', 'page=googlesitekit-splash' );
 	} );
+
+	afterEach( () => waitForFetchRequests() ); // Clean up request listeners.
 
 	describe( 'When Javascript is enabled', () => {
 		it( 'Should not display noscript notice', async () => {
 			await expect( page ).not.toMatchElement( '.googlesitekit-noscript' );
+			await waitForFetchRequests(); // Wait for compatibility checks to finish.
 		} );
 	} );
 

--- a/tests/e2e/specs/plugin-activation.test.js
+++ b/tests/e2e/specs/plugin-activation.test.js
@@ -20,9 +20,9 @@
  * WordPress dependencies
  */
 import { deactivatePlugin, activatePlugin } from '@wordpress/e2e-test-utils';
-import { useRequestInterception } from '../utils';
+import { useRequestInterception, createWaitForFetchRequests } from '../utils';
 
-describe( 'Plugin Activation Notice', () => {
+describe( 'plugin activation notice', () => {
 	beforeAll( async () => {
 		await page.setRequestInterception( true );
 		useRequestInterception( ( request ) => {
@@ -33,97 +33,80 @@ describe( 'Plugin Activation Notice', () => {
 			}
 		} );
 	} );
-	describe( 'When Javascript is enabled', () => {
+
+	beforeEach( async () => {
 		// Ensure Site Kit is disabled before running each test as it's enabled by default.
-		beforeEach( async () => {
-			await deactivatePlugin( 'google-site-kit' );
-		} );
-
-		afterEach( async () => {
-			await activatePlugin( 'google-site-kit' );
-		} );
-
-		describe( 'using Proxy auth', () => {
-			beforeEach( async () => {
-				await activatePlugin( 'e2e-tests-proxy-credentials-plugin' );
-			} );
-			afterEach( async () => {
-				await deactivatePlugin( 'e2e-tests-proxy-credentials-plugin' );
-			} );
-			it( 'Should be displayed', async () => {
-				await activatePlugin( 'google-site-kit' );
-				await page.waitForSelector( '.googlesitekit-activation__title' );
-				await expect( page ).toMatchElement( '.googlesitekit-activation__title', { text: /Congratulations, the Site Kit plugin is now activated./i } );
-			} );
-			it( 'Should not display noscript notice', async () => {
-				await activatePlugin( 'google-site-kit' );
-
-				await expect( page ).not.toMatchElement( '.googlesitekit-noscript' );
-
-				await deactivatePlugin( 'google-site-kit' );
-			} );
-		} );
-		describe( 'using GCP auth', () => {
-			beforeEach( async () => {
-				await activatePlugin( 'e2e-tests-gcp-credentials-plugin' );
-			} );
-			afterEach( async () => {
-				await deactivatePlugin( 'e2e-tests-gcp-credentials-plugin' );
-			} );
-			it( 'Should lead you to the setup wizard with GCP auth', async () => {
-				await activatePlugin( 'google-site-kit' );
-
-				await page.waitForSelector( '.googlesitekit-activation' );
-
-				await expect( page ).toMatchElement( '.googlesitekit-start-setup', { text: 'Start setup' } );
-
-				await page.click( '.googlesitekit-start-setup' );
-				await page.waitForSelector( '.googlesitekit-wizard-step__title' );
-
-				// Ensure we're on the first step.
-				await expect( page ).toMatchElement( '.googlesitekit-wizard-progress-step__number--inprogress', { text: '1' } );
-
-				await deactivatePlugin( 'google-site-kit' );
-			} );
-		} );
+		await deactivatePlugin( 'google-site-kit' );
 	} );
 
-	describe( 'When Javascript is disabled', () => {
-		beforeEach( async () => {
-			await deactivatePlugin( 'google-site-kit' );
-		} );
+	afterAll( async () => {
+		await activatePlugin( 'google-site-kit' );
+	} );
 
-		afterEach( async () => {
-			await activatePlugin( 'google-site-kit' );
-		} );
-
-		it( 'Should not display plugin html', async () => {
-			// Disabling JavaScript in `beforeEach` breaks utility functions.
-			// Each test without JavaScript must use
-			// `await page.setJavaScriptEnabled( false );` and
-			// `await page.setJavaScriptEnabled( true );` in the test itself.
-			await page.setJavaScriptEnabled( false );
+	const matrix = {
+		shouldBeDisplayed: async () => {
+			const waitForFetchRequests = createWaitForFetchRequests();
 			await activatePlugin( 'google-site-kit' );
 
-			await expect( page ).toMatchElement( '[id^=js-googlesitekit-]', { visible: false } );
-			await expect( page ).not.toMatchElement( '.googlesitekit-activation__title' );
+			await page.waitForSelector( '.googlesitekit-activation__title' );
 
-			await deactivatePlugin( 'google-site-kit' );
-			await page.setJavaScriptEnabled( true );
-		} );
+			await expect( page ).toMatchElement( '.googlesitekit-activation__title', { text: /Congratulations, the Site Kit plugin is now activated./i } );
 
-		it( 'Should display noscript notice', async () => {
-			await page.setJavaScriptEnabled( false );
+			await waitForFetchRequests(); // Wait for compatibility checks to finish.
+		},
+		shouldNotDisplayNoScriptNotice: async () => {
+			const waitForFetchRequests = createWaitForFetchRequests();
 			await activatePlugin( 'google-site-kit' );
 
-			await expect( page ).toMatchElement(
-				'.googlesitekit-noscript__text',
-				{ text: /The Site Kit by Google plugin requires JavaScript to be enabled in your browser./i },
-				{ visible: true }
-			);
+			await expect( page ).not.toMatchElement( '.googlesitekit-noscript' );
 
-			await deactivatePlugin( 'google-site-kit' );
-			await page.setJavaScriptEnabled( true );
+			await waitForFetchRequests(); // Wait for compatibility checks to finish.
+		},
+	};
+
+	describe( 'using proxy auth', () => {
+		beforeAll( async () => {
+			await activatePlugin( 'e2e-tests-proxy-credentials-plugin' );
+		} );
+
+		afterAll( async () => {
+			await deactivatePlugin( 'e2e-tests-proxy-credentials-plugin' );
+		} );
+
+		it( 'should be displayed', matrix.shouldBeDisplayed );
+
+		it( 'should not display noscript notice', matrix.shouldNotDisplayNoScriptNotice );
+	} );
+
+	describe( 'using GCP auth', () => {
+		beforeAll( async () => {
+			await activatePlugin( 'e2e-tests-gcp-credentials-plugin' );
+		} );
+
+		afterAll( async () => {
+			await deactivatePlugin( 'e2e-tests-gcp-credentials-plugin' );
+		} );
+
+		it( 'should be displayed', matrix.shouldBeDisplayed );
+
+		it( 'should not display noscript notice', matrix.shouldNotDisplayNoScriptNotice );
+
+		it( 'should lead you to the setup wizard with GCP auth', async () => {
+			const waitForFetchRequests = createWaitForFetchRequests();
+
+			await activatePlugin( 'google-site-kit' );
+
+			await page.waitForSelector( '.googlesitekit-activation__title' );
+
+			await expect( page ).toMatchElement( '.googlesitekit-start-setup', { text: 'Start setup' } );
+
+			await waitForFetchRequests(); // Wait for compatibility checks to finish.
+
+			await page.click( '.googlesitekit-start-setup' );
+			await page.waitForSelector( '.googlesitekit-wizard-step__title' );
+
+			// Ensure we're on the first step.
+			await expect( page ).toMatchElement( '.googlesitekit-wizard-progress-step__number--inprogress', { text: '1' } );
 		} );
 	} );
 } );

--- a/tests/e2e/utils/create-wait-for-fetch-requests.js
+++ b/tests/e2e/utils/create-wait-for-fetch-requests.js
@@ -32,12 +32,12 @@ export function createWaitForFetchRequests() {
 			const promise = page.waitForResponse(
 				// eslint-disable-next-line sitekit/camelcase-acronyms
 				( res ) => res.request()._requestId === req._requestId
-			).catch( () => {} );
+			);
 			// A promise may be rejected if the execution context it was
 			// captured in no longer exists (e.g. previous page) which
 			// is necessary in some cases, and can be ignored since
 			// there is nothing to wait for any more.
-			responsePromises.push( promise );
+			responsePromises.push( promise.catch( () => {} ) );
 		}
 	};
 

--- a/tests/e2e/utils/create-wait-for-fetch-requests.js
+++ b/tests/e2e/utils/create-wait-for-fetch-requests.js
@@ -1,0 +1,51 @@
+/**
+ * Fetch request wait utility.
+ *
+ * Site Kit by Google, Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Creates a function that waits for all fetch requests dispatched
+ * since the function was called to complete.
+ *
+ * @since n.e.x.t
+ *
+ * @return {Function} Wait function.
+ */
+export function createWaitForFetchRequests() {
+	const responsePromises = [];
+
+	const listener = ( req ) => {
+		if ( req.resourceType() === 'fetch' ) {
+			const promise = page.waitForResponse(
+				// eslint-disable-next-line sitekit/camelcase-acronyms
+				( res ) => res.request()._requestId === req._requestId
+			).catch( () => {} );
+			// A promise may be rejected if the execution context it was
+			// captured in no longer exists (e.g. previous page) which
+			// is necessary in some cases, and can be ignored since
+			// there is nothing to wait for any more.
+			responsePromises.push( promise );
+		}
+	};
+
+	page.on( 'request', listener );
+
+	return () => {
+		page.off( 'request', listener );
+
+		return Promise.all( responsePromises );
+	};
+}

--- a/tests/e2e/utils/index.js
+++ b/tests/e2e/utils/index.js
@@ -1,10 +1,30 @@
+/**
+ * E2E utilities.
+ *
+ * Site Kit by Google, Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 export { activateAMPWithMode, setAMPMode } from './activate-amp-and-set-mode';
 export { clearSessionStorage } from './clear-session-storage';
+export { createWaitForFetchRequests } from './create-wait-for-fetch-requests';
 export { deactivateUtilityPlugins } from './deactivate-utility-plugins';
 export { evalWithWPData } from './eval-with-wp-data';
 export { fetchPageContent } from './fetch-page-content';
 export { getWPVersion } from './get-wp-version';
 export { logoutUser } from './logout-user';
+export { pageWait } from './page-wait';
 export { pasteText } from './paste-text';
 export { resetSiteKit } from './reset';
 export { safeLoginUser } from './safe-login-user';
@@ -12,14 +32,13 @@ export { setAnalyticsExistingPropertyID } from './set-analytics-existing-propert
 export { setAuthToken } from './set-auth-token';
 export { setClientConfig } from './set-client-config';
 export { setEditPostFeature } from './set-edit-post-feature';
-export { setSiteVerification } from './set-site-verification';
 export { setSearchConsoleProperty } from './set-search-console-property';
-export { setupAnalytics } from './setup-analytics';
+export { setSiteVerification } from './set-site-verification';
 export { setupAdSense } from './setup-adsense';
+export { setupAnalytics } from './setup-analytics';
 export { setupSiteKit } from './setup-site-kit';
 export { switchDateRange } from './switch-date-range';
 export { testClientConfig } from './test-client-config';
 export { testSiteNotification } from './test-site-notification';
 export { useRequestInterception } from './use-request-interception';
 export { wpApiFetch } from './wp-api-fetch';
-export { pageWait } from './page-wait';


### PR DESCRIPTION
## Summary

Addresses issue #2674

## Relevant technical choices

The changes to `plugin-activation.test.js` look like more than there really is due to some restructuring:
* Removed an unneeded `describe` block about JS being enabled
* Updated before/after functions to optimize plugin activation handling
* Updated GCP tests to test the same cases as the proxy auth case by extracting a `matrix` variable to share test functions

I tried testing `specs/modules/tagmanager/setup.test.js` several times but I was not able to reproduce any failure locally. I have seen it fail in GHA (including in some of these runs) although most of the time it is usually an odd log statement that _does not_ cause the test to fail and some other test is the one that fails the job, or in one case I saw a timeout error which seems to be related to click instability that we've seen before, so somewhat beyond the scope here.

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
