### PR TITLE
Add setTimeout for showing the user feedback modal.

### DIFF
--- a/assets/js/googlesitekit/datastore/user/surveys.js
+++ b/assets/js/googlesitekit/datastore/user/surveys.js
@@ -107,8 +107,15 @@ const baseActions = {
 					return { response, error };
 				}
 				if ( ttl > 0 ) {
-					// With a positive ttl we cache an empty object to avoid calling fetchTriggerSurvey() again.
-					yield Data.commonActions.await( setItem( cacheKey, {}, { ttl } ) );
+					setTimeout( () => {
+						function* generator() {
+							// With a positive ttl we cache an empty object to avoid calling fetchTriggerSurvey() again after 30s.
+							yield Data.commonActions.await( setItem( cacheKey, {}, { ttl } ) );
+						}
+
+						const gen = generator();
+						gen.next();
+					}, 3000 );
 				}
 			}
 

--- a/assets/js/googlesitekit/datastore/user/surveys.test.js
+++ b/assets/js/googlesitekit/datastore/user/surveys.test.js
@@ -23,6 +23,7 @@ import {
 	createTestRegistry,
 	muteFetch,
 } from '../../../../../tests/js/utils';
+import { actHook as act } from '../../../../../tests/js/test-utils';
 import { createCacheKey } from '../../api';
 import { setItem, setSelectedStorageBackend } from '../../api/cache';
 import { STORE_NAME } from './constants';
@@ -116,6 +117,7 @@ describe( 'core/user surveys', () => {
 				fetchMock.postOnce( surveyTriggerEndpoint, { body: { triggerID } } );
 
 				await registry.dispatch( STORE_NAME ).triggerSurvey( triggerID, { ttl: 500 } );
+				act( () => jest.advanceTimersByTime( 30005 ) );
 				expect( ttl ).toBe( 500 );
 
 				// Reset the backend storage mechanism.


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #3633 

## Relevant technical choices

<!-- Please describe your changes. -->

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
