### PR TITLE
Fix sort used for modules

### DIFF
--- a/assets/js/components/ModulesList.js
+++ b/assets/js/components/ModulesList.js
@@ -88,7 +88,8 @@ function ModulesList( { moduleSlugs } ) {
 	// Filter out internal modules and remove modules with dependencies.
 	const modules = Object.values( moduleObjects )
 		.filter( ( module ) => ! module.internal && 0 === module.dependencies.length )
-		.sort( ( module1, module2 ) => module1.sort - module2.sort );
+		.sort( ( a, b ) => a.order - b.order )
+	;
 
 	return (
 		<div className="googlesitekit-modules-list">

--- a/assets/js/components/settings/SettingsInactiveModules.js
+++ b/assets/js/components/settings/SettingsInactiveModules.js
@@ -59,7 +59,7 @@ const SettingsInactiveModules = () => {
 	const inactiveModules = initialInactiveSlugs
 		.map( ( slug ) => modules[ slug ] )
 		.filter( ( module ) => ! module.internal )
-		.sort( ( a, b ) => a.sort - b.sort )
+		.sort( ( a, b ) => a.order - b.order )
 	;
 
 	if ( inactiveModules.length === 0 ) {


### PR DESCRIPTION
## Summary

Addresses issue #3093 

## Relevant technical choices

* Updates all module sorting to be consistent with sort in `normalizeModules`  
https://github.com/google/site-kit-wp/blob/b48e3186e8f09c8fd9db14b32ce25431d9f79da7/assets/js/googlesitekit/modules/datastore/modules.js#L89
* No more sorting exists in legacy components

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
