### PR TITLE
Update tour event tracking to always track close as dismiss and add test

### DIFF
--- a/assets/js/components/TourTooltips.js
+++ b/assets/js/components/TourTooltips.js
@@ -112,11 +112,18 @@ export default function TourTooltips( { steps, tourID, gaEventCategory } ) {
 
 		if ( type === EVENTS.TOOLTIP && lifecycle === LIFECYCLE.TOOLTIP ) {
 			trackEvent( gaEventCategory, GA_ACTIONS.VIEW, stepNumber );
-		} else if ( status === STATUS.FINISHED && type === EVENTS.TOUR_END && size === stepNumber ) {
+		} else if ( action === ACTIONS.CLOSE && lifecycle === LIFECYCLE.COMPLETE ) {
+			trackEvent( gaEventCategory, GA_ACTIONS.DISMISS, stepNumber );
+		} else if (
+			action === ACTIONS.NEXT &&
+			status === STATUS.FINISHED &&
+			type === EVENTS.TOUR_END &&
 			// Here we need to additionally check the size === stepNumber because
 			// it is the only way to differentiate the status/event combination
 			// from an identical combination that happens immediately after completion
 			// on index `0` to avoid duplicate measurement.
+			size === stepNumber
+		) {
 			trackEvent( gaEventCategory, GA_ACTIONS.COMPLETE, stepNumber );
 		}
 
@@ -124,11 +131,10 @@ export default function TourTooltips( { steps, tourID, gaEventCategory } ) {
 			return;
 		}
 
-		if ( action === ACTIONS.CLOSE ) {
-			trackEvent( gaEventCategory, GA_ACTIONS.DISMISS, stepNumber );
-		} else if ( action === ACTIONS.PREV ) {
+		if ( action === ACTIONS.PREV ) {
 			trackEvent( gaEventCategory, GA_ACTIONS.PREV, stepNumber );
-		} else if ( action === ACTIONS.NEXT ) {
+		}
+		if ( action === ACTIONS.NEXT ) {
 			trackEvent( gaEventCategory, GA_ACTIONS.NEXT, stepNumber );
 		}
 	};

--- a/assets/js/components/TourTooltips.test.js
+++ b/assets/js/components/TourTooltips.test.js
@@ -216,15 +216,16 @@ describe( 'TourTooltips', () => {
 			await getByRole( 'alertdialog' );
 
 			expect( mockTrackEvent ).toHaveBeenCalledTimes( 2 );
-			// Tracks the advance on the 1st step, view on the 2nd step.
+			// Tracks the advance on the 2nd step, view on the 3rd step.
 			expect( mockTrackEvent ).toHaveBeenNthCalledWith( 1, EVENT_CATEGORY, GA_ACTIONS.NEXT, 2 );
 			expect( mockTrackEvent ).toHaveBeenNthCalledWith( 2, EVENT_CATEGORY, GA_ACTIONS.VIEW, 3 );
 			mockTrackEvent.mockClear();
 
 			// Finish the tour.
 			fireEvent.click( getByRole( 'button', { name: /got it/i } ) );
-			expect( mockTrackEvent ).toHaveBeenCalledTimes( 1 );
 			expect( mockTrackEvent ).toHaveBeenCalledWith( EVENT_CATEGORY, GA_ACTIONS.COMPLETE, 3 );
+			expect( mockTrackEvent ).not.toHaveBeenCalledWith( EVENT_CATEGORY, GA_ACTIONS.DISMISS, 3 );
+			expect( mockTrackEvent ).toHaveBeenCalledTimes( 1 );
 		} );
 
 		it( 'tracks all events for a dismissed tour', async () => {
@@ -239,6 +240,24 @@ describe( 'TourTooltips', () => {
 			fireEvent.click( getByRole( 'button', { name: /close/i } ) );
 			expect( mockTrackEvent ).toHaveBeenCalledTimes( 1 );
 			expect( mockTrackEvent ).toHaveBeenCalledWith( EVENT_CATEGORY, GA_ACTIONS.DISMISS, 1 );
+		} );
+
+		it( 'tracks all events for a dismissed tour on the last step', async () => {
+			const { getByRole } = renderTourTooltipsWithMockUI( registry );
+			await getByRole( 'alertdialog' );
+			// Go to step 2/3
+			fireEvent.click( getByRole( 'button', { name: /next/i } ) );
+			await getByRole( 'alertdialog' );
+			// Go to step 3/3
+			fireEvent.click( getByRole( 'button', { name: /next/i } ) );
+			await getByRole( 'alertdialog' );
+			mockTrackEvent.mockClear();
+			// Dismissing a tour is specific to closing the dialog.
+			fireEvent.click( getByRole( 'button', { name: /close/i } ) );
+
+			expect( mockTrackEvent ).toHaveBeenCalledWith( EVENT_CATEGORY, GA_ACTIONS.DISMISS, 3 );
+			expect( mockTrackEvent ).not.toHaveBeenCalledWith( EVENT_CATEGORY, GA_ACTIONS.COMPLETE, 3 );
+			expect( mockTrackEvent ).toHaveBeenCalledTimes( 1 );
 		} );
 
 		it( 'tracks events for navigating between steps', async () => {


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #2944 (follow-up)

This PR updates the logic used for tour event tracking to address an inconsistency that came up in QA https://github.com/google/site-kit-wp/issues/2944#issuecomment-806331644 where dismissing the tour on the last step was tracked as a completion event instead of a dismissal.

**Targets `master`**

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
