### PR TITLE
Fix WP core checkbox styles introduce odd visual effect.

### DIFF
--- a/assets/sass/vendor/_mdc-switch.scss
+++ b/assets/sass/vendor/_mdc-switch.scss
@@ -29,4 +29,10 @@
 	+ label {
 		margin-left: 10px;
 	}
+
+	// Prevent the background checkbox from becoming visible when a switch
+	// loads or is set in the disabled state.
+	.mdc-switch__native-control::before {
+		opacity: 0 !important;
+	}
 }

--- a/assets/sass/vendor/_mdc-switch.scss
+++ b/assets/sass/vendor/_mdc-switch.scss
@@ -24,15 +24,15 @@
 		transition: none;
 		vertical-align: middle;
 		width: 68px;
+
+		// Prevent the background checkbox from becoming visible when a switch
+		// loads or is set in the disabled state.
+		&::before {
+			opacity: 0 !important;
+		}
 	}
 
 	+ label {
 		margin-left: 10px;
-	}
-
-	// Prevent the background checkbox from becoming visible when a switch
-	// loads or is set in the disabled state.
-	.mdc-switch__native-control::before {
-		opacity: 0 !important;
 	}
 }


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #2722

## Relevant technical choices

<!-- Please describe your changes. -->
I used `opacity: 0 !important` because this is what is causing the error, in certain states, MD set's the opacity to 0.7. By overriding this we can make sure it stays hidden.

## Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
