### PR TITLE
Fix error in combineWidgets when no widgets given

### DIFF
--- a/assets/js/googlesitekit/widgets/util/combine-widgets.js
+++ b/assets/js/googlesitekit/widgets/util/combine-widgets.js
@@ -108,6 +108,13 @@ export function combineWidgets(
 	const overrideComponents = [];
 	const gridColumnWidths = [ ...columnWidths ];
 
+	if ( ! widgets?.length ) {
+		return {
+			gridColumnWidths,
+			overrideComponents,
+		};
+	}
+
 	let currentState = null;
 	let currentRowIndex = -1;
 	let columnWidthsBuffer = [];

--- a/assets/js/googlesitekit/widgets/util/combine-widgets.test.js
+++ b/assets/js/googlesitekit/widgets/util/combine-widgets.test.js
@@ -232,4 +232,13 @@ describe( 'combineWidgets', () => {
 			expected
 		);
 	} );
+
+	it( 'works with no widgets', () => {
+		const widgets = [];
+		const widgetStates = [];
+		const layout = getWidgetLayout( widgets, widgetStates );
+		expect( () =>
+			combineWidgets( widgets, widgetStates, layout )
+		).not.toThrow();
+	} );
 } );

--- a/assets/js/googlesitekit/widgets/util/get-widget-layout.js
+++ b/assets/js/googlesitekit/widgets/util/get-widget-layout.js
@@ -119,12 +119,15 @@ function getNextActiveWidget( offset, widgets, widgetStates ) {
  *                  each active widget.
  */
 export function getWidgetLayout( widgets, widgetStates ) {
-	let counter = 0;
-	let rowIndex = 0;
-
 	let columnWidths = [];
 	const rowIndexes = [];
 
+	if ( ! widgets?.length ) {
+		return { columnWidths, rowIndexes };
+	}
+
+	let counter = 0;
+	let rowIndex = 0;
 	const ascending = ( { counter: a }, { counter: b } ) => a - b;
 	const descending = ( { counter: a }, { counter: b } ) => b - a;
 	const fitIntoRow = ( { counter: width } ) => width <= 12;

--- a/assets/js/googlesitekit/widgets/util/get-widget-layout.test.js
+++ b/assets/js/googlesitekit/widgets/util/get-widget-layout.test.js
@@ -264,4 +264,16 @@ describe( 'getWidgetLayout', () => {
 		expect( columnWidths ).toEqual( expectedColumnWidths );
 		expect( rowIndexes ).toEqual( expectedRowIndexes );
 	} );
+
+	it( 'works with no widgets', () => {
+		const widgets = [];
+		const widgetStates = {};
+
+		const { columnWidths, rowIndexes } = getWidgetLayout(
+			widgets,
+			widgetStates
+		);
+		expect( columnWidths ).toEqual( [] );
+		expect( rowIndexes ).toEqual( [] );
+	} );
 } );


### PR DESCRIPTION
## Summary

Addresses issue #3618

## Relevant technical choices

- See comments below

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
