### PR TITLE
Phase out some unnecessary legacy module fields (3301).

### DIFF
--- a/assets/js/components/settings/SettingsActiveModule/Footer.js
+++ b/assets/js/components/settings/SettingsActiveModule/Footer.js
@@ -140,7 +140,7 @@ export default function Footer( props ) {
 				/>
 			</Link>
 		);
-	} else if ( ! isEditing ) {
+	} else if ( ! isEditing && homepage ) {
 		secondaryColumn = (
 			<Link
 				href={ homepage }

--- a/includes/Core/Modules/Module.php
+++ b/includes/Core/Modules/Module.php
@@ -786,7 +786,6 @@ abstract class Module {
 				'description'  => '',
 				'order'        => 10,
 				'homepage'     => __( 'https://www.google.com', 'google-site-kit' ),
-				'group'        => '',
 				'feature'      => '',
 				'tags'         => array(),
 				'depends_on'   => array(),

--- a/includes/Core/Modules/Module.php
+++ b/includes/Core/Modules/Module.php
@@ -785,7 +785,7 @@ abstract class Module {
 				'name'         => '',
 				'description'  => '',
 				'order'        => 10,
-				'homepage'     => __( 'https://www.google.com', 'google-site-kit' ),
+				'homepage'     => '',
 				'feature'      => '',
 				'depends_on'   => array(),
 				'force_active' => false,

--- a/includes/Core/Modules/Module.php
+++ b/includes/Core/Modules/Module.php
@@ -39,7 +39,6 @@ use Exception;
  * @property-read string $slug         Unique module identifier.
  * @property-read string $name         Module name.
  * @property-read string $description  Module description.
- * @property-read string $cta          Call to action to activate module.
  * @property-read int    $order        Module order within module lists.
  * @property-read string $homepage     External module homepage URL.
  * @property-read string $learn_more   External URL to learn more about the module.
@@ -180,7 +179,6 @@ abstract class Module {
 			'slug'         => $this->slug,
 			'name'         => $this->name,
 			'description'  => $this->description,
-			'cta'          => $this->cta,
 			'sort'         => $this->order,
 			'homepage'     => $this->homepage,
 			'learnMore'    => $this->learn_more,
@@ -788,7 +786,6 @@ abstract class Module {
 				'slug'         => '',
 				'name'         => '',
 				'description'  => '',
-				'cta'          => '',
 				'order'        => 10,
 				'homepage'     => __( 'https://www.google.com', 'google-site-kit' ),
 				'learn_more'   => __( 'https://about.google/intl/en/', 'google-site-kit' ),
@@ -803,10 +800,6 @@ abstract class Module {
 
 		if ( empty( $info['name'] ) && ! empty( $info['slug'] ) ) {
 			$info['name'] = $info['slug'];
-		}
-		if ( empty( $info['cta'] ) && ! empty( $info['name'] ) ) {
-			/* translators: %s: module name */
-			$info['cta'] = sprintf( __( 'Activate %s', 'google-site-kit' ), $info['name'] );
 		}
 
 		$info['tags']       = (array) $info['tags'];

--- a/includes/Core/Modules/Module.php
+++ b/includes/Core/Modules/Module.php
@@ -787,7 +787,6 @@ abstract class Module {
 				'order'        => 10,
 				'homepage'     => __( 'https://www.google.com', 'google-site-kit' ),
 				'feature'      => '',
-				'tags'         => array(),
 				'depends_on'   => array(),
 				'force_active' => false,
 				'internal'     => false,
@@ -798,7 +797,6 @@ abstract class Module {
 			$info['name'] = $info['slug'];
 		}
 
-		$info['tags']       = (array) $info['tags'];
 		$info['depends_on'] = (array) $info['depends_on'];
 
 		return $info;

--- a/includes/Core/Modules/Module.php
+++ b/includes/Core/Modules/Module.php
@@ -41,7 +41,6 @@ use Exception;
  * @property-read string $description  Module description.
  * @property-read int    $order        Module order within module lists.
  * @property-read string $homepage     External module homepage URL.
- * @property-read string $learn_more   External URL to learn more about the module.
  * @property-read array  $depends_on   List of other module slugs the module depends on.
  * @property-read bool   $force_active Whether the module cannot be disabled.
  * @property-read bool   $internal     Whether the module is internal, thus without any UI.
@@ -181,7 +180,6 @@ abstract class Module {
 			'description'  => $this->description,
 			'sort'         => $this->order,
 			'homepage'     => $this->homepage,
-			'learnMore'    => $this->learn_more,
 			'required'     => $this->depends_on,
 			'autoActivate' => $this->force_active,
 			'internal'     => $this->internal,
@@ -788,7 +786,6 @@ abstract class Module {
 				'description'  => '',
 				'order'        => 10,
 				'homepage'     => __( 'https://www.google.com', 'google-site-kit' ),
-				'learn_more'   => __( 'https://about.google/intl/en/', 'google-site-kit' ),
 				'group'        => '',
 				'feature'      => '',
 				'tags'         => array(),

--- a/includes/Modules/AdSense.php
+++ b/includes/Modules/AdSense.php
@@ -571,7 +571,6 @@ final class AdSense extends Module
 			'description' => __( 'Earn money by placing ads on your website. It’s free and easy.', 'google-site-kit' ),
 			'order'       => 2,
 			'homepage'    => add_query_arg( $idenfifier_args, 'https://www.google.com/adsense/start' ),
-			'learn_more'  => __( 'https://www.google.com/intl/en_us/adsense/start/', 'google-site-kit' ),
 		);
 	}
 

--- a/includes/Modules/AdSense.php
+++ b/includes/Modules/AdSense.php
@@ -569,7 +569,6 @@ final class AdSense extends Module
 			'slug'        => self::MODULE_SLUG,
 			'name'        => _x( 'AdSense', 'Service name', 'google-site-kit' ),
 			'description' => __( 'Earn money by placing ads on your website. It’s free and easy.', 'google-site-kit' ),
-			'cta'         => __( 'Monetize Your Site.', 'google-site-kit' ),
 			'order'       => 2,
 			'homepage'    => add_query_arg( $idenfifier_args, 'https://www.google.com/adsense/start' ),
 			'learn_more'  => __( 'https://www.google.com/intl/en_us/adsense/start/', 'google-site-kit' ),

--- a/includes/Modules/Analytics.php
+++ b/includes/Modules/Analytics.php
@@ -980,7 +980,6 @@ final class Analytics extends Module
 			'slug'        => 'analytics',
 			'name'        => _x( 'Analytics', 'Service name', 'google-site-kit' ),
 			'description' => __( 'Get a deeper understanding of your customers. Google Analytics gives you the free tools you need to analyze data for your business in one place.', 'google-site-kit' ),
-			'cta'         => __( 'Get to know your customers.', 'google-site-kit' ),
 			'order'       => 3,
 			'homepage'    => __( 'https://analytics.google.com/analytics/web', 'google-site-kit' ),
 			'learn_more'  => __( 'https://marketingplatform.google.com/about/analytics/', 'google-site-kit' ),

--- a/includes/Modules/Analytics.php
+++ b/includes/Modules/Analytics.php
@@ -982,7 +982,6 @@ final class Analytics extends Module
 			'description' => __( 'Get a deeper understanding of your customers. Google Analytics gives you the free tools you need to analyze data for your business in one place.', 'google-site-kit' ),
 			'order'       => 3,
 			'homepage'    => __( 'https://analytics.google.com/analytics/web', 'google-site-kit' ),
-			'learn_more'  => __( 'https://marketingplatform.google.com/about/analytics/', 'google-site-kit' ),
 		);
 	}
 

--- a/includes/Modules/Analytics_4.php
+++ b/includes/Modules/Analytics_4.php
@@ -381,7 +381,6 @@ final class Analytics_4 extends Module
 			'description' => __( 'Get a deeper understanding of your customers. Google Analytics gives you the free tools you need to analyze data for your business in one place.', 'google-site-kit' ),
 			'order'       => 3,
 			'homepage'    => __( 'https://analytics.google.com/analytics/web', 'google-site-kit' ),
-			'learn_more'  => __( 'https://marketingplatform.google.com/about/analytics/', 'google-site-kit' ),
 			'internal'    => true,
 		);
 	}

--- a/includes/Modules/Analytics_4.php
+++ b/includes/Modules/Analytics_4.php
@@ -379,7 +379,6 @@ final class Analytics_4 extends Module
 			'slug'        => self::MODULE_SLUG,
 			'name'        => _x( 'Analytics 4 (Alpha)', 'Service name', 'google-site-kit' ),
 			'description' => __( 'Get a deeper understanding of your customers. Google Analytics gives you the free tools you need to analyze data for your business in one place.', 'google-site-kit' ),
-			'cta'         => __( 'Get to know your customers.', 'google-site-kit' ),
 			'order'       => 3,
 			'homepage'    => __( 'https://analytics.google.com/analytics/web', 'google-site-kit' ),
 			'learn_more'  => __( 'https://marketingplatform.google.com/about/analytics/', 'google-site-kit' ),

--- a/includes/Modules/Idea_Hub.php
+++ b/includes/Modules/Idea_Hub.php
@@ -463,7 +463,6 @@ final class Idea_Hub extends Module
 			'description' => 'TODO.',
 			'order'       => 7,
 			'homepage'    => 'https://www.google.com',
-			'learn_more'  => 'https://www.google.com',
 		);
 	}
 

--- a/includes/Modules/Idea_Hub.php
+++ b/includes/Modules/Idea_Hub.php
@@ -461,7 +461,6 @@ final class Idea_Hub extends Module
 			'slug'        => self::MODULE_SLUG,
 			'name'        => _x( 'Idea Hub', 'Service name', 'google-site-kit' ),
 			'description' => 'TODO.',
-			'cta'         => 'TODO.',
 			'order'       => 7,
 			'homepage'    => 'https://www.google.com',
 			'learn_more'  => 'https://www.google.com',

--- a/includes/Modules/Optimize.php
+++ b/includes/Modules/Optimize.php
@@ -185,7 +185,6 @@ final class Optimize extends Module
 			'description' => __( 'Create free A/B tests that help you drive metric-based design solutions to your site', 'google-site-kit' ),
 			'order'       => 5,
 			'homepage'    => __( 'https://optimize.google.com/optimize/home/', 'google-site-kit' ),
-			'learn_more'  => __( 'https://marketingplatform.google.com/about/optimize/', 'google-site-kit' ),
 			'depends_on'  => array( 'analytics' ),
 		);
 	}

