### PR TITLE
Hide all instances of HelpLink and create a generic withFeatureFlag HOC.

### DIFF
--- a/assets/js/components/PageFooter.js
+++ b/assets/js/components/PageFooter.js
@@ -27,9 +27,13 @@ export default function PageFooter() {
 	// If it isn't enabled, show help links in the footer instead.
 	const helpVisibilityEnabled = useFeature( 'helpVisibility' );
 
+	if ( helpVisibilityEnabled ) {
+		return null;
+	}
+
 	return (
 		<div className="googlesitekit-page-footer">
-			{ ! helpVisibilityEnabled && <HelpLink /> }
+			<HelpLink />
 		</div>
 	);
 }

--- a/assets/js/components/higherorder/withFeatureFlag.js
+++ b/assets/js/components/higherorder/withFeatureFlag.js
@@ -1,5 +1,5 @@
 /**
- * ModuleFooter component.
+ * `withFeatureFlag` higher-order component.
  *
  * Site Kit by Google, Copyright 2021 Google LLC
  *
@@ -17,30 +17,24 @@
  */
 
 /**
- * External dependencies
- */
-import classNames from 'classnames';
-
-/**
  * Internal dependencies
  */
-import HelpLink from '../HelpLink';
 import { useFeature } from '../../hooks/useFeature';
 
