### PR TITLE
Fix cursor jump in user input by also storing state locally.

### DIFF
--- a/assets/js/components/user-input/UserInputKeywords.js
+++ b/assets/js/components/user-input/UserInputKeywords.js
@@ -53,6 +53,10 @@ export default function UserInputKeywords( { slug, max } ) {
 		values.push( '' );
 	}
 
+	// Store values in local state to prevent
+	// https://github.com/google/site-kit-wp/issues/2900#issuecomment-814843972.
+	const [ localValues, setLocalValues ] = useState( [ '' ] );
+
 	// Need to make sure that dependencies list always has the same number of elements.
 	const dependencies = values.concat( Array( max ) ).slice( 0, max );
 
@@ -92,6 +96,7 @@ export default function UserInputKeywords( { slug, max } ) {
 			newKeywords = newKeywords.split( EOT ).slice( 0, max );
 		}
 
+		setLocalValues( newKeywords );
 		setUserInputSetting( slug, newKeywords );
 	}, [ slug ] );
 
@@ -142,11 +147,11 @@ export default function UserInputKeywords( { slug, max } ) {
 	return (
 		<Cell lgStart={ 6 } lgSize={ 6 } mdSize={ 8 } smSize={ 4 }>
 			<div ref={ keywordsContainer } className="googlesitekit-user-input__text-options">
-				{ values.map( ( value, i ) => (
+				{ localValues.map( ( value, i ) => (
 					<div
 						key={ i }
 						className={ classnames( {
-							'googlesitekit-user-input__text-option': values.length > i + 1 || value.length > 0,
+							'googlesitekit-user-input__text-option': localValues.length > i + 1 || value.length > 0,
 						} ) }
 					>
 						<VisuallyHiden>
@@ -171,7 +176,7 @@ export default function UserInputKeywords( { slug, max } ) {
 							/>
 						</TextField>
 
-						{ ( value.length > 0 || i + 1 < values.length ) && (
+						{ ( value.length > 0 || i + 1 < localValues.length ) && (
 							<Button
 								text
 								icon={ <CloseIcon width="11" height="11" /> }

--- a/assets/js/components/user-input/UserInputKeywords.js
+++ b/assets/js/components/user-input/UserInputKeywords.js
@@ -55,7 +55,7 @@ export default function UserInputKeywords( { slug, max } ) {
 
 	// Store values in local state to prevent
 	// https://github.com/google/site-kit-wp/issues/2900#issuecomment-814843972.
-	const [ localValues, setLocalValues ] = useState( [ '' ] );
+	const [ localValues, setLocalValues ] = useState( values );
 
 	// Need to make sure that dependencies list always has the same number of elements.
 	const dependencies = values.concat( Array( max ) ).slice( 0, max );


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #2900, specifically the issue mentioned in QA feedback here: https://github.com/google/site-kit-wp/issues/2900#issuecomment-814843972

## Relevant technical choices

This addresses an issue with controlled components and—I think—React's scheduler and handling of controlled components like `<input />`. It's something I've seen before but it's easy to get bit by.

@johnPhillips provided some helpful context in a Slack convo so I'm copy-pasting what he wrote 🙂 

> So we’ve effectively lifted the state out of the component, and I think during the round trip React loses its grip on where the cursor should be. It seems that this is [something people run into a lot](https://github.com/facebook/react/issues/14904), there is even a [sandbox here which reproduces something extremely similar](https://codesandbox.io/s/distracted-rhodes-gkric).

I am vastly over-simplifying here, but my understanding is that, essentially, our `<Input />` component "loses track" of cursor position because of the "complex" route from the data store to the component's `value` prop. An easy fix is to copy what is in the data store locally in the component—all validation and management of the data remains the same, but the component has a local copy of the value data and thus doesn't get "confused" about cursor positioning.

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
