### PR TITLE
Update to stop the output of the Analytics snippet if there already i…

### DIFF
--- a/assets/js/modules/analytics/hooks/useExistingTagEffect.js
+++ b/assets/js/modules/analytics/hooks/useExistingTagEffect.js
@@ -33,7 +33,7 @@ import { MODULES_TAGMANAGER } from '../../tagmanager/datastore/constants';
 const { useSelect, useDispatch } = Data;
 
 export default function useExistingTagEffect() {
-	const { setAccountID, selectProperty } = useDispatch( STORE_NAME );
+	const { setAccountID, selectProperty, setUseSnippet } = useDispatch( STORE_NAME );
 	const gtmModuleActive = useSelect( ( select ) => select( CORE_MODULES ).isModuleActive( 'tagmanager' ) );
 
 	const {
@@ -77,6 +77,8 @@ export default function useExistingTagEffect() {
 
 	useEffect( () => {
 		if ( existingTag ) {
+			// Disable the plugin snippet
+			setUseSnippet( false );
 			if ( existingTagPermission && existingTagAccountID ) {
 				// There is an existing Analytics tag, select it.
 				setAccountID( existingTagAccountID );

--- a/assets/js/modules/analytics/hooks/useExistingTagEffect.test.js
+++ b/assets/js/modules/analytics/hooks/useExistingTagEffect.test.js
@@ -77,6 +77,7 @@ describe( 'useExistingTagEffect', () => {
 
 		expect( registry.select( STORE_NAME ).getAccountID() ).toBe( existingTag.accountID );
 		expect( registry.select( STORE_NAME ).getPropertyID() ).toBe( existingTag.propertyID );
+		expect( registry.select( STORE_NAME ).getUseSnippet() ).toBe( false );
 	} );
 
 	it( 'should not select GTM tag if user doesn\'t have permissions for existing tag', async () => {


### PR DESCRIPTION
## Summary

Update to stop the output of the Analytics snippet by the plugin during setup if there is already an Analytics tag.

Addresses issue #2909 

## Relevant technical choices


## Checklist

- [X] My code is tested and passes existing unit tests.
- [X] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [X] I have added a QA Brief on the issue linked above.
- [X] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
