### PR TITLE
Align All Traffic pie chart legend and line chart x-axis labels. (#2738)

### DIFF
--- a/assets/sass/widgets/_googlesitekit-widget-analyticsAllTraffic.scss
+++ b/assets/sass/widgets/_googlesitekit-widget-analyticsAllTraffic.scss
@@ -50,7 +50,6 @@
 
 		@media (min-width: $bp-desktop) {
 			position: relative;
-			top: 16px;
 		}
 
 		@media (min-width: $bp-xlarge) {
@@ -73,6 +72,9 @@
 	}
 
 	.googlesitekit-widget--analyticsAllTraffic__dimensions {
+		display: flex;
+		flex-direction: column;
+		justify-content: space-between;
 		min-height: 450px;
 		padding-top: 30px;
 		position: relative;
@@ -85,19 +87,17 @@
 
 			&.googlesitekit-widget--analyticsAllTraffic__dimensions--loading {
 				left: 50%;
-				margin-top: -11px;
 				position: absolute;
 				top: 50%;
 				transform: translate(-50%, -50%);
 
 				@media (min-width: $bp-desktop) {
-					margin-top: -18px;
+					margin-top: 10px;
 				}
 			}
 		}
 
 		.googlesitekit-widget--analyticsAllTraffic__dimensions-container {
-			height: 100%;
 			position: relative;
 		}
 	}


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #2738

## Relevant technical choices
I felt that it was worth briefly investigating a CSS solution, intending to follow the IB if I couldn't find one. 

Messing around in-browser, I found that on the current release a couple of changes on the parent `.googlesitekit-widget--analyticsAllTraffic__dimensions` div lined the legends up correctly, but the issue was that in `develop` there have been [a few changes which made it less straightforward](https://github.com/google/site-kit-wp/commit/13348bdbee4a44e12b20b0760a8e570e0d98385e). 

I therefore removed them and then attempted to add them back in one at a time to get them to coexist with the changes I made. I've done a fair bit of cross browser testing (FF, Safari, Chrome, Brave) - hopefully I haven't introduced a regression, and both issues are still solved 🤞.

I'm assuming a CSS solution was preferable - I'm very happy to attempt the method in the IB if needed.

![Feb-08-2021 15-11-02](https://user-images.githubusercontent.com/2470911/107238666-06c4f180-6a20-11eb-87ef-6fedd3a8da91.gif)

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