--- a/includes/Modules/Optimize.php
+++ b/includes/Modules/Optimize.php
@@ -183,7 +183,6 @@ final class Optimize extends Module
 			'slug'        => 'optimize',
 			'name'        => _x( 'Optimize', 'Service name', 'google-site-kit' ),
 			'description' => __( 'Create free A/B tests that help you drive metric-based design solutions to your site', 'google-site-kit' ),
-			'cta'         => __( 'Increase your CTR.', 'google-site-kit' ),
 			'order'       => 5,
 			'homepage'    => __( 'https://optimize.google.com/optimize/home/', 'google-site-kit' ),
 			'learn_more'  => __( 'https://marketingplatform.google.com/about/optimize/', 'google-site-kit' ),

--- a/includes/Modules/PageSpeed_Insights.php
+++ b/includes/Modules/PageSpeed_Insights.php
@@ -164,7 +164,6 @@ final class PageSpeed_Insights extends Module
 			'slug'        => 'pagespeed-insights',
 			'name'        => _x( 'PageSpeed Insights', 'Service name', 'google-site-kit' ),
 			'description' => __( 'Google PageSpeed Insights gives you metrics about performance, accessibility, SEO and PWA', 'google-site-kit' ),
-			'cta'         => __( 'Learn more about your website’s performance.', 'google-site-kit' ),
 			'order'       => 4,
 			'homepage'    => __( 'https://developers.google.com/speed/pagespeed/insights/', 'google-site-kit' ),
 			'learn_more'  => __( 'https://developers.google.com/speed/docs/insights/v5/about', 'google-site-kit' ),

