### PR TITLE
Update formatting of timeofday vAxis labels in AnalyticsDashboardWidgetSiteStats

### DIFF
--- a/assets/js/modules/analytics/components/dashboard/AnalyticsDashboardWidgetSiteStats.js
+++ b/assets/js/modules/analytics/components/dashboard/AnalyticsDashboardWidgetSiteStats.js
@@ -41,12 +41,39 @@ class AnalyticsDashboardWidgetSiteStats extends Component {
 		this.setOptions = this.setOptions.bind( this );
 	}
 
-	setOptions() {
-		const { series, vAxes } = this.props;
+	setOptions( dataMap ) {
+		const {
+			vAxes = null,
+			series,
+			selectedStats,
+		} = this.props;
+		// selectedStats expects an array but only one is ever passed.
+		const [ selectedStat ] = selectedStats;
 
 		const pageTitle = '' === global._googlesitekitLegacyData.pageTitle ? '' : __( 'Users Traffic Summary', 'google-site-kit' );
 
-		const options = {
+		const getTimeColumnVaxisFormat = () => {
+			// Use a format including hours if any of the rows have a non-zero number of hours.
+			for ( let i = 1; i < dataMap.length; i++ ) {
+				// dataMap[ i ] is the row (skipping `0` for headers)
+				// selectedStat is the column index, and `0` for number of hours.
+				if ( dataMap[ i ]?.[ selectedStat ]?.[ 0 ] ) {
+					// Here we use the 24hr time format for hours so that
+					// it starts at zero since we're representing a duration.
+					return 'HH:mm:ss';
+				}
+			}
+			return 'mm:ss';
+		};
+
+		let vAxisFormat;
+		if ( dataMap[ 0 ][ selectedStat ]?.type === 'timeofday' ) {
+			vAxisFormat = getTimeColumnVaxisFormat();
+		}
+
+		return {
+			series,
+			vAxes,
 			chart: {
 				title: pageTitle,
 			},
@@ -76,6 +103,7 @@ class AnalyticsDashboardWidgetSiteStats extends Component {
 				},
 			},
 			vAxis: {
+				format: vAxisFormat,
 				gridlines: {
 					color: '#eee',
 				},
@@ -104,11 +132,6 @@ class AnalyticsDashboardWidgetSiteStats extends Component {
 				trigger: 'both',
 			},
 		};
-
-		options.series = series;
-		options.vAxes = vAxes;
-
-		return options;
 	}
 
 	render() {
@@ -125,7 +148,7 @@ class AnalyticsDashboardWidgetSiteStats extends Component {
 			return null;
 		}
 
-		const options = this.setOptions();
+		const options = this.setOptions( dataMap );
 
 		return (
 			<section className="googlesitekit-analytics-site-stats mdc-layout-grid">


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #2967 

## Relevant technical choices

* Formats the vAxis conditionally based on the selected stat and data
* if the selected stat is a `timeofday` type and there is a row with non-zero hours, it will format it as `HH:mm:ss`, otherwise it will use `mm:ss` to avoid adding a leading `00:00` to each row/tick

Reference: https://developers.google.com/chart/interactive/docs/reference#dateformat

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
