### PR TITLE
Enhancement/3614 blue notice bar updates

### DIFF
--- a/assets/js/modules/analytics-4/datastore/settings.js
+++ b/assets/js/modules/analytics-4/datastore/settings.js
@@ -97,8 +97,8 @@ export function validateCanSubmitChanges( select ) {
 	invariant( ! isDoingSubmitChanges(), INVARIANT_DOING_SUBMIT_CHANGES );
 
 	const propertyID = getPropertyID();
-	invariant( propertyID === '' || isValidPropertySelection( propertyID ), INVARIANT_INVALID_PROPERTY_SELECTION );
-	if ( propertyID && propertyID !== PROPERTY_CREATE ) {
+	invariant( isValidPropertySelection( propertyID ), INVARIANT_INVALID_PROPERTY_SELECTION );
+	if ( propertyID !== PROPERTY_CREATE ) {
 		invariant( isValidWebDataStreamSelection( getWebDataStreamID() ), INVARIANT_INVALID_WEBDATASTREAM_ID );
 	}
 }

--- a/assets/js/modules/analytics-4/datastore/settings.test.js
+++ b/assets/js/modules/analytics-4/datastore/settings.test.js
@@ -207,11 +207,6 @@ describe( 'modules/analytics-4 settings', () => {
 				expect( () => registry.select( STORE_NAME ).__dangerousCanSubmitChanges() ).toThrow( INVARIANT_INVALID_PROPERTY_SELECTION );
 			} );
 
-			it( 'should ignore propertyID if it is an empty string', () => {
-				registry.dispatch( STORE_NAME ).setPropertyID( '' );
-				expect( () => registry.select( STORE_NAME ).__dangerousCanSubmitChanges() ).not.toThrow( INVARIANT_INVALID_PROPERTY_SELECTION );
-			} );
-
 			it( 'should require a valid webDataStreamID', () => {
 				registry.dispatch( STORE_NAME ).setWebDataStreamID( '' );
 				expect( () => registry.select( STORE_NAME ).__dangerousCanSubmitChanges() ).toThrow( INVARIANT_INVALID_WEBDATASTREAM_ID );

--- a/assets/js/modules/analytics/components/common/UseUAandGA4SnippetSwitches.js
+++ b/assets/js/modules/analytics/components/common/UseUAandGA4SnippetSwitches.js
@@ -26,30 +26,28 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import Data from 'googlesitekit-data';
-import { CORE_MODULES } from '../../../../googlesitekit/modules/datastore/constants';
 import { STORE_NAME } from '../../datastore/constants';
 import { MODULES_ANALYTICS_4 } from '../../../analytics-4/datastore/constants';
 import Switch from '../../../../components/Switch';
 import { trackEvent } from '../../../../util';
-import { useFeature } from '../../../../hooks/useFeature';
 const { useSelect, useDispatch } = Data;
 
 export default function UseUAandGA4SnippetSwitches() {
-	const isGA4Enabled = useFeature( 'ga4setup' );
-
 	const useUASnippet = useSelect( ( select ) => select( STORE_NAME ).getUseSnippet() );
 	const canUseUASnippet = useSelect( ( select ) => select( STORE_NAME ).getCanUseSnippet() );
 
 	const {
+		showGA4Toggle,
 		ga4ExistingTag,
 		ga4MeasurementID,
 		useGA4Snippet,
 	} = useSelect( ( select ) => {
-		if ( ! isGA4Enabled || select( CORE_MODULES ).isModuleConnected( 'analytics-4' ) === false ) {
+		if ( ! select( STORE_NAME ).canUseGA4Controls() ) {
 			return {};
 		}
 
 		return {
+			showGA4Toggle: true,
 			ga4ExistingTag: select( MODULES_ANALYTICS_4 ).getExistingTag(),
 			ga4MeasurementID: select( MODULES_ANALYTICS_4 ).getMeasurementID(),
 			useGA4Snippet: select( MODULES_ANALYTICS_4 ).getUseSnippet(),
@@ -104,7 +102,7 @@ export default function UseUAandGA4SnippetSwitches() {
 					/>
 				</div>
 
-				{ useGA4Snippet !== undefined && (
+				{ showGA4Toggle && (
 					<div className="googlesitekit-settings-module__inline-item">
 						<Switch
 							label={ __( 'Place Google Analytics 4 code', 'google-site-kit' ) }

--- a/assets/js/modules/analytics/components/setup/SetupFormGA4Transitional.js
+++ b/assets/js/modules/analytics/components/setup/SetupFormGA4Transitional.js
@@ -59,7 +59,8 @@ export default function SetupFormGA4Transitional() {
 	const { setUseSnippet: uaSetUseSnippet } = useDispatch( STORE_NAME );
 	const { setUseSnippet: ga4SetUseSnippet } = useDispatch( MODULES_ANALYTICS_4 );
 
-	const shouldShowAssociatedPropertyNotice = accountID && accountID !== ACCOUNT_CREATE && ( propertyID || ga4PropertyID );
+	const primaryPropertyID = propertyType === PROPERTY_TYPE_UA ? propertyID : ga4PropertyID;
+	const showAssociatedPropertyNotice = accountID && accountID !== ACCOUNT_CREATE && primaryPropertyID;
 
 	useEffect( () => {
 		uaSetUseSnippet( existingTag !== propertyID );
@@ -104,27 +105,29 @@ export default function SetupFormGA4Transitional() {
 				</div>
 			) }
 
-			{ shouldShowAssociatedPropertyNotice && <GA4PropertyNotice notice={ notice }>
-				{ propertyType === PROPERTY_TYPE_GA4 && (
-					<Fragment>
-						<div className="googlesitekit-setup-module__inputs">
-							<PropertySelect />
-							<ProfileSelect />
-						</div>
-
-						{ profileID === PROFILE_CREATE && (
-							<div className="googlesitekit-setup-module__inputs googlesitekit-setup-module__inputs--multiline">
-								<ProfileNameTextField />
+			{ showAssociatedPropertyNotice && (
+				<GA4PropertyNotice notice={ notice }>
+					{ propertyType === PROPERTY_TYPE_GA4 && (
+						<Fragment>
+							<div className="googlesitekit-setup-module__inputs">
+								<PropertySelect />
+								<ProfileSelect />
 							</div>
-						) }
-					</Fragment>
-				) }
-				{ propertyType === PROPERTY_TYPE_UA && (
-					<div className="googlesitekit-setup-module__inputs">
-						<GA4PropertySelect />
-					</div>
-				) }
-			</GA4PropertyNotice> }
+
+							{ profileID === PROFILE_CREATE && (
+								<div className="googlesitekit-setup-module__inputs googlesitekit-setup-module__inputs--multiline">
+									<ProfileNameTextField />
+								</div>
+							) }
+						</Fragment>
+					) }
+					{ propertyType === PROPERTY_TYPE_UA && (
+						<div className="googlesitekit-setup-module__inputs">
+							<GA4PropertySelect />
+						</div>
+					) }
+				</GA4PropertyNotice>
+			) }
 		</Fragment>
 	);
 }

--- a/assets/js/modules/analytics/datastore/accounts.js
+++ b/assets/js/modules/analytics/datastore/accounts.js
@@ -177,6 +177,13 @@ const baseActions = {
 				return;
 			}
 
+			// Do nothing if UA is already connected but GA4 is not.
+			const isUAConnected = registry.select( CORE_MODULES ).isModuleConnected( 'analytics' );
+			const isGA4Connected = registry.select( CORE_MODULES ).isModuleConnected( 'analytics-4' );
+			if ( isUAConnected && ! isGA4Connected ) {
+				return;
+			}
+
 			registry.dispatch( STORE_NAME ).setPrimaryPropertyType( PROPERTY_TYPE_UA );
 
 			const ga4MatchProperty = registry.dispatch( MODULES_ANALYTICS_4 ).matchAndSelectProperty( accountID, GA4_PROPERTY_CREATE );

--- a/assets/js/modules/analytics/datastore/accounts.js
+++ b/assets/js/modules/analytics/datastore/accounts.js
@@ -329,13 +329,6 @@ const baseResolvers = {
 			return;
 		}
 
-		// Do nothing if UA is already connected but GA4 is not.
-		const isUAConnected = registry.select( CORE_MODULES ).isModuleConnected( 'analytics' );
-		const isGA4Connected = registry.select( CORE_MODULES ).isModuleConnected( 'analytics-4' );
-		if ( isUAConnected && ! isGA4Connected ) {
-			return;
-		}
-
 		// Do not try to find a matching GA4 property if the module has already been connected.
 		const connected = registry.select( CORE_MODULES ).isModuleConnected( 'analytics' );
 		if ( connected ) {

--- a/assets/js/modules/analytics/datastore/accounts.js
+++ b/assets/js/modules/analytics/datastore/accounts.js
@@ -173,14 +173,7 @@ const baseActions = {
 				registry.dispatch( STORE_NAME ).setProfileID( '' );
 			}
 
-			if ( ! isFeatureEnabled( 'ga4setup' ) ) {
-				return;
-			}
-
-			// Do nothing if UA is already connected but GA4 is not.
-			const isUAConnected = registry.select( CORE_MODULES ).isModuleConnected( 'analytics' );
-			const isGA4Connected = registry.select( CORE_MODULES ).isModuleConnected( 'analytics-4' );
-			if ( isUAConnected && ! isGA4Connected ) {
+			if ( ! registry.select( STORE_NAME ).canUseGA4Controls() ) {
 				return;
 			}
 

--- a/assets/js/modules/analytics/datastore/accounts.js
+++ b/assets/js/modules/analytics/datastore/accounts.js
@@ -329,6 +329,13 @@ const baseResolvers = {
 			return;
 		}
 
+		// Do nothing if UA is already connected but GA4 is not.
+		const isUAConnected = registry.select( CORE_MODULES ).isModuleConnected( 'analytics' );
+		const isGA4Connected = registry.select( CORE_MODULES ).isModuleConnected( 'analytics-4' );
+		if ( isUAConnected && ! isGA4Connected ) {
+			return;
+		}
+
 		// Do not try to find a matching GA4 property if the module has already been connected.
 		const connected = registry.select( CORE_MODULES ).isModuleConnected( 'analytics' );
 		if ( connected ) {

--- a/assets/js/modules/analytics/datastore/accounts.test.js
+++ b/assets/js/modules/analytics/datastore/accounts.test.js
@@ -252,6 +252,19 @@ describe( 'modules/analytics accounts', () => {
 					} );
 
 					provideSiteInfo( registry );
+
+					provideModules( registry, [
+						{
+							slug: 'analytics',
+							active: true,
+							connected: true,
+						},
+						{
+							slug: 'analytics-4',
+							active: true,
+							connected: true,
+						},
+					] );
 				} );
 
 				it( 'should select the correct GA4 property', async () => {

--- a/assets/js/modules/analytics/datastore/settings.js
+++ b/assets/js/modules/analytics/datastore/settings.js
@@ -98,9 +98,6 @@ export async function submitChanges( { select, dispatch } ) {
 	// TODO: Remove once legacy dataAPI is no longer used.
 	invalidateCacheGroup( TYPE_MODULES, 'analytics' );
 
-	// Try to save GA4 settings only if the Analytics-4 module has the same connection status as the Analytics module has.
-	// This check is needed to prevent saving GA4 settings unintentionally for cases when the Analytics module has been
-	// already connected by the time the GA4 functionality is revealed.
 	if ( select( STORE_NAME ).canUseGA4Controls() && select( MODULES_ANALYTICS_4 ).haveSettingsChanged() ) {
 		const { error } = await dispatch( MODULES_ANALYTICS_4 ).submitChanges();
 		if ( isPermissionScopeError( error ) ) {
@@ -166,9 +163,6 @@ export function validateCanSubmitChanges( select ) {
 	// Do existing tag check last.
 	invariant( hasExistingTagPermission() !== false, INVARIANT_INSUFFICIENT_TAG_PERMISSIONS );
 
-	// Validate GA4 settings only if the Analytics-4 module has the same connection status as the Analytics module has.
-	// This check is needed to prevent saving GA4 settings unintentionally for cases when the Analytics module has been
-	// already connected by the time the GA4 functionality is revealed.
 	if ( select( STORE_NAME ).canUseGA4Controls() ) {
 		select( MODULES_ANALYTICS_4 ).__dangerousCanSubmitChanges();
 	}

--- a/assets/js/modules/analytics/datastore/settings.test.js
+++ b/assets/js/modules/analytics/datastore/settings.test.js
@@ -28,7 +28,7 @@ import { CORE_MODULES } from '../../../googlesitekit/modules/datastore/constants
 import { withActive } from '../../../googlesitekit/modules/datastore/__fixtures__';
 import * as fixtures from './__fixtures__';
 import {
-	createTestRegistry,
+	createTestRegistry, provideModules,
 	subscribeUntil,
 	unsubscribeFromAll,
 } from '../../../../../tests/js/utils';
@@ -80,7 +80,14 @@ describe( 'modules/analytics settings', () => {
 
 	beforeEach( () => {
 		registry = createTestRegistry();
-		registry.dispatch( CORE_MODULES ).receiveGetModules( withActive() );
+
+		provideModules( registry, [
+			{
+				slug: 'analytics',
+				active: true,
+				connected: true,
+			},
+		] );
 	} );
 
 	afterAll( () => {
@@ -345,6 +352,19 @@ describe( 'modules/analytics settings', () => {
 					registry.dispatch( STORE_NAME ).receiveGetExistingTag( null );
 					registry.dispatch( STORE_NAME ).setSettings( validSettings );
 
+					provideModules( registry, [
+						{
+							slug: 'analytics',
+							active: true,
+							connected: true,
+						},
+						{
+							slug: 'analytics-4',
+							active: true,
+							connected: true,
+						},
+					] );
+
 					enabledFeatures.add( 'ga4setup' );
 				} );
 
@@ -597,6 +617,19 @@ describe( 'modules/analytics settings', () => {
 				beforeEach( () => {
 					registry.dispatch( STORE_NAME ).receiveGetExistingTag( null );
 					registry.dispatch( STORE_NAME ).setSettings( validSettings );
+
+					provideModules( registry, [
+						{
+							slug: 'analytics',
+							active: true,
+							connected: true,
+						},
+						{
+							slug: 'analytics-4',
+							active: true,
+							connected: true,
+						},
+					] );
 
 					enabledFeatures.add( 'ga4setup' );
 				} );

--- a/assets/js/modules/analytics/datastore/settings.test.js
+++ b/assets/js/modules/analytics/datastore/settings.test.js
@@ -28,7 +28,8 @@ import { CORE_MODULES } from '../../../googlesitekit/modules/datastore/constants
 import { withActive } from '../../../googlesitekit/modules/datastore/__fixtures__';
 import * as fixtures from './__fixtures__';
 import {
-	createTestRegistry, provideModules,
+	createTestRegistry,
+	provideModules,
 	subscribeUntil,
 	unsubscribeFromAll,
 } from '../../../../../tests/js/utils';

--- a/assets/js/modules/analytics/datastore/setup-flow.js
+++ b/assets/js/modules/analytics/datastore/setup-flow.js
@@ -30,10 +30,18 @@ import {
 } from './constants';
 import { MODULES_ANALYTICS_4 } from '../../analytics-4/datastore/constants';
 import { isFeatureEnabled } from '../../../features';
+import { CORE_MODULES } from '../../../googlesitekit/modules/datastore/constants';
 
 const { createRegistrySelector } = Data;
 
 const baseSelectors = {
+	/**
+	 * Gets the setup flow mode based on different conditions.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @return {string} Setup flow mode.
+	 */
 	getSetupFlowMode: createRegistrySelector( ( select ) => () => {
 		// The Google Analytics 4 is not enabled, so we have
 		// to use the legacy implementation.
@@ -91,6 +99,25 @@ const baseSelectors = {
 
 		// There are UA and GA4 properties, so use the transitional mode.
 		return SETUP_FLOW_MODE_GA4_TRANSITIONAL;
+	} ),
+
+	/**
+	 * Determines whether we can use GA4 controls or not.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @return {boolean} TRUE if we can use GA4 controls, otherwise FALSE.
+	 */
+	canUseGA4Controls: createRegistrySelector( ( select ) => () => {
+		// The Google Analytics 4 is not enabled, so can't use it.
+		if ( ! isFeatureEnabled( 'ga4setup' ) ) {
+			return false;
+		}
+
+		const uaConnected = select( CORE_MODULES ).isModuleConnected( 'analytics' );
+		const ga4Connected = select( CORE_MODULES ).isModuleConnected( 'analytics-4' );
+
+		return uaConnected === ga4Connected;
 	} ),
 };
 

--- a/assets/js/modules/analytics/datastore/setup-flow.js
+++ b/assets/js/modules/analytics/datastore/setup-flow.js
@@ -102,7 +102,7 @@ const baseSelectors = {
 	} ),
 
 	/**
-	 * Determines whether we can use GA4 controls or not.
+	 * Determines whether GA4 controls should be displayed or not.
 	 *
 	 * @since n.e.x.t
 	 *

--- a/assets/js/modules/analytics/datastore/setup-flow.test.js
+++ b/assets/js/modules/analytics/datastore/setup-flow.test.js
@@ -27,7 +27,7 @@ import {
 	SETUP_FLOW_MODE_GA4,
 	SETUP_FLOW_MODE_GA4_TRANSITIONAL,
 } from './constants';
-import { createTestRegistry, unsubscribeFromAll } from 'tests/js/utils';
+import { createTestRegistry, unsubscribeFromAll, provideModules } from '../../../../../tests/js/utils';
 import { MODULES_ANALYTICS_4 } from '../../analytics-4/datastore/constants';
 import { enabledFeatures } from '../../../features';
 
@@ -257,6 +257,42 @@ describe( 'modules/analytics setup-flow', () => {
 
 				expect( registry.select( MODULES_ANALYTICS_4 ).isAdminAPIWorking() ).toBe( true );
 				expect( registry.select( MODULES_ANALYTICS ).getSetupFlowMode() ).toBe( SETUP_FLOW_MODE_GA4_TRANSITIONAL );
+			} );
+		} );
+
+		describe( 'canUseGA4Controls', () => {
+			it( 'should return TRUE if both modules are connected', () => {
+				provideModules( registry, [
+					{
+						slug: 'analytics',
+						active: true,
+						connected: true,
+					},
+					{
+						slug: 'analytics-4',
+						active: true,
+						connected: true,
+					},
+				] );
+
+				expect( registry.select( MODULES_ANALYTICS ).canUseGA4Controls() ).toBe( true );
+			} );
+
+			it( 'should return FALSE when one of the modules is not connected', () => {
+				provideModules( registry, [
+					{
+						slug: 'analytics',
+						active: true,
+						connected: true,
+					},
+					{
+						slug: 'analytics-4',
+						active: true,
+						connected: false,
+					},
+				] );
+
+				expect( registry.select( MODULES_ANALYTICS ).canUseGA4Controls() ).toBe( false );
 			} );
 		} );
 	} );


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #3614

## Relevant technical choices

This PR does a few things:

* Updates the `SetupFormGA4Transitional` component to display the blue notice bar only when the primary property is not empty.
* Fixes the issue on the setup form when a  user could submit the setup form without selecting the associated GA4 property. Steps to reproduce the issue in the develop branch:
  1. Disconnect the Analytics module and enable the ga4setup feature flag.
  1. Using the developer plugin, set the current reference site URL to a website URL that is not present in any of your UA/GA4 properties
  1. Connect the Analytics module and go to the setup form
  1. Select an account that has both UA and GA4 properties
  1. Select a UA property and make sure you don't select a GA4 property and it doesn't say that it will create a new one for you
  1. Check the submit button - it is not disabled and allows you to submit your selection with GA4 propertyID not being selected
* Fixes the issue on the settings form when a GA4 property could be selected unintentionally in a situation when a user selects a different account. Steps to reproduce the issue in the develop branch:
   1. Disconnect the Analytics module and disable the ga4setup feature flag
   1. Connect the Analytics module again and go to the setup form
   1. Verify that GA4 functionality isn't working (you don't see new notices on the setup form).
   1. Select an account with UA properties only and submit the setup form
   1. Enable the ga4setup feature flag again
   1. Go to the Analytics settings and edit it
   1. Run `googlesitekit.data.select( 'modules/analytics-4' ).getSettings()` in the browser console to see analytics-4 settings. It should show empty propertyID, webDataStreamID, and measurementID settings.
   1. Select another account that has GA4 properties that match the current website URL
   1. Check the analytics-4 settings, now it has propertyID, webDataStreamID and measurementID added
   1. If you save settings, analytics-4 settings will be saved as well

## Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
