### PR TITLE
Fix Adsense Module being disabled and connected with adblocker active

### DIFF
--- a/assets/js/components/ModulesListItem.js
+++ b/assets/js/components/ModulesListItem.js
@@ -50,7 +50,8 @@ const ModulesListItem = ( { module, handleSetupModule } ) => {
 				'googlesitekit-modules-list__module',
 				`googlesitekit-modules-list__module--${ slug }`,
 				{
-					'googlesitekit-settings-connect-module--disabled': ! canActivateModule,
+					'googlesitekit-settings-connect-module--disabled':
+						! setupComplete && ! canActivateModule,
 				}
 			) }
 		>
@@ -64,7 +65,9 @@ const ModulesListItem = ( { module, handleSetupModule } ) => {
 				</h3>
 			</div>
 
-			<ModuleSettingsWarning slug={ slug } context="modules-list" />
+			{ ! setupComplete && (
+				<ModuleSettingsWarning slug={ slug } context="modules-list" />
+			) }
 
 			{ setupComplete && (
 				<span className="googlesitekit-settings-module__status">


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #4014

## Relevant technical choices

<!-- Please describe your changes. -->

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
