### PR TITLE
Rollback Google charts version to 49

### DIFF
--- a/assets/js/components/GoogleChart.js
+++ b/assets/js/components/GoogleChart.js
@@ -194,7 +194,7 @@ export default function GoogleChart( props ) {
 				className="googlesitekit-chart__inner"
 				chartEvents={ combinedChartEvents }
 				chartType={ chartType }
-				chartVersion="51"
+				chartVersion="49"
 				data={ modifiedData }
 				loader={ loader }
 				height={ height }


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #4074 

## Relevant technical choices

Reverts the version change in https://github.com/google/site-kit-wp/pull/3881/files#diff-e632e2b02991386dad9213942af598e92c8fbd29e11e8fe4b58b0533fcf8698d

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
