### PR TITLE
 Prevent dashboard feature tours from being triggered during module setup (3187).

### DIFF
--- a/assets/js/googlesitekit-dashboard.js
+++ b/assets/js/googlesitekit-dashboard.js
@@ -31,7 +31,10 @@ import ModuleSetup from './components/setup/ModuleSetup';
 import DashboardApp from './components/dashboard/DashboardApp';
 import NotificationCounter from './components/legacy-notifications/notification-counter';
 import './components/legacy-notifications';
-import { VIEW_CONTEXT_DASHBOARD } from './googlesitekit/constants';
+import {
+	VIEW_CONTEXT_DASHBOARD,
+	VIEW_CONTEXT_MODULE_SETUP,
+} from './googlesitekit/constants';
 
 const GoogleSitekitDashboard = ( { setupModuleSlug } ) => {
 	if ( !! setupModuleSlug ) {
@@ -60,7 +63,13 @@ domReady( () => {
 		const { setupModuleSlug } = renderTarget.dataset;
 
 		render(
-			<Root viewContext={ VIEW_CONTEXT_DASHBOARD }>
+			<Root
+				viewContext={
+					setupModuleSlug
+						? VIEW_CONTEXT_MODULE_SETUP
+						: VIEW_CONTEXT_DASHBOARD
+				}
+			>
 				<GoogleSitekitDashboard setupModuleSlug={ setupModuleSlug } />
 			</Root>,
 			renderTarget

--- a/assets/js/googlesitekit-module.js
+++ b/assets/js/googlesitekit-module.js
@@ -29,7 +29,10 @@ import './components/legacy-notifications';
 import Root from './components/Root';
 import ModuleApp from './components/module/ModuleApp';
 import ModuleSetup from './components/setup/ModuleSetup';
-import { VIEW_CONTEXT_MODULE } from './googlesitekit/constants';
+import {
+	VIEW_CONTEXT_MODULE,
+	VIEW_CONTEXT_MODULE_SETUP,
+} from './googlesitekit/constants';
 
 const GoogleSitekitModule = ( { moduleSlug, setupModuleSlug } ) => {
 	if ( !! setupModuleSlug ) {
@@ -47,7 +50,13 @@ domReady( () => {
 		const { moduleSlug, setupModuleSlug } = renderTarget.dataset;
 
 		render(
-			<Root viewContext={ VIEW_CONTEXT_MODULE }>
+			<Root
+				viewContext={
+					setupModuleSlug
+						? VIEW_CONTEXT_MODULE_SETUP
+						: VIEW_CONTEXT_MODULE
+				}
+			>
 				<GoogleSitekitModule
 					moduleSlug={ moduleSlug }
 					setupModuleSlug={ setupModuleSlug }

--- a/assets/js/googlesitekit/constants.js
+++ b/assets/js/googlesitekit/constants.js
@@ -26,3 +26,4 @@ export const VIEW_CONTEXT_ADMIN_BAR = 'adminBar';
 export const VIEW_CONTEXT_SETTINGS = 'settings';
 export const VIEW_CONTEXT_MODULE = 'module';
 export const VIEW_CONTEXT_WP_DASHBOARD = 'wpDashboard';
+export const VIEW_CONTEXT_MODULE_SETUP = 'moduleSetup';


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #3187

## Relevant technical choices

<!-- Please describe your changes. -->

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
