### PR TITLE
Set the chart area to 87% and remove the left attribute for Google Ch…

### DIFF
--- a/assets/js/modules/search-console/components/module/ModuleOverviewWidget/Stats.js
+++ b/assets/js/modules/search-console/components/module/ModuleOverviewWidget/Stats.js
@@ -55,8 +55,7 @@ const Stats = ( { data, metrics, selectedStats } ) => {
 		width: '100%',
 		chartArea: {
 			height: '77%',
-			left: 60,
-			width: '100%',
+			width: '87%',
 		},
 		legend: {
 			position: 'top',


### PR DESCRIPTION
…arts.

## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #2063 

## Relevant technical choices
Removed the left attribute from the `chartArea` options for Google Charts. If we use the left attribute, when we have a large number to be displayed on the y axis, the number gets truncated.

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