-const ModuleFooter = () => {
-	const helpVisibilityEnabled = useFeature( 'helpVisibility' );
+const withFeatureFlag = ( featureFlagName ) => ( WrappedComponent ) => {
+	return ( props ) => {
+		const featureFlagEnabled = useFeature( featureFlagName );
+		const newProps = {
+			...props,
+			[ `${ featureFlagName }Enabled` ]: featureFlagEnabled,
+		};
 
-	return (
-		<div className="mdc-layout-grid__inner">
-			<div className={ classNames( [
-				'mdc-layout-grid__cell',
-				'mdc-layout-grid__cell--span-12',
-				'mdc-layout-grid__cell--align-right',
-			] ) }>
-				{ ! helpVisibilityEnabled && <HelpLink /> }
-			</div>
-		</div>
-	);
+		WrappedComponent.displayName = `withFeatureFlag(${ WrappedComponent.displayName || WrappedComponent.name || 'Anonymous' })`;
+
+		return (
+			<WrappedComponent { ...newProps } />
+		);
+	};
 };
 
-export default ModuleFooter;
+export default withFeatureFlag;

--- a/assets/js/components/legacy-setup/SetupUsingGCP.js
+++ b/assets/js/components/legacy-setup/SetupUsingGCP.js
@@ -38,7 +38,7 @@ import { trackEvent, clearWebStorage, getSiteKitAdminURL } from '../../util';
 import STEPS from './wizard-steps';
 import WizardProgressStep from './wizard-progress-step';
 import HelpMenu from '../help/HelpMenu';
-import { useFeature } from '../../hooks/useFeature';
+import withFeatureFlag from '../higherorder/withFeatureFlag';
 
 class SetupUsingGCP extends Component {
 	constructor( props ) {
@@ -303,17 +303,4 @@ class SetupUsingGCP extends Component {
 	}
 }
 
-const withHelpVisibilityFeatureFlag = ( WrappedComponent ) => {
-	return ( props ) => {
-		const helpVisibilityEnabled = useFeature( 'helpVisibility' );
-
-		return (
-			<WrappedComponent
-				{ ...props }
-				helpVisibilityEnabled={ helpVisibilityEnabled }
-			/>
-		);
-	};
-};
-
-export default withHelpVisibilityFeatureFlag( SetupUsingGCP );
+export default withFeatureFlag( 'helpVisibility' )( SetupUsingGCP );

--- a/assets/js/components/legacy-setup/search-console.js
+++ b/assets/js/components/legacy-setup/search-console.js
@@ -36,6 +36,7 @@ import ProgressBar from '../ProgressBar';
 import HelpLink from '../HelpLink';
 import { Select, TextField, Input } from '../../material-components';
 import Button from '../Button';
+import withFeatureFlag from '../higherorder/withFeatureFlag';
 
 class SearchConsole extends Component {
 	constructor( props ) {
@@ -170,6 +171,7 @@ class SearchConsole extends Component {
 	}
 
 	matchedForm() {
+		const { helpVisibilityEnabled } = this.props;
 		const { sites, selectedURL } = this.state;
 
 		if ( ! sites ) {
@@ -204,7 +206,7 @@ class SearchConsole extends Component {
 				</div>
 				<div className="googlesitekit-wizard-step__action googlesitekit-wizard-step__action--justify">
 					<Button onClick={ this.submitPropertyEventHandler }>{ __( 'Continue', 'google-site-kit' ) }</Button>
-					<HelpLink />
+					{ ! helpVisibilityEnabled && <HelpLink /> }
 				</div>
 			</Fragment>
 		);
@@ -226,6 +228,7 @@ class SearchConsole extends Component {
 	}
 
 	noSiteForm() {
+		const { helpVisibilityEnabled } = this.props;
 		const { siteURL } = this.state;
 
 		return (
@@ -245,7 +248,7 @@ class SearchConsole extends Component {
 				</div>
 				<div className="googlesitekit-wizard-step__action googlesitekit-wizard-step__action--justify">
 					<Button onClick={ this.submitPropertyEventHandler }>{ __( 'Continue', 'google-site-kit' ) }</Button>
-					<HelpLink />
+					{ ! helpVisibilityEnabled && <HelpLink /> }
 				</div>
 			</Fragment>
 		);
@@ -308,10 +311,11 @@ class SearchConsole extends Component {
 }
 
 SearchConsole.propTypes = {
+	helpVisibilityEnabled: PropTypes.bool,
 	isAuthenticated: PropTypes.bool.isRequired,
 	shouldSetup: PropTypes.bool.isRequired,
 	searchConsoleSetup: PropTypes.func.isRequired,
 	setErrorMessage: PropTypes.func.isRequired,
 };
 
-export default SearchConsole;
+export default withFeatureFlag( 'helpVisibility' )( SearchConsole );

--- a/assets/js/components/legacy-setup/site-verification.js
+++ b/assets/js/components/legacy-setup/site-verification.js
@@ -39,6 +39,7 @@ import data, { TYPE_MODULES } from '../data';
 import Button from '../Button';
 import ProgressBar from '../ProgressBar';
 import HelpLink from '../HelpLink';
+import withFeatureFlag from '../higherorder/withFeatureFlag';
 
 class SiteVerification extends Component {
 	constructor( props ) {
@@ -160,6 +161,7 @@ class SiteVerification extends Component {
 	}
 
 	renderForm() {
+		const { helpVisibilityEnabled } = this.props;
 		const { loading, loadingMsg, siteURL } = this.state;
 
 		const loadingDiv = (
@@ -193,7 +195,7 @@ class SiteVerification extends Component {
 				</div>
 				<div className="googlesitekit-wizard-step__action googlesitekit-wizard-step__action--justify">
 					<Button onClick={ this.onProceed }>{ __( 'Continue', 'google-site-kit' ) }</Button>
-					<HelpLink />
+					{ ! helpVisibilityEnabled && <HelpLink /> }
 				</div>
 			</Fragment>
 		);
@@ -248,6 +250,7 @@ class SiteVerification extends Component {
 }
 
 SiteVerification.propTypes = {
+	helpVisibilityEnabled: PropTypes.bool,
 	isAuthenticated: PropTypes.bool.isRequired,
 	shouldSetup: PropTypes.bool.isRequired,
 	siteVerificationSetup: PropTypes.func.isRequired,
@@ -255,4 +258,4 @@ SiteVerification.propTypes = {
 	setErrorMessage: PropTypes.func.isRequired,
 };
 
-export default SiteVerification;
+export default withFeatureFlag( 'helpVisibility' )( SiteVerification );

--- a/assets/js/components/legacy-setup/wizard-step-authentication.js
+++ b/assets/js/components/legacy-setup/wizard-step-authentication.js
@@ -35,11 +35,13 @@ import Button from '../Button';
 import Link from '../Link';
 import OptIn from '../OptIn';
 import HelpLink from '../HelpLink';
+import withFeatureFlag from '../higherorder/withFeatureFlag';
 
 class WizardStepAuthentication extends Component {
 	render() {
 		const {
 			connectURL,
+			helpVisibilityEnabled,
 			needReauthenticate,
 			resetAndRestart,
 		} = this.props;
@@ -88,7 +90,7 @@ class WizardStepAuthentication extends Component {
 							<div className="googlesitekit-wizard-step__action googlesitekit-wizard-step__action--justify">
 								<OptIn optinAction="analytics_optin_setup_fallback" />
 
-								<HelpLink />
+								{ ! helpVisibilityEnabled && <HelpLink /> }
 							</div>
 						</div>
 					</div>
@@ -100,7 +102,8 @@ class WizardStepAuthentication extends Component {
 
 WizardStepAuthentication.propTypes = {
 	connectURL: PropTypes.string.isRequired,
+	helpVisibilityEnabled: PropTypes.bool,
 	resetAndRestart: PropTypes.func,
 };
 
-export default WizardStepAuthentication;
+export default withFeatureFlag( 'helpVisibility' )( WizardStepAuthentication );

--- a/assets/js/components/module/ModuleFooter.js
+++ b/assets/js/components/module/ModuleFooter.js
@@ -30,6 +30,10 @@ import { useFeature } from '../../hooks/useFeature';
 const ModuleFooter = () => {
 	const helpVisibilityEnabled = useFeature( 'helpVisibility' );
 
+	if ( helpVisibilityEnabled ) {
+		return null;
+	}
+
 	return (
 		<div className="mdc-layout-grid__inner">
 			<div className={ classNames( [
@@ -37,7 +41,7 @@ const ModuleFooter = () => {
 				'mdc-layout-grid__cell--span-12',
 				'mdc-layout-grid__cell--align-right',
 			] ) }>
-				{ ! helpVisibilityEnabled && <HelpLink /> }
+				<HelpLink />
 			</div>
 		</div>
 	);

--- a/assets/js/components/module/ModuleFooter.js
+++ b/assets/js/components/module/ModuleFooter.js
@@ -17,33 +17,13 @@
  */
 
 /**
- * External dependencies
- */
-import classNames from 'classnames';
-
-/**
  * Internal dependencies
  */
-import HelpLink from '../HelpLink';
-import { useFeature } from '../../hooks/useFeature';
+import PageFooter from '../PageFooter';
 
 const ModuleFooter = () => {
-	const helpVisibilityEnabled = useFeature( 'helpVisibility' );
-
-	if ( helpVisibilityEnabled ) {
-		return null;
-	}
-
 	return (
-		<div className="mdc-layout-grid__inner">
-			<div className={ classNames( [
-				'mdc-layout-grid__cell',
-				'mdc-layout-grid__cell--span-12',
-				'mdc-layout-grid__cell--align-right',
-			] ) }>
-				<HelpLink />
-			</div>
-		</div>
+		<PageFooter />
 	);
 };
 

--- a/assets/js/components/settings/SettingsApp.js
+++ b/assets/js/components/settings/SettingsApp.js
@@ -139,9 +139,11 @@ export default function SettingsApp() {
 						{ 'admin' === activeTabID && (
 							<SettingsAdmin />
 						) }
-						<Cell size={ 12 } alignRight>
-							{ ! helpVisibilityEnabled && <HelpLink /> }
-						</Cell>
+						{ ! helpVisibilityEnabled && (
+							<Cell size={ 12 } alignRight>
+								<HelpLink />
+							</Cell>
+						) }
 					</Row>
 				</Grid>
 			</div>

--- a/assets/js/components/settings/SettingsApp.js
+++ b/assets/js/components/settings/SettingsApp.js
@@ -140,7 +140,7 @@ export default function SettingsApp() {
 							<SettingsAdmin />
 						) }
 						<Cell size={ 12 } alignRight>
-							<HelpLink />
+							{ ! helpVisibilityEnabled && <HelpLink /> }
 						</Cell>
 					</Row>
 				</Grid>

--- a/assets/js/components/setup/ModuleSetup.js
+++ b/assets/js/components/setup/ModuleSetup.js
@@ -142,7 +142,7 @@ export default function ModuleSetup( { moduleSlug } ) {
 													mdc-layout-grid__cell--span-6-desktop
 													mdc-layout-grid__cell--align-right
 											">
-												<HelpLink />
+												{ ! helpVisibilityEnabled && <HelpLink /> }
 											</div>
 										</div>
 									</div>

--- a/assets/js/components/setup/ModuleSetup.js
+++ b/assets/js/components/setup/ModuleSetup.js
@@ -135,15 +135,17 @@ export default function ModuleSetup( { moduleSlug } ) {
 													href={ settingsPageURL }
 												>{ __( 'Cancel', 'google-site-kit' ) }</Link>
 											</div>
-											<div className="
+											{ ! helpVisibilityEnabled && (
+												<div className="
 													mdc-layout-grid__cell
 													mdc-layout-grid__cell--span-2-phone
 													mdc-layout-grid__cell--span-4-tablet
 													mdc-layout-grid__cell--span-6-desktop
 													mdc-layout-grid__cell--align-right
-											">
-												{ ! helpVisibilityEnabled && <HelpLink /> }
-											</div>
+												">
+													<HelpLink />
+												</div>
+											) }
 										</div>
 									</div>
 								</div>

--- a/assets/js/modules/adsense/components/dashboard/AdSenseDashboardWidget.js
+++ b/assets/js/modules/adsense/components/dashboard/AdSenseDashboardWidget.js
@@ -195,9 +195,11 @@ export default function AdSenseDashboardWidget() {
 							<DashboardAdSenseTopPages />
 						</Cell>
 
-						<Cell alignRight size={ 12 }>
-							{ ! helpVisibilityEnabled && <HelpLink /> }
-						</Cell>
+						{ ! helpVisibilityEnabled && (
+							<Cell alignRight size={ 12 }>
+								<HelpLink />
+							</Cell>
+						) }
 					</Row>
 				</Grid>
 			</div>

--- a/assets/js/modules/adsense/components/dashboard/AdSenseDashboardWidget.js
+++ b/assets/js/modules/adsense/components/dashboard/AdSenseDashboardWidget.js
@@ -43,6 +43,7 @@ import { STORE_NAME, DATE_RANGE_OFFSET } from '../../../adsense/datastore/consta
 import { Cell, Grid, Row } from '../../../../material-components';
 import { getCurrentDateRangeDayCount } from '../../../../util/date-range';
 import { generateDateRangeArgs } from '../../../adsense/util/report-date-range-args';
+import { useFeature } from '../../../../hooks/useFeature';
 
 const { useSelect } = Data;
 
@@ -50,6 +51,8 @@ const { useSelect } = Data;
 const AdSenseDashboardZeroData = withFilters( 'googlesitekit.AdSenseDashboardZeroData' )( () => null );
 
 export default function AdSenseDashboardWidget() {
+	const helpVisibilityEnabled = useFeature( 'helpVisibility' );
+
 	const [ receivingData, setReceivingData ] = useState( true );
 	const [ error, setError ] = useState( false );
 	const [ errorObj, setErrorObj ] = useState();
@@ -193,7 +196,7 @@ export default function AdSenseDashboardWidget() {
 						</Cell>
 
 						<Cell alignRight size={ 12 }>
-							<HelpLink />
+							{ ! helpVisibilityEnabled && <HelpLink /> }
 						</Cell>
 					</Row>
 				</Grid>

--- a/assets/js/modules/analytics/components/dashboard/AnalyticsDashboardWidget.js
+++ b/assets/js/modules/analytics/components/dashboard/AnalyticsDashboardWidget.js
@@ -46,10 +46,13 @@ import HelpLink from '../../../../components/HelpLink';
 import { getCurrentDateRangeDayCount } from '../../../../util/date-range';
 import { CORE_USER } from '../../../../googlesitekit/datastore/user/constants';
 import { STORE_NAME } from '../../datastore/constants';
+import { useFeature } from '../../../../hooks/useFeature';
 
 const { useSelect } = Data;
 
 export default function AnalyticsDashboardWidget() {
+	const helpVisibilityEnabled = useFeature( 'helpVisibility' );
+
 	const [ selectedStats, setSelectedStats ] = useState( [ 0 ] );
 	const [ receivingData, setReceivingData ] = useState( true );
 	const [ error, setError ] = useState( false );
@@ -262,7 +265,7 @@ export default function AnalyticsDashboardWidget() {
 								mdc-layout-grid__cell--span-12
 								mdc-layout-grid__cell--align-right
 							">
-							<HelpLink />
+							{ ! helpVisibilityEnabled && <HelpLink /> }
 						</div>
 					</div>
 				</div>

--- a/assets/js/modules/analytics/components/dashboard/AnalyticsDashboardWidget.js
+++ b/assets/js/modules/analytics/components/dashboard/AnalyticsDashboardWidget.js
@@ -260,13 +260,15 @@ export default function AnalyticsDashboardWidget() {
 								</div>
 							</Layout>
 						</div>
-						<div className="
+						{ ! helpVisibilityEnabled && (
+							<div className="
 								mdc-layout-grid__cell
 								mdc-layout-grid__cell--span-12
 								mdc-layout-grid__cell--align-right
 							">
-							{ ! helpVisibilityEnabled && <HelpLink /> }
-						</div>
+								<HelpLink />
+							</div>
+						) }
 					</div>
 				</div>
 			</div>

--- a/assets/js/modules/search-console/components/dashboard/GoogleSitekitSearchConsoleDashboardWidget.js
+++ b/assets/js/modules/search-console/components/dashboard/GoogleSitekitSearchConsoleDashboardWidget.js
@@ -250,13 +250,15 @@ const GoogleSitekitSearchConsoleDashboardWidget = () => {
 								<LegacySearchConsoleDashboardWidgetKeywordTable />
 							</Layout>
 						</div>
-						<div className="
-							mdc-layout-grid__cell
-							mdc-layout-grid__cell--span-12
-							mdc-layout-grid__cell--align-right
-						">
-							{ ! helpVisibilityEnabled && <HelpLink /> }
-						</div>
+						{ ! helpVisibilityEnabled && (
+							<div className="
+								mdc-layout-grid__cell
+								mdc-layout-grid__cell--span-12
+								mdc-layout-grid__cell--align-right
+							">
+								<HelpLink />
+							</div>
+						) }
 					</div>
 				</div>
 			</div>

--- a/assets/js/modules/search-console/components/dashboard/GoogleSitekitSearchConsoleDashboardWidget.js
+++ b/assets/js/modules/search-console/components/dashboard/GoogleSitekitSearchConsoleDashboardWidget.js
@@ -47,10 +47,13 @@ import { CORE_USER } from '../../../../googlesitekit/datastore/user/constants';
 import { CORE_SITE } from '../../../../googlesitekit/datastore/site/constants';
 import { untrailingslashit } from '../../../../util';
 import { generateDateRangeArgs } from '../../util/report-date-range-args';
+import { useFeature } from '../../../../hooks/useFeature';
 
 const { useSelect } = Data;
 
 const GoogleSitekitSearchConsoleDashboardWidget = () => {
+	const helpVisibilityEnabled = useFeature( 'helpVisibility' );
+
 	const [ selectedStats, setSelectedStats ] = useState( [ 0, 1 ] );
 	const [ receivingData, setReceivingData ] = useState( true );
 	const [ error, setError ] = useState( false );
@@ -248,11 +251,11 @@ const GoogleSitekitSearchConsoleDashboardWidget = () => {
 							</Layout>
 						</div>
 						<div className="
-								mdc-layout-grid__cell
-								mdc-layout-grid__cell--span-12
-								mdc-layout-grid__cell--align-right
-							">
-							<HelpLink />
+							mdc-layout-grid__cell
+							mdc-layout-grid__cell--span-12
+							mdc-layout-grid__cell--align-right
+						">
+							{ ! helpVisibilityEnabled && <HelpLink /> }
 						</div>
 					</div>
 				</div>


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #2846.

This hides the HelpLink everywhere when `helpVisibility` is enabled.

## Relevant technical choices

Added a more generic `withFeatureFlag` HOC as it was needed by several components.

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
