### PR TITLE
Remove SunSmallSVG from Alert notifications

### DIFF
--- a/assets/js/components/Alert.js
+++ b/assets/js/components/Alert.js
@@ -32,7 +32,6 @@ import { Component, Fragment } from '@wordpress/element';
  */
 import data, { TYPE_MODULES } from './data';
 import Notification from './legacy-notifications/notification';
-import SunSmallSVG from '../../svg/sun-small.svg';
 
 class Alert extends Component {
 	constructor( props ) {
@@ -83,7 +82,6 @@ class Alert extends Component {
 				key={ item.id }
 				title={ item.title }
 				description={ item.message || item.description }
-				WinImageSVG={ SunSmallSVG }
 				dismiss={ __( 'Dismiss', 'google-site-kit' ) }
 				isDismissable={ item.isDismissible }
 				format="small"


### PR DESCRIPTION
## Summary

Addresses issue #2468 (follow-up)

## Relevant technical choices

* Removes an image that was added to the `Alert` component as part of our transition from all images to svg, where no image was used before
    * Note – this was defined as such in the IB and was missed in review

See https://github.com/google/site-kit-wp/issues/2468#issuecomment-796069561

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
