### PR TITLE
Show helper text when supplied to survey component

### DIFF
--- a/assets/js/components/surveys/SurveyQuestionOpenText.js
+++ b/assets/js/components/surveys/SurveyQuestionOpenText.js
@@ -74,7 +74,7 @@ const SurveyQuestionOpenText = ( {
 					name={ `survey-opentext-${ instanceID }` }
 					helperText={
 						subtitle ? (
-							<HelperText>{ subtitle }</HelperText>
+							<HelperText persistent>{ subtitle }</HelperText>
 						) : undefined
 					}
 					onChange={ onChange }

--- a/assets/js/components/surveys/SurveyQuestionOpenText.js
+++ b/assets/js/components/surveys/SurveyQuestionOpenText.js
@@ -71,8 +71,12 @@ const SurveyQuestionOpenText = ( {
 					<label htmlFor={ instanceID }>{ placeholder }</label>
 				</VisuallyHidden>
 				<TextField
-					name="open-text"
-					helperText={ <HelperText>{ subtitle }</HelperText> }
+					name={ `survey-opentext-${ instanceID }` }
+					helperText={
+						subtitle ? (
+							<HelperText>{ subtitle }</HelperText>
+						) : undefined
+					}
 					onChange={ onChange }
 					label={ placeholder }
 					noLabel

--- a/assets/sass/components/surveys/_googlesitekit-surveys.scss
+++ b/assets/sass/components/surveys/_googlesitekit-surveys.scss
@@ -60,10 +60,6 @@
 		.mdc-text-field-helper-line {
 			padding-left: 0;
 		}
-
-		.mdc-text-field-helper-text {
-			opacity: 1;
-		}
 	}
 
 	.googlesitekit-survey__choices {

--- a/assets/sass/components/surveys/_googlesitekit-surveys.scss
+++ b/assets/sass/components/surveys/_googlesitekit-surveys.scss
@@ -17,16 +17,17 @@
  */
 
 .googlesitekit-plugin {
-
 	.googlesitekit-survey {
 		background-color: $c-white;
 		border-radius: 8px;
 		// The following is the same shadow used by surveys in
 		// other Google services so we're using the same style here.
-		box-shadow: rgb(0 0 0 / 14%) 0 16px 24px 2px, rgb(0 0 0 / 12%) 0 6px 30px 5px, rgb(0 0 0 / 20%) 0 8px 10px -5px;
+		box-shadow: rgb( 0 0 0 / 14% ) 0 16px 24px 2px,
+			rgb( 0 0 0 / 12% ) 0 6px 30px 5px,
+			rgb( 0 0 0 / 20% ) 0 8px 10px -5px;
 		max-width: 400px;
 
-		@media (max-width: $bp-xsmallOnly) {
+		@media ( max-width: $bp-xsmallOnly ) {
 			max-width: none;
 		}
 	}
@@ -35,13 +36,12 @@
 		padding: 0 0 $grid-gap-phone;
 		position: relative;
 
-		@media (min-width: $bp-desktop) {
+		@media ( min-width: $bp-desktop ) {
 			padding-bottom: $grid-gap-desktop;
 		}
 	}
 
 	.googlesitekit-survey__open-text {
-
 		.googlesitekit-survey__body {
 			align-items: center;
 			display: flex;
@@ -56,6 +56,10 @@
 
 		.mdc-text-field-helper-line {
 			padding-left: 0;
+		}
+
+		.mdc-text-field-helper-text {
+			opacity: 1;
 		}
 	}
 
@@ -76,7 +80,7 @@
 		position: relative;
 		text-align: right;
 
-		@media (min-width: $bp-desktop) {
+		@media ( min-width: $bp-desktop ) {
 			padding: 0 $grid-gap-desktop $grid-gap-desktop;
 		}
 
@@ -94,7 +98,7 @@
 			margin: 0;
 			padding-top: 12px;
 
-			@media (min-width: $bp-desktop) {
+			@media ( min-width: $bp-desktop ) {
 				margin: 0 0 -12px;
 			}
 
@@ -106,7 +110,6 @@
 	}
 
 	.googlesitekit-survey__choice {
-
 		p {
 			color: $c-boulder;
 			font-family: $f-primary;
@@ -123,35 +126,34 @@
 		&:first-child {
 			margin-left: 8px;
 
-			@media (min-width: $bp-desktop) {
+			@media ( min-width: $bp-desktop ) {
 				margin-left: 15px;
 			}
 
 			p {
-				transform: translateX(9px);
+				transform: translateX( 9px );
 			}
 		}
 
 		&:last-child {
 			margin-right: 7px;
 
-			@media (min-width: $bp-desktop) {
+			@media ( min-width: $bp-desktop ) {
 				margin-right: 17px;
 			}
 
 			p {
-				transform: translateX(-9px);
+				transform: translateX( -9px );
 			}
 		}
 
-		&:not(:first-child):not(:last-child) {
-
+		&:not( :first-child ):not( :last-child ) {
 			p {
 				display: none;
 			}
 		}
 
-		.mdc-button:not(:disabled) {
+		.mdc-button:not( :disabled ) {
 			background-color: transparent;
 			border-radius: 50%;
 			box-shadow: none;
@@ -170,12 +172,10 @@
 	}
 
 	.googlesitekit-survey__multi-select {
-
 		.googlesitekit-survey__body {
-
 			padding: $grid-gap-phone;
 
-			@media (min-width: $bp-desktop) {
+			@media ( min-width: $bp-desktop ) {
 				padding: $grid-gap-phone $grid-gap-desktop;
 			}
 		}

--- a/assets/sass/components/surveys/_googlesitekit-surveys.scss
+++ b/assets/sass/components/surveys/_googlesitekit-surveys.scss
@@ -17,14 +17,16 @@
  */
 
 .googlesitekit-plugin {
+
 	.googlesitekit-survey {
 		background-color: $c-white;
 		border-radius: 8px;
 		// The following is the same shadow used by surveys in
 		// other Google services so we're using the same style here.
-		box-shadow: rgb( 0 0 0 / 14% ) 0 16px 24px 2px,
-			rgb( 0 0 0 / 12% ) 0 6px 30px 5px,
-			rgb( 0 0 0 / 20% ) 0 8px 10px -5px;
+		box-shadow:
+			rgb(0 0 0 / 14%) 0 16px 24px 2px,
+			rgb(0 0 0 / 12%) 0 6px 30px 5px,
+			rgb(0 0 0 / 20%) 0 8px 10px -5px;
 		max-width: 400px;
 
 		@media ( max-width: $bp-xsmallOnly ) {
@@ -42,6 +44,7 @@
 	}
 
 	.googlesitekit-survey__open-text {
+
 		.googlesitekit-survey__body {
 			align-items: center;
 			display: flex;
@@ -110,6 +113,7 @@
 	}
 
 	.googlesitekit-survey__choice {
+
 		p {
 			color: $c-boulder;
 			font-family: $f-primary;
@@ -131,7 +135,7 @@
 			}
 
 			p {
-				transform: translateX( 9px );
+				transform: translateX(9px);
 			}
 		}
 
@@ -143,17 +147,18 @@
 			}
 
 			p {
-				transform: translateX( -9px );
+				transform: translateX(-9px);
 			}
 		}
 
-		&:not( :first-child ):not( :last-child ) {
+		&:not(:first-child):not(:last-child) {
+
 			p {
 				display: none;
 			}
 		}
 
-		.mdc-button:not( :disabled ) {
+		.mdc-button:not(:disabled) {
 			background-color: transparent;
 			border-radius: 50%;
 			box-shadow: none;
@@ -172,6 +177,7 @@
 	}
 
 	.googlesitekit-survey__multi-select {
+
 		.googlesitekit-survey__body {
 			padding: $grid-gap-phone;
 

--- a/assets/sass/widgets/_widgets.scss
+++ b/assets/sass/widgets/_widgets.scss
@@ -32,7 +32,7 @@
 	&__header {
 		border-bottom: 1px solid $c-border-light;
 
-		@media (min-width: $bp-tablet) {
+		@media ( min-width: $bp-tablet ) {
 			display: flex;
 			justify-content: space-between;
 		}
@@ -50,9 +50,9 @@
 	&__body,
 	&__footer {
 
-		@each $size in map-keys($mdc-layout-grid-columns) {
+		@each $size in map-keys( $mdc-layout-grid-columns ) {
 
-			@include mdc-layout-grid-media-query_($size) {
+			@include mdc-layout-grid-media-query_( $size ) {
 				$margin: map-get($mdc-layout-grid-default-margin, $size);
 
 				padding: $margin;
@@ -62,7 +62,8 @@
 	}
 
 	.googlesitekit-widget-area--composite & {
-		// Background, shadow, and padding are applied to entire widget area instead.
+		// Background, shadow, and padding are applied to entire widget
+		// area instead.
 		background: transparent;
 		box-shadow: none;
 
@@ -95,7 +96,7 @@
 	.googlesitekit-widget__header--cta {
 		margin: $grid-gap-phone 0 0;
 
-		@media (min-width: $bp-tablet) {
+		@media ( min-width: $bp-tablet ) {
 			margin: 0;
 		}
 
@@ -103,7 +104,7 @@
 			font-size: 15px;
 			font-weight: $fw-primary-normal;
 
-			@media (min-width: $bp-tablet) {
+			@media ( min-width: $bp-tablet ) {
 				font-size: 16px;
 			}
 		}


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #3762.

It turns out we _had_ a subtitle in here but it was being hidden with an odd `opacity: 0` rule. This removes it and makes sure the `HelperText` component isn't rendered _if_ there isn't a `subtitle` prop.

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
