### PR TITLE
Fix Other radio/checkbox getting disabled for text input with trailing spaces

### DIFF
--- a/assets/js/components/user-input/UserInputSelectOptions.js
+++ b/assets/js/components/user-input/UserInputSelectOptions.js
@@ -135,7 +135,7 @@ export default function UserInputSelectOptions( { slug, options, max } ) {
 						name={ max === 1 ? slug : `${ slug }-other` }
 						value={ other }
 						checked={ values.includes( other.trim() ) }
-						disabled={ max > 1 && values.length >= max && ! values.includes( other ) }
+						disabled={ max > 1 && values.length >= max && ! values.includes( other.trim() ) }
 						{ ...onClickProps }
 					>
 						{ __( 'Other:', 'google-site-kit' ) }


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #2897 (follow-up to #2950)

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
