### PR TITLE
Bug/4025 Allow non-domain Publication IDs

### DIFF
--- a/assets/js/modules/subscribe-with-google/datastore/settings.test.js
+++ b/assets/js/modules/subscribe-with-google/datastore/settings.test.js
@@ -182,7 +182,7 @@ describe( 'modules/subscribe-with-google settings', () => {
 					true
 				);
 
-				registry.dispatch( STORE_NAME ).setPublicationID( '...' );
+				registry.dispatch( STORE_NAME ).setPublicationID( '!' );
 
 				expect( registry.select( STORE_NAME ).canSubmitChanges() ).toBe(
 					false

--- a/assets/js/modules/subscribe-with-google/util/validation.js
+++ b/assets/js/modules/subscribe-with-google/util/validation.js
@@ -27,7 +27,7 @@
 export function isValidPublicationID( publicationID ) {
 	return (
 		typeof publicationID === 'string' &&
-		/^[a-z0-9_.-]+[a-z]$/.test( publicationID )
+		/^[A-Za-z0-9_.-]+$/.test( publicationID )
 	);
 }
 


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #4025

## Relevant technical choices

<!-- Please describe your changes. -->

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
