### PR TITLE
Remove optimize settings datapoints

### DIFF
--- a/includes/Modules/Optimize.php
+++ b/includes/Modules/Optimize.php
@@ -21,13 +21,9 @@ use Google\Site_Kit\Core\Modules\Module_With_Assets;
 use Google\Site_Kit\Core\Modules\Module_With_Assets_Trait;
 use Google\Site_Kit\Core\Modules\Module_With_Owner;
 use Google\Site_Kit\Core\Modules\Module_With_Owner_Trait;
-use Google\Site_Kit\Core\REST_API\Exception\Invalid_Datapoint_Exception;
 use Google\Site_Kit\Core\Authentication\Clients\Google_Site_Kit_Client;
-use Google\Site_Kit\Core\REST_API\Data_Request;
 use Google\Site_Kit\Core\Util\Debug_Data;
 use Google\Site_Kit\Modules\Optimize\Settings;
-use Google\Site_Kit_Dependencies\Psr\Http\Message\RequestInterface;
-use WP_Error;
 
 /**
  * Class representing the Optimize module.
@@ -96,8 +92,9 @@ final class Optimize extends Module
 	 * @return bool True if module is connected, false otherwise.
 	 */
 	public function is_connected() {
-		$optimize_id = $this->get_data( 'optimize-id' );
-		if ( is_wp_error( $optimize_id ) ) {
+		$settings = $this->get_settings()->get();
+
+		if ( ! $settings['optimizeID'] ) {
 			return false;
 		}
 
@@ -122,12 +119,11 @@ final class Optimize extends Module
 	 * @return array Filtered $gtag_config.
 	 */
 	protected function gtag_config_add_optimize_id( $gtag_config ) {
-		$optimize_id = $this->get_data( 'optimize-id' );
-		if ( is_wp_error( $optimize_id ) || empty( $optimize_id ) ) {
-			return $gtag_config;
-		}
+		$settings = $this->get_settings()->get();
 
-		$gtag_config['optimize_id'] = $optimize_id;
+		if ( $settings['optimizeID'] ) {
+			$gtag_config['optimize_id'] = $settings['optimizeID'];
+		}
 
 		return $gtag_config;
 	}
@@ -142,15 +138,16 @@ final class Optimize extends Module
 			return;
 		}
 
-		$amp_experiment_json = $this->get_data( 'amp-experiment-json' );
-		if ( is_wp_error( $amp_experiment_json ) || ! $amp_experiment_json ) {
+		$settings = $this->get_settings()->get();
+
+		if ( ! $settings['ampExperimentJSON'] ) {
 			return;
 		}
 
 		?>
 		<amp-experiment>
 			<script type="application/json">
-				<?php echo $amp_experiment_json; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+				<?php echo $settings['ampExperimentJSON']; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 			</script>
 		</amp-experiment>
 		<?php
@@ -184,86 +181,13 @@ final class Optimize extends Module
 	 * @return array Filtered $data.
 	 */
 	protected function amp_data_load_experiment_component( $data ) {
-		$amp_experiment_json = $this->get_data( 'amp-experiment-json' );
-		if ( is_wp_error( $amp_experiment_json ) || ! $amp_experiment_json ) {
-			return $data;
+		$settings = $this->get_settings()->get();
+
+		if ( $settings['ampExperimentJSON'] ) {
+			$data['amp_component_scripts']['amp-experiment'] = 'https://cdn.ampproject.org/v0/amp-experiment-0.1.js';
 		}
 
-		$data['amp_component_scripts']['amp-experiment'] = 'https://cdn.ampproject.org/v0/amp-experiment-0.1.js';
 		return $data;
-	}
-
-	/**
-	 * Gets map of datapoint to definition data for each.
-	 *
-	 * @since 1.12.0
-	 *
-	 * @return array Map of datapoints to their definitions.
-	 */
-	protected function get_datapoint_definitions() {
-		return array(
-			'GET:amp-experiment-json'  => array( 'service' => '' ),
-			'POST:amp-experiment-json' => array( 'service' => '' ),
-			'GET:optimize-id'          => array( 'service' => '' ),
-			'POST:optimize-id'         => array( 'service' => '' ),
-			'POST:settings'            => array( 'service' => '' ),
-		);
-	}
-
-	/**
-	 * Creates a request object for the given datapoint.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @param Data_Request $data Data request object.
-	 * @return RequestInterface|callable|WP_Error Request object or callable on success, or WP_Error on failure.
-	 *
-	 * @throws Invalid_Datapoint_Exception Thrown if the datapoint does not exist.
-	 */
-	protected function create_data_request( Data_Request $data ) {
-		switch ( "{$data->method}:{$data->datapoint}" ) {
-			case 'GET:amp-experiment-json':
-				return function() {
-					$option = $this->get_settings()->get();
-
-					if ( empty( $option['ampExperimentJSON'] ) ) {
-						return new WP_Error( 'amp_experiment_json_not_set', __( 'AMP experiment JSON not set.', 'google-site-kit' ), array( 'status' => 404 ) );
-					}
-
-					return $option['ampExperimentJSON'];
-				};
-			case 'POST:amp-experiment-json':
-				if ( ! isset( $data['ampExperimentJSON'] ) ) {
-					/* translators: %s: Missing parameter name */
-					return new WP_Error( 'missing_required_param', sprintf( __( 'Request parameter is empty: %s.', 'google-site-kit' ), 'ampExperimentJSON' ), array( 'status' => 400 ) );
-				}
-				return function() use ( $data ) {
-					$json = $data['ampExperimentJSON'];
-					$this->get_settings()->merge( array( 'ampExperimentJSON' => $json ) );
-					return true;
-				};
-			case 'GET:optimize-id':
-				return function() {
-					$option = $this->get_settings()->get();
-
-					if ( empty( $option['optimizeID'] ) ) {
-						return new WP_Error( 'optimize_id_not_set', __( 'Optimize ID not set.', 'google-site-kit' ), array( 'status' => 404 ) );
-					}
-
-					return $option['optimizeID'];
-				};
-			case 'POST:optimize-id':
-				if ( ! isset( $data['optimizeID'] ) ) {
-					/* translators: %s: Missing parameter name */
-					return new WP_Error( 'missing_required_param', sprintf( __( 'Request parameter is empty: %s.', 'google-site-kit' ), 'optimizeID' ), array( 'status' => 400 ) );
-				}
-				return function() use ( $data ) {
-					$this->get_settings()->merge( array( 'optimizeID' => $data['optimizeID'] ) );
-					return true;
-				};
-		}
-
-		return parent::create_data_request( $data );
 	}
 
 	/**

--- a/includes/Modules/Optimize.php
+++ b/includes/Modules/Optimize.php
@@ -10,6 +10,7 @@
 
 namespace Google\Site_Kit\Modules;
 
+use Google\Site_Kit\Core\Assets\Asset;
 use Google\Site_Kit\Core\Assets\Script;
 use Google\Site_Kit\Core\Modules\Module;
 use Google\Site_Kit\Core\Modules\Module_Settings;

--- a/tests/phpunit/integration/Modules/OptimizeTest.php
+++ b/tests/phpunit/integration/Modules/OptimizeTest.php
@@ -28,16 +28,27 @@ class OptimizeTest extends TestCase {
 	use Module_With_Owner_ContractTests;
 
 	public function test_register() {
-		$this->markTestSkipped( 'All register method implementation currently depends on get_data.' );
+		remove_all_filters( 'googlesitekit_gtag_opt' );
+		remove_all_actions( 'wp_footer' );
+		remove_all_actions( 'amp_post_template_footer' );
+		remove_all_filters( 'amp_post_template_data' );
 		$optimize = new Optimize( new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE ) );
 		$optimize->register();
+
+		$this->assertTrue( has_filter( 'googlesitekit_gtag_opt' ) );
+		$this->assertTrue( has_action( 'wp_footer' ) );
+		$this->assertTrue( has_action( 'amp_post_template_footer' ) );
+		$this->assertTrue( has_filter( 'amp_post_template_data' ) );
 	}
 
 	public function test_is_connected() {
 		$optimize = new Optimize( new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE ) );
 
-		// Depends on get_data
 		$this->assertFalse( $optimize->is_connected() );
+
+		$optimize->get_settings()->merge( array( 'optimizeID' => 'GTM-XXXXX' ) );
+
+		$this->assertTrue( $optimize->is_connected() );
 	}
 
 	public function test_prepare_info_for_js() {
@@ -82,11 +93,7 @@ class OptimizeTest extends TestCase {
 		$optimize = new Optimize( new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE ) );
 
 		$this->assertEqualSets(
-			array(
-				'optimize-id',
-				'amp-experiment-json',
-				'settings',
-			),
+			array(),
 			$optimize->get_datapoints()
 		);
 	}


### PR DESCRIPTION
## Summary

Addresses issue #2507 (QA follow-up)

## Relevant technical choices

* Removed all datapoint related methods as there were no longer any datapoints defined
* Updated test for `register` method which was skipped for some reason before 😄 

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
