### PR TITLE
Use current Google charts library verrsion again to prevent conflict with react-google-charts

### DIFF
--- a/includes/Core/Assets/Assets.php
+++ b/includes/Core/Assets/Assets.php
@@ -393,7 +393,7 @@ final class Assets {
 					'in_footer'    => false,
 					'before_print' => function( $handle ) {
 						// The "42" version is important because it contains a fix for the tooltip flickering issue.
-						wp_add_inline_script( $handle, 'google.charts.load( "42", { packages: [ "corechart" ] } );' );
+						wp_add_inline_script( $handle, 'google.charts.load( "current", { packages: [ "corechart" ] } );' );
 					},
 				)
 			),


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #2714

## Relevant technical choices

* `react-google-charts` (used for new `GoogleChartV2` component) doesn't specify any Google charts library version, i.e. it relies on the latest one.
* In PHP however (used for old `GoogleChart` component), we load the Google charts library in a specific version 42. This results in a conflict between versions, which causes the error.
* We only used the specific 42 version for about the last month (see https://github.com/google/site-kit-wp/commit/8097bbdd5f9d617348546a536ba021e64b7f924c#diff-3ff56820a1aad4fa15985200da4db645e6e443ca74ce9495f1faa159fa43e2d9), to fix the tooltip flickering issue (it was basically introduced after version 42). However, in the meantime we've already resolved that issue in a different way anyway, so we can safely go back to "current".

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [ ] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
