### PR TITLE
Fix dashboard crash when report doesn't contain rows (3880 / 3983).

### DIFF
--- a/assets/js/modules/analytics/components/dashboard/DashboardGoalsWidget.js
+++ b/assets/js/modules/analytics/components/dashboard/DashboardGoalsWidget.js
@@ -161,7 +161,8 @@ function DashboardGoalsWidget( { WidgetReportZero, WidgetReportError } ) {
 		],
 	];
 
-	const dataRows = data[ 0 ].data.rows;
+	const dataRows = data?.[ 0 ]?.data?.rows || [];
+
 	// We only want half the date range, having `multiDateRange` in the query doubles the range.
 	for ( let i = Math.ceil( dataRows.length / 2 ); i < dataRows.length; i++ ) {
 		const { values } = dataRows[ i ].metrics[ 0 ];

--- a/assets/js/modules/analytics/components/dashboard/DashboardSearchVisitorsWidget.js
+++ b/assets/js/modules/analytics/components/dashboard/DashboardSearchVisitorsWidget.js
@@ -171,18 +171,6 @@ function DashboardSearchVisitorsWidget( {
 			{ type: 'number', label: 'Unique Visitors from Search' },
 		],
 	];
-	sparkData[ 0 ].data = {
-		dataLastRefreshed: null,
-		isDataGolden: null,
-		rowCount: null,
-		samplesReadCounts: null,
-		samplingSpaceSizes: null,
-		totals: [
-			{
-				values: [ '0' ],
-			},
-		],
-	};
 
 	const dataRows = sparkData?.[ 0 ]?.data?.rows || [];
 

--- a/assets/js/modules/analytics/components/dashboard/DashboardSearchVisitorsWidget.js
+++ b/assets/js/modules/analytics/components/dashboard/DashboardSearchVisitorsWidget.js
@@ -171,7 +171,20 @@ function DashboardSearchVisitorsWidget( {
 			{ type: 'number', label: 'Unique Visitors from Search' },
 		],
 	];
-	const dataRows = sparkData[ 0 ].data.rows;
+	sparkData[ 0 ].data = {
+		dataLastRefreshed: null,
+		isDataGolden: null,
+		rowCount: null,
+		samplesReadCounts: null,
+		samplingSpaceSizes: null,
+		totals: [
+			{
+				values: [ '0' ],
+			},
+		],
+	};
+
+	const dataRows = sparkData?.[ 0 ]?.data?.rows || [];
 
 	// Loop the rows to build the chart data.
 	for ( let i = 0; i < dataRows.length; i++ ) {


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issues #3880 and #3983

## Relevant technical choices

This bug was raised while #3880 was in QA for the release - I think the work on #3880 exposed an existing issue. This problem (we have a couple of places where report row length isn't checked before we access them) was later identified and raised separately as #3983.

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
