### PR TITLE
Update 'Choose only' wording on user-input flow questions.

### DIFF
--- a/assets/js/components/user-input/UserInputSelectOptions.js
+++ b/assets/js/components/user-input/UserInputSelectOptions.js
@@ -124,9 +124,9 @@ export default function UserInputSelectOptions( { slug, options, max } ) {
 			</div>
 
 			<p className="googlesitekit-user-input__note">
-				{ max === 1 && __( 'Choose only one (1) answer', 'google-site-kit' ) }
-				{ max === 2 && __( 'Choose only two (2) answers', 'google-site-kit' ) }
-				{ max === 3 && __( 'Choose only three (3) answers', 'google-site-kit' ) }
+				{ max === 1 && __( 'Choose up to one (1) answer', 'google-site-kit' ) }
+				{ max === 2 && __( 'Choose up to two (2) answers', 'google-site-kit' ) }
+				{ max === 3 && __( 'Choose up to three (3) answers', 'google-site-kit' ) }
 			</p>
 		</Cell>
 	);


### PR DESCRIPTION
## Summary

Update 'Choose only' wording on user-input flow questions.

Addresses issue #2857

## Relevant technical choices


## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [X] I have added a QA Brief on the issue linked above.
- [X] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
