### PR TITLE
Enable and disable the Other: input in user-input flow.

### DIFF
--- a/assets/js/components/user-input/UserInputSelectOptions.js
+++ b/assets/js/components/user-input/UserInputSelectOptions.js
@@ -24,7 +24,7 @@ import PropTypes from 'prop-types';
 /**
  * WordPress dependencies
  */
-import { useCallback, useState } from '@wordpress/element';
+import { useCallback, useState, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -41,17 +41,35 @@ export default function UserInputSelectOptions( { slug, options, max } ) {
 	const values = useSelect( ( select ) => select( CORE_USER ).getUserInputSetting( slug ) || [] );
 	const [ other, setOther ] = useState( values.filter( ( value ) => ! options[ value ] )[ 0 ] || '' );
 	const { setUserInputSetting } = useDispatch( CORE_USER );
+	const inputRef = useRef();
+	const [ disabled, setDisabled ] = useState( false );
 
 	// Need to make sure that dependencies list always has the same number of elements.
 	const dependencies = values.concat( Array( max ) ).slice( 0, max );
 
 	const onClick = useCallback( ( event ) => {
 		const { target } = event;
-		const { value, checked } = target;
+		const { value, checked, name, type, id } = target;
 
 		const newValues = new Set( [ value, ...values ] );
 		if ( ! checked ) {
 			newValues.delete( value );
+		}
+
+		if ( name === slug + '-other' && checked === true ) {
+			inputRef.current.handleFocus();
+			setDisabled( false );
+		}
+
+		if ( type === 'radio' && id === slug + '-other' ) {
+			inputRef.current.handleFocus();
+			setDisabled( false );
+		}
+
+		if ( type !== 'radio' && newValues.size === max && ! newValues.has( '' ) && ! newValues.has( other ) ) {
+			setDisabled( true );
+		} else {
+			setDisabled( false );
 		}
 
 		setUserInputSetting( slug, Array.from( newValues ).slice( 0, max ) );
@@ -113,11 +131,16 @@ export default function UserInputSelectOptions( { slug, options, max } ) {
 						{ __( 'Other:', 'google-site-kit' ) }
 					</ListComponent>
 
-					<TextField>
+					<TextField
+						label={ __( 'Other', 'google-site-kit' ) }
+						floatingLabelClassName="screen-reader-text"
+					>
 						<Input
 							id={ `${ slug }-select-options` }
 							value={ other }
 							onChange={ onOtherChange }
+							ref={ ( input ) => inputRef.current = input }
+							disabled={ disabled }
 						/>
 					</TextField>
 				</div>

--- a/assets/js/components/user-input/UserInputSelectOptions.js
+++ b/assets/js/components/user-input/UserInputSelectOptions.js
@@ -56,17 +56,26 @@ export default function UserInputSelectOptions( { slug, options, max } ) {
 			newValues.delete( value );
 		}
 
-		if ( name === slug + '-other' && checked === true ) {
-			inputRef.current.handleFocus();
+		if ( name === `${ slug }-other` && checked === true ) {
+			if ( inputRef.current ) {
+				inputRef.current.inputElement.focus();
+			}
 			setDisabled( false );
 		}
 
-		if ( type === 'radio' && id === slug + '-other' ) {
-			inputRef.current.handleFocus();
+		if ( type === 'radio' && id === `${ slug }-other` ) {
+			if ( inputRef.current ) {
+				inputRef.current.inputElement.focus();
+			}
 			setDisabled( false );
 		}
 
-		if ( type !== 'radio' && newValues.size === max && ! newValues.has( '' ) && ! newValues.has( other ) ) {
+		if (
+			type !== 'radio' &&
+			newValues.size === max &&
+			! newValues.has( '' ) &&
+			! newValues.has( other )
+		) {
 			setDisabled( true );
 		} else {
 			setDisabled( false );
@@ -139,7 +148,7 @@ export default function UserInputSelectOptions( { slug, options, max } ) {
 							id={ `${ slug }-select-options` }
 							value={ other }
 							onChange={ onOtherChange }
-							ref={ ( input ) => inputRef.current = input }
+							ref={ inputRef }
 							disabled={ disabled }
 						/>
 					</TextField>

--- a/assets/js/components/user-input/UserInputSelectOptions.js
+++ b/assets/js/components/user-input/UserInputSelectOptions.js
@@ -141,7 +141,7 @@ export default function UserInputSelectOptions( { slug, options, max } ) {
 					</ListComponent>
 
 					<TextField
-						label={ __( 'Other', 'google-site-kit' ) }
+						label={ __( 'Type your own answer', 'google-site-kit' ) }
 						floatingLabelClassName="screen-reader-text"
 					>
 						<Input


### PR DESCRIPTION
## Summary
Enable and disable the Other: input in user-input flow.

Addresses issue #2897  

## Relevant technical choices

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [X] I have added a QA Brief on the issue linked above.
- [X] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
