### PR TITLE
Fix header position wrong at 600px when scrolled.

### DIFF
--- a/assets/sass/components/global/_googlesitekit-header.scss
+++ b/assets/sass/components/global/_googlesitekit-header.scss
@@ -34,7 +34,7 @@
 
 	body.admin-bar & {
 
-		@media (min-width: $bp-tablet) {
+		@media (min-width: $width-tablet + 1 + px) {
 			top: 46px;
 		}
 


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #3986

## Relevant technical choices

<!-- Please describe your changes. -->

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
