### PR TITLE
Move user input requirement post-authentication

### DIFF
--- a/includes/Core/Authentication/Authentication.php
+++ b/includes/Core/Authentication/Authentication.php
@@ -1109,6 +1109,10 @@ final class Authentication {
 			return;
 		}
 
+		// Refresh user input settings from the proxy.
+		// This will ensure the user input state is updated as well.
+		$this->user_input_settings->set_settings( null );
+
 		if ( User_Input_State::VALUE_COMPLETED !== $this->user_input_state->get() ) {
 			$this->user_input_state->set( User_Input_State::VALUE_REQUIRED );
 		}

--- a/includes/Core/Authentication/Authentication.php
+++ b/includes/Core/Authentication/Authentication.php
@@ -281,7 +281,6 @@ final class Authentication {
 				$site_code = $this->context->input()->filter( INPUT_GET, 'googlesitekit_site_code', FILTER_SANITIZE_STRING );
 
 				$this->handle_site_code( $code, $site_code );
-				$this->require_user_input();
 				$this->redirect_to_proxy( $code );
 			}
 		);
@@ -293,7 +292,13 @@ final class Authentication {
 			}
 		);
 
-		add_action( 'googlesitekit_authorize_user', $this->get_method_proxy( 'set_connected_proxy_url' ) );
+		add_action(
+			'googlesitekit_authorize_user',
+			function () {
+				$this->set_connected_proxy_url();
+				$this->require_user_input();
+			}
+		);
 
 		add_filter(
 			'googlesitekit_rest_routes',
@@ -1106,13 +1111,6 @@ final class Authentication {
 
 		if ( User_Input_State::VALUE_COMPLETED !== $this->user_input_state->get() ) {
 			$this->user_input_state->set( User_Input_State::VALUE_REQUIRED );
-			// Set the `mode` query parameter in the proxy setup URL.
-			add_filter(
-				'googlesitekit_proxy_setup_url_params',
-				function ( $params ) {
-					return array_merge( $params, array( 'mode' => 'user_input' ) );
-				}
-			);
 		}
 	}
 

--- a/includes/Core/Authentication/Clients/OAuth_Client.php
+++ b/includes/Core/Authentication/Clients/OAuth_Client.php
@@ -931,6 +931,7 @@ final class OAuth_Client {
 	 * @since 1.1.0
 	 * @since 1.1.2 Added 'credentials_retrieval'
 	 * @since 1.2.0 Added 'short_verification_token' (Supported as of 1.0.1)
+	 * @since n.e.x.t Added 'user_input_flow'
 	 * @return array Array of supported features.
 	 */
 	private function get_proxy_setup_supports() {
@@ -938,6 +939,7 @@ final class OAuth_Client {
 			array(
 				'credentials_retrieval',
 				'short_verification_token',
+				'user_input_flow',
 				$this->supports_file_verification() ? 'file_verification' : false,
 			)
 		);

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -31,5 +31,11 @@ $GLOBALS['wp_tests_options'] = array(
 	'active_plugins' => array( basename( TESTS_PLUGIN_DIR ) . '/google-site-kit.php' ),
 );
 
+// Give access to tests_add_filter() function.
+require $_test_root . '/includes/functions.php';
+
+// Ensure all features are disabled when bootstrapping the plugin.
+tests_add_filter( 'googlesitekit_is_feature_enabled', '__return_false', 0 );
+
 // Start up the WP testing environment.
 require $_test_root . '/includes/bootstrap.php';

--- a/tests/phpunit/includes/TestCase.php
+++ b/tests/phpunit/includes/TestCase.php
@@ -10,6 +10,7 @@
 
 namespace Google\Site_Kit\Tests;
 
+use Closure;
 use Google\Site_Kit\Context;
 use Google\Site_Kit\Core\Util\Feature_Flags;
 use Google\Site_Kit\Core\Util\Input;
@@ -75,6 +76,27 @@ class TestCase extends \WP_UnitTestCase {
 		parent::tearDown();
 		// Clear screen related globals.
 		unset( $GLOBALS['current_screen'], $GLOBALS['taxnow'], $GLOBALS['typenow'] );
+	}
+
+	/**
+	 * Enables a feature.
+	 *
+	 * @param string $feature Feature to enable.
+	 * @return Closure Function to reset the enabled state.
+	 */
+	protected function enable_feature( $feature ) {
+		$enable_callback = function ( $enabled, $feature_name ) use ( $feature ) {
+			if ( $feature_name === $feature ) {
+				return true;
+			}
+			return $enabled;
+		};
+
+		add_filter( 'googlesitekit_is_feature_enabled', $enable_callback, 10, 2 );
+
+		return function () use ( $enable_callback ) {
+			remove_filter( 'googlesitekit_is_feature_enabled', $enable_callback, 10 );
+		};
 	}
 
 	/**

--- a/tests/phpunit/integration/Core/Util/Feature_FlagsTest.php
+++ b/tests/phpunit/integration/Core/Util/Feature_FlagsTest.php
@@ -56,6 +56,7 @@ class Feature_FlagsTest extends TestCase {
 	 * @param boolean $expected
 	 */
 	public function test_enabled( $features, $mode, $feature, $expected ) {
+		remove_all_filters( 'googlesitekit_is_feature_enabled' );
 		Feature_Flags::set_features( $features );
 		Feature_Flags::set_mode( $mode );
 


### PR DESCRIPTION
## Summary

Addresses issue #2603

## Relevant technical choices

- Updated PHPUnit bootstrap to disable all features before boostrapping the plugin to ensure the environment starts without any extra features
- Added method for enabling features (via filter) to base `TestCase`  
This way features are naturally reset after each test (like all other added filters) and is cleaner than adding the filters in the test itself. Also returns a reset function to remove the added filter for tests where we might want to add+remove in the same test.

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
