### PR TITLE
Fix/legacy all traffic classnames

### DIFF
--- a/assets/js/modules/analytics/components/dashboard/DashboardAllTrafficWidget/LegacyDashboardAllTraffic.js
+++ b/assets/js/modules/analytics/components/dashboard/DashboardAllTrafficWidget/LegacyDashboardAllTraffic.js
@@ -42,7 +42,7 @@ function LegacyDashboardAllTraffic() {
 				/>
 			</Cell>
 			<Cell size={ 12 }>
-				<Layout className="googlesitekit-pagespeed-widget">
+				<Layout>
 					<DashboardAllTrafficWidget { ...widgetComponentProps } />
 				</Layout>
 			</Cell>

--- a/assets/sass/widgets/_googlesitekit-widget-analyticsAllTraffic.scss
+++ b/assets/sass/widgets/_googlesitekit-widget-analyticsAllTraffic.scss
@@ -18,6 +18,7 @@
 
 .googlesitekit-plugin {
 
+	.googlesitekit-widget.googlesitekit-widget--legacy-all-traffic-widget,
 	.googlesitekit-widget.googlesitekit-widget--analyticsAllTraffic {
 
 		.mdc-tab-scroller__scroll-content {


### PR DESCRIPTION
## Summary

This PR fixes a regression where the all traffic widget dimension tabs were displayed as 

Addresses issue #2801

## Relevant technical choices

* Also removes a stray "pagespeed" class that was missed before
* Targets `master` for the release

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
