### PR TITLE
Update to solve Portugese language bug.

### DIFF
--- a/includes/Context.php
+++ b/includes/Context.php
@@ -493,7 +493,7 @@ class Context {
 
 		} elseif ( 'language-variant' === $format ) {
 			$variant_array  = explode( '_', $wp_locale );
-			$variant_string = array_key_exists( 1, $variant_array ) ? $variant_array[0] . '_' . $variant_array[1] : $variant_array[0];
+			$variant_string = implode( '_', array_slice( $variant_array, 0, 2 ) );
 			return $variant_string;
 		}
 

--- a/includes/Context.php
+++ b/includes/Context.php
@@ -467,4 +467,36 @@ class Context {
 
 		return $url;
 	}
+
+	/**
+	 * Calls the WordPress core functions to get the locale and return it in the required format.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param string $context Optional. Defines which WordPress core locale function to call.
+	 * @param string $format Optional. Defines the format the locale is returned in.
+	 * @return string Locale in the required format.
+	 */
+	public function get_locale( $context = 'site', $format = 'default' ) {
+
+		// Get the site or user locale.
+		if ( 'user' === $context ) {
+			$wp_locale = get_user_locale();
+		} else {
+			$wp_locale = get_locale();
+		}
+
+		// Return locale in the required format.
+		if ( 'language-code' === $format ) {
+			$code_array = explode( '_', $wp_locale );
+			return $code_array[0];
+
+		} elseif ( 'language-variant' === $format ) {
+			$variant_array  = explode( '_', $wp_locale );
+			$variant_string = array_key_exists( 1, $variant_array ) ? $variant_array[0] . '_' . $variant_array[1] : $variant_array[0];
+			return $variant_string;
+		}
+
+		return $wp_locale;
+	}
 }

--- a/includes/Core/Assets/Assets.php
+++ b/includes/Core/Assets/Assets.php
@@ -777,7 +777,7 @@ final class Assets {
 			 * @param array $data Data about each module.
 			 */
 			'modules'       => apply_filters( 'googlesitekit_modules_data', array() ),
-			'locale'        => get_user_locale(),
+			'locale'        => $this->context->get_locale( 'user' ),
 			'permissions'   => array(
 				'canAuthenticate'      => current_user_can( Permissions::AUTHENTICATE ),
 				'canSetup'             => current_user_can( Permissions::SETUP ),

--- a/includes/Core/Authentication/Clients/OAuth_Client.php
+++ b/includes/Core/Authentication/Clients/OAuth_Client.php
@@ -641,7 +641,7 @@ final class OAuth_Client {
 		$this->get_client()->setScopes( array_unique( $scopes ) );
 
 		$query_params = array(
-			'hl' => get_user_locale(),
+			'hl' => $this->context->get_locale( 'user' ),
 		);
 
 		return add_query_arg( $query_params, $this->get_client()->createAuthUrl() );

--- a/includes/Core/Authentication/Google_Proxy.php
+++ b/includes/Core/Authentication/Google_Proxy.php
@@ -136,7 +136,7 @@ class Google_Proxy {
 		$params      = array_merge( $params, $user_fields );
 
 		$params['application_name'] = rawurlencode( self::get_application_name() );
-		$params['hl']               = get_user_locale();
+		$params['hl']               = $this->context->get_locale( 'user' );
 
 		return add_query_arg( $params, $this->url( self::SETUP_URI ) );
 	}
@@ -159,7 +159,7 @@ class Google_Proxy {
 		}
 
 		$query_args['application_name'] = rawurlencode( self::get_application_name() );
-		$query_args['hl']               = get_user_locale();
+		$query_args['hl']               = $this->context->get_locale( 'user' );
 
 		return add_query_arg( $query_args, $this->url( self::PERMISSIONS_URI ) );
 	}

--- a/includes/Modules/AdSense.php
+++ b/includes/Modules/AdSense.php
@@ -517,7 +517,7 @@ final class AdSense extends Module
 		}
 
 		$opt_params = array(
-			'locale' => get_locale(),
+			'locale' => $this->context->get_locale(),
 			'metric' => array( 'EARNINGS', 'PAGE_VIEWS_RPM', 'IMPRESSIONS' ),
 		);
 

--- a/includes/Modules/PageSpeed_Insights.php
+++ b/includes/Modules/PageSpeed_Insights.php
@@ -115,7 +115,7 @@ final class PageSpeed_Insights extends Module
 				return $service->pagespeedapi->runpagespeed(
 					$page_url,
 					array(
-						'locale'   => substr( get_locale(), 0, 2 ),
+						'locale'   => $this->context->get_locale( 'site', 'language-code' ),
 						'strategy' => $data['strategy'],
 					)
 				);

--- a/tests/phpunit/integration/ContextTest.php
+++ b/tests/phpunit/integration/ContextTest.php
@@ -359,4 +359,34 @@ class ContextTest extends TestCase {
 		$context = new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE );
 		$this->assertTrue( $context->is_network_active() );
 	}
+
+	public function test_get_locale() {
+
+		// Set locale site and user.
+		$original_locale   = $GLOBALS['locale'];
+		$GLOBALS['locale'] = 'pt_PT_ao90';
+		$user              = wp_get_current_user();
+		$user->locale      = 'nl_NL_formal';
+
+		$context = new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE );
+		$locale  = $context->get_locale();
+
+		$this->assertEquals( 'pt_PT_ao90', $context->get_locale() );
+		$this->assertEquals( 'pt_PT_ao90', $context->get_locale( 'site' ) );
+		$this->assertEquals( 'pt', $context->get_locale( 'site', 'language-code' ) );
+		$this->assertEquals( 'pt_PT', $context->get_locale( 'site', 'language-variant' ) );
+		$this->assertEquals( 'nl_NL_formal', $context->get_locale( 'user' ) );
+		$this->assertEquals( 'nl', $context->get_locale( 'user', 'language-code' ) );
+		$this->assertEquals( 'nl_NL', $context->get_locale( 'user', 'language-variant' ) );
+
+		// Change site locale
+		$GLOBALS['locale'] = 'te';
+		$this->assertEquals( 'te', $context->get_locale() );
+		$this->assertEquals( 'te', $context->get_locale( 'site' ) );
+		$this->assertEquals( 'te', $context->get_locale( 'site', 'language-code' ) );
+
+		// Reset locale.
+		$GLOBALS['locale'] = $original_locale;
+		unset( $user->locale );
+	}
 }


### PR DESCRIPTION
## Summary

Update to solve Portugese language bug.

Addresses issue #2105 

## Relevant technical choices

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [X] I have added a QA Brief on the issue linked above.
- [X] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
