### PR TITLE
Add a new workflow for PHP Tests with PHP 8.0 and update PHPUnit setup for compatibility

### DIFF
--- a/.github/workflows/php-tests-wp-latest-multisite-php-7-4.yml
+++ b/.github/workflows/php-tests-wp-latest-multisite-php-7-4.yml
@@ -60,4 +60,4 @@ jobs:
       - name: Set up PHP test data
         run: tests/bin/install-wp-tests.sh ${MYSQL_DATABASE} ${MYSQL_USER} ${MYSQL_PASSWORD} ${DB_HOST}:${DB_PORT} ${WP_VERSION}
       - name: Run Unit Tests
-        run: composer test
+        run: composer test:multisite

--- a/.github/workflows/php-tests-wp-latest-php-8-0.yml
+++ b/.github/workflows/php-tests-wp-latest-php-8-0.yml
@@ -1,0 +1,62 @@
+name: PHP Tests
+
+on:
+  push:
+    branches:
+      - develop
+      - master
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+
+jobs:
+  php-tests-wp-latest-php-8-0:
+    name: PHP (PHP 8.0, WordPress Latest)
+    runs-on: ubuntu-latest
+    services:
+      mysql:
+        image: mysql:5.7
+        env:
+          MYSQL_ALLOW_EMPTY_PASSWORD: yes
+        ports:
+          - 3306:3306
+        options: --health-cmd="mysqladmin ping" --health-interval=5s --health-timeout=2s --health-retries=3
+    env:
+      DB_HOST: 127.0.0.1
+      DB_PORT: 3306
+      MYSQL_USER: wordpress
+      MYSQL_PASSWORD: wordpress
+      MYSQL_DATABASE: wordpress_test
+      MYSQL_ROOT_PASSWORD: root
+      WP_VERSION: latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Grant database access
+        env:
+          MYSQL_TCP_PORT: ${{ env.DB_PORT }}
+        run: |
+          mysql -u root -h ${DB_HOST} -e "CREATE USER ${MYSQL_USER} IDENTIFIED BY '${MYSQL_PASSWORD}';"
+          mysql -u root -h ${DB_HOST} -e "GRANT ALL PRIVILEGES ON *.* TO ${MYSQL_USER};"
+      - uses: shivammathur/setup-php@v2
+        with:
+          extensions: mysqli
+          tools: composer
+          php-version: '8.0'
+      - name: Get Composer Cache Directory
+        id: composer-cache
+        run: |
+          echo "::set-output name=dir::$(composer config cache-files-dir)"
+      - uses: actions/cache@v2
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-composer-
+      - name: Composer Install
+        run: composer install --no-interaction --no-progress
+      - name: Set up PHP test data
+        run: tests/bin/install-wp-tests.sh ${MYSQL_DATABASE} ${MYSQL_USER} ${MYSQL_PASSWORD} ${DB_HOST}:${DB_PORT} ${WP_VERSION}
+      - name: Run Unit Tests
+        run: composer test

--- a/.github/workflows/php-tests-wp-latest-php-8-0.yml
+++ b/.github/workflows/php-tests-wp-latest-php-8-0.yml
@@ -56,6 +56,8 @@ jobs:
             ${{ runner.os }}-composer-
       - name: Composer Install
         run: composer install --no-interaction --no-progress
+      - name: Update PHPUnit
+        run: composer update phpunit/phpunit --with-dependencies --ignore-platform-reqs --no-scripts
       - name: Set up PHP test data
         run: tests/bin/install-wp-tests.sh ${MYSQL_DATABASE} ${MYSQL_USER} ${MYSQL_PASSWORD} ${DB_HOST}:${DB_PORT} ${WP_VERSION}
       - name: Run Unit Tests

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     "automattic/vipwpcs": "^2",
     "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
     "phpcompatibility/phpcompatibility-wp": "^2.1",
-    "phpunit/phpunit": "^5",
+    "phpunit/phpunit": "^5 || ^6 || ^7",
     "roave/security-advisories": "dev-master",
     "squizlabs/php_codesniffer": "^3.3",
     "wp-coding-standards/wpcs": "^2"

--- a/composer.json
+++ b/composer.json
@@ -72,6 +72,7 @@
     ],
     "lint": "phpcs",
     "lint-fix": "phpcbf",
-    "test":  "phpunit"
+    "test":  "phpunit",
+    "test:multisite": "@test --configuration=phpunit.multisite.xml"
   }
 }

--- a/phpunit.multisite.xml
+++ b/phpunit.multisite.xml
@@ -10,7 +10,7 @@
     </testsuites>
     <groups>
         <exclude>
-            <group>ms-required</group>
+            <group>ms-excluded</group>
         </exclude>
     </groups>
     <php>
@@ -19,5 +19,6 @@
         <ini name="display_startup_errors" value="1" />
         <const name="GOOGLESITEKIT_TESTS" value="1" />
         <const name="WP_HTTP_BLOCK_EXTERNAL" value="1" />
