### PR TITLE
Fix some Google charts in Safari with new date utility

### DIFF
--- a/assets/js/modules/adsense/util/site-stats-data.js
+++ b/assets/js/modules/adsense/util/site-stats-data.js
@@ -29,7 +29,7 @@ import { __, _x, sprintf } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { getLocale, numFmt, getChartDifferenceArrow } from '../../../util';
+import { getLocale, numFmt, getChartDifferenceArrow, stringToDate } from '../../../util';
 import { adsenseDateToInstance } from './date';
 
 /**
@@ -60,7 +60,6 @@ export function getSiteStatsDataForGoogleChart( current, previous, label, select
 		next.setDate( date.getDate() + 1 );
 		return next;
 	};
-	const stringToDate = ( dateString ) => new Date( `${ dateString } 00:00:00` );
 	const findRowByDate = ( searchDate ) => ( row ) => searchDate.getTime() === stringToDate( row.cells[ 0 ].value ).getTime();
 
 	let currentDate = adsenseDateToInstance( current.startDate );

--- a/assets/js/modules/search-console/util/site-stats-data.js
+++ b/assets/js/modules/search-console/util/site-stats-data.js
@@ -30,7 +30,7 @@ import { __, _x, sprintf } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { getLocale, numFmt, calculateChange, getChartDifferenceArrow } from '../../../util';
-import { getPreviousDate } from '../../../util/date-range/get-previous-date';
+import { getPreviousDate, stringToDate } from '../../../util/date-range';
 
 /**
  * Gets data for a Google chart from a Search Console report.
@@ -55,7 +55,6 @@ export const getSiteStatsDataForGoogleChart = ( current, previous, label, select
 		],
 	];
 
-	const stringToDate = ( dateString ) => new Date( `${ dateString } 00:00:00` );
 	const locale = getLocale();
 	const localeDateOptions = {
 		weekday: 'short',
@@ -93,7 +92,7 @@ export const getSiteStatsDataForGoogleChart = ( current, previous, label, select
 		);
 
 		dataMap.push( [
-			new Date( stringToDate( currentDate ) ),
+			stringToDate( currentDate ),
 			`<div class="${ classnames( 'googlesitekit-visualization-tooltip', {
 				'googlesitekit-visualization-tooltip--up': difference > 0,
 				'googlesitekit-visualization-tooltip--down': difference < 0,

--- a/assets/js/util/date-range/index.js
+++ b/assets/js/util/date-range/index.js
@@ -28,3 +28,4 @@ export { isValidDateRange } from './is-valid-date-range';
 export { isValidDateString } from './is-valid-date-string';
 export { getCurrentDateRangeDayCount } from './get-current-date-range-day-count';
 export { getAvailableDateRanges } from './get-available-date-ranges';
+export { stringToDate } from './string-to-date';

--- a/assets/js/util/date-range/string-to-date.js
+++ b/assets/js/util/date-range/string-to-date.js
@@ -1,0 +1,50 @@
+/**
+ * String to Date utility.
+ *
+ * Site Kit by Google, Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import invariant from 'invariant';
+
+/**
+ * Internal dependencies
+ */
+import { INVALID_DATE_STRING_ERROR } from './constants';
+import { isValidDateString } from './is-valid-date-string';
+
+/**
+ * Converts a valid date string to a Date instance.
+ *
+ * @since n.e.x.t
+ *
+ * @param {string} dateString The date string to parse.
+ * @return {Date} Date instance.
+ */
+export const stringToDate = ( dateString ) => {
+	invariant( isValidDateString( dateString ), INVALID_DATE_STRING_ERROR );
+
+	/**
+	 * Split date into explicit parts rather than pass directly into date constructor
+	 * to avoid timezone issues caused by parsing as UTC. Ensures date is accurate for
+	 * the user's local time, otherwise has a chance to return a different day than was
+	 * passed in depending on timezone.
+	 */
+	const [ year, month, day ] = dateString.split( '-' );
+
+	return new Date( year, month - 1, day );
+};

--- a/assets/js/util/date-range/string-to-date.test.js
+++ b/assets/js/util/date-range/string-to-date.test.js
@@ -1,5 +1,5 @@
 /**
- * `getPreviousDate` utility.
+ * String to Date utility tests.
  *
  * Site Kit by Google, Copyright 2021 Google LLC
  *
@@ -19,22 +19,26 @@
 /**
  * Internal dependencies
  */
-import { getDateString } from './get-date-string';
 import { stringToDate } from './string-to-date';
+import { INVALID_DATE_STRING_ERROR } from './constants';
 
-/**
- * Parses the given date and returns the previous date (daysBefore).
- *
- * @since 1.18.0
- *
- * @param {string} relativeDate Date string (YYYY-MM-DD) to subtract days from.
- * @param {number} daysBefore   Number of days to subtract from relativeDate.
- * @return {string}             The date string (YYYY-MM-DD) for the previous date.
- */
-export const getPreviousDate = ( relativeDate = '', daysBefore ) => {
-	const date = stringToDate( relativeDate );
+describe( 'stringToDate', () => {
+	it.each( [
+		null,
+		NaN,
+		'',
+		'12345',
+		'1900-00-00',
+		'not a date string',
+	] )( 'throws an error when given the invalid date string: %s', ( invalidDateString ) => {
+		expect( () => stringToDate( invalidDateString ) ).toThrow( INVALID_DATE_STRING_ERROR );
+	} );
 
-	date.setDate( date.getDate() - daysBefore );
+	it( 'returns a valid date instance for the given date string', () => {
+		const date = stringToDate( '2019-10-31' );
 
-	return getDateString( date );
-};
+		expect( date.getFullYear() ).toBe( 2019 );
+		expect( date.getMonth() ).toBe( 10 - 1 ); // 0-based month
+		expect( date.getDate() ).toBe( 31 );
+	} );
+} );


### PR DESCRIPTION
## Summary

Addresses issue #3784 

## Relevant technical choices

- Took code that we were already using for parsing our date strings from an existing utility to create the new one we needed

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
