### PR TITLE
Add event tracking for feature tours

### DIFF
--- a/assets/js/components/FeatureTours.js
+++ b/assets/js/components/FeatureTours.js
@@ -40,6 +40,7 @@ export default function FeatureTours( { viewContext } ) {
 		<TourTooltips
 			tourID={ nextTour.slug }
 			steps={ nextTour.steps }
+			gaEventCategory={ nextTour.gaEventCategory }
 		/>
 	);
 }

--- a/assets/js/components/TourTooltips.js
+++ b/assets/js/components/TourTooltips.js
@@ -71,6 +71,15 @@ const floaterProps = {
 	},
 };
 
+// GA Event Tracking actions (do not change!)
+export const GA_ACTIONS = {
+	VIEW: 'feature_tooltip_view',
+	NEXT: 'feature_tooltip_advance',
+	PREV: 'feature_tooltip_return',
+	DISMISS: 'feature_tooltip_dismiss',
+	COMPLETE: 'feature_tooltip_complete',
+};
+
 export default function TourTooltips( { steps, tourID, gaEventCategory } ) {
 	const stepKey = `${ tourID }-step`;
 	const runKey = `${ tourID }-run`;
@@ -102,13 +111,13 @@ export default function TourTooltips( { steps, tourID, gaEventCategory } ) {
 		const stepNumber = index + 1;
 
 		if ( type === EVENTS.TOOLTIP && lifecycle === LIFECYCLE.TOOLTIP ) {
-			trackEvent( gaEventCategory, 'feature_tooltip_view', stepNumber );
+			trackEvent( gaEventCategory, GA_ACTIONS.VIEW, stepNumber );
 		} else if ( status === STATUS.FINISHED && type === EVENTS.TOUR_END && size === stepNumber ) {
 			// Here we need to additionally check the size === stepNumber because
 			// it is the only way to differentiate the status/event combination
 			// from an identical combination that happens immediately after completion
 			// on index `0` to avoid duplicate measurement.
-			trackEvent( gaEventCategory, 'feature_tooltip_complete', stepNumber );
+			trackEvent( gaEventCategory, GA_ACTIONS.COMPLETE, stepNumber );
 		}
 
 		if ( lifecycle !== LIFECYCLE.COMPLETE || status === STATUS.FINISHED ) {
@@ -116,11 +125,11 @@ export default function TourTooltips( { steps, tourID, gaEventCategory } ) {
 		}
 
 		if ( action === ACTIONS.CLOSE ) {
-			trackEvent( gaEventCategory, 'feature_tooltip_dismiss', stepNumber );
+			trackEvent( gaEventCategory, GA_ACTIONS.DISMISS, stepNumber );
 		} else if ( action === ACTIONS.PREV ) {
-			trackEvent( gaEventCategory, 'feature_tooltip_return', stepNumber );
+			trackEvent( gaEventCategory, GA_ACTIONS.PREV, stepNumber );
 		} else if ( action === ACTIONS.NEXT ) {
-			trackEvent( gaEventCategory, 'feature_tooltip_advance', stepNumber );
+			trackEvent( gaEventCategory, GA_ACTIONS.NEXT, stepNumber );
 		}
 	};
 

--- a/assets/js/components/TourTooltips.js
+++ b/assets/js/components/TourTooltips.js
@@ -98,6 +98,7 @@ export default function TourTooltips( { steps, tourID, gaEventCategory } ) {
 	};
 
 	const trackAllTourEvents = ( { index, action, lifecycle, size, status, type } ) => {
+		// The index is 0-based, but step numbers are 1-based.
 		const stepNumber = index + 1;
 
 		if ( type === EVENTS.TOOLTIP && lifecycle === LIFECYCLE.TOOLTIP ) {

--- a/assets/js/components/TourTooltips.js
+++ b/assets/js/components/TourTooltips.js
@@ -97,12 +97,16 @@ export default function TourTooltips( { steps, tourID, gaEventCategory } ) {
 		dismissTour( tourID );
 	};
 
-	const trackAllTourEvents = ( { index, action, lifecycle, status, type } ) => {
+	const trackAllTourEvents = ( { index, action, lifecycle, size, status, type } ) => {
 		const stepNumber = index + 1;
 
 		if ( type === EVENTS.TOOLTIP && lifecycle === LIFECYCLE.TOOLTIP ) {
 			trackEvent( gaEventCategory, 'feature_tooltip_view', stepNumber );
-		} else if ( status === STATUS.FINISHED && type === EVENTS.TOUR_END ) {
+		} else if ( status === STATUS.FINISHED && type === EVENTS.TOUR_END && size === stepNumber ) {
+			// Here we need to additionally check the size === stepNumber because
+			// it is the only way to differentiate the status/event combination
+			// from an identical combination that happens immediately after completion
+			// on index `0` to avoid duplicate measurement.
 			trackEvent( gaEventCategory, 'feature_tooltip_complete', stepNumber );
 		}
 

--- a/assets/js/components/TourTooltips.test.js
+++ b/assets/js/components/TourTooltips.test.js
@@ -23,10 +23,12 @@ import { render, createTestRegistry, fireEvent } from '../../../tests/js/test-ut
 import TourTooltips from './TourTooltips';
 import { CORE_UI } from '../googlesitekit/datastore/ui/constants';
 import { CORE_USER } from '../googlesitekit/datastore/user/constants';
+import * as tracking from '../util/tracking';
 
 const SECOND_STEP = 1;
 const FINAL_STEP = 2;
 const TOUR_ID = 'mock-feature';
+const EVENT_CATEGORY = 'test-event-category';
 const STEP_KEY = `${ TOUR_ID }-step`;
 const RUN_KEY = `${ TOUR_ID }-run`;
 const MOCK_STEPS = [
@@ -56,9 +58,16 @@ const MockUIWrapper = ( { children } ) => (
 	</div>
 );
 
+const mockTrackEvent = jest.spyOn( tracking, 'trackEvent' );
+mockTrackEvent.mockImplementation( () => Promise.resolve() );
+
 const renderTourTooltipsWithMockUI = ( registry ) => render( (
 	<MockUIWrapper>
-		<TourTooltips steps={ MOCK_STEPS } tourID={ TOUR_ID } />
+		<TourTooltips
+			steps={ MOCK_STEPS }
+			tourID={ TOUR_ID }
+			gaEventCategory={ EVENT_CATEGORY }
+		/>
 	</MockUIWrapper>
 ), { registry } );
 
@@ -179,5 +188,78 @@ describe( 'TourTooltips', () => {
 		const { queryByRole } = renderTourTooltipsWithMockUI( registry );
 
 		expect( queryByRole( 'alertdialog' ) ).not.toBeInTheDocument();
+	} );
+
+	describe( 'event tracking', () => {
+		beforeEach( () => mockTrackEvent.mockClear() );
+
+		it( 'tracks all events for a completed tour', async () => {
+			const { getByRole } = renderTourTooltipsWithMockUI( registry );
+			await getByRole( 'alertdialog' );
+
+			expect( mockTrackEvent ).toHaveBeenCalledTimes( 1 );
+			expect( mockTrackEvent ).toHaveBeenLastCalledWith( EVENT_CATEGORY, 'feature_tooltip_view', 1 );
+			mockTrackEvent.mockClear();
+
+			// Go to step 2
+			fireEvent.click( getByRole( 'button', { name: /next/i } ) );
+			await getByRole( 'alertdialog' );
+
+			expect( mockTrackEvent ).toHaveBeenCalledTimes( 2 );
+			// Tracks the advance on the 1st step, view on the 2nd step.
+			expect( mockTrackEvent ).toHaveBeenNthCalledWith( 1, EVENT_CATEGORY, 'feature_tooltip_advance', 1 );
+			expect( mockTrackEvent ).toHaveBeenNthCalledWith( 2, EVENT_CATEGORY, 'feature_tooltip_view', 2 );
+			mockTrackEvent.mockClear();
+
+			// Go to step 3
+			fireEvent.click( getByRole( 'button', { name: /next/i } ) );
+			await getByRole( 'alertdialog' );
+
+			expect( mockTrackEvent ).toHaveBeenCalledTimes( 2 );
+			// Tracks the advance on the 1st step, view on the 2nd step.
+			expect( mockTrackEvent ).toHaveBeenNthCalledWith( 1, EVENT_CATEGORY, 'feature_tooltip_advance', 2 );
+			expect( mockTrackEvent ).toHaveBeenNthCalledWith( 2, EVENT_CATEGORY, 'feature_tooltip_view', 3 );
+			mockTrackEvent.mockClear();
+
+			// Finish the tour.
+			fireEvent.click( getByRole( 'button', { name: /got it/i } ) );
+			expect( mockTrackEvent ).toHaveBeenCalledTimes( 1 );
+			expect( mockTrackEvent ).toHaveBeenCalledWith( EVENT_CATEGORY, 'feature_tooltip_complete', 3 );
+		} );
+
+		it( 'tracks all events for a dismissed tour', async () => {
+			const { getByRole } = renderTourTooltipsWithMockUI( registry );
+			await getByRole( 'alertdialog' );
+
+			expect( mockTrackEvent ).toHaveBeenCalledTimes( 1 );
+			expect( mockTrackEvent ).toHaveBeenCalledWith( EVENT_CATEGORY, 'feature_tooltip_view', 1 );
+			mockTrackEvent.mockClear();
+
+			// Dismissing a tour is specific to closing the dialog.
+			fireEvent.click( getByRole( 'button', { name: /close/i } ) );
+			expect( mockTrackEvent ).toHaveBeenCalledTimes( 1 );
+			expect( mockTrackEvent ).toHaveBeenCalledWith( EVENT_CATEGORY, 'feature_tooltip_dismiss', 1 );
+		} );
+
+		it( 'tracks events for navigating between steps', async () => {
+			const { getByRole } = renderTourTooltipsWithMockUI( registry );
+			await getByRole( 'alertdialog' );
+			mockTrackEvent.mockClear();
+
+			// Go to step 2
+			fireEvent.click( getByRole( 'button', { name: /next/i } ) );
+			await getByRole( 'alertdialog' );
+			// Tracks the advance on the 1st step, view on the 2nd step.
+			expect( mockTrackEvent ).toHaveBeenNthCalledWith( 1, EVENT_CATEGORY, 'feature_tooltip_advance', 1 );
+			expect( mockTrackEvent ).toHaveBeenNthCalledWith( 2, EVENT_CATEGORY, 'feature_tooltip_view', 2 );
+			mockTrackEvent.mockClear();
+
+			// Go back to step 1
+			fireEvent.click( getByRole( 'button', { name: /back/i } ) );
+			await getByRole( 'alertdialog' );
+			// Tracks the return on the 2nd step, view on the 1st step.
+			expect( mockTrackEvent ).toHaveBeenNthCalledWith( 1, EVENT_CATEGORY, 'feature_tooltip_return', 2 );
+			expect( mockTrackEvent ).toHaveBeenNthCalledWith( 2, EVENT_CATEGORY, 'feature_tooltip_view', 1 );
+		} );
 	} );
 } );

--- a/assets/js/components/TourTooltips.test.js
+++ b/assets/js/components/TourTooltips.test.js
@@ -20,7 +20,7 @@
  * Internal dependencies
  */
 import { render, createTestRegistry, fireEvent } from '../../../tests/js/test-utils';
-import TourTooltips from './TourTooltips';
+import TourTooltips, { GA_ACTIONS } from './TourTooltips';
 import { CORE_UI } from '../googlesitekit/datastore/ui/constants';
 import { CORE_USER } from '../googlesitekit/datastore/user/constants';
 import * as tracking from '../util/tracking';
@@ -198,7 +198,7 @@ describe( 'TourTooltips', () => {
 			await getByRole( 'alertdialog' );
 
 			expect( mockTrackEvent ).toHaveBeenCalledTimes( 1 );
-			expect( mockTrackEvent ).toHaveBeenLastCalledWith( EVENT_CATEGORY, 'feature_tooltip_view', 1 );
+			expect( mockTrackEvent ).toHaveBeenLastCalledWith( EVENT_CATEGORY, GA_ACTIONS.VIEW, 1 );
 			mockTrackEvent.mockClear();
 
 			// Go to step 2
@@ -207,8 +207,8 @@ describe( 'TourTooltips', () => {
 
 			expect( mockTrackEvent ).toHaveBeenCalledTimes( 2 );
 			// Tracks the advance on the 1st step, view on the 2nd step.
-			expect( mockTrackEvent ).toHaveBeenNthCalledWith( 1, EVENT_CATEGORY, 'feature_tooltip_advance', 1 );
-			expect( mockTrackEvent ).toHaveBeenNthCalledWith( 2, EVENT_CATEGORY, 'feature_tooltip_view', 2 );
+			expect( mockTrackEvent ).toHaveBeenNthCalledWith( 1, EVENT_CATEGORY, GA_ACTIONS.NEXT, 1 );
+			expect( mockTrackEvent ).toHaveBeenNthCalledWith( 2, EVENT_CATEGORY, GA_ACTIONS.VIEW, 2 );
 			mockTrackEvent.mockClear();
 
 			// Go to step 3
@@ -217,14 +217,14 @@ describe( 'TourTooltips', () => {
 
 			expect( mockTrackEvent ).toHaveBeenCalledTimes( 2 );
 			// Tracks the advance on the 1st step, view on the 2nd step.
-			expect( mockTrackEvent ).toHaveBeenNthCalledWith( 1, EVENT_CATEGORY, 'feature_tooltip_advance', 2 );
-			expect( mockTrackEvent ).toHaveBeenNthCalledWith( 2, EVENT_CATEGORY, 'feature_tooltip_view', 3 );
+			expect( mockTrackEvent ).toHaveBeenNthCalledWith( 1, EVENT_CATEGORY, GA_ACTIONS.NEXT, 2 );
+			expect( mockTrackEvent ).toHaveBeenNthCalledWith( 2, EVENT_CATEGORY, GA_ACTIONS.VIEW, 3 );
 			mockTrackEvent.mockClear();
 
 			// Finish the tour.
 			fireEvent.click( getByRole( 'button', { name: /got it/i } ) );
 			expect( mockTrackEvent ).toHaveBeenCalledTimes( 1 );
-			expect( mockTrackEvent ).toHaveBeenCalledWith( EVENT_CATEGORY, 'feature_tooltip_complete', 3 );
+			expect( mockTrackEvent ).toHaveBeenCalledWith( EVENT_CATEGORY, GA_ACTIONS.COMPLETE, 3 );
 		} );
 
 		it( 'tracks all events for a dismissed tour', async () => {
@@ -232,13 +232,13 @@ describe( 'TourTooltips', () => {
 			await getByRole( 'alertdialog' );
 
 			expect( mockTrackEvent ).toHaveBeenCalledTimes( 1 );
-			expect( mockTrackEvent ).toHaveBeenCalledWith( EVENT_CATEGORY, 'feature_tooltip_view', 1 );
+			expect( mockTrackEvent ).toHaveBeenCalledWith( EVENT_CATEGORY, GA_ACTIONS.VIEW, 1 );
 			mockTrackEvent.mockClear();
 
 			// Dismissing a tour is specific to closing the dialog.
 			fireEvent.click( getByRole( 'button', { name: /close/i } ) );
 			expect( mockTrackEvent ).toHaveBeenCalledTimes( 1 );
-			expect( mockTrackEvent ).toHaveBeenCalledWith( EVENT_CATEGORY, 'feature_tooltip_dismiss', 1 );
+			expect( mockTrackEvent ).toHaveBeenCalledWith( EVENT_CATEGORY, GA_ACTIONS.DISMISS, 1 );
 		} );
 
 		it( 'tracks events for navigating between steps', async () => {
@@ -250,16 +250,16 @@ describe( 'TourTooltips', () => {
 			fireEvent.click( getByRole( 'button', { name: /next/i } ) );
 			await getByRole( 'alertdialog' );
 			// Tracks the advance on the 1st step, view on the 2nd step.
-			expect( mockTrackEvent ).toHaveBeenNthCalledWith( 1, EVENT_CATEGORY, 'feature_tooltip_advance', 1 );
-			expect( mockTrackEvent ).toHaveBeenNthCalledWith( 2, EVENT_CATEGORY, 'feature_tooltip_view', 2 );
+			expect( mockTrackEvent ).toHaveBeenNthCalledWith( 1, EVENT_CATEGORY, GA_ACTIONS.NEXT, 1 );
+			expect( mockTrackEvent ).toHaveBeenNthCalledWith( 2, EVENT_CATEGORY, GA_ACTIONS.VIEW, 2 );
 			mockTrackEvent.mockClear();
 
 			// Go back to step 1
 			fireEvent.click( getByRole( 'button', { name: /back/i } ) );
 			await getByRole( 'alertdialog' );
 			// Tracks the return on the 2nd step, view on the 1st step.
-			expect( mockTrackEvent ).toHaveBeenNthCalledWith( 1, EVENT_CATEGORY, 'feature_tooltip_return', 2 );
-			expect( mockTrackEvent ).toHaveBeenNthCalledWith( 2, EVENT_CATEGORY, 'feature_tooltip_view', 1 );
+			expect( mockTrackEvent ).toHaveBeenNthCalledWith( 1, EVENT_CATEGORY, GA_ACTIONS.PREV, 2 );
+			expect( mockTrackEvent ).toHaveBeenNthCalledWith( 2, EVENT_CATEGORY, GA_ACTIONS.VIEW, 1 );
 		} );
 	} );
 } );

--- a/assets/js/feature-tours/index.js
+++ b/assets/js/feature-tours/index.js
@@ -33,6 +33,7 @@ const allTrafficWidget = {
 	slug: 'allTrafficWidget',
 	contexts: [ VIEW_CONTEXT_DASHBOARD ],
 	version: '1.25.0',
+	gaEventCategory: 'all_traffic_widget',
 	checkRequirements: async ( registry ) => {
 		// Here we need to wait for the underlying selector to be resolved before selecting `isModuleConnected`.
 		await registry.__experimentalResolveSelect( CORE_MODULES ).getModules();


### PR DESCRIPTION
## Summary

Addresses issue #2944

## Relevant technical choices

* Added tests for event tracking to the existing component tests as the logic proved to be a bit tricky

## Console logs (logging not included)

* Full tour, with back navigation, completing at end  
![image](https://user-images.githubusercontent.com/1621608/111987908-74346980-8b18-11eb-92f4-89693aeb6df1.png)
* Tour forward to step 2, back to 1, and then dismissing
![image](https://user-images.githubusercontent.com/1621608/111987900-726aa600-8b18-11eb-9250-ee367e86083d.png)

## Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
