### PR TITLE
Fix the <title> tag on the user input page.

### DIFF
--- a/includes/Core/Admin/Screen.php
+++ b/includes/Core/Admin/Screen.php
@@ -139,6 +139,19 @@ final class Screen {
 			}
 		}
 
+		// If $parent_slug is NULL then add_submenu_page does not add the title automatically.
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		if ( null === $parent_slug && isset( $_GET['page'] ) && $this->slug === $_GET['page'] ) {
+			add_filter(
+				'admin_title',
+				function ( $admin_title ) {
+					return $this->args['title'] . $admin_title;
+				},
+				10,
+				2
+			);
+		}
+
 		// If submenu item or not in menu, use add_submenu_page().
 		return (string) add_submenu_page(
 			$parent_slug,


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #2529

## Relevant technical choices

<!-- Please describe your changes. -->

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [ ] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
