### PR TITLE
Replace caret in All Traffic total count with WP chevron icon

### DIFF
--- a/assets/js/modules/analytics/components/dashboard/DashboardAllTrafficWidget/TotalUserCount.js
+++ b/assets/js/modules/analytics/components/dashboard/DashboardAllTrafficWidget/TotalUserCount.js
@@ -26,6 +26,7 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { Fragment } from '@wordpress/element';
+import { Icon, chevronRight } from '@wordpress/icons';
 import { __, sprintf } from '@wordpress/i18n';
 
 /**
@@ -79,7 +80,8 @@ export default function TotalUserCount( { loaded, error, report, dimensionValue 
 				{ dimensionValue && (
 					<Fragment>
 						{ __( 'Users', 'google-site-kit' ) }
-						<span>{ dimensionValue[ 0 ].toUpperCase() }{ dimensionValue.substring( 1 ) }</span>
+						<Icon icon={ chevronRight } size="18" fill="currentColor" />
+						{ dimensionValue }
 					</Fragment>
 				) }
 			</h3>

--- a/assets/sass/widgets/_googlesitekit-widget-analyticsAllTraffic.scss
+++ b/assets/sass/widgets/_googlesitekit-widget-analyticsAllTraffic.scss
@@ -91,12 +91,12 @@
 
 	.googlesitekit-widget--analyticsAllTraffic__totalcount {
 
-		h3 {
+		.googlesitekit-data-block__title {
+			text-transform: capitalize;
+		}
 
-			span::before {
-				content: ">";
-				margin: 0 0.5rem;
-			}
+		svg {
+			vertical-align: bottom;
 		}
 	}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8573,8 +8573,7 @@
     "@types/prop-types": {
       "version": "15.7.0",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.0.tgz",
-      "integrity": "sha512-eItQyV43bj4rR3JPV0Skpl1SncRCdziTEK9/v8VwXmV6d/qOUO8/EuWeHBbCZcsfSHfzI5UyMJLCSXtxxznyZg==",
-      "dev": true
+      "integrity": "sha512-eItQyV43bj4rR3JPV0Skpl1SncRCdziTEK9/v8VwXmV6d/qOUO8/EuWeHBbCZcsfSHfzI5UyMJLCSXtxxznyZg=="
     },
     "@types/puppeteer": {
       "version": "1.12.3",
@@ -8613,10 +8612,17 @@
       "version": "16.8.8",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-16.8.8.tgz",
       "integrity": "sha512-xwEvyet96u7WnB96kqY0yY7qxx/pEpU51QeACkKFtrgjjXITQn0oO1iwPEraXVgh10ZFPix7gs1R4OJXF7P5sg==",
-      "dev": true,
       "requires": {
         "@types/prop-types": "*",
         "csstype": "^2.2.0"
+      }
+    },
+    "@types/react-dom": {
+      "version": "16.9.10",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-16.9.10.tgz",
+      "integrity": "sha512-ItatOrnXDMAYpv6G8UCk2VhbYVTjZT9aorLtA/OzDN9XJ2GKcfam68jutoAcILdRjsRUO8qb7AmyObF77Q8QFw==",
+      "requires": {
+        "@types/react": "^16"
       }
     },
     "@types/react-syntax-highlighter": {
@@ -9752,13 +9758,99 @@
       }
     },
     "@wordpress/icons": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-2.4.0.tgz",
-      "integrity": "sha512-G7ClNkJX8Hr/eSudoGM/cONrnwGspYLcL5Jf38lrk7Irrfl3rJXULnqe1FFcs4QHMgQuZUTphtrcMbiG6alKpw==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-2.9.0.tgz",
+      "integrity": "sha512-eQJQIaCLdmdo8iTjequNkB14Fzx3qLRbjzZTk26fnggG41L+uGRblIeheZDcHY/jPKDd2H4+v9c9/0LqfjuPCA==",
       "requires": {
-        "@babel/runtime": "^7.9.2",
-        "@wordpress/element": "^2.16.0",
-        "@wordpress/primitives": "^1.7.0"
+        "@babel/runtime": "^7.12.5",
+        "@wordpress/element": "^2.19.0",
+        "@wordpress/primitives": "^1.11.0"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.12.5",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.5.tgz",
+          "integrity": "sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        },
+        "@types/react": {
+          "version": "16.14.2",
+          "resolved": "https://registry.npmjs.org/@types/react/-/react-16.14.2.tgz",
+          "integrity": "sha512-BzzcAlyDxXl2nANlabtT4thtvbbnhee8hMmH/CcJrISDBVcJS1iOsP1f0OAgSdGE0MsY9tqcrb9YoZcOFv9dbQ==",
+          "requires": {
+            "@types/prop-types": "*",
+            "csstype": "^3.0.2"
+          }
+        },
+        "@wordpress/element": {
+          "version": "2.19.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.19.0.tgz",
+          "integrity": "sha512-t6GnllujeJU2N7RagWvPSSki+VnIxUQktg+cDAFDWC4XHCVoZKgs/0B48yeZSvd9T/t4ry0aILh+zeEJ+5DuHg==",
+          "requires": {
+            "@babel/runtime": "^7.12.5",
+            "@types/react": "^16.9.0",
+            "@types/react-dom": "^16.9.0",
+            "@wordpress/escape-html": "^1.11.0",
+            "lodash": "^4.17.19",
+            "react": "^16.13.1",
+            "react-dom": "^16.13.1"
+          }
+        },
+        "@wordpress/escape-html": {
+          "version": "1.11.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-1.11.0.tgz",
+          "integrity": "sha512-f/jk3SpYRUp04+LzdonNWBpH8jlm8RXGjK2TimfLz+wRFzFFdF7i2dI9GX+4gea/UuV+WtXAWkfARyV0HVDXwQ==",
+          "requires": {
+            "@babel/runtime": "^7.12.5"
+          }
+        },
+        "@wordpress/primitives": {
+          "version": "1.11.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-1.11.0.tgz",
+          "integrity": "sha512-RjWKYITSBi4RaQchmswI1qTF3n3M3QoGFoItRSnCajOHyNti4K1chPaBpr52ithnentfblF3zquR3J6ZnAkPjA==",
+          "requires": {
+            "@babel/runtime": "^7.12.5",
+            "@wordpress/element": "^2.19.0",
+            "classnames": "^2.2.5"
+          }
+        },
+        "csstype": {
+          "version": "3.0.6",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.6.tgz",
+          "integrity": "sha512-+ZAmfyWMT7TiIlzdqJgjMb7S4f1beorDbWbsocyK4RaiqA5RTX3K14bnBWmmA9QEM0gRdsjyyrEmcyga8Zsxmw=="
+        },
+        "react": {
+          "version": "16.14.0",
+          "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
+          "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
+          "requires": {
+            "loose-envify": "^1.1.0",
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "react-dom": {
+          "version": "16.14.0",
+          "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",
+          "integrity": "sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==",
+          "requires": {
+            "loose-envify": "^1.1.0",
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "scheduler": "^0.19.1"
+          }
+        },
+        "scheduler": {
+          "version": "0.19.1",
+          "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
+          "integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
+          "requires": {
+            "loose-envify": "^1.1.0",
+            "object-assign": "^4.1.1"
+          }
+        }
       }
     },
     "@wordpress/is-shallow-equal": {

--- a/package.json
+++ b/package.json
@@ -124,6 +124,7 @@
     "@wordpress/element": "^2.16.0",
     "@wordpress/hooks": "^2.9.0",
     "@wordpress/i18n": "^3.14.0",
+    "@wordpress/icons": "^2.9.0",
     "@wordpress/keycodes": "^2.16.0",
     "@wordpress/scripts": "^12.2.0",
     "@wordpress/url": "^2.17.0",


### PR DESCRIPTION
## Summary

Addresses issue #2623

## Relevant technical choices

* Used `chevronRight` icon from `@wordpress/icons` instead of literal ">" character for consistency with the design
* Added `@wordpress/icons` – it was already installed as a dependency of `@wordpress/components` so this is more of a proper declaration since we weren't using it before
* Replaced JS-based capitalization of dimension name (which only seems to be necessary for devices) with CSS

![image](https://user-images.githubusercontent.com/1621608/106121181-f2e7d880-615f-11eb-8079-f38a60697c93.png)
![image](https://user-images.githubusercontent.com/1621608/106121184-f4190580-615f-11eb-8887-51a608879b9e.png)
![image](https://user-images.githubusercontent.com/1621608/106121187-f54a3280-615f-11eb-90f4-4c4752b8b8f6.png)


## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
