### PR TITLE
Always render the same idea hub Footer component regardless of footerText.

### DIFF
--- a/assets/js/modules/idea-hub/components/dashboard/DashboardIdeasWidget/Footer.js
+++ b/assets/js/modules/idea-hub/components/dashboard/DashboardIdeasWidget/Footer.js
@@ -28,14 +28,6 @@ import { Grid, Cell, Row } from '../../../../../material-components';
 import Pagination from './Pagination';
 
 export default function Footer( { tab, footerText } ) {
-	if ( ! footerText ) {
-		return (
-			<div className="googlesitekit-idea-hub__footer">
-				<Pagination tab={ tab } />
-			</div>
-		);
-	}
-
 	return (
 		<Grid className="googlesitekit-idea-hub__footer">
 			<Row>

--- a/assets/js/modules/idea-hub/components/dashboard/DashboardIdeasWidget/index.js
+++ b/assets/js/modules/idea-hub/components/dashboard/DashboardIdeasWidget/index.js
@@ -19,6 +19,7 @@
 /**
  * External dependencies
  */
+import classnames from 'classnames';
 import PropTypes from 'prop-types';
 import Tab from '@material/react-tab';
 import TabBar from '@material/react-tab-bar';
@@ -199,23 +200,33 @@ function DashboardIdeasWidget( props ) {
 		);
 	}
 
-	let WrappedFooter;
-	if ( activeTab === 'new-ideas' ) {
-		WrappedFooter = () => (
-			<Footer
-				tab={ activeTab }
-				footerText={ __( 'Updated every 2-3 days', 'google-site-kit' ) }
-			/>
-		);
-	} else if (
-		( activeTab === 'saved-ideas' && savedIdeas?.length > 0 ) ||
-		( activeTab === 'draft-ideas' && draftIdeas?.length > 0 )
-	) {
-		WrappedFooter = () => <Footer tab={ activeTab } />;
-	}
+	const tabIdeasMap = {
+		'new-ideas': newIdeas,
+		'saved-ideas': savedIdeas,
+		'draft-ideas': draftIdeas,
+	};
+	// The footer should be hidden in zero-states, except for on the new ideas tab.
+	// This is done using a special CSS class rather than conditionally
+	// rendering the component to avoid a layout shift when changing tabs.
+	const hideFooter =
+		'new-ideas' !== activeTab && tabIdeasMap[ activeTab ]?.length === 0;
 
 	return (
-		<Widget noPadding Footer={ WrappedFooter }>
+		<Widget
+			className={ classnames( {
+				'googlesitekit-widget--hidden-footer': hideFooter,
+			} ) }
+			Footer={ () => (
+				<Footer
+					tab={ activeTab }
+					footerText={
+						activeTab === 'new-ideas' &&
+						__( 'Updated every 2-3 days', 'google-site-kit' )
+					}
+				/>
+			) }
+			noPadding
+		>
 			<div className="googlesitekit-idea-hub" ref={ ideaHubContainer }>
 				<div className="googlesitekit-idea-hub__header">
 					<h3 className="googlesitekit-idea-hub__title">

--- a/assets/sass/widgets/_widgets.scss
+++ b/assets/sass/widgets/_widgets.scss
@@ -61,6 +61,12 @@
 		}
 	}
 
+	&--hidden-footer .googlesitekit-widget__footer {
+		// This intentionally uses `visibility` rather than `display`
+		// to preserve content dimensions.
+		visibility: hidden;
+	}
+
 	.googlesitekit-widget-area--composite & {
 		// Background, shadow, and padding are applied to entire widget area instead.
 		background: transparent;


### PR DESCRIPTION
## Summary

Addresses issue #3865 (follow-up)

This PR updates the Idea Hub widget footer to be hidden in zero states in a way that preserves the height of the footer but keeps it invisible. The tradeoff here is that the zero state may appear somewhat uncentered in the widget but it isn't very obvious and better than the layout shift so I think it's acceptable.

Using zero-state for adjacent Search Console widget to ensure its height does not interfere with Idea Hub widget, to show that the height is preserved across tabs by the widget itself.

https://user-images.githubusercontent.com/1621608/130656920-9f1c6489-f43f-4782-9d68-e193ed4fbc39.mp4

https://user-images.githubusercontent.com/1621608/130656930-143f4ff5-d6e4-4076-9fcb-cdd21938aa40.mp4

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
