### PR TITLE
Don't output a button tag when href/to + onClick is set in the Link component

### DIFF
--- a/assets/js/components/Link.js
+++ b/assets/js/components/Link.js
@@ -54,8 +54,9 @@ function Link( {
 	...otherProps
 } ) {
 	const getType = () => {
-		// Force button element if `onClick` prop is passed.
-		if ( onClick ) {
+		// Force button element if `onClick` prop is passed and there's no `href`
+		// or `to` prop.
+		if ( ! href && ! to && onClick ) {
 			if ( disabled ) {
 				return BUTTON_DISABLED;
 			}

--- a/assets/js/components/Link.test.js
+++ b/assets/js/components/Link.test.js
@@ -90,13 +90,25 @@ describe( 'Link', () => {
 			expect( container.firstChild.tagName ).toEqual( 'A' );
 		} );
 
+		it( 'creates an <a> attribute even when an onClick prop is supplied', () => {
+			const { container } = render( <Link href="/" onClick={ () => {} }>text content</Link> );
+
+			expect( container.firstChild.tagName ).toEqual( 'A' );
+		} );
+
 		it( 'creates an <a> attribute when using React Router', () => {
 			const { container } = render( <Link to="/">text content</Link> );
 
 			expect( container.firstChild.tagName ).toEqual( 'A' );
 		} );
 
-		it( 'creates a <button> tag when `onClick` is set', () => {
+		it( 'creates an <a> attribute when using React Router, even when an onClick prop is supplied', () => {
+			const { container } = render( <Link to="/" onClick={ () => {} }>text content</Link> );
+
+			expect( container.firstChild.tagName ).toEqual( 'A' );
+		} );
+
+		it( 'creates a <button> tag when no `href` or `to` prop exists, but `onClick` is set', () => {
 			const { container } = render( <Link onClick={ () => {} }>text content</Link> );
 
 			expect( container.firstChild.tagName ).toEqual( 'BUTTON' );


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #3719, specifically the comment in https://github.com/google/site-kit-wp/issues/3713#issuecomment-880728616

## Relevant technical choices

Looks like the React Router PR forced any `<Link>` tag with an `onClick` to be a `button` tag, which isn't correct. This fixes that 🙂 

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
