### PR TITLE
Add margin to WP dashboard notice copy (3911).

### DIFF
--- a/assets/js/components/wp-dashboard/WPDashboardIdeaHub.js
+++ b/assets/js/components/wp-dashboard/WPDashboardIdeaHub.js
@@ -116,7 +116,7 @@ function WPDashboardIdeaHub() {
 
 			<div className="googlesitekit-idea-hub__wpdashboard--link">
 				<Link href={ dashboardURL } onClick={ onClick }>
-					{ __( 'View Idea Hub', 'google-site-kit' ) }
+					{ __( 'View Ideas', 'google-site-kit' ) }
 				</Link>
 			</div>
 		</div>

--- a/assets/sass/components/idea-hub/_googlesitekit-idea-hub-wpdashboard-widget.scss
+++ b/assets/sass/components/idea-hub/_googlesitekit-idea-hub-wpdashboard-widget.scss
@@ -42,6 +42,7 @@
 
 	.googlesitekit-idea-hub__wpdashboard--copy {
 		color: map-get($wp-colors, "blue-80");
+		margin-right: 14px;
 	}
 
 	.googlesitekit-idea-hub__wpdashboard--link {


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #3911

## Relevant technical choices
Added margin to the notice copy to improve how it looks on smaller screens.
See discussion on the issue: https://github.com/google/site-kit-wp/issues/3911#issuecomment-913459933

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
