### PR TITLE
Follow-up for SettingsNotice

### DIFF
--- a/assets/js/components/SettingsNotice/SettingsNotice.js
+++ b/assets/js/components/SettingsNotice/SettingsNotice.js
@@ -43,8 +43,10 @@ export default function SettingsNotice( props ) {
 			className={ classnames(
 				'googlesitekit-settings-notice',
 				`googlesitekit-settings-notice--${ type }`,
-				{ 'googlesitekit-settings-notice--single-row': ! children },
-				{ 'googlesitekit-settings-notice--multi-row': children },
+				{
+					'googlesitekit-settings-notice--single-row': ! children,
+					'googlesitekit-settings-notice--multi-row': children,
+				}
 			) }
 		>
 			<div className="googlesitekit-settings-notice__icon">

--- a/assets/js/components/SettingsNotice/SettingsNotice.js
+++ b/assets/js/components/SettingsNotice/SettingsNotice.js
@@ -48,7 +48,7 @@ export default function SettingsNotice( props ) {
 			) }
 		>
 			<div className="googlesitekit-settings-notice__icon">
-				{ Icon && <Icon width="20" height="20" /> }
+				<Icon width="20" height="20" />
 			</div>
 
 			<div className="googlesitekit-settings-notice__body">

--- a/assets/js/components/SettingsNotice/SettingsNotice.js
+++ b/assets/js/components/SettingsNotice/SettingsNotice.js
@@ -27,10 +27,14 @@ import PropTypes from 'prop-types';
  */
 import SettingsNoticeSingleRow from './SettingsNoticeSingleRow';
 import SettingsNoticeMultiRow from './SettingsNoticeMultiRow';
-import { TYPE_WARNING, TYPE_INFO, TYPE_SUGGESTION } from './utils';
+import { TYPE_WARNING, TYPE_INFO, TYPE_SUGGESTION, getIconFromType } from './utils';
 
 export default function SettingsNotice( props ) {
-	const { children, type } = props;
+	const {
+		children,
+		type,
+		Icon = getIconFromType( type ),
+	} = props;
 
 	const Layout = children ? SettingsNoticeMultiRow : SettingsNoticeSingleRow;
 
@@ -39,9 +43,17 @@ export default function SettingsNotice( props ) {
 			className={ classnames(
 				'googlesitekit-settings-notice',
 				`googlesitekit-settings-notice--${ type }`,
+				{ 'googlesitekit-settings-notice--single-row': ! children },
+				{ 'googlesitekit-settings-notice--multi-row': children },
 			) }
 		>
-			<Layout { ...props } />
+			<div className="googlesitekit-settings-notice__icon">
+				{ Icon && <Icon width="20" height="20" /> }
+			</div>
+
+			<div className="googlesitekit-settings-notice__body">
+				<Layout { ...props } />
+			</div>
 		</div>
 	);
 }

--- a/assets/js/components/SettingsNotice/SettingsNotice.js
+++ b/assets/js/components/SettingsNotice/SettingsNotice.js
@@ -19,6 +19,7 @@
 /**
  * External dependencies
  */
+import classnames from 'classnames';
 import PropTypes from 'prop-types';
 
 /**
@@ -31,12 +32,16 @@ import { TYPE_WARNING, TYPE_INFO, TYPE_SUGGESTION } from './utils';
 export default function SettingsNotice( props ) {
 	const { children, type } = props;
 
+	const Layout = children ? SettingsNoticeMultiRow : SettingsNoticeSingleRow;
+
 	return (
-		<div className={ `googlesitekit-settings-notice googlesitekit-settings-notice--${ type }` } >
-			{ !! children && <SettingsNoticeMultiRow { ...props } /> }
-			{ ! children && (
-				<SettingsNoticeSingleRow { ...props } />
+		<div
+			className={ classnames(
+				'googlesitekit-settings-notice',
+				`googlesitekit-settings-notice--${ type }`,
 			) }
+		>
+			<Layout { ...props } />
 		</div>
 	);
 }
@@ -45,7 +50,11 @@ export default function SettingsNotice( props ) {
 SettingsNotice.propTypes = {
 	children: PropTypes.node,
 	notice: PropTypes.node.isRequired,
-	type: PropTypes.oneOf( [ TYPE_WARNING, TYPE_INFO, TYPE_SUGGESTION ] ),
+	type: PropTypes.oneOf( [
+		TYPE_INFO,
+		TYPE_WARNING,
+		TYPE_SUGGESTION,
+	] ),
 	Icon: PropTypes.elementType,
 	LearnMore: PropTypes.elementType,
 };

--- a/assets/js/components/SettingsNotice/SettingsNoticeMultiRow.js
+++ b/assets/js/components/SettingsNotice/SettingsNoticeMultiRow.js
@@ -17,54 +17,43 @@
  */
 
 /**
+ * WordPress dependencies
+ */
+import { Fragment } from '@wordpress/element';
+
+/**
  * External dependencies
  */
 import PropTypes from 'prop-types';
 
