### PR TITLE
Site Kit widgets always return content wrapped in a Widget component. (3060)

### DIFF
--- a/assets/js/modules/adsense/components/dashboard/DashboardSummaryWidget.js
+++ b/assets/js/modules/adsense/components/dashboard/DashboardSummaryWidget.js
@@ -107,7 +107,7 @@ function DashboardSummaryWidget( { Widget, WidgetReportZero, WidgetReportError }
 
 	if ( error ) {
 		return (
-			<Widget noPadding>
+			<Widget>
 				<WidgetReportError moduleSlug="adsense" error={ error } />
 			</Widget>
 		);
@@ -115,7 +115,7 @@ function DashboardSummaryWidget( { Widget, WidgetReportZero, WidgetReportError }
 
 	if ( isZeroReport( today ) && isZeroReport( period ) && isZeroReport( daily ) ) {
 		return (
-			<Widget noPadding>
+			<Widget>
 				<WidgetReportZero moduleSlug="adsense" />
 			</Widget>
 		);

--- a/assets/js/modules/adsense/components/dashboard/DashboardSummaryWidget.js
+++ b/assets/js/modules/adsense/components/dashboard/DashboardSummaryWidget.js
@@ -98,15 +98,27 @@ function DashboardSummaryWidget( { Widget, WidgetReportZero, WidgetReportError }
 	} );
 
 	if ( loading ) {
-		return <PreviewBlock width="100%" height="276px" />;
+		return (
+			<Widget>
+				<PreviewBlock width="100%" height="276px" />
+			</Widget>
+		);
 	}
 
 	if ( error ) {
-		return <WidgetReportError moduleSlug="adsense" error={ error } />;
+		return (
+			<Widget noPadding>
+				<WidgetReportError moduleSlug="adsense" error={ error } />
+			</Widget>
+		);
 	}
 
 	if ( isZeroReport( today ) && isZeroReport( period ) && isZeroReport( daily ) ) {
-		return <WidgetReportZero moduleSlug="adsense" />;
+		return (
+			<Widget noPadding>
+				<WidgetReportZero moduleSlug="adsense" />
+			</Widget>
+		);
 	}
 
 	const processedData = reduceAdSenseData( daily.rows );

--- a/assets/js/modules/adsense/components/dashboard/DashboardTopEarningPagesWidget.js
+++ b/assets/js/modules/adsense/components/dashboard/DashboardTopEarningPagesWidget.js
@@ -112,9 +112,11 @@ function DashboardTopEarningPagesWidget( { Widget, WidgetReportZero, WidgetRepor
 	}
 
 	if ( isZeroReport( data ) ) {
-		<Widget Footer={ Footer }>
-			 <WidgetReportZero moduleSlug="analytics" />
-		</Widget>;
+		return (
+			<Widget Footer={ Footer }>
+				<WidgetReportZero moduleSlug="analytics" />
+			</Widget>
+		);
 	}
 
 	const tableColumns = [

--- a/assets/js/modules/adsense/components/dashboard/DashboardTopEarningPagesWidget.js
+++ b/assets/js/modules/adsense/components/dashboard/DashboardTopEarningPagesWidget.js
@@ -77,21 +77,75 @@ function DashboardTopEarningPagesWidget( { Widget, WidgetReportZero, WidgetRepor
 	} );
 
 	if ( loading ) {
-		return <PreviewTable rows={ 5 } padding />;
+		return (
+			<Widget
+				noPadding
+				Footer={ () => (
+					<SourceLink
+						className="googlesitekit-data-block__source"
+						name={ _x( 'Analytics', 'Service name', 'google-site-kit' ) }
+						href={ analyticsMainURL }
+						external
+					/>
+				) }
+			>
+				<PreviewTable rows={ 5 } padding />
+			</Widget>
+		);
 	}
 
 	// A restricted metrics error will cause this value to change in the resolver
 	// so this check should happen before an error, which is only relevant if they are linked.
 	if ( ! isAdSenseLinked ) {
-		return <AdSenseLinkCTA />;
+		return (
+			<Widget
+				noPadding
+				Footer={ () => (
+					<SourceLink
+						className="googlesitekit-data-block__source"
+						name={ _x( 'Analytics', 'Service name', 'google-site-kit' ) }
+						href={ analyticsMainURL }
+						external
+					/>
+				) }
+			>
+				<AdSenseLinkCTA />
+			</Widget>
+		);
 	}
 
 	if ( error ) {
-		return <WidgetReportError moduleSlug="analytics" error={ error } />;
+		return (
+			<Widget
+				noPadding
+				Footer={ () => (
+					<SourceLink
+						className="googlesitekit-data-block__source"
+						name={ _x( 'Analytics', 'Service name', 'google-site-kit' ) }
+						href={ analyticsMainURL }
+						external
+					/>
+				) }
+			>
+				<WidgetReportError moduleSlug="analytics" error={ error } />
+			</Widget>
+		);
 	}
 
 	if ( isZeroReport( data ) ) {
-		return <WidgetReportZero moduleSlug="analytics" />;
+		<Widget
+			noPadding
+			Footer={ () => (
+				<SourceLink
+					className="googlesitekit-data-block__source"
+					name={ _x( 'Analytics', 'Service name', 'google-site-kit' ) }
+					href={ analyticsMainURL }
+					external
+				/>
+			) }
+		>
+			return <WidgetReportZero moduleSlug="analytics" />;
+		</Widget>;
 	}
 
 	const tableColumns = [

--- a/assets/js/modules/adsense/components/dashboard/DashboardTopEarningPagesWidget.js
+++ b/assets/js/modules/adsense/components/dashboard/DashboardTopEarningPagesWidget.js
@@ -87,17 +87,7 @@ function DashboardTopEarningPagesWidget( { Widget, WidgetReportZero, WidgetRepor
 
 	if ( loading ) {
 		return (
-			<Widget
-				noPadding
-				Footer={ () => (
-					<SourceLink
-						className="googlesitekit-data-block__source"
-						name={ _x( 'Analytics', 'Service name', 'google-site-kit' ) }
-						href={ analyticsMainURL }
-						external
-					/>
-				) }
-			>
+			<Widget noPadding Footer={ Footer }>
 				<PreviewTable rows={ 5 } padding />
 			</Widget>
 		);
@@ -122,7 +112,7 @@ function DashboardTopEarningPagesWidget( { Widget, WidgetReportZero, WidgetRepor
 	}
 
 	if ( isZeroReport( data ) ) {
-		<Widget Footer={ Footer } >
+		<Widget Footer={ Footer }>
 			 <WidgetReportZero moduleSlug="analytics" />
 		</Widget>;
 	}
@@ -159,17 +149,7 @@ function DashboardTopEarningPagesWidget( { Widget, WidgetReportZero, WidgetRepor
 	];
 
 	return (
-		<Widget
-			noPadding
-			Footer={ () => (
-				<SourceLink
-					className="googlesitekit-data-block__source"
-					name={ _x( 'Analytics', 'Service name', 'google-site-kit' ) }
-					href={ analyticsMainURL }
-					external
-				/>
-			) }
-		>
+		<Widget noPadding Footer={ Footer }>
 			<TableOverflowContainer>
 				<ReportTable
 					rows={ data[ 0 ].data.rows }

--- a/assets/js/modules/adsense/components/dashboard/DashboardTopEarningPagesWidget.js
+++ b/assets/js/modules/adsense/components/dashboard/DashboardTopEarningPagesWidget.js
@@ -76,6 +76,15 @@ function DashboardTopEarningPagesWidget( { Widget, WidgetReportZero, WidgetRepor
 		};
 	} );
 
+	const Footer = () => (
+		<SourceLink
+			className="googlesitekit-data-block__source"
+			name={ _x( 'Analytics', 'Service name', 'google-site-kit' ) }
+			href={ analyticsMainURL }
+			external
+		/>
+	);
+
 	if ( loading ) {
 		return (
 			<Widget
@@ -98,17 +107,7 @@ function DashboardTopEarningPagesWidget( { Widget, WidgetReportZero, WidgetRepor
 	// so this check should happen before an error, which is only relevant if they are linked.
 	if ( ! isAdSenseLinked ) {
 		return (
-			<Widget
-				noPadding
-				Footer={ () => (
-					<SourceLink
-						className="googlesitekit-data-block__source"
-						name={ _x( 'Analytics', 'Service name', 'google-site-kit' ) }
-						href={ analyticsMainURL }
-						external
-					/>
-				) }
-			>
+			<Widget Footer={ Footer }>
 				<AdSenseLinkCTA />
 			</Widget>
 		);
@@ -116,35 +115,15 @@ function DashboardTopEarningPagesWidget( { Widget, WidgetReportZero, WidgetRepor
 
 	if ( error ) {
 		return (
-			<Widget
-				noPadding
-				Footer={ () => (
-					<SourceLink
-						className="googlesitekit-data-block__source"
-						name={ _x( 'Analytics', 'Service name', 'google-site-kit' ) }
-						href={ analyticsMainURL }
-						external
-					/>
-				) }
-			>
+			<Widget Footer={ Footer } >
 				<WidgetReportError moduleSlug="analytics" error={ error } />
 			</Widget>
 		);
 	}
 
 	if ( isZeroReport( data ) ) {
-		<Widget
-			noPadding
-			Footer={ () => (
-				<SourceLink
-					className="googlesitekit-data-block__source"
-					name={ _x( 'Analytics', 'Service name', 'google-site-kit' ) }
-					href={ analyticsMainURL }
-					external
-				/>
-			) }
-		>
-			return <WidgetReportZero moduleSlug="analytics" />;
+		<Widget Footer={ Footer } >
+			 <WidgetReportZero moduleSlug="analytics" />
 		</Widget>;
 	}
 

--- a/assets/js/modules/analytics/components/dashboard/DashboardAllTrafficWidget/index.js
+++ b/assets/js/modules/analytics/components/dashboard/DashboardAllTrafficWidget/index.js
@@ -169,11 +169,19 @@ function DashboardAllTrafficWidget( { Widget, WidgetReportZero, WidgetReportErro
 	}, [ firstLoad, pieChartLoaded, totalUsersLoaded, userCountGraphLoaded ] );
 
 	if ( pieChartError ) {
-		return <WidgetReportError moduleSlug="analytics" error={ pieChartError } />;
+		return (
+			<Widget noPadding>
+				<WidgetReportError moduleSlug="analytics" error={ pieChartError } />
+			</Widget>
+		);
 	}
 
 	if ( isZeroReport( pieChartReport ) ) {
-		return <WidgetReportZero moduleSlug="analytics" />;
+		return (
+			<Widget noPadding>
+				<WidgetReportZero moduleSlug="analytics" />
+			</Widget>
+		);
 	}
 
 	return (

--- a/assets/js/modules/analytics/components/dashboard/DashboardAllTrafficWidget/index.js
+++ b/assets/js/modules/analytics/components/dashboard/DashboardAllTrafficWidget/index.js
@@ -170,7 +170,7 @@ function DashboardAllTrafficWidget( { Widget, WidgetReportZero, WidgetReportErro
 
 	if ( pieChartError ) {
 		return (
-			<Widget noPadding>
+			<Widget>
 				<WidgetReportError moduleSlug="analytics" error={ pieChartError } />
 			</Widget>
 		);
@@ -178,7 +178,7 @@ function DashboardAllTrafficWidget( { Widget, WidgetReportZero, WidgetReportErro
 
 	if ( isZeroReport( pieChartReport ) ) {
 		return (
-			<Widget noPadding>
+			<Widget>
 				<WidgetReportZero moduleSlug="analytics" />
 			</Widget>
 		);

--- a/assets/js/modules/analytics/components/dashboard/DashboardPopularPagesWidget.js
+++ b/assets/js/modules/analytics/components/dashboard/DashboardPopularPagesWidget.js
@@ -93,17 +93,7 @@ function DashboardPopularPagesWidget( { Widget, WidgetReportZero, WidgetReportEr
 
 	if ( loading ) {
 		return (
-			<Widget
-				noPadding
-				Footer={ () => (
-					<SourceLink
-						className="googlesitekit-data-block__source"
-						name={ _x( 'Analytics', 'Service name', 'google-site-kit' ) }
-						href={ analyticsMainURL }
-						external
-					/>
-				) }
-			>
+			<Widget noPadding Footer={ Footer }>
 				<PreviewTable padding />
 			</Widget>
 		);
@@ -111,7 +101,7 @@ function DashboardPopularPagesWidget( { Widget, WidgetReportZero, WidgetReportEr
 
 	if ( error ) {
 		return (
-			<Widget Footer={ Footer } >
+			<Widget Footer={ Footer }>
 				<WidgetReportError moduleSlug="analytics" error={ error } />
 			</Widget>
 		);
@@ -119,14 +109,14 @@ function DashboardPopularPagesWidget( { Widget, WidgetReportZero, WidgetReportEr
 
 	if ( isZeroReport( data ) ) {
 		return (
-			<Widget Footer={ Footer } >
+			<Widget Footer={ Footer }>
 				<WidgetReportZero moduleSlug="analytics" />
 			</Widget>
 		);
 	}
 
 	return (
-		<Widget noPadding Footer={ Footer } >
+		<Widget noPadding Footer={ Footer }>
 			<TableOverflowContainer>
 				<ReportTable
 					rows={ data[ 0 ].data.rows }

--- a/assets/js/modules/analytics/components/dashboard/DashboardPopularPagesWidget.js
+++ b/assets/js/modules/analytics/components/dashboard/DashboardPopularPagesWidget.js
@@ -83,15 +83,57 @@ function DashboardPopularPagesWidget( { Widget, WidgetReportZero, WidgetReportEr
 	} );
 
 	if ( loading ) {
-		return <PreviewTable padding />;
+		return (
+			<Widget
+				noPadding
+				Footer={ () => (
+					<SourceLink
+						className="googlesitekit-data-block__source"
+						name={ _x( 'Analytics', 'Service name', 'google-site-kit' ) }
+						href={ analyticsMainURL }
+						external
+					/>
+				) }
+			>
+				<PreviewTable padding />
+			</Widget>
+		);
 	}
 
 	if ( error ) {
-		return <WidgetReportError moduleSlug="analytics" error={ error } />;
+		return (
+			<Widget
+				noPadding
+				Footer={ () => (
+					<SourceLink
+						className="googlesitekit-data-block__source"
+						name={ _x( 'Analytics', 'Service name', 'google-site-kit' ) }
+						href={ analyticsMainURL }
+						external
+					/>
+				) }
+			>
+				<WidgetReportError moduleSlug="analytics" error={ error } />
+			</Widget>
+		);
 	}
 
 	if ( isZeroReport( data ) ) {
-		return <WidgetReportZero moduleSlug="analytics" />;
+		return (
+			<Widget
+				noPadding
+				Footer={ () => (
+					<SourceLink
+						className="googlesitekit-data-block__source"
+						name={ _x( 'Analytics', 'Service name', 'google-site-kit' ) }
+						href={ analyticsMainURL }
+						external
+					/>
+				) }
+			>
+				<WidgetReportZero moduleSlug="analytics" />
+			</Widget>
+		);
 	}
 
 	return (

--- a/assets/js/modules/analytics/components/dashboard/DashboardPopularPagesWidget.js
+++ b/assets/js/modules/analytics/components/dashboard/DashboardPopularPagesWidget.js
@@ -82,6 +82,15 @@ function DashboardPopularPagesWidget( { Widget, WidgetReportZero, WidgetReportEr
 		};
 	} );
 
+	const Footer = () => (
+		<SourceLink
+			className="googlesitekit-data-block__source"
+			name={ _x( 'Analytics', 'Service name', 'google-site-kit' ) }
+			href={ analyticsMainURL }
+			external
+		/>
+	);
+
 	if ( loading ) {
 		return (
 			<Widget
@@ -102,17 +111,7 @@ function DashboardPopularPagesWidget( { Widget, WidgetReportZero, WidgetReportEr
 
 	if ( error ) {
 		return (
-			<Widget
-				noPadding
-				Footer={ () => (
-					<SourceLink
-						className="googlesitekit-data-block__source"
-						name={ _x( 'Analytics', 'Service name', 'google-site-kit' ) }
-						href={ analyticsMainURL }
-						external
-					/>
-				) }
-			>
+			<Widget Footer={ Footer } >
 				<WidgetReportError moduleSlug="analytics" error={ error } />
 			</Widget>
 		);
@@ -120,34 +119,14 @@ function DashboardPopularPagesWidget( { Widget, WidgetReportZero, WidgetReportEr
 
 	if ( isZeroReport( data ) ) {
 		return (
-			<Widget
-				noPadding
-				Footer={ () => (
-					<SourceLink
-						className="googlesitekit-data-block__source"
-						name={ _x( 'Analytics', 'Service name', 'google-site-kit' ) }
-						href={ analyticsMainURL }
-						external
-					/>
-				) }
-			>
+			<Widget Footer={ Footer } >
 				<WidgetReportZero moduleSlug="analytics" />
 			</Widget>
 		);
 	}
 
 	return (
-		<Widget
-			noPadding
-			Footer={ () => (
-				<SourceLink
-					className="googlesitekit-data-block__source"
-					name={ _x( 'Analytics', 'Service name', 'google-site-kit' ) }
-					href={ analyticsMainURL }
-					external
-				/>
-			) }
-		>
+		<Widget noPadding Footer={ Footer } >
 			<TableOverflowContainer>
 				<ReportTable
 					rows={ data[ 0 ].data.rows }

--- a/assets/js/modules/search-console/components/dashboard/DashboardPopularKeywordsWidget.js
+++ b/assets/js/modules/search-console/components/dashboard/DashboardPopularKeywordsWidget.js
@@ -62,15 +62,57 @@ function DashboardPopularKeywordsWidget( { Widget, WidgetReportZero, WidgetRepor
 	} ) );
 
 	if ( loading ) {
-		return <PreviewTable padding />;
+		return (
+			<Widget
+				noPadding
+				Footer={ () => (
+					<SourceLink
+						className="googlesitekit-data-block__source"
+						name={ _x( 'Search Console', 'Service name', 'google-site-kit' ) }
+						href={ baseServiceURL }
+						external
+					/>
+				) }
+			>
+				<PreviewTable padding />
+			</Widget>
+		);
 	}
 
 	if ( error ) {
-		return <WidgetReportError moduleSlug="search-console" error={ error } />;
+		return (
+			<Widget
+				noPadding
+				Footer={ () => (
+					<SourceLink
+						className="googlesitekit-data-block__source"
+						name={ _x( 'Search Console', 'Service name', 'google-site-kit' ) }
+						href={ baseServiceURL }
+						external
+					/>
+				) }
+			>
+				<WidgetReportError moduleSlug="search-console" error={ error } />
+			</Widget>
+		);
 	}
 
 	if ( isZeroReport( data ) ) {
-		return <WidgetReportZero moduleSlug="search-console" />;
+		return (
+			<Widget
+				noPadding
+				Footer={ () => (
+					<SourceLink
+						className="googlesitekit-data-block__source"
+						name={ _x( 'Search Console', 'Service name', 'google-site-kit' ) }
+						href={ baseServiceURL }
+						external
+					/>
+				) }
+			>
+				<WidgetReportZero moduleSlug="search-console" />
+			</Widget>
+		);
 	}
 
 	const tableColumns = [

--- a/assets/js/modules/search-console/components/dashboard/DashboardPopularKeywordsWidget.js
+++ b/assets/js/modules/search-console/components/dashboard/DashboardPopularKeywordsWidget.js
@@ -61,19 +61,18 @@ function DashboardPopularKeywordsWidget( { Widget, WidgetReportZero, WidgetRepor
 		page: url ? `!${ url }` : undefined,
 	} ) );
 
+	const Footer = () => (
+		<SourceLink
+			className="googlesitekit-data-block__source"
+			name={ _x( 'Search Console', 'Service name', 'google-site-kit' ) }
+			href={ baseServiceURL }
+			external
+		/>
+	);
+
 	if ( loading ) {
 		return (
-			<Widget
-				noPadding
-				Footer={ () => (
-					<SourceLink
-						className="googlesitekit-data-block__source"
-						name={ _x( 'Search Console', 'Service name', 'google-site-kit' ) }
-						href={ baseServiceURL }
-						external
-					/>
-				) }
-			>
+			<Widget noPadding Footer={ Footer } >
 				<PreviewTable padding />
 			</Widget>
 		);
@@ -81,17 +80,7 @@ function DashboardPopularKeywordsWidget( { Widget, WidgetReportZero, WidgetRepor
 
 	if ( error ) {
 		return (
-			<Widget
-				noPadding
-				Footer={ () => (
-					<SourceLink
-						className="googlesitekit-data-block__source"
-						name={ _x( 'Search Console', 'Service name', 'google-site-kit' ) }
-						href={ baseServiceURL }
-						external
-					/>
-				) }
-			>
+			<Widget Footer={ Footer } >
 				<WidgetReportError moduleSlug="search-console" error={ error } />
 			</Widget>
 		);
@@ -99,17 +88,7 @@ function DashboardPopularKeywordsWidget( { Widget, WidgetReportZero, WidgetRepor
 
 	if ( isZeroReport( data ) ) {
 		return (
-			<Widget
-				noPadding
-				Footer={ () => (
-					<SourceLink
-						className="googlesitekit-data-block__source"
-						name={ _x( 'Search Console', 'Service name', 'google-site-kit' ) }
-						href={ baseServiceURL }
-						external
-					/>
-				) }
-			>
+			<Widget Footer={ Footer } >
 				<WidgetReportZero moduleSlug="search-console" />
 			</Widget>
 		);
@@ -156,17 +135,7 @@ function DashboardPopularKeywordsWidget( { Widget, WidgetReportZero, WidgetRepor
 	];
 
 	return (
-		<Widget
-			noPadding
-			Footer={ () => (
-				<SourceLink
-					className="googlesitekit-data-block__source"
-					name={ _x( 'Search Console', 'Service name', 'google-site-kit' ) }
-					href={ baseServiceURL }
-					external
-				/>
-			) }
-		>
+		<Widget noPadding Footer={ Footer }>
 			<TableOverflowContainer>
 				<ReportTable
 					rows={ data }


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #3060

## Relevant technical choices

<!-- Please describe your changes. -->

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
