### PR TITLE
Badge component font should be Roboto.

### DIFF
--- a/assets/sass/components/global/_googlesitekit-badge.scss
+++ b/assets/sass/components/global/_googlesitekit-badge.scss
@@ -21,6 +21,7 @@
 	border-radius: 100px;
 	color: $c-badge-text;
 	display: inline-block;
+	font-family: $f-primary;
 	font-size: 10px;
 	line-height: 1;
 	padding: 6px 12px;


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #4012

## Relevant technical choices

A detail in the ACs was missed first time around: the `Badge` component font needs to always be Roboto.

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
