### PR TITLE
`surveys` datastore fixes

### DIFF
--- a/assets/js/googlesitekit/datastore/user/surveys.js
+++ b/assets/js/googlesitekit/datastore/user/surveys.js
@@ -99,14 +99,18 @@ const baseActions = {
 
 			const cacheKey = createCacheKey( 'core', 'user', 'survey-trigger', { triggerID } );
 			const { cacheHit } = yield Data.commonActions.await( getItem( cacheKey ) );
-			if ( false === cacheHit && ttl ) {
-				const { error } = yield fetchTriggerSurveyStore.actions.fetchTriggerSurvey( triggerID );
-				if ( ! error && ttl > 0 ) {
+
+			if ( false === cacheHit ) {
+				const { response, error } = yield fetchTriggerSurveyStore.actions.fetchTriggerSurvey( triggerID );
+				if ( error ) {
+					return { response, error };
+				}
+				if ( ttl > 0 ) {
 					// With a positive ttl we cache an empty object to avoid calling fetchTriggerSurvey() again.
 					yield Data.commonActions.await( setItem( cacheKey, {} ) );
-					return { response: {}, error };
 				}
 			}
+
 			return {
 				response: {},
 				error: false,

--- a/assets/js/googlesitekit/datastore/user/surveys.js
+++ b/assets/js/googlesitekit/datastore/user/surveys.js
@@ -92,10 +92,12 @@ const baseActions = {
 		function* ( triggerID, options = {} ) {
 			const { ttl = 0 } = options;
 			const { select } = yield Data.commonActions.getRegistry();
-			if ( null !== select( STORE_NAME ).getCurrentSurvey() ) {
-				return;
+			// Bail if there is already a current survey.
+			if ( select( STORE_NAME ).getCurrentSurvey() ) {
+				return {};
 			}
-			const cacheKey = createCacheKey( 'core', 'user', 'survey-event', { triggerID } );
+
+			const cacheKey = createCacheKey( 'core', 'user', 'survey-trigger', { triggerID } );
 			const { cacheHit } = yield Data.commonActions.await( getItem( cacheKey ) );
 			if ( false === cacheHit && ttl ) {
 				const { error } = yield fetchTriggerSurveyStore.actions.fetchTriggerSurvey( triggerID );

--- a/assets/js/googlesitekit/datastore/user/surveys.test.js
+++ b/assets/js/googlesitekit/datastore/user/surveys.test.js
@@ -56,7 +56,7 @@ describe( 'core/user surveys', () => {
 			} );
 
 			it( 'does not throw an error when parameters are correct', () => {
-				muteFetch( surveyTriggerEndpoint, [] );
+				muteFetch( surveyTriggerEndpoint );
 
 				expect( () => {
 					registry.dispatch( STORE_NAME ).triggerSurvey( 'adSenseSurvey' );
@@ -68,7 +68,7 @@ describe( 'core/user surveys', () => {
 			} );
 
 			it( 'makes network requests to endpoints', async () => {
-				muteFetch( surveyTriggerEndpoint, [] );
+				muteFetch( surveyTriggerEndpoint );
 
 				await registry.dispatch( STORE_NAME ).triggerSurvey( 'optimizeSurvey', { ttl: 1 } );
 

--- a/assets/js/googlesitekit/datastore/user/surveys.test.js
+++ b/assets/js/googlesitekit/datastore/user/surveys.test.js
@@ -23,9 +23,6 @@ import {
 	createTestRegistry,
 	muteFetch,
 } from '../../../../../tests/js/utils';
-import {
-	act,
-} from '../../../../../tests/js/test-utils';
 import { STORE_NAME } from './constants';
 
 describe( 'core/user surveys', () => {
@@ -73,7 +70,7 @@ describe( 'core/user surveys', () => {
 			it( 'makes network requests to endpoints', async () => {
 				muteFetch( surveyTriggerEndpoint, [] );
 
-				await act( () => registry.dispatch( STORE_NAME ).triggerSurvey( 'optimizeSurvey', { ttl: 1 } ) );
+				await registry.dispatch( STORE_NAME ).triggerSurvey( 'optimizeSurvey', { ttl: 1 } );
 
 				expect( fetchMock ).toHaveFetched( surveyTriggerEndpoint, {
 					body: {
@@ -109,9 +106,9 @@ describe( 'core/user surveys', () => {
 				muteFetch( surveyEventEndpoint, {} );
 
 				// Trigger a survey to appear.
-				await act( () => registry.dispatch( STORE_NAME ).triggerSurvey( 'optimizeSurvey', { ttl: 1 } ) );
+				await registry.dispatch( STORE_NAME ).triggerSurvey( 'optimizeSurvey', { ttl: 1 } );
 				// Send a survey event.
-				await act( () => registry.dispatch( STORE_NAME ).sendSurveyEvent( 'answer_question', { foo: 'bar' } ) );
+				await registry.dispatch( STORE_NAME ).sendSurveyEvent( 'answer_question', { foo: 'bar' } );
 
 				expect( fetchMock ).toHaveFetched( surveyEventEndpoint, {
 					body: {
@@ -133,7 +130,7 @@ describe( 'core/user surveys', () => {
 
 			it( 'returns the current survey when it is set', async () => {
 				muteFetch( surveyTriggerEndpoint, survey );
-				await act( () => registry.dispatch( STORE_NAME ).triggerSurvey( 'optimizeSurvey', { ttl: 1 } ) );
+				await registry.dispatch( STORE_NAME ).triggerSurvey( 'optimizeSurvey', { ttl: 1 } );
 
 				expect(
 					registry.select( STORE_NAME ).getCurrentSurvey()
@@ -157,7 +154,7 @@ describe( 'core/user surveys', () => {
 			it( 'returns the error once set', async () => {
 				muteFetch( surveyTriggerEndpoint, survey );
 
-				await act( () => registry.dispatch( STORE_NAME ).triggerSurvey( 'optimizeSurvey', { ttl: 1 } ) );
+				await registry.dispatch( STORE_NAME ).triggerSurvey( 'optimizeSurvey', { ttl: 1 } );
 
 				expect(
 					registry.select( STORE_NAME ).getCurrentSurveySession()

--- a/assets/js/googlesitekit/datastore/user/surveys.test.js
+++ b/assets/js/googlesitekit/datastore/user/surveys.test.js
@@ -23,6 +23,8 @@ import {
 	createTestRegistry,
 	muteFetch,
 } from '../../../../../tests/js/utils';
+import { createCacheKey } from '../../api';
+import { setItem } from '../../api/cache';
 import { STORE_NAME } from './constants';
 
 describe( 'core/user surveys', () => {
@@ -81,6 +83,17 @@ describe( 'core/user surveys', () => {
 						data: { triggerID: 'optimizeSurvey' },
 					},
 				} );
+			} );
+
+			it( 'does not fetch if there is a cache value present for the trigger ID', async () => {
+				await setItem(
+					createCacheKey( 'core', 'user', 'survey-trigger', { triggerID: 'optimizeSurvey' } ),
+					{} // Any value will due for now.
+				);
+
+				await registry.dispatch( STORE_NAME ).triggerSurvey( 'optimizeSurvey' );
+
+				expect( fetchMock ).not.toHaveFetched();
 			} );
 		} );
 

--- a/assets/js/googlesitekit/datastore/user/surveys.test.js
+++ b/assets/js/googlesitekit/datastore/user/surveys.test.js
@@ -55,12 +55,16 @@ describe( 'core/user surveys', () => {
 				} ).toThrow( 'options.ttl must be a number' );
 			} );
 
-			it( 'does not throw an error when parameters are correct', () => {
+			it( 'does not throw when called with only a triggerID', async () => {
 				muteFetch( surveyTriggerEndpoint );
 
 				expect( () => {
 					registry.dispatch( STORE_NAME ).triggerSurvey( 'adSenseSurvey' );
 				} ).not.toThrow();
+			} );
+
+			it( 'does not throw when called with a numeric ttl', () => {
+				muteFetch( surveyTriggerEndpoint );
 
 				expect( () => {
 					registry.dispatch( STORE_NAME ).triggerSurvey( 'analyticsSurvey', { ttl: 1 } );
@@ -70,7 +74,7 @@ describe( 'core/user surveys', () => {
 			it( 'makes network requests to endpoints', async () => {
 				muteFetch( surveyTriggerEndpoint );
 
-				await registry.dispatch( STORE_NAME ).triggerSurvey( 'optimizeSurvey', { ttl: 1 } );
+				await registry.dispatch( STORE_NAME ).triggerSurvey( 'optimizeSurvey' );
 
 				expect( fetchMock ).toHaveFetched( surveyTriggerEndpoint, {
 					body: {

--- a/assets/js/googlesitekit/datastore/user/surveys.test.js
+++ b/assets/js/googlesitekit/datastore/user/surveys.test.js
@@ -124,7 +124,7 @@ describe( 'core/user surveys', () => {
 	describe( 'selectors', () => {
 		describe( 'getCurrentSurvey', () => {
 			it( 'returns null when no current survey is set', async () => {
-				expect( registry.select( STORE_NAME ).getCurrentSurvey() ).toEqual( null );
+				expect( registry.select( STORE_NAME ).getCurrentSurvey() ).toBeNull();
 			} );
 
 			it( 'returns the current survey when it is set', () => {
@@ -140,7 +140,7 @@ describe( 'core/user surveys', () => {
 			it( 'returns null when no current survey session is set', async () => {
 				expect(
 					registry.select( STORE_NAME ).getCurrentSurveySession()
-				).toEqual( null );
+				).toBeNull();
 			} );
 
 			it( 'returns the current survey session when set', () => {


### PR DESCRIPTION
## Summary

Addresses issue #3355 (follow-up)

## Relevant technical choices

* Addresses QA feedback in https://github.com/google/site-kit-wp/issues/3355#issuecomment-851975653

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
