### PR TITLE
Update copy of the pop-up screen for disconnecting AdSense in Settings

### DIFF
--- a/assets/js/modules/adsense/index.js
+++ b/assets/js/modules/adsense/index.js
@@ -64,8 +64,9 @@ export const registerModule = ( modules ) => {
 			SetupComponent: SetupMain,
 			Icon: AdSenseIcon,
 			features: [
-				__( 'Monetize your website', 'google-site-kit' ),
 				__( 'Intelligent, automatic ad placement', 'google-site-kit' ),
+				__( 'Revenue from ads placed on your site', 'google-site-kit' ),
+				__( 'AdSense insights through Site Kit', 'google-site-kit' ),
 			],
 			checkRequirements: async ( registry ) => {
 				const adBlockerActive = await registry.__experimentalResolveSelect( STORE_NAME ).isAdBlockerActive();


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #683

## Relevant technical choices

<!-- Please describe your changes. -->

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).


**Before**
![disconnect-adsense-before](https://user-images.githubusercontent.com/8496063/125043850-a81da580-e09b-11eb-9dff-01122f58728f.png)



**After**
![disconnect-adsense-after](https://user-images.githubusercontent.com/8496063/125043858-ab189600-e09b-11eb-8341-7b5adc648c8a.png)