--- a/includes/Modules/PageSpeed_Insights.php
+++ b/includes/Modules/PageSpeed_Insights.php
@@ -166,7 +166,6 @@ final class PageSpeed_Insights extends Module
 			'description' => __( 'Google PageSpeed Insights gives you metrics about performance, accessibility, SEO and PWA', 'google-site-kit' ),
 			'order'       => 4,
 			'homepage'    => __( 'https://developers.google.com/speed/pagespeed/insights/', 'google-site-kit' ),
-			'learn_more'  => __( 'https://developers.google.com/speed/docs/insights/v5/about', 'google-site-kit' ),
 		);
 	}
 

--- a/includes/Modules/Search_Console.php
+++ b/includes/Modules/Search_Console.php
@@ -479,7 +479,6 @@ final class Search_Console extends Module
 			'description'  => __( 'Google Search Console and helps you understand how Google views your site and optimize its performance in search results.', 'google-site-kit' ),
 			'order'        => 1,
 			'homepage'     => __( 'https://search.google.com/search-console', 'google-site-kit' ),
-			'learn_more'   => __( 'https://search.google.com/search-console/about', 'google-site-kit' ),
 			'force_active' => true,
 		);
 	}

--- a/includes/Modules/Search_Console.php
+++ b/includes/Modules/Search_Console.php
@@ -477,7 +477,6 @@ final class Search_Console extends Module
 			'slug'         => 'search-console',
 			'name'         => _x( 'Search Console', 'Service name', 'google-site-kit' ),
 			'description'  => __( 'Google Search Console and helps you understand how Google views your site and optimize its performance in search results.', 'google-site-kit' ),
-			'cta'          => __( 'Connect your site to Google Search Console.', 'google-site-kit' ),
 			'order'        => 1,
 			'homepage'     => __( 'https://search.google.com/search-console', 'google-site-kit' ),
 			'learn_more'   => __( 'https://search.google.com/search-console/about', 'google-site-kit' ),

