### PR TITLE
Fix Sparkline JS errors due to mixing old and new Google charts implementation

### DIFF
--- a/.storybook/storybook-data.js
+++ b/.storybook/storybook-data.js
@@ -65,7 +65,7 @@ module.exports = [
 			options: {
 				hierarchyRootSeparator: '|',
 				hierarchySeparator: {},
-				readySelector: '.googlesitekit-line-chart > div[style="position: relative;"]',
+				readySelector: '.googlesitekit-chart-v2 > div[style="position: relative;"]',
 			},
 		},
 	},
@@ -79,7 +79,7 @@ module.exports = [
 			options: {
 				hierarchyRootSeparator: '|',
 				hierarchySeparator: {},
-				readySelector: '.googlesitekit-line-chart > div[style="position: relative;"]',
+				readySelector: '.googlesitekit-chart-v2 > div[style="position: relative;"]',
 			},
 		},
 	},

--- a/assets/js/components/Sparkline.js
+++ b/assets/js/components/Sparkline.js
@@ -22,28 +22,18 @@
 import PropTypes from 'prop-types';
 
 /**
- * WordPress dependencies
- */
-import { withInstanceId } from '@wordpress/compose';
-
-/**
  * Internal dependencies
  */
-import GoogleChart from './GoogleChart';
+import GoogleChartV2 from './GoogleChartV2';
 
 function Sparkline( {
-	data,
 	change,
-	// eslint-disable-next-line sitekit/acronym-case
-	instanceId,
+	data,
 	invertChangeColor,
-	loadSmall,
-	loadCompressed,
-	loadHeight,
-	loadText,
+	loadingHeight,
 } ) {
 	if ( ! data ) {
-		return 'loading...';
+		return null;
 	}
 
 	const positiveColor = ! invertChangeColor ? 'green' : 'red';
@@ -78,37 +68,24 @@ function Sparkline( {
 
 	return (
 		<div className="googlesitekit-analytics-sparkline-chart-wrap">
-			<GoogleChart
-				chartType="line"
+			<GoogleChartV2
+				chartType="LineChart"
 				data={ data }
+				loadingHeight={ loadingHeight }
 				options={ chartOptions }
-				// eslint-disable-next-line sitekit/acronym-case
-				id={ `googlesitekit-sparkline-${ instanceId }` }
-				loadSmall={ loadSmall }
-				loadCompressed={ loadCompressed }
-				loadHeight={ loadHeight }
-				loadText={ loadText }
 			/>
 		</div>
 	);
 }
 
 Sparkline.propTypes = {
-	// eslint-disable-next-line sitekit/acronym-case
-	instanceId: PropTypes.number.isRequired,
 	invertChangeColor: PropTypes.bool,
-	loadSmall: PropTypes.bool,
-	loadCompressed: PropTypes.bool,
-	loadHeight: PropTypes.number,
-	loadText: PropTypes.bool,
+	loadingHeight: PropTypes.string,
 };
 
 Sparkline.defaultProps = {
 	invertChangeColor: false,
-	loadSmall: true,
-	loadCompressed: true,
-	loadHeight: 46,
-	loadText: false,
+	loadingHeight: '46px',
 };
 
-export default withInstanceId( Sparkline );
+export default Sparkline;

--- a/assets/js/modules/adsense/components/dashboard/DashboardSummaryWidget.js
+++ b/assets/js/modules/adsense/components/dashboard/DashboardSummaryWidget.js
@@ -115,7 +115,6 @@ function DashboardSummaryWidget( { Widget, WidgetReportZero, WidgetReportError }
 							<Sparkline
 								data={ extractForSparkline( processedData.dataMap, 2 ) }
 								change={ 1 }
-								loadSmall={ false }
 							/>
 						}
 						context="compact"
@@ -138,7 +137,6 @@ function DashboardSummaryWidget( { Widget, WidgetReportZero, WidgetReportError }
 							<Sparkline
 								data={ extractForSparkline( processedData.dataMap, 1 ) }
 								change={ 1 }
-								loadSmall={ false }
 							/>
 						}
 						context="compact"
@@ -158,7 +156,6 @@ function DashboardSummaryWidget( { Widget, WidgetReportZero, WidgetReportError }
 							<Sparkline
 								data={ extractForSparkline( processedData.dataMap, 3 ) }
 								change={ 1 }
-								loadSmall={ false }
 							/>
 						}
 						context="compact"

--- a/assets/js/modules/adsense/components/dashboard/LegacyAdSenseDashboardMainSummary.js
+++ b/assets/js/modules/adsense/components/dashboard/LegacyAdSenseDashboardMainSummary.js
@@ -132,7 +132,6 @@ class LegacyAdSenseDashboardMainSummary extends Component {
 											<Sparkline
 												data={ extractForSparkline( processedData.dataMap, 2 ) }
 												change={ 1 }
-												loadSmall={ false }
 											/>
 										}
 										context="compact"
@@ -157,7 +156,6 @@ class LegacyAdSenseDashboardMainSummary extends Component {
 											<Sparkline
 												data={ extractForSparkline( processedData.dataMap, 1 ) }
 												change={ 1 }
-												loadSmall={ false }
 											/>
 										}
 										context="compact"
@@ -179,7 +177,6 @@ class LegacyAdSenseDashboardMainSummary extends Component {
 											<Sparkline
 												data={ extractForSparkline( processedData.dataMap, 3 ) }
 												change={ 1 }
-												loadSmall={ false }
 											/>
 										}
 										context="compact"

--- a/includes/Core/Assets/Assets.php
+++ b/includes/Core/Assets/Assets.php
@@ -393,7 +393,7 @@ final class Assets {
 					'in_footer'    => false,
 					'before_print' => function( $handle ) {
 						// The "42" version is important because it contains a fix for the tooltip flickering issue.
-						wp_add_inline_script( $handle, 'google.charts.load( "42", { packages: [ "corechart" ] } );' );
+						wp_add_inline_script( $handle, 'google.charts.load( "current", { packages: [ "corechart" ] } );' );
 					},
 				)
 			),

--- a/stories/dashboard.stories.js
+++ b/stories/dashboard.stories.js
@@ -135,7 +135,7 @@ storiesOf( 'Dashboard', module )
 			</WithTestRegistry>
 		);
 	},
-	{ options: { readySelector: '.googlesitekit-line-chart > div[style="position: relative;"]' } } )
+	{ options: { readySelector: '.googlesitekit-chart-v2 > div[style="position: relative;"]' } } )
 	.add( 'Search Funnel', () => {
 		global._googlesitekitLegacyData = analyticsDashboardData;
 
@@ -192,6 +192,6 @@ storiesOf( 'Dashboard', module )
 		);
 	}, {
 		options: {
-			readySelector: '.googlesitekit-line-chart > div[style="position: relative;"]',
+			readySelector: '.googlesitekit-chart-v2 > div[style="position: relative;"]',
 		},
 	} );


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #2714

## Relevant technical choices

* Same code as #2879, but based off `master`, without extra changes.

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [ ] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
