### PR TITLE
Fix Optimize settings form displays "use snippet instructions" flash.

### DIFF
--- a/assets/js/modules/optimize/components/common/UseSnippetInstructions.js
+++ b/assets/js/modules/optimize/components/common/UseSnippetInstructions.js
@@ -95,7 +95,7 @@ export default function UseSnippetInstructions() {
 	}
 
 	// If we don't use auto insert gtag, but use auto insert gtm. Show instruction of how to implement it on GTM.
-	if ( ! analyticsUseSnippet && gtmActive && gtmUseSnippet ) {
+	if ( false === analyticsUseSnippet && gtmActive && gtmUseSnippet ) {
 		return (
 			<Fragment>
 				<p>
@@ -124,7 +124,7 @@ export default function UseSnippetInstructions() {
 		);
 	}
 
-	if ( ! analyticsUseSnippet ) {
+	if ( false === analyticsUseSnippet ) {
 		return (
 			<Fragment>
 				<p>

--- a/assets/js/modules/optimize/components/common/UseSnippetInstructions.test.js
+++ b/assets/js/modules/optimize/components/common/UseSnippetInstructions.test.js
@@ -45,11 +45,24 @@ describe( 'UseSnippetInstructions', () => {
 		unsubscribeFromAll( registry );
 	} );
 
+	it( 'should not render with analytics active and unresolved useSnippet', async () => {
+		registry.dispatch( MODULES_OPTIMIZE ).setOptimizeID( 'OPT-1234567' );
+		registry
+			.dispatch( CORE_MODULES )
+			.receiveGetModules( withActive( 'analytics' ) );
+		const { container } = render( <UseSnippetInstructions />, {
+			registry,
+		} );
+
+		expect( container ).toBeEmptyDOMElement();
+	} );
+
 	it( 'should render with analytics active and no useSnippet', async () => {
 		registry.dispatch( MODULES_OPTIMIZE ).setOptimizeID( 'OPT-1234567' );
 		registry
 			.dispatch( CORE_MODULES )
 			.receiveGetModules( withActive( 'analytics' ) );
+		registry.dispatch( MODULES_ANALYTICS ).setUseSnippet( false );
 		const { container } = render( <UseSnippetInstructions />, {
 			registry,
 		} );
@@ -96,6 +109,7 @@ describe( 'UseSnippetInstructions', () => {
 		registry.dispatch( MODULES_OPTIMIZE ).setOptimizeID( 'OPT-1234567' );
 		registry.dispatch( CORE_MODULES ).receiveGetModules( newFixtures );
 		registry.dispatch( MODULES_TAGMANAGER ).setUseSnippet( true );
+		registry.dispatch( MODULES_ANALYTICS ).setUseSnippet( false );
 
 		const { container } = render( <UseSnippetInstructions />, {
 			registry,


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #3720

## Relevant technical choices

<!-- Please describe your changes. -->

## Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
