### PR TITLE
Show ellipsis instead of overflowing text in select.

### DIFF
--- a/assets/sass/vendor/_mdc-select.scss
+++ b/assets/sass/vendor/_mdc-select.scss
@@ -9,6 +9,8 @@
 	@include mdc-select-focused-outline-color($c-input);
 	@include mdc-select-focused-bottom-line-color($c-border-brand);
 
+	max-width: 100%;
+
 	&--minimal {
 		background-color: transparent;
 		background-position: right center;
@@ -22,6 +24,12 @@
 		&::before {
 			background-color: transparent;
 		}
+	}
+
+	.mdc-select__selected-text {
+		display: block;
+		overflow: hidden;
+		text-overflow: ellipsis;
 	}
 
 	// Overriding WordPress load-styles.php


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #3497


**Before**

![iphone5](https://user-images.githubusercontent.com/8496063/126302447-f41c9665-92a3-41c4-be5c-28da2eaefdea.png)


**After**

![after](https://user-images.githubusercontent.com/8496063/126302468-0c1dbce8-bdb2-4d85-a9cf-f5f203dd05fa.png)


## Relevant technical choices

<!-- Please describe your changes. -->

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
