### PR TITLE
Add hidden label to user input search terms.

### DIFF
--- a/assets/js/components/user-input/UserInputKeywords.js
+++ b/assets/js/components/user-input/UserInputKeywords.js
@@ -26,7 +26,7 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { useCallback, useRef } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { ENTER } from '@wordpress/keycodes';
 
 /**
@@ -122,16 +122,16 @@ export default function UserInputKeywords( { slug, max } ) {
 						} ) }
 					>
 						<VisuallyHiden>
-							<label
-								htmlFor={ `${ slug }-keyword-${ i }` }
-							>
-								{ __( 'Enter minimum one (1), maximum three (3) terms', 'google-site-kit' ) }
+							<label htmlFor={ `${ slug }-keyword-${ i }` } >
+								{ sprintf(
+									/* translators: %s is the keyword number; 1, 2, or 3 */
+									__( 'Keyword %s', 'google-site-kit' ),
+									i + 1, // Keys are zero-indexed; this starts keyword at "1".
+								) }
 							</label>
 						</VisuallyHiden>
 						<TextField
-							label={ values.length === 1 && values[ 0 ] === ''
-								? __( 'Enter minimum one (1), maximum three (3) terms', 'google-site-kit' )
-								: '' }
+							label={ __( 'Enter minimum one (1), maximum three (3) terms', 'google-site-kit' ) }
 							noLabel
 						>
 							<Input

--- a/assets/js/components/user-input/UserInputKeywords.js
+++ b/assets/js/components/user-input/UserInputKeywords.js
@@ -120,8 +120,16 @@ export default function UserInputKeywords( { slug, max } ) {
 							'googlesitekit-user-input__text-option': values.length > i + 1 || value.length > 0,
 						} ) }
 					>
+						<label
+							htmlFor={ `${ slug }-keyword-${ i }` }
+							className="screen-reader-text"
+						>
+							{ __( 'Enter minimum one (1), maximum three (3) terms', 'google-site-kit' ) }
+						</label>
 						<TextField
-							label={ i + 1 === values.length ? __( 'Enter minimum one (1), maximum three (3) terms', 'google-site-kit' ) : '' }
+							label={ values.length === 1 && values[ 0 ] === ''
+								? __( 'Enter minimum one (1), maximum three (3) terms', 'google-site-kit' )
+								: '' }
 							noLabel
 						>
 							<Input

--- a/assets/js/components/user-input/UserInputKeywords.js
+++ b/assets/js/components/user-input/UserInputKeywords.js
@@ -113,6 +113,12 @@ export default function UserInputKeywords( { slug, max } ) {
 	return (
 		<Cell lgStart={ 6 } lgSize={ 6 } mdSize={ 8 } smSize={ 4 }>
 			<div ref={ keywordsContainer } className="googlesitekit-user-input__text-options">
+				<label
+					htmlFor={ `${ slug }-keyword-0` }
+					className="screen-reader-text"
+				>
+					{ __( 'Enter minimum one (1), maximum three (3) terms', 'google-site-kit' ) }
+				</label>
 				{ values.map( ( value, i ) => (
 					<div
 						key={ i }
@@ -120,12 +126,6 @@ export default function UserInputKeywords( { slug, max } ) {
 							'googlesitekit-user-input__text-option': values.length > i + 1 || value.length > 0,
 						} ) }
 					>
-						<label
-							htmlFor={ `${ slug }-keyword-${ i }` }
-							className="screen-reader-text"
-						>
-							{ __( 'Enter minimum one (1), maximum three (3) terms', 'google-site-kit' ) }
-						</label>
 						<TextField
 							label={ values.length === 1 && values[ 0 ] === ''
 								? __( 'Enter minimum one (1), maximum three (3) terms', 'google-site-kit' )

--- a/assets/js/components/user-input/UserInputKeywords.js
+++ b/assets/js/components/user-input/UserInputKeywords.js
@@ -38,6 +38,7 @@ import { Cell, Input, TextField } from '../../material-components';
 import Button from '../Button';
 import CloseIcon from '../../../svg/close.svg';
 import { COMMA } from '../../util/key-codes';
+import VisuallyHiden from '../VisuallyHidden';
 const { useSelect, useDispatch } = Data;
 
 export default function UserInputKeywords( { slug, max } ) {
@@ -113,12 +114,6 @@ export default function UserInputKeywords( { slug, max } ) {
 	return (
 		<Cell lgStart={ 6 } lgSize={ 6 } mdSize={ 8 } smSize={ 4 }>
 			<div ref={ keywordsContainer } className="googlesitekit-user-input__text-options">
-				<label
-					htmlFor={ `${ slug }-keyword-0` }
-					className="screen-reader-text"
-				>
-					{ __( 'Enter minimum one (1), maximum three (3) terms', 'google-site-kit' ) }
-				</label>
 				{ values.map( ( value, i ) => (
 					<div
 						key={ i }
@@ -126,6 +121,13 @@ export default function UserInputKeywords( { slug, max } ) {
 							'googlesitekit-user-input__text-option': values.length > i + 1 || value.length > 0,
 						} ) }
 					>
+						<VisuallyHiden>
+							<label
+								htmlFor={ `${ slug }-keyword-${ i }` }
+							>
+								{ __( 'Enter minimum one (1), maximum three (3) terms', 'google-site-kit' ) }
+							</label>
+						</VisuallyHiden>
 						<TextField
 							label={ values.length === 1 && values[ 0 ] === ''
 								? __( 'Enter minimum one (1), maximum three (3) terms', 'google-site-kit' )


### PR DESCRIPTION
## Summary

Add hidden label to user input search terms.

Addresses issue #2901 

## Relevant technical choices



## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [X] I have added a QA Brief on the issue linked above.
- [X] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
