### PR TITLE
Refactor durationFormat with createDurationFormat

### DIFF
--- a/assets/js/util/i18n.js
+++ b/assets/js/util/i18n.js
@@ -36,62 +36,110 @@ import { __, sprintf, _x } from '@wordpress/i18n';
  * @since 1.28.0 Refactored and renamed to improve localization.
  * @private
  *
- * @param {number}                     seconds   The number of seconds.
- * @param {(Intl.NumberFormatOptions)} [options] Optional formatting options.
+ * @param {number}                     durationInSeconds The number of seconds.
+ * @param {(Intl.NumberFormatOptions)} [options]         Optional formatting options.
  * @return {string} Human readable string indicating time elapsed.
  */
-const durationFormat = ( seconds, options = {} ) => {
-	options = {
-		unitDisplay: 'short',
-		...options,
-		style: 'unit',
-	};
+const durationFormat = ( durationInSeconds, options = {} ) => {
+	const { formatUnit, formatDecimal } = createDurationFormat( durationInSeconds, options );
 
-	seconds = parseInt( seconds, 10 );
+	try {
+		// Some browsers, e.g. Safari, throw a RangeError when options.style is
+		// not one of decimal, percent, or currency.
+		return formatUnit();
+	} catch {
+		// Fallback to XXh YYm ZZs using localized decimals with hardcoded units.
+		return formatDecimal();
+	}
+};
 
-	if ( Number.isNaN( seconds ) ) {
-		seconds = 0;
+/**
+ * Creates duration formatting utilities.
+ *
+ * Not intended to be used directly.
+ * Use `numFmt( number, { style: 'duration' } )` instead.
+ *
+ * @since n.e.x.t
+ * @private
+ *
+ * @param {number} durationInSeconds Duration to format.
+ * @param {Object} [options]         Formatting options.
+ * @return {Object} Formatting functions.
+ */
+export const createDurationFormat = ( durationInSeconds, options = {} ) => {
+	durationInSeconds = parseInt( durationInSeconds, 10 );
+
+	if ( Number.isNaN( durationInSeconds ) ) {
+		durationInSeconds = 0;
 	}
 
-	let hours = Math.floor( seconds / 60 / 60 ) || '';
-	let minutes = Math.floor( ( seconds / 60 ) % 60 ) || '';
+	const hours = Math.floor( durationInSeconds / 60 / 60 );
+	const minutes = Math.floor( ( durationInSeconds / 60 ) % 60 );
+	const seconds = Math.floor( durationInSeconds % 60 );
 
-	seconds = Math.floor( seconds % 60 ) || '';
-
-	if ( ! hours && ! minutes && ! seconds ) {
-		seconds = 0;
-	}
-
-	if ( hours ) {
-		hours = numberFormat( hours, {
-			...options,
-			unit: 'hour',
-		} );
-	}
-
-	if ( minutes ) {
-		minutes = numberFormat( minutes, {
-			...options,
-			unit: 'minute',
-		} );
-	}
-
-	if ( '' !== seconds ) {
-		seconds = numberFormat( seconds, {
-			...options,
-			unit: 'second',
-		} );
-	}
-
-	const formattedString = sprintf(
-		/* translators: 1: formatted seconds, 2: formatted minutes, 3: formatted hours */
-		_x( '%3$s %2$s %1$s', 'duration of time: hh mm ss', 'google-site-kit' ),
-		seconds,
-		minutes,
+	return {
 		hours,
-	);
+		minutes,
+		seconds,
+		formatUnit() {
+			const { unitDisplay = 'short', ...restOptions } = options;
+			const commonOptions = {
+				unitDisplay,
+				...restOptions,
+				style: 'unit',
+			};
 
-	return formattedString.trim();
+			if ( durationInSeconds === 0 ) {
+				return numberFormat( seconds, { ...commonOptions, unit: 'second' } );
+			}
+
+			return sprintf(
+				/* translators: 1: formatted seconds, 2: formatted minutes, 3: formatted hours */
+				_x( '%3$s %2$s %1$s', 'duration of time: hh mm ss', 'google-site-kit' ),
+				seconds ? numberFormat( seconds, { ...commonOptions, unit: 'second' } ) : '',
+				minutes ? numberFormat( minutes, { ...commonOptions, unit: 'minute' } ) : '',
+				hours ? numberFormat( hours, { ...commonOptions, unit: 'hour' } ) : '',
+			).trim();
+		},
+		/**
+		 * Formats the duration using integers and translatable strings.
+		 * This is only used as a fallback when the above `formatUnit` fails.
+		 *
+		 * @since n.e.x.t
+		 *
+		 * @return {string} Formatted duration.
+		 */
+		formatDecimal() {
+			const formattedSeconds = sprintf(
+				// translators: %s number of seconds with "s" as the abbreviated unit.
+				__( '%ds', 'google-site-kit' ),
+				seconds
+			);
+
+			if ( durationInSeconds === 0 ) {
+				return formattedSeconds;
+			}
+
+			const formattedMinutes = sprintf(
+				// translators: %s number of minutes with "m" as the abbreviated unit.
+				__( '%dm', 'google-site-kit' ),
+				minutes
+			);
+			const formattedHours = sprintf(
+				// translators: %s number of hours with "h" as the abbreviated unit.
+				__( '%dh', 'google-site-kit' ),
+				hours
+			);
+
+			return sprintf(
+				/* translators: 1: formatted seconds, 2: formatted minutes, 3: formatted hours */
+				_x( '%3$s %2$s %1$s', 'duration of time: hh mm ss', 'google-site-kit' ),
+				seconds ? formattedSeconds : '',
+				minutes ? formattedMinutes : '',
+				hours ? formattedHours : '',
+			).trim();
+		},
+	};
 };
 
 /**

--- a/assets/js/util/test/durationFormat.js
+++ b/assets/js/util/test/durationFormat.js
@@ -1,0 +1,103 @@
+/**
+ * Duration Formatting tests.
+ *
+ * Site Kit by Google, Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createDurationFormat } from '../i18n';
+
+describe( 'durationFormat', () => {
+	describe( 'formatUnit', () => {
+		it.each( [
+			[
+				0,
+				{},
+				'0 sec',
+				'en-US',
+			],
+			[
+				0,
+				{ unitDisplay: 'narrow' },
+				'0s',
+				'en-US',
+			],
+			[
+				( 60 * 60 * 3 ) + ( 60 * 5 ) + 12,
+				{},
+				'3 hr 5 min 12 sec',
+				'en-US',
+			],
+			[
+				( 60 * 60 * 3 ) + ( 60 * 5 ) + 12,
+				{ unitDisplay: 'narrow' },
+				'3h 5m 12s',
+				'en-US',
+			],
+			[
+				( 60 * 60 * 3 ) + ( 60 * 5 ) + 12,
+				{ unitDisplay: 'long' },
+				'3 hours 5 minutes 12 seconds',
+				'en-US',
+			],
+		] )( 'formats %s seconds with options %o as %s', ( duration, options, expected, locale ) => {
+			const { formatUnit } = createDurationFormat( duration, { locale, ...options } );
+			expect( formatUnit() ).toStrictEqual( expected );
+		} );
+	} );
+
+	describe( 'formatDecimal', () => {
+		it.each( [
+			[
+				0,
+				'0s',
+			],
+			[
+				9,
+				`9s`,
+			],
+			[
+				12,
+				`12s`,
+			],
+			[
+				35,
+				'35s',
+			],
+			[
+				60,
+				'1m',
+			],
+			[
+				65,
+				'1m 5s',
+			],
+			[
+				125,
+				'2m 5s',
+			],
+			[
+				( 60 * 60 * 3 ) + ( 60 * 5 ) + 12,
+				'3h 5m 12s',
+			],
+			[
+				( 60 * 60 * 7 ) + ( 60 * 2 ) + 42,
+				'7h 2m 42s',
+			],
+		] )( 'formats %s seconds with options %o as %s', ( duration, expected ) => {
+			const { formatDecimal } = createDurationFormat( duration );
+			expect( formatDecimal() ).toStrictEqual( expected );
+		} );
+	} );
+} );


### PR DESCRIPTION
## Summary

Addresses issue #2588 (follow-up to #2818)

This PR primarily fixes a bug in Safari where a fatal client-side error was raised due to lack of support for `Intl.NumberFormat` using `{ style: 'unit' }`. This adds a fallback using translation strings. Not perfect but a little better than what we had previously and more i18n-able.

co-authored with @johnPhillips 

## Relevant technical choices

* Introduces a new `createDurationFormat` utility which `durationFormat` uses internally that allows for easy testing of both try and catch branches of the function
* Targets `master`

## Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
