### PR TITLE
Fix scrolling in User Input.

### DIFF
--- a/assets/js/components/user-input/UserInputQuestionWrapper.js
+++ b/assets/js/components/user-input/UserInputQuestionWrapper.js
@@ -66,7 +66,6 @@ export default function UserInputQuestionWrapper( props ) {
 					'googlesitekit-user-input__question--next': ! isActive,
 				}
 			) }
-			id={ `googlesitekit-user-input-question-${ questionNumber }` }
 		>
 			<Row>
 				<Cell lgSize={ 12 } mdSize={ 8 } smSize={ 4 }>

--- a/assets/js/components/user-input/UserInputQuestionnaire.js
+++ b/assets/js/components/user-input/UserInputQuestionnaire.js
@@ -101,7 +101,6 @@ export default function UserInputQuestionnaire() {
 		setSingle( singleType );
 		if ( steps.length >= num && num > 0 ) {
 			setActiveSlug( steps[ num - 1 ] );
-			global.scrollTo( 0, 0 );
 		}
 	}, [ activeSlugIndex ] );
 
@@ -132,11 +131,8 @@ export default function UserInputQuestionnaire() {
 			return;
 		}
 
-		// The `activeSlugIndex` deals with a zero-based index, but the IDs
-		// we need to select use a one-based index, hence the ` + 1` here for
-		// the `activeSlugIndex` selector.
-		global.document.getElementById( `googlesitekit-user-input-question-${ activeSlugIndex + 1 }` )?.scrollIntoView( { behavior: 'smooth' } );
-	}, [ activeSlugIndex ] );
+		global.document.querySelector( '#googlesitekit-user-input-container' )?.scrollIntoView( { behavior: 'smooth' } );
+	}, [ activeSlug ] );
 
 	// Update the callbacks and labels for the questions if the user is editing a *single question*.
 	let backCallback = back;
@@ -179,7 +175,7 @@ export default function UserInputQuestionnaire() {
 	}
 
 	return (
-		<Fragment>
+		<div id="googlesitekit-user-input-container">
 			{ settingsProgress }
 
 			{ activeSlugIndex <= steps.indexOf( USER_INPUT_QUESTION_ROLE ) && (
@@ -285,6 +281,6 @@ export default function UserInputQuestionnaire() {
 					error={ error }
 				/>
 			) }
-		</Fragment>
+		</div>
 	);
 }

--- a/assets/js/components/user-input/UserInputQuestionnaire.js
+++ b/assets/js/components/user-input/UserInputQuestionnaire.js
@@ -19,7 +19,7 @@
 /**
  * WordPress dependencies
  */
-import { useCallback, Fragment, useEffect, useState } from '@wordpress/element';
+import { useCallback, Fragment, useEffect, useState, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -54,6 +54,8 @@ export default function UserInputQuestionnaire() {
 	const [ shouldScrollToActiveQuestion, setShouldScrollToActiveQuestion ] = useState( false );
 	const [ redirectURL ] = useQueryArg( 'redirect_url' );
 	const [ single, setSingle ] = useQueryArg( 'single', false );
+
+	const containerRef = useRef();
 
 	const activeSlugIndex = steps.indexOf( activeSlug );
 	if ( activeSlugIndex === -1 ) {
@@ -131,7 +133,7 @@ export default function UserInputQuestionnaire() {
 			return;
 		}
 
-		global.document.querySelector( '#googlesitekit-user-input-container' )?.scrollIntoView( { behavior: 'smooth' } );
+		containerRef.current?.scrollIntoView( { behavior: 'smooth' } );
 	}, [ activeSlug ] );
 
 	// Update the callbacks and labels for the questions if the user is editing a *single question*.
@@ -175,7 +177,7 @@ export default function UserInputQuestionnaire() {
 	}
 
 	return (
-		<div id="googlesitekit-user-input-container">
+		<div ref={ containerRef }>
 			{ settingsProgress }
 
 			{ activeSlugIndex <= steps.indexOf( USER_INPUT_QUESTION_ROLE ) && (


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #2848.

## Relevant technical choices

This checks for changes to the `activeSlug` rather than `activeSlug`, because listening to changes in `activeSlugIndex` meant changes to the "Preview" screen weren't accommodated. This fixes the issues reported here: https://github.com/google/site-kit-wp/issues/2848#issuecomment-802794834

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
