### PR TITLE
Don't fail E2E tests when blocks are updated.

### DIFF
--- a/tests/e2e/config/bootstrap.js
+++ b/tests/e2e/config/bootstrap.js
@@ -184,6 +184,14 @@ function observeConsoleLogging() {
 			return;
 		}
 
+		// WordPress 5.3 logs when a block is saved and causes console logs
+		// that should not cause failures.
+		if (
+			text.startsWith( 'Block successfully updated for' )
+		) {
+			return;
+		}
+
 		// As of WordPress 5.3.2 in Chrome 79, navigating to the block editor
 		// (Posts > Add New) will display a console warning about
 		// non - unique IDs.


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue TBD.

## Relevant technical choices

It seems this change was [introduced in 2019](https://github.com/WordPress/WordPress/commit/03390f00c58a5d1a21052397e414ee43be845dd3), so I'm not sure why it's only Nightly triggering it, but at any rate this console message isn't a valid failure and should be ignored by the E2E tests.

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
