### PR TITLE
Update description for new Ads conversion ID field

### DIFF
--- a/assets/js/modules/analytics/components/common/AdsConversionIDTextField.js
+++ b/assets/js/modules/analytics/components/common/AdsConversionIDTextField.js
@@ -91,7 +91,7 @@ export default function AdsConversionIDTextField() {
 			</TextField>
 
 			<p>
-				{ __( 'Insert your Ads Conversion ID here if you want Site Kit to place the snippet on your site', 'google-site-kit' ) }
+				{ __( 'If you’re using Google Ads, insert your Ads conversion ID if you’d like Site Kit to place the snippet on your site', 'google-site-kit' ) }
 			</p>
 		</div>
 	);


### PR DESCRIPTION
## Summary

Addresses issue #3161 (follow-up to #3257)

## Relevant technical choices

* Missed checking for that new requirement in the original PR 🤦 

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [ ] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
