### PR TITLE
Update to redirect to the settings page after a module is disconnected.

### DIFF
--- a/assets/js/components/settings/SettingsActiveModule/ConfirmDisconnect.js
+++ b/assets/js/components/settings/SettingsActiveModule/ConfirmDisconnect.js
@@ -49,7 +49,7 @@ export default function ConfirmDisconnect( { slug } ) {
 	const dependentModules = useSelect( ( select ) => select( CORE_MODULES ).getModuleDependantNames( slug ) );
 	const provides = useSelect( ( select ) => select( CORE_MODULES ).getModuleFeatures( slug ) );
 	const module = useSelect( ( select ) => select( CORE_MODULES ).getModule( slug ) );
-	const dashboardURL = useSelect( ( select ) => select( CORE_SITE ).getAdminURL( 'googlesitekit-dashboard' ) );
+	const settingsURL = useSelect( ( select ) => select( CORE_SITE ).getAdminURL( 'googlesitekit-settings' ) );
 	const dialogActive = useSelect( ( select ) => select( CORE_UI ).getValue( dialogActiveKey ) );
 
 	const handleDialog = useCallback( () => {
@@ -85,12 +85,12 @@ export default function ConfirmDisconnect( { slug } ) {
 
 		if ( ! error ) {
 			clearWebStorage();
-			navigateTo( dashboardURL );
+			navigateTo( settingsURL );
 		} else {
 			// Only set deactivating to false if there is an error.
 			setIsDeactivating( false );
 		}
-	}, [ slug, module?.forceActive, dashboardURL, deactivateModule, navigateTo ] );
+	}, [ slug, module?.forceActive, settingsURL, deactivateModule, navigateTo ] );
 
 	if ( ! module || ! dialogActive ) {
 		return null;


### PR DESCRIPTION
## Summary

Update to redirect to the settings page after a module is disconnected.

Addresses issue #3393

## Relevant technical choices

## Checklist

- [X] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [X] I have added a QA Brief on the issue linked above.
- [X] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
