### PR TITLE
Trigger authorization action hooks also for sites that do not use the proxy 

### DIFF
--- a/includes/Core/Authentication/Authentication.php
+++ b/includes/Core/Authentication/Authentication.php
@@ -295,6 +295,9 @@ final class Authentication {
 		add_action(
 			'googlesitekit_authorize_user',
 			function () {
+				if ( ! $this->credentials->using_proxy() ) {
+					return;
+				}
 				$this->set_connected_proxy_url();
 				$this->require_user_input();
 			}

--- a/includes/Core/Authentication/Clients/Google_Site_Kit_Client.php
+++ b/includes/Core/Authentication/Clients/Google_Site_Kit_Client.php
@@ -184,22 +184,18 @@ class Google_Site_Kit_Client extends Google_Client {
 			}
 			$this->setAccessToken( $token_response );
 
-			// TODO: In the future, once the old authentication mechanism no longer exists, this check can be removed.
-			// For now the below action should only fire for the proxy despite not clarifying that in the hook name.
-			if ( $this instanceof Google_Site_Kit_Proxy_Client ) {
-				/**
-				 * Fires when the current user has just been reauthorized to access Google APIs with a refreshed access token.
-				 *
-				 * In other words, this action fires whenever Site Kit has just obtained a new access token based on
-				 * the refresh token for the current user, which typically happens once every hour when using Site Kit,
-				 * since that is the lifetime of every access token.
-				 *
-				 * @since 1.25.0
-				 *
-				 * @param array $token_response Token response data.
-				 */
-				do_action( 'googlesitekit_reauthorize_user', $token_response );
-			}
+			/**
+			 * Fires when the current user has just been reauthorized to access Google APIs with a refreshed access token.
+			 *
+			 * In other words, this action fires whenever Site Kit has just obtained a new access token based on
+			 * the refresh token for the current user, which typically happens once every hour when using Site Kit,
+			 * since that is the lifetime of every access token.
+			 *
+			 * @since 1.25.0
+			 *
+			 * @param array $token_response Token response data.
+			 */
+			do_action( 'googlesitekit_reauthorize_user', $token_response );
 		}
 
 		return $token_response;

--- a/includes/Core/Authentication/Clients/OAuth_Client.php
+++ b/includes/Core/Authentication/Clients/OAuth_Client.php
@@ -722,23 +722,19 @@ final class OAuth_Client {
 
 		$this->refresh_profile_data( 2 * MINUTE_IN_SECONDS );
 
-		// TODO: In the future, once the old authentication mechanism no longer exists, this check can be removed.
-		// For now the below action should only fire for the proxy despite not clarifying that in the hook name.
-		if ( $this->credentials->using_proxy() ) {
-			/**
-			 * Fires when the current user has just been authorized to access Google APIs.
-			 *
-			 * In other words, this action fires whenever Site Kit has just obtained a new set of access token and
-			 * refresh token for the current user, which may happen to set up the initial connection or to request
-			 * access to further scopes.
-			 *
-			 * @since 1.3.0
-			 * @since 1.6.0 The $token_response parameter was added.
-			 *
-			 * @param array $token_response Token response data.
-			 */
-			do_action( 'googlesitekit_authorize_user', $token_response );
-		}
+		/**
+		 * Fires when the current user has just been authorized to access Google APIs.
+		 *
+		 * In other words, this action fires whenever Site Kit has just obtained a new set of access token and
+		 * refresh token for the current user, which may happen to set up the initial connection or to request
+		 * access to further scopes.
+		 *
+		 * @since 1.3.0
+		 * @since 1.6.0 The $token_response parameter was added.
+		 *
+		 * @param array $token_response Token response data.
+		 */
+		do_action( 'googlesitekit_authorize_user', $token_response );
 
 		// This must happen after googlesitekit_authorize_user as the permissions checks depend on
 		// values set which affect the meta capability mapping.

--- a/includes/Modules/Site_Verification.php
+++ b/includes/Modules/Site_Verification.php
@@ -85,6 +85,9 @@ final class Site_Verification extends Module implements Module_With_Scopes {
 		add_action(
 			'googlesitekit_authorize_user',
 			function() {
+				if ( ! $this->authentication->credentials()->using_proxy() ) {
+					return;
+				}
 				$this->user_options->set( Verification::OPTION, 'verified' );
 			}
 		);


### PR DESCRIPTION
Remove the if statements limiting googlesitekit_authorize_user and googlesitekit_reauthorize_user.

## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #2693

## Relevant technical choices

<!-- Please describe your changes. -->

## Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
