### PR TITLE
Fix bug with determining whether tooltip is open (2659).

### DIFF
--- a/assets/js/modules/analytics/components/dashboard/DashboardAllTrafficWidget/UserDimensionsPieChart.js
+++ b/assets/js/modules/analytics/components/dashboard/DashboardAllTrafficWidget/UserDimensionsPieChart.js
@@ -112,9 +112,9 @@ export default function UserDimensionsPieChart( {
 
 		const isTooltipOpen = () =>
 			// If initial values are set, the tooltip is closed.
-			( ! isNull( activeRowIndex ) || activeRowIndex !== undefined ) &&
-			!! dimensionValue &&
-			!! dimensionColor;
+			! isNull( activeRowIndex ) &&
+			activeRowIndex === undefined &&
+			( !! dimensionValue || !! dimensionColor );
 
 		// When the user hits the 'escape' key and the tooltip is open, close the tooltip.
 		const onEscape = ( event = {} ) => {


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #2659

## Relevant technical choices
The logic around determining if the tooltip was open needed adjustment, because when you are a viewing a given dimension the `dimensionColor` and `dimensionValue` can both be set in Redux even when the tooltip is closed.
I've adjusted the logic to always check if the `activeRowIndex` is set to initial values (can be `null` or `undefined` if unset, but `0` is a valid row), and *either* of the other two is `undefined`.

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
