### PR TITLE
Use latest auto ads code

### DIFF
--- a/includes/Modules/AdSense/Web_Tag.php
+++ b/includes/Modules/AdSense/Web_Tag.php
@@ -86,7 +86,6 @@ class Web_Tag extends Module_Web_Tag {
 
 		printf( "\n<!-- %s -->\n", esc_html__( 'Google AdSense snippet added by Site Kit', 'google-site-kit' ) );
 		BC_Functions::wp_print_script_tag( array_merge( $adsense_script_attributes, $adsense_consent_attribute ) );
-		BC_Functions::wp_print_inline_script_tag( $adsense_inline_script );
 		printf( "\n<!-- %s -->\n", esc_html__( 'End Google AdSense snippet added by Site Kit', 'google-site-kit' ) );
 	}
 

--- a/includes/Modules/AdSense/Web_Tag.php
+++ b/includes/Modules/AdSense/Web_Tag.php
@@ -54,7 +54,7 @@ class Web_Tag extends Module_Web_Tag {
 		// because it is required for account verification.
 
 		$adsense_script_src = sprintf(
-			'//pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=%s',
+			'https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=%s',
 			esc_attr( $this->tag_id )
 		);
 


### PR DESCRIPTION
Use latest code snippet as per https://support.google.com/adsense/answer/9274634

## Summary

<!-- Please reference the issue this PR addresses. -->

With latest auto ads snippet below part is not required, and is leading to  error – adsbygoogle.push() error: Only one ‘enable_page_level_ads’ allowed per page

<script type="text/javascript"> (adsbygoogle = window.adsbygoogle \|\| []).push({"google_ad_client":"ca-pub-XXXX","enable_page_level_ads":true,"tag_partner":"site_kit"}); </script>

## Relevant technical choices

<!-- Please describe your changes. -->

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
