### PR TITLE
Remove userInput feature flag so User Input is displayed #2133.

### DIFF
--- a/assets/js/components/legacy-notifications/index.js
+++ b/assets/js/components/legacy-notifications/index.js
@@ -24,7 +24,6 @@ import { addFilter } from '@wordpress/hooks';
 /**
  * Internal dependencies
  */
-import { isFeatureEnabled } from '../../features';
 import { createAddToFilter } from '../../util/helpers';
 import { getQueryParameter } from '../../util';
 import DashboardCoreSiteAlerts from './dashboard-core-site-alerts';
@@ -52,11 +51,9 @@ if ( setup.needReauthenticate ) {
 		addAuthNotification, 1 );
 }
 
-if ( isFeatureEnabled( 'userInput' ) ) {
-	addFilter( 'googlesitekit.DashboardNotifications',
-		'googlesitekit.UserInputSettings',
-		addUserInputSettings, 1 );
-}
+addFilter( 'googlesitekit.DashboardNotifications',
+	'googlesitekit.UserInputSettings',
+	addUserInputSettings, 1 );
 
 if ( 'authentication_success' === notification || 'authentication_failure' === notification || 'user_input_success' === notification ) {
 	addFilter( 'googlesitekit.DashboardNotifications',

--- a/assets/js/components/settings/SettingsAdmin.js
+++ b/assets/js/components/settings/SettingsAdmin.js
@@ -38,12 +38,10 @@ import ResetButton from '../ResetButton';
 import UserInputPreview from '../user-input/UserInputPreview';
 import { USER_INPUT_QUESTIONS_LIST } from '../user-input/util/constants';
 import UserInputSettings from '../notifications/UserInputSettings';
-import { useFeature } from '../../hooks/useFeature';
 const { useSelect, useDispatch } = Data;
 
 const SettingsAdmin = () => {
-	const userInputEnabled = useFeature( 'userInput' );
-	const isUserInputCompleted = useSelect( ( select ) => userInputEnabled && select( CORE_USER ).getUserInputState() === 'completed' );
+	const isUserInputCompleted = useSelect( ( select ) => select( CORE_USER ).getUserInputState() === 'completed' );
 	const userInputURL = useSelect( ( select ) => select( CORE_SITE ).getAdminURL( 'googlesitekit-user-input' ) );
 
 	const { navigateTo } = useDispatch( CORE_LOCATION );
@@ -57,42 +55,40 @@ const SettingsAdmin = () => {
 
 	return (
 		<Fragment>
-			{ userInputEnabled && (
-				<Cell size={ 12 }>
-					{ isUserInputCompleted && (
-						<Layout>
-							<div className="
-								googlesitekit-settings-module
-								googlesitekit-settings-module--active
-								googlesitekit-settings-user-input
-							">
-								<div className="mdc-layout-grid">
-									<div className="mdc-layout-grid__inner">
-										<div className="
-											mdc-layout-grid__cell
-											mdc-layout-grid__cell--span-12
+			<Cell size={ 12 }>
+				{ isUserInputCompleted && (
+					<Layout>
+						<div className="
+							googlesitekit-settings-module
+							googlesitekit-settings-module--active
+							googlesitekit-settings-user-input
+						">
+							<div className="mdc-layout-grid">
+								<div className="mdc-layout-grid__inner">
+									<div className="
+										mdc-layout-grid__cell
+										mdc-layout-grid__cell--span-12
+									">
+										<h3 className="
+											googlesitekit-heading-4
+											googlesitekit-settings-module__title
 										">
-											<h3 className="
-												googlesitekit-heading-4
-												googlesitekit-settings-module__title
-											">
-												{ __( 'Your site goals', 'google-site-kit' ) }
-											</h3>
-											<p>
-												{ __( 'Based on your responses, Site Kit will show you metrics and suggestions that are specific to your site to help you achieve your goals', 'google-site-kit' ) }
-											</p>
-										</div>
+											{ __( 'Your site goals', 'google-site-kit' ) }
+										</h3>
+										<p>
+											{ __( 'Based on your responses, Site Kit will show you metrics and suggestions that are specific to your site to help you achieve your goals', 'google-site-kit' ) }
+										</p>
 									</div>
-									<UserInputPreview goTo={ goTo } noFooter />
 								</div>
+								<UserInputPreview goTo={ goTo } noFooter />
 							</div>
-						</Layout>
-					) }
-					{ ! isUserInputCompleted && (
-						<UserInputSettings isDimissable={ false } />
-					) }
-				</Cell>
-			) }
+						</div>
+					</Layout>
+				) }
+				{ ! isUserInputCompleted && (
+					<UserInputSettings isDimissable={ false } />
+				) }
+			</Cell>
 			<div className="
 				mdc-layout-grid__cell
 				mdc-layout-grid__cell--span-12

--- a/assets/js/components/settings/SettingsApp.test.js
+++ b/assets/js/components/settings/SettingsApp.test.js
@@ -55,6 +55,8 @@ describe( 'SettingsApp', () => {
 			active: true,
 			setupComplete: true,
 		};
+
+		global._googlesitekitUserData.userInputState = 'missing';
 	} );
 
 	it( 'should change location hash & DOM correctly when module accordion clicked and opened', async () => {

--- a/assets/js/components/user-input/UserInputApp.js
+++ b/assets/js/components/user-input/UserInputApp.js
@@ -27,7 +27,6 @@ import { __ } from '@wordpress/i18n';
  */
 import Data from 'googlesitekit-data';
 import { CORE_USER } from '../../googlesitekit/datastore/user/constants';
-import { useFeature } from '../../hooks/useFeature';
 import { Grid, Row, Cell } from '../../material-components';
 import Header from '../Header';
 import PageHeader from '../PageHeader';
@@ -36,15 +35,10 @@ import UserInputQuestionnaire from './UserInputQuestionnaire';
 const { useSelect } = Data;
 
 export default function UserInputApp() {
-	const userInputEnabled = useFeature( 'userInput' );
 	const { hasFinishedGettingInputSettings } = useSelect( ( select ) => ( {
 		userInputSettings: select( CORE_USER ).getUserInputSettings(), // This will be used in the children components.
 		hasFinishedGettingInputSettings: select( CORE_USER ).hasFinishedResolution( 'getUserInputSettings' ),
 	} ) );
-
-	if ( ! userInputEnabled ) {
-		return <div>{ __( 'Something went wrong.', 'google-site-kit' ) }</div>;
-	}
 
 	return (
 		<Fragment>

--- a/feature-flags.json
+++ b/feature-flags.json
@@ -1,7 +1,6 @@
 [
   "serviceSetupV2",
   "storeErrorNotifications",
-  "userInput",
   "widgets.dashboard",
   "widgets.pageDashboard"
 ]

--- a/includes/Core/Authentication/Authentication.php
+++ b/includes/Core/Authentication/Authentication.php
@@ -1101,10 +1101,6 @@ final class Authentication {
 	 * @since 1.22.0
 	 */
 	private function require_user_input() {
-		if ( ! Feature_Flags::enabled( 'userInput' ) ) {
-			return;
-		}
-
 		// Refresh user input settings from the proxy.
 		// This will ensure the user input state is updated as well.
 		$this->user_input_settings->set_settings( null );

--- a/includes/Core/Authentication/Google_Proxy.php
+++ b/includes/Core/Authentication/Google_Proxy.php
@@ -89,9 +89,7 @@ class Google_Proxy {
 
 		// Informs the proxy the user input feature is already enabled locally.
 		// TODO: Remove once the feature is fully rolled out.
-		if ( Feature_Flags::enabled( 'userInput' ) ) {
-			$supports[] = 'user_input_flow_feature';
-		}
+		$supports[] = 'user_input_flow_feature';
 
 		return $supports;
 	}

--- a/stories/setup.stories.js
+++ b/stories/setup.stories.js
@@ -70,7 +70,7 @@ storiesOf( 'Setup / Using Proxy', module )
 	} )
 	.add( 'Start [User Input]', () => {
 		return (
-			<WithTestRegistry features={ [ 'serviceSetupV2', 'userInput' ] }>
+			<WithTestRegistry features={ [ 'serviceSetupV2' ] }>
 				<SetupUsingProxy />
 			</WithTestRegistry>
 		);
@@ -79,7 +79,7 @@ storiesOf( 'Setup / Using Proxy', module )
 		global._googlesitekitLegacyData.setup.isSiteKitConnected = false;
 
 		return (
-			<WithTestRegistry features={ [ 'serviceSetupV2', 'userInput' ] }>
+			<WithTestRegistry features={ [ 'serviceSetupV2' ] }>
 				<SetupUsingProxy />
 			</WithTestRegistry>
 		);
@@ -107,7 +107,7 @@ storiesOf( 'Setup / Using Proxy', module )
 		return (
 			<WithTestRegistry
 				callback={ setupRegistry }
-				features={ [ 'serviceSetupV2', 'userInput' ] }
+				features={ [ 'serviceSetupV2' ] }
 			>
 				<SetupUsingProxy />
 			</WithTestRegistry>

--- a/stories/user-input.stories.js
+++ b/stories/user-input.stories.js
@@ -30,7 +30,7 @@ import { WithTestRegistry } from '../tests/js/utils';
 storiesOf( 'User Input', module )
 	.add( 'UserInputApp', () => {
 		return (
-			<WithTestRegistry features={ [ 'userInput' ] }>
+			<WithTestRegistry>
 				<UserInputApp />
 			</WithTestRegistry>
 		);

--- a/tests/phpunit/integration/Core/Authentication/AuthenticationTest.php
+++ b/tests/phpunit/integration/Core/Authentication/AuthenticationTest.php
@@ -371,7 +371,7 @@ class AuthenticationTest extends TestCase {
 
 		$this->assertEmpty( $user_input_state->get() );
 		do_action( 'googlesitekit_authorize_user', array() );
-		$this->assertEmpty( $user_input_state->get() );
+		$this->assertEquals( User_Input_State::VALUE_REQUIRED, $user_input_state->get() );
 	}
 
 	public function test_get_oauth_client() {


### PR DESCRIPTION
## Summary

Remove userInput feature flag so User Input is displayed.

Addresses issue #2133 

## Relevant technical choices

I found other files which were not mentioned in the IB that contained the userInput feature flag.  I removed it from those files too.

## Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [X] I have added a QA Brief on the issue linked above.
- [X] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
