### PR TITLE
Update to always return AMP mode secondary.

### DIFF
--- a/includes/Context.php
+++ b/includes/Context.php
@@ -28,7 +28,11 @@ class Context {
 	/**
 	 * Primary "standard" AMP website mode.
 	 *
-	 * @since 1.0.0
+	 * This mode is currently unused due to Tag Manager setup not showing the Web Container dropdown
+	 * when AMP is in standard mode and some urls have AMP disabled.
+	 *
+	 * @since 1.0.0 Originally introduced.
+	 * @since n.e.x.t Marked as unused, see description.
 	 * @var string
 	 */
 	const AMP_MODE_PRIMARY = 'primary';
@@ -348,27 +352,7 @@ class Context {
 				&& $exposes_support_mode;
 		}
 
-		if ( $exposes_support_mode ) {
-			// If recent version, we can properly detect the mode.
-			if ( $amp_plugin_version_2_or_higher ) {
-				$mode = AMP_Options_Manager::get_option( 'theme_support' );
-			} else {
-				$mode = AMP_Theme_Support::get_support_mode();
-			}
-
-			if ( AMP_Theme_Support::STANDARD_MODE_SLUG === $mode ) {
-				return self::AMP_MODE_PRIMARY;
-			}
-
-			if ( in_array( $mode, array( AMP_Theme_Support::TRANSITIONAL_MODE_SLUG, AMP_Theme_Support::READER_MODE_SLUG ), true ) ) {
-				return self::AMP_MODE_SECONDARY;
-			}
-		} elseif ( function_exists( 'amp_is_canonical' ) ) {
-			// On older versions, if it is not primary AMP, it is definitely secondary AMP (transitional or reader mode).
-			if ( amp_is_canonical() ) {
-				return self::AMP_MODE_PRIMARY;
-			}
-
+		if ( $exposes_support_mode || function_exists( 'amp_is_canonical' ) ) {
 			return self::AMP_MODE_SECONDARY;
 		}
 

--- a/includes/Context.php
+++ b/includes/Context.php
@@ -352,7 +352,28 @@ class Context {
 				&& $exposes_support_mode;
 		}
 
-		if ( $exposes_support_mode || function_exists( 'amp_is_canonical' ) ) {
+		if ( $exposes_support_mode ) {
+			// If recent version, we can properly detect the mode.
+			if ( $amp_plugin_version_2_or_higher ) {
+				$mode = AMP_Options_Manager::get_option( 'theme_support' );
+			} else {
+				$mode = AMP_Theme_Support::get_support_mode();
+			}
+
+			if (
+				in_array(
+					$mode,
+					array(
+						AMP_Theme_Support::STANDARD_MODE_SLUG,
+						AMP_Theme_Support::TRANSITIONAL_MODE_SLUG,
+						AMP_Theme_Support::READER_MODE_SLUG,
+					),
+					true
+				)
+			) {
+				return self::AMP_MODE_SECONDARY;
+			}
+		} elseif ( function_exists( 'amp_is_canonical' ) ) {
 			return self::AMP_MODE_SECONDARY;
 		}
 

--- a/tests/e2e/specs/modules/tagmanager/setup.test.js
+++ b/tests/e2e/specs/modules/tagmanager/setup.test.js
@@ -221,26 +221,6 @@ describe( 'Tag Manager module setup', () => {
 			await deactivatePlugin( 'amp' );
 		} );
 
-		describe( 'with Primary AMP', () => {
-			beforeAll( async () => {
-				await setAMPMode( 'primary' );
-			} );
-
-			it( 'renders only the AMP container select menu', async () => {
-				await expect( page ).toMatchElement( '.googlesitekit-tagmanager__select-container--amp' );
-				await expect( page ).toMatchElement( '.googlesitekit-tagmanager__select-container--amp .mdc-floating-label', { text: 'Container' } );
-				await expect( page ).not.toMatchElement( '.googlesitekit-tagmanager__select-container--web' );
-			} );
-
-			it( 'validates Homepage AMP for logged-in users', async () => {
-				await expect( '/' ).toHaveValidAMPForUser();
-			} );
-
-			it( 'validates Homepage AMP for non-logged-in users', async () => {
-				await expect( '/' ).toHaveValidAMPForVisitor();
-			} );
-		} );
-
 		describe( 'with Secondary AMP', () => {
 			beforeAll( async () => {
 				await setAMPMode( 'secondary' );


### PR DESCRIPTION
## Summary

Update to always return AMP mode secondary.

Addresses issue #2998

## Relevant technical choices


## Checklist

- [X] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [X] I have added a QA Brief on the issue linked above.
- [X] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
