### PR TITLE
Fix issue when toggling GA4 feature flag (3542).

### DIFF
--- a/assets/js/modules/analytics/components/settings/SettingsForm.js
+++ b/assets/js/modules/analytics/components/settings/SettingsForm.js
@@ -55,7 +55,7 @@ export default function SettingsForm() {
 	const setupFlowMode = useSelect( ( select ) => select( STORE_NAME ).getSetupFlowMode() );
 	const hasExistingTag = useSelect( ( select ) => select( STORE_NAME ).hasExistingTag() );
 	const profileID = useSelect( ( select ) => select( STORE_NAME ).getProfileID() );
-	const hasExistingGA4Property = useSelect( ( select ) => select( MODULES_ANALYTICS_4 ).getPropertyID() );
+	const hasExistingGA4Property = useSelect( ( select ) => isGA4Enabled && select( MODULES_ANALYTICS_4 ).getPropertyID() );
 
 	const useAnalyticsSnippet = useSelect( ( select ) => select( STORE_NAME ).getUseSnippet() );
 	const useTagManagerSnippet = useSelect( ( select ) => select( MODULES_TAGMANAGER ).getUseSnippet() );


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #3542

This came back from QA with an issue where an error was thrown when toggling the GA4 feature flag. See https://github.com/google/site-kit-wp/issues/3542#issuecomment-871195848

## Relevant technical choices

<!-- Please describe your changes. -->

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
