### PR TITLE
Ensure widgets in an area are combined beyond their row if all of them have the same special state (3225).

### DIFF
--- a/assets/js/googlesitekit/widgets/util/combine-widgets.js
+++ b/assets/js/googlesitekit/widgets/util/combine-widgets.js
@@ -57,6 +57,30 @@ export function combineWidgets( widgets, widgetStates, {
 	let currentRowIndex = -1;
 	let columnWidthsBuffer = [];
 
+	const states = [];
+
+	widgets.forEach( ( widget ) => {
+		const state = widgetStates?.[widget.slug]?.Component?.name;
+		if ( state && ! states.includes( state ) ) {
+			states.push( state );
+		}
+	} );
+
+	if ( states.length === 1 && widgets.length > 1 ) {
+		// All widgets have the same state, so we should only render one and hide the rest.
+		const hiddenRows = Array.from( { length: widgets.length - 1 } ).fill( 0 );
+		// All the components are the same, pick the first.
+		const overrideComponent = widgetStates[ widgets[ 0 ].slug ];
+
+		return {
+			overrideComponents: [ overrideComponent ],
+			gridColumnWidths: [
+				12, // full width row
+				...hiddenRows,
+			],
+		};
+	}
+
 	widgets.forEach( ( widget, i ) => {
 		overrideComponents.push( null );
 

--- a/assets/js/googlesitekit/widgets/util/combine-widgets.test.js
+++ b/assets/js/googlesitekit/widgets/util/combine-widgets.test.js
@@ -30,12 +30,36 @@ import Null from '../../../components/Null';
 describe( 'combineWidgets', () => {
 	const getQuarterWidget = ( slug ) => ( { slug, width: WIDGET_WIDTHS.QUARTER } );
 	const getHalfWidget = ( slug ) => ( { slug, width: WIDGET_WIDTHS.HALF } );
+	const getFullWidget = ( slug ) => ( { slug, width: WIDGET_WIDTHS.FULL } );
 
 	const getRegularState = () => null;
 	const getReportZeroState = ( moduleSlug ) => ( { Component: ReportZero, metadata: { moduleSlug } } );
 	const getActivateModuleCTAState = ( moduleSlug ) => ( { Component: ActivateModuleCTA, metadata: { moduleSlug } } );
 	const getCompleteModuleActivationCTAState = ( moduleSlug ) => ( { Component: CompleteModuleActivationCTA, metadata: { moduleSlug } } );
 	const getNullState = () => ( { Component: Null, metadata: {} } );
+
+	it( 'Widgets in an area are combined beyond their row if all of them have the same special state', () => {
+		const widgets = [
+			getFullWidget( 'test1' ),
+			getFullWidget( 'test2' ),
+			getFullWidget( 'test3' ),
+			getFullWidget( 'test4' ),
+		];
+		const widgetStates = {
+			test1: getReportZeroState( 'analytics' ),
+			test2: getReportZeroState( 'analytics' ),
+			test3: getReportZeroState( 'analytics' ),
+			test4: getReportZeroState( 'analytics' ),
+		};
+
+		const expected = {
+			overrideComponents: [ getReportZeroState( 'analytics' ) ],
+			gridColumnWidths: [ 12, 0, 0, 0 ],
+		};
+
+		const layout = getWidgetLayout( widgets, widgetStates );
+		expect( combineWidgets( widgets, widgetStates, layout ) ).toEqual( expected );
+	} );
 
 	// Every test case below corresponds to a matching story in `stories/widgets.stories.js` under
 	// "Global/Widgets/Widget Area/Special combination states".
@@ -72,7 +96,7 @@ describe( 'combineWidgets', () => {
 		expect( combineWidgets( widgets, widgetStates, layout ) ).toEqual( expected );
 	} );
 
-	it( 'combines adjacent widgets of the same component per the same metadata', () => {
+	it.only( 'combines adjacent widgets of the same component per the same metadata', () => {
 		const widgets = [
 			getQuarterWidget( 'test1' ),
 			getQuarterWidget( 'test2' ),

--- a/assets/js/googlesitekit/widgets/util/combine-widgets.test.js
+++ b/assets/js/googlesitekit/widgets/util/combine-widgets.test.js
@@ -61,6 +61,33 @@ describe( 'combineWidgets', () => {
 		expect( combineWidgets( widgets, widgetStates, layout ) ).toEqual( expected );
 	} );
 
+	it( 'Widgets in an area from different modules are not combined if all of them have the same special state', () => {
+		const widgets = [
+			getQuarterWidget( 'test1' ),
+			getQuarterWidget( 'test2' ),
+			getQuarterWidget( 'test3' ),
+			getQuarterWidget( 'test4' ),
+		];
+		const widgetStates = {
+			// This widget should not be combined even though it is in the same
+			// special state as the others.
+			test1: getReportZeroState( 'search-console' ),
+			// The following widgets should be combined as they are all from the same
+			// module and in the same state.
+			test2: getReportZeroState( 'analytics' ),
+			test3: getReportZeroState( 'analytics' ),
+			test4: getReportZeroState( 'analytics' ),
+		};
+
+		const expected = {
+			overrideComponents: [ null, null, null, getReportZeroState( 'analytics' ) ],
+			gridColumnWidths: [ 3, 0, 0, 9 ],
+		};
+
+		const layout = getWidgetLayout( widgets, widgetStates );
+		expect( combineWidgets( widgets, widgetStates, layout ) ).toEqual( expected );
+	} );
+
 	// Every test case below corresponds to a matching story in `stories/widgets.stories.js` under
 	// "Global/Widgets/Widget Area/Special combination states".
 	it( 'does not combine adjacent widgets of different component and metadata', () => {
@@ -96,7 +123,7 @@ describe( 'combineWidgets', () => {
 		expect( combineWidgets( widgets, widgetStates, layout ) ).toEqual( expected );
 	} );
 
-	it.only( 'combines adjacent widgets of the same component per the same metadata', () => {
+	it( 'combines adjacent widgets of the same component per the same metadata', () => {
 		const widgets = [
 			getQuarterWidget( 'test1' ),
 			getQuarterWidget( 'test2' ),

--- a/assets/js/googlesitekit/widgets/util/constants.js
+++ b/assets/js/googlesitekit/widgets/util/constants.js
@@ -28,3 +28,8 @@ export const WIDTH_GRID_COUNTER_MAP = {
 };
 
 export const HIDDEN_CLASS = 'googlesitekit-hidden';
+export const SPECIAL_WIDGET_STATES = [
+	'ReportZero',
+	'ModuleActivateCTA',
+	'CompleteModuleActivationCTA',
+];


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #3225

## Relevant technical choices
Although in the AC / IB it suggested inserting a check in the `combineWidgets` function I ended up pulling it out into a separate function as I felt `combineWidgets` was getting a bit long. Happy to revert if required.
I also added a `SPECIAL_WIDGET_STATES` constant as there are only certain states where we want to combine the widgets and I couldn't see another way around this.

<!-- Please describe your changes. -->

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [ ] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
