### PR TITLE
Update to only show menu options to admins.

### DIFF
--- a/assets/js/googlesitekit/datastore/user/constants.js
+++ b/assets/js/googlesitekit/datastore/user/constants.js
@@ -28,4 +28,3 @@ export const PERMISSION_VIEW_POSTS_INSIGHTS = 'googlesitekit_view_posts_insights
 export const PERMISSION_VIEW_DASHBOARD = 'googlesitekit_view_dashboard';
 export const PERMISSION_VIEW_MODULE_DETAILS = 'googlesitekit_view_module_details';
 export const PERMISSION_MANAGE_OPTIONS = 'googlesitekit_manage_options';
-export const PERMISSION_PUBLISH_POSTS = 'googlesitekit_publish_posts';

--- a/includes/Core/Assets/Assets.php
+++ b/includes/Core/Assets/Assets.php
@@ -785,7 +785,6 @@ final class Assets {
 				'canViewDashboard'     => current_user_can( Permissions::VIEW_DASHBOARD ),
 				'canViewModuleDetails' => current_user_can( Permissions::VIEW_MODULE_DETAILS ),
 				'canManageOptions'     => current_user_can( Permissions::MANAGE_OPTIONS ),
-				'canPublishPosts'      => current_user_can( Permissions::PUBLISH_POSTS ),
 			),
 
 			/**

--- a/includes/Core/Permissions/Permissions.php
+++ b/includes/Core/Permissions/Permissions.php
@@ -30,7 +30,6 @@ final class Permissions {
 	const VIEW_DASHBOARD      = 'googlesitekit_view_dashboard';
 	const VIEW_MODULE_DETAILS = 'googlesitekit_view_module_details';
 	const MANAGE_OPTIONS      = 'googlesitekit_manage_options';
-	const PUBLISH_POSTS       = 'googlesitekit_publish_posts';
 
 	/*
 	 * Custom meta capabilities.
@@ -108,34 +107,36 @@ final class Permissions {
 			self::AUTHENTICATE        => 'manage_options',
 
 			// Allow contributors and up to view their own post's insights.
-			self::VIEW_POSTS_INSIGHTS => 'edit_posts',
+			// TODO change to map to edit_posts when Site Kit supports non admin access.
+			self::VIEW_POSTS_INSIGHTS => 'manage_options',
 
 			// Allow editors and up to view the dashboard and module details.
-			self::VIEW_DASHBOARD      => 'edit_others_posts',
-			self::VIEW_MODULE_DETAILS => 'edit_others_posts',
+			// TODO change to map to edit_others_posts when Site Kit supports non admin access.
+			self::VIEW_DASHBOARD      => 'manage_options',
+			self::VIEW_MODULE_DETAILS => 'manage_options',
 
 			// Allow administrators and up to manage options and set up the plugin.
 			self::MANAGE_OPTIONS      => 'manage_options',
 			self::SETUP               => 'manage_options',
-
-			// Allow to differentiate between authors and contributors.
-			self::PUBLISH_POSTS       => 'publish_posts',
 		);
 
 		$this->meta_to_core = array(
 			// Allow users that can edit a post to view that post's insights.
-			self::VIEW_POST_INSIGHTS => 'edit_post',
+			// TODO change to map to edit_post when Site Kit supports non admin access.
+			self::VIEW_POST_INSIGHTS => 'manage_options',
 		);
 
 		$this->meta_to_base = array(
 			// Allow users that can generally view posts insights to view a specific post's insights.
-			self::VIEW_POST_INSIGHTS => self::VIEW_POSTS_INSIGHTS,
+			// TODO change to map to self::VIEW_POSTS_INSIGHTS when Site Kit supports non admin access.
+			self::VIEW_POST_INSIGHTS => 'manage_options',
 		);
 
 		$this->network_base = array(
 			// Require network admin access to view the dashboard and module details in network mode.
-			self::VIEW_DASHBOARD      => 'manage_network',
-			self::VIEW_MODULE_DETAILS => 'manage_network',
+			// TODO change to map to manage_network when Site Kit supports non admin access.
+			self::VIEW_DASHBOARD      => 'manage_options',
+			self::VIEW_MODULE_DETAILS => 'manage_options',
 
 			// Require network admin access to manage options and set up the plugin in network mode.
 			self::MANAGE_OPTIONS      => 'manage_network_options',
@@ -194,7 +195,6 @@ final class Permissions {
 			self::VIEW_DASHBOARD,
 			self::VIEW_MODULE_DETAILS,
 			self::MANAGE_OPTIONS,
-			self::PUBLISH_POSTS,
 		);
 
 		return array_combine(

--- a/includes/Core/Permissions/Permissions.php
+++ b/includes/Core/Permissions/Permissions.php
@@ -122,14 +122,12 @@ final class Permissions {
 
 		$this->meta_to_core = array(
 			// Allow users that can edit a post to view that post's insights.
-			// TODO change to map to edit_post when Site Kit supports non admin access.
-			self::VIEW_POST_INSIGHTS => 'manage_options',
+			self::VIEW_POST_INSIGHTS => 'edit_post',
 		);
 
 		$this->meta_to_base = array(
 			// Allow users that can generally view posts insights to view a specific post's insights.
-			// TODO change to map to self::VIEW_POSTS_INSIGHTS when Site Kit supports non admin access.
-			self::VIEW_POST_INSIGHTS => 'manage_options',
+			self::VIEW_POST_INSIGHTS => self::VIEW_POSTS_INSIGHTS,
 		);
 
 		$this->network_base = array(

--- a/tests/js/utils.js
+++ b/tests/js/utils.js
@@ -35,7 +35,6 @@ import {
 	PERMISSION_VIEW_DASHBOARD,
 	PERMISSION_VIEW_MODULE_DETAILS,
 	PERMISSION_MANAGE_OPTIONS,
-	PERMISSION_PUBLISH_POSTS,
 	CORE_USER,
 } from '../../assets/js/googlesitekit/datastore/user/constants';
 import { CORE_MODULES } from '../../assets/js/googlesitekit/modules/datastore/constants';
@@ -242,7 +241,6 @@ export const provideUserCapabilities = ( registry, extraData = {} ) => {
 		[ PERMISSION_VIEW_DASHBOARD ]: true,
 		[ PERMISSION_VIEW_MODULE_DETAILS ]: true,
 		[ PERMISSION_MANAGE_OPTIONS ]: true,
-		[ PERMISSION_PUBLISH_POSTS ]: true,
 	};
 
 	registry.dispatch( CORE_USER ).receiveCapabilities( {


### PR DESCRIPTION
## Summary

Update to only show menu options to admins.

Addresses issue #2938 

## Relevant technical choices


## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [X] I have added a QA Brief on the issue linked above.
- [X] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
