### PR TITLE
Make button inactive if there are no form changes.

### DIFF
--- a/assets/js/modules/search-console/datastore/settings.js
+++ b/assets/js/modules/search-console/datastore/settings.js
@@ -29,6 +29,7 @@ import { TYPE_MODULES } from '../../../components/data/constants';
 import { invalidateCacheGroup } from '../../../components/data/invalidate-cache-group';
 import { createStrictSelect } from '../../../googlesitekit/data/utils';
 import { isValidPropertyID } from '../util';
+import { INVARIANT_SETTINGS_NOT_CHANGED } from '../../../googlesitekit/data/create-settings-store';
 import { STORE_NAME } from './constants';
 
 // Invariant error messages.
@@ -53,6 +54,8 @@ export async function submitChanges( { select, dispatch } ) {
 
 export function validateCanSubmitChanges( select ) {
 	const strictSelect = createStrictSelect( select );
-	const { getPropertyID } = strictSelect( STORE_NAME );
+	const { getPropertyID, haveSettingsChanged } = strictSelect( STORE_NAME );
+
 	invariant( isValidPropertyID( getPropertyID() ), INVARIANT_INVALID_PROPERTY_SELECTION );
+	invariant( haveSettingsChanged(), INVARIANT_SETTINGS_NOT_CHANGED );
 }

--- a/assets/js/modules/search-console/datastore/settings.test.js
+++ b/assets/js/modules/search-console/datastore/settings.test.js
@@ -23,6 +23,7 @@ import API from 'googlesitekit-api';
 import { createTestRegistry, unsubscribeFromAll } from '../../../../../tests/js/utils';
 import { STORE_NAME } from './constants';
 import { validateCanSubmitChanges, INVARIANT_INVALID_PROPERTY_SELECTION } from './settings';
+import { INVARIANT_SETTINGS_NOT_CHANGED } from '../../../googlesitekit/data/create-settings-store';
 
 describe( 'modules/search-console settings', () => {
 	let registry;
@@ -90,7 +91,27 @@ describe( 'modules/search-console settings', () => {
 				propertyID: 'http://example.com/',
 			} );
 
-			expect( () => validateCanSubmitChanges( registry.select ) ).not.toThrow();
+			expect( () => validateCanSubmitChanges( registry.select ) ).not.toThrow( INVARIANT_INVALID_PROPERTY_SELECTION );
+		} );
+
+		it( 'should throw if there are no changes to the form', () => {
+			registry.dispatch( STORE_NAME ).receiveGetSettings( {
+				propertyID: 'http://example.com/',
+			} );
+
+			expect( () => validateCanSubmitChanges( registry.select ) ).toThrow( INVARIANT_SETTINGS_NOT_CHANGED );
+		} );
+
+		it( 'should not throw if there are changes to the form', () => {
+			registry.dispatch( STORE_NAME ).receiveGetSettings( {
+				propertyID: 'http://example.com/',
+			} );
+
+			registry.dispatch( STORE_NAME ).receiveGetSettings( {
+				propertyID: 'http://sitekit.google.com/',
+			} );
+
+			expect( () => validateCanSubmitChanges( registry.select ) ).not.toThrow( INVARIANT_SETTINGS_NOT_CHANGED );
 		} );
 	} );
 } );


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #3318 

## Relevant technical choices

<!-- Please describe your changes. -->

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
