### PR TITLE
Fix classname to not rely on widget slug.

### DIFF
--- a/assets/js/modules/analytics/components/dashboard/DashboardAllTrafficWidget/index.js
+++ b/assets/js/modules/analytics/components/dashboard/DashboardAllTrafficWidget/index.js
@@ -178,7 +178,7 @@ function DashboardAllTrafficWidget( { Widget, WidgetReportZero, WidgetReportErro
 
 	return (
 		<Widget
-			className="googlesitekit-widget--footer-v2"
+			className="googlesitekit-widget--footer-v2 googlesitekit-widget__analytics--all-traffic"
 			Footer={ () => (
 				<SourceLink
 					className="googlesitekit-data-block__source"

--- a/assets/sass/widgets/_googlesitekit-widget-analyticsAllTraffic.scss
+++ b/assets/sass/widgets/_googlesitekit-widget-analyticsAllTraffic.scss
@@ -18,8 +18,8 @@
 
 .googlesitekit-plugin {
 
-	.googlesitekit-widget.googlesitekit-widget--legacy-all-traffic-widget,
-	.googlesitekit-widget.googlesitekit-widget--analyticsAllTraffic {
+	.googlesitekit-widget__analytics--all-traffic,
+	.googlesitekit-widget.googlesitekit-widget--legacy-all-traffic-widget {
 
 		.mdc-tab-scroller__scroll-content {
 			justify-content: center;


### PR DESCRIPTION
## Summary

Addresses issue #2904.

**Before**
![before](https://user-images.githubusercontent.com/8496063/114594443-8b84f380-9c8d-11eb-953b-0c46f255e49b.png)

**After**
![after](https://user-images.githubusercontent.com/8496063/114594458-8f187a80-9c8d-11eb-9afe-3566da36cb08.png)

## Relevant technical choices

<!-- Please describe your changes. -->

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
