### PR TITLE
Add bool proptype support to DataBlock changeDataUnit prop.

### DIFF
--- a/assets/js/components/DataBlock.js
+++ b/assets/js/components/DataBlock.js
@@ -184,7 +184,10 @@ DataBlock.propTypes = {
 		PropTypes.string,
 		PropTypes.number,
 	] ),
-	changeDataUnit: PropTypes.string,
+	changeDataUnit: PropTypes.oneOfType( [
+		PropTypes.string,
+		PropTypes.bool,
+	] ),
 	context: PropTypes.string,
 	period: PropTypes.string,
 	selected: PropTypes.bool,


### PR DESCRIPTION
## Summary

Addresses issue: #3091 (follow-up)

## Relevant technical choices

* Fixes console error accidentally introduced by this commit: https://github.com/google/site-kit-wp/pull/3214/commits/181775aaa91c0e4131b31001fbcf6409fd452757

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
