### PR TITLE
Update the Analytics module to support a new canUseSnippet setting.

### DIFF
--- a/assets/js/modules/analytics/components/common/UseSnippetSwitch.js
+++ b/assets/js/modules/analytics/components/common/UseSnippetSwitch.js
@@ -33,6 +33,7 @@ const { useSelect, useDispatch } = Data;
 
 export default function UseSnippetSwitch() {
 	const useSnippet = useSelect( ( select ) => select( STORE_NAME ).getUseSnippet() );
+	const canUseSnippet = useSelect( ( select ) => select( STORE_NAME ).getCanUseSnippet() );
 
 	const { setUseSnippet } = useDispatch( STORE_NAME );
 	const onChange = useCallback( () => {
@@ -51,10 +52,12 @@ export default function UseSnippetSwitch() {
 				checked={ useSnippet }
 				onClick={ onChange }
 				hideLabel={ false }
+				disabled={ ! canUseSnippet }
 			/>
 			<p>
-				{ useSnippet && __( 'Site Kit will add the code automatically.', 'google-site-kit' ) }
-				{ ! useSnippet && __( 'Site Kit will not add the code to your site.', 'google-site-kit' ) }
+				{ ! canUseSnippet && __( 'The code is controlled by the Tag Manager module.', 'google-site-kit' ) }
+				{ canUseSnippet && useSnippet && __( 'Site Kit will add the code automatically.', 'google-site-kit' ) }
+				{ canUseSnippet && ! useSnippet && __( 'Site Kit will not add the code to your site.', 'google-site-kit' ) }
 			</p>
 		</div>
 	);

--- a/assets/js/modules/analytics/components/settings/SettingsView.js
+++ b/assets/js/modules/analytics/components/settings/SettingsView.js
@@ -40,6 +40,7 @@ export default function SettingsView() {
 	const internalWebPropertyID = useSelect( ( select ) => select( STORE_NAME ).getInternalWebPropertyID() );
 	const profileID = useSelect( ( select ) => select( STORE_NAME ).getProfileID() );
 	const useSnippet = useSelect( ( select ) => select( STORE_NAME ).getUseSnippet() );
+	const canUseSnippet = useSelect( ( select ) => select( STORE_NAME ).getCanUseSnippet() );
 	const anonymizeIP = useSelect( ( select ) => select( STORE_NAME ).getAnonymizeIP() );
 	const trackingDisabled = useSelect( ( select ) => select( STORE_NAME ).getTrackingDisabled() ) || [];
 	const hasExistingTag = useSelect( ( select ) => select( STORE_NAME ).hasExistingTag() );
@@ -103,7 +104,8 @@ export default function SettingsView() {
 						{ __( 'Analytics Code Snippet', 'google-site-kit' ) }
 					</h5>
 					<p className="googlesitekit-settings-module__meta-item-data">
-						{ useSnippet && __( 'Snippet is inserted', 'google-site-kit' ) }
+						{ ! canUseSnippet && __( 'The code is controlled by the Tag Manager module.', 'google-site-kit' ) }
+						{ canUseSnippet && useSnippet && __( 'Snippet is inserted', 'google-site-kit' ) }
 						{ ( ! useSnippet && ! hasExistingTag ) && __( 'Snippet is not inserted', 'google-site-kit' ) }
 						{ ( ! useSnippet && hasExistingTag ) && __( 'Inserted by another plugin or theme', 'google-site-kit' ) }
 					</p>

--- a/assets/js/modules/analytics/datastore/base.js
+++ b/assets/js/modules/analytics/datastore/base.js
@@ -32,6 +32,7 @@ const baseModuleStore = Modules.createModuleStore( 'analytics', {
 		'propertyID',
 		'internalWebPropertyID',
 		'useSnippet',
+		'canUseSnippet',
 		'trackingDisabled',
 		'ownerID',
 	],

--- a/assets/js/modules/analytics/hooks/useExistingTagEffect.js
+++ b/assets/js/modules/analytics/hooks/useExistingTagEffect.js
@@ -33,7 +33,7 @@ import { MODULES_TAGMANAGER } from '../../tagmanager/datastore/constants';
 const { useSelect, useDispatch } = Data;
 
 export default function useExistingTagEffect() {
-	const { setAccountID, selectProperty, setUseSnippet } = useDispatch( STORE_NAME );
+	const { setAccountID, selectProperty } = useDispatch( STORE_NAME );
 	const gtmModuleActive = useSelect( ( select ) => select( CORE_MODULES ).isModuleActive( 'tagmanager' ) );
 
 	const {
@@ -86,7 +86,6 @@ export default function useExistingTagEffect() {
 			// GTM container has GA tag and user has access to it, force select it.
 			setAccountID( gtmAnalyticsAccountID );
 			selectProperty( gtmAnalyticsPropertyID );
-			setUseSnippet( false );
 		}
 	}, [
 		existingTag,

--- a/includes/Modules/Analytics/Settings.php
+++ b/includes/Modules/Analytics/Settings.php
@@ -121,9 +121,22 @@ class Settings extends Module_Settings implements Setting_With_Owned_Keys_Interf
 				 * @param bool $adsense_linked Null by default, will fallback to the option value if not set.
 				 */
 				$adsense_linked = apply_filters( 'googlesitekit_analytics_adsense_linked', null );
-
 				if ( is_bool( $adsense_linked ) ) {
 					$option['adsenseLinked'] = $adsense_linked;
+				}
+
+				/**
+				 * Filters the state of the can use snipped setting.
+				 *
+				 * This filter exists so that useSnippet can be restored to true when the Tag Manager module
+				 * is disconnected, ensuring the analytics snippet is always included.
+				 *
+				 * @since n.e.x.t
+				 * @param bool $can_use_snippet Null by default, will fallback to the option value if not set.
+				 */
+				$can_use_snippet = apply_filters( 'googlesitekit_analytics_can_use_snippet', null );
+				if ( is_bool( $can_use_snippet ) ) {
+					$option['canUseSnippet'] = $can_use_snippet;
 				}
 
 				return $option;
@@ -165,6 +178,7 @@ class Settings extends Module_Settings implements Setting_With_Owned_Keys_Interf
 			'propertyID'            => '',
 			'trackingDisabled'      => array( 'loggedinUsers' ),
 			'useSnippet'            => true,
+			'canUseSnippet'         => true,
 		);
 	}
 

--- a/includes/Modules/Analytics/Tag_Guard.php
+++ b/includes/Modules/Analytics/Tag_Guard.php
@@ -30,7 +30,7 @@ class Tag_Guard extends Module_Tag_Guard {
 	 */
 	public function can_activate() {
 		$settings = $this->settings->get();
-		return ! empty( $settings['useSnippet'] ) && ! empty( $settings['propertyID'] );
+		return apply_filters( 'googlesitekit_analytics_can_use_snippet', ! empty( $settings['useSnippet'] ) && ! empty( $settings['propertyID'] ) );
 	}
 
 }


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #2579

## Relevant technical choices

<!-- Please describe your changes. -->

I used `getLiveContainerAnalyticsPropertyID` instead of `getLiveContainerAnalyticsTag` as it returns the propertyID from the tag for us.

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [ ] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
