### PR TITLE
Fix issue: tooltips not being activated by click on pie chart legend (2659).

### DIFF
--- a/assets/js/modules/analytics/components/dashboard/DashboardAllTrafficWidget/UserDimensionsPieChart.js
+++ b/assets/js/modules/analytics/components/dashboard/DashboardAllTrafficWidget/UserDimensionsPieChart.js
@@ -123,9 +123,14 @@ export default function UserDimensionsPieChart( {
 			}
 		};
 
-		// When the use clicks outside of the chart and the tooltip is open, close the tooltip.
-		const onExitClick = () => {
-			if ( isTooltipOpen() ) {
+		// When the use clicks on anything except the legend while the tooltip is open, close the tooltip.
+		const onExitClick = ( event ) => {
+			if (
+				isTooltipOpen() &&
+				! event?.target?.closest(
+					'.googlesitekit-widget--analyticsAllTraffic__legend'
+				)
+			) {
 				closeToolTip();
 			}
 		};


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #2659

## Relevant technical choices

<!-- Please describe your changes. -->

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
