### PR TITLE
Move Idea Hub widget footer into Widget.Footer - changing height fix 

### DIFF
--- a/assets/sass/components/idea-hub/_googlesitekit-idea-hub-dashboard-ideas-widget.scss
+++ b/assets/sass/components/idea-hub/_googlesitekit-idea-hub-dashboard-ideas-widget.scss
@@ -265,5 +265,9 @@
 
 	.googlesitekit-widget--ideaHubIdeas .googlesitekit-idea-hub__footer {
 		padding: 0;
+
+		.googlesitekit-idea-hub__footer--updated {
+			height: 36px;
+		}
 	}
 }

--- a/assets/sass/components/idea-hub/_googlesitekit-idea-hub-dashboard-ideas-widget.scss
+++ b/assets/sass/components/idea-hub/_googlesitekit-idea-hub-dashboard-ideas-widget.scss
@@ -267,7 +267,7 @@
 		padding: 0;
 
 		.googlesitekit-idea-hub__footer--updated {
-			// Fix the height of the container the same with and without buttons
+			// Fix the height of the container the same with and without buttons.
 			height: $mdc-button-min-height;
 		}
 	}

--- a/assets/sass/components/idea-hub/_googlesitekit-idea-hub-dashboard-ideas-widget.scss
+++ b/assets/sass/components/idea-hub/_googlesitekit-idea-hub-dashboard-ideas-widget.scss
@@ -267,7 +267,8 @@
 		padding: 0;
 
 		.googlesitekit-idea-hub__footer--updated {
-			height: 36px;
+			// Fix the height of the container the same with and without buttons
+			height: $mdc-button-min-height;
 		}
 	}
 }

--- a/assets/sass/components/idea-hub/_googlesitekit-idea-hub-pagination.scss
+++ b/assets/sass/components/idea-hub/_googlesitekit-idea-hub-pagination.scss
@@ -46,7 +46,7 @@
 			background-color: transparent;
 			border-radius: 50%;
 			box-shadow: none;
-			height: 36px;
+			height: $mdc-button-min-height;
 			min-width: 36px;
 			padding: 0;
 			width: 36px;

--- a/assets/sass/config/_variables.scss
+++ b/assets/sass/config/_variables.scss
@@ -232,3 +232,5 @@ $mdc-layout-grid-breakpoints: (
 
 // Base64 images for reuse
 $icon-checked: url("data:image/svg+xml;charset=UTF-8,%3Csvg%20width%3D%2216%22%20height%3D%2212%22%20viewBox%3D%220%200%2016%2012%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cg%20fill%3D%22%23FFF%22%20fill-rule%3D%22evenodd%22%3E%3Cpath%20d%3D%22M0%206.414L1.415%205l5.292%205.292-1.414%201.415z%22%2F%3E%3Cpath%20d%3D%22M14.146.146l1.415%201.414L5.414%2011.707%204%2010.292z%22%2F%3E%3C%2Fg%3E%3C%2Fsvg%3E");
+
+$mdc-button-min-height: 36px;

--- a/assets/sass/vendor/_mdc-button.scss
+++ b/assets/sass/vendor/_mdc-button.scss
@@ -8,7 +8,7 @@
 		@include mdc-button-filled-accessible($c-background-brand);
 		font-family: $f-primary;
 		height: auto;
-		min-height: 36px;
+		min-height: $mdc-button-min-height;
 		padding-bottom: 8px;
 		padding-top: 8px;
 		text-align: center;


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #3773

## Relevant technical choices

**NO QA BRIEF AS IS SECOND ROUND**
-> To QA: Change tabs on Idea Hub widget (where one tab has no ideas) and observe footer height does not jump



**BEFORE**

https://user-images.githubusercontent.com/8496063/128498489-433c57fe-f002-4369-8dd2-73340df4debe.mp4


**AFTER**

https://user-images.githubusercontent.com/8496063/128498510-4ac46c16-4b98-44b3-80e8-88141e51bdaa.mp4




## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
