### PR TITLE
Add Ads Conversion ID to AMP output.

### DIFF
--- a/includes/Modules/Analytics/AMP_Tag.php
+++ b/includes/Modules/Analytics/AMP_Tag.php
@@ -106,18 +106,26 @@ class AMP_Tag extends Module_AMP_Tag implements Tag_Interface {
 	 * @since 1.24.0
 	 */
 	protected function render() {
+		$config = array(
+			$this->tag_id => array(
+				'groups' => 'default',
+				'linker' => array(
+					'domains' => array( $this->home_domain ),
+				),
+			),
+		);
+
+		if ( ! empty( $this->ads_conversion_id ) ) {
+			$config[ $this->ads_conversion_id ] = array(
+				'groups' => 'default',
+			);
+		}
+
 		$gtag_amp_opt = array(
 			'optoutElementId' => '__gaOptOutExtension',
 			'vars'            => array(
 				'gtag_id' => $this->tag_id,
-				'config'  => array(
-					$this->tag_id => array(
-						'groups' => 'default',
-						'linker' => array(
-							'domains' => array( $this->home_domain ),
-						),
-					),
-				),
+				'config'  => $config,
 			),
 		);
 


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #3282.

For the life of me I can't get the `<amp-analytics />` tag that outputs this to render on my development site. I've tried all AMP modes, viewing anonymously, etc. but it never appears. Oddly the Tag Manager `<amp-analytics />` tag _will_ appear when I enable Tag Manager, so I'm not sure what's up.

I can't see the tag without this commit as well, so it's unrelated to this change.

But if the reviewer could see if they too aren't seeing the AMP Analytics tag that'd be handy—if so seems there's another bug? Or if not something's up with my install/approach.

Either way, the logic here seems right so I think this is best to review and have someone else idiot-check my tag not working 😅

## Relevant technical choices

I attempted to write some PHPUnit tests for this, but given the `render()` method is protected it implied that we shouldn't be testing this behaviour, so I left it alone.

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
