### PR TITLE
Remove tooltip link for Others slice and replace it with more precise text

### DIFF
--- a/assets/js/modules/analytics/components/dashboard/DashboardAllTrafficWidget/UserDimensionsPieChart.js
+++ b/assets/js/modules/analytics/components/dashboard/DashboardAllTrafficWidget/UserDimensionsPieChart.js
@@ -51,7 +51,6 @@ export default function UserDimensionsPieChart( {
 	dimensionValue,
 	loaded,
 	report,
-	sourceLink,
 } ) {
 	const [ selectable, setSelectable ] = useState( false );
 
@@ -79,8 +78,6 @@ export default function UserDimensionsPieChart( {
 			const label = target.dataset.rowLabel;
 			if ( label === '(other)' || label === '(not set)' ) {
 				trackEvent( 'all_traffic_widget', 'help_click', label );
-			} else if ( label === 'others' ) {
-				trackEvent( 'all_traffic_widget', 'others_source_click', null );
 			}
 		};
 
@@ -160,12 +157,19 @@ export default function UserDimensionsPieChart( {
 			);
 
 			const othersLabel = __( 'Others', 'google-site-kit' ).toLowerCase();
-			if ( sourceLink && rowLabel === othersLabel ) {
-				tooltip += getTooltipHelp(
-					sourceLink,
-					__( 'See the detailed breakdown in Analytics', 'google-site-kit' ),
-					'others'
-				);
+			if ( rowLabel === othersLabel ) {
+				switch ( dimensionName ) {
+					case 'ga:country':
+						tooltip += `<p>${ __( 'See the full list of locations in Analytics', 'google-site-kit' ) }`;
+						break;
+					case 'ga:deviceCategory':
+						tooltip += `<p>${ __( 'See the full list of devices in Analytics', 'google-site-kit' ) }`;
+						break;
+					case 'ga:channelGrouping':
+					default:
+						tooltip += `<p>${ __( 'See the full list of channels in Analytics', 'google-site-kit' ) }`;
+						break;
+				}
 			}
 
 			if ( otherSupportURL && rowLabel === '(other)' ) {
@@ -499,7 +503,6 @@ UserDimensionsPieChart.chartOptions = {
 };
 
 UserDimensionsPieChart.propTypes = {
-	sourceLink: PropTypes.string,
 	dimensionName: PropTypes.string.isRequired,
 	dimensionValue: PropTypes.string,
 	report: PropTypes.arrayOf( PropTypes.object ),

--- a/assets/js/modules/analytics/components/dashboard/DashboardAllTrafficWidget/UserDimensionsPieChart.js
+++ b/assets/js/modules/analytics/components/dashboard/DashboardAllTrafficWidget/UserDimensionsPieChart.js
@@ -160,14 +160,14 @@ export default function UserDimensionsPieChart( {
 			if ( rowLabel === othersLabel ) {
 				switch ( dimensionName ) {
 					case 'ga:country':
-						tooltip += `<p>${ __( 'See the full list of locations in Analytics', 'google-site-kit' ) }`;
+						tooltip += `<p>${ __( 'See the full list of locations in Analytics', 'google-site-kit' ) }</p>`;
 						break;
 					case 'ga:deviceCategory':
-						tooltip += `<p>${ __( 'See the full list of devices in Analytics', 'google-site-kit' ) }`;
+						tooltip += `<p>${ __( 'See the full list of devices in Analytics', 'google-site-kit' ) }</p>`;
 						break;
 					case 'ga:channelGrouping':
 					default:
-						tooltip += `<p>${ __( 'See the full list of channels in Analytics', 'google-site-kit' ) }`;
+						tooltip += `<p>${ __( 'See the full list of channels in Analytics', 'google-site-kit' ) }</p>`;
 						break;
 				}
 			}

--- a/assets/js/modules/analytics/components/dashboard/DashboardAllTrafficWidget/index.js
+++ b/assets/js/modules/analytics/components/dashboard/DashboardAllTrafficWidget/index.js
@@ -212,7 +212,6 @@ function DashboardAllTrafficWidget( { Widget, WidgetReportZero, WidgetReportErro
 						<UserDimensionsPieChart
 							dimensionName={ dimensionName }
 							dimensionValue={ dimensionValue }
-							sourceLink={ serviceReportURL }
 							loaded={ pieChartLoaded && ! firstLoad }
 							report={ pieChartReport }
 						/>


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #2737

This addresses https://github.com/google/site-kit-wp/issues/2737#issuecomment-786055768, i.e. the new AC requirement after determining we cannot make the "Others" tooltip link reachable.

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [ ] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
