### PR TITLE
Improve multi-select behaviour by disabling options after the maximum number has been reached.

### DIFF
--- a/assets/js/components/surveys/CurrentSurvey.test.js
+++ b/assets/js/components/surveys/CurrentSurvey.test.js
@@ -147,7 +147,7 @@ describe( 'CurrentSurvey', () => {
 			// Submit button should be enabled if text has been entered.
 			expect(
 				getByRole( 'button', { name: 'Submit' } )
-			).not.toHaveAttribute( 'disabled' );
+			).not.toBeDisabled();
 
 			// Clear and enter input again.
 			fireEvent.change( getByLabelText( 'Write here' ), {
@@ -162,7 +162,7 @@ describe( 'CurrentSurvey', () => {
 			} );
 			expect(
 				getByRole( 'button', { name: 'Submit' } )
-			).not.toHaveAttribute( 'disabled' );
+			).not.toBeDisabled();
 		} );
 
 		it( 'should submit answer in correct shape', async () => {
@@ -260,7 +260,7 @@ describe( 'CurrentSurvey', () => {
 
 			expect(
 				getByRole( 'button', { name: 'Submit' } )
-			).not.toHaveAttribute( 'disabled' );
+			).not.toBeDisabled();
 		} );
 
 		it( 'should disable the "other" text input if "other" is not selected', () => {
@@ -277,7 +277,7 @@ describe( 'CurrentSurvey', () => {
 
 			expect(
 				getByLabelText( `Text input for option Other` )
-			).not.toHaveAttribute( 'disabled' );
+			).not.toBeDisabled();
 
 			// The text input should be disabled again if "other" is not selected.
 			fireEvent.click( getByText( 'Satisfied' ) );
@@ -310,7 +310,7 @@ describe( 'CurrentSurvey', () => {
 
 			expect(
 				getByRole( 'button', { name: 'Submit' } )
-			).not.toHaveAttribute( 'disabled' );
+			).not.toBeDisabled();
 		} );
 
 		it( 'should enforce a maxiumum text input length of 100 characters', () => {
@@ -436,7 +436,7 @@ describe( 'CurrentSurvey', () => {
 
 			expect(
 				getByRole( 'button', { name: 'Submit' } )
-			).not.toHaveAttribute( 'disabled' );
+			).not.toBeDisabled();
 
 			// Ensure the submit button is disabled again when the second item is
 			// un-selected.
@@ -460,9 +460,7 @@ describe( 'CurrentSurvey', () => {
 
 			// This option will be enabled because we still haven't selected the
 			// maximum number of items.
-			expect( getByLabelText( 'Sweetcorn' ) ).not.toHaveAttribute(
-				'disabled'
-			);
+			expect( getByLabelText( 'Sweetcorn' ) ).not.toBeDisabled();
 
 			fireEvent.click( getByLabelText( 'Black Olives' ) );
 
@@ -470,7 +468,7 @@ describe( 'CurrentSurvey', () => {
 			// items have been selected.
 			expect(
 				getByRole( 'button', { name: 'Submit' } )
-			).not.toHaveAttribute( 'disabled' );
+			).not.toBeDisabled();
 
 			// All unselected options should be disabled.
 			expect( getByLabelText( 'Sweetcorn' ) ).toHaveAttribute(
@@ -480,25 +478,15 @@ describe( 'CurrentSurvey', () => {
 
 			// Existing selections should still be enabled, so the user can de-select
 			// them.
-			expect( getByLabelText( 'Pepperoni' ) ).not.toHaveAttribute(
-				'disabled'
-			);
-			expect( getByLabelText( 'Sausage' ) ).not.toHaveAttribute(
-				'disabled'
-			);
-			expect( getByLabelText( 'Mushrooms' ) ).not.toHaveAttribute(
-				'disabled'
-			);
-			expect( getByLabelText( 'Black Olives' ) ).not.toHaveAttribute(
-				'disabled'
-			);
+			expect( getByLabelText( 'Pepperoni' ) ).not.toBeDisabled();
+			expect( getByLabelText( 'Sausage' ) ).not.toBeDisabled();
+			expect( getByLabelText( 'Mushrooms' ) ).not.toBeDisabled();
+			expect( getByLabelText( 'Black Olives' ) ).not.toBeDisabled();
 
 			// Removing a few selected items should enable other options again.
 			fireEvent.click( getByLabelText( 'Mushrooms' ) );
 
-			expect( getByLabelText( 'Sweetcorn' ) ).not.toHaveAttribute(
-				'disabled'
-			);
+			expect( getByLabelText( 'Sweetcorn' ) ).not.toBeDisabled();
 		} );
 
 		it( 'should disable "other" text input unless the "other" option is selected', async () => {
@@ -515,7 +503,7 @@ describe( 'CurrentSurvey', () => {
 			// Ensure the button is not disabled.
 			expect(
 				getByRole( 'button', { name: 'Submit' } )
-			).not.toHaveAttribute( 'disabled' );
+			).not.toBeDisabled();
 
 			// The text input should be disabled because "Other" is not selected.
 			expect(
@@ -527,7 +515,7 @@ describe( 'CurrentSurvey', () => {
 
 			expect(
 				getByLabelText( `Text input for option Other` )
-			).not.toHaveAttribute( 'disabled' );
+			).not.toBeDisabled();
 
 			// Ensure the input is disabled if "Other" is deselected.
 			fireEvent.click( getByText( 'Other' ) );
@@ -562,7 +550,7 @@ describe( 'CurrentSurvey', () => {
 
 			expect(
 				getByRole( 'button', { name: 'Submit' } )
-			).not.toHaveAttribute( 'disabled' );
+			).not.toBeDisabled();
 		} );
 
 		it( 'should limit text input to 100 characters', async () => {

--- a/assets/js/components/surveys/CurrentSurvey.test.js
+++ b/assets/js/components/surveys/CurrentSurvey.test.js
@@ -447,31 +447,58 @@ describe( 'CurrentSurvey', () => {
 			);
 		} );
 
-		it( 'should disable the submit button when the number of options selected is more than `maxChoices`', async () => {
-			const { getByText, getByRole } = render( <CurrentSurvey />, {
+		it( 'should disable other options once the number of options selected equals `maxChoices`', async () => {
+			const { getByLabelText, getByRole } = render( <CurrentSurvey />, {
 				registry,
 			} );
 
 			// Five items selected is too high and shoud cause the sub, button to be
 			// disabled.
-			fireEvent.click( getByText( 'Pepperoni' ) );
-			fireEvent.click( getByText( 'Sausage' ) );
-			fireEvent.click( getByText( 'Mushrooms' ) );
-			fireEvent.click( getByText( 'Black Olives' ) );
-			fireEvent.click( getByText( 'Sweetcorn' ) );
+			fireEvent.click( getByLabelText( 'Pepperoni' ) );
+			fireEvent.click( getByLabelText( 'Sausage' ) );
+			fireEvent.click( getByLabelText( 'Mushrooms' ) );
 
-			expect( getByRole( 'button', { name: 'Submit' } ) ).toHaveAttribute(
+			// This option will be enabled because we still haven't selected the
+			// maximum number of items.
+			expect( getByLabelText( 'Sweetcorn' ) ).not.toHaveAttribute(
 				'disabled'
 			);
 
-			// Removing a few selected items should enable the submit button.
-			fireEvent.click( getByText( 'Mushrooms' ) );
-			fireEvent.click( getByText( 'Sweetcorn' ) );
-			fireEvent.click( getByText( 'Black Olives' ) );
+			fireEvent.click( getByLabelText( 'Black Olives' ) );
 
+			// The submit button should be active even when the maximum number of
+			// items have been selected.
 			expect(
 				getByRole( 'button', { name: 'Submit' } )
 			).not.toHaveAttribute( 'disabled' );
+
+			// All unselected options should be disabled.
+			expect( getByLabelText( 'Sweetcorn' ) ).toHaveAttribute(
+				'disabled'
+			);
+			expect( getByLabelText( 'Other' ) ).toHaveAttribute( 'disabled' );
+
+			// Existing selections should still be enabled, so the user can de-select
+			// them.
+			expect( getByLabelText( 'Pepperoni' ) ).not.toHaveAttribute(
+				'disabled'
+			);
+			expect( getByLabelText( 'Sausage' ) ).not.toHaveAttribute(
+				'disabled'
+			);
+			expect( getByLabelText( 'Mushrooms' ) ).not.toHaveAttribute(
+				'disabled'
+			);
+			expect( getByLabelText( 'Black Olives' ) ).not.toHaveAttribute(
+				'disabled'
+			);
+
+			// Removing a few selected items should enable other options again.
+			fireEvent.click( getByLabelText( 'Mushrooms' ) );
+
+			expect( getByLabelText( 'Sweetcorn' ) ).not.toHaveAttribute(
+				'disabled'
+			);
 		} );
 
 		it( 'should disable "other" text input unless the "other" option is selected', async () => {

--- a/assets/js/components/surveys/SurveyQuestionMultiSelect.js
+++ b/assets/js/components/surveys/SurveyQuestionMultiSelect.js
@@ -165,8 +165,6 @@ const SurveyQuestionMultiSelect = ( {
 									disabled={
 										hasMaximumNumberOfChoices &&
 										! answer.selected
-											? true
-											: undefined
 									}
 									onChange={ () =>
 										handleCheck( answer_ordinal )

--- a/assets/js/components/surveys/SurveyQuestionMultiSelect.js
+++ b/assets/js/components/surveys/SurveyQuestionMultiSelect.js
@@ -19,6 +19,7 @@
 /**
  * External dependencies
  */
+import classnames from 'classnames';
 import PropTypes from 'prop-types';
 import keyBy from 'lodash/keyBy';
 
@@ -158,7 +159,14 @@ const SurveyQuestionMultiSelect = ( {
 						return (
 							<div
 								key={ id }
-								className="googlesitekit-survey__multi-select__choice"
+								className={ classnames(
+									'googlesitekit-survey__multi-select__choice',
+									{
+										'googlesitekit-survey__multi-select__choice--disabled':
+											hasMaximumNumberOfChoices &&
+											! answer.selected,
+									}
+								) }
 							>
 								<Checkbox
 									checked={ answer.selected }

--- a/assets/js/components/surveys/SurveyQuestionMultiSelect.js
+++ b/assets/js/components/surveys/SurveyQuestionMultiSelect.js
@@ -134,14 +134,14 @@ const SurveyQuestionMultiSelect = ( {
 	const totalSelectedValues = Object.values( selectedValues ).filter(
 		( { selected } ) => selected
 	).length;
+
 	const hasLessThanMinChoices = totalSelectedValues < minChoices;
-	const hasMoreThanMaxChoices =
-		maxChoices && totalSelectedValues > maxChoices;
+
+	const hasMaximumNumberOfChoices =
+		maxChoices && totalSelectedValues === maxChoices;
 
 	const isSubmitButtonDisabled =
-		hasEmptySelectedTextValue ||
-		hasLessThanMinChoices ||
-		hasMoreThanMaxChoices;
+		hasEmptySelectedTextValue || hasLessThanMinChoices;
 
 	return (
 		<div className="googlesitekit-survey__multi-select">
@@ -162,6 +162,12 @@ const SurveyQuestionMultiSelect = ( {
 							>
 								<Checkbox
 									checked={ answer.selected }
+									disabled={
+										hasMaximumNumberOfChoices &&
+										! answer.selected
+											? true
+											: undefined
+									}
 									onChange={ () =>
 										handleCheck( answer_ordinal )
 									}

--- a/assets/sass/components/surveys/_googlesitekit-surveys.scss
+++ b/assets/sass/components/surveys/_googlesitekit-surveys.scss
@@ -196,6 +196,14 @@
 					font-size: 12px;
 				}
 			}
+
+			&--disabled {
+				opacity: 0.25;
+
+				:hover {
+					cursor: default;
+				}
+			}
 		}
 	}
 }


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #3761.

## Relevant technical choices

See comment at https://github.com/google/site-kit-wp/issues/3761#issuecomment-902763594. Instead of allowing too many items to be selected and disabling the submit button, we disable options after too many are selected. This is in line with other components and a more reasonable UX.

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
