### PR TITLE
Update to add a hidden label to user input other fields.

### DIFF
--- a/assets/js/components/user-input/UserInputSelectOptions.js
+++ b/assets/js/components/user-input/UserInputSelectOptions.js
@@ -153,7 +153,9 @@ export default function UserInputSelectOptions( { slug, options, max } ) {
 							disabled={ disabled }
 						/>
 					</TextField>
-					<label htmlFor={ `${ slug }-select-options` } className="screen-reader-text">Enter your own answer here</label>
+					<label htmlFor={ `${ slug }-select-options` } className="screen-reader-text">
+						{ __( 'Enter your own answer here', 'google-site-kit' ) }
+					</label>
 				</div>
 			</div>
 

--- a/assets/js/components/user-input/UserInputSelectOptions.js
+++ b/assets/js/components/user-input/UserInputSelectOptions.js
@@ -143,7 +143,7 @@ export default function UserInputSelectOptions( { slug, options, max } ) {
 
 					<TextField
 						label={ __( 'Type your own answer', 'google-site-kit' ) }
-						floatingLabelClassName="screen-reader-text"
+						noLabel
 					>
 						<Input
 							id={ `${ slug }-select-options` }
@@ -153,6 +153,7 @@ export default function UserInputSelectOptions( { slug, options, max } ) {
 							disabled={ disabled }
 						/>
 					</TextField>
+					<label htmlFor={ `${ slug }-select-options` } className="screen-reader-text">Enter your own answer here</label>
 				</div>
 			</div>
 


### PR DESCRIPTION
## Summary

Update to add a hidden label to user input other fields.

Addresses issue #2993

## Relevant technical choices

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [X] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
