### PR TITLE
Store initial Site Kit version per user.

### DIFF
--- a/includes/Core/Authentication/Authentication.php
+++ b/includes/Core/Authentication/Authentication.php
@@ -480,17 +480,6 @@ final class Authentication {
 	}
 
 	/**
-	 * Gets the Initial_Version instance.
-	 *
-	 * @since n.e.x.t
-	 *
-	 * @return Initial_Version An instance of the Initial_Version class.
-	 */
-	public function get_initial_version() {
-		return $this->initial_version;
-	}
-
-	/**
 	 * Revokes authentication along with user options settings.
 	 *
 	 * @since 1.0.0

--- a/includes/Core/Authentication/Authentication.php
+++ b/includes/Core/Authentication/Authentication.php
@@ -480,6 +480,17 @@ final class Authentication {
 	}
 
 	/**
+	 * Gets the Initial_Version instance.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @return Initial_Version An instance of the Initial_Version class.
+	 */
+	public function get_initial_version() {
+		return $this->initial_version;
+	}
+
+	/**
 	 * Revokes authentication along with user options settings.
 	 *
 	 * @since 1.0.0

--- a/includes/Core/Authentication/Authentication.php
+++ b/includes/Core/Authentication/Authentication.php
@@ -186,10 +186,9 @@ final class Authentication {
 	 * Initial_Version instance.
 	 *
 	 * @since n.e.x.t
-	 *
-	 * @var User_Input_State
+	 * @var Initial_Version
 	 */
-	private $initial_version = null;
+	protected $initial_version;
 
 	/**
 	 * Flag set when site fields are synchronized during the current request.

--- a/includes/Core/Authentication/Clients/Google_Site_Kit_Client.php
+++ b/includes/Core/Authentication/Clients/Google_Site_Kit_Client.php
@@ -103,10 +103,10 @@ class Google_Site_Kit_Client extends Google_Client {
 			$callback = $this->getConfig( 'token_callback' );
 
 			try {
-				$creds = $this->fetchAccessTokenWithRefreshToken( $token['refresh_token'] );
+				$token_response = $this->fetchAccessTokenWithRefreshToken( $token['refresh_token'] );
 				if ( $callback ) {
 					// Due to original callback signature this can only accept the token itself.
-					call_user_func( $callback, '', $creds['access_token'] );
+					call_user_func( $callback, '', $token_response['access_token'] );
 				}
 			} catch ( Exception $e ) {
 				// Pass exception to special callback if provided.
@@ -142,13 +142,13 @@ class Google_Site_Kit_Client extends Google_Client {
 
 		$http_handler = HttpHandlerFactory::build( $this->getHttpClient() );
 
-		$creds = $this->fetchAuthToken( $auth, $http_handler );
-		if ( $creds && isset( $creds['access_token'] ) ) {
-			$creds['created'] = time();
-			$this->setAccessToken( $creds );
+		$token_response = $this->fetchAuthToken( $auth, $http_handler );
+		if ( $token_response && isset( $token_response['access_token'] ) ) {
+			$token_response['created'] = time();
+			$this->setAccessToken( $token_response );
 		}
 
-		return $creds;
+		return $token_response;
 	}
 
 	/**
@@ -176,16 +176,33 @@ class Google_Site_Kit_Client extends Google_Client {
 
 		$http_handler = HttpHandlerFactory::build( $this->getHttpClient() );
 
-		$creds = $this->fetchAuthToken( $auth, $http_handler );
-		if ( $creds && isset( $creds['access_token'] ) ) {
-			$creds['created'] = time();
-			if ( ! isset( $creds['refresh_token'] ) ) {
-				$creds['refresh_token'] = $refresh_token;
+		$token_response = $this->fetchAuthToken( $auth, $http_handler );
+		if ( $token_response && isset( $token_response['access_token'] ) ) {
+			$token_response['created'] = time();
+			if ( ! isset( $token_response['refresh_token'] ) ) {
+				$token_response['refresh_token'] = $refresh_token;
 			}
-			$this->setAccessToken( $creds );
+			$this->setAccessToken( $token_response );
+
+			// TODO: In the future, once the old authentication mechanism no longer exists, this check can be removed.
+			// For now the below action should only fire for the proxy despite not clarifying that in the hook name.
+			if ( $this instanceof Google_Site_Kit_Proxy_Client ) {
+				/**
+				 * Fires when the current user has just been reauthorized to access Google APIs with a refreshed access token.
+				 *
+				 * In other words, this action fires whenever Site Kit has just obtained a new access token based on
+				 * the refresh token for the current user, which typically happens once every hour when using Site Kit,
+				 * since that is the lifetime of every access token.
+				 *
+				 * @since n.e.x.t
+				 *
+				 * @param array $token_response Token response data.
+				 */
+				do_action( 'googlesitekit_reauthorize_user', $token_response );
+			}
 		}
 
