### PR TITLE
Add missing dependencies to googlesitekit-idea-hub-notice asset

### DIFF
--- a/includes/Modules/Idea_Hub.php
+++ b/includes/Modules/Idea_Hub.php
@@ -648,6 +648,8 @@ final class Idea_Hub extends Module
 					'src'           => $base_url . 'js/googlesitekit-idea-hub-notice.js',
 					'dependencies'  => array(
 						'googlesitekit-i18n',
+						'googlesitekit-runtime',
+						'googlesitekit-vendor',
 					),
 					'load_contexts' => array( Asset::CONTEXT_ADMIN_POST_EDITOR ),
 				)


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #3827

## Relevant technical choices

<!-- Please describe your changes. -->

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
