### PR TITLE
Ensure URL channels request has been completed if needed for determing AdSense account status

### DIFF
--- a/assets/js/modules/adsense/components/setup/SetupMain.js
+++ b/assets/js/modules/adsense/components/setup/SetupMain.js
@@ -110,6 +110,7 @@ export default function SetupMain( { finishSetup } ) {
 		accounts,
 		clients,
 		alerts,
+		urlChannels,
 		accountsError,
 		alertsError,
 		urlChannelsError,

--- a/assets/js/modules/adsense/util/status.js
+++ b/assets/js/modules/adsense/util/status.js
@@ -46,9 +46,10 @@ export const SITE_STATUS_ADDED = 'added';
  * @param {(Array|undefined)}  data.accounts          List of account objects retrieved from the API.
  * @param {(Array|undefined)}  data.clients           List of client objects retrieved from the API.
  * @param {(Array|undefined)}  data.alerts            List of alert objects retrieved from the API.
+ * @param {(Array|undefined)}  data.urlChannels       List of URL channel objects retrieved from the API.
  * @param {(Object|undefined)} data.accountsError     Error object if account API request failed.
  * @param {(Object|undefined)} data.alertsError       Error object if alert API request failed.
- * @param {(Object|undefined)} data.urlChannelsError  Error object if getURLChannels request failed.
+ * @param {(Object|undefined)} data.urlChannelsError  Error object if URL Channel API request failed.
  * @param {(string|undefined)} data.previousAccountID Account ID, if already known from before.
  * @param {(string|undefined)} data.previousClientID  Client ID, if already known from before.
  * @return {(string|undefined)} Account status determined, or undefined if one of the required
@@ -59,16 +60,13 @@ export function determineAccountStatus( data ) {
 		accounts,
 		clients,
 		alerts,
+		urlChannels,
 		accountsError,
 		alertsError,
 		urlChannelsError,
 		previousAccountID,
 		previousClientID,
 	} = data;
-
-	if ( urlChannelsError ) {
-		return urlChannelsErrorToStatus( urlChannelsError );
-	}
 
 	if ( undefined === accounts || undefined === previousAccountID ) {
 		return accountsErrorToStatus( accountsError );
@@ -99,6 +97,10 @@ export function determineAccountStatus( data ) {
 	const clientID = determineClientID( { clients, previousClientID } );
 	if ( ! clientID ) {
 		return ACCOUNT_STATUS_NO_CLIENT;
+	}
+
+	if ( undefined === urlChannels ) {
+		return urlChannelsErrorToStatus( urlChannelsError );
 	}
 
 	return ACCOUNT_STATUS_APPROVED;

--- a/assets/js/modules/adsense/util/status.test.js
+++ b/assets/js/modules/adsense/util/status.test.js
@@ -109,12 +109,6 @@ const otherURLChannelA = {
 
 describe( 'determineAccountStatus', () => {
 	test.each( [
-		[ 'ACCOUNT_STATUS_PENDING if urlChannelsError has "Ad client not found." message', ACCOUNT_STATUS_PENDING, {
-			urlChannelsError: {
-				code: '404',
-				message: 'Ad client not found.',
-			},
-		} ],
 		[ 'none for noAdSenseAccount error', ACCOUNT_STATUS_NONE, {
 			accounts: undefined,
 			previousAccountID: '',
@@ -183,10 +177,23 @@ describe( 'determineAccountStatus', () => {
 			previousAccountID: '',
 			previousClientID: '',
 		} ],
-		[ 'approved for single account, no alerts, and AFC client', ACCOUNT_STATUS_APPROVED, {
+		[ 'pending for "Ad client not found" URL channels error', ACCOUNT_STATUS_PENDING, {
 			accounts: [ accountA ],
 			alerts: [ otherAlert ],
 			clients: [ afcClientA, afsClientA ],
+			urlChannels: undefined,
+			previousAccountID: '',
+			previousClientID: '',
+			urlChannelsError: {
+				code: '404',
+				message: 'Ad client not found.',
+			},
+		} ],
+		[ 'approved for single account, no alerts, AFC client, and URL channels', ACCOUNT_STATUS_APPROVED, {
+			accounts: [ accountA ],
+			alerts: [ otherAlert ],
+			clients: [ afcClientA, afsClientA ],
+			urlChannels: [],
 			previousAccountID: '',
 			previousClientID: '',
 		} ],


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #2812 (follow-up to #2936)

## Relevant technical choices

* Brings the URL channels logic in line with the existing approach:
    * URL channels are only relevant if the higher-level checks (accounts, clients, alerts) haven't already been enough to know the account status.
    * If that is necessary though, it is crucial that either URL channels have loaded or a URL channels request error has returned.

## Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
