### PR TITLE
Limit All Traffic graph width so that y-axis values display again

### DIFF
--- a/assets/js/modules/analytics/components/dashboard/DashboardAllTrafficWidget/UserCountGraph.js
+++ b/assets/js/modules/analytics/components/dashboard/DashboardAllTrafficWidget/UserCountGraph.js
@@ -114,9 +114,8 @@ UserCountGraph.chartOptions = {
 	chartArea: {
 		left: '1%',
 		height: 300,
-		right: '9%',
 		top: 21,
-		width: '100%',
+		width: '90%',
 	},
 	legend: {
 		position: 'none',


### PR DESCRIPTION
## Summary

Addresses issue #2708 (follow-up)

## Relevant technical choices

* Using 100% width for the chart will use the entire space for the actual chart, cutting away y-axis labels.

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
