### PR TITLE
2865 Hide legends with no users on all traffic widget.

### DIFF
--- a/assets/js/modules/analytics/components/dashboard/DashboardAllTrafficWidget/UserDimensionsPieChart.js
+++ b/assets/js/modules/analytics/components/dashboard/DashboardAllTrafficWidget/UserDimensionsPieChart.js
@@ -197,6 +197,7 @@ export default function UserDimensionsPieChart( {
 
 			return tooltip;
 		},
+		hideEmpty: true,
 	} );
 
 	const { slices } = UserDimensionsPieChart.chartOptions;

--- a/assets/js/modules/analytics/util/index.js
+++ b/assets/js/modules/analytics/util/index.js
@@ -68,6 +68,7 @@ export function extractAnalyticsDataForPieChart( reports, options = {} ) {
 		maxSlices,
 		withOthers = false,
 		tooltipCallback,
+		hideEmpty = false,
 	} = options;
 
 	const data = reports[ 0 ].data;
@@ -111,7 +112,9 @@ export function extractAnalyticsDataForPieChart( reports, options = {} ) {
 			rowData.push( tooltipCallback( row, rowData ) );
 		}
 
-		dataMap.push( rowData );
+		if ( ! ( hideEmpty && users < 1 ) ) {
+			dataMap.push( rowData );
+		}
 	}
 
 	if ( hasOthers && others > 0 ) {


### PR DESCRIPTION
## Summary
Hide legends with no users on all traffic widget.

Addresses issue #2865

## Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [X] I have added a QA Brief on the issue linked above.
- [X] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
