### PR TITLE
Remove hit term from codebase where problematic

### DIFF
--- a/assets/js/googlesitekit/api/middleware/preloading.js
+++ b/assets/js/googlesitekit/api/middleware/preloading.js
@@ -25,7 +25,7 @@ import { getStablePath } from '@wordpress/api-fetch/build/middlewares/preloading
  * Creates a preloading middleware.
  *
  * Based on preloadMiddleware from from @wordpress/api-fetch, this middle is a single-use per-endpoint and provides cached
- * data for the first request only and any subsequent requests hit the server.
+ * data for the first request only and any subsequent requests reach the server.
  *
  * @since 1.13.0
  *

--- a/assets/js/modules/analytics/components/dashboard/AnalyticsAdSenseDashboardWidgetTopPagesTable.js
+++ b/assets/js/modules/analytics/components/dashboard/AnalyticsAdSenseDashboardWidgetTopPagesTable.js
@@ -145,7 +145,7 @@ const getDataError = ( data ) => {
 		return data.message;
 	}
 
-	// Legacy errors? Maybe this is never hit but better be safe than sorry.
+	// Legacy errors? Maybe this is never reached but better be safe than sorry.
 	if ( data.error ) {
 		if ( data.error.message ) {
 			return data.error.message;

--- a/assets/js/modules/analytics/components/dashboard/LegacyAdSenseDashboardWidgetTopPagesTableSmall.js
+++ b/assets/js/modules/analytics/components/dashboard/LegacyAdSenseDashboardWidgetTopPagesTableSmall.js
@@ -141,7 +141,7 @@ const getDataError = ( data ) => {
 		return data.message;
 	}
 
-	// Legacy errors? Maybe this is never hit but better be safe than sorry.
+	// Legacy errors? Maybe this is never reached but better be safe than sorry.
 	if ( data && data.errors ) {
 		const errors = Object.values( data.errors );
 		if ( errors[ 0 ] && errors[ 0 ][ 0 ] ) {


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #3031 (follow-up to #3032)

## Relevant technical choices

* Removes the term "hit" from the codebase, except in "cache hit" where it's acceptable.

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
