### PR TITLE
 Make use of new script_tag and inline_script_tag functions introduced in WP 5.7

### DIFF
--- a/includes/Core/Assets/Assets.php
+++ b/includes/Core/Assets/Assets.php
@@ -250,31 +250,28 @@ final class Assets {
 			$action = 'wp_head';
 		}
 
-		$fonts = sprintf( "'%s'", implode( "','", $font_families ) );
-
-		$fonts_script = sprintf(
-			"
-		
-		WebFontConfig = {
-			google: { families: [%s] }
-		};
-
-		( function() {
-			var wf = document.createElement( 'script' );
-			wf.src = ( 'https:' === document.location.protocol ? 'https' : 'http' ) + '://ajax.googleapis.com/ajax/libs/webfont/1/webfont.js';
-			wf.type = 'text/javascript';
-			wf.async = 'true';
-			var s = document.getElementsByTagName( 'script' )[0];
-			s.parentNode.insertBefore( wf, s );
-		} )();
-
-		",
-			$fonts
-		);
-
 		add_action(
 			$action,
-			function() use ( $fonts_script ) {
+			function() use ( $font_families ) {
+				$fonts_script = sprintf(
+					"
+				
+				WebFontConfig = {
+					google: { families: %s }
+				};
+		
+				( function() {
+					var wf = document.createElement( 'script' );
+					wf.src = ( 'https:' === document.location.protocol ? 'https' : 'http' ) + '://ajax.googleapis.com/ajax/libs/webfont/1/webfont.js';
+					wf.type = 'text/javascript';
+					wf.async = 'true';
+					var s = document.getElementsByTagName( 'script' )[0];
+					s.parentNode.insertBefore( wf, s );
+				} )();
+		
+				",
+					wp_json_encode( $font_families )
+				);
 				BC_Functions::wp_print_inline_script_tag( $fonts_script );
 			}
 		);

--- a/includes/Core/Assets/Assets.php
+++ b/includes/Core/Assets/Assets.php
@@ -253,12 +253,13 @@ final class Assets {
 		add_action(
 			$action,
 			function() use ( $font_families ) {
-				$fonts_script = sprintf(
-					"
+				?>
+				<script>
+
 					WebFontConfig = {
-						google: { families: %s }
+						google: { families: [<?php echo "'" . implode( "','", $font_families ) . "'"; /* phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped */ ?>] }
 					};
-			
+
 					( function() {
 						var wf = document.createElement( 'script' );
 						wf.src = ( 'https:' === document.location.protocol ? 'https' : 'http' ) + '://ajax.googleapis.com/ajax/libs/webfont/1/webfont.js';
@@ -267,10 +268,9 @@ final class Assets {
 						var s = document.getElementsByTagName( 'script' )[0];
 						s.parentNode.insertBefore( wf, s );
 					} )();
-					",
-					wp_json_encode( $font_families )
-				);
-				BC_Functions::wp_print_inline_script_tag( $fonts_script );
+
+				</script>
+				<?php
 			}
 		);
 	}

--- a/includes/Core/Assets/Assets.php
+++ b/includes/Core/Assets/Assets.php
@@ -255,21 +255,19 @@ final class Assets {
 			function() use ( $font_families ) {
 				$fonts_script = sprintf(
 					"
-				
-				WebFontConfig = {
-					google: { families: %s }
-				};
-		
-				( function() {
-					var wf = document.createElement( 'script' );
-					wf.src = ( 'https:' === document.location.protocol ? 'https' : 'http' ) + '://ajax.googleapis.com/ajax/libs/webfont/1/webfont.js';
-					wf.type = 'text/javascript';
-					wf.async = 'true';
-					var s = document.getElementsByTagName( 'script' )[0];
-					s.parentNode.insertBefore( wf, s );
-				} )();
-		
-				",
+					WebFontConfig = {
+						google: { families: %s }
+					};
+			
+					( function() {
+						var wf = document.createElement( 'script' );
+						wf.src = ( 'https:' === document.location.protocol ? 'https' : 'http' ) + '://ajax.googleapis.com/ajax/libs/webfont/1/webfont.js';
+						wf.type = 'text/javascript';
+						wf.async = 'true';
+						var s = document.getElementsByTagName( 'script' )[0];
+						s.parentNode.insertBefore( wf, s );
+					} )();
+					",
 					wp_json_encode( $font_families )
 				);
 				BC_Functions::wp_print_inline_script_tag( $fonts_script );

--- a/includes/Core/Assets/Assets.php
+++ b/includes/Core/Assets/Assets.php
@@ -250,27 +250,32 @@ final class Assets {
 			$action = 'wp_head';
 		}
 
+		$fonts = sprintf( "'%s'", implode( "','", $font_families ) );
+
+		$fonts_script = sprintf(
+			"
+		
+		WebFontConfig = {
+			google: { families: [%s] }
+		};
+
+		( function() {
+			var wf = document.createElement( 'script' );
+			wf.src = ( 'https:' === document.location.protocol ? 'https' : 'http' ) + '://ajax.googleapis.com/ajax/libs/webfont/1/webfont.js';
+			wf.type = 'text/javascript';
+			wf.async = 'true';
+			var s = document.getElementsByTagName( 'script' )[0];
+			s.parentNode.insertBefore( wf, s );
+		} )();
+
+		",
+			$fonts
+		);
+
 		add_action(
 			$action,
-			function() use ( $font_families ) {
-				?>
-				<script>
-
-					WebFontConfig = {
-						google: { families: [<?php echo "'" . implode( "','", $font_families ) . "'"; /* phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped */ ?>] }
-					};
-
-					( function() {
-						var wf = document.createElement( 'script' );
-						wf.src = ( 'https:' === document.location.protocol ? 'https' : 'http' ) + '://ajax.googleapis.com/ajax/libs/webfont/1/webfont.js';
-						wf.type = 'text/javascript';
-						wf.async = 'true';
-						var s = document.getElementsByTagName( 'script' )[0];
-						s.parentNode.insertBefore( wf, s );
-					} )();
-
-				</script>
-				<?php
+			function() use ( $fonts_script ) {
+				BC_Functions::wp_print_inline_script_tag( $fonts_script );
 			}
 		);
 	}

--- a/includes/Core/Authentication/Authentication.php
+++ b/includes/Core/Authentication/Authentication.php
@@ -28,6 +28,7 @@ use WP_REST_Server;
 use WP_REST_Request;
 use WP_REST_Response;
 use Exception;
+use Google\Site_Kit\Core\Util\BC_Functions;
 
 /**
  * Authentication Class.
@@ -980,18 +981,23 @@ final class Authentication {
 							onclick="clearSiteKitAppStorage()"
 						><?php esc_html_e( 'Click here', 'google-site-kit' ); ?></a>
 					</p>
-					<script>
-						function clearSiteKitAppStorage() {
-							if ( localStorage ) {
-								localStorage.clear();
-							}
-							if ( sessionStorage ) {
-								sessionStorage.clear();
-							}
-							document.location = '<?php echo esc_url_raw( $this->get_connect_url() ); ?>';
-						}
-					</script>
 					<?php
+					BC_Functions::wp_print_inline_script_tag(
+						sprintf(
+							"
+							function clearSiteKitAppStorage() {
+								if ( localStorage ) {
+									localStorage.clear();
+								}
+								if ( sessionStorage ) {
+									sessionStorage.clear();
+								}
+								document.location = '%s';
+							}
+							",
+							esc_url_raw( $this->get_connect_url() )
+						)
+					);
 					return ob_get_clean();
 				},
 				'type'            => Notice::TYPE_SUCCESS,

--- a/includes/Core/Modules/Tags/Module_Web_Tag.php
+++ b/includes/Core/Modules/Tags/Module_Web_Tag.php
@@ -43,8 +43,9 @@ abstract class Module_Web_Tag extends Module_Tag implements Blockable_Tag_Interf
 	 * Gets the HTML attributes for a script tag that may potentially require user consent before loading.
 	 *
 	 * @since 1.24.0
+	 * @since n.e.x.t return value updated to be an array.
 	 *
-	 * @return string HTML attributes to add if the tag requires consent to load, or an empty string.
+	 * @return array containing HTML attributes to add if the tag requires consent to load, or an empty array.
 	 */
 	public function get_tag_blocked_on_consent_attribute() {
 		/**
@@ -55,10 +56,13 @@ abstract class Module_Web_Tag extends Module_Tag implements Blockable_Tag_Interf
 		 * @param bool $blocked Whether or not the tag requires user consent to load. Default: false.
 		 */
 		if ( apply_filters( "googlesitekit_{$this->module_slug}_tag_block_on_consent", false ) ) {
-			return ' type="text/plain" data-block-on-consent';
+			return array(
+				'type'                  => 'text/plain',
+				'data-block-on-consent' => true,
+			);
 		}
 
-		return '';
+		return array();
 	}
 
 	/**

--- a/includes/Core/Modules/Tags/Module_Web_Tag.php
+++ b/includes/Core/Modules/Tags/Module_Web_Tag.php
@@ -43,11 +43,32 @@ abstract class Module_Web_Tag extends Module_Tag implements Blockable_Tag_Interf
 	 * Gets the HTML attributes for a script tag that may potentially require user consent before loading.
 	 *
 	 * @since 1.24.0
-	 * @since n.e.x.t return value updated to be an array.
+	 *
+	 * @return string HTML attributes to add if the tag requires consent to load, or an empty string.
+	 */
+	public function get_tag_blocked_on_consent_attribute() {
+		/**
+		 * Filters whether the tag requires user consent before loading.
+		 *
+		 * @since 1.24.0
+		 *
+		 * @param bool $blocked Whether or not the tag requires user consent to load. Default: false.
+		 */
+		if ( apply_filters( "googlesitekit_{$this->module_slug}_tag_block_on_consent", false ) ) {
+			return ' type="text/plain" data-block-on-consent';
+		}
+
+		return '';
+	}
+
+	/**
+	 * Gets the array of HTML attributes for a script tag that may potentially require user consent before loading.
+	 *
+	 * @since n.e.x.t
 	 *
 	 * @return array containing HTML attributes to add if the tag requires consent to load, or an empty array.
 	 */
-	public function get_tag_blocked_on_consent_attribute() {
+	public function get_tag_blocked_on_consent_attribute_array() {
 		/**
 		 * Filters whether the tag requires user consent before loading.
 		 *

--- a/includes/Core/Util/BC_Functions.php
+++ b/includes/Core/Util/BC_Functions.php
@@ -156,7 +156,7 @@ class BC_Functions {
 	 * @param array $attributes Key-value pairs representing `<script>` tag attributes.
 	 * @return string String containing `<script>` opening and closing tags.
 	 */
-	public static function wp_get_script_tag( $attributes ) {
+	protected static function wp_get_script_tag( $attributes ) {
 		return sprintf( "<script %s></script>\n", self::sanitize_attributes( $attributes ) );
 	}
 
@@ -167,7 +167,7 @@ class BC_Functions {
 	 *
 	 * @param array $attributes Key-value pairs representing `<script>` tag attributes.
 	 */
-	public static function wp_print_script_tag( $attributes ) {
+	protected static function wp_print_script_tag( $attributes ) {
 		echo self::wp_get_script_tag( $attributes ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	}
 
@@ -180,7 +180,7 @@ class BC_Functions {
 	 * @param array  $attributes  Optional. Key-value pairs representing `<script>` tag attributes.
 	 * @return string String containing inline JavaScript code wrapped around `<script>` tag.
 	 */
-	public static function wp_get_inline_script_tag( $javascript, $attributes ) {
+	protected static function wp_get_inline_script_tag( $javascript, $attributes ) {
 		$javascript = "\n" . trim( $javascript, "\n\r " ) . "\n";
 		return sprintf( "<script%s>%s</script>\n", self::sanitize_attributes( $attributes ), $javascript );
 	}
@@ -193,7 +193,7 @@ class BC_Functions {
 	 * @param string $javascript Inline JavaScript code.
 	 * @param array  $attributes Optional. Key-value pairs representing `<script>` tag attributes.
 	 */
-	public static function wp_print_inline_script_tag( $javascript, $attributes ) {
+	protected static function wp_print_inline_script_tag( $javascript, $attributes ) {
 		echo self::wp_get_inline_script_tag( $attributes, $javascript ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	}
 }

--- a/includes/Core/Util/BC_Functions.php
+++ b/includes/Core/Util/BC_Functions.php
@@ -132,7 +132,7 @@ class BC_Functions {
 	 * @param array $attributes Key-value pairs representing `<script>` tag attributes.
 	 * @return string String made of sanitized `<script>` tag attributes.
 	 */
-	private static function wp_sanitize_script_attributes( $attributes ) {
+	protected static function wp_sanitize_script_attributes( $attributes ) {
 		$attributes_string = '';
 
 		foreach ( $attributes as $attribute_name => $attribute_value ) {

--- a/includes/Core/Util/BC_Functions.php
+++ b/includes/Core/Util/BC_Functions.php
@@ -124,4 +124,76 @@ class BC_Functions {
 		return false;
 	}
 
+	/**
+	 * Basic implementation of the wp_sanitize_script_attributes function introduced in the WordPress version 5.7.0.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param array $attributes Key-value pairs representing `<script>` tag attributes.
+	 * @return string String made of sanitized `<script>` tag attributes.
+	 */
+	private static function sanitize_attributes( $attributes ) {
+		$attributes_string = '';
+
+		foreach ( $attributes as $attribute_name => $attribute_value ) {
+			if ( is_bool( $attribute_value ) ) {
+				if ( $attribute_value ) {
+					$attributes_string .= ' ' . esc_attr( $attribute_name );
+				}
+			} else {
+				$attributes_string .= sprintf( ' %1$s="%2$s"', esc_attr( $attribute_name ), esc_attr( $attribute_value ) );
+			}
+		}
+
+		return $attributes_string;
+	}
+
+	/**
+	 * A fallback for the wp_get_script_tag function introduced in the WordPress version 5.7.0.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param array $attributes Key-value pairs representing `<script>` tag attributes.
+	 * @return string String containing `<script>` opening and closing tags.
+	 */
+	public static function wp_get_script_tag( $attributes ) {
+		return sprintf( "<script %s></script>\n", self::sanitize_attributes( $attributes ) );
+	}
+
+	/**
+	 * A fallback for the wp_print_script_tag function introduced in the WordPress version 5.7.0.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param array $attributes Key-value pairs representing `<script>` tag attributes.
+	 */
+	public static function wp_print_script_tag( $attributes ) {
+		echo self::wp_get_script_tag( $attributes ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+	}
+
+	/**
+	 * A fallback for the wp_get_inline_script_tag function introduced in the WordPress version 5.7.0.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param string $javascript Inline JavaScript code.
+	 * @param array  $attributes  Optional. Key-value pairs representing `<script>` tag attributes.
+	 * @return string String containing inline JavaScript code wrapped around `<script>` tag.
+	 */
+	public static function wp_get_inline_script_tag( $javascript, $attributes ) {
+		$javascript = "\n" . trim( $javascript, "\n\r " ) . "\n";
+		return sprintf( "<script%s>%s</script>\n", self::sanitize_attributes( $attributes ), $javascript );
+	}
+
+	/**
+	 * A fallback for the wp_get_inline_script_tag function introduced in the WordPress version 5.7.0.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param string $javascript Inline JavaScript code.
+	 * @param array  $attributes Optional. Key-value pairs representing `<script>` tag attributes.
+	 */
+	public static function wp_print_inline_script_tag( $javascript, $attributes ) {
+		echo self::wp_get_inline_script_tag( $attributes, $javascript ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+	}
 }

--- a/includes/Core/Util/BC_Functions.php
+++ b/includes/Core/Util/BC_Functions.php
@@ -132,7 +132,7 @@ class BC_Functions {
 	 * @param array $attributes Key-value pairs representing `<script>` tag attributes.
 	 * @return string String made of sanitized `<script>` tag attributes.
 	 */
-	private static function sanitize_attributes( $attributes ) {
+	private static function wp_sanitize_script_attributes( $attributes ) {
 		$attributes_string = '';
 
 		foreach ( $attributes as $attribute_name => $attribute_value ) {
@@ -157,7 +157,7 @@ class BC_Functions {
 	 * @return string String containing `<script>` opening and closing tags.
 	 */
 	protected static function wp_get_script_tag( $attributes ) {
-		return sprintf( "<script %s></script>\n", self::sanitize_attributes( $attributes ) );
+		return sprintf( "<script %s></script>\n", self::wp_sanitize_script_attributes( $attributes ) );
 	}
 
 	/**
@@ -182,7 +182,7 @@ class BC_Functions {
 	 */
 	protected static function wp_get_inline_script_tag( $javascript, $attributes = array() ) {
 		$javascript = "\n" . trim( $javascript, "\n\r " ) . "\n";
-		return sprintf( "<script%s>%s</script>\n", self::sanitize_attributes( $attributes ), $javascript );
+		return sprintf( "<script%s>%s</script>\n", self::wp_sanitize_script_attributes( $attributes ), $javascript );
 	}
 
 	/**

--- a/includes/Core/Util/BC_Functions.php
+++ b/includes/Core/Util/BC_Functions.php
@@ -180,7 +180,7 @@ class BC_Functions {
 	 * @param array  $attributes  Optional. Key-value pairs representing `<script>` tag attributes.
 	 * @return string String containing inline JavaScript code wrapped around `<script>` tag.
 	 */
-	protected static function wp_get_inline_script_tag( $javascript, $attributes ) {
+	protected static function wp_get_inline_script_tag( $javascript, $attributes = array() ) {
 		$javascript = "\n" . trim( $javascript, "\n\r " ) . "\n";
 		return sprintf( "<script%s>%s</script>\n", self::sanitize_attributes( $attributes ), $javascript );
 	}
@@ -193,7 +193,7 @@ class BC_Functions {
 	 * @param string $javascript Inline JavaScript code.
 	 * @param array  $attributes Optional. Key-value pairs representing `<script>` tag attributes.
 	 */
-	protected static function wp_print_inline_script_tag( $javascript, $attributes ) {
-		echo self::wp_get_inline_script_tag( $attributes, $javascript ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+	protected static function wp_print_inline_script_tag( $javascript, $attributes = array() ) {
+		echo self::wp_get_inline_script_tag( $javascript, $attributes ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	}
 }

--- a/includes/Modules/AdSense/Web_Tag.php
+++ b/includes/Modules/AdSense/Web_Tag.php
@@ -63,7 +63,7 @@ class Web_Tag extends Module_Web_Tag {
 			'crossorigin' => 'anonymous',
 		);
 
-		$adsense_consent_attribute = $this->get_tag_blocked_on_consent_attribute();
+		$adsense_consent_attribute = $this->get_tag_blocked_on_consent_attribute_array();
 
 		$auto_ads_opt = array(
 			'google_ad_client'      => $this->tag_id,

--- a/includes/Modules/AdSense/Web_Tag.php
+++ b/includes/Modules/AdSense/Web_Tag.php
@@ -13,6 +13,7 @@ namespace Google\Site_Kit\Modules\AdSense;
 use Google\Site_Kit\Core\Modules\Tags\Module_Web_Tag;
 use Google\Site_Kit\Core\Util\Method_Proxy_Trait;
 use Google\Site_Kit\Core\Tags\Tag_With_DNS_Prefetch_Trait;
+use Google\Site_Kit\Core\Util\BC_Functions;
 
 /**
  * Class for Web tag.
@@ -52,13 +53,17 @@ class Web_Tag extends Module_Web_Tag {
 		// If we haven't completed the account connection yet, we still insert the AdSense tag
 		// because it is required for account verification.
 
-		printf( "\n<!-- %s -->\n", esc_html__( 'Google AdSense snippet added by Site Kit', 'google-site-kit' ) );
-
-		printf(
-			'<script async src="//pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=%s" crossorigin="anonymous"%s></script>', // // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
-			esc_attr( $this->tag_id ),
-			$this->get_tag_blocked_on_consent_attribute() // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		$adsense_script_src = sprintf(
+			'//pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=%s',
+			esc_attr( $this->tag_id )
 		);
+
+		$adsense_script_attributes = array(
+			'src'         => $adsense_script_src,
+			'crossorigin' => 'anonymous',
+		);
+
+		$adsense_consent_attribute = $this->get_tag_blocked_on_consent_attribute();
 
 		$auto_ads_opt = array(
 			'google_ad_client'      => $this->tag_id,
@@ -74,11 +79,14 @@ class Web_Tag extends Module_Web_Tag {
 
 		$auto_ads_opt_filtered['google_ad_client'] = $this->tag_id;
 
-		printf(
-			'<script>(adsbygoogle = window.adsbygoogle || []).push(%s);</script>',
+		$adsense_inline_script = sprintf(
+			'(adsbygoogle = window.adsbygoogle || []).push(%s);',
 			wp_json_encode( $auto_ads_opt_filtered )
 		);
 
+		printf( "\n<!-- %s -->\n", esc_html__( 'Google AdSense snippet added by Site Kit', 'google-site-kit' ) );
+		BC_Functions::wp_print_script_tag( array_merge( $adsense_script_attributes, $adsense_consent_attribute ) );
+		BC_Functions::wp_print_inline_script_tag( $adsense_inline_script );
 		printf( "\n<!-- %s -->\n", esc_html__( 'End Google AdSense snippet added by Site Kit', 'google-site-kit' ) );
 	}
 

--- a/includes/Modules/Analytics.php
+++ b/includes/Modules/Analytics.php
@@ -1207,7 +1207,11 @@ final class Analytics extends Module
 			<!-- <?php esc_html_e( 'End Google Analytics AMP opt-out snippet added by Site Kit', 'google-site-kit' ); ?> -->
 		<?php else : ?>
 			<!-- <?php esc_html_e( 'Google Analytics opt-out snippet added by Site Kit', 'google-site-kit' ); ?> -->
-			<?php BC_Functions::wp_print_inline_script_tag( sprintf( 'window["ga-disable-%s"] = true;', esc_attr( $property_id ) ) ); ?>
+			<?php
+			BC_Functions::wp_print_inline_script_tag(
+				sprintf( 'window["ga-disable-%s"] = true;', esc_attr( $property_id ) )
+			);
+			?>
 			<?php do_action( 'googlesitekit_analytics_tracking_opt_out', $property_id, $account_id ); ?>
 			<!-- <?php esc_html_e( 'End Google Analytics opt-out snippet added by Site Kit', 'google-site-kit' ); ?> -->
 			<?php

--- a/includes/Modules/Analytics.php
+++ b/includes/Modules/Analytics.php
@@ -61,6 +61,7 @@ use Google\Site_Kit_Dependencies\Google\Service\Exception as Google_Service_Exce
 use Google\Site_Kit_Dependencies\Psr\Http\Message\RequestInterface;
 use WP_Error;
 use Exception;
+use Google\Site_Kit\Core\Util\BC_Functions;
 
 /**
  * Class representing the Analytics module.
@@ -1206,7 +1207,7 @@ final class Analytics extends Module
 			<!-- <?php esc_html_e( 'End Google Analytics AMP opt-out snippet added by Site Kit', 'google-site-kit' ); ?> -->
 		<?php else : ?>
 			<!-- <?php esc_html_e( 'Google Analytics opt-out snippet added by Site Kit', 'google-site-kit' ); ?> -->
-			<script type="text/javascript">window["ga-disable-<?php echo esc_attr( $property_id ); ?>"] = true; </script>
+			<?php BC_Functions::wp_print_inline_script_tag( sprintf( 'window["ga-disable-%s"] = true;', esc_attr( $property_id ) ) ); ?>
 			<?php do_action( 'googlesitekit_analytics_tracking_opt_out', $property_id, $account_id ); ?>
 			<!-- <?php esc_html_e( 'End Google Analytics opt-out snippet added by Site Kit', 'google-site-kit' ); ?> -->
 			<?php

--- a/includes/Modules/Analytics/Advanced_Tracking/Script_Injector.php
+++ b/includes/Modules/Analytics/Advanced_Tracking/Script_Injector.php
@@ -12,6 +12,7 @@ namespace Google\Site_Kit\Modules\Analytics\Advanced_Tracking;
 
 use Google\Site_Kit\Context;
 use Google\Site_Kit\Core\Assets\Manifest;
+use Google\Site_Kit\Core\Util\BC_Functions;
 
 /**
  * Class for injecting JavaScript based on the registered event configurations.
@@ -67,11 +68,15 @@ final class Script_Injector {
 			return;
 		}
 
-		?>
-		<script>
-			var _googlesitekitAnalyticsTrackingData = <?php echo wp_json_encode( array_values( $events ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>;
-			<?php echo $script_content; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
-		</script>
-		<?php
+		$script = sprintf(
+			'
+			var _googlesitekitAnalyticsTrackingData = %s;
+			%s
+			',
+			wp_json_encode( array_values( $events ) ),
+			$script_content
+		);
+
+		BC_Functions::wp_print_inline_script_tag( $script );
 	}
 }

--- a/includes/Modules/Analytics/Advanced_Tracking/Script_Injector.php
+++ b/includes/Modules/Analytics/Advanced_Tracking/Script_Injector.php
@@ -68,15 +68,10 @@ final class Script_Injector {
 			return;
 		}
 
-		$script = sprintf(
-			'
-			var _googlesitekitAnalyticsTrackingData = %s;
-			%s
-			',
-			wp_json_encode( array_values( $events ) ),
-			$script_content
+		$data_var = sprintf(
+			'var _googlesitekitAnalyticsTrackingData = %s;',
+			wp_json_encode( array_values( $events ) )
 		);
-
-		BC_Functions::wp_print_inline_script_tag( $script );
+		BC_Functions::wp_print_inline_script_tag( $data_var . "\n" . $script_content );
 	}
 }

--- a/includes/Modules/Analytics_4.php
+++ b/includes/Modules/Analytics_4.php
@@ -30,6 +30,7 @@ use Google\Site_Kit\Core\REST_API\Exception\Invalid_Datapoint_Exception;
 use Google\Site_Kit\Core\REST_API\Data_Request;
 use Google\Site_Kit\Core\Tags\Guards\Tag_Production_Guard;
 use Google\Site_Kit\Core\Tags\Guards\Tag_Verify_Guard;
+use Google\Site_Kit\Core\Util\BC_Functions;
 use Google\Site_Kit\Core\Util\Debug_Data;
 use Google\Site_Kit\Core\Util\Method_Proxy_Trait;
 use Google\Site_Kit\Modules\Analytics\Settings as Analytics_Settings;
@@ -259,9 +260,7 @@ final class Analytics_4 extends Module
 		if ( ! $measurement_id ) {
 			return;
 		}
-		?>
-		<script type="text/javascript">window["ga-disable-<?php echo esc_attr( $measurement_id ); ?>"] = true; </script>
-		<?php
+		BC_Functions::wp_print_inline_script_tag( sprintf( 'window["ga-disable-%s"] = true;', esc_attr( $measurement_id ) ) );
 
 	}
 

--- a/includes/Modules/Optimize/Web_Tag.php
+++ b/includes/Modules/Optimize/Web_Tag.php
@@ -54,7 +54,7 @@ class Web_Tag extends Module_Web_Tag {
 		);
 
 		printf( "\n<!-- %s -->\n", esc_html__( 'Anti-flicker snippet added by Site Kit', 'google-site-kit' ) );
-		printf( '<style>.async-hide { opacity: 0 !important} </style>' );
+		echo '<style>.async-hide { opacity: 0 !important} </style>';
 		BC_Functions::wp_print_inline_script_tag( $anti_flicker_script );
 		printf( "\n<!-- %s -->\n", esc_html__( 'End Anti-flicker snippet added by Site Kit', 'google-site-kit' ) );
 	}

--- a/includes/Modules/Optimize/Web_Tag.php
+++ b/includes/Modules/Optimize/Web_Tag.php
@@ -13,6 +13,7 @@ namespace Google\Site_Kit\Modules\Optimize;
 use Google\Site_Kit\Core\Modules\Tags\Module_Web_Tag;
 use Google\Site_Kit\Core\Util\Method_Proxy_Trait;
 use Google\Site_Kit\Core\Tags\Tag_With_DNS_Prefetch_Trait;
+use Google\Site_Kit\Core\Util\BC_Functions;
 
 /**
  * Class for Web tag.
@@ -42,16 +43,20 @@ class Web_Tag extends Module_Web_Tag {
 	 * @since 1.39.0
 	 */
 	protected function render() {
-		?>
-		<!-- Anti-flicker snippet added by Site Kit -->
-		<style>.async-hide { opacity: 0 !important} </style>
-		<script>(function(a,s,y,n,c,h,i,d,e){s.className+=' '+y;h.start=1*new Date;
-		h.end=i=function(){s.className=s.className.replace(RegExp(' ?'+y),'')};
-		(a[n]=a[n]||[]).hide=h;setTimeout(function(){i();h.end=null},c);h.timeout=c;
-		})(window,document.documentElement,'async-hide','dataLayer',4000,
-		{'<?php echo esc_js( $this->tag_id ); ?>':true});</script>
-		<!-- End Anti-flicker snippet added by Site Kit -->
-		<?php
+
+		$anti_flicker_script = sprintf(
+			"(function(a,s,y,n,c,h,i,d,e){s.className+=' '+y;h.start=1*new Date;
+			h.end=i=function(){s.className=s.className.replace(RegExp(' ?'+y),'')};
+			(a[n]=a[n]||[]).hide=h;setTimeout(function(){i();h.end=null},c);h.timeout=c;
+			})(window,document.documentElement,'async-hide','dataLayer',4000,
+			{'%s':true});",
+			esc_js( $this->tag_id )
+		);
+
+		printf( "\n<!-- %s -->\n", esc_html__( 'Anti-flicker snippet added by Site Kit', 'google-site-kit' ) );
+		printf( '<style>.async-hide { opacity: 0 !important} </style>' );
+		BC_Functions::wp_print_inline_script_tag( $anti_flicker_script );
+		printf( "\n<!-- %s -->\n", esc_html__( 'End Anti-flicker snippet added by Site Kit', 'google-site-kit' ) );
 	}
 
 }

--- a/includes/Modules/Tag_Manager.php
+++ b/includes/Modules/Tag_Manager.php
@@ -659,7 +659,12 @@ final class Tag_Manager extends Module
 			return;
 		}
 
-		BC_Functions::wp_print_inline_script_tag( sprintf( 'window["ga-disable-%s"] = true;', esc_attr( $ga_property_id ) ) );
+		BC_Functions::wp_print_inline_script_tag(
+			sprintf(
+				'window["ga-disable-%s"] = true;',
+				esc_attr( $ga_property_id )
+			)
+		);
 
 	}
 

--- a/includes/Modules/Tag_Manager.php
+++ b/includes/Modules/Tag_Manager.php
@@ -31,6 +31,7 @@ use Google\Site_Kit\Core\REST_API\Data_Request;
 use Google\Site_Kit\Core\REST_API\Exception\Invalid_Datapoint_Exception;
 use Google\Site_Kit\Core\Tags\Guards\Tag_Production_Guard;
 use Google\Site_Kit\Core\Tags\Guards\Tag_Verify_Guard;
+use Google\Site_Kit\Core\Util\BC_Functions;
 use Google\Site_Kit\Core\Util\Debug_Data;
 use Google\Site_Kit\Core\Util\Method_Proxy_Trait;
 use Google\Site_Kit\Modules\Tag_Manager\AMP_Tag;
@@ -657,9 +658,8 @@ final class Tag_Manager extends Module
 		if ( ! $ga_property_id || $ga_property_id === $property_id ) {
 			return;
 		}
-		?>
-		<script type="text/javascript">window["ga-disable-<?php echo esc_attr( $ga_property_id ); ?>"] = true; </script>
-		<?php
+
+		BC_Functions::wp_print_inline_script_tag( sprintf( 'window["ga-disable-%s"] = true;', esc_attr( $ga_property_id ) ) );
 
 	}
 

--- a/includes/Modules/Tag_Manager/Web_Tag.php
+++ b/includes/Modules/Tag_Manager/Web_Tag.php
@@ -13,6 +13,7 @@ namespace Google\Site_Kit\Modules\Tag_Manager;
 use Google\Site_Kit\Core\Modules\Tags\Module_Web_Tag;
 use Google\Site_Kit\Core\Util\Method_Proxy_Trait;
 use Google\Site_Kit\Core\Tags\Tag_With_DNS_Prefetch_Trait;
+use Google\Site_Kit\Core\Util\BC_Functions;
 
 /**
  * Class for Web tag.
@@ -55,21 +56,27 @@ class Web_Tag extends Module_Web_Tag {
 	 * @since 1.24.0
 	 */
 	protected function render() {
-		?>
-<!-- <?php esc_html_e( 'Google Tag Manager snippet added by Site Kit', 'google-site-kit' ); ?> -->
-<script<?php echo $this->get_tag_blocked_on_consent_attribute(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
-( function( w, d, s, l, i ) {
-	w[l] = w[l] || [];
-	w[l].push( {'gtm.start': new Date().getTime(), event: 'gtm.js'} );
-	var f = d.getElementsByTagName( s )[0],
-		j = d.createElement( s ), dl = l != 'dataLayer' ? '&l=' + l : '';
-	j.async = true;
-	j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
-	f.parentNode.insertBefore( j, f );
-} )( window, document, 'script', 'dataLayer', '<?php echo esc_js( $this->tag_id ); ?>' );
-</script>
-<!-- <?php esc_html_e( 'End Google Tag Manager snippet added by Site Kit', 'google-site-kit' ); ?> -->
-		<?php
+
+		$tag_manager_inline_script = sprintf(
+			"
+			( function( w, d, s, l, i ) {
+				w[l] = w[l] || [];
+				w[l].push( {'gtm.start': new Date().getTime(), event: 'gtm.js'} );
+				var f = d.getElementsByTagName( s )[0],
+					j = d.createElement( s ), dl = l != 'dataLayer' ? '&l=' + l : '';
+				j.async = true;
+				j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
+				f.parentNode.insertBefore( j, f );
+			} )( window, document, 'script', 'dataLayer', '%s' );
+			",
+			esc_js( $this->tag_id )
+		);
+
+		$tag_manager_consent_attribute = $this->get_tag_blocked_on_consent_attribute_array();
+
+		printf( "\n<!-- %s -->\n", esc_html__( 'Google Tag Manager snippet added by Site Kit', 'google-site-kit' ) );
+		BC_Functions::wp_print_inline_script_tag( $tag_manager_inline_script, $tag_manager_consent_attribute );
+		printf( "\n<!-- %s -->\n", esc_html__( 'End Google Tag Manager snippet added by Site Kit', 'google-site-kit' ) );
 	}
 
 	/**

--- a/tests/phpunit/integration/Modules/Analytics/Advanced_Tracking/Script_InjectorTest.php
+++ b/tests/phpunit/integration/Modules/Analytics/Advanced_Tracking/Script_InjectorTest.php
@@ -64,7 +64,7 @@ class Script_InjectorTest extends TestCase {
 		$output = ob_get_clean();
 
 		$expected_json = '[{"action":"test_event_without_metadata","selector":".some-button","on":"click","metadata":null},{"action":"test_event_with_metadata","selector":".a-very-specific-button","on":"click","metadata":{"event_category":"test_event_category"}},{"action":"test_event_onload","on":"DOMContentLoaded","metadata":null,"selector":""}]';
-		$this->assertRegExp( '/^<script?.+>.+<\/script>$/ms', trim( $output ) );
+		$this->assertRegExp( '/<script( [^>]*)?>.+<\/script>/ms', trim( $output ) );
 		$this->assertContains( $expected_json, $output );
 	}
 

--- a/tests/phpunit/integration/Modules/Analytics/Advanced_Tracking/Script_InjectorTest.php
+++ b/tests/phpunit/integration/Modules/Analytics/Advanced_Tracking/Script_InjectorTest.php
@@ -64,7 +64,7 @@ class Script_InjectorTest extends TestCase {
 		$output = ob_get_clean();
 
 		$expected_json = '[{"action":"test_event_without_metadata","selector":".some-button","on":"click","metadata":null},{"action":"test_event_with_metadata","selector":".a-very-specific-button","on":"click","metadata":{"event_category":"test_event_category"}},{"action":"test_event_onload","on":"DOMContentLoaded","metadata":null,"selector":""}]';
-		$this->assertRegExp( '/^<script>.+<\/script>$/ms', trim( $output ) );
+		$this->assertRegExp( '/^<script.+>.+<\/script>$/ms', trim( $output ) );
 		$this->assertContains( $expected_json, $output );
 	}
 

--- a/tests/phpunit/integration/Modules/Analytics/Advanced_Tracking/Script_InjectorTest.php
+++ b/tests/phpunit/integration/Modules/Analytics/Advanced_Tracking/Script_InjectorTest.php
@@ -64,7 +64,7 @@ class Script_InjectorTest extends TestCase {
 		$output = ob_get_clean();
 
 		$expected_json = '[{"action":"test_event_without_metadata","selector":".some-button","on":"click","metadata":null},{"action":"test_event_with_metadata","selector":".a-very-specific-button","on":"click","metadata":{"event_category":"test_event_category"}},{"action":"test_event_onload","on":"DOMContentLoaded","metadata":null,"selector":""}]';
-		$this->assertRegExp( '/^<script.+>.+<\/script>$/ms', trim( $output ) );
+		$this->assertRegExp( '/^<script?.+>.+<\/script>$/ms', trim( $output ) );
 		$this->assertContains( $expected_json, $output );
 	}
 


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #2994

## Relevant technical choices

<!-- Please describe your changes. -->

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
