### PR TITLE
Update Idea Hub module description with more clear message (3908).

### DIFF
--- a/assets/js/modules/idea-hub/components/dashboard/DashboardIdeasWidget/index.js
+++ b/assets/js/modules/idea-hub/components/dashboard/DashboardIdeasWidget/index.js
@@ -236,7 +236,7 @@ function DashboardIdeasWidget( props ) {
 				<div className="googlesitekit-idea-hub__header">
 					<h3 className="googlesitekit-idea-hub__title">
 						{ __(
-							'Ideas to write about based on unanswered searches',
+							'Ideas to write about, from actual questions people asked on Search',
 							'google-site-kit'
 						) }
 

--- a/assets/js/modules/idea-hub/components/setup/Setup.stories.js
+++ b/assets/js/modules/idea-hub/components/setup/Setup.stories.js
@@ -52,8 +52,7 @@ DefaultSetup.decorators = [
 				slug: 'idea-hub',
 				name: 'Idea Hub',
 				description:
-					"Idea Hub suggests what you can write about next, based on searches that haven't been answered yet",
-				homepage: 'https://www.google.com/webmasters/verification/home',
+					'Idea Hub suggests what you can write about next, from actual questions people asked on Google Search',
 				internal: true,
 				order: 0,
 				active: false,

--- a/includes/Modules/Idea_Hub.php
+++ b/includes/Modules/Idea_Hub.php
@@ -649,7 +649,7 @@ final class Idea_Hub extends Module
 		return array(
 			'slug'        => self::MODULE_SLUG,
 			'name'        => _x( 'Idea Hub', 'Service name', 'google-site-kit' ),
-			'description' => __( "Idea Hub suggests what you can write about next, based on searches that haven't been answered yet", 'google-site-kit' ),
+			'description' => __( 'Idea Hub suggests what you can write about next, from actual questions people asked on Google Search', 'google-site-kit' ),
 			'order'       => 7,
 		);
 	}


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #3908

## Relevant technical choices

Although in the IB I mentioned that it might be a good idea to check the styles on the 'Experimental' badge across different viewports, I found that although the heading text and badge wrap somewhat awkwardly here and there, actually there isn't a particular viewport that can be targeted to make a uniform fix.

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
