### PR TITLE
Add temporary user_input_flow_feature proxy support flag in case the feature is force-enabled from WP side

### DIFF
--- a/includes/Core/Authentication/Clients/OAuth_Client.php
+++ b/includes/Core/Authentication/Clients/OAuth_Client.php
@@ -23,6 +23,7 @@ use Google\Site_Kit\Core\Storage\Encrypted_User_Options;
 use Google\Site_Kit\Core\Storage\Options;
 use Google\Site_Kit\Core\Storage\User_Options;
 use Google\Site_Kit\Core\Util\Scopes;
+use Google\Site_Kit\Core\Util\Feature_Flags;
 use Google\Site_Kit_Dependencies\Google\Task\Runner;
 use Google\Site_Kit_Dependencies\Google_Service_PeopleService;
 use WP_HTTP_Proxy;
@@ -908,6 +909,7 @@ final class OAuth_Client {
 	 * @since 1.1.2 Added 'credentials_retrieval'
 	 * @since 1.2.0 Added 'short_verification_token' (Supported as of 1.0.1)
 	 * @since 1.26.0 Added 'user_input_flow'
+	 * @since n.e.x.t Added 'user_input_flow_feature' (temporarily)
 	 * @return array Array of supported features.
 	 */
 	private function get_proxy_setup_supports() {
@@ -916,6 +918,7 @@ final class OAuth_Client {
 				'credentials_retrieval',
 				'short_verification_token',
 				'user_input_flow',
+				Feature_Flags::enabled( 'userInput' ) ? 'user_input_flow_feature' : false,
 				$this->supports_file_verification() ? 'file_verification' : false,
 			)
 		);

--- a/includes/Core/Authentication/Clients/OAuth_Client.php
+++ b/includes/Core/Authentication/Clients/OAuth_Client.php
@@ -917,7 +917,10 @@ final class OAuth_Client {
 			array(
 				'credentials_retrieval',
 				'short_verification_token',
+				// Informs the proxy the user input feature is generally supported.
 				'user_input_flow',
+				// Informs the proxy the user input feature is already enabled locally.
+				// TODO: Remove once the feature is fully rolled out.
 				Feature_Flags::enabled( 'userInput' ) ? 'user_input_flow_feature' : false,
 				$this->supports_file_verification() ? 'file_verification' : false,
 			)


### PR DESCRIPTION
## Summary

Addresses issue #2814

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
