### PR TITLE
Existing GA4 tag detected but useSnippet not disabled (3542).

### DIFF
--- a/assets/js/modules/analytics/components/common/UseUASnippetSwitch.js
+++ b/assets/js/modules/analytics/components/common/UseUASnippetSwitch.js
@@ -48,7 +48,7 @@ export default function UseUASnippetSwitch() {
 	return (
 		<div className="googlesitekit-analytics-usesnippet">
 			<Switch
-				label={ __( 'Let Site Kit place code on your site', 'google-site-kit' ) }
+				label={ __( 'Place Universal Analytics code', 'google-site-kit' ) }
 				checked={ useSnippet }
 				onClick={ onChange }
 				hideLabel={ false }

--- a/assets/js/modules/analytics/components/common/UseUASnippetSwitch.js
+++ b/assets/js/modules/analytics/components/common/UseUASnippetSwitch.js
@@ -31,7 +31,7 @@ import Switch from '../../../../components/Switch';
 import { trackEvent } from '../../../../util';
 const { useSelect, useDispatch } = Data;
 
-export default function UseSnippetSwitch() {
+export default function UseUASnippetSwitch() {
 	const useSnippet = useSelect( ( select ) => select( STORE_NAME ).getUseSnippet() );
 	const canUseSnippet = useSelect( ( select ) => select( STORE_NAME ).getCanUseSnippet() );
 

--- a/assets/js/modules/analytics/components/common/UseUAandGA4SnippetSwitches.js
+++ b/assets/js/modules/analytics/components/common/UseUAandGA4SnippetSwitches.js
@@ -36,7 +36,6 @@ export default function UseUAandGA4SnippetSwitches() {
 	const useUASnippet = useSelect( ( select ) => select( STORE_NAME ).getUseSnippet() );
 	const canUseUASnippet = useSelect( ( select ) => select( STORE_NAME ).getCanUseSnippet() );
 	const useGA4Snippet = useSelect( ( select ) => select( MODULES_ANALYTICS_4 ).getUseSnippet() );
-	const canUseGA4Snippet = useSelect( ( select ) => select( MODULES_ANALYTICS_4 ).getCanUseSnippet() );
 
 	const { setUseSnippet: setUseUASnippet } = useDispatch( STORE_NAME );
 	const { setUseSnippet: setUseGA4Snippet } = useDispatch( MODULES_ANALYTICS_4 );
@@ -71,7 +70,7 @@ export default function UseUAandGA4SnippetSwitches() {
 			<div className="googlesitekit-settings-module__inline-items">
 				<div className="googlesitekit-settings-module__inline-item">
 					<Switch
-						label={ __( 'Let Site Kit place code on your site', 'google-site-kit' ) }
+						label={ __( 'Place Universal Analytics code', 'google-site-kit' ) }
 						checked={ useUASnippet }
 						onClick={ onUAChange }
 						hideLabel={ false }
@@ -80,11 +79,10 @@ export default function UseUAandGA4SnippetSwitches() {
 				</div>
 				<div className="googlesitekit-settings-module__inline-item">
 					<Switch
-						label={ __( 'Let Site Kit place code on your site', 'google-site-kit' ) }
+						label={ __( 'Place Google Analytics 4 code', 'google-site-kit' ) }
 						checked={ useGA4Snippet }
 						onClick={ onGA4Change }
 						hideLabel={ false }
-						disabled={ ! canUseGA4Snippet }
 					/>
 				</div>
 			</div>

--- a/assets/js/modules/analytics/components/common/UseUAandGA4SnippetSwitches.js
+++ b/assets/js/modules/analytics/components/common/UseUAandGA4SnippetSwitches.js
@@ -35,10 +35,52 @@ const { useSelect, useDispatch } = Data;
 export default function UseUAandGA4SnippetSwitches() {
 	const useUASnippet = useSelect( ( select ) => select( STORE_NAME ).getUseSnippet() );
 	const canUseUASnippet = useSelect( ( select ) => select( STORE_NAME ).getCanUseSnippet() );
-	const useGA4Snippet = useSelect( select( MODULES_ANALYTICS_4 ).getUseSnippet() );
+	const useGA4Snippet = useSelect( ( select ) => select( MODULES_ANALYTICS_4 ).getUseSnippet() );
 	const canUseGA4Snippet = useSelect( ( select ) => select( MODULES_ANALYTICS_4 ).getCanUseSnippet() );
+
+	const { setUseSnippet: setUseUASnippet } = useDispatch( STORE_NAME );
+	const { setUseSnippet: setUseGA4Snippet } = useDispatch( MODULES_ANALYTICS_4 );
+
+	const onUAChange = useCallback( () => {
+		setUseUASnippet( ! useUASnippet );
+		trackEvent( 'analytics_setup', useUASnippet ? 'analytics_tag_enabled' : 'analytics_tag_disabled' );
+	}, [ useUASnippet, setUseUASnippet ] );
+
+	const onGA4Change = useCallback( () => {
+		setUseGA4Snippet( ! useGA4Snippet );
+		// ...
+	}, [ useGA4Snippet, setUseGA4Snippet ] );
 
 	if ( useGA4Snippet === undefined || useUASnippet === undefined ) {
 		return null;
 	}
+
+	const message = '';
+
+	return (
+		<div className="googlesitekit-analytics-usesnippet">
+			<div className="googlesitekit-settings-module__inline-items">
+				<div className="googlesitekit-settings-module__inline-item">
+					<Switch
+						label={ __( 'Let Site Kit place code on your site', 'google-site-kit' ) }
+						checked={ useUASnippet }
+						onClick={ onUAChange }
+						hideLabel={ false }
+						disabled={ ! canUseUASnippet }
+					/>
+				</div>
+				<div className="googlesitekit-settings-module__inline-item">
+					<Switch
+						label={ __( 'Let Site Kit place code on your site', 'google-site-kit' ) }
+						checked={ useGA4Snippet }
+						onClick={ onGA4Change }
+						hideLabel={ false }
+						disabled={ ! canUseGA4Snippet }
+					/>
+				</div>
+			</div>
+
+			<p className="googlesitekit-margin-top-0">{ message }</p>
+		</div>
+	);
 }

--- a/assets/js/modules/analytics/components/common/UseUAandGA4SnippetSwitches.js
+++ b/assets/js/modules/analytics/components/common/UseUAandGA4SnippetSwitches.js
@@ -55,7 +55,17 @@ export default function UseUAandGA4SnippetSwitches() {
 		return null;
 	}
 
-	const message = '';
+	let message;
+
+	if ( useUASnippet && useGA4Snippet ) {
+		message = 'Site Kit will add the Universal Analytics and Google Analytics 4 codes automatically';
+	} else if ( useUASnippet && ! useGA4Snippet ) {
+		message = 'Site Kit will add the Universal Analytics code automatically';
+	} else if ( ! useUASnippet && useGA4Snippet ) {
+		message = 'Site Kit will add the Google Analytics 4 code automatically';
+	} else {
+		message = 'Site Kit will not add the code to your site';
+	}
 
 	return (
 		<div className="googlesitekit-analytics-usesnippet">

--- a/assets/js/modules/analytics/components/common/UseUAandGA4SnippetSwitches.js
+++ b/assets/js/modules/analytics/components/common/UseUAandGA4SnippetSwitches.js
@@ -47,6 +47,7 @@ export default function UseUAandGA4SnippetSwitches() {
 
 	const onGA4Change = useCallback( () => {
 		setUseGA4Snippet( ! useGA4Snippet );
+		trackEvent( 'analytics_setup', useGA4Snippet ? 'analytics4_tag_enabled' : 'analytics4_tag_disabled' );
 	}, [ useGA4Snippet, setUseGA4Snippet ] );
 
 	if ( useGA4Snippet === undefined || useUASnippet === undefined ) {

--- a/assets/js/modules/analytics/components/common/UseUAandGA4SnippetSwitches.js
+++ b/assets/js/modules/analytics/components/common/UseUAandGA4SnippetSwitches.js
@@ -48,7 +48,6 @@ export default function UseUAandGA4SnippetSwitches() {
 
 	const onGA4Change = useCallback( () => {
 		setUseGA4Snippet( ! useGA4Snippet );
-		// ...
 	}, [ useGA4Snippet, setUseGA4Snippet ] );
 
 	if ( useGA4Snippet === undefined || useUASnippet === undefined ) {

--- a/assets/js/modules/analytics/components/common/UseUAandGA4SnippetSwitches.js
+++ b/assets/js/modules/analytics/components/common/UseUAandGA4SnippetSwitches.js
@@ -56,13 +56,13 @@ export default function UseUAandGA4SnippetSwitches() {
 	let message;
 
 	if ( useUASnippet && useGA4Snippet ) {
-		message = 'Site Kit will add the Universal Analytics and Google Analytics 4 codes automatically';
+		message = __( 'Site Kit will add the Universal Analytics and Google Analytics 4 codes automatically', 'google-site-kit' );
 	} else if ( useUASnippet && ! useGA4Snippet ) {
-		message = 'Site Kit will add the Universal Analytics code automatically';
+		message = __( 'Site Kit will add the Universal Analytics code automatically', 'google-site-kit' );
 	} else if ( ! useUASnippet && useGA4Snippet ) {
-		message = 'Site Kit will add the Google Analytics 4 code automatically';
+		message = __( 'Site Kit will add the Google Analytics 4 code automatically', 'google-site-kit' );
 	} else {
-		message = 'Site Kit will not add the code to your site';
+		message = __( 'Site Kit will not add the code to your site', 'google-site-kit' );
 	}
 
 	return (

--- a/assets/js/modules/analytics/components/common/UseUAandGA4SnippetSwitches.js
+++ b/assets/js/modules/analytics/components/common/UseUAandGA4SnippetSwitches.js
@@ -1,0 +1,44 @@
+/**
+ * Analytics Use UA and GA4 Snippet Switch component.
+ *
+ * Site Kit by Google, Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { useCallback } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import Data from 'googlesitekit-data';
+import { STORE_NAME } from '../../datastore/constants';
+import { MODULES_ANALYTICS_4 } from '../../../analytics-4/datastore/constants';
+import Switch from '../../../../components/Switch';
+import { trackEvent } from '../../../../util';
+const { useSelect, useDispatch } = Data;
+
+export default function UseUAandGA4SnippetSwitches() {
+	const useUASnippet = useSelect( ( select ) => select( STORE_NAME ).getUseSnippet() );
+	const canUseUASnippet = useSelect( ( select ) => select( STORE_NAME ).getCanUseSnippet() );
+	const useGA4Snippet = useSelect( select( MODULES_ANALYTICS_4 ).getUseSnippet() );
+	const canUseGA4Snippet = useSelect( ( select ) => select( MODULES_ANALYTICS_4 ).getCanUseSnippet() );
+
+	if ( useGA4Snippet === undefined || useUASnippet === undefined ) {
+		return null;
+	}
+}

--- a/assets/js/modules/analytics/components/common/index.js
+++ b/assets/js/modules/analytics/components/common/index.js
@@ -32,5 +32,5 @@ export { default as ProfileSelect } from './ProfileSelect';
 export { default as PropertySelect } from './PropertySelect';
 export { default as PropertySelectIncludingGA4 } from './PropertySelectIncludingGA4';
 export { default as TrackingExclusionSwitches } from './TrackingExclusionSwitches';
-export { default as UseSnippetSwitch } from './UseSnippetSwitch';
+export { default as UseUASnippetSwitch } from './UseUASnippetSwitch';
 export { default as GA4PropertyNotice } from './GA4PropertyNotice';

--- a/assets/js/modules/analytics/components/common/index.js
+++ b/assets/js/modules/analytics/components/common/index.js
@@ -33,4 +33,5 @@ export { default as PropertySelect } from './PropertySelect';
 export { default as PropertySelectIncludingGA4 } from './PropertySelectIncludingGA4';
 export { default as TrackingExclusionSwitches } from './TrackingExclusionSwitches';
 export { default as UseUASnippetSwitch } from './UseUASnippetSwitch';
+export { default as UseUAandGA4SnippetSwitches } from './UseUAandGA4SnippetSwitches';
 export { default as GA4PropertyNotice } from './GA4PropertyNotice';

--- a/assets/js/modules/analytics/components/settings/SettingsForm.js
+++ b/assets/js/modules/analytics/components/settings/SettingsForm.js
@@ -34,6 +34,7 @@ import {
 	PropertySelect,
 	TrackingExclusionSwitches,
 	UseUASnippetSwitch,
+	UseUAandGA4SnippetSwitches,
 	ProfileNameTextField,
 	ExistingGTMPropertyNotice,
 	GA4Notice,
@@ -44,6 +45,7 @@ import StoreErrorNotices from '../../../../components/StoreErrorNotices';
 import { CORE_MODULES } from '../../../../googlesitekit/modules/datastore/constants';
 import { SETUP_FLOW_MODE_LEGACY, STORE_NAME, PROFILE_CREATE, SETUP_FLOW_MODE_UA } from '../../datastore/constants';
 import { MODULES_TAGMANAGER } from '../../../tagmanager/datastore/constants';
+import { MODULES_ANALYTICS_4 } from '../../../analytics-4/datastore/constants';
 import { useFeature } from '../../../../hooks/useFeature';
 const { useSelect } = Data;
 
@@ -53,11 +55,16 @@ export default function SettingsForm() {
 	const setupFlowMode = useSelect( ( select ) => select( STORE_NAME ).getSetupFlowMode() );
 	const hasExistingTag = useSelect( ( select ) => select( STORE_NAME ).hasExistingTag() );
 	const profileID = useSelect( ( select ) => select( STORE_NAME ).getProfileID() );
+	const hasExistingGA4Property = useSelect( ( select ) => select( MODULES_ANALYTICS_4 ).getPropertyID() );
 
 	const useAnalyticsSnippet = useSelect( ( select ) => select( STORE_NAME ).getUseSnippet() );
 	const useTagManagerSnippet = useSelect( ( select ) => select( MODULES_TAGMANAGER ).getUseSnippet() );
 	const analyticsSinglePropertyID = useSelect( ( select ) => select( MODULES_TAGMANAGER ).getSingleAnalyticsPropertyID() );
 	const shouldShowTrackingExclusionSwitches = useAnalyticsSnippet || ( useTagManagerSnippet && analyticsSinglePropertyID );
+
+	const SnippetSwitchComponent = ( isGA4Enabled && hasExistingGA4Property )
+		? UseUAandGA4SnippetSwitches
+		: UseUASnippetSwitch;
 
 	return (
 		<div className="googlesitekit-analytics-settings-fields">
@@ -92,7 +99,13 @@ export default function SettingsForm() {
 			) }
 
 			<div className="googlesitekit-setup-module__inputs googlesitekit-setup-module__inputs--multiline">
-				<UseUASnippetSwitch />
+				<fieldset>
+					<legend className="googlesitekit-setup-module__text">
+						{ __( 'Let Site Kit place the Analytics code on your site', 'google-site-kit' ) }
+					</legend>
+					<SnippetSwitchComponent />
+				</fieldset>
+
 				<AnonymizeIPSwitch />
 				{ shouldShowTrackingExclusionSwitches && <TrackingExclusionSwitches /> }
 				<AdsConversionIDTextField />

--- a/assets/js/modules/analytics/components/settings/SettingsForm.js
+++ b/assets/js/modules/analytics/components/settings/SettingsForm.js
@@ -33,7 +33,7 @@ import {
 	ProfileSelect,
 	PropertySelect,
 	TrackingExclusionSwitches,
-	UseSnippetSwitch,
+	UseUASnippetSwitch,
 	ProfileNameTextField,
 	ExistingGTMPropertyNotice,
 	GA4Notice,
@@ -92,7 +92,7 @@ export default function SettingsForm() {
 			) }
 
 			<div className="googlesitekit-setup-module__inputs googlesitekit-setup-module__inputs--multiline">
-				<UseSnippetSwitch />
+				<UseUASnippetSwitch />
 				<AnonymizeIPSwitch />
 				{ shouldShowTrackingExclusionSwitches && <TrackingExclusionSwitches /> }
 				<AdsConversionIDTextField />

--- a/assets/js/modules/analytics/components/settings/SettingsForm.stories.js
+++ b/assets/js/modules/analytics/components/settings/SettingsForm.stories.js
@@ -58,7 +58,7 @@ export default {
 	decorators: [
 		( Story ) => {
 			const setupRegistry = ( registry ) => {
-				const accounts = fixtures.accountsPropertiesProfiles.accounts.slice( 0, 1 );
+				const account = fixtures.accountsPropertiesProfiles.accounts[ 0 ];
 				const properties = [
 					{
 						...fixtures.accountsPropertiesProfiles.properties[ 0 ],
@@ -69,7 +69,7 @@ export default {
 					},
 				];
 
-				const accountID = accounts[ 0 ].id;
+				const accountID = account.id;
 
 				provideModules( registry, [
 					{
@@ -96,7 +96,7 @@ export default {
 					useSnippet: true,
 					canUseSnippet: true,
 				} );
-				registry.dispatch( STORE_NAME ).receiveGetAccounts( accounts );
+				registry.dispatch( STORE_NAME ).receiveGetAccounts( [ account ] );
 				registry.dispatch( STORE_NAME ).receiveGetProperties( properties, { accountID } );
 				registry.dispatch( STORE_NAME ).receiveGetProfiles( fixtures.accountsPropertiesProfiles.profiles, { accountID, propertyID: properties[ 0 ].id } );
 				registry.dispatch( STORE_NAME ).receiveGetProfiles( fixtures.accountsPropertiesProfiles.profiles, { accountID, propertyID: properties[ 1 ].id } );

--- a/assets/js/modules/analytics/components/settings/SettingsForm.stories.js
+++ b/assets/js/modules/analytics/components/settings/SettingsForm.stories.js
@@ -1,0 +1,114 @@
+/**
+ * Analytics SettingsView component stories.
+ *
+ * Site Kit by Google, Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import SettingsForm from './SettingsForm';
+import { STORE_NAME } from '../../datastore/constants';
+import { MODULES_ANALYTICS_4 } from '../../../analytics-4/datastore/constants';
+import { provideModules, provideModuleRegistrations, provideSiteInfo } from '../../../../../../tests/js/utils';
+import WithRegistrySetup from '../../../../../../tests/js/WithRegistrySetup';
+import * as fixtures from '../../datastore/__fixtures__';
+import * as ga4Fixtures from '../../../analytics-4/datastore/__fixtures__';
+
+const features = [ 'ga4setup' ];
+
+function Template() {
+	return (
+		<div className="googlesitekit-layout">
+			<div className="googlesitekit-settings-module googlesitekit-settings-module--active googlesitekit-settings-module--analytics">
+				<div className="googlesitekit-setup-module">
+					<div className="googlesitekit-settings-module__content googlesitekit-settings-module__content--open">
+						<div className="mdc-layout-grid">
+							<div className="mdc-layout-inner">
+								<div className="mdc-layout-grid__cell mdc-layout-grid__cell--span-12">
+									<SettingsForm />
+								</div>
+							</div>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+	);
+}
+
+export const WithGA4andUASnippet = Template.bind( null );
+WithGA4andUASnippet.storyName = 'UA and GA4 tag snippet switches';
+WithGA4andUASnippet.parameters = { features };
+
+export default {
+	title: 'Modules/Analytics/Settings/SettingsEdit',
+	decorators: [
+		( Story ) => {
+			const setupRegistry = ( registry ) => {
+				const accounts = fixtures.accountsPropertiesProfiles.accounts.slice( 0, 1 );
+				const properties = [
+					{
+						...fixtures.accountsPropertiesProfiles.properties[ 0 ],
+						websiteUrl: 'http://example.com', // eslint-disable-line sitekit/acronym-case
+					},
+					{
+						...fixtures.accountsPropertiesProfiles.properties[ 1 ],
+					},
+				];
+
+				const accountID = accounts[ 0 ].id;
+
+				provideModules( registry, [
+					{
+						slug: 'analytics',
+						active: true,
+						connected: true,
+					},
+					{
+						slug: 'analytics-4',
+						active: true,
+						connected: true,
+					},
+				] );
+				provideSiteInfo( registry );
+				provideModuleRegistrations( registry );
+
+				registry.dispatch( MODULES_ANALYTICS_4 ).receiveGetSettings( {} );
+				registry.dispatch( MODULES_ANALYTICS_4 ).receiveGetProperties( ga4Fixtures.properties, { accountID } );
+				registry.dispatch( MODULES_ANALYTICS_4 ).receiveGetSettings( {
+					useSnippet: true,
+				} );
+
+				registry.dispatch( STORE_NAME ).receiveGetSettings( {
+					useSnippet: true,
+					canUseSnippet: true,
+				} );
+				registry.dispatch( STORE_NAME ).receiveGetAccounts( accounts );
+				registry.dispatch( STORE_NAME ).receiveGetProperties( properties, { accountID } );
+				registry.dispatch( STORE_NAME ).receiveGetProfiles( fixtures.accountsPropertiesProfiles.profiles, { accountID, propertyID: properties[ 0 ].id } );
+				registry.dispatch( STORE_NAME ).receiveGetProfiles( fixtures.accountsPropertiesProfiles.profiles, { accountID, propertyID: properties[ 1 ].id } );
+
+				registry.dispatch( STORE_NAME ).selectAccount( accountID );
+			};
+
+			return (
+				<WithRegistrySetup func={ setupRegistry }>
+					<Story />
+				</WithRegistrySetup>
+			);
+		},
+	],
+};


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #3542

## Relevant technical choices

<!-- Please describe your changes. -->

## Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
