### PR TITLE
Do not show message if no saved ideas: bug in logic fixed.

### DIFF
--- a/assets/js/components/wp-dashboard/WPDashboardIdeaHub.js
+++ b/assets/js/components/wp-dashboard/WPDashboardIdeaHub.js
@@ -63,7 +63,7 @@ function WPDashboardIdeaHub() {
 		}
 	);
 
-	if ( ! isModuleActive && ! hasSavedIdeas ) {
+	if ( ! isModuleActive || ! hasSavedIdeas ) {
 		return null;
 	}
 


### PR DESCRIPTION
## Summary

Addresses issue #3845

**Before** _tested on a site with no saved ideas_

![before](https://user-images.githubusercontent.com/8496063/129231588-84fe8766-f07e-4bf7-b5a0-75889754b412.png)

**After**

![after](https://user-images.githubusercontent.com/8496063/129231600-d85e47a5-d885-414e-87e8-d260b3d42936.png)

## Relevant technical choices

<!-- Please describe your changes. -->

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
