### PR TITLE
Fix notification alert height

### DIFF
--- a/assets/js/components/legacy-notifications/dashboard-modules-alerts.js
+++ b/assets/js/components/legacy-notifications/dashboard-modules-alerts.js
@@ -75,7 +75,7 @@ class DashboardModulesAlerts extends Component {
 						title={ notification.title || '' }
 						description={ notification.description || '' }
 						blockData={ notification.blockData || [] }
-						WinImageSVG={ NotificationAlertSVG }
+						WinImageSVG={ () => <NotificationAlertSVG height="136" /> }
 						format={ notification.format || 'small' }
 						learnMoreURL={ notification.learnMoreURL || '' }
 						learnMoreDescription={ notification.learnMoreDescription || '' }


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #2616 (follow-up)

## Relevant technical choices

Fixes an inconsistency in the height of the graphic used for dashboard module alerts to match previous.
See https://github.com/google/site-kit-wp/issues/2616#issuecomment-815889318

Targets **main**

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
