### PR TITLE
Update for not displaying blue notice in GA4 setup.

### DIFF
--- a/assets/js/modules/analytics/components/setup/SetupFormGA4.js
+++ b/assets/js/modules/analytics/components/setup/SetupFormGA4.js
@@ -42,6 +42,7 @@ const { useSelect, useDispatch } = Data;
 export default function SetupFormGA4() {
 	const accounts = useSelect( ( select ) => select( STORE_NAME ).getAccounts() ) || [];
 
+	const ga4PropertyID = useSelect( ( select ) => select( MODULES_ANALYTICS_4 ).getPropertyID() );
 	const ga4HasExistingTag = useSelect( ( select ) => select( MODULES_ANALYTICS_4 ).hasExistingTag() );
 	const ga4ExistingTag = useSelect( ( select ) => select( MODULES_ANALYTICS_4 ).getExistingTag() );
 	const ga4MeasurementID = useSelect( ( select ) => select( MODULES_ANALYTICS_4 ).getMeasurementID() );
@@ -77,9 +78,9 @@ export default function SetupFormGA4() {
 				<GA4PropertySelect />
 			</div>
 
-			<GA4PropertyNotice
+			{ ga4PropertyID && ( ga4PropertyID !== PROPERTY_CREATE ) && <GA4PropertyNotice
 				notice={ __( 'An associated Universal Analytics property will also be created.', 'google-site-kit' ) }
-			/>
+			/> }
 		</Fragment>
 	);
 }

--- a/assets/js/modules/analytics/components/setup/SetupFormGA4.js
+++ b/assets/js/modules/analytics/components/setup/SetupFormGA4.js
@@ -32,7 +32,7 @@ import { Fragment, useEffect } from '@wordpress/element';
  */
 import Data from 'googlesitekit-data';
 import { CORE_FORMS } from '../../../../googlesitekit/datastore/forms/constants';
-import { STORE_NAME, PROPERTY_CREATE, FORM_SETUP } from '../../datastore/constants';
+import { STORE_NAME, PROPERTY_CREATE, FORM_SETUP, ACCOUNT_CREATE } from '../../datastore/constants';
 import { MODULES_ANALYTICS_4 } from '../../../analytics-4/datastore/constants';
 import StoreErrorNotices from '../../../../components/StoreErrorNotices';
 import GA4PropertySelect from '../../../analytics-4/components/common/PropertySelect';
