### PR TITLE
Pre-format Search Console CTR and position values in dataMap

### DIFF
--- a/assets/js/modules/search-console/util/index.js
+++ b/assets/js/modules/search-console/util/index.js
@@ -24,7 +24,7 @@ import { each } from 'lodash';
 /**
  * Internal dependencies
  */
-import { calculateChange } from '../../../util';
+import { calculateChange, numFmt } from '../../../util';
 export * from './is-zero-report';
 
 function reduceSearchConsoleData( rows ) {
@@ -49,8 +49,8 @@ function reduceSearchConsoleData( rows ) {
 			( date.getMonth() + 1 ) + '/' + date.getUTCDate(),
 			row.clicks,
 			row.impressions,
-			row.ctr,
-			row.position,
+			numFmt( row.ctr, { style: 'decimal', maximumFractionDigits: 3 } ),
+			numFmt( row.position, { style: 'decimal', maximumFractionDigits: 3 } ),
 		] );
 		totalClicks += row.clicks;
 		totalImpressions += row.impressions;

--- a/assets/js/modules/search-console/util/index.js
+++ b/assets/js/modules/search-console/util/index.js
@@ -19,12 +19,13 @@
 /**
  * External dependencies
  */
-import { each } from 'lodash';
+import each from 'lodash/each';
+import round from 'lodash/round';
 
 /**
  * Internal dependencies
  */
-import { calculateChange, numFmt } from '../../../util';
+import { calculateChange } from '../../../util';
 export * from './is-zero-report';
 
 function reduceSearchConsoleData( rows ) {
@@ -43,14 +44,15 @@ function reduceSearchConsoleData( rows ) {
 	let totalCTR = 0;
 	let totalPosition = 0;
 	const count = rows.length;
+
 	each( rows, ( row ) => {
 		const date = new Date( row.keys[ 0 ] );
 		dataMap.push( [
 			( date.getMonth() + 1 ) + '/' + date.getUTCDate(),
 			row.clicks,
 			row.impressions,
-			numFmt( row.ctr, { style: 'decimal', maximumFractionDigits: 3 } ),
-			numFmt( row.position, { style: 'decimal', maximumFractionDigits: 3 } ),
+			round( row.ctr, 3 ),
+			round( row.position, 3 ),
 		] );
 		totalClicks += row.clicks;
 		totalImpressions += row.impressions;


### PR DESCRIPTION
## Summary

Addresses issue #2725

## Relevant technical choices

* Attempted possibly using [`NumberFormat` as provided by Google charts](https://developers.google.com/chart/interactive/docs/reference#numberformat), but proved to be more complicated (and potentially less performant) than necessary here due to the separation of parent component and `dataTable` instance

![image](https://user-images.githubusercontent.com/1621608/106312860-fd919300-626f-11eb-9ba6-b1aa256fa180.png)
![image](https://user-images.githubusercontent.com/1621608/106312908-100bcc80-6270-11eb-9d8f-2c232e478fa3.png)


## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
