### PR TITLE
Pin wordpress image to 5.6-php7.4 for now

### DIFF
--- a/bin/local-env/docker-compose.yml
+++ b/bin/local-env/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.1'
 
 services:
   wordpress:
-    image: wordpress
+    image: wordpress:5.6-php7.4
     restart: always
     ports:
       - 9002:80


### PR DESCRIPTION
## Summary

Addresses issue #2954 

## Relevant technical choices

<!-- Please describe your changes. -->

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
