### PR TITLE
Enhancement/3773 move idea hub widget footer  hiding when empty fix

### DIFF
--- a/assets/js/googlesitekit/widgets/components/Widget.js
+++ b/assets/js/googlesitekit/widgets/components/Widget.js
@@ -51,9 +51,7 @@ const Widget = ( {
 					<Footer />
 				</div>
 			) }
-			{ placeholderFooter && (
-				<div className="googlesitekit-widget__placeholder-footer" />
-			) }
+			{ placeholderFooter }
 		</div>
 	);
 };

--- a/assets/js/googlesitekit/widgets/components/Widget.js
+++ b/assets/js/googlesitekit/widgets/components/Widget.js
@@ -29,6 +29,7 @@ const Widget = ( {
 	noPadding,
 	Header,
 	Footer,
+	placeholderFooter,
 } ) => {
 	return (
 		<div
@@ -49,6 +50,9 @@ const Widget = ( {
 				<div className="googlesitekit-widget__footer">
 					<Footer />
 				</div>
+			) }
+			{ placeholderFooter && (
+				<div className="googlesitekit-widget__placeholder-footer" />
 			) }
 		</div>
 	);

--- a/assets/js/modules/idea-hub/components/dashboard/DashboardIdeasWidget/index.js
+++ b/assets/js/modules/idea-hub/components/dashboard/DashboardIdeasWidget/index.js
@@ -144,10 +144,18 @@ const DashboardIdeasWidget = ( {
 		);
 	}
 
-	const WrappedFooter = total > 0 ? () => <Footer tab={ activeTab } /> : null;
+	const shouldRenderFooter = total > 0;
+
+	const WrappedFooter = shouldRenderFooter
+		? () => <Footer tab={ activeTab } />
+		: null;
 
 	return (
-		<Widget noPadding Footer={ WrappedFooter }>
+		<Widget
+			noPadding
+			Footer={ WrappedFooter }
+			placeholderFooter={ ! shouldRenderFooter }
+		>
 			<div className="googlesitekit-idea-hub" ref={ ideaHubContainer }>
 				<div className="googlesitekit-idea-hub__header">
 					<h3 className="googlesitekit-idea-hub__title">

--- a/assets/js/modules/idea-hub/components/dashboard/DashboardIdeasWidget/index.js
+++ b/assets/js/modules/idea-hub/components/dashboard/DashboardIdeasWidget/index.js
@@ -105,6 +105,21 @@ const DashboardIdeasWidget = ( {
 		[ setHash, setActiveTabIndex ]
 	);
 
+	// Duplicated from Pagination.js
+	const total = useSelect( ( select ) => {
+		if ( activeTab === 'new-ideas' ) {
+			return select( MODULES_IDEA_HUB ).getNewIdeas()?.length || 0;
+		}
+		if ( activeTab === 'saved-ideas' ) {
+			return select( MODULES_IDEA_HUB ).getSavedIdeas()?.length || 0;
+		}
+		if ( activeTab === 'draft-ideas' ) {
+			return select( MODULES_IDEA_HUB ).getDraftPostIdeas()?.length || 0;
+		}
+
+		return 0;
+	} );
+
 	if (
 		newIdeas?.length === 0 &&
 		savedIdeas?.length === 0 &&
@@ -129,7 +144,7 @@ const DashboardIdeasWidget = ( {
 		);
 	}
 
-	const WrappedFooter = () => <Footer tab={ activeTab } />;
+	const WrappedFooter = total > 0 ? () => <Footer tab={ activeTab } /> : null;
 
 	return (
 		<Widget noPadding Footer={ WrappedFooter }>

--- a/assets/js/modules/idea-hub/components/dashboard/DashboardIdeasWidget/index.js
+++ b/assets/js/modules/idea-hub/components/dashboard/DashboardIdeasWidget/index.js
@@ -150,11 +150,15 @@ const DashboardIdeasWidget = ( {
 		? () => <Footer tab={ activeTab } />
 		: null;
 
+	const PlaceholderFooter = ! shouldRenderFooter && (
+		<div style={ { height: 64 } } />
+	);
+
 	return (
 		<Widget
 			noPadding
 			Footer={ WrappedFooter }
-			placeholderFooter={ ! shouldRenderFooter }
+			placeholderFooter={ PlaceholderFooter }
 		>
 			<div className="googlesitekit-idea-hub" ref={ ideaHubContainer }>
 				<div className="googlesitekit-idea-hub__header">

--- a/assets/sass/components/idea-hub/_googlesitekit-idea-hub-dashboard-ideas-widget.scss
+++ b/assets/sass/components/idea-hub/_googlesitekit-idea-hub-dashboard-ideas-widget.scss
@@ -265,10 +265,5 @@
 
 	.googlesitekit-widget--ideaHubIdeas .googlesitekit-idea-hub__footer {
 		padding: 0;
-
-		.googlesitekit-idea-hub__footer--updated {
-			// Fix the height of the container the same with and without buttons.
-			height: $mdc-button-min-height;
-		}
 	}
 }

--- a/assets/sass/components/idea-hub/_googlesitekit-idea-hub-pagination.scss
+++ b/assets/sass/components/idea-hub/_googlesitekit-idea-hub-pagination.scss
@@ -46,7 +46,7 @@
 			background-color: transparent;
 			border-radius: 50%;
 			box-shadow: none;
-			height: $mdc-button-min-height;
+			height: 36px;
 			min-width: 36px;
 			padding: 0;
 			width: 36px;

--- a/assets/sass/config/_variables.scss
+++ b/assets/sass/config/_variables.scss
@@ -232,5 +232,3 @@ $mdc-layout-grid-breakpoints: (
 
 // Base64 images for reuse
 $icon-checked: url("data:image/svg+xml;charset=UTF-8,%3Csvg%20width%3D%2216%22%20height%3D%2212%22%20viewBox%3D%220%200%2016%2012%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cg%20fill%3D%22%23FFF%22%20fill-rule%3D%22evenodd%22%3E%3Cpath%20d%3D%22M0%206.414L1.415%205l5.292%205.292-1.414%201.415z%22%2F%3E%3Cpath%20d%3D%22M14.146.146l1.415%201.414L5.414%2011.707%204%2010.292z%22%2F%3E%3C%2Fg%3E%3C%2Fsvg%3E");
-
-$mdc-button-min-height: 36px;

--- a/assets/sass/vendor/_mdc-button.scss
+++ b/assets/sass/vendor/_mdc-button.scss
@@ -8,7 +8,7 @@
 		@include mdc-button-filled-accessible($c-background-brand);
 		font-family: $f-primary;
 		height: auto;
-		min-height: $mdc-button-min-height;
+		min-height: 36px;
 		padding-bottom: 8px;
 		padding-top: 8px;
 		text-align: center;

--- a/assets/sass/widgets/_widgets.scss
+++ b/assets/sass/widgets/_widgets.scss
@@ -61,6 +61,11 @@
 		}
 	}
 
+	.googlesitekit-widget__placeholder-footer {
+		// Manually set to match existing Footer on idea hub tab
+		height: 64px;
+	}
+
 	.googlesitekit-widget-area--composite & {
 		// Background, shadow, and padding are applied to entire widget area instead.
 		background: transparent;

--- a/assets/sass/widgets/_widgets.scss
+++ b/assets/sass/widgets/_widgets.scss
@@ -61,11 +61,6 @@
 		}
 	}
 
-	.googlesitekit-widget__placeholder-footer {
-		// Manually set to match existing Footer on idea hub tab
-		height: 64px;
-	}
-
 	.googlesitekit-widget-area--composite & {
 		// Background, shadow, and padding are applied to entire widget area instead.
 		background: transparent;


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #

## Relevant technical choices

<!-- Please describe your changes. -->

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
