### PR TITLE
Followup 2653 module setup redirect error

### DIFF
--- a/assets/js/modules/adsense/index.legacy.js
+++ b/assets/js/modules/adsense/index.legacy.js
@@ -20,7 +20,7 @@
  * Internal dependencies
  */
 import { createAddToFilter } from '../../util/helpers';
-import { getSiteKitAdminURL, getModulesData } from '../../util';
+import { getModulesData } from '../../util';
 import AdSenseDashboardWidget from './components/dashboard/AdSenseDashboardWidget';
 import LegacyDashboardEarnings from './components/dashboard/LegacyDashboardEarnings';
 
@@ -48,23 +48,6 @@ if ( modulesData.adsense.active ) {
 			'googlesitekit.DashboardEarningModule',
 			addLegacyDashboardEarnings, 50 );
 	} else {
-		const {
-			reAuth,
-			currentScreen,
-		} = global._googlesitekitLegacyData.admin;
-		const id = currentScreen ? currentScreen.id : null;
-
-		if ( ! reAuth && 'site-kit_page_googlesitekit-module-adsense' === id ) {
-			// Setup incomplete: redirect to the setup flow.
-			global.location = getSiteKitAdminURL(
-				`googlesitekit-module-${ slug }`,
-				{
-					reAuth: true,
-					slug,
-				}
-			);
-		}
-
 		// Show module as connected in the settings when status is pending review.
 		addFilter( `googlesitekit.Connected-${ slug }`,
 			'googlesitekit.AdSenseModuleConnected', ( isConnected ) => {

--- a/assets/js/modules/analytics/index.legacy.js
+++ b/assets/js/modules/analytics/index.legacy.js
@@ -24,7 +24,7 @@ import { addFilter } from '@wordpress/hooks';
 /**
  * Internal dependencies
  */
-import { getSiteKitAdminURL, getModulesData } from '../../util';
+import { getModulesData } from '../../util';
 import { createAddToFilter } from '../../util/helpers';
 import AnalyticsDashboardWidget from './components/dashboard/AnalyticsDashboardWidget';
 import LegacyAnalyticsDashboardWidgetTopLevel from './components/dashboard/LegacyAnalyticsDashboardWidgetTopLevel';
@@ -37,25 +37,6 @@ import LegacyDashboardAllTraffic from './components/dashboard/DashboardAllTraffi
 const slug = 'analytics';
 
 const modulesData = getModulesData();
-
-// If setup is not complete, show the signup flow.
-if ( ! modulesData[ slug ].setupComplete ) {
-	const {
-		reAuth,
-		currentScreen,
-	} = global._googlesitekitLegacyData.admin;
-	const id = currentScreen ? currentScreen.id : null;
-	if ( ! reAuth && 'site-kit_page_googlesitekit-module-analytics' === id ) {
-		// Setup incomplete: redirect to the setup flow.
-		global.location = getSiteKitAdminURL(
-			`googlesitekit-module-${ slug }`,
-			{
-				reAuth: true,
-				slug,
-			}
-		);
-	}
-}
 
 if ( modulesData.analytics.active ) {
 	const addAnalyticsDashboardWidget = createAddToFilter( <AnalyticsDashboardWidget /> );


### PR DESCRIPTION
## Summary

Addresses issue #2653 (follow-up)

## Relevant technical choices

* Replaces legacy client-side redirects to module setup with server side redirect in Module screen trait
* Targets `master` for release

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
