### PR TITLE
Remove pagespeed id from LegacyDashboardAllTraffic

### DIFF
--- a/assets/js/modules/analytics/components/dashboard/DashboardAllTrafficWidget/LegacyDashboardAllTraffic.js
+++ b/assets/js/modules/analytics/components/dashboard/DashboardAllTrafficWidget/LegacyDashboardAllTraffic.js
@@ -33,7 +33,7 @@ import { Cell } from '../../../../../material-components';
 function LegacyDashboardAllTraffic() {
 	return (
 		<Fragment>
-			<Cell id="googlesitekit-pagespeed-header" size={ 12 }>
+			<Cell size={ 12 }>
 				<DashboardModuleHeader
 					title={ __( 'Your Traffic at a Glance', 'google-site-kit' ) }
 					description={ __( 'How people found your site.', 'google-site-kit' ) }


### PR DESCRIPTION
## Summary

Addresses issue #2429 

## Relevant technical choices

* Targets `master`

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
