### PR TITLE
Remove unused propType declaration (3685).

### DIFF
--- a/assets/js/components/legacy-setup/wizard-step-authentication.js
+++ b/assets/js/components/legacy-setup/wizard-step-authentication.js
@@ -97,7 +97,6 @@ class WizardStepAuthentication extends Component {
 
 WizardStepAuthentication.propTypes = {
 	connectURL: PropTypes.string.isRequired,
-	helpVisibilityEnabled: PropTypes.bool,
 	resetAndRestart: PropTypes.func,
 };
 


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #3685
See https://github.com/google/site-kit-wp/issues/3685#issuecomment-881279334

## Relevant technical choices

<!-- Please describe your changes. -->

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
