### PR TITLE
Remove left margin on pagination button so that does not collapse.

### DIFF
--- a/assets/sass/components/idea-hub/_googlesitekit-idea-hub-pagination.scss
+++ b/assets/sass/components/idea-hub/_googlesitekit-idea-hub-pagination.scss
@@ -53,6 +53,10 @@
 
 			&:first-child {
 				margin: 0 12px 0 16px;
+
+				@media only screen and (min-width: 961px) and  (max-width: 981px) {
+					margin-right: 0;
+				}
 			}
 
 			&:hover {


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #3838

## Relevant technical choices

<!-- Please describe your changes. -->

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [ ] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
