### PR TITLE
Always scroll to top of User Input.

### DIFF
--- a/assets/js/components/user-input/UserInputQuestionnaire.js
+++ b/assets/js/components/user-input/UserInputQuestionnaire.js
@@ -19,7 +19,7 @@
 /**
  * WordPress dependencies
  */
-import { useCallback, Fragment, useEffect, useState, useRef } from '@wordpress/element';
+import { useCallback, Fragment, useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -55,8 +55,6 @@ export default function UserInputQuestionnaire() {
 	const [ shouldScrollToActiveQuestion, setShouldScrollToActiveQuestion ] = useState( false );
 	const [ redirectURL ] = useQueryArg( 'redirect_url' );
 	const [ single, setSingle ] = useQueryArg( 'single', false );
-
-	const containerRef = useRef();
 
 	const activeSlugIndex = steps.indexOf( activeSlug );
 	if ( activeSlugIndex === -1 ) {
@@ -201,7 +199,7 @@ export default function UserInputQuestionnaire() {
 	}
 
 	return (
-		<div ref={ containerRef }>
+		<div>
 			{ settingsProgress }
 
 			{ activeSlugIndex <= steps.indexOf( USER_INPUT_QUESTION_ROLE ) && (

--- a/assets/js/components/user-input/UserInputQuestionnaire.js
+++ b/assets/js/components/user-input/UserInputQuestionnaire.js
@@ -157,7 +157,7 @@ export default function UserInputQuestionnaire() {
 			return;
 		}
 
-		containerRef.current?.scrollIntoView( { behavior: 'smooth' } );
+		global.document?.querySelector( '.googlesitekit-user-input__header' )?.scrollIntoView( { behavior: 'smooth' } );
 	}, [ activeSlug ] );
 
 	// Update the callbacks and labels for the questions if the user is editing a *single question*.


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #2848.

## Relevant technical choices

In the end the only consistent way to get a good scrolling experience was to use a querySelector rather than a ref.

When this moves to React Router it should be less of a problem, but for now this is the best UX.

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
