### PR TITLE
2827 Add enabled features to anonymous usage tracking

### DIFF
--- a/assets/js/util/tracking/createTrackEvent.js
+++ b/assets/js/util/tracking/createTrackEvent.js
@@ -3,6 +3,7 @@
  * Internal dependencies
  */
 import createDataLayerPush from './createDataLayerPush';
+import { enabledFeatures } from '../../features/index';
 
 /**
  * Returns a function which, when invoked tracks a single event.
@@ -55,6 +56,7 @@ export default function createTrackEvent( config, dataLayerTarget, _global ) {
 			dimension2: isFirstAdmin ? 'true' : 'false',
 			dimension3: userIDHash,
 			dimension4: global.GOOGLESITEKIT_VERSION || '',
+			dimension5: enabledFeatures.join( ', ' ),
 		};
 
 		return new Promise( ( resolve ) => {

--- a/assets/js/util/tracking/index.test.js
+++ b/assets/js/util/tracking/index.test.js
@@ -114,7 +114,7 @@ describe( 'trackEvent', () => {
 			dimension2: 'true',
 			dimension3: config.userIDHash,
 			dimension4: global.GOOGLESITEKIT_VERSION || '',
-			dimension5: ( 'feature1, feature2' ),
+			dimension5: 'feature1, feature2',
 		} ) );
 		expect( pushArgs[ 0 ][ 2 ] ).toHaveProperty( 'event_callback' );
 	} );

--- a/assets/js/util/tracking/index.test.js
+++ b/assets/js/util/tracking/index.test.js
@@ -1,3 +1,11 @@
+/**
+ * Mock enabledFeatures.
+ */
+jest.mock( '../../features/index', () => {
+	return {
+		enabledFeatures: [ 'feature1', 'feature2' ],
+	};
+} );
 
 /**
  * Internal dependencies
@@ -106,6 +114,7 @@ describe( 'trackEvent', () => {
 			dimension2: 'true',
 			dimension3: config.userIDHash,
 			dimension4: global.GOOGLESITEKIT_VERSION || '',
+			dimension5: ( 'feature1, feature2' ),
 		} ) );
 		expect( pushArgs[ 0 ][ 2 ] ).toHaveProperty( 'event_callback' );
 	} );


### PR DESCRIPTION
## Summary
Add enabled features to anonymous usage tracking

Addresses issue #2827 

## Relevant technical choices


## Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
