### PR TITLE
Add interfaces for modules with (de)activation and fix GA4 deactivation

### DIFF
--- a/includes/Core/Modules/Module_With_Activation.php
+++ b/includes/Core/Modules/Module_With_Activation.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Interface Google\Site_Kit\Core\Modules\Module_With_Activation
+ *
+ * @package   Google\Site_Kit
+ * @copyright 2021 Google LLC
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
+ * @link      https://sitekit.withgoogle.com
+ */
+
+namespace Google\Site_Kit\Core\Modules;
+
+/**
+ * Interface for a module that has additional behavior when activated.
+ *
+ * @since n.e.x.t
+ * @access private
+ * @ignore
+ */
+interface Module_With_Activation {
+	/**
+	 * Handles module activation.
+	 *
+	 * @since n.e.x.t
+	 */
+	public function on_activation();
+}

--- a/includes/Core/Modules/Module_With_Deactivation.php
+++ b/includes/Core/Modules/Module_With_Deactivation.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Interface Google\Site_Kit\Core\Modules\Module_With_Deactivation
+ *
+ * @package   Google\Site_Kit
+ * @copyright 2021 Google LLC
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
+ * @link      https://sitekit.withgoogle.com
+ */
+
+namespace Google\Site_Kit\Core\Modules;
+
+/**
+ * Interface for a module that has additional behavior when deactivated.
+ *
+ * @since n.e.x.t
+ * @access private
+ * @ignore
+ */
+interface Module_With_Deactivation {
+	/**
+	 * Handles module deactivation.
+	 *
+	 * @since n.e.x.t
+	 */
+	public function on_deactivation();
+}

--- a/includes/Core/Modules/Modules.php
+++ b/includes/Core/Modules/Modules.php
@@ -433,6 +433,13 @@ final class Modules {
 			return false;
 		}
 
