### PR TITLE
Don't show GA4 notice when no account is selected (3536).

### DIFF
--- a/assets/js/modules/analytics/components/setup/SetupFormUA.js
+++ b/assets/js/modules/analytics/components/setup/SetupFormUA.js
@@ -39,7 +39,7 @@ import {
 	PropertySelect,
 	ProfileNameTextField,
 } from '../common';
-import { STORE_NAME, PROFILE_CREATE } from '../../datastore/constants';
+import { STORE_NAME, PROFILE_CREATE, ACCOUNT_CREATE } from '../../datastore/constants';
 import { MODULES_ANALYTICS_4, PROPERTY_CREATE } from '../../../analytics-4/datastore/constants';
 import GA4PropertyNotice from '../common/GA4PropertyNotice';
 import StoreErrorNotices from '../../../../components/StoreErrorNotices';
@@ -53,6 +53,9 @@ export default function SetupFormUA() {
 
 	// Needed to conditionally show the profile name field and surrounding container.
 	const profileID = useSelect( ( select ) => select( STORE_NAME ).getProfileID() );
+
+	const accountID = useSelect( ( select ) => select( STORE_NAME ).getAccountID() );
+	const shouldShowGA4PropertyNotice = accountID && accountID !== ACCOUNT_CREATE;
 
 	useMount( () => {
 		selectProperty( PROPERTY_CREATE );
@@ -85,9 +88,11 @@ export default function SetupFormUA() {
 				</div>
 			) }
 
-			<GA4PropertyNotice
-				notice={ __( 'A Google Analytics 4 property will also be created.', 'google-site-kit' ) }
-			/>
+			{ shouldShowGA4PropertyNotice && (
+				<GA4PropertyNotice
+					notice={ __( 'A Google Analytics 4 property will also be created.', 'google-site-kit' ) }
+				/>
+			) }
 		</Fragment>
 	);
 }


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #3536

## Relevant technical choices

<!-- Please describe your changes. -->

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