--- a/includes/Modules/Site_Verification.php
+++ b/includes/Modules/Site_Verification.php
@@ -351,7 +351,6 @@ final class Site_Verification extends Module implements Module_With_Scopes {
 			'description'  => __( 'Google Site Verification allows you to manage ownership of your site.', 'google-site-kit' ),
 			'order'        => 0,
 			'homepage'     => __( 'https://www.google.com/webmasters/verification/home', 'google-site-kit' ),
-			'learn_more'   => __( 'https://developers.google.com/site-verification/', 'google-site-kit' ),
 			'force_active' => true,
 			'internal'     => true,
 		);

--- a/includes/Modules/Site_Verification.php
+++ b/includes/Modules/Site_Verification.php
@@ -349,7 +349,6 @@ final class Site_Verification extends Module implements Module_With_Scopes {
 			'slug'         => 'site-verification',
 			'name'         => _x( 'Site Verification', 'Service name', 'google-site-kit' ),
 			'description'  => __( 'Google Site Verification allows you to manage ownership of your site.', 'google-site-kit' ),
-			'cta'          => __( 'Verify ownership with Google Site Verification.', 'google-site-kit' ),
 			'order'        => 0,
 			'homepage'     => __( 'https://www.google.com/webmasters/verification/home', 'google-site-kit' ),
 			'learn_more'   => __( 'https://developers.google.com/site-verification/', 'google-site-kit' ),

--- a/includes/Modules/Tag_Manager.php
+++ b/includes/Modules/Tag_Manager.php
@@ -534,7 +534,6 @@ final class Tag_Manager extends Module
 			'description' => __( 'Tag Manager creates an easy to manage way to create tags on your site without updating code', 'google-site-kit' ),
 			'order'       => 6,
 			'homepage'    => __( 'https://tagmanager.google.com/', 'google-site-kit' ),
-			'learn_more'  => __( 'https://marketingplatform.google.com/about/tag-manager/', 'google-site-kit' ),
 			'group'       => __( 'Marketing Platform', 'google-site-kit' ),
 			'tags'        => array( 'marketing' ),
 		);

--- a/includes/Modules/Tag_Manager.php
+++ b/includes/Modules/Tag_Manager.php
@@ -534,7 +534,6 @@ final class Tag_Manager extends Module
 			'description' => __( 'Tag Manager creates an easy to manage way to create tags on your site without updating code', 'google-site-kit' ),
 			'order'       => 6,
 			'homepage'    => __( 'https://tagmanager.google.com/', 'google-site-kit' ),
-			'tags'        => array( 'marketing' ),
 		);
 	}
 

--- a/includes/Modules/Tag_Manager.php
+++ b/includes/Modules/Tag_Manager.php
@@ -534,7 +534,6 @@ final class Tag_Manager extends Module
 			'description' => __( 'Tag Manager creates an easy to manage way to create tags on your site without updating code', 'google-site-kit' ),
 			'order'       => 6,
 			'homepage'    => __( 'https://tagmanager.google.com/', 'google-site-kit' ),
-			'group'       => __( 'Marketing Platform', 'google-site-kit' ),
 			'tags'        => array( 'marketing' ),
 		);
 	}

--- a/includes/Modules/Tag_Manager.php
+++ b/includes/Modules/Tag_Manager.php
@@ -532,7 +532,6 @@ final class Tag_Manager extends Module
 			'slug'        => self::MODULE_SLUG,
 			'name'        => _x( 'Tag Manager', 'Service name', 'google-site-kit' ),
 			'description' => __( 'Tag Manager creates an easy to manage way to create tags on your site without updating code', 'google-site-kit' ),
-			'cta'         => __( 'Tag management made simple.', 'google-site-kit' ),
 			'order'       => 6,
 			'homepage'    => __( 'https://tagmanager.google.com/', 'google-site-kit' ),
 			'learn_more'  => __( 'https://marketingplatform.google.com/about/tag-manager/', 'google-site-kit' ),

--- a/tests/phpunit/integration/Core/Modules/ModuleTest.php
+++ b/tests/phpunit/integration/Core/Modules/ModuleTest.php
@@ -69,7 +69,6 @@ class ModuleTest extends TestCase {
 			'description',
 			'sort',
 			'homepage',
-			'learnMore',
 			'required',
 			'autoActivate',
 			'internal',

--- a/tests/phpunit/integration/Core/Modules/ModuleTest.php
+++ b/tests/phpunit/integration/Core/Modules/ModuleTest.php
@@ -67,7 +67,6 @@ class ModuleTest extends TestCase {
 			'slug',
 			'name',
 			'description',
-			'cta',
 			'sort',
 			'homepage',
 			'learnMore',


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #3301

## Relevant technical choices

<!-- Please describe your changes. -->

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
