### PR TITLE
Bug/3537 setup form doesnt load

### DIFF
--- a/assets/js/modules/analytics/components/settings/SettingsForm.js
+++ b/assets/js/modules/analytics/components/settings/SettingsForm.js
@@ -49,25 +49,13 @@ import {
 	STORE_NAME,
 	PROFILE_CREATE,
 } from '../../datastore/constants';
-import { MODULES_ANALYTICS_4 } from '../../../analytics-4/datastore/constants';
 import { useFeature } from '../../../../hooks/useFeature';
 const { useSelect } = Data;
 
 export default function SettingsForm() {
 	const isGA4Enabled = useFeature( 'ga4setup' );
-	useSelect( ( select ) => {
-		if ( ! isGA4Enabled ) {
-			return;
-		}
-
-		// We need to call getProperties for getSetupFlowMode to work.
-		const accountID = select( STORE_NAME ).getAccountID();
-		return select( MODULES_ANALYTICS_4 ).getProperties( accountID );
-	} );
-
 	const setupFlowMode = useSelect( ( select ) => select( STORE_NAME ).getSetupFlowMode() );
 	const hasExistingTag = useSelect( ( select ) => select( STORE_NAME ).hasExistingTag() );
-
 	const profileID = useSelect( ( select ) => select( STORE_NAME ).getProfileID() );
 
 	return (

--- a/assets/js/modules/analytics/components/setup/SetupMain.js
+++ b/assets/js/modules/analytics/components/setup/SetupMain.js
@@ -39,9 +39,7 @@ import { STORE_NAME, ACCOUNT_CREATE } from '../../datastore/constants';
 import { CORE_SITE } from '../../../../googlesitekit/datastore/site/constants';
 import { CORE_LOCATION } from '../../../../googlesitekit/datastore/location/constants';
 import { MODULES_TAGMANAGER } from '../../../tagmanager/datastore/constants';
-import { MODULES_ANALYTICS_4 } from '../../../analytics-4/datastore/constants';
 import useExistingTagEffect from '../../hooks/useExistingTagEffect';
-import { useFeature } from '../../../../hooks/useFeature';
 import {
 	AccountCreate,
 	AccountCreateLegacy,
@@ -51,7 +49,6 @@ import {
 const { useSelect } = Data;
 
 export default function SetupMain( { finishSetup } ) {
-	const isGA4Enabled = useFeature( 'ga4setup' );
 	const accounts = useSelect( ( select ) => select( STORE_NAME ).getAccounts() );
 	const accountID = useSelect( ( select ) => select( STORE_NAME ).getAccountID() );
 	const hasExistingTag = useSelect( ( select ) => select( STORE_NAME ).hasExistingTag() );
@@ -60,19 +57,7 @@ export default function SetupMain( { finishSetup } ) {
 	const hasResolvedAccounts = useSelect( ( select ) => select( STORE_NAME ).hasFinishedResolution( 'getAccounts' ) );
 	const usingProxy = useSelect( ( select ) => select( CORE_SITE ).isUsingProxy() );
 	const isNavigating = useSelect( ( select ) => select( CORE_LOCATION ).isNavigating() );
-	const setupFlowMode = useSelect( ( select ) => {
-		// If the ga4setup feature is enabled we need to try to pull ga4 properties to see whether Admin API works or not.
-		// This will affect the isAdminAPIWorking selector behavior which is used in the getSetupFlowMode.
-		if ( isGA4Enabled && ( accountID || accounts ) ) {
-			if ( accountID ) {
-				select( MODULES_ANALYTICS_4 ).getProperties( accountID );
-			} else if ( Array.isArray( accounts ) && accounts.length > 0 ) {
-				select( MODULES_ANALYTICS_4 ).getProperties( accounts[ 0 ].id );
-			}
-		}
-
-		return select( STORE_NAME ).getSetupFlowMode();
-	} );
+	const setupFlowMode = useSelect( ( select ) => select( STORE_NAME ).getSetupFlowMode() );
 
 	const { hasGTMAnalyticsPropertyID, hasGTMAnalyticsPropertyIDPermission } = useSelect( ( select ) => {
 		const gtmPropertyID = select( MODULES_TAGMANAGER ).getSingleAnalyticsPropertyID();

--- a/assets/js/modules/analytics/datastore/setup-flow.js
+++ b/assets/js/modules/analytics/datastore/setup-flow.js
@@ -41,15 +41,9 @@ const baseSelectors = {
 			return SETUP_FLOW_MODE_LEGACY;
 		}
 
-		// Check to see if the Admin API is working—if it's `undefined` the request
-		// is loading, but if it's `false` we should also use the legacy analytics
-		// because the API isn't working properly.
+		// Check to see if the Admin API is working—if it's `false` we should also use
+		// the legacy analytics because the API isn't working properly.
 		const isAdminAPIWorking = select( MODULES_ANALYTICS_4 ).isAdminAPIWorking();
-
-		if ( isAdminAPIWorking === undefined ) {
-			return undefined;
-		}
-
 		if ( isAdminAPIWorking === false ) {
 			return SETUP_FLOW_MODE_LEGACY;
 		}
@@ -100,11 +94,9 @@ const baseSelectors = {
 	} ),
 };
 
-const store = Data.combineStores(
-	{
-		selectors: baseSelectors,
-	}
-);
+const store = Data.combineStores( {
+	selectors: baseSelectors,
+} );
 
 export const initialState = store.initialState;
 export const actions = store.actions;

--- a/assets/js/modules/analytics/datastore/setup-flow.test.js
+++ b/assets/js/modules/analytics/datastore/setup-flow.test.js
@@ -128,14 +128,12 @@ describe( 'modules/analytics setup-flow', () => {
 				);
 
 				expect( registry.select( MODULES_ANALYTICS_4 ).isAdminAPIWorking() ).toBe( false );
-
 				expect( registry.select( MODULES_ANALYTICS ).getSetupFlowMode() ).toBe( SETUP_FLOW_MODE_LEGACY );
 			} );
 
-			it( 'should return undefined if isAdminAPIWorking() returns undefined ', () => {
-				expect( registry.select( MODULES_ANALYTICS_4 ).isAdminAPIWorking() ).toBe( undefined );
-
-				expect( registry.select( MODULES_ANALYTICS ).getSetupFlowMode() ).toBe( undefined );
+			it( 'should not return undefined if isAdminAPIWorking() returns undefined ', () => {
+				expect( registry.select( MODULES_ANALYTICS_4 ).isAdminAPIWorking() ).toBeUndefined();
+				expect( registry.select( MODULES_ANALYTICS ).getSetupFlowMode() ).not.toBeUndefined();
 			} );
 
 			it( 'should return undefined if settings are still loading', () => {
@@ -152,21 +150,19 @@ describe( 'modules/analytics setup-flow', () => {
 				);
 
 				registry = createTestRegistry();
-
 				populateAnalytics4Datastore( registry );
+
 				expect( registry.select( MODULES_ANALYTICS_4 ).isAdminAPIWorking() ).toBe( true );
-
-				expect( registry.select( MODULES_ANALYTICS ).getSettings() ).toBe( undefined );
-
-				expect( registry.select( MODULES_ANALYTICS ).getSetupFlowMode() ).toBe( undefined );
+				expect( registry.select( MODULES_ANALYTICS ).getSettings() ).toBeUndefined();
+				expect( registry.select( MODULES_ANALYTICS ).getSetupFlowMode() ).toBeUndefined();
 			} );
 
 			it( 'should return "ua" if there is no account selected', () => {
-				expect( registry.select( MODULES_ANALYTICS ).getAccountID( accountID ) ).toBe( undefined );
+				expect( registry.select( MODULES_ANALYTICS ).getAccountID( accountID ) ).toBeUndefined();
 
 				populateAnalytics4Datastore( registry );
-				expect( registry.select( MODULES_ANALYTICS_4 ).isAdminAPIWorking() ).toBe( true );
 
+				expect( registry.select( MODULES_ANALYTICS_4 ).isAdminAPIWorking() ).toBe( true );
 				expect( registry.select( MODULES_ANALYTICS ).getSetupFlowMode() ).toBe( SETUP_FLOW_MODE_UA );
 			} );
 
@@ -174,9 +170,8 @@ describe( 'modules/analytics setup-flow', () => {
 				registry.dispatch( MODULES_ANALYTICS ).setAccountID( accountID );
 				populateAnalyticsDatastore( registry );
 
-				expect( registry.select( MODULES_ANALYTICS ).getProperties() ).toBe( undefined );
-
-				expect( registry.select( MODULES_ANALYTICS ).getSetupFlowMode() ).toBe( undefined );
+				expect( registry.select( MODULES_ANALYTICS ).getProperties() ).toBeUndefined();
+				expect( registry.select( MODULES_ANALYTICS ).getSetupFlowMode() ).toBeUndefined();
 			} );
 
 			it( 'should return "ua" if selected account returns an empty array from GA4 getProperties selector', () => {
@@ -230,7 +225,6 @@ describe( 'modules/analytics setup-flow', () => {
 				);
 
 				expect( registry.select( MODULES_ANALYTICS_4 ).isAdminAPIWorking() ).toBe( true );
-
 				expect( registry.select( MODULES_ANALYTICS ).getSetupFlowMode() ).toBe( SETUP_FLOW_MODE_UA );
 			} );
 
@@ -240,8 +234,7 @@ describe( 'modules/analytics setup-flow', () => {
 				populateAnalytics4Datastore( registry );
 
 				expect( registry.select( MODULES_ANALYTICS_4 ).isAdminAPIWorking() ).toBe( true );
-
-				expect( registry.select( MODULES_ANALYTICS ).getSetupFlowMode() ).toBe( undefined );
+				expect( registry.select( MODULES_ANALYTICS ).getSetupFlowMode() ).toBeUndefined();
 			} );
 
 			it( 'should return "ga4" if selected account returns an empty array from UA getProperties selector', () => {
@@ -254,7 +247,6 @@ describe( 'modules/analytics setup-flow', () => {
 				);
 
 				expect( registry.select( MODULES_ANALYTICS_4 ).isAdminAPIWorking() ).toBe( true );
-
 				expect( registry.select( MODULES_ANALYTICS ).getSetupFlowMode() ).toBe( SETUP_FLOW_MODE_GA4 );
 			} );
 
@@ -264,7 +256,6 @@ describe( 'modules/analytics setup-flow', () => {
 				populateAnalyticsDatastore( registry );
 
 				expect( registry.select( MODULES_ANALYTICS_4 ).isAdminAPIWorking() ).toBe( true );
-
 				expect( registry.select( MODULES_ANALYTICS ).getSetupFlowMode() ).toBe( SETUP_FLOW_MODE_GA4_TRANSITIONAL );
 			} );
 		} );


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #3537

## Relevant technical choices

* Updated the `getSetupFlowMode` selector not to return `undefined` if when the `isAdminAPIWorking` selector returns `undefined`. It lets us to remove unnecessary calls to the ga4 `getProperties` selector.

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
