### PR TITLE
Add dedicated reset tool

### DIFF
--- a/includes/Core/Admin/Available_Tools.php
+++ b/includes/Core/Admin/Available_Tools.php
@@ -42,13 +42,6 @@ class Available_Tools {
 		if ( ! current_user_can( Permissions::SETUP ) ) {
 			return;
 		}
-		$reset_url = add_query_arg(
-			array(
-				'action' => Reset::ACTION,
-				'nonce'  => wp_create_nonce( Reset::ACTION ),
-			),
-			admin_url( 'index.php' )
-		);
 		?>
 		<div class="card">
 			<h2 class="title"><?php esc_html_e( 'Reset Site Kit', 'google-site-kit' ); ?></h2>
@@ -63,7 +56,7 @@ class Available_Tools {
 			<p>
 				<a
 					class="button button-primary"
-					href="<?php echo esc_url( $reset_url ); ?>"
+					href="<?php echo esc_url( Reset::url() ); ?>"
 				>
 					<?php esc_html_e( 'Reset Site Kit', 'google-site-kit' ); ?>
 				</a>

--- a/includes/Core/Admin/Available_Tools.php
+++ b/includes/Core/Admin/Available_Tools.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Class Google\Site_Kit\Core\Admin\Available_Tools
+ *
+ * @package   Google\Site_Kit\Core\Admin
+ * @copyright 2021 Google LLC
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
+ * @link      https://sitekit.withgoogle.com
+ */
+
+namespace Google\Site_Kit\Core\Admin;
+
+use Google\Site_Kit\Core\Permissions\Permissions;
+use Google\Site_Kit\Core\Util\Method_Proxy_Trait;
+use Google\Site_Kit\Core\Util\Reset;
+
+/**
+ * Class for extending available tools for Site Kit.
+ *
+ * @since n.e.x.t
+ * @access private
+ * @ignore
+ */
+class Available_Tools {
+	use Method_Proxy_Trait;
+
+	/**
+	 * Registers functionality through WordPress hooks.
+	 *
+	 * @since n.e.x.t
+	 */
+	public function register() {
+		add_action( 'tool_box', $this->get_method_proxy( 'render_tool_box' ) );
+	}
+
+	/**
+	 * Renders tool box output.
+	 *
+	 * @since n.e.x.t
+	 */
+	private function render_tool_box() {
+		if ( ! current_user_can( Permissions::SETUP ) ) {
+			return;
+		}
+		$reset_url = add_query_arg(
+			array(
+				'action' => Reset::ACTION,
+				'nonce'  => wp_create_nonce( Reset::ACTION ),
+			),
+			admin_url( 'index.php' )
+		);
+		?>
+		<div class="card">
+			<h2 class="title"><?php esc_html_e( 'Reset Site Kit', 'google-site-kit' ); ?></h2>
+			<p>
+				<?php
+				esc_html_e(
+					'Resetting will disconnect all users and remove all Site Kit settings and data within WordPress. You and any other users who wish to use Site Kit will need to reconnect to restore access.',
+					'google-site-kit'
+				)
+				?>
+			</p>
+			<p>
+				<a
+					class="button button-primary"
+					href="<?php echo esc_url( $reset_url ); ?>"
+				>
+					<?php esc_html_e( 'Reset Site Kit', 'google-site-kit' ); ?>
+				</a>
+			</p>
+		</div>
+		<?php
+	}
+}

--- a/includes/Core/Util/Reset.php
+++ b/includes/Core/Util/Reset.php
@@ -218,7 +218,7 @@ class Reset {
 	 * @param string $nonce WP nonce for action.
 	 */
 	private function handle_reset_action( $nonce ) {
-		if ( empty( $nonce ) || ! wp_verify_nonce( $nonce, static::ACTION ) ) {
+		if ( ! wp_verify_nonce( $nonce, static::ACTION ) ) {
 			wp_die( esc_html__( 'Invalid nonce.', 'google-site-kit' ), 400 );
 		}
 		if ( ! current_user_can( Permissions::SETUP ) ) {

--- a/includes/Core/Util/Reset.php
+++ b/includes/Core/Util/Reset.php
@@ -51,6 +51,23 @@ class Reset {
 	private $context;
 
 	/**
+	 * Gets the URL to handle a reset action.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @return string
+	 */
+	public static function url() {
+		return add_query_arg(
+			array(
+				'action' => static::ACTION,
+				'nonce'  => wp_create_nonce( static::ACTION ),
+			),
+			admin_url( 'index.php' )
+		);
+	}
+
+	/**
 	 * Constructor.
 	 *
 	 * @since 1.0.0

--- a/includes/Core/Util/Reset.php
+++ b/includes/Core/Util/Reset.php
@@ -38,6 +38,11 @@ class Reset {
 	const REST_ROUTE = 'core/site/data/reset';
 
 	/**
+	 * Action for triggering a reset.
+	 */
+	const ACTION = 'googlesitekit_reset';
+
+	/**
 	 * Plugin context.
 	 *
 	 * @since 1.0.0
@@ -67,6 +72,15 @@ class Reset {
 			'googlesitekit_rest_routes',
 			function( $routes ) {
 				return array_merge( $routes, $this->get_rest_routes() );
+			}
+		);
+
+		add_action(
+			'admin_action_' . static::ACTION,
+			function () {
+				$this->handle_reset_action(
+					$this->context->input()->filter( INPUT_GET, 'nonce' )
+				);
 			}
 		);
 	}
@@ -177,5 +191,36 @@ class Reset {
 				)
 			),
 		);
+	}
+
+	/**
+	 * Handles the reset admin action.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param string $nonce WP nonce for action.
+	 */
+	private function handle_reset_action( $nonce ) {
+		if ( empty( $nonce ) || ! wp_verify_nonce( $nonce, static::ACTION ) ) {
+			wp_die( esc_html__( 'Invalid nonce.', 'google-site-kit' ), 400 );
+		}
+		if ( ! current_user_can( Permissions::SETUP ) ) {
+			wp_die( esc_html__( 'You don\'t have permissions to set up Site Kit.', 'google-site-kit' ), 403 );
+		}
+
+		$this->all();
+
+		wp_safe_redirect(
+			$this->context->admin_url(
+				'splash',
+				array(
+					// Trigger client-side storage reset.
+					'googlesitekit_reset_session' => 1,
+					// Show reset-success notification.
+					'notification'                => 'reset_success',
+				)
+			)
+		);
+		exit;
 	}
 }

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -176,6 +176,7 @@ final class Plugin {
 				( new Core\Util\Tracking( $this->context, $user_options, $screens ) )->register();
 				( new Core\REST_API\REST_Routes( $this->context, $authentication, $modules ) )->register();
 				( new Core\Admin_Bar\Admin_Bar( $this->context, $assets, $modules ) )->register();
+				( new Core\Admin\Available_Tools() )->register();
 				( new Core\Admin\Notices() )->register();
 				( new Core\Admin\Dashboard( $this->context, $assets, $modules ) )->register();
 				( new Core\Notifications\Notifications( $this->context, $options, $authentication ) )->register();

--- a/tests/phpunit/integration/Core/Admin/Available_ToolsTest.php
+++ b/tests/phpunit/integration/Core/Admin/Available_ToolsTest.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Class Google\Site_Kit\Tests\Core\Admin\Available_ToolsTest
+ *
+ * @package   Google\Site_Kit\Tests\Core\Admin
+ * @copyright 2021 Google LLC
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
+ * @link      https://sitekit.withgoogle.com
+ */
+
+namespace Google\Site_Kit\Tests\Core\Admin;
+
+use Google\Site_Kit\Core\Admin\Available_Tools;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @group Admin
+ */
+class Available_ToolsTest extends TestCase {
+
+	public function test_register() {
+		$tools = new Available_Tools();
+		remove_all_actions( 'tool_box' );
+
+		$tools->register();
+
+		$this->assertTrue( has_action( 'tool_box' ) );
+	}
+}


### PR DESCRIPTION
## Summary

Addresses issue #2384

## Relevant technical choices

* Redirects to splash page rather than dashboard to avoid an immediate redirect from dashboard to splash due to missing authentication
* Reset also triggers client side session reset and adds success notification as are done/shown when doing a normal client-side reset

## Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
