### PR TITLE
Add styles to prevent PreviewBlock from jumping.

### DIFF
--- a/assets/js/modules/analytics/components/dashboard/DashboardAllTrafficWidget/UserDimensionsPieChart.js
+++ b/assets/js/modules/analytics/components/dashboard/DashboardAllTrafficWidget/UserDimensionsPieChart.js
@@ -243,8 +243,8 @@ export default function UserDimensionsPieChart( { dimensionName, dimensionValue,
 					'googlesitekit-widget--analyticsAllTraffic__dimensions--not-loading': loaded,
 					'googlesitekit-widget--analyticsAllTraffic__dimensions--loading': ! loaded,
 				} ) }
-				width="282px"
-				height="282px"
+				width="300px"
+				height="300px"
 				shape="circular"
 			/>
 			<div className={ classnames(

--- a/assets/sass/widgets/_googlesitekit-widget-analyticsAllTraffic.scss
+++ b/assets/sass/widgets/_googlesitekit-widget-analyticsAllTraffic.scss
@@ -73,6 +73,7 @@
 	}
 
 	.googlesitekit-widget--analyticsAllTraffic__dimensions {
+		min-height: 450px;
 		padding-top: 30px;
 		position: relative;
 
@@ -84,13 +85,19 @@
 
 			&.googlesitekit-widget--analyticsAllTraffic__dimensions--loading {
 				left: 50%;
+				margin-top: -11px;
 				position: absolute;
 				top: 50%;
 				transform: translate(-50%, -50%);
+
+				@media (min-width: $bp-desktop) {
+					margin-top: -18px;
+				}
 			}
 		}
 
 		.googlesitekit-widget--analyticsAllTraffic__dimensions-container {
+			height: 100%;
 			position: relative;
 		}
 	}


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #2710 

## Relevant technical choices

<!-- Please describe your changes. -->

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
