### PR TITLE
Allow ability to select what user roles are excluded - UI fix (1891).

### DIFF
--- a/assets/js/modules/analytics/components/common/TrackingExclusionSwitches.js
+++ b/assets/js/modules/analytics/components/common/TrackingExclusionSwitches.js
@@ -78,8 +78,8 @@ export default function TrackingExclusionSwitches() {
 			<legend className="googlesitekit-setup-module__text">
 				{ __( 'Exclude from Analytics', 'google-site-kit' ) }
 			</legend>
-			<div>
-				<div className="googlesitekit-analytics-trackingdisabled__inlineswitch">
+			<div className="googlesitekit-settings-module__inline-items">
+				<div className="googlesitekit-settings-module__inline-item">
 					<Switch
 						label={ trackingExclusionLabels[ TRACKING_LOGGED_IN_USERS ] }
 						checked={ trackingDisabled.includes( TRACKING_LOGGED_IN_USERS ) }
@@ -88,7 +88,7 @@ export default function TrackingExclusionSwitches() {
 					/>
 				</div>
 				{ ! trackingDisabled.includes( TRACKING_LOGGED_IN_USERS ) && (
-					<div className="googlesitekit-analytics-trackingdisabled__inlineswitch">
+					<div className="googlesitekit-settings-module__inline-item">
 						<Switch
 							label={ trackingExclusionLabels[ TRACKING_CONTENT_CREATORS ] }
 							checked={ trackingDisabled.includes( TRACKING_CONTENT_CREATORS ) }
@@ -98,7 +98,7 @@ export default function TrackingExclusionSwitches() {
 					</div>
 				) }
 			</div>
-			<p>{ message }</p>
+			<p className="googlesitekit-margin-top-0">{ message }</p>
 		</fieldset>
 	);
 }

--- a/assets/js/modules/analytics/components/common/TrackingExclusionSwitches.js
+++ b/assets/js/modules/analytics/components/common/TrackingExclusionSwitches.js
@@ -28,9 +28,6 @@ import { __ } from '@wordpress/i18n';
 import Data from 'googlesitekit-data';
 import { STORE_NAME } from '../../datastore/constants';
 import Switch from '../../../../components/Switch';
-import Grid from '../../../../material-components/layout/Grid';
-import Row from '../../../../material-components/layout/Row';
-import Cell from '../../../../material-components/layout/Cell';
 const { useSelect, useDispatch } = Data;
 
 const TRACKING_LOGGED_IN_USERS = 'loggedinUsers';
@@ -81,29 +78,26 @@ export default function TrackingExclusionSwitches() {
 			<legend className="googlesitekit-setup-module__text">
 				{ __( 'Exclude from Analytics', 'google-site-kit' ) }
 			</legend>
-			<Grid>
-				<Row>
-					<Cell lgSize={ 6 } mdSize={ 4 } smSize={ 4 }>
+			<div>
+				<div className="googlesitekit-analytics-trackingdisabled__inlineswitch">
+					<Switch
+						label={ trackingExclusionLabels[ TRACKING_LOGGED_IN_USERS ] }
+						checked={ trackingDisabled.includes( TRACKING_LOGGED_IN_USERS ) }
+						onClick={ onChangeTrackLoggedInUsers }
+						hideLabel={ false }
+					/>
+				</div>
+				{ ! trackingDisabled.includes( TRACKING_LOGGED_IN_USERS ) && (
+					<div className="googlesitekit-analytics-trackingdisabled__inlineswitch">
 						<Switch
-							label={ trackingExclusionLabels[ TRACKING_LOGGED_IN_USERS ] }
-							checked={ trackingDisabled.includes( TRACKING_LOGGED_IN_USERS ) }
-							onClick={ onChangeTrackLoggedInUsers }
+							label={ trackingExclusionLabels[ TRACKING_CONTENT_CREATORS ] }
+							checked={ trackingDisabled.includes( TRACKING_CONTENT_CREATORS ) }
+							onClick={ onChangeTrackContentCreators }
 							hideLabel={ false }
 						/>
-					</Cell>
-
-					{ ! trackingDisabled.includes( TRACKING_LOGGED_IN_USERS ) && (
-						<Cell lgSize={ 6 } mdSize={ 4 } smSize={ 4 }>
-							<Switch
-								label={ trackingExclusionLabels[ TRACKING_CONTENT_CREATORS ] }
-								checked={ trackingDisabled.includes( TRACKING_CONTENT_CREATORS ) }
-								onClick={ onChangeTrackContentCreators }
-								hideLabel={ false }
-							/>
-						</Cell>
-					) }
-				</Row>
-			</Grid>
+					</div>
+				) }
+			</div>
 			<p>{ message }</p>
 		</fieldset>
 	);

--- a/assets/sass/components/settings/_googlesitekit-settings-module.scss
+++ b/assets/sass/components/settings/_googlesitekit-settings-module.scss
@@ -158,6 +158,14 @@
 		}
 	}
 
+	.googlesitekit-analytics-trackingdisabled__inlineswitch {
+		margin: 0 1rem 1rem 0;
+
+		@media (min-width: $bp-tablet) {
+			display: inline;
+		}
+	}
+
 	.googlesitekit-settings-module__meta-item-type {
 		color: $c-primary;
 		font-size: 0.75rem;

--- a/assets/sass/components/settings/_googlesitekit-settings-module.scss
+++ b/assets/sass/components/settings/_googlesitekit-settings-module.scss
@@ -158,12 +158,13 @@
 		}
 	}
 
-	.googlesitekit-analytics-trackingdisabled__inlineswitch {
-		margin: 0 1rem 1rem 0;
+	.googlesitekit-settings-module__inline-items {
+		display: flex;
+		flex-wrap: wrap;
+	}
 
-		@media (min-width: $bp-tablet) {
-			display: inline;
-		}
+	.googlesitekit-settings-module__inline-item {
+		margin: 0 1rem 1rem 0;
 	}
 
 	.googlesitekit-settings-module__meta-item-type {

--- a/assets/sass/utilities/_margin.scss
+++ b/assets/sass/utilities/_margin.scss
@@ -18,6 +18,10 @@
 
 .googlesitekit-plugin {
 
+	.googlesitekit-margin-top-0 {
+		margin-top: 0 !important;
+	}
+
 	.googlesitekit-margin-bottom-0 {
 		margin-bottom: 0 !important;
 	}


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #1891

## Relevant technical choices

I played around with the UI a bit here but settled for the simplest implementation I could think of to show the switches inline on desktop and tablet but stacked on mobile.
I was unsure where to put the new CSS. In the end `assets/sass/components/settings/_googlesitekit-settings-module.scss` seemed like the most logical place.

| Mobile  | Tablet, desktop |
| ------------- | ------------- |
| ![Screenshot 2021-05-11 at 12 10 28](https://user-images.githubusercontent.com/2470911/117807250-484d7e80-b253-11eb-9ffb-80e33103c23d.png) | ![Screenshot 2021-05-11 at 12 10 47](https://user-images.githubusercontent.com/2470911/117807203-38359f00-b253-11eb-8ff5-43e73d403f8a.png) |
| ![Screenshot 2021-05-11 at 12 10 14](https://user-images.githubusercontent.com/2470911/117807248-47b4e800-b253-11eb-8e86-22438fc32c15.png) | ![Screenshot 2021-05-11 at 12 11 11](https://user-images.githubusercontent.com/2470911/117807207-38ce3580-b253-11eb-8af8-665d6390a0b5.png) |

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