-		return $creds;
+		return $token_response;
 	}
 
 	/**

--- a/includes/Core/Authentication/Initial_Version.php
+++ b/includes/Core/Authentication/Initial_Version.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Class Google\Site_Kit\Core\Authentication\Initial_Version
+ *
+ * @package   Google\Site_Kit
+ * @copyright 2021 Google LLC
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
+ * @link      https://sitekit.withgoogle.com
+ */
+
+namespace Google\Site_Kit\Core\Authentication;
+
+use Google\Site_Kit\Core\Storage\User_Setting;
+
+/**
+ * Class representing the initial Site Kit version the user started with.
+ *
+ * @since n.e.x.t
+ * @access private
+ * @ignore
+ */
+final class Initial_Version extends User_Setting {
+
+	/**
+	 * User option key.
+	 */
+	const OPTION = 'googlesitekitpersistent_initial_version';
+}

--- a/tests/phpunit/integration/Core/Authentication/AuthenticationTest.php
+++ b/tests/phpunit/integration/Core/Authentication/AuthenticationTest.php
@@ -104,7 +104,7 @@ class AuthenticationTest extends TestCase {
 		wp_set_current_user( $user_id );
 
 		$auth            = new Authentication( new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE ) );
-		$initial_version = $auth->get_initial_version();
+		$initial_version = $this->force_get_property( $auth, 'initial_version' );
 
 		// Ensure no version is set yet.
 		$initial_version->delete();
@@ -125,7 +125,7 @@ class AuthenticationTest extends TestCase {
 		wp_set_current_user( $user_id );
 
 		$auth            = new Authentication( new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE ) );
-		$initial_version = $auth->get_initial_version();
+		$initial_version = $this->force_get_property( $auth, 'initial_version' );
 
 		// Ensure a version is already set.
 		$initial_version->set( '1.1.0' );
@@ -141,7 +141,7 @@ class AuthenticationTest extends TestCase {
 		// Response is not used here, so just pass an array.
 		do_action( 'googlesitekit_authorize_user', array() );
 		do_action( 'googlesitekit_reauthorize_user', array() );
-		$this->assertEquals( '1.1.0', $this->initial_version->get() );
+		$this->assertEquals( '1.1.0', $initial_version->get() );
 	}
 
 	public function option_action_provider() {

--- a/tests/phpunit/integration/Core/Authentication/AuthenticationTest.php
+++ b/tests/phpunit/integration/Core/Authentication/AuthenticationTest.php
@@ -99,6 +99,42 @@ class AuthenticationTest extends TestCase {
 		$this->assertTrue( has_action( 'shutdown' ), $option );
 	}
 
+	public function test_register_set_initial_version_if_not_set() {
+		$auth            = new Authentication( new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE ) );
+		$initial_version = $this->force_get_property( $auth, 'initial_version' );
+
+		// Ensure no version is set yet.
+		$initial_version->delete();
+		remove_all_actions( 'googlesitekit_authorize_user' );
+		remove_all_actions( 'googlesitekit_reauthorize_user' );
+		$auth->register();
+
+		$this->assertTrue( has_action( 'googlesitekit_authorize_user' ) );
+		$this->assertTrue( has_action( 'googlesitekit_reauthorize_user' ) );
+
+		// Response is not used here, so just pass an array.
+		do_action( 'googlesitekit_reauthorize_user', array() );
+		$this->assertEquals( GOOGLESITEKIT_VERSION, $this->initial_version->get() );
+	}
+
+	public function test_register_do_not_set_initial_version_if_already_set() {
+		$auth            = new Authentication( new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE ) );
+		$initial_version = $this->force_get_property( $auth, 'initial_version' );
+
+		// Ensure a version is already set.
+		$initial_version->set( '1.1.0' );
+		remove_all_actions( 'googlesitekit_authorize_user' );
+		remove_all_actions( 'googlesitekit_reauthorize_user' );
+		$auth->register();
+
+		$this->assertFalse( has_action( 'googlesitekit_authorize_user' ) );
+		$this->assertFalse( has_action( 'googlesitekit_reauthorize_user' ) );
+
+		// Response is not used here, so just pass an array.
+		do_action( 'googlesitekit_reauthorize_user', array() );
+		$this->assertEquals( '1.1.0', $this->initial_version->get() );
+	}
+
 	public function option_action_provider() {
 		return array(
 			array( 'blogname', 'example.com', 'new.example.com' ),

--- a/tests/phpunit/integration/Core/Authentication/AuthenticationTest.php
+++ b/tests/phpunit/integration/Core/Authentication/AuthenticationTest.php
@@ -100,6 +100,9 @@ class AuthenticationTest extends TestCase {
 	}
 
 	public function test_register_set_initial_version_if_not_set() {
+		$user_id = $this->factory()->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $user_id );
+
 		$auth            = new Authentication( new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE ) );
 		$initial_version = $auth->get_initial_version();
 
@@ -118,6 +121,9 @@ class AuthenticationTest extends TestCase {
 	}
 
 	public function test_register_do_not_set_initial_version_if_already_set() {
+		$user_id = $this->factory()->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $user_id );
+
 		$auth            = new Authentication( new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE ) );
 		$initial_version = $auth->get_initial_version();
 

