### PR TITLE
Improve `uasort` call for PHP 8 compatibility.

### DIFF
--- a/includes/Core/Modules/Modules.php
+++ b/includes/Core/Modules/Modules.php
@@ -263,7 +263,10 @@ final class Modules {
 			uasort(
 				$this->modules,
 				function( Module $a, Module $b ) {
-					return $a->order > $b->order;
+					if ( $a->order === $b->order ) {
+						return 0;
+					}
+					return ( $a->order < $b->order ) ? -1 : 1;
 				}
 			);
 


### PR DESCRIPTION
## Summary

Fix a PHP notice when running PHP 8.

`uasort` requires an integer return, booleans are no longer valid.

<!-- Please reference the issue this PR addresses. -->
Addresses issue https://github.com/google/site-kit-wp/issues/2797

## Relevant technical choices

<!-- Please describe your changes. -->

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [ ] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
