### PR TITLE
Followup/2739 disable tours on small viewports

### DIFF
--- a/assets/js/components/FeatureToursDesktop.js
+++ b/assets/js/components/FeatureToursDesktop.js
@@ -1,0 +1,41 @@
+/**
+ * Feature Tours for desktop viewports.
+ *
+ * Site Kit by Google, Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import { useWindowWidth } from '@react-hook/window-size/throttled';
+
+/**
+ * Internal dependencies
+ */
+import FeatureTours from './FeatureTours';
+
+// TODO: Remove this once tour conflicts in smaller viewports are resolved.
+// @see https://github.com/google/site-kit-wp/issues/3003
+export function FeatureToursDesktop( props ) {
+	const windowWidth = useWindowWidth();
+	if ( windowWidth < 783 ) {
+		return null;
+	}
+	return <FeatureTours { ...props } />;
+}
+
+FeatureToursDesktop.propTypes = {
+	...FeatureTours.propTypes,
+};

--- a/assets/js/components/Root/index.js
+++ b/assets/js/components/Root/index.js
@@ -31,7 +31,7 @@ import { enabledFeatures } from '../../features';
 import PermissionsModal from '../PermissionsModal';
 import RestoreSnapshots from '../RestoreSnapshots';
 import CollectModuleData from '../data/collect-module-data';
-import FeatureTours from '../FeatureTours';
+import { FeatureToursDesktop } from '../FeatureToursDesktop';
 
 export default function Root( {
 	children,
@@ -47,7 +47,12 @@ export default function Root( {
 				<ErrorHandler>
 					<RestoreSnapshots>
 						{ children }
-						{ viewContext && <FeatureTours viewContext={ viewContext } /> }
+						{ /*
+							TODO: Replace `FeatureToursDesktop` with `FeatureTours`
+							once tour conflicts in smaller viewports are resolved.
+							@see https://github.com/google/site-kit-wp/issues/3003
+						*/ }
+						{ viewContext && <FeatureToursDesktop viewContext={ viewContext } /> }
 						{ dataAPIContext && (
 						// Legacy dataAPI support.
 							<CollectModuleData context={ dataAPIContext } args={ dataAPIModuleArgs } />


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #2739 (follow-up)

## Relevant technical choices

Adds temporary HOC variant of `FeatureTours` component to only render the normal tours component if the window size is above 782px. This is done over modifying `FeatureTours` to prevent invoking its resolver for `getFeatureToursForView` and unnecessarily "processing" ready tours when we won't show them anyways.

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
