### PR TITLE
Remove margin from pagination buttons to prevent broken layout.

### DIFF
--- a/assets/sass/components/idea-hub/_googlesitekit-idea-hub-pagination.scss
+++ b/assets/sass/components/idea-hub/_googlesitekit-idea-hub-pagination.scss
@@ -51,10 +51,6 @@
 			padding: 0;
 			width: 36px;
 
-			&:first-child {
-				margin: 0 12px 0 16px;
-			}
-
 			&:hover {
 				background-color: $c-idea-hub-button-hover;
 			}


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #3838 

## Relevant technical choices

<!-- Please describe your changes. -->

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
