### PR TITLE
Compressed Size Action configuration

### DIFF
--- a/.github/workflows/compressed-size.yml
+++ b/.github/workflows/compressed-size.yml
@@ -1,0 +1,32 @@
+name: Compressed Size
+
+on:
+  pull_request:
+    branches:
+      - develop
+      - master
+    types:
+      - opened
+      - reopened
+      - synchronize
+    paths:
+      - 'assets/js/**.js'
+      - '!assets/js/**.test.js'
+      - '!assets/js/**/test/**'
+      - 'assets/sass/**/*.scss'
+      - 'assets/svg/**/*.svg'
+      - './*.config.js'
+      - './package-lock.json'
+
+jobs:
+  build:
+    name: Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: preactjs/compressed-size-action@v2
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          pattern: "./dist/assets/**/*.{css,js}"
+          # The sub-match below will be replaced by asterisks.
+          # The length of 20 corresponds to webpack's `output.hashDigestLength`.
+          strip-hash: "\\.([a-f0-9]{20})\\.(?:css|js)$"

--- a/.github/workflows/compressed-size.yml
+++ b/.github/workflows/compressed-size.yml
@@ -24,6 +24,21 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.pull_request.draft == false
     steps:
+      - uses: actions/checkout@v2
+      - name: Read .nvmrc
+        run: echo "##[set-output name=NVMRC;]$(cat .nvmrc)"
+        id: nvm
+      - name: Setup Node.js (.nvmrc)
+        uses: actions/setup-node@v1
+        with:
+          node-version: "${{ steps.nvm.outputs.NVMRC }}"
+      - name: Cache Node - npm
+        uses: actions/cache@v1
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-cache-
       - uses: preactjs/compressed-size-action@v2
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/compressed-size.yml
+++ b/.github/workflows/compressed-size.yml
@@ -22,6 +22,7 @@ jobs:
   build:
     name: Check
     runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
     steps:
       - uses: preactjs/compressed-size-action@v2
         with:

--- a/.github/workflows/compressed-size.yml
+++ b/.github/workflows/compressed-size.yml
@@ -25,13 +25,16 @@ jobs:
     if: github.event.pull_request.draft == false
     steps:
       - uses: actions/checkout@v2
+      
       - name: Read .nvmrc
         run: echo "##[set-output name=NVMRC;]$(cat .nvmrc)"
         id: nvm
+      
       - name: Setup Node.js (.nvmrc)
         uses: actions/setup-node@v1
         with:
           node-version: "${{ steps.nvm.outputs.NVMRC }}"
+      
       - name: Cache Node - npm
         uses: actions/cache@v1
         with:
@@ -39,6 +42,7 @@ jobs:
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-node-cache-
+      
       - uses: preactjs/compressed-size-action@v2
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/js-css-lint.yml
+++ b/.github/workflows/js-css-lint.yml
@@ -46,4 +46,4 @@ jobs:
           pattern: "./dist/assets/**/*.{css,js}"
           # The sub-match below will be replaced by asterisks.
           # The length of 20 corresponds to webpack's `output.hashDigestLength`.
-          strip-hash: "\\.\\([a-f0-9]{20})\\.{css,js}$"
+          strip-hash: "\\.([a-f0-9]{20})\\.{css,js}$"

--- a/.github/workflows/js-css-lint.yml
+++ b/.github/workflows/js-css-lint.yml
@@ -39,3 +39,11 @@ jobs:
         run: npm run lint:css
       - name: JS Lint
         run: npm run lint:js
+      - name: Compressed Size
+        uses: preactjs/compressed-size-action@v2
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          pattern: "./dist/assets/**/*.{css,js}"
+          # The sub-match below will be replaced by asterisks.
+          # The length of 20 corresponds to webpack's `output.hashDigestLength`.
+          strip-hash: "\\.\\([a-f0-9]{20})\\.{css,js}$"

--- a/.github/workflows/js-css-lint.yml
+++ b/.github/workflows/js-css-lint.yml
@@ -46,4 +46,4 @@ jobs:
           pattern: "./dist/assets/**/*.{css,js}"
           # The sub-match below will be replaced by asterisks.
           # The length of 20 corresponds to webpack's `output.hashDigestLength`.
-          strip-hash: "\\.([a-f0-9]{20})\\.{css,js}$"
+          strip-hash: "\\.([a-f0-9]{20})\\.(?:css|js)$"

--- a/.github/workflows/js-css-lint.yml
+++ b/.github/workflows/js-css-lint.yml
@@ -39,11 +39,3 @@ jobs:
         run: npm run lint:css
       - name: JS Lint
         run: npm run lint:js
-      - name: Compressed Size
-        uses: preactjs/compressed-size-action@v2
-        with:
-          repo-token: "${{ secrets.GITHUB_TOKEN }}"
-          pattern: "./dist/assets/**/*.{css,js}"
-          # The sub-match below will be replaced by asterisks.
-          # The length of 20 corresponds to webpack's `output.hashDigestLength`.
-          strip-hash: "\\.([a-f0-9]{20})\\.(?:css|js)$"

--- a/.github/workflows/js-tests.yml
+++ b/.github/workflows/js-tests.yml
@@ -37,8 +37,6 @@ jobs:
           PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: true
       - name: Jest Tests
         run: npm run test:js
-      - name: Build JS (Production Version, with tests)
-        run: npm run build:test
       - name: Bundlesize
         uses: preactjs/compressed-size-action@v2
         with:

--- a/.github/workflows/js-tests.yml
+++ b/.github/workflows/js-tests.yml
@@ -41,3 +41,4 @@ jobs:
         uses: preactjs/compressed-size-action@v2
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          pattern: "./dist/assets/**/*.{css,js}"

--- a/.github/workflows/js-tests.yml
+++ b/.github/workflows/js-tests.yml
@@ -37,11 +37,3 @@ jobs:
           PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: true
       - name: Jest Tests
         run: npm run test:js
-      - name: Bundlesize
-        uses: preactjs/compressed-size-action@v2
-        with:
-          repo-token: "${{ secrets.GITHUB_TOKEN }}"
-          pattern: "./dist/assets/**/*.{css,js}"
-          # The sub-match below will be replaced by asterisks.
-          # The length of 20 corresponds to webpack's `output.hashDigestLength`.
-          strip-hash: "\\.\\([a-f0-9]{20})\\.{css,js}$"

--- a/.github/workflows/js-tests.yml
+++ b/.github/workflows/js-tests.yml
@@ -42,3 +42,6 @@ jobs:
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           pattern: "./dist/assets/**/*.{css,js}"
+          # The sub-match below will be replaced by asterisks.
+          # The length of 20 corresponds to webpack's `output.hashDigestLength`.
+          strip-hash: "\\.\\([a-f0-9]{20})\\.{css,js}$"


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #2539 (follow-up)

## Relevant technical choices

* Moves the compressed size check to its own workflow as it currently only works for PRs
    * Included built CSS files in report
    * Scoped workflow to only run when source assets or config files change
    * Added condition to only run on non-drafts
    * This makes sense due to the runtime of this job which runs NPM install and the build two times: once for the current branch and once for the base branch to generate a diff
* Scopes the analyzed files to `dist/assets` only (this excludes some insignificant files in the dist root such as JS files generated for scss inputs)
* Adds `strip-hash` configuration to allow comparing of built files since hashes will always differ
* Configures hash to be replaced by asterisks rather than be completely stripped to differentiate between files that have a hash and those that don't


## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
