### PR TITLE
Include dates in all service deep links for refactored module page widgets

### DIFF
--- a/assets/js/modules/analytics/components/module/ModuleAcquisitionChannelsWidget/Footer.js
+++ b/assets/js/modules/analytics/components/module/ModuleAcquisitionChannelsWidget/Footer.js
@@ -25,12 +25,20 @@ import { _x } from '@wordpress/i18n';
  * Internal dependencies
  */
 import Data from 'googlesitekit-data';
-import { MODULES_ANALYTICS } from '../../../datastore/constants';
+import { CORE_USER } from '../../../../../googlesitekit/datastore/user/constants';
+import { MODULES_ANALYTICS, DATE_RANGE_OFFSET } from '../../../datastore/constants';
 import SourceLink from '../../../../../components/SourceLink';
+import { generateDateRangeArgs } from '../../../util/report-date-range-args';
 const { useSelect } = Data;
 
 export default function Footer() {
-	const url = useSelect( ( select ) => select( MODULES_ANALYTICS ).getServiceReportURL( 'trafficsources-overview' ) );
+	const dates = useSelect( ( select ) => select( CORE_USER ).getDateRangeDates( {
+		offsetDays: DATE_RANGE_OFFSET,
+	} ) );
+	const url = useSelect( ( select ) => select( MODULES_ANALYTICS ).getServiceReportURL(
+		'trafficsources-overview',
+		generateDateRangeArgs( dates )
+	) );
 	return (
 		<SourceLink
 			className="googlesitekit-data-block__source"

--- a/assets/js/modules/analytics/components/module/ModulePopularPagesWidget/Footer.js
+++ b/assets/js/modules/analytics/components/module/ModulePopularPagesWidget/Footer.js
@@ -25,12 +25,20 @@ import { _x } from '@wordpress/i18n';
  * Internal dependencies
  */
 import Data from 'googlesitekit-data';
-import { MODULES_ANALYTICS } from '../../../datastore/constants';
+import { CORE_USER } from '../../../../../googlesitekit/datastore/user/constants';
+import { MODULES_ANALYTICS, DATE_RANGE_OFFSET } from '../../../datastore/constants';
 import SourceLink from '../../../../../components/SourceLink';
+import { generateDateRangeArgs } from '../../../util/report-date-range-args';
 const { useSelect } = Data;
 
 export default function Footer() {
-	const contentPagesURL = useSelect( ( select ) => select( MODULES_ANALYTICS ).getServiceReportURL( 'content-pages' ) );
+	const dates = useSelect( ( select ) => select( CORE_USER ).getDateRangeDates( {
+		offsetDays: DATE_RANGE_OFFSET,
+	} ) );
+	const contentPagesURL = useSelect( ( select ) => select( MODULES_ANALYTICS ).getServiceReportURL(
+		'content-pages',
+		generateDateRangeArgs( dates )
+	) );
 
 	return (
 		<SourceLink


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #3042

## Relevant technical choices

Note that some of the IB was already done in this PR https://github.com/google/site-kit-wp/pull/3163 , this PR is applying the same changes to the relevant `Footer` components

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