-/**
- * Internal dependencies
- */
-import { TYPE_WARNING, TYPE_INFO, TYPE_SUGGESTION, getIconFromType } from './utils';
-
-const SettingsNoticeMultiRow = ( {
+export default function SettingsNoticeMultiRow( {
 	notice,
-	type,
-	Icon = getIconFromType( type ),
 	LearnMore,
 	children,
-} ) => {
+} ) {
 	return (
-		<div className="googlesitekit-settings-notice__row">
-			<div className="googlesitekit-settings-notice__icon">
-				{ Icon && <Icon width="20" height="20" /> }
+		<Fragment>
+			<div className="googlesitekit-settings-notice__text">
+				{ notice }
 			</div>
-			<div>
-				<div className="googlesitekit-settings-notice__text">
-					{ notice }
-				</div>
-				<div className="googlesitekit-settings-notice--multi-row__inner-row">
-					<div className="googlesitekit-settings-notice__children-container">
-						{ children }
-					</div>
-					{ LearnMore && (
-						<div
-							className="googlesitekit-settings-notice__learn-more--multi-row"
-						>
-							<LearnMore />
-						</div>
-					) }
-				</div>
-			</div>
-		</div>
-	);
-};
 
-export default SettingsNoticeMultiRow;
+			<div className="googlesitekit-settings-notice__inner-row">
+				<div className="googlesitekit-settings-notice__children-container">
+					{ children }
+				</div>
+
+				{ LearnMore && (
+					<div className="googlesitekit-settings-notice__learn-more">
+						<LearnMore />
+					</div>
+				) }
+			</div>
+		</Fragment>
+	);
+}
 
 SettingsNoticeMultiRow.propTypes = {
 	children: PropTypes.node.isRequired,
 	notice: PropTypes.node.isRequired,
-	type: PropTypes.oneOf( [ TYPE_WARNING, TYPE_INFO, TYPE_SUGGESTION ] ),
-	Icon: PropTypes.elementType,
 	LearnMore: PropTypes.elementType,
 };

--- a/assets/js/components/SettingsNotice/SettingsNoticeMultiRow.js
+++ b/assets/js/components/SettingsNotice/SettingsNoticeMultiRow.js
@@ -17,14 +17,14 @@
  */
 
 /**
- * WordPress dependencies
- */
-import { Fragment } from '@wordpress/element';
-
-/**
  * External dependencies
  */
 import PropTypes from 'prop-types';
