### PR TITLE
Restore base path in CSS output filename.

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -389,8 +389,8 @@ function* webpackConfig( env, argv ) {
 			new MiniCssExtractPlugin( {
 				filename:
 					'production' === mode
-						? '[name].[contenthash].css'
-						: '[name].css',
+						? '/assets/css/[name].[contenthash].css'
+						: '/assets/css/[name].css',
 			} ),
 			new WebpackBar( {
 				name: 'Plugin CSS',


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #2806

## Relevant technical choices

<!-- Please describe your changes. -->

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
