### PR TITLE
Dismissing Idea Hub widget CTA results in a blank space (3722).

### DIFF
--- a/assets/js/modules/idea-hub/components/dashboard/DashboardCTA.js
+++ b/assets/js/modules/idea-hub/components/dashboard/DashboardCTA.js
@@ -44,7 +44,7 @@ const { useSelect, useDispatch } = Data;
 
 const DISMISS_ITEM_IDEA_HUB_CTA = 'idea-hub-cta';
 
-function DashboardCTA( { Widget } ) {
+function DashboardCTA( { Widget, WidgetNull } ) {
 	const { connected, active } = useSelect( ( select ) => select( CORE_MODULES ).getModule( 'idea-hub' ) );
 	const dismissed = useSelect( ( select ) => select( CORE_USER ).isItemDismissed( DISMISS_ITEM_IDEA_HUB_CTA ) );
 
@@ -72,7 +72,7 @@ function DashboardCTA( { Widget } ) {
 
 	// Don't render this component if it has been dismissed or dismissed items aren't loaded yet.
 	if ( dismissed || dismissed === undefined ) {
-		return null;
+		return <WidgetNull />;
 	}
 
 	return (


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #3722

**Before**

https://user-images.githubusercontent.com/8496063/126311602-a11d151e-af4b-4374-a34c-657d4e380aca.mp4


**After**

https://user-images.githubusercontent.com/8496063/126311608-2d384eaa-7ccb-4028-9c79-a7c13e5f4ac8.mp4




## Relevant technical choices

<!-- Please describe your changes. -->

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
