### PR TITLE
Update to change application name if multisite is enabled.

### DIFF
--- a/includes/Core/Authentication/Google_Proxy.php
+++ b/includes/Core/Authentication/Google_Proxy.php
@@ -66,7 +66,8 @@ class Google_Proxy {
 	 * @return string The application name.
 	 */
 	public static function get_application_name() {
-		return 'wordpress/google-site-kit/' . GOOGLESITEKIT_VERSION;
+		$platform = self::get_platform();
+		return $platform . '/google-site-kit/' . GOOGLESITEKIT_VERSION;
 	}
 
 	/**
@@ -441,16 +442,31 @@ class Google_Proxy {
 	 * @return array|WP_Error Response of the wp_remote_post request.
 	 */
 	public function get_features( Credentials $credentials ) {
+		$platform = self::get_platform();
 		return $this->request(
 			self::FEATURES_URI,
 			$credentials,
 			array(
 				'body' => array(
-					'platform' => 'wordpress/google-site-kit',
+					'platform' => $platform . '/google-site-kit',
 					'version'  => GOOGLESITEKIT_VERSION,
 				),
 			)
 		);
+	}
+
+	/**
+	 * Gets the platform.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @return string WordPress multisite or WordPress.
+	 */
+	public static function get_platform() {
+		if ( is_multisite() ) {
+			return 'wordpress-multisite';
+		}
+		return 'wordpress'; // phpcs:ignore WordPress.WP.CapitalPDangit.Misspelled
 	}
 
 	/**

--- a/tests/phpunit/integration/Core/Authentication/Google_ProxyTest.php
+++ b/tests/phpunit/integration/Core/Authentication/Google_ProxyTest.php
@@ -295,13 +295,14 @@ class Google_ProxyTest extends TestCase {
 	}
 
 	public function test_get_platform() {
-		$platform = $this->google_proxy->get_platform();
+		$this->assertEquals( 'wordpress', Google_Proxy::get_platform() ); // phpcs:ignore WordPress.WP.CapitalPDangit.Misspelled
+	}
 
-		if ( is_multisite() ) {
-			$this->assertEquals( 'wordpress-multisite', $platform );
-		} else {
-			$this->assertEquals( 'wordpress', $platform ); // phpcs:ignore WordPress.WP.CapitalPDangit.Misspelled
-		}
+	/**
+	 * @group ms-required
+	 */
+	public function test_get_platform__multiste() {
+		$this->assertEquals( 'wordpress-multisite', Google_Proxy::get_platform() );
 	}
 
 	public function test_send_survey_trigger() {

--- a/tests/phpunit/integration/Core/Authentication/Google_ProxyTest.php
+++ b/tests/phpunit/integration/Core/Authentication/Google_ProxyTest.php
@@ -284,7 +284,7 @@ class Google_ProxyTest extends TestCase {
 		$this->assertEquals( 'POST', $this->request_args['method'] );
 		$this->assertEqualSetsWithIndex(
 			array(
-				'platform'    => 'wordpress/google-site-kit',
+				'platform'    => is_multisite() ? 'wordpress-multisite/google-site-kit' : 'wordpress/google-site-kit',
 				'version'     => GOOGLESITEKIT_VERSION,
 				'site_id'     => $fake_creds['client_id'],
 				'site_secret' => $fake_creds['client_secret'],
@@ -292,6 +292,16 @@ class Google_ProxyTest extends TestCase {
 			$this->request_args['body']
 		);
 		$this->assertEqualSetsWithIndex( $expected_success_response, $features );
+	}
+
+	public function test_get_platform() {
+		$platform = $this->google_proxy->get_platform();
+
+		if ( is_multisite() ) {
+			$this->assertEquals( 'wordpress-multisite', $platform );
+		} else {
+			$this->assertEquals( 'wordpress', $platform ); // phpcs:ignore WordPress.WP.CapitalPDangit.Misspelled
+		}
 	}
 
 	public function test_send_survey_trigger() {

--- a/tests/phpunit/integration/Core/Authentication/Google_ProxyTest.php
+++ b/tests/phpunit/integration/Core/Authentication/Google_ProxyTest.php
@@ -294,6 +294,9 @@ class Google_ProxyTest extends TestCase {
 		$this->assertEqualSetsWithIndex( $expected_success_response, $features );
 	}
 
+	/**
+	 * @group ms-excluded
+	 */
 	public function test_get_platform() {
 		$this->assertEquals( 'wordpress', Google_Proxy::get_platform() ); // phpcs:ignore WordPress.WP.CapitalPDangit.Misspelled
 	}


### PR DESCRIPTION
## Summary

Update to change application name if multisite is enabled.

Addresses issue #3118

## Relevant technical choices


## Checklist

- [X] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [X] I have added a QA Brief on the issue linked above.
- [X] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