+        <const name="WP_TESTS_MULTISITE" value="1" />
     </php>
 </phpunit>

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -31,6 +31,23 @@ $GLOBALS['wp_tests_options'] = array(
 	'active_plugins' => array( basename( TESTS_PLUGIN_DIR ) . '/google-site-kit.php' ),
 );
 
+/**
+ * PHP 8 Compatibility with PHPUnit 7.
+ *
+ * WordPress core loads these via the main autoloader but these files
+ * aren't installed via Composer (yet) so we need to require them manually
+ * before PHPUnit's bundled versions are autoloaded to use the compatible versions.
+ *
+ * @see https://core.trac.wordpress.org/ticket/50902
+ * @see https://core.trac.wordpress.org/ticket/50913
+ */
+if ( version_compare( '8.0', phpversion(), '<=' ) ) {
+	require_once $_test_root . '/includes/phpunit7/MockObject/Builder/NamespaceMatch.php';
+	require_once $_test_root . '/includes/phpunit7/MockObject/Builder/ParametersMatch.php';
+	require_once $_test_root . '/includes/phpunit7/MockObject/InvocationMocker.php';
+	require_once $_test_root . '/includes/phpunit7/MockObject/MockMethod.php';
+}
+
 // Give access to tests_add_filter() function.
 require $_test_root . '/includes/functions.php';
 

--- a/tests/phpunit/includes/TestCase.php
+++ b/tests/phpunit/includes/TestCase.php
@@ -146,39 +146,6 @@ class TestCase extends \WP_UnitTestCase {
 		return $this;
 	}
 
-	protected function checkRequirements() {
-		parent::checkRequirements();
-
-		/**
-		 * Proper handling for MS group annotation handling was fixed in 5.1
-		 * @see https://core.trac.wordpress.org/ticket/43863
-		 */
-		if ( version_compare( $GLOBALS['wp_version'], '5.1', '<' ) ) {
-			$annotations = $this->getAnnotations();
-			$groups      = array();
-
-			if ( ! empty( $annotations['class']['group'] ) ) {
-				$groups = array_merge( $groups, $annotations['class']['group'] );
-			}
-			if ( ! empty( $annotations['method']['group'] ) ) {
-				$groups = array_merge( $groups, $annotations['method']['group'] );
-			}
-
-			if ( ! empty( $groups ) ) {
-				if ( in_array( 'ms-required', $groups, true ) ) {
-					if ( ! is_multisite() ) {
-						$this->markTestSkipped( 'Test only runs on Multisite' );
-					}
-				}
-				if ( in_array( 'ms-excluded', $groups, true ) ) {
-					if ( is_multisite() ) {
-						$this->markTestSkipped( 'Test does not run on Multisite' );
-					}
-				}
-			}
-		}
-	}
-
 	/**
 	 * Capture the output of an action.
 	 *

--- a/tests/phpunit/integration/Core/Feature_Tours/REST_Feature_Tours_ControllerTest.php
+++ b/tests/phpunit/integration/Core/Feature_Tours/REST_Feature_Tours_ControllerTest.php
@@ -36,8 +36,8 @@ class REST_Feature_Tours_ControllerTest extends TestCase {
 
 		$controller->register();
 
-		has_filter( 'googlesitekit_rest_routes' );
-		has_filter( 'googlesitekit_apifetch_preload_paths' );
+		$this->assertTrue( has_filter( 'googlesitekit_rest_routes' ) );
+		$this->assertTrue( has_filter( 'googlesitekit_apifetch_preload_paths' ) );
 	}
 
 	public function test_get_dismissed_tours() {


### PR DESCRIPTION
## Summary

Addresses issue #2724

Started by @benbowler, finished by @aaemnnosttv 

## Relevant technical choices

* WP core compatibility with PHP 8 is for PHPUnit 7 only so we needed to allow for this to be installed by widening the version constraint for `phpunit/phpunit` 
    * `config.platform.php` will still limit packages to those compatible with PHP 5.6 during install/update so we explicitly update it in the workflow with an added step, which ignores platform requirements
* PHPUnit 7 updated the `TestCase::checkRequirements` method to be private so it's no longer extendable. This was only used for polyfiling the `ms-required|ms-excluded` group test skip-by-annotation that we had added to fix for older versions of WordPress but this will no longer work at all because `checkRequirements` is no longer extendable.
    * To work around this, I split out a separate `phpunit.multisite.xml` config file and updated the default config file to exclude the groups that don't apply (this is what core does). I looked for a ticket on trac for this but found nothing so they may not even be aware that this skip-by-annotation no longer works.
    * The result is a bit better experience anyways IMO since PHPUnit would previously finish with warnings due to skipped tests. Now these tests are filtered out by group so they aren't even included in the list of tests to be run, so they're no longer counted as skipped, resulting in happier looking finish when all passes 😄 
* I added missing assertions to one test (my own from recently) that cause the test to fail in the newer version of PHPUnit
* Added a new `test:multisite` script to Composer

## Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
