### PR TITLE
Wrap `ReportTable` components with span tags for simple values

### DIFF
--- a/assets/js/components/wp-dashboard/WPDashboardPopularPages.js
+++ b/assets/js/components/wp-dashboard/WPDashboardPopularPages.js
@@ -108,7 +108,11 @@ const tableColumns = [
 		title: __( 'Pageviews', 'google-site-kit' ),
 		description: __( 'Pageviews', 'google-site-kit' ),
 		field: 'metrics.0.values.0',
-		Component: ( { fieldValue } ) => numFmt( fieldValue, { style: 'decimal' } ),
+		Component: ( { fieldValue } ) => (
+			<span>
+				{ numFmt( fieldValue, { style: 'decimal' } ) }
+			</span>
+		),
 	},
 ];
 

--- a/assets/js/modules/adsense/components/dashboard/DashboardTopEarningPagesWidget.js
+++ b/assets/js/modules/adsense/components/dashboard/DashboardTopEarningPagesWidget.js
@@ -163,9 +163,11 @@ function DashboardTopEarningPagesWidget( { Widget, WidgetReportZero, WidgetRepor
 		{
 			title: __( 'Earnings', 'google-site-kit' ),
 			tooltip: __( 'Earnings', 'google-site-kit' ),
-			Component: ( { row } ) => numFmt(
-				row.metrics[ 0 ].values[ 0 ],
-				currencyFormat,
+			field: 'metrics.0.values.0',
+			Component: ( { fieldValue } ) => (
+				<span>
+					{ numFmt( fieldValue, currencyFormat ) }
+				</span>
 			),
 		},
 	];

--- a/assets/js/modules/adsense/components/module/ModuleTopEarningPagesWidget/Table.js
+++ b/assets/js/modules/adsense/components/module/ModuleTopEarningPagesWidget/Table.js
@@ -84,25 +84,31 @@ export default function Table( { report } ) {
 			title: __( 'Earnings', 'google-site-kit' ),
 			description: __( 'Earnings', 'google-site-kit' ),
 			field: 'metrics.0.values.0',
-			Component: ( { fieldValue } ) => numFmt(
-				fieldValue,
-				currencyFormat,
+			Component: ( { fieldValue } ) => (
+				<span>
+					{ numFmt( fieldValue, currencyFormat ) }
+				</span>
 			),
 		},
 		{
 			title: __( 'Page RPM', 'google-site-kit' ),
 			description: __( 'Page RPM', 'google-site-kit' ),
 			field: 'metrics.0.values.1',
-			Component: ( { fieldValue } ) => numFmt(
-				fieldValue,
-				currencyFormat,
+			Component: ( { fieldValue } ) => (
+				<span>
+					{ numFmt( fieldValue, currencyFormat ) }
+				</span>
 			),
 		},
 		{
 			title: __( 'Impressions', 'google-site-kit' ),
 			description: __( 'Impressions', 'google-site-kit' ),
 			field: 'metrics.0.values.2',
-			Component: ( { fieldValue } ) => numFmt( fieldValue, { style: 'decimal' } ),
+			Component: ( { fieldValue } ) => (
+				<span>
+					{ numFmt( fieldValue, { style: 'decimal' } ) }
+				</span>
+			),
 		},
 	];
 

--- a/assets/js/modules/analytics/components/dashboard/DashboardPopularPagesWidget.js
+++ b/assets/js/modules/analytics/components/dashboard/DashboardPopularPagesWidget.js
@@ -139,7 +139,11 @@ const tableColumns = [
 	{
 		title: __( 'Views', 'google-site-kit' ),
 		field: 'metrics.0.values.0',
-		Component: ( { fieldValue } ) => numFmt( fieldValue, { style: 'decimal' } ),
+		Component: ( { fieldValue } ) => (
+			<span>
+				{ numFmt( fieldValue, { style: 'decimal' } ) }
+			</span>
+		),
 	},
 ];
 

--- a/assets/js/modules/analytics/components/dashboard/LegacyAdSenseDashboardWidgetTopPagesTableSmall.js
+++ b/assets/js/modules/analytics/components/dashboard/LegacyAdSenseDashboardWidgetTopPagesTableSmall.js
@@ -118,9 +118,10 @@ const LegacyAdSenseDashboardWidgetTopPagesTableSmall = ( { data } ) => {
 			title: __( 'Earnings', 'google-site-kit' ),
 			description: __( 'Earnings', 'google-site-kit' ),
 			field: 'metrics.0.values.0',
-			Component: ( { fieldValue } ) => numFmt(
-				fieldValue,
-				currencyFormat,
+			Component: ( { fieldValue } ) => (
+				<span>
+					{ numFmt( fieldValue, currencyFormat ) }
+				</span>
 			),
 		},
 	];

--- a/assets/js/modules/analytics/components/dashboard/LegacyAnalyticsAdSenseDashboardWidgetTopPagesTable.js
+++ b/assets/js/modules/analytics/components/dashboard/LegacyAnalyticsAdSenseDashboardWidgetTopPagesTable.js
@@ -99,25 +99,31 @@ const LegacyAnalyticsAdSenseDashboardWidgetTopPagesTable = ( { data } ) => {
 			title: __( 'Earnings', 'google-site-kit' ),
 			description: __( 'Earnings', 'google-site-kit' ),
 			field: 'metrics.0.values.0',
-			Component: ( { fieldValue } ) => numFmt(
-				fieldValue,
-				currencyFormat,
+			Component: ( { fieldValue } ) => (
+				<span>
+					{ numFmt( fieldValue, currencyFormat ) }
+				</span>
 			),
 		},
 		{
 			title: __( 'Page RPM', 'google-site-kit' ),
 			description: __( 'Page RPM', 'google-site-kit' ),
 			field: 'metrics.0.values.1',
-			Component: ( { fieldValue } ) => numFmt(
-				fieldValue,
-				currencyFormat,
+			Component: ( { fieldValue } ) => (
+				<span>
+					{ numFmt( fieldValue, currencyFormat ) }
+				</span>
 			),
 		},
 		{
 			title: __( 'Impressions', 'google-site-kit' ),
 			description: __( 'Impressions', 'google-site-kit' ),
 			field: 'metrics.0.values.2',
-			Component: ( { fieldValue } ) => numFmt( fieldValue, { style: 'decimal' } ),
+			Component: ( { fieldValue } ) => (
+				<span>
+					{ numFmt( fieldValue, { style: 'decimal' } ) }
+				</span>
+			),
 		},
 	];
 	return (

--- a/assets/js/modules/analytics/components/dashboard/LegacyAnalyticsDashboardWidgetTopPagesTable.js
+++ b/assets/js/modules/analytics/components/dashboard/LegacyAnalyticsDashboardWidgetTopPagesTable.js
@@ -86,21 +86,33 @@ const LegacyAnalyticsDashboardWidgetTopPagesTable = ( props ) => {
 			title: __( 'Pageviews', 'google-site-kit' ),
 			description: __( 'Pageviews', 'google-site-kit' ),
 			field: 'metrics.0.values.0',
-			Component: ( { fieldValue } ) => numFmt( fieldValue, { style: 'decimal' } ),
+			Component: ( { fieldValue } ) => (
+				<span>
+					{ numFmt( fieldValue, { style: 'decimal' } ) }
+				</span>
+			),
 		},
 		{
 			title: __( 'Unique Pageviews', 'google-site-kit' ),
 			description: __( 'Unique Pageviews', 'google-site-kit' ),
 			hideOnMobile: true,
 			field: 'metrics.0.values.1',
-			Component: ( { fieldValue } ) => numFmt( fieldValue, { style: 'decimal' } ),
+			Component: ( { fieldValue } ) => (
+				<span>
+					{ numFmt( fieldValue, { style: 'decimal' } ) }
+				</span>
+			),
 		},
 		{
 			title: __( 'Bounce Rate', 'google-site-kit' ),
 			description: __( 'Bounce Rate', 'google-site-kit' ),
 			hideOnMobile: true,
 			field: 'metrics.0.values.2',
-			Component: ( { fieldValue } ) => numFmt( Number( fieldValue ) / 100, '%' ),
+			Component: ( { fieldValue } ) => (
+				<span>
+					{ numFmt( Number( fieldValue ) / 100, '%' ) }
+				</span>
+			),
 		},
 	];
 

--- a/assets/js/modules/analytics/components/module/ModuleAcquisitionChannelsWidget/AcquisitionChannelsTable.js
+++ b/assets/js/modules/analytics/components/module/ModuleAcquisitionChannelsWidget/AcquisitionChannelsTable.js
@@ -46,13 +46,17 @@ export default function AcquisitionChannelsTable( { report } ) {
 		{
 			title: __( 'Channel', 'google-site-kit' ),
 			tooltip: __( 'Channel refers to where your traffic originated from', 'google-site-kit' ),
-			Component: ( { row } ) => row.dimensions[ 0 ],
+			Component: ( { row } ) => <span>{ row.dimensions[ 0 ] }</span>,
 		},
 		{
 			title: __( 'Users', 'google-site-kit' ),
 			tooltip: __( 'Number of users that originated from that traffic', 'google-site-kit' ),
 			field: 'metrics.0.values.0',
-			Component: ( { fieldValue } ) => numFmt( fieldValue, { style: 'decimal' } ),
+			Component: ( { fieldValue } ) => (
+				<span>
+					{ numFmt( fieldValue, { style: 'decimal' } ) }
+				</span>
+			),
 		},
 		{
 			title: __( 'New Users', 'google-site-kit' ),
@@ -62,7 +66,11 @@ export default function AcquisitionChannelsTable( { report } ) {
 				dateRangeNumberOfDays,
 			),
 			field: 'metrics.0.values.1',
-			Component: ( { fieldValue } ) => numFmt( fieldValue, { style: 'decimal' } ),
+			Component: ( { fieldValue } ) => (
+				<span>
+					{ numFmt( fieldValue, { style: 'decimal' } ) }
+				</span>
+			),
 		},
 		{
 			title: __( 'Sessions', 'google-site-kit' ),
@@ -72,7 +80,11 @@ export default function AcquisitionChannelsTable( { report } ) {
 				dateRangeNumberOfDays,
 			),
 			field: 'metrics.0.values.2',
-			Component: ( { fieldValue } ) => numFmt( fieldValue, { style: 'decimal' } ),
+			Component: ( { fieldValue } ) => (
+				<span>
+					{ numFmt( fieldValue, { style: 'decimal' } ) }
+				</span>
+			),
 		},
 		{
 			title: __( 'Percentage', 'google-site-kit' ),

--- a/assets/js/modules/analytics/components/module/ModulePopularPagesWidget/index.js
+++ b/assets/js/modules/analytics/components/module/ModulePopularPagesWidget/index.js
@@ -129,21 +129,33 @@ export default function ModulePopularPagesWidget( { Widget, WidgetReportError, W
 			title: __( 'Pageviews', 'google-site-kit' ),
 			description: __( 'Pageviews', 'google-site-kit' ),
 			field: 'metrics.0.values.0',
-			Component: ( { fieldValue } ) => numFmt( fieldValue, { style: 'decimal' } ),
+			Component: ( { fieldValue } ) => (
+				<span>
+					{ numFmt( fieldValue, { style: 'decimal' } ) }
+				</span>
+			),
 		},
 		{
 			title: __( 'Unique Pageviews', 'google-site-kit' ),
 			description: __( 'Unique Pageviews', 'google-site-kit' ),
 			hideOnMobile: true,
 			field: 'metrics.0.values.1',
-			Component: ( { fieldValue } ) => numFmt( fieldValue, { style: 'decimal' } ),
+			Component: ( { fieldValue } ) => (
+				<span>
+					{ numFmt( fieldValue, { style: 'decimal' } ) }
+				</span>
+			),
 		},
 		{
 			title: __( 'Bounce Rate', 'google-site-kit' ),
 			description: __( 'Bounce Rate', 'google-site-kit' ),
 			hideOnMobile: true,
 			field: 'metrics.0.values.2',
-			Component: ( { fieldValue } ) => numFmt( Number( fieldValue ) / 100, '%' ),
+			Component: ( { fieldValue } ) => (
+				<span>
+					{ numFmt( Number( fieldValue ) / 100, '%' ) }
+				</span>
+			),
 		},
 	];
 

--- a/assets/js/modules/search-console/components/dashboard/DashboardPopularKeywordsWidget.js
+++ b/assets/js/modules/search-console/components/dashboard/DashboardPopularKeywordsWidget.js
@@ -125,12 +125,20 @@ function DashboardPopularKeywordsWidget( { Widget, WidgetReportZero, WidgetRepor
 		{
 			title: __( 'Clicks', 'google-site-kit' ),
 			description: __( 'Number of times users clicked on your content in search results', 'google-site-kit' ),
-			Component: ( { row } ) => numFmt( row.clicks, { style: 'decimal' } ),
+			Component: ( { row } ) => (
+				<span>
+					{ numFmt( row.clicks, { style: 'decimal' } ) }
+				</span>
+			),
 		},
 		{
 			title: __( 'Impressions', 'google-site-kit' ),
 			description: __( 'Counted each time your content appears in search results', 'google-site-kit' ),
-			Component: ( { row } ) => numFmt( row.impressions, { style: 'decimal' } ),
+			Component: ( { row } ) => (
+				<span>
+					{ numFmt( row.impressions, { style: 'decimal' } ) }
+				</span>
+			),
 		},
 	];
 

--- a/assets/js/modules/search-console/components/module/ModulePopularKeywordsWidget/index.js
+++ b/assets/js/modules/search-console/components/module/ModulePopularKeywordsWidget/index.js
@@ -121,12 +121,20 @@ function ModulePopularKeywordsWidget( { Widget, WidgetReportZero, WidgetReportEr
 		{
 			title: __( 'Clicks', 'google-site-kit' ),
 			description: __( 'Number of times users clicked on your content in search results', 'google-site-kit' ),
-			Component: ( { row } ) => numFmt( row.clicks, { style: 'decimal' } ),
+			Component: ( { row } ) => (
+				<span>
+					{ numFmt( row.clicks, { style: 'decimal' } ) }
+				</span>
+			),
 		},
 		{
 			title: __( 'Impressions', 'google-site-kit' ),
 			description: __( 'Counted each time your content appears in search results', 'google-site-kit' ),
-			Component: ( { row } ) => numFmt( row.impressions, { style: 'decimal' } ),
+			Component: ( { row } ) => (
+				<span>
+					{ numFmt( row.impressions, { style: 'decimal' } ) }
+				</span>
+			),
 		},
 	];
 


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #3636

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
