### PR TITLE
Fully disable adsense module in dashboard when adblock is detected.

### DIFF
--- a/assets/js/components/ModulesList.js
+++ b/assets/js/components/ModulesList.js
@@ -17,24 +17,16 @@
  */
 
 /**
- * External dependencies
- */
-import classnames from 'classnames';
-
-/**
  * WordPress dependencies
  */
 import { useCallback } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
 import { trackEvent } from '../util';
 import Data from 'googlesitekit-data';
-import Link from './Link';
-import ModuleIcon from './ModuleIcon';
-import ModuleSettingsWarning from './legacy-notifications/module-settings-warning';
+import ModulesListItem from './ModulesListItem';
 import { CORE_SITE } from '../googlesitekit/datastore/site/constants';
 import { CORE_MODULES } from '../googlesitekit/modules/datastore/constants';
 import { CORE_LOCATION } from '../googlesitekit/datastore/location/constants';
@@ -95,49 +87,13 @@ function ModulesList( { moduleSlugs } ) {
 		.sort( ( a, b ) => a.order - b.order );
 	return (
 		<div className="googlesitekit-modules-list">
-			{ modulesToShow.map( ( module ) => {
-				const { slug, name, connected, active } = module;
-				const setupComplete = connected && active;
-
-				return (
-					<div
-						key={ slug }
-						className={ classnames(
-							'googlesitekit-modules-list__module',
-							`googlesitekit-modules-list__module--${ slug }`
-						) }
-					>
-						<div className="googlesitekit-settings-connect-module__wrapper">
-							<div className="googlesitekit-settings-connect-module__logo">
-								<ModuleIcon slug={ slug } />
-							</div>
-							<h3 className="googlesitekit-settings-connect-module__title">
-								{ name }
-							</h3>
-						</div>
-						<ModuleSettingsWarning
-							slug={ slug }
-							context="modules-list"
-						/>
-						{ setupComplete && (
-							<span className="googlesitekit-settings-module__status">
-								<span className="googlesitekit-settings-module__status-icon googlesitekit-settings-module__status-icon--connected" />
-								{ __( 'Connected', 'google-site-kit' ) }
-							</span>
-						) }
-						{ ! setupComplete && (
-							<Link
-								onClick={ () => handleSetupModule( slug ) }
-								arrow
-								small
-								inherit
-							>
-								{ __( 'Connect Service', 'google-site-kit' ) }
-							</Link>
-						) }
-					</div>
-				);
-			} ) }
+			{ modulesToShow.map( ( module ) => (
+				<ModulesListItem
+					key={ module.slug }
+					module={ module }
+					handleSetupModule={ handleSetupModule }
+				/>
+			) ) }
 		</div>
 	);
 }

--- a/assets/js/components/ModulesListItem.js
+++ b/assets/js/components/ModulesListItem.js
@@ -58,17 +58,21 @@ const ModulesListItem = ( { module, handleSetupModule } ) => {
 				<div className="googlesitekit-settings-connect-module__logo">
 					<ModuleIcon slug={ slug } />
 				</div>
+
 				<h3 className="googlesitekit-settings-connect-module__title">
 					{ name }
 				</h3>
 			</div>
+
 			<ModuleSettingsWarning slug={ slug } context="modules-list" />
+
 			{ setupComplete && (
 				<span className="googlesitekit-settings-module__status">
 					<span className="googlesitekit-settings-module__status-icon googlesitekit-settings-module__status-icon--connected" />
 					{ __( 'Connected', 'google-site-kit' ) }
 				</span>
 			) }
+
 			{ ! setupComplete && (
 				<Link
 					onClick={ () => handleSetupModule( slug ) }

--- a/assets/js/components/ModulesListItem.js
+++ b/assets/js/components/ModulesListItem.js
@@ -1,5 +1,5 @@
 /**
- * ModulesList component.
+ * ModulesListItem component.
  *
  * Site Kit by Google, Copyright 2021 Google LLC
  *

--- a/assets/js/components/ModulesListItem.js
+++ b/assets/js/components/ModulesListItem.js
@@ -1,0 +1,87 @@
+/**
+ * ModulesList component.
+ *
+ * Site Kit by Google, Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import Link from './Link';
+import ModuleIcon from './ModuleIcon';
+import ModuleSettingsWarning from './legacy-notifications/module-settings-warning';
+import Data from 'googlesitekit-data';
+import { CORE_MODULES } from '../googlesitekit/modules/datastore/constants';
+const { useSelect } = Data;
+
+const ModulesListItem = ( { module, handleSetupModule } ) => {
+	const { slug, name, connected, active } = module;
+	const setupComplete = connected && active;
+
+	const canActivateModule = useSelect( ( select ) =>
+		select( CORE_MODULES ).canActivateModule( slug )
+	);
+
+	return (
+		<div
+			className={ classnames(
+				'googlesitekit-modules-list__module',
+				`googlesitekit-modules-list__module--${ slug }`,
+				{
+					'googlesitekit-settings-connect-module--disabled': ! canActivateModule,
+				}
+			) }
+		>
+			<div className="googlesitekit-settings-connect-module__wrapper">
+				<div className="googlesitekit-settings-connect-module__logo">
+					<ModuleIcon slug={ slug } />
+				</div>
+				<h3 className="googlesitekit-settings-connect-module__title">
+					{ name }
+				</h3>
+			</div>
+			<ModuleSettingsWarning slug={ slug } context="modules-list" />
+			{ setupComplete && (
+				<span className="googlesitekit-settings-module__status">
+					<span className="googlesitekit-settings-module__status-icon googlesitekit-settings-module__status-icon--connected" />
+					{ __( 'Connected', 'google-site-kit' ) }
+				</span>
+			) }
+			{ ! setupComplete && (
+				<Link
+					onClick={ () => handleSetupModule( slug ) }
+					arrow
+					small
+					inherit
+					disabled={ ! canActivateModule }
+				>
+					{ __( 'Connect Service', 'google-site-kit' ) }
+				</Link>
+			) }
+		</div>
+	);
+};
+
+export default ModulesListItem;


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #3721 

## Relevant technical choices

<!-- Please describe your changes. -->

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
