### PR TITLE
Enhancement/3356 implement generating ideas state

### DIFF
--- a/assets/js/modules/idea-hub/components/dashboard/DashboardIdeasWidget/index.js
+++ b/assets/js/modules/idea-hub/components/dashboard/DashboardIdeasWidget/index.js
@@ -85,7 +85,7 @@ const DashboardIdeasWidget = ( { defaultActiveTabIndex, Widget, WidgetReportErro
 		setHash( DashboardIdeasWidget.tabIDsByIndex[ tabIndex ] );
 	}, [ setHash, setActiveTabIndex ] );
 
-	if ( ! ( newIdeas?.length > 0 ) && ! ( savedIdeas?.length > 0 ) && ! ( draftIdeas?.length > 0 ) ) {
+	if ( newIdeas?.length === 0 && savedIdeas?.length === 0 && draftIdeas?.length === 0 ) {
 		return (
 			<Widget noPadding>
 				<div className="googlesitekit-idea-hub" ref={ ideaHubContainer }>

--- a/assets/js/modules/idea-hub/components/dashboard/DashboardIdeasWidget/index.js
+++ b/assets/js/modules/idea-hub/components/dashboard/DashboardIdeasWidget/index.js
@@ -84,7 +84,7 @@ const DashboardIdeasWidget = ( { defaultActiveTabIndex, Widget, WidgetReportErro
 	if ( newIdeas?.length === 0 && savedIdeas?.length === 0 && draftIdeas?.length === 0 ) {
 		return (
 			<Widget noPadding>
-				<div className="googlesitekit-idea-hub" ref={ ideaHubContainer }>
+				<div className="googlesitekit-idea-hub">
 					<Empty
 						Icon={ <EmptyIcon /> }
 						title={ __( 'Idea Hub is generating ideas', 'google-site-kit' ) }

--- a/assets/js/modules/idea-hub/components/dashboard/DashboardIdeasWidget/index.js
+++ b/assets/js/modules/idea-hub/components/dashboard/DashboardIdeasWidget/index.js
@@ -36,9 +36,11 @@ import { useState, useRef, useCallback } from '@wordpress/element';
 import Data from 'googlesitekit-data';
 import { STORE_NAME } from '../../../datastore/constants';
 import whenActive from '../../../../../util/when-active';
+import EmptyIcon from '../../../../../../svg/idea-hub-empty-new-ideas.svg';
 import NewIdeas from './NewIdeas';
 import SavedIdeas from './SavedIdeas';
 import DraftIdeas from './DraftIdeas';
+import Empty from './Empty';
 const { useSelect } = Data;
 
 const getHash = ( hash ) => hash ? hash.replace( '#', '' ) : false;
@@ -84,7 +86,17 @@ const DashboardIdeasWidget = ( { defaultActiveTabIndex, Widget, WidgetReportErro
 	}, [ setHash, setActiveTabIndex ] );
 
 	if ( ! ( newIdeas?.length > 0 ) && ! ( savedIdeas?.length > 0 ) && ! ( draftIdeas?.length > 0 ) ) {
-		return <p>Add here</p>;
+		return (
+			<Widget noPadding>
+				<div className="googlesitekit-idea-hub" ref={ ideaHubContainer }>
+					<Empty
+						Icon={ <EmptyIcon /> }
+						title={ __( 'Idea Hub is generating ideas', 'google-site-kit' ) }
+						subtitle={ __( 'This could take 24 hours.', 'google-site-kit' ) }
+					/>
+				</div>
+			</Widget>
+		);
 	}
 
 	return (

--- a/assets/js/modules/idea-hub/components/dashboard/DashboardIdeasWidget/index.js
+++ b/assets/js/modules/idea-hub/components/dashboard/DashboardIdeasWidget/index.js
@@ -53,7 +53,12 @@ const getIdeaHubContainerOffset = ( ideaHubWidgetOffsetTop ) => {
 
 const DashboardIdeasWidget = ( { defaultActiveTabIndex, Widget, WidgetReportError } ) => {
 	const ideaHubContainer = useRef();
+	// ADD getNewIdeas?
+	const newIdeas = useSelect( ( select ) => select( STORE_NAME ).getNewIdeas() );
+
+	// THIS
 	const savedIdeas = useSelect( ( select ) => select( STORE_NAME ).getSavedIdeas() );
+	// THIS
 	const draftIdeas = useSelect( ( select ) => select( STORE_NAME ).getDraftPostIdeas() );
 
 	const [ hash, setHash ] = useHash();
@@ -77,6 +82,10 @@ const DashboardIdeasWidget = ( { defaultActiveTabIndex, Widget, WidgetReportErro
 		setActiveTabIndex( tabIndex );
 		setHash( DashboardIdeasWidget.tabIDsByIndex[ tabIndex ] );
 	}, [ setHash, setActiveTabIndex ] );
+
+	if ( ! ( newIdeas?.length > 0 ) && ! ( savedIdeas?.length > 0 ) && ! ( draftIdeas?.length > 0 ) ) {
+		return <p>Add here</p>;
+	}
 
 	return (
 		<Widget noPadding>

--- a/assets/js/modules/idea-hub/components/dashboard/DashboardIdeasWidget/index.js
+++ b/assets/js/modules/idea-hub/components/dashboard/DashboardIdeasWidget/index.js
@@ -55,12 +55,8 @@ const getIdeaHubContainerOffset = ( ideaHubWidgetOffsetTop ) => {
 
 const DashboardIdeasWidget = ( { defaultActiveTabIndex, Widget, WidgetReportError } ) => {
 	const ideaHubContainer = useRef();
-	// ADD getNewIdeas?
 	const newIdeas = useSelect( ( select ) => select( STORE_NAME ).getNewIdeas() );
-
-	// THIS
 	const savedIdeas = useSelect( ( select ) => select( STORE_NAME ).getSavedIdeas() );
-	// THIS
 	const draftIdeas = useSelect( ( select ) => select( STORE_NAME ).getDraftPostIdeas() );
 
 	const [ hash, setHash ] = useHash();

--- a/assets/js/modules/idea-hub/components/dashboard/DashboardIdeasWidget/index.stories.js
+++ b/assets/js/modules/idea-hub/components/dashboard/DashboardIdeasWidget/index.stories.js
@@ -169,6 +169,20 @@ DataUnavailableDrafts.args = {
 	defaultActiveTabIndex: 2,
 };
 
+export const DataUnavailableAll = Template.bind( {} );
+DataUnavailableAll.storyName = 'Data Unavailable: All';
+DataUnavailableAll.decorators = [
+	( Story ) => {
+		mockEndpoints( {
+			draftPostIdeas: [],
+			newIdeas: [],
+			savedIdeas: [],
+		} );
+
+		return <Story />;
+	},
+];
+
 export default {
 	title: 'Modules/Idea Hub/Widgets/DashboardIdeasWidget',
 	component: DashboardIdeasWidget,


### PR DESCRIPTION
## Summary

Addresses issue #3356

## Relevant technical choices

The loading state is not mentioned in the ticket, so I took the decision to **only show** when `getNewIdeas`, `getSavedIdeas` and `getDraftPostIdeas` selectors have all loaded **and** are all 0.

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