+		// TODO: Remove this hack.
+		if ( Analytics::MODULE_SLUG === $slug ) {
+			// GA4 needs to be handled first to pass conditions below
+			// due to special handling in active modules option.
+			$this->activate_module( Analytics_4::MODULE_SLUG );
+		}
+
 		$option = $this->get_active_modules_option();
 
 		if ( in_array( $slug, $option, true ) ) {
@@ -463,6 +470,13 @@ final class Modules {
 			$module = $this->get_module( $slug );
 		} catch ( Exception $e ) {
 			return false;
+		}
+
+		// TODO: Remove this hack.
+		if ( Analytics::MODULE_SLUG === $slug ) {
+			// GA4 needs to be handled first to pass conditions below
+			// due to special handling in active modules option.
+			$this->deactivate_module( Analytics_4::MODULE_SLUG );
 		}
 
 		$option = $this->get_active_modules_option();

--- a/includes/Core/Modules/Modules.php
+++ b/includes/Core/Modules/Modules.php
@@ -443,8 +443,8 @@ final class Modules {
 
 		$this->set_active_modules_option( $option );
 
-		if ( is_callable( array( $module, 'on_activation' ) ) ) {
-			call_user_func( array( $module, 'on_activation' ) );
+		if ( $module instanceof Module_With_Activation ) {
+			$module->on_activation();
 		}
 
 		return true;
@@ -481,8 +481,8 @@ final class Modules {
 
 		$this->set_active_modules_option( array_values( $option ) );
 
-		if ( is_callable( array( $module, 'on_deactivation' ) ) ) {
-			call_user_func( array( $module, 'on_deactivation' ) );
+		if ( $module instanceof Module_With_Deactivation ) {
+			$module->on_deactivation();
 		}
 
 		return true;

--- a/includes/Modules/AdSense.php
+++ b/includes/Modules/AdSense.php
@@ -12,6 +12,7 @@ namespace Google\Site_Kit\Modules;
 
 use Google\Site_Kit\Core\Modules\Module;
 use Google\Site_Kit\Core\Modules\Module_Settings;
+use Google\Site_Kit\Core\Modules\Module_With_Deactivation;
 use Google\Site_Kit\Core\Modules\Module_With_Debug_Fields;
 use Google\Site_Kit\Core\Modules\Module_With_Screen;
 use Google\Site_Kit\Core\Modules\Module_With_Screen_Trait;
@@ -49,7 +50,7 @@ use WP_Error;
  * @ignore
  */
 final class AdSense extends Module
-	implements Module_With_Screen, Module_With_Scopes, Module_With_Settings, Module_With_Assets, Module_With_Debug_Fields, Module_With_Owner {
+	implements Module_With_Screen, Module_With_Scopes, Module_With_Settings, Module_With_Assets, Module_With_Debug_Fields, Module_With_Owner, Module_With_Deactivation {
 	use Method_Proxy_Trait;
 	use Module_With_Assets_Trait;
 	use Module_With_Owner_Trait;

--- a/includes/Modules/Analytics.php
+++ b/includes/Modules/Analytics.php
@@ -12,6 +12,7 @@ namespace Google\Site_Kit\Modules;
 
 use Google\Site_Kit\Core\Modules\Module;
 use Google\Site_Kit\Core\Modules\Module_Settings;
+use Google\Site_Kit\Core\Modules\Module_With_Deactivation;
 use Google\Site_Kit\Core\Modules\Module_With_Debug_Fields;
 use Google\Site_Kit\Core\Modules\Module_With_Screen;
 use Google\Site_Kit\Core\Modules\Module_With_Screen_Trait;
@@ -68,7 +69,7 @@ use Exception;
  * @ignore
  */
 final class Analytics extends Module
-	implements Module_With_Screen, Module_With_Scopes, Module_With_Settings, Module_With_Assets, Module_With_Debug_Fields, Module_With_Owner {
+	implements Module_With_Screen, Module_With_Scopes, Module_With_Settings, Module_With_Assets, Module_With_Debug_Fields, Module_With_Owner, Module_With_Deactivation {
 	use Method_Proxy_Trait;
 	use Module_With_Assets_Trait;
 	use Module_With_Owner_Trait;

--- a/includes/Modules/Analytics_4.php
+++ b/includes/Modules/Analytics_4.php
@@ -16,6 +16,7 @@ use Google\Site_Kit\Core\Assets\Script;
 use Google\Site_Kit\Core\Authentication\Clients\Google_Site_Kit_Client;
 use Google\Site_Kit\Core\Modules\Module;
 use Google\Site_Kit\Core\Modules\Module_Settings;
+use Google\Site_Kit\Core\Modules\Module_With_Deactivation;
 use Google\Site_Kit\Core\Modules\Module_With_Debug_Fields;
 use Google\Site_Kit\Core\Modules\Module_With_Assets;
 use Google\Site_Kit\Core\Modules\Module_With_Assets_Trait;
@@ -49,7 +50,7 @@ use WP_Error;
  * @ignore
  */
 final class Analytics_4 extends Module
-	implements Module_With_Scopes, Module_With_Settings, Module_With_Debug_Fields, Module_With_Owner, Module_With_Assets {
+	implements Module_With_Scopes, Module_With_Settings, Module_With_Debug_Fields, Module_With_Owner, Module_With_Assets, Module_With_Deactivation {
 	use Method_Proxy_Trait;
 	use Module_With_Assets_Trait;
 	use Module_With_Owner_Trait;

--- a/includes/Modules/Idea_Hub.php
+++ b/includes/Modules/Idea_Hub.php
@@ -13,6 +13,7 @@ namespace Google\Site_Kit\Modules;
 use Google\Site_Kit\Core\Assets\Asset;
 use Google\Site_Kit\Core\Modules\Module;
 use Google\Site_Kit\Core\Modules\Module_Settings;
+use Google\Site_Kit\Core\Modules\Module_With_Deactivation;
 use Google\Site_Kit\Core\Modules\Module_With_Debug_Fields;
 use Google\Site_Kit\Core\Modules\Module_With_Assets;
 use Google\Site_Kit\Core\Modules\Module_With_Assets_Trait;
@@ -40,7 +41,7 @@ use WP_Error;
  * @ignore
  */
 final class Idea_Hub extends Module
-	implements Module_With_Scopes, Module_With_Settings, Module_With_Debug_Fields, Module_With_Assets {
+	implements Module_With_Scopes, Module_With_Settings, Module_With_Debug_Fields, Module_With_Assets, Module_With_Deactivation {
 	use Module_With_Assets_Trait;
 	use Module_With_Scopes_Trait;
 	use Module_With_Settings_Trait;

--- a/includes/Modules/Optimize.php
+++ b/includes/Modules/Optimize.php
@@ -14,6 +14,7 @@ use Google\Site_Kit\Core\Assets\Asset;
 use Google\Site_Kit\Core\Assets\Script;
 use Google\Site_Kit\Core\Modules\Module;
 use Google\Site_Kit\Core\Modules\Module_Settings;
+use Google\Site_Kit\Core\Modules\Module_With_Deactivation;
 use Google\Site_Kit\Core\Modules\Module_With_Debug_Fields;
 use Google\Site_Kit\Core\Modules\Module_With_Settings;
 use Google\Site_Kit\Core\Modules\Module_With_Settings_Trait;
@@ -33,7 +34,7 @@ use Google\Site_Kit\Modules\Optimize\Settings;
  * @ignore
  */
 final class Optimize extends Module
-	implements Module_With_Settings, Module_With_Debug_Fields, Module_With_Assets, Module_With_Owner {
+	implements Module_With_Settings, Module_With_Debug_Fields, Module_With_Assets, Module_With_Owner, Module_With_Deactivation {
 	use Module_With_Settings_Trait, Module_With_Assets_Trait, Module_With_Owner_Trait;
 
 	/**

--- a/includes/Modules/PageSpeed_Insights.php
+++ b/includes/Modules/PageSpeed_Insights.php
@@ -14,6 +14,7 @@ use Google\Site_Kit\Core\Assets\Script;
 use Google\Site_Kit\Core\Modules\Module;
 use Google\Site_Kit\Core\Modules\Module_With_Assets;
 use Google\Site_Kit\Core\Modules\Module_With_Assets_Trait;
+use Google\Site_Kit\Core\Modules\Module_With_Deactivation;
 use Google\Site_Kit\Core\Modules\Module_With_Scopes;
 use Google\Site_Kit\Core\Modules\Module_With_Scopes_Trait;
 use Google\Site_Kit\Core\REST_API\Exception\Invalid_Datapoint_Exception;
@@ -31,7 +32,7 @@ use WP_Error;
  * @ignore
  */
 final class PageSpeed_Insights extends Module
-	implements Module_With_Scopes, Module_With_Assets {
+	implements Module_With_Scopes, Module_With_Assets, Module_With_Deactivation {
 	use Module_With_Scopes_Trait, Module_With_Assets_Trait;
 
 	/**

--- a/includes/Modules/Tag_Manager.php
+++ b/includes/Modules/Tag_Manager.php
@@ -17,6 +17,7 @@ use Google\Site_Kit\Core\Modules\Module;
 use Google\Site_Kit\Core\Modules\Module_Settings;
 use Google\Site_Kit\Core\Modules\Module_With_Assets;
 use Google\Site_Kit\Core\Modules\Module_With_Assets_Trait;
+use Google\Site_Kit\Core\Modules\Module_With_Deactivation;
 use Google\Site_Kit\Core\Modules\Module_With_Debug_Fields;
 use Google\Site_Kit\Core\Modules\Module_With_Scopes;
 use Google\Site_Kit\Core\Modules\Module_With_Scopes_Trait;
@@ -51,7 +52,7 @@ use Exception;
  * @ignore
  */
 final class Tag_Manager extends Module
-	implements Module_With_Scopes, Module_With_Settings, Module_With_Assets, Module_With_Debug_Fields, Module_With_Owner {
+	implements Module_With_Scopes, Module_With_Settings, Module_With_Assets, Module_With_Debug_Fields, Module_With_Owner, Module_With_Deactivation {
 	use Method_Proxy_Trait;
 	use Module_With_Assets_Trait;
 	use Module_With_Owner_Trait;

--- a/tests/phpunit/includes/Core/Modules/FakeModule.php
+++ b/tests/phpunit/includes/Core/Modules/FakeModule.php
@@ -12,12 +12,15 @@ namespace Google\Site_Kit\Tests\Core\Modules;
 
 use Google\Site_Kit\Core\Modules\Module;
 use Google\Site_Kit\Core\Authentication\Clients\Google_Site_Kit_Client;
+use Google\Site_Kit\Core\Modules\Module_With_Activation;
+use Google\Site_Kit\Core\Modules\Module_With_Deactivation;
 use Google\Site_Kit\Core\REST_API\Data_Request;
 use Psr\Http\Message\RequestInterface;
 use WP_Error;
 use Exception;
 
-class FakeModule extends Module {
+class FakeModule extends Module
+	implements Module_With_Activation, Module_With_Deactivation {
 
 	/**
 	 * Whether or not the module has been registered.


### PR DESCRIPTION
## Summary

Addresses issue #3616

## Relevant technical choices

* Also replaces conditionals based on method callability with interfaces

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
