### PR TITLE
Enhancement/2452 e2e feature flags

### DIFF
--- a/tests/e2e/mu-plugins/e2e-rest-feature-flag.php
+++ b/tests/e2e/mu-plugins/e2e-rest-feature-flag.php
@@ -26,7 +26,7 @@ add_action(
 			array(
 				'methods'             => WP_REST_Server::EDITABLE,
 				'callback'            => function ( WP_REST_Request $request ) {
-					$feature_flag_overrides = get_option( '_e2e_feature_flags', array() );
+					$feature_flag_overrides = get_option( 'googlesitekit_e2e_feature_flags', array() );
 
 					if ( $request['feature_value'] ) {
 						$feature_flag_overrides[ $request['feature_name'] ] = (bool) $request['feature_value'];
@@ -34,7 +34,7 @@ add_action(
 						unset( $feature_flag_overrides[ $request['feature_name'] ] );
 					}
 
-					update_option( '_e2e_feature_flags', $feature_flag_overrides );
+					update_option( 'googlesitekit_e2e_feature_flags', $feature_flag_overrides );
 
 					return array(
 						'success' => true,
@@ -51,7 +51,7 @@ add_action(
 add_filter(
 	'googlesitekit_is_feature_enabled',
 	function ( $feature_enabled, $feature_name ) {
-		$features = get_option( '_e2e_feature_flags', array() );
+		$features = get_option( 'googlesitekit_e2e_feature_flags', array() );
 
 		return ! empty( $features[ $feature_name ] );
 	},

--- a/tests/e2e/mu-plugins/e2e-rest-feature-flag.php
+++ b/tests/e2e/mu-plugins/e2e-rest-feature-flag.php
@@ -26,7 +26,7 @@ add_action(
 			array(
 				'methods'             => WP_REST_Server::EDITABLE,
 				'callback'            => function ( WP_REST_Request $request ) {
-					$feature_flag_overrides = get_option( 'googlesitekit_e2e_feature_flags', array() );
+					$feature_flag_overrides = get_option( '_e2e_feature_flags', array() );
 
 					if ( $request['feature_value'] ) {
 						$feature_flag_overrides[ $request['feature_name'] ] = (bool) $request['feature_value'];
@@ -34,7 +34,7 @@ add_action(
 						unset( $feature_flag_overrides[ $request['feature_name'] ] );
 					}
 
-					update_option( 'googlesitekit_e2e_feature_flags', $feature_flag_overrides );
+					update_option( '_e2e_feature_flags', $feature_flag_overrides );
 
 					return array(
 						'success' => true,
@@ -50,10 +50,11 @@ add_action(
 // Enforce feature activation as defined by the E2E feature flags option.
 add_filter(
 	'googlesitekit_is_feature_enabled',
-	function ( $feature_name ) {
-		$features = get_option( 'googlesitekit_e2e_feature_flags', array() );
+	function ( $feature_enabled, $feature_name ) {
+		$features = get_option( '_e2e_feature_flags', array() );
 
 		return ! empty( $features[ $feature_name ] );
 	},
-	999
+	999,
+	2
 );

--- a/tests/e2e/utils/features.js
+++ b/tests/e2e/utils/features.js
@@ -33,7 +33,10 @@ export async function disableFeature( feature ) {
 	return await wpApiFetch( {
 		path: 'google-site-kit/v1/e2e/feature/set-flag',
 		method: 'post',
-		data: { [ feature ]: false },
+		data: {
+			feature_name: feature,
+			feature_value: false,
+		},
 	} );
 }
 
@@ -49,6 +52,9 @@ export async function enableFeature( feature ) {
 	return await wpApiFetch( {
 		path: 'google-site-kit/v1/e2e/feature/set-flag',
 		method: 'post',
-		data: { [ feature ]: true },
+		data: {
+			feature_name: feature,
+			feature_value: true,
+		},
 	} );
 }

--- a/tests/e2e/utils/index.js
+++ b/tests/e2e/utils/index.js
@@ -42,3 +42,4 @@ export { testClientConfig } from './test-client-config';
 export { testSiteNotification } from './test-site-notification';
 export { useRequestInterception } from './use-request-interception';
 export { wpApiFetch } from './wp-api-fetch';
+export * from './features';


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #2452

## Relevant technical choices

- Renamed the option name to escape it from being deleted when the site kit is reset.

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
