### PR TITLE
Update multiple user notice to be in the correct place.

### DIFF
--- a/assets/js/components/user-input/UserInputQuestionInfo.js
+++ b/assets/js/components/user-input/UserInputQuestionInfo.js
@@ -67,7 +67,7 @@ export default function UserInputQuestionInfo( { title, description, scope, ques
 
 			{ scope === 'site' && hasMultipleUser && (
 				<p>
-					{ __( 'This question applies to the entire site and may have an effect for other users.', 'google-site-kit' ) }
+					{ __( 'The goals you pick will apply to the entire WordPress site: any other admins with access to Site Kit can see them and edit them in Settings.', 'google-site-kit' ) }
 				</p>
 			) }
 

--- a/assets/js/components/user-input/UserInputQuestionnaire.js
+++ b/assets/js/components/user-input/UserInputQuestionnaire.js
@@ -250,7 +250,7 @@ export default function UserInputQuestionnaire() {
 					isActive={ activeSlug === USER_INPUT_QUESTION_GOALS }
 					questionNumber={ 3 }
 					title={ __( 'What are the goals of this site?', 'google-site-kit' ) }
-					description={ __( 'The goals you pick will apply to the entire WordPress site: any other admins with access to Site Kit can see them and edit them in Settings.', 'google-site-kit' ) }
+					description={ __( 'Based on your answer, Site Kit will tailor the metrics you see on your dashboard to help you track how close you’re getting to your specific goals.', 'google-site-kit' ) }
 					next={ nextCallback }
 					nextLabel={ nextLabel }
 					back={ backCallback }


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #2853.

## Relevant technical choices

This updates the text to appear in the correct place, under the correct conditions, and restores the old text that was mistakenly replaced.

## Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