@@ -45,12 +45,14 @@ export default function SetupFormGA4() {
 	const ga4HasExistingTag = useSelect( ( select ) => select( MODULES_ANALYTICS_4 ).hasExistingTag() );
 	const ga4ExistingTag = useSelect( ( select ) => select( MODULES_ANALYTICS_4 ).getExistingTag() );
 	const ga4MeasurementID = useSelect( ( select ) => select( MODULES_ANALYTICS_4 ).getMeasurementID() );
+	const ga4PropertyID = useSelect( ( select ) => select( MODULES_ANALYTICS_4 ).getPropertyID() );
 
+	const accountID = useSelect( ( select ) => select( STORE_NAME ).getAccountID() );
 	const { selectProperty } = useDispatch( STORE_NAME );
 	const { setValues } = useDispatch( CORE_FORMS );
 	const { setUseSnippet } = useDispatch( MODULES_ANALYTICS_4 );
 
-	const shouldShowAssociatedPropertyNotice = useSelect( ( select ) => select( MODULES_ANALYTICS_4 ).getPropertyID() );
+	const shouldShowAssociatedPropertyNotice = accountID && accountID !== ACCOUNT_CREATE && ga4PropertyID;
 
 	useMount( () => {
 		selectProperty( PROPERTY_CREATE );

--- a/assets/js/modules/analytics/components/setup/SetupFormGA4.js
+++ b/assets/js/modules/analytics/components/setup/SetupFormGA4.js
@@ -42,7 +42,6 @@ const { useSelect, useDispatch } = Data;
 export default function SetupFormGA4() {
 	const accounts = useSelect( ( select ) => select( STORE_NAME ).getAccounts() ) || [];
 
-	const ga4PropertyID = useSelect( ( select ) => select( MODULES_ANALYTICS_4 ).getPropertyID() );
 	const ga4HasExistingTag = useSelect( ( select ) => select( MODULES_ANALYTICS_4 ).hasExistingTag() );
 	const ga4ExistingTag = useSelect( ( select ) => select( MODULES_ANALYTICS_4 ).getExistingTag() );
 	const ga4MeasurementID = useSelect( ( select ) => select( MODULES_ANALYTICS_4 ).getMeasurementID() );
@@ -50,6 +49,8 @@ export default function SetupFormGA4() {
 	const { selectProperty } = useDispatch( STORE_NAME );
 	const { setValues } = useDispatch( CORE_FORMS );
 	const { setUseSnippet } = useDispatch( MODULES_ANALYTICS_4 );
+
+	const shouldShowAssociatedPropertyNotice = useSelect( ( select ) => select( MODULES_ANALYTICS_4 ).getPropertyID() );
 
 	useMount( () => {
 		selectProperty( PROPERTY_CREATE );
@@ -78,7 +79,7 @@ export default function SetupFormGA4() {
 				<GA4PropertySelect />
 			</div>
 
-			{ ga4PropertyID && ( ga4PropertyID !== PROPERTY_CREATE ) && <GA4PropertyNotice
+			{ shouldShowAssociatedPropertyNotice && <GA4PropertyNotice
 				notice={ __( 'An associated Universal Analytics property will also be created.', 'google-site-kit' ) }
 			/> }
 		</Fragment>

--- a/assets/js/modules/analytics/components/setup/SetupFormGA4Transitional.js
+++ b/assets/js/modules/analytics/components/setup/SetupFormGA4Transitional.js
@@ -27,7 +27,7 @@ import { Fragment, useEffect } from '@wordpress/element';
  */
 import Data from 'googlesitekit-data';
 import { MODULES_ANALYTICS_4 } from '../../../analytics-4/datastore/constants';
-import { STORE_NAME, PROFILE_CREATE, PROPERTY_TYPE_UA, PROPERTY_TYPE_GA4 } from '../../datastore/constants';
+import { STORE_NAME, PROFILE_CREATE, PROPERTY_TYPE_UA, PROPERTY_TYPE_GA4, ACCOUNT_CREATE } from '../../datastore/constants';
 import StoreErrorNotices from '../../../../components/StoreErrorNotices';
 import GA4PropertySelect from '../../../analytics-4/components/common/PropertySelect';
 import {
@@ -48,6 +48,7 @@ export default function SetupFormGA4Transitional() {
 	const hasExistingTag = useSelect( ( select ) => select( STORE_NAME ).hasExistingTag() );
 	const existingTag = useSelect( ( select ) => select( STORE_NAME ).getExistingTag() );
 
+	const accountID = useSelect( ( select ) => select( STORE_NAME ).getAccountID() );
 	const propertyID = useSelect( ( select ) => select( STORE_NAME ).getPropertyID() );
 	const profileID = useSelect( ( select ) => select( STORE_NAME ).getProfileID() );
 
@@ -58,7 +59,7 @@ export default function SetupFormGA4Transitional() {
 	const { setUseSnippet: uaSetUseSnippet } = useDispatch( STORE_NAME );
 	const { setUseSnippet: ga4SetUseSnippet } = useDispatch( MODULES_ANALYTICS_4 );
 
-	const shouldShowAssociatedPropertyNotice = propertyID || ga4PropertyID;
+	const shouldShowAssociatedPropertyNotice = accountID && accountID !== ACCOUNT_CREATE && ( propertyID || ga4PropertyID );
 
 	useEffect( () => {
 		uaSetUseSnippet( existingTag !== propertyID );

--- a/assets/js/modules/analytics/components/setup/SetupFormGA4Transitional.js
+++ b/assets/js/modules/analytics/components/setup/SetupFormGA4Transitional.js
@@ -27,7 +27,7 @@ import { Fragment, useEffect } from '@wordpress/element';
  */
 import Data from 'googlesitekit-data';
 import { MODULES_ANALYTICS_4 } from '../../../analytics-4/datastore/constants';
-import { STORE_NAME, PROFILE_CREATE, PROPERTY_TYPE_UA, PROPERTY_TYPE_GA4 } from '../../datastore/constants';
+import { STORE_NAME, PROFILE_CREATE, PROPERTY_TYPE_UA, PROPERTY_TYPE_GA4, PROPERTY_CREATE } from '../../datastore/constants';
 import StoreErrorNotices from '../../../../components/StoreErrorNotices';
 import GA4PropertySelect from '../../../analytics-4/components/common/PropertySelect';
 import {
@@ -51,6 +51,7 @@ export default function SetupFormGA4Transitional() {
 	const propertyID = useSelect( ( select ) => select( STORE_NAME ).getPropertyID() );
 	const profileID = useSelect( ( select ) => select( STORE_NAME ).getProfileID() );
 
+	const ga4PropertyID = useSelect( ( select ) => select( MODULES_ANALYTICS_4 ).getPropertyID() );
 	const ga4ExistingTag = useSelect( ( select ) => select( MODULES_ANALYTICS_4 ).getExistingTag() );
 	const ga4MeasurementID = useSelect( ( select ) => select( MODULES_ANALYTICS_4 ).getMeasurementID() );
 
@@ -100,7 +101,7 @@ export default function SetupFormGA4Transitional() {
 				</div>
 			) }
 
-			<GA4PropertyNotice notice={ notice }>
+			{ ( propertyID || ga4PropertyID ) && ( ga4PropertyID !== PROPERTY_CREATE ) && <GA4PropertyNotice notice={ notice }>
 				{ propertyType === PROPERTY_TYPE_GA4 && (
 					<Fragment>
 						<div className="googlesitekit-setup-module__inputs">
@@ -120,7 +121,7 @@ export default function SetupFormGA4Transitional() {
 						<GA4PropertySelect />
 					</div>
 				) }
-			</GA4PropertyNotice>
+			</GA4PropertyNotice> }
 		</Fragment>
 	);
 }

--- a/assets/js/modules/analytics/components/setup/SetupFormGA4Transitional.js
+++ b/assets/js/modules/analytics/components/setup/SetupFormGA4Transitional.js
@@ -27,7 +27,7 @@ import { Fragment, useEffect } from '@wordpress/element';
  */
 import Data from 'googlesitekit-data';
 import { MODULES_ANALYTICS_4 } from '../../../analytics-4/datastore/constants';
-import { STORE_NAME, PROFILE_CREATE, PROPERTY_TYPE_UA, PROPERTY_TYPE_GA4, PROPERTY_CREATE } from '../../datastore/constants';
+import { STORE_NAME, PROFILE_CREATE, PROPERTY_TYPE_UA, PROPERTY_TYPE_GA4 } from '../../datastore/constants';
 import StoreErrorNotices from '../../../../components/StoreErrorNotices';
 import GA4PropertySelect from '../../../analytics-4/components/common/PropertySelect';
 import {
@@ -57,6 +57,8 @@ export default function SetupFormGA4Transitional() {
 
 	const { setUseSnippet: uaSetUseSnippet } = useDispatch( STORE_NAME );
 	const { setUseSnippet: ga4SetUseSnippet } = useDispatch( MODULES_ANALYTICS_4 );
+
+	const shouldShowAssociatedPropertyNotice = propertyID || ga4PropertyID;
 
 	useEffect( () => {
 		uaSetUseSnippet( existingTag !== propertyID );
@@ -101,7 +103,7 @@ export default function SetupFormGA4Transitional() {
 				</div>
 			) }
 
-			{ ( propertyID || ga4PropertyID ) && ( ga4PropertyID !== PROPERTY_CREATE ) && <GA4PropertyNotice notice={ notice }>
+			{ shouldShowAssociatedPropertyNotice && <GA4PropertyNotice notice={ notice }>
 				{ propertyType === PROPERTY_TYPE_GA4 && (
 					<Fragment>
 						<div className="googlesitekit-setup-module__inputs">

--- a/assets/js/modules/analytics/components/setup/SetupFormUA.js
+++ b/assets/js/modules/analytics/components/setup/SetupFormUA.js
@@ -55,7 +55,8 @@ export default function SetupFormUA() {
 	const profileID = useSelect( ( select ) => select( STORE_NAME ).getProfileID() );
 
 	const accountID = useSelect( ( select ) => select( STORE_NAME ).getAccountID() );
-	const shouldShowGA4PropertyNotice = accountID && accountID !== ACCOUNT_CREATE;
+	const propertyID = useSelect( ( select ) => select( STORE_NAME ).getPropertyID() );
+	const shouldShowGA4PropertyNotice = accountID && accountID !== ACCOUNT_CREATE && propertyID;
 
 	useMount( () => {
 		selectProperty( PROPERTY_CREATE );


### PR DESCRIPTION
## Summary

Update for not displaying blue notice in GA4 setup.

Addresses issue #3614

## Relevant technical choice

## Checklist

- [X] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [X] I have added a QA Brief on the issue linked above.
- [X] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