--- a/tests/phpunit/integration/Core/Authentication/AuthenticationTest.php
+++ b/tests/phpunit/integration/Core/Authentication/AuthenticationTest.php
@@ -114,7 +114,7 @@ class AuthenticationTest extends TestCase {
 
 		// Response is not used here, so just pass an array.
 		do_action( 'googlesitekit_reauthorize_user', array() );
-		$this->assertEquals( GOOGLESITEKIT_VERSION, $this->initial_version->get() );
+		$this->assertEquals( GOOGLESITEKIT_VERSION, $initial_version->get() );
 	}
 
 	public function test_register_do_not_set_initial_version_if_already_set() {
@@ -127,10 +127,13 @@ class AuthenticationTest extends TestCase {
 		remove_all_actions( 'googlesitekit_reauthorize_user' );
 		$auth->register();
 
-		$this->assertFalse( has_action( 'googlesitekit_authorize_user' ) );
+		// We cannot test that the hook has not been added to 'googlesitekit_authorize_user'
+		// since the `register` method also adds another unrelated callback to it unconditionally.
+		// That should be fine though since we're covering the integration below.
 		$this->assertFalse( has_action( 'googlesitekit_reauthorize_user' ) );
 
 		// Response is not used here, so just pass an array.
+		do_action( 'googlesitekit_authorize_user', array() );
 		do_action( 'googlesitekit_reauthorize_user', array() );
 		$this->assertEquals( '1.1.0', $this->initial_version->get() );
 	}

--- a/tests/phpunit/integration/Core/Authentication/AuthenticationTest.php
+++ b/tests/phpunit/integration/Core/Authentication/AuthenticationTest.php
@@ -101,7 +101,7 @@ class AuthenticationTest extends TestCase {
 
 	public function test_register_set_initial_version_if_not_set() {
 		$auth            = new Authentication( new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE ) );
-		$initial_version = $this->force_get_property( $auth, 'initial_version' );
+		$initial_version = $auth->get_initial_version();
 
 		// Ensure no version is set yet.
 		$initial_version->delete();
@@ -119,7 +119,7 @@ class AuthenticationTest extends TestCase {
 
 	public function test_register_do_not_set_initial_version_if_already_set() {
 		$auth            = new Authentication( new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE ) );
-		$initial_version = $this->force_get_property( $auth, 'initial_version' );
+		$initial_version = $auth->get_initial_version();
 
 		// Ensure a version is already set.
 		$initial_version->set( '1.1.0' );


### PR DESCRIPTION
## Summary

Addresses issue #2692

## Relevant technical choices

* The new hook is, similar to the old one, only run when using the proxy. This is a bit odd, but I didn't wanna diverge from that behavior in here, and I also didn't wanna introduce a broader change where we would run these hooks for any sites. Mostly irrelevant anyway since probably almost nobody does not use the proxy, but I think it's worth addressing, so I opened a follow-up issue #2693 to run these hooks in any scenario.

## Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