+
+/**
+ * WordPress dependencies
+ */
+import { Fragment } from '@wordpress/element';
 
 export default function SettingsNoticeMultiRow( {
 	notice,

--- a/assets/js/components/SettingsNotice/SettingsNoticeMultiRow.js
+++ b/assets/js/components/SettingsNotice/SettingsNoticeMultiRow.js
@@ -29,14 +29,14 @@ import { TYPE_WARNING, TYPE_INFO, TYPE_SUGGESTION, getIconFromType } from './uti
 const SettingsNoticeMultiRow = ( {
 	notice,
 	type,
-	Icon,
+	Icon = getIconFromType( type ),
 	LearnMore,
 	children,
 } ) => {
 	return (
 		<div className="googlesitekit-settings-notice__row">
 			<div className="googlesitekit-settings-notice__icon">
-				{ Icon ? <Icon /> : getIconFromType( type ) }
+				{ Icon && <Icon width="20" height="20" /> }
 			</div>
 			<div>
 				<div className="googlesitekit-settings-notice__text">

--- a/assets/js/components/SettingsNotice/SettingsNoticeSingleRow.js
+++ b/assets/js/components/SettingsNotice/SettingsNoticeSingleRow.js
@@ -17,47 +17,35 @@
  */
 
 /**
+ * WordPress dependencies
+ */
+import { Fragment } from '@wordpress/element';
+
+/**
  * External dependencies
  */
 import PropTypes from 'prop-types';
 
-/**
- * Internal dependencies
- */
-import { TYPE_WARNING, TYPE_INFO, TYPE_SUGGESTION, getIconFromType } from './utils';
-
-const SettingsNoticeSingleRow = ( {
+export default function SettingsNoticeSingleRow( {
 	notice,
-	type,
-	Icon = getIconFromType( type ),
 	LearnMore,
-} ) => {
+} ) {
 	return (
-		<div
-			className="googlesitekit-settings-notice__row"
-		>
-			<div className="googlesitekit-settings-notice__icon">
-				{ Icon && <Icon width="20" height="20" /> }
+		<Fragment>
+			<div className="googlesitekit-settings-notice__text">
+				{ notice }
 			</div>
-			<div className="googlesitekit-settings-notice--single-row__inner-row">
-				<div className="googlesitekit-settings-notice__text">
-					{ notice }
-				</div>
-				{ LearnMore && (
-					<div className="googlesitekit-settings-notice__learn-more--single-row">
-						<LearnMore />
-					</div>
-				) }
-			</div>
-		</div>
-	);
-};
 
-export default SettingsNoticeSingleRow;
+			{ LearnMore && (
+				<div className="googlesitekit-settings-notice__learn-more">
+					<LearnMore />
+				</div>
+			) }
+		</Fragment>
+	);
+}
 
 SettingsNoticeSingleRow.propTypes = {
 	notice: PropTypes.node.isRequired,
-	type: PropTypes.oneOf( [ TYPE_WARNING, TYPE_INFO, TYPE_SUGGESTION ] ),
-	Icon: PropTypes.elementType,
 	LearnMore: PropTypes.elementType,
 };

--- a/assets/js/components/SettingsNotice/SettingsNoticeSingleRow.js
+++ b/assets/js/components/SettingsNotice/SettingsNoticeSingleRow.js
@@ -29,7 +29,7 @@ import { TYPE_WARNING, TYPE_INFO, TYPE_SUGGESTION, getIconFromType } from './uti
 const SettingsNoticeSingleRow = ( {
 	notice,
 	type,
-	Icon,
+	Icon = getIconFromType( type ),
 	LearnMore,
 } ) => {
 	return (
@@ -37,7 +37,7 @@ const SettingsNoticeSingleRow = ( {
 			className="googlesitekit-settings-notice__row"
 		>
 			<div className="googlesitekit-settings-notice__icon">
-				{ Icon ? <Icon /> : getIconFromType( type ) }
+				{ Icon && <Icon width="20" height="20" /> }
 			</div>
 			<div className="googlesitekit-settings-notice--single-row__inner-row">
 				<div className="googlesitekit-settings-notice__text">

--- a/assets/js/components/SettingsNotice/SettingsNoticeSingleRow.js
+++ b/assets/js/components/SettingsNotice/SettingsNoticeSingleRow.js
@@ -17,14 +17,14 @@
  */
 
 /**
- * WordPress dependencies
- */
-import { Fragment } from '@wordpress/element';
-
-/**
  * External dependencies
  */
 import PropTypes from 'prop-types';
+
+/**
+ * WordPress dependencies
+ */
+import { Fragment } from '@wordpress/element';
 
 export default function SettingsNoticeSingleRow( {
 	notice,

--- a/assets/js/components/SettingsNotice/index.js
+++ b/assets/js/components/SettingsNotice/index.js
@@ -19,8 +19,5 @@
 /**
  * Internal dependencies
  */
-import SettingsNotice from './SettingsNotice';
-
+export { default } from './SettingsNotice';
 export { TYPE_WARNING, TYPE_INFO, TYPE_SUGGESTION } from './utils';
-
-export default SettingsNotice;

--- a/assets/js/components/SettingsNotice/utils.js
+++ b/assets/js/components/SettingsNotice/utils.js
@@ -22,20 +22,18 @@
 import InfoIcon from '../../../svg/info-icon.svg';
 import SuggestionIcon from '../../../svg/suggestion-icon.svg';
 import WarningIcon from '../../../svg/warning-icon.svg';
+import Null from '../Null';
 
 export const TYPE_WARNING = 'warning';
 export const TYPE_INFO = 'info';
 export const TYPE_SUGGESTION = 'suggestion';
 
+const typeIconMap = {
+	[ TYPE_INFO ]: InfoIcon,
+	[ TYPE_WARNING ]: WarningIcon,
+	[ TYPE_SUGGESTION ]: SuggestionIcon,
+};
+
 export const getIconFromType = ( type ) => {
-	switch ( type ) {
-		case TYPE_WARNING:
-			return <WarningIcon />;
-		case TYPE_INFO:
-			return <InfoIcon />;
-		case TYPE_SUGGESTION:
-			return <SuggestionIcon />;
-		default:
-			return null;
-	}
+	return typeIconMap[ type ] || Null;
 };

--- a/assets/sass/components/settings/_googlesitekit-settings-notice.scss
+++ b/assets/sass/components/settings/_googlesitekit-settings-notice.scss
@@ -51,35 +51,37 @@
 		flex-grow: 1;
 		line-height: 20px; // Match icon height.
 
-		.mdc-select:not(.mdc-select--disabled) {
+	}
 
-			.mdc-floating-label {
-				color: $c-text-notice-info-selected-text;
-			}
+	// TODO: decouple select styles from type-specific colors.
+	.mdc-select:not(.mdc-select--disabled) {
 
-			.mdc-select__selected-text {
-				color: $c-text-notice-info-selected-text;
-			}
+		.mdc-floating-label {
+			color: $c-text-notice-info-selected-text;
+		}
 
-			.mdc-select__dropdown-icon {
-				background-image: url("data:image/svg+xml,%3Csvg%20width%3D%2210px%22%20height%3D%225px%22%20viewBox%3D%227%2010%2010%205%22%20version%3D%221.1%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20xmlns%3Axlink%3D%22http%3A%2F%2Fwww.w3.org%2F1999%2Fxlink%22%3E%0A%20%20%20%20%3Cpolygon%20id%3D%22Shape%22%20stroke%3D%22none%22%20fill%3D%22%231a73e8%22%20fill-rule%3D%22evenodd%22%20opacity%3D%221%22%20points%3D%227%2010%2012%2015%2017%2010%22%3E%3C%2Fpolygon%3E%0A%3C%2Fsvg%3E");
-			}
+		.mdc-select__selected-text {
+			color: $c-text-notice-info-selected-text;
+		}
 
-			.mdc-notched-outline__leading,
-			.mdc-notched-outline__notch,
-			.mdc-notched-outline__trailing {
-				border-color: $c-border-brand;
-			}
+		.mdc-select__dropdown-icon {
+			background-image: url("data:image/svg+xml,%3Csvg%20width%3D%2210px%22%20height%3D%225px%22%20viewBox%3D%227%2010%2010%205%22%20version%3D%221.1%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20xmlns%3Axlink%3D%22http%3A%2F%2Fwww.w3.org%2F1999%2Fxlink%22%3E%0A%20%20%20%20%3Cpolygon%20id%3D%22Shape%22%20stroke%3D%22none%22%20fill%3D%22%231a73e8%22%20fill-rule%3D%22evenodd%22%20opacity%3D%221%22%20points%3D%227%2010%2012%2015%2017%2010%22%3E%3C%2Fpolygon%3E%0A%3C%2Fsvg%3E");
+		}
 
-			&:not(.mdc-select--focused) {
+		.mdc-notched-outline__leading,
+		.mdc-notched-outline__notch,
+		.mdc-notched-outline__trailing {
+			border-color: $c-border-brand;
+		}
 
-				.mdc-select__selected-text:hover ~ .mdc-notched-outline {
+		&:not(.mdc-select--focused) {
 
-					.mdc-notched-outline__leading,
-					.mdc-notched-outline__notch,
-					.mdc-notched-outline__trailing {
-						border-color: $c-border-notice-info-hover;
-					}
+			.mdc-select__selected-text:hover ~ .mdc-notched-outline {
+
+				.mdc-notched-outline__leading,
+				.mdc-notched-outline__notch,
+				.mdc-notched-outline__trailing {
+					border-color: $c-border-notice-info-hover;
 				}
 			}
 		}

--- a/assets/sass/components/settings/_googlesitekit-settings-notice.scss
+++ b/assets/sass/components/settings/_googlesitekit-settings-notice.scss
@@ -20,33 +20,17 @@
 	background-color: $c-background-notice;
 	border-radius: 4px;
 	color: $c-text-notice;
+	display: flex;
 	font-size: 0.875rem;
 	line-height: 1.42;
 	margin: 1.5em 0;
+	padding: $grid-gap-phone;
 
-	.googlesitekit-settings-notice__row {
-		display: flex;
-		padding: $grid-gap-phone;
-
-		@media (min-width: $bp-desktop) {
-			padding: $grid-gap-phone $grid-gap-phone $grid-gap-phone $grid-gap-desktop;
-		}
+	@media (min-width: $bp-desktop) {
+		padding-left: $grid-gap-desktop;
 	}
 
-	.googlesitekit-settings-notice--multi-row__inner-row {
-		padding-top: $grid-gap-phone;
-
-		@media (min-width: $bp-tablet) {
-			display: flex;
-			padding-top: $grid-gap-desktop;
-		}
-
-		@media (min-width: $bp-desktop) {
-			padding-top: $grid-gap-desktop;
-		}
-	}
-
-	.googlesitekit-settings-notice--single-row__inner-row {
+	.googlesitekit-settings-notice__body {
 		flex-grow: 1;
 
 		@media (min-width: $bp-tablet) {
@@ -59,11 +43,13 @@
 	}
 
 	.googlesitekit-settings-notice__icon {
+		line-height: 0;
 		margin-right: 10px;
 	}
 
 	.googlesitekit-settings-notice__text {
 		flex-grow: 1;
+		line-height: 20px; // Match icon height.
 
 		.mdc-select:not(.mdc-select--disabled) {
 
@@ -97,16 +83,39 @@
 				}
 			}
 		}
+	}
 
-		.googlesitekit-settings-notice__learn-more--single-row {
+	&--single-row {
+
+		.googlesitekit-settings-notice__learn-more {
 			flex-shrink: 0;
 
 			@media (min-width: $bp-tablet) {
 				padding-left: $grid-gap-desktop;
 			}
 		}
+	}
 
-		.googlesitekit-settings-notice__learn-more--multi-row {
+	&--multi-row {
+
+		.googlesitekit-settings-notice__body {
+			flex-direction: column;
+		}
+
+		.googlesitekit-settings-notice__inner-row {
+			padding-top: $grid-gap-phone;
+
+			@media (min-width: $bp-tablet) {
+				display: flex;
+				padding-top: $grid-gap-desktop;
+			}
+
+			@media (min-width: $bp-desktop) {
+				padding-top: $grid-gap-desktop;
+			}
+		}
+
+		.googlesitekit-settings-notice__learn-more {
 			flex-shrink: 0;
 			text-align: right;
 

--- a/assets/sass/components/settings/_googlesitekit-settings-notice.scss
+++ b/assets/sass/components/settings/_googlesitekit-settings-notice.scss
@@ -28,11 +28,6 @@
 	&--info,
 	&--suggestion {
 
-		svg {
-			height: 20px;
-			width: 20px;
-		}
-
 		.googlesitekit-settings-notice__row {
 			display: flex;
 			padding: $grid-gap-phone;

--- a/assets/sass/components/settings/_googlesitekit-settings-notice.scss
+++ b/assets/sass/components/settings/_googlesitekit-settings-notice.scss
@@ -24,80 +24,75 @@
 	line-height: 1.42;
 	margin: 1.5em 0;
 
-	&--warning,
-	&--info,
-	&--suggestion {
+	.googlesitekit-settings-notice__row {
+		display: flex;
+		padding: $grid-gap-phone;
 
-		.googlesitekit-settings-notice__row {
+		@media (min-width: $bp-desktop) {
+			padding: $grid-gap-phone $grid-gap-phone $grid-gap-phone $grid-gap-desktop;
+		}
+	}
+
+	.googlesitekit-settings-notice--multi-row__inner-row {
+		padding-top: $grid-gap-phone;
+
+		@media (min-width: $bp-tablet) {
 			display: flex;
-			padding: $grid-gap-phone;
+			padding-top: $grid-gap-desktop;
+		}
 
-			@media (min-width: $bp-desktop) {
-				padding: $grid-gap-phone $grid-gap-phone $grid-gap-phone $grid-gap-desktop;
+		@media (min-width: $bp-desktop) {
+			padding-top: $grid-gap-desktop;
+		}
+	}
+
+	.googlesitekit-settings-notice--single-row__inner-row {
+		flex-grow: 1;
+
+		@media (min-width: $bp-tablet) {
+			display: flex;
+		}
+	}
+
+	.googlesitekit-settings-notice__children-container {
+		flex-grow: 1;
+	}
+
+	.googlesitekit-settings-notice__icon {
+		margin-right: 10px;
+	}
+
+	.googlesitekit-settings-notice__text {
+		flex-grow: 1;
+
+		.mdc-select:not(.mdc-select--disabled) {
+
+			.mdc-floating-label {
+				color: $c-text-notice-info-selected-text;
 			}
-		}
 
-		.googlesitekit-settings-notice--multi-row__inner-row {
-			padding-top: $grid-gap-phone;
-
-			@media (min-width: $bp-tablet) {
-				display: flex;
-				padding-top: $grid-gap-desktop;
+			.mdc-select__selected-text {
+				color: $c-text-notice-info-selected-text;
 			}
 
-			@media (min-width: $bp-desktop) {
-				padding-top: $grid-gap-desktop;
+			.mdc-select__dropdown-icon {
+				background-image: url("data:image/svg+xml,%3Csvg%20width%3D%2210px%22%20height%3D%225px%22%20viewBox%3D%227%2010%2010%205%22%20version%3D%221.1%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20xmlns%3Axlink%3D%22http%3A%2F%2Fwww.w3.org%2F1999%2Fxlink%22%3E%0A%20%20%20%20%3Cpolygon%20id%3D%22Shape%22%20stroke%3D%22none%22%20fill%3D%22%231a73e8%22%20fill-rule%3D%22evenodd%22%20opacity%3D%221%22%20points%3D%227%2010%2012%2015%2017%2010%22%3E%3C%2Fpolygon%3E%0A%3C%2Fsvg%3E");
 			}
-		}
 
-		.googlesitekit-settings-notice--single-row__inner-row {
-			flex-grow: 1;
-
-			@media (min-width: $bp-tablet) {
-				display: flex;
+			.mdc-notched-outline__leading,
+			.mdc-notched-outline__notch,
+			.mdc-notched-outline__trailing {
+				border-color: $c-border-brand;
 			}
-		}
 
-		.googlesitekit-settings-notice__children-container {
-			flex-grow: 1;
-		}
+			&:not(.mdc-select--focused) {
 
-		.googlesitekit-settings-notice__icon {
-			margin-right: 10px;
-		}
+				.mdc-select__selected-text:hover ~ .mdc-notched-outline {
 
-		.googlesitekit-settings-notice__text {
-			flex-grow: 1;
-
-			.mdc-select:not(.mdc-select--disabled) {
-
-				.mdc-floating-label {
-					color: $c-text-notice-info-selected-text;
-				}
-
-				.mdc-select__selected-text {
-					color: $c-text-notice-info-selected-text;
-				}
-
-				.mdc-select__dropdown-icon {
-					background-image: url("data:image/svg+xml,%3Csvg%20width%3D%2210px%22%20height%3D%225px%22%20viewBox%3D%227%2010%2010%205%22%20version%3D%221.1%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20xmlns%3Axlink%3D%22http%3A%2F%2Fwww.w3.org%2F1999%2Fxlink%22%3E%0A%20%20%20%20%3Cpolygon%20id%3D%22Shape%22%20stroke%3D%22none%22%20fill%3D%22%231a73e8%22%20fill-rule%3D%22evenodd%22%20opacity%3D%221%22%20points%3D%227%2010%2012%2015%2017%2010%22%3E%3C%2Fpolygon%3E%0A%3C%2Fsvg%3E");
-				}
-
-				.mdc-notched-outline__leading,
-				.mdc-notched-outline__notch,
-				.mdc-notched-outline__trailing {
-					border-color: $c-border-brand;
-				}
-
-				&:not(.mdc-select--focused) {
-
-					.mdc-select__selected-text:hover ~ .mdc-notched-outline {
-
-						.mdc-notched-outline__leading,
-						.mdc-notched-outline__notch,
-						.mdc-notched-outline__trailing {
-							border-color: $c-border-notice-info-hover;
-						}
+					.mdc-notched-outline__leading,
+					.mdc-notched-outline__notch,
+					.mdc-notched-outline__trailing {
+						border-color: $c-border-notice-info-hover;
 					}
 				}
 			}

--- a/assets/svg/info-icon.svg
+++ b/assets/svg/info-icon.svg
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg width="20px" height="20px" viewBox="0 0 20 20"  fill="#1967d2" xmlns="http://www.w3.org/2000/svg">
+<svg width="20px" height="20px" viewBox="0 0 20 20"  fill="currentColor" xmlns="http://www.w3.org/2000/svg">
 	<path d="M10 15.27L16.18 19L14.54 11.97L20 7.24L12.81 6.63L10 0L7.19 6.63L0 7.24L5.46 11.97L3.82 19L10 15.27Z" />
 </svg>

--- a/assets/svg/suggestion-icon.svg
+++ b/assets/svg/suggestion-icon.svg
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg width="2" height="11" viewBox="0 0 2 11" xmlns="http://www.w3.org/2000/svg">
-	<g fill="#1967d2" fill-rule="evenodd">
+	<g fill="currentColor" fill-rule="evenodd">
 		<path d="M0 4h2v7H0zM0 0h2v2H0z"/>
 	</g>
 </svg>

--- a/assets/svg/warning-icon.svg
+++ b/assets/svg/warning-icon.svg
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg width="2" height="12" viewBox="0 0 2 12" xmlns="http://www.w3.org/2000/svg">
-	<g fill="#f8a708" fill-rule="evenodd">
+	<g fill="currentColor" fill-rule="evenodd">
 		<path d="M0 0h2v7H0zM0 10h2v2H0z"/>
 	</g>
 </svg>

--- a/stories/notices.stories.js
+++ b/stories/notices.stories.js
@@ -34,7 +34,7 @@ const LearnMore = () => (
 		external
 		inherit
 	>
-		Learn more here
+		Learn more
 	</Link>
 );
 

--- a/stories/notices.stories.js
+++ b/stories/notices.stories.js
@@ -46,12 +46,12 @@ storiesOf( 'Global/Notices', module )
 	.add( 'Settings info notice single line', () => (
 		<SettingsNotice type={ TYPE_INFO } LearnMore={ LearnMore } notice="This is an information." />
 	) )
-	.add( 'Settings info notice multi line', () => (
+	.add( 'Settings info notice with a long notice', () => (
 		<SettingsNotice type={ TYPE_INFO } LearnMore={ LearnMore } notice={ new Array( 10 ).fill( 'This is an information. ' ) } />
 	) )
 	.add( 'Settings info notice with children', () => (
 		<SettingsNotice type={ TYPE_INFO } LearnMore={ LearnMore } notice={ new Array( 5 ).fill( 'This is an information. ' ) }>
-			 { new Array( 10 ).fill( 'This is an information. ' ) }
+			<p>This is more information about the information!</p>
 		</SettingsNotice>
 	) )
 	.add( 'Settings info notice no LearnMore', () => (


### PR DESCRIPTION
## Summary

Addresses issue #3251

## Relevant technical choices

* Decouples common styles from type-specific styles
* Simplifies markup into more common classes between line-variant components, making the variable part more specific to the body of the notice
* Move svg sizing to props on `Icon`
* Fixes some styles for sizing of notice line-height with icon
* Updated icons to inherit color rather than have a hardcoded value (like others)

**Fixes alignment/sizing of icon relative to notice text**
![image](https://user-images.githubusercontent.com/1621608/121386920-ef0c6400-c952-11eb-8d20-66bb98a2aba0.png)

**Fixes styling of borders and text in inner Select components**
![image](https://user-images.githubusercontent.com/1621608/121386485-b66c8a80-c952-11eb-9a38-89a7d9c7c660.png)


## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
