### PR TITLE
Update for user input field width on IOS.

### DIFF
--- a/assets/sass/components/user-input/googlesitekit-user-input-controls.scss
+++ b/assets/sass/components/user-input/googlesitekit-user-input-controls.scss
@@ -145,9 +145,13 @@
 			}
 		}
 
-		.mdc-text-field .mdc-text-field__input {
-			color: $c-user-input-color;
-			font-weight: 500;
+		.mdc-text-field {
+			width: auto;
+
+			.mdc-text-field__input {
+				color: $c-user-input-color;
+				font-weight: 500;
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary

Update for user input field width on IOS.

Addresses issue #3420

## Relevant technical choices

## Checklist

- [X] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [X] I have added a QA Brief on the issue linked above.
- [X] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
