### PR TITLE
Update to remove GA4 account ID.

### DIFF
--- a/assets/js/modules/analytics-4/datastore/base.js
+++ b/assets/js/modules/analytics-4/datastore/base.js
@@ -25,7 +25,8 @@ import { STORE_NAME } from './constants';
 const baseModuleStore = Modules.createModuleStore( 'analytics-4', {
 	storeName: STORE_NAME,
 	settingSlugs: [
-		'accountID',
+		// TODO: This can be uncommented when Analytics and Analytics 4 modules are officially separated.
+		// 'accountID',
 		'propertyID',
 		'webDataStreamID',
 		'measurementID',

--- a/includes/Modules/Analytics_4.php
+++ b/includes/Modules/Analytics_4.php
@@ -95,7 +95,8 @@ final class Analytics_4 extends Module
 	 */
 	public function is_connected() {
 		$required_keys = array(
-			'accountID',
+			// TODO: This can be uncommented when Analytics and Analytics 4 modules are officially separated.
+			/* 'accountID', */
 			'propertyID',
 			'webDataStreamID',
 			'measurementID',
@@ -131,11 +132,15 @@ final class Analytics_4 extends Module
 		$settings = $this->get_settings()->get();
 
 		return array(
+			// TODO: This can be uncommented when Analytics and Analytics 4 modules are officially separated.
+
+			/* // phpcs:ignore Squiz.PHP.CommentedOutCode.Found
 			'analytics_4_account_id'         => array(
 				'label' => __( 'Analytics 4 account ID', 'google-site-kit' ),
 				'value' => $settings['accountID'],
 				'debug' => Debug_Data::redact_debug_value( $settings['accountID'] ),
 			),
+			*/
 			'analytics_4_property_id'        => array(
 				'label' => __( 'Analytics 4 property ID', 'google-site-kit' ),
 				'value' => $settings['propertyID'],

--- a/includes/Modules/Analytics_4.php
+++ b/includes/Modules/Analytics_4.php
@@ -133,7 +133,6 @@ final class Analytics_4 extends Module
 
 		return array(
 			// TODO: This can be uncommented when Analytics and Analytics 4 modules are officially separated.
-
 			/* // phpcs:ignore Squiz.PHP.CommentedOutCode.Found
 			'analytics_4_account_id'         => array(
 				'label' => __( 'Analytics 4 account ID', 'google-site-kit' ),

--- a/includes/Modules/Analytics_4/Settings.php
+++ b/includes/Modules/Analytics_4/Settings.php
@@ -46,7 +46,8 @@ class Settings extends Module_Settings implements Setting_With_Owned_Keys_Interf
 	 */
 	public function get_owned_keys() {
 		return array(
-			'accountID',
+			// TODO: This can be uncommented when Analytics and Analytics 4 modules are officially separated.
+			/* 'accountID', */
 			'propertyID',
 			'webDataStreamID',
 			'measurementID',
@@ -63,7 +64,8 @@ class Settings extends Module_Settings implements Setting_With_Owned_Keys_Interf
 	protected function get_default() {
 		return array(
 			'ownerID'         => 0,
-			'accountID'       => '',
+			// TODO: This can be uncommented when Analytics and Analytics 4 modules are officially separated.
+			/* 'accountID'       => '', */ // phpcs:ignore Squiz.PHP.CommentedOutCode.Found
 			'propertyID'      => '',
 			'webDataStreamID' => '',
 			'measurementID'   => '',

--- a/tests/phpunit/integration/Modules/Analytics_4/SettingsTest.php
+++ b/tests/phpunit/integration/Modules/Analytics_4/SettingsTest.php
@@ -30,7 +30,8 @@ class SettingsTest extends SettingsTestCase {
 
 		$this->assertEqualSetsWithIndex(
 			array(
-				'accountID'       => '',
+				// TODO: This can be uncommented when Analytics and Analytics 4 modules are officially separated.
+				// 'accountID'       => '',
 				'propertyID'      => '',
 				'webDataStreamID' => '',
 				'measurementID'   => '',


### PR DESCRIPTION
## Summary

Update to remove GA4 account ID.

Addresses issue #3165

## Relevant technical choices

## Checklist

- [X] My code is tested and passes existing unit tests.
- [X] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [X] I have added a QA Brief on the issue linked above.
- [X] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
