### PR TITLE
Update device icons to remove extra whitespace

### DIFF
--- a/assets/svg/device-size-desktop-icon.svg
+++ b/assets/svg/device-size-desktop-icon.svg
@@ -1,4 +1,4 @@
-<svg name="google-sitekit-device-size-desktop" xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24">
+<svg name="google-sitekit-device-size-desktop" xmlns="http://www.w3.org/2000/svg" height="16" width="16" viewBox="0 4 24 16" >
     <path d="M0 0h24v24H0z" fill="none"/>
     <path d="M20 18c1.1 0 1.99-.9 1.99-2L22 6c0-1.1-.9-2-2-2H4c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2H0v2h24v-2h-4zM4 6h16v10H4V6z" fill="currentColor"/>
 </svg>

--- a/assets/svg/device-size-mobile-icon.svg
+++ b/assets/svg/device-size-mobile-icon.svg
@@ -1,4 +1,4 @@
-<svg name="google-sitekit-device-size-mobile" xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24">
+<svg name="google-sitekit-device-size-mobile" xmlns="http://www.w3.org/2000/svg" width="16" viewBox="5 1 14 22">
   <path d="M0 0h24v24H0z" fill="none"/>
   <path d="M17 1.01L7 1c-1.1 0-2 .9-2 2v18c0 1.1.9 2 2 2h10c1.1 0 2-.9 2-2V3c0-1.1-.9-1.99-2-1.99zM17 19H7V5h10v14z" fill="currentColor"/>
 </svg>


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #3162 

## Relevant technical choices

![image](https://user-images.githubusercontent.com/1621608/130644842-2f381dbc-6082-4bb1-a118-c3b4e621398c.png)
![image](https://user-images.githubusercontent.com/1621608/130644853-cb9cb457-06b0-40f1-b78c-7eb6dbbd0fe2.png)


## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
