### PR TITLE
Use useEffectOnce instead of useMount.

### DIFF
--- a/assets/js/components/Menu.js
+++ b/assets/js/components/Menu.js
@@ -19,7 +19,7 @@
 /**
  * External dependencies
  */
-import { useMount } from 'react-use';
+import { useEffectOnce } from 'react-use';
 import classnames from 'classnames';
 import PropTypes from 'prop-types';
 import useMergedRef from '@react-hook/merged-ref';
@@ -51,7 +51,7 @@ const Menu = forwardRef( ( {
 		onSelected( index, event );
 	}, [ onSelected ] );
 
-	useMount( () => {
+	useEffectOnce( () => {
 		if ( ! menuRef?.current ) {
 			return;
 		}

--- a/assets/js/components/Modal.js
+++ b/assets/js/components/Modal.js
@@ -19,7 +19,7 @@
 /**
  * External dependencies
  */
-import { useMount } from 'react-use';
+import { useEffectOnce } from 'react-use';
 
 /**
  * WordPress dependencies
@@ -30,7 +30,7 @@ function Modal( { children } ) {
 	// Using state as we need `el` to not change when the component re-renders
 	const [ el ] = useState( document.createElement( 'div' ) );
 
-	useMount( () => {
+	useEffectOnce( () => {
 		const root = document.querySelector( '.googlesitekit-plugin' ) || document.body;
 		root.appendChild( el );
 


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #3372.

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
