### PR TITLE
Add Idea Hub events for pagination (3980).

### DIFF
--- a/assets/js/modules/idea-hub/components/dashboard/DashboardIdeasWidget/Pagination.js
+++ b/assets/js/modules/idea-hub/components/dashboard/DashboardIdeasWidget/Pagination.js
@@ -78,7 +78,9 @@ const Pagination = ( { tab } ) => {
 			};
 			const event = eventMap[ direction ][ tab ];
 
-			trackEvent( IDEA_HUB_GA_CATEGORY_WIDGET, event, page );
+			if ( event ) {
+				trackEvent( IDEA_HUB_GA_CATEGORY_WIDGET, event, page );
+			}
 		},
 		[ tab, page ]
 	);
@@ -89,9 +91,10 @@ const Pagination = ( { tab } ) => {
 		( shouldTrackEvent = true ) => {
 			if ( page > 1 ) {
 				setValue( uniqueKey, page - 1 );
-			}
-			if ( shouldTrackEvent ) {
-				trackPage( 'back' );
+
+				if ( shouldTrackEvent ) {
+					trackPage( 'back' );
+				}
 			}
 		},
 		[ page, setValue, uniqueKey, trackPage ]
@@ -100,8 +103,8 @@ const Pagination = ( { tab } ) => {
 	const handleNext = useCallback( () => {
 		if ( page < Math.ceil( total / IDEA_HUB_IDEAS_PER_PAGE ) ) {
 			setValue( uniqueKey, page + 1 );
+			trackPage( 'forward' );
 		}
-		trackPage( 'forward' );
 	}, [ page, setValue, total, uniqueKey, trackPage ] );
 
 	const from = page === 1 ? page : ( page - 1 ) * IDEA_HUB_IDEAS_PER_PAGE + 1;


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #3980

## Relevant technical choices
I deviated from the IB slightly, as when I started implementing this it felt sensible to pull the tracking calls out into a function. 

<!-- Please describe your changes. -->

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
