### PR TITLE
Update the colors of the search term bubble and close icon.

### DIFF
--- a/assets/js/components/user-input/UserInputKeywords.js
+++ b/assets/js/components/user-input/UserInputKeywords.js
@@ -136,7 +136,7 @@ export default function UserInputKeywords( { slug, max } ) {
 						{ ( value.length > 0 || i + 1 < values.length ) && (
 							<Button
 								text
-								icon={ <CloseIcon width="14" height="14" /> }
+								icon={ <CloseIcon width="11" height="11" /> }
 								onClick={ onKeywordDelete.bind( null, i ) }
 							/>
 						) }

--- a/assets/sass/components/user-input/googlesitekit-user-input-controls.scss
+++ b/assets/sass/components/user-input/googlesitekit-user-input-controls.scss
@@ -133,15 +133,22 @@
 		button {
 			border-radius: 100px;
 			margin: 0;
-			min-width: 0;
+			min-width: 35px;
 			padding: 0 12px;
 
 			svg {
+				height: 11px;
+				width: 11px;
 
 				path {
-					fill: $c-user-input-placeholder;
+					fill: $c-user-input-color;
 				}
 			}
+		}
+
+		.mdc-text-field .mdc-text-field__input {
+			color: $c-user-input-color;
+			font-weight: 500;
 		}
 	}
 

--- a/assets/sass/components/user-input/googlesitekit-user-input-controls.scss
+++ b/assets/sass/components/user-input/googlesitekit-user-input-controls.scss
@@ -137,8 +137,6 @@
 			padding: 0 12px;
 
 			svg {
-				height: 11px;
-				width: 11px;
 
 				path {
 					fill: $c-user-input-color;

--- a/assets/sass/config/_variables.scss
+++ b/assets/sass/config/_variables.scss
@@ -116,6 +116,7 @@ $c-progress-bg: $c-solitude;
 $c-user-input-options: $c-cape-cod;
 $c-user-input-note: $c-device-icon-gray;
 $c-user-input-placeholder: $c-heather;
+$c-user-input-color: $c-denim;
 
 // Google MDC Theme Overrides
 $mdc-theme-primary: $c-brand;


### PR DESCRIPTION
## Summary

Update the colors of the search term bubble and close icon.

Addresses issue #2896 

## Relevant technical choices

<!-- Please describe your changes. -->

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [X] I have added a QA Brief on the issue linked above.
- [X] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
