### PR TITLE
Revert "Remove charts loader."

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -27,3 +27,4 @@
 		document.body.classList.add( 'backstopjs-ready' );
 	} );
 </script>
+<script src="https://www.gstatic.com/charts/loader.js"></script>


### PR DESCRIPTION
This reverts commit 78bb18cdafca0c6746f9342bc0b638290956826b.

## Summary

Addresses issue #3962 

## Relevant technical choices

- Even though we load Google charts via React now, keeping this script tag to "preload" the loader is apparently quite important for Storybook

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
