### PR TITLE
Fix profile select issue when propertyID equals PROPERTY_CREATE.

### DIFF
--- a/assets/js/modules/analytics/components/common/ProfileSelect.js
+++ b/assets/js/modules/analytics/components/common/ProfileSelect.js
@@ -29,7 +29,7 @@ import Data from 'googlesitekit-data';
 import { Select, Option } from '../../../../material-components';
 import ProgressBar from '../../../../components/ProgressBar';
 import { STORE_NAME, PROFILE_CREATE } from '../../datastore/constants';
-import { isValidPropertyID, isValidAccountID } from '../../util';
+import { isValidPropertySelection, isValidAccountSelection } from '../../util';
 import { trackEvent } from '../../../../util';
 const { useSelect, useDispatch } = Data;
 
@@ -53,7 +53,7 @@ export default function ProfileSelect() {
 		}
 	}, [ profileID, setProfileID ] );
 
-	if ( ! isValidAccountID( accountID ) || ! isValidPropertyID( propertyID ) ) {
+	if ( ! isValidAccountSelection( accountID ) || ! isValidPropertySelection( propertyID ) ) {
 		return null;
 	}
 
@@ -67,7 +67,6 @@ export default function ProfileSelect() {
 			label={ __( 'View', 'google-site-kit' ) }
 			value={ profileID }
 			onEnhancedChange={ onChange }
-			disabled={ ! isValidAccountID( accountID ) || ! isValidPropertyID( propertyID ) }
 			enhanced
 			outlined
 		>

--- a/assets/js/modules/analytics/components/common/PropertySelect.js
+++ b/assets/js/modules/analytics/components/common/PropertySelect.js
@@ -30,7 +30,7 @@ import { Select, Option } from '../../../../material-components';
 import ProgressBar from '../../../../components/ProgressBar';
 import { STORE_NAME, PROPERTY_CREATE } from '../../datastore/constants';
 import { MODULES_TAGMANAGER } from '../../../tagmanager/datastore/constants';
-import { isValidAccountID } from '../../util';
+import { isValidAccountSelection } from '../../util';
 import { trackEvent } from '../../../../util';
 const { useSelect, useDispatch } = Data;
 
@@ -68,7 +68,7 @@ export default function PropertySelect() {
 		}
 	}, [ propertyID, selectProperty ] );
 
-	if ( ! isValidAccountID( accountID ) ) {
+	if ( ! isValidAccountSelection( accountID ) ) {
 		return null;
 	}
 

--- a/assets/js/modules/analytics/components/common/PropertySelect.test.js
+++ b/assets/js/modules/analytics/components/common/PropertySelect.test.js
@@ -95,7 +95,7 @@ describe( 'PropertySelect', () => {
 			.toHaveClass( 'mdc-select--disabled' );
 	} );
 
-	it( 'should not render if account ID is invalid', async () => {
+	it( 'should not render if account ID is invalid', () => {
 		const { container, registry } = render( <PropertySelect />, {
 			setupRegistry( { dispatch } ) {
 				setupRegistry( { dispatch } );
@@ -103,20 +103,23 @@ describe( 'PropertySelect', () => {
 			},
 		} );
 
-		const accountID = fixtures.accountsPropertiesProfiles.properties[ 0 ].accountId; // eslint-disable-line sitekit/acronym-case
-
 		// A valid accountID is provided, so ensure it is not currently disabled.
 		const selectWrapper = container.querySelector( '.googlesitekit-analytics__select-property' );
 		const selectedText = container.querySelector( '.mdc-select__selected-text' );
 		expect( selectWrapper ).not.toHaveClass( 'mdc-select--disabled' );
 		expect( selectedText ).not.toHaveAttribute( 'aria-disabled', 'true' );
 
-		await act( () => registry.dispatch( STORE_NAME ).setAccountID( ACCOUNT_CREATE ) );
+		act( () => {
+			registry.dispatch( STORE_NAME ).setAccountID( 'abcd' );
+		} );
 
-		// ACCOUNT_CREATE is an invalid account ID (but valid selection), so ensure the property select dropdown is not rendered.
+		// abcd is an invalid account ID, so ensure the property select dropdown is not rendered.
 		expect( container ).toBeEmptyDOMElement();
 
-		await act( () => registry.dispatch( STORE_NAME ).setAccountID( accountID ) );
+		act( () => {
+			const accountID = fixtures.accountsPropertiesProfiles.properties[ 0 ].accountId; // eslint-disable-line sitekit/acronym-case
+			registry.dispatch( STORE_NAME ).setAccountID( accountID );
+		} );
 
 		// A valid account ID was set, so the select should be visible.
 		expect( container.querySelector( '.googlesitekit-analytics__select-property' ) ).toBeInTheDocument();

--- a/tests/e2e/specs/modules/analytics/setup-with-account-no-tag.test.js
+++ b/tests/e2e/specs/modules/analytics/setup-with-account-no-tag.test.js
@@ -186,8 +186,8 @@ describe( 'setting up the Analytics module with an existing account and no exist
 					await expect( page ).toMatchElement( '.mdc-select__selected-text', { text: /test account a/i } );
 					// Property dropdown should select "Set up a new property" option because there is no property associated with the current reference URL.
 					await expect( page ).toMatchElement( '.mdc-select__selected-text', { text: /set up a new property/i } );
-					// Profile should be hidden since no property is selected.
-					await expect( page ).not.toMatchElement( '.googlesitekit-analytics__select-profile' );
+					// Profile dropdown should select "Set up a new view" option.
+					await expect( page ).toMatchElement( '.googlesitekit-analytics__select-profile', { text: /set up a new view/i } );
 				},
 			);
 


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #3243

## Relevant technical choices

<!-- Please describe your changes. -->

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
