### PR TITLE
Add tracking to help menu links.

### DIFF
--- a/assets/js/components/Menu.js
+++ b/assets/js/components/Menu.js
@@ -109,4 +109,8 @@ Menu.propTypes = {
 	id: PropTypes.string.isRequired,
 };
 
+Menu.defaultProps = {
+	onSelected: () => {},
+};
+
 export default Menu;

--- a/assets/js/components/Menu.js
+++ b/assets/js/components/Menu.js
@@ -107,6 +107,7 @@ Menu.propTypes = {
 	menuOpen: PropTypes.bool.isRequired,
 	menuItems: PropTypes.array,
 	id: PropTypes.string.isRequired,
+	onSelected: PropTypes.func,
 };
 
 Menu.defaultProps = {

--- a/assets/js/components/help/HelpMenu.js
+++ b/assets/js/components/help/HelpMenu.js
@@ -83,15 +83,16 @@ function HelpMenu( { children } ) {
 					ref={ menuRef }
 					menuOpen={ menuOpen }
 					id="googlesitekit-help-menu"
+					onSelected={ () => {} }
 				>
 					{ children }
-					<HelpMenuLink href="https://sitekit.withgoogle.com/documentation/fix-common-issues/">
+					<HelpMenuLink gaEventLabel="fix_common_issues" href="https://sitekit.withgoogle.com/documentation/fix-common-issues/">
 						{ __( 'Fix common issues', 'google-site-kit' ) }
 					</HelpMenuLink>
-					<HelpMenuLink href="https://sitekit.withgoogle.com/documentation/">
+					<HelpMenuLink gaEventLabel="documentation" href="https://sitekit.withgoogle.com/documentation/">
 						{ __( 'Read help docs', 'google-site-kit' ) }
 					</HelpMenuLink>
-					<HelpMenuLink href="https://wordpress.org/support/plugin/google-site-kit/">
+					<HelpMenuLink gaEventLabel="support_forum" href="https://wordpress.org/support/plugin/google-site-kit/">
 						{ __( 'Get support', 'google-site-kit' ) }
 					</HelpMenuLink>
 				</Menu>

--- a/assets/js/components/help/HelpMenu.js
+++ b/assets/js/components/help/HelpMenu.js
@@ -83,7 +83,6 @@ function HelpMenu( { children } ) {
 					ref={ menuRef }
 					menuOpen={ menuOpen }
 					id="googlesitekit-help-menu"
-					onSelected={ () => {} }
 				>
 					{ children }
 					<HelpMenuLink gaEventLabel="fix_common_issues" href="https://sitekit.withgoogle.com/documentation/fix-common-issues/">

--- a/assets/js/components/help/HelpMenuLink.js
+++ b/assets/js/components/help/HelpMenuLink.js
@@ -22,11 +22,23 @@
 import PropTypes from 'prop-types';
 
 /**
+ * WordPress dependencies
+ */
+import { useCallback } from '@wordpress/element';
+
+/**
  * Internal dependencies
  */
 import Link from '../Link';
+import { trackEvent } from '../../util';
 
-function HelpMenuLink( { children, href } ) {
+function HelpMenuLink( { children, href, gaEventLabel } ) {
+	const onClick = useCallback( async () => {
+		if ( gaEventLabel ) {
+			await trackEvent( 'global_help_menu', 'click_outgoing_link', gaEventLabel );
+		}
+	}, [] );
+
 	return (
 		<li className="googlesitekit-help-menu-link mdc-list-item" role="none">
 			<Link
@@ -36,6 +48,7 @@ function HelpMenuLink( { children, href } ) {
 				hideExternalIndicator
 				inherit
 				role="menuitem"
+				onClick={ onClick }
 			>
 				{ children }
 			</Link>
@@ -46,6 +59,7 @@ function HelpMenuLink( { children, href } ) {
 HelpMenuLink.propTypes = {
 	children: PropTypes.node.isRequired,
 	href: PropTypes.string.isRequired,
+	gaEventLabel: PropTypes.string,
 };
 
 export default HelpMenuLink;

--- a/assets/js/components/help/HelpMenuLink.js
+++ b/assets/js/components/help/HelpMenuLink.js
@@ -37,7 +37,7 @@ function HelpMenuLink( { children, href, gaEventLabel } ) {
 		if ( gaEventLabel ) {
 			await trackEvent( 'global_help_menu', 'click_outgoing_link', gaEventLabel );
 		}
-	}, [] );
+	}, [ gaEventLabel ] );
 
 	return (
 		<li className="googlesitekit-help-menu-link mdc-list-item" role="none">

--- a/assets/js/components/module/ModuleApp.js
+++ b/assets/js/components/module/ModuleApp.js
@@ -59,7 +59,7 @@ function ModuleApp( { moduleSlug } ) {
 				{ helpVisibilityEnabled && (
 					<HelpMenu>
 						{ moduleSlug === 'adsense' && (
-							<HelpMenuLink href="https://support.google.com/adsense/">
+							<HelpMenuLink gaEventLabel="adsense_help" href="https://support.google.com/adsense/">
 								{ __( 'Get help with AdSense', 'google-site-kit' ) }
 							</HelpMenuLink>
 						) }


### PR DESCRIPTION
## Summary

Add tracking to help menu links.

Addresses issue #3027 

## Relevant technical choices

<!-- Please describe your changes. -->

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [X] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
