### PR TITLE
Fix refactored AdSense module screen to behave similar to legacy one (3667).

### DIFF
--- a/assets/js/modules/adsense/components/module/ModuleOverviewWidget/index.js
+++ b/assets/js/modules/adsense/components/module/ModuleOverviewWidget/index.js
@@ -33,6 +33,8 @@ import { __ } from '@wordpress/i18n';
 import { STORE_NAME } from '../../../datastore/constants';
 import { CORE_USER } from '../../../../../googlesitekit/datastore/user/constants';
 import { isZeroReport } from '../../../util';
+import DashboardZeroData from '../../dashboard/DashboardZeroData';
+import { HIDDEN_CLASS } from '../../../../../googlesitekit/widgets/util/constants';
 import PreviewBlock from '../../../../../components/PreviewBlock';
 import Header from './Header';
 import Overview from './Overview';
@@ -110,8 +112,11 @@ const ModuleOverviewWidget = ( { Widget, WidgetReportZero, WidgetReportError } )
 
 	if ( isZeroReport( currentRangeData ) || isZeroReport( currentRangeChartData ) ) {
 		return (
-			<Widget Header={ Header }>
-				<WidgetReportZero moduleSlug="adsense" />
+			<Widget noPadding>
+				<DashboardZeroData />
+				<div className={ HIDDEN_CLASS }>
+					<WidgetReportZero moduleSlug="adsense" />
+				</div>
 			</Widget>
 		);
 	}

--- a/assets/js/modules/adsense/components/module/ModuleTopEarningPagesWidget/index.js
+++ b/assets/js/modules/adsense/components/module/ModuleTopEarningPagesWidget/index.js
@@ -31,6 +31,7 @@ import { DATE_RANGE_OFFSET } from '../../../datastore/constants';
 import { CORE_USER } from '../../../../../googlesitekit/datastore/user/constants';
 import { MODULES_ANALYTICS } from '../../../../analytics/datastore/constants';
 import { isZeroReport } from '../../../../analytics/util/is-zero-report';
+import WhenActive from '../../../../../util/when-active';
 import { isRestrictedMetricsError } from '../../../../analytics/util/error';
 import Header from './Header';
 import Table from './Table';
@@ -118,4 +119,4 @@ ModuleTopEarningPagesWidget.propTypes = {
 	WidgetReportError: PropTypes.func.isRequired,
 };
 
-export default ModuleTopEarningPagesWidget;
+export default WhenActive( { moduleName: 'analytics' } )( ModuleTopEarningPagesWidget );


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #3667

## Relevant technical choices

<!-- Please describe your changes. -->

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
