### PR TITLE
Restore working Idea Hub notice dismissal code.

### DIFF
--- a/assets/js/googlesitekit-idea-hub-post-list.js
+++ b/assets/js/googlesitekit-idea-hub-post-list.js
@@ -51,17 +51,16 @@ domReady( () => {
 
 	trackEvent( eventsCategory, 'view_notification' );
 
-	const dismiss = notice.querySelector( '.notice-dismiss' );
-	if ( dismiss ) {
-		dismiss.addEventListener( 'click', () => {
+	notice.addEventListener( 'click', ( { target } ) => {
+		if ( target.classList.contains( 'notice-dismiss' ) ) {
 			dispatch( CORE_USER ).dismissItem( type, {
 				expiresInSeconds:
 					type === 'idea-hub_new-ideas' ? WEEK_IN_SECONDS : 0,
 			} );
 
 			trackEvent( eventsCategory, 'dismiss_notification' );
-		} );
-	}
+		}
+	} );
 
 	const link = notice.querySelector( 'a' );
 	if ( link ) {


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #4110.

## Relevant technical choices

Given there isn't much (any?) infrastructure I could find for getting Idea Hub setup for E2E I skipped the E2E tests here. If I'm missing something though let me know.

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
