### PR TITLE
Update to rename the acquisition widget first column title and constants.

### DIFF
--- a/assets/js/googlesitekit/widgets/default-areas.js
+++ b/assets/js/googlesitekit/widgets/default-areas.js
@@ -18,23 +18,23 @@
 
 export const AREA_DASHBOARD_ALL_TRAFFIC = 'dashboardAllTraffic';
 export const AREA_DASHBOARD_SEARCH_FUNNEL = 'dashboardSearchFunnel';
-export const AREA_DASHBOARD_POPULARITY = 'dashboardPopularity';
+export const AREA_DASHBOARD_ACQUISITION = 'dashboardAcquisition';
 export const AREA_DASHBOARD_SPEED = 'dashboardSpeed';
 export const AREA_DASHBOARD_EARNINGS = 'dashboardEarnings';
 
 export const AREA_PAGE_DASHBOARD_SEARCH_FUNNEL = 'pageDashboardSearchFunnel';
 export const AREA_PAGE_DASHBOARD_ALL_TRAFFIC = 'pageDashboardAllTraffic';
-export const AREA_PAGE_DASHBOARD_POPULARITY = 'pageDashboardPopularity';
+export const AREA_PAGE_DASHBOARD_ACQUISITION = 'pageDashboardAcquisition';
 export const AREA_PAGE_DASHBOARD_SPEED = 'pageDashboardSpeed';
 
 export default {
 	AREA_DASHBOARD_ALL_TRAFFIC,
 	AREA_DASHBOARD_SEARCH_FUNNEL,
-	AREA_DASHBOARD_POPULARITY,
+	AREA_DASHBOARD_ACQUISITION,
 	AREA_DASHBOARD_SPEED,
 	AREA_DASHBOARD_EARNINGS,
 	AREA_PAGE_DASHBOARD_SEARCH_FUNNEL,
 	AREA_PAGE_DASHBOARD_ALL_TRAFFIC,
-	AREA_PAGE_DASHBOARD_POPULARITY,
+	AREA_PAGE_DASHBOARD_ACQUISITION,
 	AREA_PAGE_DASHBOARD_SPEED,
 };

