### PR TITLE
Show the legend in SearchConsole Dashboard only when 2 or fewer stats are selected.

### DIFF
--- a/assets/js/modules/search-console/components/dashboard/SearchConsoleDashboardWidgetSiteStats.js
+++ b/assets/js/modules/search-console/components/dashboard/SearchConsoleDashboardWidgetSiteStats.js
@@ -85,24 +85,24 @@ class SearchConsoleDashboardWidgetSiteStats extends Component {
 				minorGridlines: {
 					color: '#eee',
 				},
-				textStyle: {
-					color: '#616161',
-					fontSize: 12,
-				},
-				titleTextStyle: {
-					color: '#616161',
-					fontSize: 12,
-					italic: false,
-				},
 			},
 		};
 
 		options.series = series;
 		options.vAxes = vAxes;
 
-		// Clean up chart if more than three stats are selected.
-		if ( 3 <= selectedStats.length ) {
-			options.vAxis.textPosition = 'none';
+		if ( selectedStats.length < 3 ) {
+			options.vAxis.textStyle = {
+				color: '#616161',
+				fontSize: 12,
+			};
+			options.vAxis.titleTextStyle = {
+				color: '#616161',
+				fontSize: 12,
+				italic: false,
+			};
+		} else {
+			// Clean up chart if three or more stats are selected.
 			options.vAxis.gridlines.color = '#fff';
 			options.vAxis.minorGridlines.color = '#fff';
 			options.chartArea.width = '98%';


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #2721.

## Relevant technical choices

I slightly tweaked the logic of the if/else statement from what it was and what was in the IB, just to make it a bit more obvious 🙂 

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
