### PR TITLE
Use the activateModule action to activate module.

### DIFF
--- a/assets/js/components/notifications/IdeaHubModuleNotification.js
+++ b/assets/js/components/notifications/IdeaHubModuleNotification.js
@@ -28,6 +28,8 @@ import { useCallback } from '@wordpress/element';
 import Data from 'googlesitekit-data';
 import { CORE_MODULES } from '../../googlesitekit/modules/datastore/constants';
 import { CORE_USER } from '../../googlesitekit/datastore/user/constants';
+import { CORE_LOCATION } from '../../googlesitekit/datastore/location/constants';
+import { CORE_SITE } from '../../googlesitekit/datastore/site/constants';
 import { MODULES_IDEA_HUB } from '../../modules/idea-hub/datastore/constants';
 import Notification from '../legacy-notifications/notification';
 import IdeaHubNotificationSVG from '../../../svg/idea-hub-notification.svg';
@@ -37,6 +39,9 @@ const NOTIFICATION_ID = 'idea-hub-module-notification';
 
 const IdeaHubModuleNotification = () => {
 	const { dismissItem } = useDispatch( CORE_USER );
+	const { activateModule } = useDispatch( CORE_MODULES );
+	const { navigateTo } = useDispatch( CORE_LOCATION );
+	const { setInternalServerError } = useDispatch( CORE_SITE );
 
 	const isActive = useSelect( ( select ) => select( CORE_MODULES ).isModuleActive( 'idea-hub' ) );
 	const isItemDismissed = useSelect( ( select ) => select( CORE_USER ).isItemDismissed( NOTIFICATION_ID ) );
@@ -45,6 +50,20 @@ const IdeaHubModuleNotification = () => {
 	const handleOnDismiss = useCallback( async () => {
 		await dismissItem( NOTIFICATION_ID );
 	}, [ dismissItem ] );
+
+	const handleOnCTAClick = useCallback( async ( event ) => {
+		event.preventDefault();
+		const { error, response } = await activateModule( 'idea-hub' );
+
+		if ( ! error ) {
+			navigateTo( response.moduleReauthURL );
+		} else {
+			setInternalServerError( {
+				id: 'idea-hub-setup-error',
+				description: error.message,
+			} );
+		}
+	}, [ activateModule, navigateTo, setInternalServerError ] );
 
 	if ( isActive || isActive === undefined || isItemDismissed || isItemDismissed === undefined ) {
 		return null;
@@ -62,6 +81,7 @@ const IdeaHubModuleNotification = () => {
 			type="win-success"
 			dismiss={ __( 'Dismiss', 'google-site-kit' ) }
 			onDismiss={ handleOnDismiss }
+			onCTAClick={ handleOnCTAClick }
 		/>
 	);
 };


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #3523 

## Relevant technical choices
* Using the `getAdminReauthURL` selector is not enough to get the auth url for a module, rather `activateModule` must be dispatched.

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
