### PR TITLE
Feature/3338 disable snippet existing tag

### DIFF
--- a/assets/js/modules/tagmanager/hooks/useExistingTagEffect.js
+++ b/assets/js/modules/tagmanager/hooks/useExistingTagEffect.js
@@ -35,6 +35,9 @@ export default function useExistingTagEffect() {
 	const existingTag = useSelect( ( select ) =>
 		select( MODULES_TAGMANAGER ).getExistingTag()
 	);
+	const containerID = useSelect( ( select ) =>
+		select( MODULES_TAGMANAGER ).getContainerID()
+	);
 	const existingTagPermission = useSelect( ( select ) =>
 		select( MODULES_TAGMANAGER ).getTagPermission( existingTag )
 	);
@@ -42,11 +45,15 @@ export default function useExistingTagEffect() {
 		select( MODULES_TAGMANAGER ).hasExistingTagPermission()
 	);
 	// Set the accountID and containerID if there is an existing tag.
-	const { selectAccount, selectContainerByID } = useDispatch(
+	const { selectAccount, selectContainerByID, setUseSnippet } = useDispatch(
 		MODULES_TAGMANAGER
 	);
 	useEffect( () => {
 		( async () => {
+			if ( hasExistingTag && existingTag === containerID ) {
+				// Disable the plugin snippet as we already show the tag via other means.
+				setUseSnippet( false );
+			}
 			if ( hasExistingTag && hasExistingTagPermission ) {
 				await selectAccount( existingTagPermission.accountID );
 				await selectContainerByID( existingTag );
@@ -59,5 +66,7 @@ export default function useExistingTagEffect() {
 		existingTagPermission,
 		selectAccount,
 		selectContainerByID,
+		setUseSnippet,
+		containerID,
 	] );
 }

--- a/assets/js/modules/tagmanager/hooks/useExistingTagEffect.js
+++ b/assets/js/modules/tagmanager/hooks/useExistingTagEffect.js
@@ -51,7 +51,7 @@ export default function useExistingTagEffect() {
 	useEffect( () => {
 		( async () => {
 			if ( hasExistingTag && existingTag === containerID ) {
-				// Disable the plugin snippet as we already show the tag via other means.
+				// Disable the plugin snippet to avoid duplicate tagging.
 				setUseSnippet( false );
 			}
 			if ( hasExistingTag && hasExistingTagPermission ) {

--- a/assets/js/modules/tagmanager/hooks/useExistingTagEffect.test.js
+++ b/assets/js/modules/tagmanager/hooks/useExistingTagEffect.test.js
@@ -38,65 +38,6 @@ describe( 'useExistingTagEffect', () => {
 		registry.dispatch( MODULES_TAGMANAGER ).receiveGetExistingTag( null );
 	} );
 
-	it( 'turns off snippet display when the tag is displayed via a non sitekit method', async () => {
-		const account = factories.accountBuilder();
-		// eslint-disable-next-line sitekit/acronym-case
-		const accountID = account.accountId;
-		const container = factories.containerBuilder( {
-			// eslint-disable-next-line sitekit/acronym-case
-			accountId: account.accountId,
-		} );
-		registry
-			.dispatch( MODULES_TAGMANAGER )
-			.receiveGetAccounts( [ account ] );
-		registry
-			.dispatch( MODULES_TAGMANAGER )
-			.receiveGetContainers( [ container ], { accountID } );
-		registry.dispatch( MODULES_TAGMANAGER ).setAccountID( accountID );
-
-		let rerender;
-		await act(
-			() =>
-				new Promise( async ( resolve ) => {
-					( { rerender } = renderHook( () => useExistingTagEffect(), {
-						registry,
-					} ) );
-					await untilResolved(
-						registry,
-						MODULES_TAGMANAGER
-					).getTagPermission( null );
-					resolve();
-				} )
-		);
-
-		await act(
-			() =>
-				new Promise( async ( resolve ) => {
-					registry
-						.dispatch( MODULES_TAGMANAGER )
-						.receiveGetTagPermission(
-							{ accountID, permission: true },
-							// eslint-disable-next-line sitekit/acronym-case
-							{ containerID: container.publicId }
-						);
-					registry
-						.dispatch( MODULES_TAGMANAGER )
-						// eslint-disable-next-line sitekit/acronym-case
-						.receiveGetExistingTag( container.publicId );
-					await untilResolved(
-						registry,
-						MODULES_TAGMANAGER
-						// eslint-disable-next-line sitekit/acronym-case
-					).getUseSnippet();
-					rerender();
-					resolve();
-				} )
-		);
-
-		expect( registry.select( MODULES_TAGMANAGER ).getUseSnippet() ).toBe(
-			false
-		);
-	} );
 	it( 'sets the accountID and containerID when there is an existing tag with permission', async () => {
 		const account = factories.accountBuilder();
 		// eslint-disable-next-line sitekit/acronym-case
@@ -179,5 +120,8 @@ describe( 'useExistingTagEffect', () => {
 			registry.select( MODULES_TAGMANAGER ).getInternalContainerID()
 			// eslint-disable-next-line sitekit/acronym-case
 		).toBe( existingContainer.containerId );
+		expect( registry.select( MODULES_TAGMANAGER ).getUseSnippet() ).toBe(
+			false
+		);
 	} );
 } );


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #3338

## Relevant technical choices

<!-- Please describe your changes. -->

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [ ] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
