### PR TITLE
Add `id` to DashboardPageSpeed html for jump link

### DIFF
--- a/assets/js/modules/pagespeed-insights/components/dashboard/DashboardPageSpeed.js
+++ b/assets/js/modules/pagespeed-insights/components/dashboard/DashboardPageSpeed.js
@@ -142,7 +142,10 @@ export default function DashboardPageSpeed() {
 
 	if ( ! referenceURL || isFetchingMobile || isFetchingDesktop || ! dataSrc ) {
 		return (
-			<div className="mdc-layout-grid">
+			<div
+				id="googlesitekit-pagespeed-header" // Used by jump link.
+				className="mdc-layout-grid"
+			>
 				<div className="mdc-layout-grid__inner">
 					<div className=" mdc-layout-grid__cell mdc-layout-grid__cell--span-12">
 						<ProgressBar />
@@ -160,7 +163,11 @@ export default function DashboardPageSpeed() {
 
 	return (
 		<Fragment>
-			<header className="googlesitekit-pagespeed-widget__header" ref={ trackingRef }>
+			<header
+				id="googlesitekit-pagespeed-header" // Used by jump link.
+				className="googlesitekit-pagespeed-widget__header"
+				ref={ trackingRef }
+			>
 				<div className="googlesitekit-pagespeed-widget__data-src-tabs">
 					<TabBar
 						activeIndex={ [ DATA_SRC_LAB, DATA_SRC_FIELD ].indexOf( dataSrc ) }


### PR DESCRIPTION
## Summary

Addresses issue #3310 

## Relevant technical choices

* The legacy jump link is located [on the dashboard section itself](https://github.com/google/site-kit-wp/blob/a194a8f034d72bf2776746399182b3c7f1068662/assets/js/modules/pagespeed-insights/components/dashboard/LegacyDashboardSpeed.js#L44) which isn't possible in the widget-based dashboard, so I added it to the widget – this results in a slightly different jump location but not sure we can do much about that without putting in an ugly hack somewhere
* Targets `main` 

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
