### PR TITLE
Remove last instance of `helpVisibility` feature flag

### DIFF
--- a/assets/js/feature-tours/help-visibility.js
+++ b/assets/js/feature-tours/help-visibility.js
@@ -28,16 +28,12 @@ import {
 	VIEW_CONTEXT_DASHBOARD,
 	VIEW_CONTEXT_PAGE_DASHBOARD,
 } from '../googlesitekit/constants';
-import { isFeatureEnabled } from '../features/index';
 
 const helpVisibility = {
 	slug: 'helpVisibility',
 	contexts: [ VIEW_CONTEXT_DASHBOARD, VIEW_CONTEXT_PAGE_DASHBOARD ],
 	version: '1.29.0',
 	gaEventCategory: 'global_help_menu',
-	checkRequirements: async () => {
-		return isFeatureEnabled( 'helpVisibility' );
-	},
 	steps: [
 		{
 			target: '.googlesitekit-help-menu',


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #4069 

## Relevant technical choices

<!-- Please describe your changes. -->

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
