### PR TITLE
Fix admin bar layout breaking between the wpAdminBarTablet and mobile

### DIFF
--- a/assets/sass/components/adminbar/_googlesitekit-adminbar.scss
+++ b/assets/sass/components/adminbar/_googlesitekit-adminbar.scss
@@ -42,6 +42,7 @@
 
 	.googlesitekit-plugin.ab-sub-wrapper {
 		left: 0;
+		width: 100%;
 	}
 
 	.googlesitekit-plugin .googlesitekit-adminbar {

--- a/assets/sass/components/adminbar/_googlesitekit-wp-adminbar.scss
+++ b/assets/sass/components/adminbar/_googlesitekit-wp-adminbar.scss
@@ -45,8 +45,6 @@
 			opacity: 0.6;
 			padding: 0;
 			position: relative;
-			speak: none;
-			vertical-align: middle;
 			width: 26px;
 
 			@media (min-width: $bp-wpAdminBarTablet) {


### PR DESCRIPTION
## Summary

Fix admin bar layout breaking between the wpAdminBarTablet and mobile because of the width of the parent div becoming zero.

<!-- Please reference the issue this PR addresses. -->
Addresses issue #2241

## Relevant technical choices

I also removed two css classes that were ineffective from the main admin bar css file:

<img width="394" alt="Screenshot 2021-02-09 at 12 20 39" src="https://user-images.githubusercontent.com/119352/107365456-bc517c80-6ad4-11eb-87f4-1e814fc79b25.png">
<img width="989" alt="Screenshot 2021-02-09 at 12 20 56" src="https://user-images.githubusercontent.com/119352/107365465-bf4c6d00-6ad4-11eb-9c78-0977486da0cd.png">


## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [ ] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
