### PR TITLE
Fix for space in other input causing deselection of radio or checkbox.

### DIFF
--- a/assets/js/components/user-input/UserInputSelectOptions.js
+++ b/assets/js/components/user-input/UserInputSelectOptions.js
@@ -99,6 +99,7 @@ export default function UserInputSelectOptions( { slug, options, max } ) {
 	};
 
 	const ListComponent = max === 1 ? Radio : Checkbox;
+
 	const items = Object.keys( options ).map( ( optionSlug ) => {
 		const props = {
 			id: `${ slug }-${ optionSlug }`,
@@ -133,7 +134,7 @@ export default function UserInputSelectOptions( { slug, options, max } ) {
 						id={ `${ slug }-other` }
 						name={ max === 1 ? slug : `${ slug }-other` }
 						value={ other }
-						checked={ values.includes( other ) }
+						checked={ values.includes( other.trim() ) }
 						disabled={ max > 1 && values.length >= max && ! values.includes( other ) }
 						{ ...onClickProps }
 					>


### PR DESCRIPTION
## Summary
Fix for space in other input causing deselection of radio or checkbox.

Addresses issue #2897

## Relevant technical choices

<!-- Please describe your changes. -->

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [X] I have added a QA Brief on the issue linked above.
- [X] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
