### PR TITLE
Adjust verbiage from 'Cancel' to 'Back' where user is presented an expected error message

### DIFF
--- a/assets/js/components/setup/ModuleSetup.js
+++ b/assets/js/components/setup/ModuleSetup.js
@@ -24,7 +24,7 @@ import PropTypes from 'prop-types';
 /**
  * WordPress dependencies
  */
-import { Fragment, useCallback } from '@wordpress/element';
+import { Fragment, useCallback, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -41,6 +41,8 @@ import HelpMenuLink from '../help/HelpMenuLink';
 const { useSelect, useDispatch } = Data;
 
 export default function ModuleSetup( { moduleSlug } ) {
+	const [ cancelButtonText, setCancelButtonText ] = useState( null );
+
 	const { navigateTo } = useDispatch( CORE_LOCATION );
 
 	const settingsPageURL = useSelect( ( select ) =>
@@ -76,6 +78,10 @@ export default function ModuleSetup( { moduleSlug } ) {
 		},
 		[ adminURL, navigateTo ]
 	);
+
+	const failSetup = useCallback( ( buttonText ) => {
+		setCancelButtonText( buttonText );
+	}, [] );
 
 	if ( ! module?.SetupComponent ) {
 		return null;
@@ -126,6 +132,8 @@ export default function ModuleSetup( { moduleSlug } ) {
 											<SetupComponent
 												module={ module }
 												finishSetup={ finishSetup }
+												// another similar callback here
+												failSetup={ failSetup }
 											/>
 										</div>
 									</div>
@@ -145,10 +153,12 @@ export default function ModuleSetup( { moduleSlug } ) {
 													id={ `setup-${ module.slug }-cancel` }
 													href={ settingsPageURL }
 												>
-													{ __(
-														'Cancel',
-														'google-site-kit'
-													) }
+													{ /* default fall back for button text */ }
+													{ cancelButtonText ||
+														__(
+															'Cancel',
+															'google-site-kit'
+														) }
 												</Link>
 											</div>
 										</div>

--- a/assets/js/components/setup/ModuleSetup.js
+++ b/assets/js/components/setup/ModuleSetup.js
@@ -150,7 +150,6 @@ export default function ModuleSetup( { moduleSlug } ) {
 													id={ `setup-${ module.slug }-cancel` }
 													href={ settingsPageURL }
 												>
-													{ /* default fall back for button text */ }
 													{ cancelButtonText ||
 														__(
 															'Cancel',

--- a/assets/js/components/setup/ModuleSetup.js
+++ b/assets/js/components/setup/ModuleSetup.js
@@ -35,7 +35,10 @@ import Header from '../Header';
 import Link from '../Link';
 import { CORE_SITE } from '../../googlesitekit/datastore/site/constants';
 import { CORE_MODULES } from '../../googlesitekit/modules/datastore/constants';
-import { CORE_UI } from '../../googlesitekit/datastore/ui/constants';
+import {
+	CORE_UI,
+	MODULE_SETUP_CANCEL_BUTTON_TEXT,
+} from '../../googlesitekit/datastore/ui/constants';
 import { CORE_LOCATION } from '../../googlesitekit/datastore/location/constants';
 import HelpMenu from '../help/HelpMenu';
 import HelpMenuLink from '../help/HelpMenuLink';
@@ -43,7 +46,7 @@ const { useSelect, useDispatch } = Data;
 
 export default function ModuleSetup( { moduleSlug } ) {
 	const cancelButtonText = useSelect( ( select ) =>
-		select( CORE_UI ).getValue( 'cancelButtonText' )
+		select( CORE_UI ).getValue( MODULE_SETUP_CANCEL_BUTTON_TEXT )
 	);
 
 	const { navigateTo } = useDispatch( CORE_LOCATION );

--- a/assets/js/components/setup/ModuleSetup.js
+++ b/assets/js/components/setup/ModuleSetup.js
@@ -24,7 +24,7 @@ import PropTypes from 'prop-types';
 /**
  * WordPress dependencies
  */
-import { Fragment, useCallback, useState } from '@wordpress/element';
+import { Fragment, useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -35,13 +35,16 @@ import Header from '../Header';
 import Link from '../Link';
 import { CORE_SITE } from '../../googlesitekit/datastore/site/constants';
 import { CORE_MODULES } from '../../googlesitekit/modules/datastore/constants';
+import { CORE_UI } from '../../googlesitekit/datastore/ui/constants';
 import { CORE_LOCATION } from '../../googlesitekit/datastore/location/constants';
 import HelpMenu from '../help/HelpMenu';
 import HelpMenuLink from '../help/HelpMenuLink';
 const { useSelect, useDispatch } = Data;
 
 export default function ModuleSetup( { moduleSlug } ) {
-	const [ cancelButtonText, setCancelButtonText ] = useState( null );
+	const cancelButtonText = useSelect( ( select ) =>
+		select( CORE_UI ).getValue( 'cancelButtonText' )
+	);
 
 	const { navigateTo } = useDispatch( CORE_LOCATION );
 
@@ -78,10 +81,6 @@ export default function ModuleSetup( { moduleSlug } ) {
 		},
 		[ adminURL, navigateTo ]
 	);
-
-	const failSetup = useCallback( ( buttonText ) => {
-		setCancelButtonText( buttonText );
-	}, [] );
 
 	if ( ! module?.SetupComponent ) {
 		return null;
@@ -132,8 +131,6 @@ export default function ModuleSetup( { moduleSlug } ) {
 											<SetupComponent
 												module={ module }
 												finishSetup={ finishSetup }
-												// another similar callback here
-												failSetup={ failSetup }
 											/>
 										</div>
 									</div>

--- a/assets/js/googlesitekit/datastore/ui/constants.js
+++ b/assets/js/googlesitekit/datastore/ui/constants.js
@@ -17,3 +17,4 @@
  */
 
 export const CORE_UI = 'core/ui';
+export const MODULE_SETUP_CANCEL_BUTTON_TEXT = 'cancelButtonText';

--- a/assets/js/modules/tagmanager/components/setup/SetupMain.js
+++ b/assets/js/modules/tagmanager/components/setup/SetupMain.js
@@ -41,12 +41,13 @@ import {
 } from '../../datastore/constants';
 import { CORE_FORMS } from '../../../../googlesitekit/datastore/forms/constants';
 import { CORE_LOCATION } from '../../../../googlesitekit/datastore/location/constants';
+import { CORE_UI } from '../../../../googlesitekit/datastore/ui/constants';
 import { useExistingTagEffect } from '../../hooks';
 import { AccountCreate, ExistingTagError } from '../common';
 import useGAPropertyIDEffect from '../../hooks/useGAPropertyIDEffect';
-const { useSelect } = Data;
+const { useSelect, useDispatch } = Data;
 
-export default function SetupMain( { finishSetup, failSetup } ) {
+export default function SetupMain( { finishSetup } ) {
 	const accounts = useSelect( ( select ) =>
 		select( MODULES_TAGMANAGER ).getAccounts()
 	);
@@ -73,6 +74,8 @@ export default function SetupMain( { finishSetup, failSetup } ) {
 	);
 	const isCreateAccount = ACCOUNT_CREATE === accountID;
 
+	const { setValue } = useDispatch( CORE_UI );
+
 	// Set the accountID and containerID if there is an existing tag.
 	useExistingTagEffect();
 	// Synchronize the gaPropertyID setting with the singular GA property ID in selected containers.
@@ -80,9 +83,9 @@ export default function SetupMain( { finishSetup, failSetup } ) {
 
 	useEffect( () => {
 		if ( hasExistingTag && hasExistingTagPermission === false ) {
-			failSetup( 'Back' );
+			setValue( 'cancelButtonText', 'Back' );
 		}
-	}, [ hasExistingTag, hasExistingTagPermission, failSetup ] );
+	}, [ hasExistingTag, hasExistingTagPermission, setValue ] );
 
 	let viewComponent;
 	// Here we also check for `hasResolvedAccounts` to prevent showing a different case below

--- a/assets/js/modules/tagmanager/components/setup/SetupMain.js
+++ b/assets/js/modules/tagmanager/components/setup/SetupMain.js
@@ -24,6 +24,7 @@ import PropTypes from 'prop-types';
 /**
  * WordPress dependencies
  */
+import { useEffect } from '@wordpress/element';
 import { _x } from '@wordpress/i18n';
 
 /**
@@ -45,7 +46,7 @@ import { AccountCreate, ExistingTagError } from '../common';
 import useGAPropertyIDEffect from '../../hooks/useGAPropertyIDEffect';
 const { useSelect } = Data;
 
-export default function SetupMain( { finishSetup } ) {
+export default function SetupMain( { finishSetup, failSetup } ) {
 	const accounts = useSelect( ( select ) =>
 		select( MODULES_TAGMANAGER ).getAccounts()
 	);
@@ -77,6 +78,12 @@ export default function SetupMain( { finishSetup } ) {
 	// Synchronize the gaPropertyID setting with the singular GA property ID in selected containers.
 	useGAPropertyIDEffect();
 
+	useEffect( () => {
+		if ( hasExistingTag && hasExistingTagPermission === false ) {
+			failSetup( 'Back' );
+		}
+	}, [ hasExistingTag, hasExistingTagPermission, failSetup ] );
+
 	let viewComponent;
 	// Here we also check for `hasResolvedAccounts` to prevent showing a different case below
 	// when the component initially loads and has yet to start fetching accounts.
@@ -88,6 +95,7 @@ export default function SetupMain( { finishSetup } ) {
 	) {
 		viewComponent = <ProgressBar />;
 	} else if ( hasExistingTag && hasExistingTagPermission === false ) {
+		// when this is rendered, then need to tell parent to change button text
 		viewComponent = <ExistingTagError />;
 	} else if ( isCreateAccount || ! accounts?.length ) {
 		viewComponent = <AccountCreate />;
@@ -112,8 +120,10 @@ export default function SetupMain( { finishSetup } ) {
 
 SetupMain.propTypes = {
 	finishSetup: PropTypes.func,
+	failSetup: PropTypes.func,
 };
 
 SetupMain.defaultProps = {
 	finishSetup: () => {},
+	failSetup: () => {},
 };

--- a/assets/js/modules/tagmanager/components/setup/SetupMain.js
+++ b/assets/js/modules/tagmanager/components/setup/SetupMain.js
@@ -41,7 +41,10 @@ import {
 } from '../../datastore/constants';
 import { CORE_FORMS } from '../../../../googlesitekit/datastore/forms/constants';
 import { CORE_LOCATION } from '../../../../googlesitekit/datastore/location/constants';
-import { CORE_UI } from '../../../../googlesitekit/datastore/ui/constants';
+import {
+	CORE_UI,
+	MODULE_SETUP_CANCEL_BUTTON_TEXT,
+} from '../../../../googlesitekit/datastore/ui/constants';
 import { useExistingTagEffect } from '../../hooks';
 import { AccountCreate, ExistingTagError } from '../common';
 import useGAPropertyIDEffect from '../../hooks/useGAPropertyIDEffect';
@@ -83,7 +86,10 @@ export default function SetupMain( { finishSetup } ) {
 
 	useEffect( () => {
 		if ( hasExistingTag && hasExistingTagPermission === false ) {
-			setValue( 'cancelButtonText', __( 'Back', 'google-site-kit' ) );
+			setValue(
+				MODULE_SETUP_CANCEL_BUTTON_TEXT,
+				__( 'Back', 'google-site-kit' )
+			);
 		}
 	}, [ hasExistingTag, hasExistingTagPermission, setValue ] );
 

--- a/assets/js/modules/tagmanager/components/setup/SetupMain.js
+++ b/assets/js/modules/tagmanager/components/setup/SetupMain.js
@@ -25,7 +25,7 @@ import PropTypes from 'prop-types';
  * WordPress dependencies
  */
 import { useEffect } from '@wordpress/element';
-import { _x } from '@wordpress/i18n';
+import { _x, __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -83,7 +83,7 @@ export default function SetupMain( { finishSetup } ) {
 
 	useEffect( () => {
 		if ( hasExistingTag && hasExistingTagPermission === false ) {
-			setValue( 'cancelButtonText', 'Back' );
+			setValue( 'cancelButtonText', __( 'Back', 'google-site-kit' ) );
 		}
 	}, [ hasExistingTag, hasExistingTagPermission, setValue ] );
 
@@ -98,7 +98,6 @@ export default function SetupMain( { finishSetup } ) {
 	) {
 		viewComponent = <ProgressBar />;
 	} else if ( hasExistingTag && hasExistingTagPermission === false ) {
-		// when this is rendered, then need to tell parent to change button text
 		viewComponent = <ExistingTagError />;
 	} else if ( isCreateAccount || ! accounts?.length ) {
 		viewComponent = <AccountCreate />;

--- a/assets/js/modules/tagmanager/components/setup/SetupMain.js
+++ b/assets/js/modules/tagmanager/components/setup/SetupMain.js
@@ -128,10 +128,8 @@ export default function SetupMain( { finishSetup } ) {
 
 SetupMain.propTypes = {
 	finishSetup: PropTypes.func,
-	failSetup: PropTypes.func,
 };
 
 SetupMain.defaultProps = {
 	finishSetup: () => {},
-	failSetup: () => {},
 };


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #1045

## Relevant technical choices

<!-- Please describe your changes. -->

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
