### PR TITLE
Add constants for Idea Hub tab names to avoid future typos (3980).

### DIFF
--- a/assets/js/modules/idea-hub/components/dashboard/DashboardIdeasWidget/Pagination.js
+++ b/assets/js/modules/idea-hub/components/dashboard/DashboardIdeasWidget/Pagination.js
@@ -36,6 +36,9 @@ import {
 	IDEA_HUB_IDEAS_PER_PAGE,
 	MODULES_IDEA_HUB,
 	IDEA_HUB_GA_CATEGORY_WIDGET,
+	IDEA_HUB_TAB_NAMES_NEW,
+	IDEA_HUB_TAB_NAMES_SAVED,
+	IDEA_HUB_TAB_NAMES_DRAFT,
 } from '../../../datastore/constants';
 import { trackEvent } from '../../../../../util';
 import { CORE_UI } from '../../../../../googlesitekit/datastore/ui/constants';
@@ -49,13 +52,13 @@ const Pagination = ( { tab } ) => {
 		useSelect( ( select ) => select( CORE_UI ).getValue( uniqueKey ) ) || 1;
 
 	const total = useSelect( ( select ) => {
-		if ( tab === 'new-ideas' ) {
+		if ( tab === IDEA_HUB_TAB_NAMES_NEW ) {
 			return select( MODULES_IDEA_HUB ).getNewIdeas()?.length || 0;
 		}
-		if ( tab === 'saved-ideas' ) {
+		if ( tab === IDEA_HUB_TAB_NAMES_SAVED ) {
 			return select( MODULES_IDEA_HUB ).getSavedIdeas()?.length || 0;
 		}
-		if ( tab === 'draft-ideas' ) {
+		if ( tab === IDEA_HUB_TAB_NAMES_DRAFT ) {
 			return select( MODULES_IDEA_HUB ).getDraftPostIdeas()?.length || 0;
 		}
 
@@ -66,14 +69,14 @@ const Pagination = ( { tab } ) => {
 		( direction ) => {
 			const eventMap = {
 				forward: {
-					'new-ideas': 'new_page_advance',
-					'save-ideas': 'saved_page_advance',
-					'draft-ideas': 'draft_page_advance',
+					[ IDEA_HUB_TAB_NAMES_NEW ]: 'new_page_advance',
+					[ IDEA_HUB_TAB_NAMES_SAVED ]: 'saved_page_advance',
+					[ IDEA_HUB_TAB_NAMES_DRAFT ]: 'draft_page_advance',
 				},
 				back: {
-					'new-ideas': 'new_page_return',
-					'save-ideas': 'saved_page_return',
-					'draft-ideas': 'draft_page_return',
+					[ IDEA_HUB_TAB_NAMES_NEW ]: 'new_page_return',
+					[ IDEA_HUB_TAB_NAMES_SAVED ]: 'saved_page_return',
+					[ IDEA_HUB_TAB_NAMES_DRAFT ]: 'draft_page_return',
 				},
 			};
 			const event = eventMap[ direction ][ tab ];
@@ -159,11 +162,15 @@ const Pagination = ( { tab } ) => {
 };
 
 Pagination.propTypes = {
-	tab: PropTypes.oneOf( [ 'new-ideas', 'saved-ideas', 'draft-ideas' ] ),
+	tab: PropTypes.oneOf( [
+		IDEA_HUB_TAB_NAMES_NEW,
+		IDEA_HUB_TAB_NAMES_SAVED,
+		IDEA_HUB_TAB_NAMES_DRAFT,
+	] ),
 };
 
 Pagination.defaultProps = {
-	tab: 'new-ideas',
+	tab: IDEA_HUB_TAB_NAMES_NEW,
 };
 
 export default Pagination;

--- a/assets/js/modules/idea-hub/components/dashboard/DashboardIdeasWidget/index.js
+++ b/assets/js/modules/idea-hub/components/dashboard/DashboardIdeasWidget/index.js
@@ -48,6 +48,9 @@ import { CORE_UI } from '../../../../../googlesitekit/datastore/ui/constants';
 import {
 	MODULES_IDEA_HUB,
 	IDEA_HUB_GA_CATEGORY_WIDGET,
+	IDEA_HUB_TAB_NAMES_NEW,
+	IDEA_HUB_TAB_NAMES_SAVED,
+	IDEA_HUB_TAB_NAMES_DRAFT,
 } from '../../../datastore/constants';
 import { trackEvent } from '../../../../../util';
 import whenActive from '../../../../../util/when-active';
@@ -231,15 +234,16 @@ function DashboardIdeasWidget( props ) {
 	}, [ page ] );
 
 	const tabIdeasMap = {
-		'new-ideas': newIdeas,
-		'saved-ideas': savedIdeas,
-		'draft-ideas': draftIdeas,
+		[ IDEA_HUB_TAB_NAMES_NEW ]: newIdeas,
+		[ IDEA_HUB_TAB_NAMES_SAVED ]: savedIdeas,
+		[ IDEA_HUB_TAB_NAMES_DRAFT ]: draftIdeas,
 	};
 	// The footer should be hidden in zero-states, except for on the new ideas tab.
 	// This is done using a special CSS class rather than conditionally
 	// rendering the component to avoid a layout shift when changing tabs.
 	const hideFooter =
-		'new-ideas' !== activeTab && tabIdeasMap[ activeTab ]?.length === 0;
+		IDEA_HUB_TAB_NAMES_NEW !== activeTab &&
+		tabIdeasMap[ activeTab ]?.length === 0;
 
 	return (
 		<Widget
@@ -250,7 +254,7 @@ function DashboardIdeasWidget( props ) {
 				<Footer
 					tab={ activeTab }
 					footerText={
-						( activeTab === 'new-ideas' &&
+						( activeTab === IDEA_HUB_TAB_NAMES_NEW &&
 							__(
 								'Updated every 2-3 days',
 								'google-site-kit'
@@ -338,21 +342,21 @@ function DashboardIdeasWidget( props ) {
 				<div className="googlesitekit-idea-hub__body">
 					<div
 						className="googlesitekit-idea-hub__content"
-						aria-hidden={ activeTab !== 'new-ideas' }
+						aria-hidden={ activeTab !== IDEA_HUB_TAB_NAMES_NEW }
 					>
 						<NewIdeas WidgetReportError={ WidgetReportError } />
 					</div>
 
 					<div
 						className="googlesitekit-idea-hub__content"
-						aria-hidden={ activeTab !== 'saved-ideas' }
+						aria-hidden={ activeTab !== IDEA_HUB_TAB_NAMES_SAVED }
 					>
 						<SavedIdeas WidgetReportError={ WidgetReportError } />
 					</div>
 
 					<div
 						className="googlesitekit-idea-hub__content"
-						aria-hidden={ activeTab !== 'draft-ideas' }
+						aria-hidden={ activeTab !== IDEA_HUB_TAB_NAMES_DRAFT }
 					>
 						<DraftIdeas WidgetReportError={ WidgetReportError } />
 					</div>
@@ -363,9 +367,9 @@ function DashboardIdeasWidget( props ) {
 }
 
 DashboardIdeasWidget.tabToIndex = {
-	'new-ideas': 0,
-	'saved-ideas': 1,
-	'draft-ideas': 2,
+	[ IDEA_HUB_TAB_NAMES_NEW ]: 0,
+	[ IDEA_HUB_TAB_NAMES_SAVED ]: 1,
+	[ IDEA_HUB_TAB_NAMES_DRAFT ]: 2,
 };
 
 DashboardIdeasWidget.tabIDsByIndex = Object.keys(

--- a/assets/js/modules/idea-hub/datastore/constants.js
+++ b/assets/js/modules/idea-hub/datastore/constants.js
@@ -46,3 +46,7 @@ export const IDEA_HUB_GA_CATEGORY_WIDGET = `${ VIEW_CONTEXT_DASHBOARD }_idea-hub
 export const IDEA_HUB_GA_CATEGORY_DASHBOARD = 'idea_hub_dashboard';
 export const IDEA_HUB_GA_CATEGORY_WPDASHBOARD = `${ VIEW_CONTEXT_WP_DASHBOARD }_idea-hub-saved-ideas-notification`;
 export const IDEA_HUB_GA_CATEGORY_POSTS = `${ VIEW_CONTEXT_POSTS_LIST }_idea-hub`;
+
+export const IDEA_HUB_TAB_NAMES_NEW = 'new-ideas';
+export const IDEA_HUB_TAB_NAMES_SAVED = 'saved-ideas';
+export const IDEA_HUB_TAB_NAMES_DRAFT = 'draft-ideas';


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #3980

## Relevant technical choices

There was a silly typo in one of the instances where the tab names were inlined. It occurred to me that we are inlining these strings all over the place in the dashboard widget now, so to avoid this happening again I've made them constants.

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [ ] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
