### PR TITLE
Include config.json in release zip unconditionally

### DIFF
--- a/bin/release
+++ b/bin/release
@@ -32,11 +32,6 @@ const getRepoInfo = require( 'git-repo-info' );
 const sanitizeFilename = require( 'sanitize-filename' );
 
 /**
- * Internal dependencies
- */
-const { flagMode } = require( '../dist/config.json' );
-
-/**
  * Retrieves the plugin version from the plugin's file header.
  *
  * @since 1.20.0

--- a/bin/release
+++ b/bin/release
@@ -119,12 +119,10 @@ async function makeRelease() {
 		cp( 'google-site-kit.php' ),
 		cp( 'uninstall.php' ),
 		cp( 'dist/assets' ),
+		cp( 'dist/config.json' ),
 		cp( 'includes' ),
 		cp( 'third-party' ),
 	];
-	if ( 'production' !== flagMode ) {
-		fileCopyPromises.push( cp( 'dist/config.json' ) );
-	}
 	await Promise.all( fileCopyPromises );
 
 	// Archive the release directory.


### PR DESCRIPTION
## Summary

Addresses issue #

Related to #2683, but done as a quick fix to unblock testing.

## Relevant technical choices

<!-- Please describe your changes. -->

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
