### PR TITLE
Cache goals endpoint data.

### DIFF
--- a/includes/Modules/Analytics.php
+++ b/includes/Modules/Analytics.php
@@ -77,6 +77,7 @@ final class Analytics extends Module
 	use Module_With_Settings_Trait;
 
 	const PROVISION_ACCOUNT_TICKET_ID = 'googlesitekit_analytics_provision_account_ticket_id';
+	const GOALS_DATA_ID               = 'googlesitekit_analytics_goals_data';
 
 	/**
 	 * Module slug name.
@@ -427,8 +428,14 @@ final class Analytics extends Module
 						);
 					};
 				}
-				$service = $this->get_service( 'analytics' );
-				return $service->management_goals->listManagementGoals( $connection['accountID'], $connection['propertyID'], $connection['profileID'] );
+				$goals_data = get_transient( self::GOALS_DATA_ID );
+				if ( false !== $goals_data ) {
+					return $goals_data;
+				}
+				$service    = $this->get_service( 'analytics' );
+				$goals_data = $service->management_goals->listManagementGoals( $connection['accountID'], $connection['propertyID'], $connection['profileID'] );
+				set_transient( self::GOALS_DATA_ID, $goals_data, DAY_IN_SECONDS );
+				return $goals_data;
 			case 'GET:profiles':
 				if ( ! isset( $data['accountID'] ) ) {
 					return new WP_Error(


### PR DESCRIPTION
## Summary

Calls to the goals endpoint occurs when any user visits the Site Kit page. These calls are management API calls and may help explain our quota issues with that API. This PR attempts to address this by caching the data returned from this call for one day.

* We could consider a shorter cache (1 hr?). As is, newly added goals will take up to a day to appear in Site Kit. 

Addresses issue #

## Relevant technical choices

<!-- Please describe your changes. -->

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [ ] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
