### PR TITLE
Set all input colors to the same as the notice text.

### DIFF
--- a/assets/sass/components/settings/_googlesitekit-settings-notice.scss
+++ b/assets/sass/components/settings/_googlesitekit-settings-notice.scss
@@ -64,7 +64,7 @@
 		}
 
 		.mdc-floating-label {
-			color: $c-text-notice-info-selected-text;
+			color: $c-text-notice-info;
 		}
 	}
 
@@ -72,7 +72,7 @@
 
 
 		.mdc-text-field__input {
-			color: $c-text-notice-info-selected-text;
+			color: $c-text-notice-info;
 		}
 
 
@@ -94,7 +94,7 @@
 	.mdc-select:not(.mdc-select--disabled) {
 
 		.mdc-select__selected-text {
-			color: $c-text-notice-info-selected-text;
+			color: $c-text-notice-info;
 		}
 
 		.mdc-select__dropdown-icon {


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #

## Relevant technical choices

<!-- Please describe your changes. -->

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
