### PR TITLE
Update to insert Adsense snippet on legacy reader theme AMP sites.

### DIFF
--- a/includes/Modules/AdSense/AMP_Tag.php
+++ b/includes/Modules/AdSense/AMP_Tag.php
@@ -50,10 +50,14 @@ class AMP_Tag extends Module_AMP_Tag {
 			// If Web Stories are enabled, render the auto ads code.
 			add_action( 'web_stories_print_analytics', $this->get_method_proxy( 'render_story_auto_ads' ) );
 		} else {
-			// For AMP Reader, and AMP Native and Transitional (if `wp_body_open` supported).
+			// For AMP Native and Transitional (if `wp_body_open` supported).
 			add_action( 'wp_body_open', $this->get_method_proxy( 'render' ), -9999 );
-			// For AMP Reader, and AMP Native and Transitional (as fallback).
+			// For AMP Native and Transitional (as fallback).
 			add_filter( 'the_content', $this->get_method_proxy( 'amp_content_add_auto_ads' ) );
+			// For AMP Reader (if `amp_post_template_body_open` supported).
+			add_action( 'amp_post_template_body_open', $this->get_method_proxy( 'render' ), -9999 );
+			// For AMP Reader (as fallback).
+			add_action( 'amp_post_template_footer', $this->get_method_proxy( 'render' ), -9999 );
 
 			// Load amp-auto-ads component for AMP Reader.
 			$this->enqueue_amp_reader_component_script( 'amp-auto-ads', 'https://cdn.ampproject.org/v0/amp-auto-ads-0.1.js' );


### PR DESCRIPTION
## Summary

Update to insert Adsense snippet on legacy reader theme AMP sites.

Addresses issue #3218

## Relevant technical choices


## Checklist

- [X] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [X] I have added a QA Brief on the issue linked above.
- [X] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
