### PR TITLE
Enhancement/3747 unsave ideas

### DIFF
--- a/assets/js/modules/idea-hub/datastore/idea-state.js
+++ b/assets/js/modules/idea-hub/datastore/idea-state.js
@@ -98,20 +98,18 @@ const fetchPostUpdateIdeaStateStore = createFetchStore( {
 				newIdeas: newIdeas.filter( optOut ),
 				savedIdeas: [ ...savedIdeas, ideaDetails ],
 			};
-		} else if ( idea.saved === false ) {
-			let ideaDetails = savedIdeas.find( optIn );
-			if ( ! ideaDetails ) {
-				ideaDetails = idea;
-			}
-
-			return {
-				...state,
-				newIdeas: [ ...newIdeas, ideaDetails ],
-				savedIdeas: savedIdeas.filter( optOut ),
-			};
 		}
 
-		return state;
+		let ideaDetails = savedIdeas.find( optIn );
+		if ( ! ideaDetails ) {
+			ideaDetails = idea;
+		}
+
+		return {
+			...state,
+			newIdeas: [ ...newIdeas, ideaDetails ],
+			savedIdeas: savedIdeas.filter( optOut ),
+		};
 	},
 } );
 

--- a/includes/Modules/Idea_Hub.php
+++ b/includes/Modules/Idea_Hub.php
@@ -475,13 +475,11 @@ final class Idea_Hub extends Module
 
 				if ( isset( $data['saved'] ) ) {
 					$body->setSaved( filter_var( $data['saved'], FILTER_VALIDATE_BOOLEAN ) );
-					$body->setDismissed( false );
 					$update_mask[] = 'saved';
 				}
 
 				if ( isset( $data['dismissed'] ) ) {
 					$body->setDismissed( filter_var( $data['dismissed'], FILTER_VALIDATE_BOOLEAN ) );
-					$body->setSaved( false );
 					$update_mask[] = 'dismissed';
 				}
 


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #3747

## Relevant technical choices

Currently, when you un-pin an idea it doesn't re-appear in the new ideas list. This happens because the Idea Hub API doesn't return `saved: false` (which is currently expected in our codebase) in its response to the idea state update request. This pr fixes this problem.

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
