### PR TITLE
Update the Auto_Ad_Guard class to return true if the autoAdsDisabled …

### DIFF
--- a/includes/Modules/AdSense/Auto_Ad_Guard.php
+++ b/includes/Modules/AdSense/Auto_Ad_Guard.php
@@ -30,9 +30,8 @@ class Auto_Ad_Guard extends Module_Tag_Guard {
 	 */
 	public function can_activate() {
 		$settings = $this->settings->get();
-
 		if ( ! isset( $settings['autoAdsDisabled'] ) ) {
-			return false;
+			return true;
 		}
 
 		if (


### PR DESCRIPTION
…setting is not set.

## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #2681 

## Relevant technical choices

<!-- Please describe your changes. -->

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
