### PR TITLE
Add Idea Hub Gutenberg notices.

### DIFF
--- a/assets/js/googlesitekit-idea-hub-notice.js
+++ b/assets/js/googlesitekit-idea-hub-notice.js
@@ -58,22 +58,18 @@ const loadIdeaHubNotices = async ( _global = global ) => {
 
 		const { cacheHit } = await getItem( noticeKey );
 
-		if ( hasNotice( postID ) !== false ) {
+		// We've already shown this notice on a previous visit to this page in
+		// the editor, so don't show it again.
+		if ( cacheHit ) {
+			unsubscribeFromListener();
 			return;
 		}
 
 		// We've already shown this notice, so when it's hidden, mark it as shown
 		// so it doesn't appear again.
-		if ( shownNotices.includes( noticeKey ) ) {
+		if ( hasNotice( postID ) === false && shownNotices.includes( noticeKey ) ) {
 			// Don't show this notice for another 90 days.
 			setItem( noticeKey, true, { ttl: 108000 } );
-			unsubscribeFromListener();
-			return;
-		}
-
-		// We've already shown this notice on a previous visit to this page in
-		// the editor, so don't show it again.
-		if ( cacheHit ) {
 			unsubscribeFromListener();
 			return;
 		}
@@ -94,8 +90,7 @@ const loadIdeaHubNotices = async ( _global = global ) => {
 			);
 
 			// Mark the notice as shown locally, so if it is no longer marked as
-			// visible, we known it was dismissed (rather than having yet to be
-			// displayed).
+			// visible, we know it was dismissed.
 			shownNotices.push( noticeKey );
 		}
 	};

--- a/assets/js/googlesitekit-idea-hub-notice.js
+++ b/assets/js/googlesitekit-idea-hub-notice.js
@@ -36,13 +36,13 @@ const loadIdeaHubNotices = async ( _global = global ) => {
 	const { wp } = _global;
 
 	const hasNotice = ( postID ) => {
-		if ( wp.data.select( 'core/notices' ).getNotices() === undefined ) {
+		const notices = wp.data.select( 'core/notices' ).getNotices();
+		if ( notices === undefined ) {
 			return undefined;
 		}
 
-		return wp.data.select( 'core/notices' ).getNotices().some( ( notice ) => {
-			return notice.id === editorNoticeKey( postID );
-		} );
+		const key = editorNoticeKey( postID );
+		return notices.some( ( { id } ) => id === key );
 	};
 
 	const listener = async () => {
@@ -55,7 +55,9 @@ const loadIdeaHubNotices = async ( _global = global ) => {
 
 		const { cacheHit } = await getItem( editorNoticeKey( postID ) );
 
-		if ( hasNotice( postID ) === false ) {
+		if ( hasNotice( postID ) !== false ) {
+			return;
+		}
 			// We've already shown this notice, so when it's hidden, mark it as shown
 			// so it doesn't appear again.
 			if ( shownNotices.includes( editorNoticeKey( postID ) ) ) {

--- a/assets/js/googlesitekit-idea-hub-notice.js
+++ b/assets/js/googlesitekit-idea-hub-notice.js
@@ -65,11 +65,8 @@ const loadIdeaHubNotices = async ( _global = global ) => {
 		// We've already shown this notice, so when it's hidden, mark it as shown
 		// so it doesn't appear again.
 		if ( shownNotices.includes( noticeKey ) ) {
-			setItem(
-				noticeKey,
-				postMeta.googlesitekitpersistent_idea_text,
-				{ ttl: 108000 } // Don't show this notice for another 90 days.
-			);
+			// Don't show this notice for another 90 days.
+			setItem( noticeKey, true, { ttl: 108000 } );
 			unsubscribeFromListener();
 			return;
 		}

--- a/assets/js/googlesitekit-idea-hub-notice.js
+++ b/assets/js/googlesitekit-idea-hub-notice.js
@@ -79,7 +79,7 @@ const loadIdeaHubNotices = async ( _global = global ) => {
 		const postMeta = wp.data.select( 'core/editor' ).getEditedPostAttribute( 'meta' );
 
 		// eslint-disable-next-line camelcase
-		if ( postMeta?.googlesitekitpersistent_idea_text ) {
+		if ( postMeta?.googlesitekitpersistent_idea_text && ! shownNotices.includes( noticeKey ) ) {
 			wp.data.dispatch( 'core/notices' ).createInfoNotice(
 				sprintf(
 					/* translators: %s: Idea post name */

--- a/assets/js/googlesitekit-idea-hub-notice.js
+++ b/assets/js/googlesitekit-idea-hub-notice.js
@@ -1,0 +1,101 @@
+/**
+ * Idea Hub Notice (for Block Editor) entrypoint.
+ *
+ * Site Kit by Google, Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __, sprintf } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { getItem, setItem } from './googlesitekit/api/cache';
+
+const shownNotices = [];
+
+const editorNoticeKey = ( postID ) => {
+	return `modules::idea-hub::dismissed-editor-notice-${ postID }`;
+};
+
+const loadIdeaHubNotices = async ( _global = global ) => {
+	const { wp } = _global;
+
+	const hasNotice = ( postID ) => {
+		if ( wp.data.select( 'core/notices' ).getNotices() === undefined ) {
+			return undefined;
+		}
+
+		return wp.data.select( 'core/notices' ).getNotices().some( ( notice ) => {
+			return notice.id === editorNoticeKey( postID );
+		} );
+	};
+
+	const listener = async () => {
+		// eslint-disable-next-line sitekit/acronym-case
+		const postID = wp.data.select( 'core/editor' ).getCurrentPostId();
+
+		if ( ! postID ) {
+			return;
+		}
+
+		const { cacheHit } = await getItem( editorNoticeKey( postID ) );
+
+		if ( hasNotice( postID ) === false ) {
+			// We've already shown this notice, so when it's hidden, mark it as shown
+			// so it doesn't appear again.
+			if ( shownNotices.includes( editorNoticeKey( postID ) ) ) {
+				setItem(
+					editorNoticeKey( postID ),
+					postMeta.googlesitekitpersistent_idea_text,
+					{ ttl: 108000 } // Don't show this notice for another 90 days.
+				);
+				unsubscribeFromListener();
+				return;
+			}
+
+			// We've already shown this notice on a previous visit to this page in
+			// the editor, so don't show it again.
+			if ( cacheHit ) {
+				unsubscribeFromListener();
+				return;
+			}
+
+			// We haven't shown any notice for this post before, so let's check for
+			// Idea Hub postmeta.
+			const postMeta = wp.data.select( 'core/editor' ).getEditedPostAttribute( 'meta' );
+
+			// eslint-disable-next-line camelcase
+			if ( postMeta?.googlesitekitpersistent_idea_text ) {
+				wp.data.dispatch( 'core/notices' ).createInfoNotice(
+					/* translators: %s: Idea post name */
+					sprintf( __( 'This post was created from an idea you picked in Site Kit’s Idea Hub: %s', 'google-site-kit' ), postMeta.googlesitekitpersistent_idea_text ),
+					{ id: editorNoticeKey( postID ) }
+				);
+
+				// Mark the notice as shown locally, so if it is no longer marked as
+				// visible, we known it was dismissed (rather than having yet to be
+				// displayed).
+				shownNotices.push( editorNoticeKey( postID ) );
+			}
+		}
+	};
+
+	const unsubscribeFromListener = wp.data.subscribe( listener );
+};
+
+loadIdeaHubNotices();

--- a/includes/Core/Assets/Asset.php
+++ b/includes/Core/Assets/Asset.php
@@ -21,6 +21,12 @@ use Google\Site_Kit\Context;
  */
 abstract class Asset {
 
+	// Various page contexts for Site Kit in the WordPress Admin.
+	const CONTEXT_ADMIN_GLOBAL      = 'admin-global';
+	const CONTEXT_ADMIN_POST_EDITOR = 'admin-post-editor';
+	const CONTEXT_ADMIN_POSTS       = 'admin-posts';
+	const CONTEXT_ADMIN_SITEKIT     = 'admin-sitekit';
+
 	/**
 	 * Unique asset handle.
 	 *
@@ -41,16 +47,18 @@ abstract class Asset {
 	 * Constructor.
 	 *
 	 * @since 1.0.0
+	 * @since n.e.x.t Add the 'load_contexts' argument.
 	 *
 	 * @param string $handle Unique asset handle.
 	 * @param array  $args {
 	 *     Associative array of asset arguments.
 	 *
-	 *     @type string   $src          Required asset source URL.
-	 *     @type array    $dependencies List of asset dependencies. Default empty array.
-	 *     @type string   $version      Asset version. Default is the version of Site Kit.
-	 *     @type bool     $fallback     Whether to only register as a fallback. Default false.
-	 *     @type callable $before_print Optional callback to execute before printing. Default none.
+	 *     @type string   $src           Required asset source URL.
+	 *     @type array    $dependencies  List of asset dependencies. Default empty array.
+	 *     @type string   $version       Asset version. Default is the version of Site Kit.
+	 *     @type bool     $fallback      Whether to only register as a fallback. Default false.
+	 *     @type callable $before_print  Optional callback to execute before printing. Default none.
+	 *     @type string[] $load_contexts Optional array of page context values to determine on which page types to load this asset (see the `CONTEXT_` variables above).
 	 * }
 	 */
 	public function __construct( $handle, array $args ) {
@@ -58,11 +66,12 @@ abstract class Asset {
 		$this->args   = wp_parse_args(
 			$args,
 			array(
-				'src'          => '',
-				'dependencies' => array(),
-				'version'      => GOOGLESITEKIT_VERSION,
-				'fallback'     => false,
-				'before_print' => null,
+				'src'           => '',
+				'dependencies'  => array(),
+				'version'       => GOOGLESITEKIT_VERSION,
+				'fallback'      => false,
+				'before_print'  => null,
+				'load_contexts' => array( self::CONTEXT_ADMIN_SITEKIT ),
 			)
 		);
 	}
@@ -76,6 +85,18 @@ abstract class Asset {
 	 */
 	public function get_handle() {
 		return $this->handle;
+	}
+
+	/**
+	 * Checks to see if the specified context exists for the current request.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param string $context Context value (see the `CONTEXT_` variables above).
+	 * @return bool TRUE if context exists; FALSE otherwise.
+	 */
+	public function has_context( $context ) {
+		return in_array( $context, $this->args['load_contexts'], true );
 	}
 
 	/**

--- a/includes/Core/Assets/Assets.php
+++ b/includes/Core/Assets/Assets.php
@@ -80,7 +80,7 @@ final class Assets {
 	/**
 	 * Registers functionality through WordPress hooks.
 	 *
-	 * @since 1.0.0 Function introduced.
+	 * @since 1.0.0
 	 * @since n.e.x.t Enqueues Block Editor assets.
 	 */
 	public function register() {

--- a/includes/Core/Assets/Assets.php
+++ b/includes/Core/Assets/Assets.php
@@ -80,7 +80,8 @@ final class Assets {
 	/**
 	 * Registers functionality through WordPress hooks.
 	 *
-	 * @since 1.0.0
+	 * @since 1.0.0 Function introduced.
+	 * @since n.e.x.t Enqueues Block Editor assets.
 	 */
 	public function register() {
 		$register_callback = function() {
@@ -120,6 +121,22 @@ final class Assets {
 			'admin_enqueue_scripts',
 			function() {
 				$this->enqueue_minimal_admin_script();
+			}
+		);
+
+		add_action(
+			'enqueue_block_editor_assets',
+			function() {
+				$assets = $this->get_assets();
+
+				array_walk(
+					$assets,
+					function( $asset ) {
+						if ( $asset->has_context( Asset::CONTEXT_ADMIN_POST_EDITOR ) ) {
+							$this->enqueue_asset( $asset->get_handle() );
+						}
+					}
+				);
 			}
 		);
 

--- a/includes/Core/Modules/Module_With_Assets.php
+++ b/includes/Core/Modules/Module_With_Assets.php
@@ -33,7 +33,10 @@ interface Module_With_Assets {
 	/**
 	 * Enqueues all assets necessary for the module.
 	 *
-	 * @since 1.7.0
+	 * @since 1.7.0 Function introduced.
+	 * @since n.e.x.t Added the $asset_context argument.
+	 *
+	 * @param string $asset_context Context for page, see `Asset::CONTEXT_*` constants.
 	 */
-	public function enqueue_assets();
+	public function enqueue_assets( $asset_context = Asset::CONTEXT_ADMIN_SITEKIT );
 }

--- a/includes/Core/Modules/Module_With_Assets.php
+++ b/includes/Core/Modules/Module_With_Assets.php
@@ -33,7 +33,7 @@ interface Module_With_Assets {
 	/**
 	 * Enqueues all assets necessary for the module.
 	 *
-	 * @since 1.7.0 Function introduced.
+	 * @since 1.7.0
 	 * @since n.e.x.t Added the $asset_context argument.
 	 *
 	 * @param string $asset_context Context for page, see `Asset::CONTEXT_*` constants.

--- a/includes/Core/Modules/Module_With_Assets_Trait.php
+++ b/includes/Core/Modules/Module_With_Assets_Trait.php
@@ -50,15 +50,21 @@ trait Module_With_Assets_Trait {
 	 * This default implementation simply enqueues all assets that the module
 	 * has registered.
 	 *
-	 * @since 1.7.0
+	 * @since 1.7.0 Function introduced.
+	 * @since n.e.x.t Added the $asset_context argument; only enqueue assets in the correct context.
+	 *
+	 * @param string $asset_context The page context to load this asset, see `Asset::CONTEXT_*` constants.
 	 */
-	public function enqueue_assets() {
+	public function enqueue_assets( $asset_context = Asset::CONTEXT_ADMIN_SITEKIT ) {
 		$assets = $this->get_assets();
 		array_walk(
 			$assets,
-			function( Asset $asset ) {
-				$asset->enqueue();
-			}
+			function( Asset $asset, $index, $context ) {
+				if ( $asset->has_context( $context ) ) {
+					$asset->enqueue();
+				}
+			},
+			$context
 		);
 	}
 

--- a/includes/Core/Modules/Module_With_Assets_Trait.php
+++ b/includes/Core/Modules/Module_With_Assets_Trait.php
@@ -59,12 +59,12 @@ trait Module_With_Assets_Trait {
 		$assets = $this->get_assets();
 		array_walk(
 			$assets,
-			function( Asset $asset, $index, $context ) {
-				if ( $asset->has_context( $context ) ) {
+			function( Asset $asset, $index, $asset_context ) {
+				if ( $asset->has_context( $asset_context ) ) {
 					$asset->enqueue();
 				}
 			},
-			$context
+			$asset_context
 		);
 	}
 

--- a/includes/Core/Modules/Module_With_Assets_Trait.php
+++ b/includes/Core/Modules/Module_With_Assets_Trait.php
@@ -50,7 +50,7 @@ trait Module_With_Assets_Trait {
 	 * This default implementation simply enqueues all assets that the module
 	 * has registered.
 	 *
-	 * @since 1.7.0 Function introduced.
+	 * @since 1.7.0
 	 * @since n.e.x.t Added the $asset_context argument; only enqueue assets in the correct context.
 	 *
 	 * @param string $asset_context The page context to load this asset, see `Asset::CONTEXT_*` constants.

--- a/includes/Core/Storage/Post_Meta_Setting.php
+++ b/includes/Core/Storage/Post_Meta_Setting.php
@@ -34,14 +34,25 @@ abstract class Post_Meta_Setting {
 	protected $post_meta;
 
 	/**
+	 * Arguments for `register_meta` call.
+	 *
+	 * @since n.e.x.t
+	 * @var array
+	 */
+	protected $args = array();
+
+	/**
 	 * Post_Meta_Setting constructor.
 	 *
-	 * @since 1.33.0
+	 * @since 1.33.0 Function introduced.
+	 * @since n.e.x.t Added the $args option.
 	 *
 	 * @param Post_Meta_Interface $post_meta Post_Meta_Interface instance.
+	 * @param array               $args      Options to pass to `register_meta`.
 	 */
-	public function __construct( Post_Meta_Interface $post_meta ) {
+	public function __construct( Post_Meta_Interface $post_meta, $args = array() ) {
 		$this->post_meta = $post_meta;
+		$this->args      = $args;
 	}
 
 	/**
@@ -53,10 +64,13 @@ abstract class Post_Meta_Setting {
 		register_meta(
 			'post',
 			static::META_KEY,
-			array(
-				'type'              => $this->get_type(),
-				'sanitize_callback' => $this->get_sanitize_callback(),
-				'single'            => true,
+			wp_parse_args(
+				$this->args,
+				array(
+					'type'              => $this->get_type(),
+					'sanitize_callback' => $this->get_sanitize_callback(),
+					'single'            => true,
+				)
 			)
 		);
 	}

--- a/includes/Core/Storage/Post_Meta_Setting.php
+++ b/includes/Core/Storage/Post_Meta_Setting.php
@@ -34,25 +34,14 @@ abstract class Post_Meta_Setting {
 	protected $post_meta;
 
 	/**
-	 * Arguments for `register_meta` call.
-	 *
-	 * @since n.e.x.t
-	 * @var array
-	 */
-	protected $args = array();
-
-	/**
 	 * Post_Meta_Setting constructor.
 	 *
-	 * @since 1.33.0 Function introduced.
-	 * @since n.e.x.t Added the $args option.
+	 * @since 1.33.0
 	 *
 	 * @param Post_Meta_Interface $post_meta Post_Meta_Interface instance.
-	 * @param array               $args      Options to pass to `register_meta`.
 	 */
-	public function __construct( Post_Meta_Interface $post_meta, $args = array() ) {
+	public function __construct( Post_Meta_Interface $post_meta ) {
 		$this->post_meta = $post_meta;
-		$this->args      = $args;
 	}
 
 	/**
@@ -64,13 +53,11 @@ abstract class Post_Meta_Setting {
 		register_meta(
 			'post',
 			static::META_KEY,
-			wp_parse_args(
-				$this->args,
-				array(
-					'type'              => $this->get_type(),
-					'sanitize_callback' => $this->get_sanitize_callback(),
-					'single'            => true,
-				)
+			array(
+				'type'              => $this->get_type(),
+				'sanitize_callback' => $this->get_sanitize_callback(),
+				'single'            => true,
+				'show_in_rest'      => $this->get_show_in_rest(),
 			)
 		);
 	}
@@ -118,6 +105,17 @@ abstract class Post_Meta_Setting {
 	 */
 	protected function get_sanitize_callback() {
 		return null;
+	}
+
+	/**
+	 * Gets the `show_in_rest` value for this postmeta setting value.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @return bool|Array Any valid value for the `show_in_rest`
+	 */
+	protected function get_show_in_rest() {
+		return false;
 	}
 
 	/**

--- a/includes/Modules/Idea_Hub.php
+++ b/includes/Modules/Idea_Hub.php
@@ -504,6 +504,9 @@ final class Idea_Hub extends Module
 				'googlesitekit-idea-hub-notice',
 				array(
 					'src'           => $base_url . 'js/googlesitekit-idea-hub-notice.js',
+					'dependencies'  => array(
+						'googlesitekit-i18n',
+					),
 					'load_contexts' => array( Asset::CONTEXT_ADMIN_POST_EDITOR ),
 				)
 			),

--- a/includes/Modules/Idea_Hub.php
+++ b/includes/Modules/Idea_Hub.php
@@ -121,7 +121,7 @@ final class Idea_Hub extends Module
 		$this->post_name_setting = new Post_Idea_Name( $post_meta );
 		$this->post_name_setting->register();
 
-		$this->post_text_setting = new Post_Idea_Text( $post_meta, array( 'show_in_rest' => true ) );
+		$this->post_text_setting = new Post_Idea_Text( $post_meta );
 		$this->post_text_setting->register();
 
 		$this->post_topic_setting = new Post_Idea_Topics( $post_meta );

--- a/includes/Modules/Idea_Hub.php
+++ b/includes/Modules/Idea_Hub.php
@@ -121,7 +121,7 @@ final class Idea_Hub extends Module
 		$this->post_name_setting = new Post_Idea_Name( $post_meta );
 		$this->post_name_setting->register();
 
-		$this->post_text_setting = new Post_Idea_Text( $post_meta );
+		$this->post_text_setting = new Post_Idea_Text( $post_meta, array( 'show_in_rest' => true ) );
 		$this->post_text_setting->register();
 
 		$this->post_topic_setting = new Post_Idea_Topics( $post_meta );
@@ -498,6 +498,18 @@ final class Idea_Hub extends Module
 						'googlesitekit-data',
 						'googlesitekit-modules',
 					),
+				)
+			),
+			new Script(
+				'googlesitekit-idea-hub-notice',
+				array(
+					'src'           => $base_url . 'js/googlesitekit-idea-hub-notice.js',
+					'dependencies'  => array(
+						'googlesitekit-vendor',
+						'googlesitekit-api',
+						'googlesitekit-data',
+					),
+					'load_contexts' => array( Asset::CONTEXT_ADMIN_POST_EDITOR ),
 				)
 			),
 		);

--- a/includes/Modules/Idea_Hub.php
+++ b/includes/Modules/Idea_Hub.php
@@ -504,11 +504,6 @@ final class Idea_Hub extends Module
 				'googlesitekit-idea-hub-notice',
 				array(
 					'src'           => $base_url . 'js/googlesitekit-idea-hub-notice.js',
-					'dependencies'  => array(
-						'googlesitekit-vendor',
-						'googlesitekit-api',
-						'googlesitekit-data',
-					),
 					'load_contexts' => array( Asset::CONTEXT_ADMIN_POST_EDITOR ),
 				)
 			),

--- a/includes/Modules/Idea_Hub/Post_Idea_Text.php
+++ b/includes/Modules/Idea_Hub/Post_Idea_Text.php
@@ -23,4 +23,15 @@ class Post_Idea_Text extends Post_Meta_Setting {
 
 	const META_KEY = 'googlesitekitpersistent_idea_text';
 
+	/**
+	 * Gets the `show_in_rest` value for this setting, which should be true.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @return bool Always returns true for this postmeta setting.
+	 */
+	protected function get_show_in_rest() {
+		return true;
+	}
+
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -285,6 +285,8 @@ const webpackConfig = ( env, argv ) => {
 				'googlesitekit-i18n': './assets/js/googlesitekit-i18n.js',
 				// Analytics advanced tracking script to be injected in the frontend.
 				'analytics-advanced-tracking': './assets/js/analytics-advanced-tracking.js',
+				// Idea Hub Block Editor notice.
+				'googlesitekit-idea-hub-notice': './assets/js/googlesitekit-idea-hub-notice.js',
 			},
 			externals,
 			output: {


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #3272.

## Relevant technical choices

I needed to add the ability for the Idea Hub postmeta to be exposed in the REST API; I went with the `$args` approach as it was straightforward and quick, but obviously it moves the source of truth from the meta file to the instantiation of the meta. This might not be ideal, but I wasn't sure.

Let me know what you think on that point, we can refactor it to be something fancier but I didn't want to start modifying too many classes 😅 

Regarding the IB, I put everything in one listener rather than listening for the `hasNotices` in its own listener, because we need to wait for the postmeta requests to resolve anyway, which involves a listener. I think my approach is a bit less complex than the one proposed in the IB, and it accomplishes the same thing 🙂 

It might be nice to eventually store the "has viewed" meta on the server, as we _do_ have a TTL on these and it might get annoying to see the notice in different browsers/computers, but for now it's client-side only.

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
