### PR TITLE
Update to display property id and name.

### DIFF
--- a/assets/js/modules/analytics/components/common/PropertySelect.js
+++ b/assets/js/modules/analytics/components/common/PropertySelect.js
@@ -91,7 +91,7 @@ export default function PropertySelect() {
 					<Option
 						key={ index }
 						value={ id }
-						data-internal-id={ internalWebPropertyId } /* eslint-disable-line sitekit/acronym-case */
+						data-internal-id={ internalWebPropertyId } // eslint-disable-line sitekit/acronym-case
 					>
 						{ internalWebPropertyId // eslint-disable-line sitekit/acronym-case
 							? sprintf(

--- a/assets/js/modules/analytics/components/common/PropertySelect.js
+++ b/assets/js/modules/analytics/components/common/PropertySelect.js
@@ -91,14 +91,16 @@ export default function PropertySelect() {
 					<Option
 						key={ index }
 						value={ id }
-						data-internal-id={ internalWebPropertyId } // eslint-disable-line sitekit/acronym-case
+						data-internal-id={ internalWebPropertyId } /* eslint-disable-line sitekit/acronym-case */
 					>
-						{ sprintf(
-							/* translators: %1$s: property name, %2$s: property ID */
-							__( '%1$s (%2$s)', 'google-site-kit' ),
-							name,
-							id
-						) }
+						{ internalWebPropertyId // eslint-disable-line sitekit/acronym-case
+							? sprintf(
+								/* translators: %1$s: property name, %2$s: property ID */
+								__( '%1$s (%2$s)', 'google-site-kit' ),
+								name,
+								id
+							) : name
+						}
 					</Option>
 				) ) }
 		</Select>

--- a/assets/js/modules/analytics/components/common/PropertySelect.js
+++ b/assets/js/modules/analytics/components/common/PropertySelect.js
@@ -20,7 +20,7 @@
  * WordPress dependencies
  */
 import { useCallback } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { sprintf, __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -93,7 +93,12 @@ export default function PropertySelect() {
 						value={ id }
 						data-internal-id={ internalWebPropertyId } // eslint-disable-line sitekit/acronym-case
 					>
-						{ name }
+						{ sprintf(
+							/* translators: %1$s: property name, %2$s: property ID */
+							__( '%1$s (%2$s)', 'google-site-kit' ),
+							name,
+							id
+						) }
 					</Option>
 				) ) }
 		</Select>


### PR DESCRIPTION
## Summary

Update to display property id and name.

Addresses issue #3164

## Relevant technical choices


## Checklist

- [X] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [X] I have added a QA Brief on the issue linked above.
- [X] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