--- a/assets/js/googlesitekit/widgets/register-defaults.js
+++ b/assets/js/googlesitekit/widgets/register-defaults.js
@@ -32,12 +32,12 @@ import {
 import {
 	AREA_DASHBOARD_ALL_TRAFFIC,
 	AREA_DASHBOARD_SEARCH_FUNNEL,
-	AREA_DASHBOARD_POPULARITY,
+	AREA_DASHBOARD_ACQUISITION,
 	AREA_DASHBOARD_SPEED,
 	AREA_DASHBOARD_EARNINGS,
 	AREA_PAGE_DASHBOARD_SEARCH_FUNNEL,
 	AREA_PAGE_DASHBOARD_ALL_TRAFFIC,
-	AREA_PAGE_DASHBOARD_POPULARITY,
+	AREA_PAGE_DASHBOARD_ACQUISITION,
 	AREA_PAGE_DASHBOARD_SPEED,
 } from './default-areas';
 import { WIDGET_URL_SEARCH } from './default-widgets';
@@ -74,9 +74,9 @@ export function registerDefaults( widgetsAPI ) {
 	);
 
 	widgetsAPI.registerWidgetArea(
-		AREA_DASHBOARD_POPULARITY,
+		AREA_DASHBOARD_ACQUISITION,
 		{
-			title: __( 'Popularity', 'google-site-kit' ),
+			title: __( 'Acquisition', 'google-site-kit' ),
 			subtitle: __( 'Your most popular pages and how people found them from Search.', 'google-site-kit' ),
 			style: WIDGET_AREA_STYLES.BOXES,
 			priority: 3,
@@ -129,9 +129,9 @@ export function registerDefaults( widgetsAPI ) {
 	);
 
 	widgetsAPI.registerWidgetArea(
-		AREA_PAGE_DASHBOARD_POPULARITY,
+		AREA_PAGE_DASHBOARD_ACQUISITION,
 		{
-			title: __( 'Popularity', 'google-site-kit' ),
+			title: __( 'Acquisition', 'google-site-kit' ),
 			subtitle: __( 'What people searched for to find your page.', 'google-site-kit' ),
 			style: WIDGET_AREA_STYLES.BOXES,
 			priority: 3,
@@ -159,7 +159,7 @@ export function registerDefaults( widgetsAPI ) {
 			wrapWidget: false,
 		},
 		[
-			AREA_DASHBOARD_POPULARITY,
+			AREA_DASHBOARD_ACQUISITION,
 		],
 	);
 }

--- a/assets/js/modules/analytics/index.js
+++ b/assets/js/modules/analytics/index.js
@@ -29,7 +29,7 @@ import {
 	AREA_PAGE_DASHBOARD_ALL_TRAFFIC,
 	AREA_DASHBOARD_SEARCH_FUNNEL,
 	AREA_PAGE_DASHBOARD_SEARCH_FUNNEL,
-	AREA_DASHBOARD_POPULARITY,
+	AREA_DASHBOARD_ACQUISITION,
 } from '../../googlesitekit/widgets/default-areas';
 import { WIDGET_AREA_STYLES } from '../../googlesitekit/widgets/datastore/constants';
 import AnalyticsIcon from '../../../svg/analytics.svg';
@@ -129,7 +129,7 @@ export const registerWidgets = ( widgets ) => {
 			wrapWidget: false,
 		},
 		[
-			AREA_DASHBOARD_POPULARITY,
+			AREA_DASHBOARD_ACQUISITION,
 		],
 	);
 

--- a/assets/js/modules/search-console/components/dashboard/DashboardPopularKeywordsWidget.js
+++ b/assets/js/modules/search-console/components/dashboard/DashboardPopularKeywordsWidget.js
@@ -75,7 +75,7 @@ function DashboardPopularKeywordsWidget( { Widget, WidgetReportZero, WidgetRepor
 
 	const tableColumns = [
 		{
-			title: __( 'Keyword', 'google-site-kit' ),
+			title: url ? __( 'Top search queries for your page', 'google-site-kit' ) : __( 'Top search queries for your site', 'google-site-kit' ),
 			description: __( 'Most searched for keywords related to your content', 'google-site-kit' ),
 			primary: true,
 			field: 'keys.0',

--- a/assets/js/modules/search-console/index.js
+++ b/assets/js/modules/search-console/index.js
@@ -31,9 +31,9 @@ import DashboardPopularKeywordsWidget from './components/dashboard/DashboardPopu
 import ModulePopularKeywordsWidget from './components/module/ModulePopularKeywordsWidget';
 import ModuleOverviewWidget from './components/module/ModuleOverviewWidget';
 import {
-	AREA_DASHBOARD_POPULARITY,
+	AREA_DASHBOARD_ACQUISITION,
 	AREA_DASHBOARD_SEARCH_FUNNEL,
-	AREA_PAGE_DASHBOARD_POPULARITY,
+	AREA_PAGE_DASHBOARD_ACQUISITION,
 	AREA_PAGE_DASHBOARD_SEARCH_FUNNEL,
 } from '../../googlesitekit/widgets/default-areas';
 import SearchConsoleIcon from '../../../svg/search-console.svg';
@@ -92,8 +92,8 @@ export const registerWidgets = ( widgets ) => {
 			wrapWidget: false,
 		},
 		[
-			AREA_DASHBOARD_POPULARITY,
-			AREA_PAGE_DASHBOARD_POPULARITY,
+			AREA_DASHBOARD_ACQUISITION,
+			AREA_PAGE_DASHBOARD_ACQUISITION,
 		],
 	);
 	widgets.registerWidget(


### PR DESCRIPTION
## Summary

Update to rename the acquisition widget first column title and constants.

Addresses issue #3065

## Relevant technical choices


## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [X] I have added a QA Brief on the issue linked above.
- [X] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
