### PR TITLE
Move fsevents to optionalDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -192,7 +192,6 @@
     "fetch-mock-jest": "^1.3.0",
     "file-loader": "^6.1.1",
     "fs-extra": "^9.0.1",
-    "fsevents": "^2.2.1",
     "git-repo-info": "^2.1.1",
     "husky": "^3.1.0",
     "jest-localstorage-mock": "^2.4.2",
@@ -222,5 +221,8 @@
     "webpack-manifest-plugin": "^2.2.0",
     "webpack-stream": "^5.2.1",
     "webpackbar": "^4.0.0"
+  },
+  "optionalDependencies": {
+    "fsevents": "^2.2.1"
   }
 }


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #2928

## Relevant technical choices

<!-- Please describe your changes. -->
Moves `fsevents` to `optionalDependencies`, since it only works on Macs

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [ ] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
