### PR TITLE
Update adsense earning widget layout on smaller viewports.

### DIFF
--- a/assets/sass/components/global/_googlesitekit-data-block.scss
+++ b/assets/sass/components/global/_googlesitekit-data-block.scss
@@ -34,6 +34,11 @@
 	.googlesitekit-dashboard-adsense-stats & {
 		align-items: flex-end;
 		display: flex;
+
+		@media (max-width: $bp-mobileOnly ) {
+			align-items: normal;
+			flex-direction: column;
+		}
 	}
 
 	&--button {
@@ -103,6 +108,12 @@
 		.googlesitekit-dashboard-adsense-stats & {
 			flex: 0 0 auto;
 			margin-bottom: 2px;
+
+			@media (max-width: $bp-mobileOnly ) {
+				align-items: flex-end;
+				display: flex;
+				justify-content: space-between;
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #3317 

## Relevant technical choices

Added mobile only specific media query to achieve desired layouts using flexbox and related attributes. 

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [ ] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
