### PR TITLE
Followup 2794 adblocker detection

### DIFF
--- a/assets/js/modules/adsense/datastore/adblocker.js
+++ b/assets/js/modules/adsense/datastore/adblocker.js
@@ -53,7 +53,24 @@ export const actions = {
 };
 
 export const controls = {
-	[ CHECK_ADBLOCKER ]: () => detectAnyAdblocker(),
+	[ CHECK_ADBLOCKER ]: async () => {
+		if ( await detectAnyAdblocker() ) {
+			return true;
+		}
+		// The above is good about detecting most adblockers.
+		// For the rest, we'll make a dummy request to the favicon with some
+		// additional stuff in the query string to (hopefully) trigger a filter.
+		// If this throws, then the fetch request failed completely and we'll assume it was blocked.
+		try {
+			await fetch(
+				'/favicon.ico?google-site-kit=/adsense/pagead2.googlesyndication.com/pagead/js/adsbygoogle.js',
+				{ credentials: 'omit' }
+			);
+		} catch {
+			return true;
+		}
+		return false;
+	},
 };
 
 export const reducer = ( state, { payload, type } ) => {


### PR DESCRIPTION
## Summary

Addresses issue #2794

## Relevant technical choices

* Adds a secondary fallback adblocker detection mechanism

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
