### PR TITLE
Fix module deactivation in active/connected modules view

### DIFF
--- a/assets/js/components/settings/settings-module.js
+++ b/assets/js/components/settings/settings-module.js
@@ -68,6 +68,7 @@ class SettingsModule extends Component {
 		super( props );
 		this.state = {
 			isSaving: false,
+			active: props.active,
 			setupComplete: props.setupComplete,
 			dialogActive: false,
 		};


### PR DESCRIPTION
## Summary

Addresses issue #2184 (follow-up)

Fixes an [issue raised in QA](https://github.com/google/site-kit-wp/issues/2184#issuecomment-811134311) where modules were no longer able to be deactivated via _Settings > Connected Services_.

## Relevant technical choices

- Restores initialization of `state.active` from props ([removed in original PR](https://github.com/google/site-kit-wp/pull/2836/files?file-filters%5B%5D=.js&file-filters%5B%5D=.json&file-filters%5B%5D=.php&file-filters%5B%5D=.scss&hide-deleted-files=true#diff-6d33cbec4183cae98c82ae1d28df73b2c5e5c0c0987187e73446c1e33c33d2ceL72)) so that deactivation works as expected in `activateOrDeactivate`

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
