### PR TITLE
Update to change CTA button to text to uppercase.

### DIFF
--- a/assets/js/modules/idea-hub/components/dashboard/DashboardCTA.js
+++ b/assets/js/modules/idea-hub/components/dashboard/DashboardCTA.js
@@ -87,7 +87,7 @@ function DashboardCTA( { Widget } ) {
 						</Link>
 					</p>
 
-					<Button className="googlesitekit-idea-hub__dashboard-cta__setup" onClick={ onClick }>
+					<Button onClick={ onClick }>
 						{
 							active && ! connected
 								? __( 'Complete set up', 'google-site-kit' )

--- a/assets/sass/components/idea-hub/_googlesitekit-idea-hub-dashboard-cta.scss
+++ b/assets/sass/components/idea-hub/_googlesitekit-idea-hub-dashboard-cta.scss
@@ -73,9 +73,4 @@
 		display: flex;
 		font-size: 14px;
 	}
-
-	.googlesitekit-idea-hub__dashboard-cta__setup {
-		font-family: $f-secondary;
-		text-transform: none;
-	}
 }

--- a/assets/sass/components/surveys/_googlesitekit-surveys.scss
+++ b/assets/sass/components/surveys/_googlesitekit-surveys.scss
@@ -53,10 +53,6 @@
 		@media (min-width: $bp-desktop) {
 			padding: 0 $grid-gap-desktop $grid-gap-desktop;
 		}
-
-		.mdc-button {
-			text-transform: none;
-		}
 	}
 
 	.googlesitekit-survey__choice {


### PR DESCRIPTION
## Summary

Update to change CTA button to text to uppercase.

Addresses issue #3507

## Relevant technical choices

## Checklist

- [X] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [X] I have added a QA Brief on the issue linked above.
- [X] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
