### PR TITLE
Update Idea Hub WP dashboard widget to only render when connected

### DIFF
--- a/assets/js/components/wp-dashboard/WPDashboardIdeaHub.js
+++ b/assets/js/components/wp-dashboard/WPDashboardIdeaHub.js
@@ -31,8 +31,6 @@ import { useEffect, useCallback } from '@wordpress/element';
  * Internal dependencies
  */
 import Data from 'googlesitekit-data';
-import { useFeature } from '../../hooks/useFeature';
-import { CORE_MODULES } from '../../googlesitekit/modules/datastore/constants';
 import { CORE_SITE } from '../../googlesitekit/datastore/site/constants';
 import {
 	MODULES_IDEA_HUB,
@@ -41,36 +39,18 @@ import {
 import { trackEvent } from '../../util';
 import GoogleLogoIcon from '../../../svg/logo-g.svg';
 import Link from '../Link';
+import whenActive from '../../util/when-active';
 
 const { useSelect } = Data;
 
 function WPDashboardIdeaHub() {
-	const isIdeaHubEnabled = useFeature( 'ideaHubModule' );
-
-	const { hasSavedIdeas, isModuleActive, dashboardURL } = useSelect(
-		( select ) => {
-			if ( ! isIdeaHubEnabled ) {
-				return {};
-			}
-
-			const isActive = select( CORE_MODULES ).isModuleActive(
-				'idea-hub'
-			);
-			if ( ! isActive ) {
-				return {};
-			}
-
-			const savedIdeas = select( MODULES_IDEA_HUB ).getSavedIdeas();
-			const adminURL = select( CORE_SITE ).getAdminURL(
-				'googlesitekit-dashboard'
-			);
-
-			return {
-				isModuleActive: isActive,
-				hasSavedIdeas: savedIdeas?.length > 0,
-				dashboardURL: `${ adminURL }#saved-ideas`,
-			};
-		}
+	const savedIdeas = useSelect( ( select ) =>
+		select( MODULES_IDEA_HUB ).getSavedIdeas()
+	);
+	const dashboardURL = useSelect( ( select ) =>
+		select( CORE_SITE ).getAdminURL( 'googlesitekit-dashboard', {
+			'idea-hub-tab': 'saved-ideas',
+		} )
 	);
 
 	const [ trackingRef, inView ] = useInView( {
@@ -91,7 +71,7 @@ function WPDashboardIdeaHub() {
 		);
 	}, [] );
 
-	if ( ! isModuleActive || ! hasSavedIdeas ) {
+	if ( ! savedIdeas?.length ) {
 		return null;
 	}
 
@@ -120,4 +100,6 @@ function WPDashboardIdeaHub() {
 	);
 }
 
-export default WPDashboardIdeaHub;
+export default whenActive( {
+	moduleName: 'idea-hub',
+} )( WPDashboardIdeaHub );

--- a/assets/js/util/when-active.test.js
+++ b/assets/js/util/when-active.test.js
@@ -1,0 +1,151 @@
+/**
+ * HOC whenActive tests.
+ *
+ * Site Kit by Google, Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import { render } from '../../../tests/js/test-utils';
+import { createTestRegistry, provideModules } from '../../../tests/js/utils';
+import whenActive from './when-active';
+
+describe( 'whenActive', () => {
+	let registry;
+	const slug = 'test-module';
+
+	const TestComponent = () => <div data-testid="component" />;
+	const TestFallbackComponent = () => (
+		<div data-testid="fallback-component" />
+	);
+	const TestIncompleteComponent = () => (
+		<div data-testid="incomplete-component" />
+	);
+	const FakeWidgetNull = () => <div data-testid="widget-null" />;
+
+	beforeEach( () => {
+		registry = createTestRegistry();
+	} );
+
+	it( 'renders nothing for modules that have not been registered', () => {
+		provideModules( registry );
+		const WhenActiveComponent = whenActive( { moduleName: slug } )(
+			TestComponent
+		);
+
+		const { queryByTestID } = render( <WhenActiveComponent />, {
+			registry,
+		} );
+
+		expect( queryByTestID( 'component' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'renders the given component when the module is active and connected', () => {
+		provideModules( registry, [ { slug, active: true, connected: true } ] );
+		const WhenActiveComponent = whenActive( { moduleName: slug } )(
+			TestComponent
+		);
+
+		const { queryByTestID } = render( <WhenActiveComponent />, {
+			registry,
+		} );
+
+		expect( queryByTestID( 'component' ) ).toBeInTheDocument();
+	} );
+
+	it( 'renders the given `FallbackComponent` when the module is not active', () => {
+		provideModules( registry, [ { slug, active: false } ] );
+		const WhenActiveComponent = whenActive( {
+			moduleName: slug,
+			FallbackComponent: TestFallbackComponent,
+		} )( TestComponent );
+
+		const { queryByTestID } = render( <WhenActiveComponent />, {
+			registry,
+		} );
+
+		expect( queryByTestID( 'component' ) ).not.toBeInTheDocument();
+		expect( queryByTestID( 'fallback-component' ) ).toBeInTheDocument();
+	} );
+
+	it( 'renders nothing when the module is not active and no `FallbackComponent` is provided', () => {
+		provideModules( registry, [ { slug, active: false } ] );
+		const WhenActiveComponent = whenActive( { moduleName: slug } )(
+			TestComponent
+		);
+
+		const { queryByTestID } = render( <WhenActiveComponent />, {
+			registry,
+		} );
+
+		expect( queryByTestID( 'component' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'renders the given `IncompleteComponent` when the module is active, but not connected', () => {
+		provideModules( registry, [
+			{ slug, active: true, connected: false },
+		] );
+		const WhenActiveComponent = whenActive( {
+			moduleName: slug,
+			FallbackComponent: TestFallbackComponent,
+			IncompleteComponent: TestIncompleteComponent,
+		} )( TestComponent );
+
+		const { queryByTestID } = render( <WhenActiveComponent />, {
+			registry,
+		} );
+
+		expect( queryByTestID( 'component' ) ).not.toBeInTheDocument();
+		expect( queryByTestID( 'fallback-component' ) ).not.toBeInTheDocument();
+		expect( queryByTestID( 'incomplete-component' ) ).toBeInTheDocument();
+	} );
+
+	it( 'renders the given `FallbackComponent` when the module is active, but not connected, and no `IncompleteComponent` is provided', () => {
+		provideModules( registry, [
+			{ slug, active: true, connected: false },
+		] );
+		const WhenActiveComponent = whenActive( {
+			moduleName: slug,
+			FallbackComponent: TestFallbackComponent,
+		} )( TestComponent );
+
+		const { queryByTestID } = render( <WhenActiveComponent />, {
+			registry,
+		} );
+
+		expect( queryByTestID( 'component' ) ).not.toBeInTheDocument();
+		expect( queryByTestID( 'fallback-component' ) ).toBeInTheDocument();
+	} );
+
+	it( 'renders `WidgetNull` from the components ownProps for the default `FallbackComponent`', () => {
+		provideModules( registry, [ { slug, active: false } ] );
+		const WhenActiveComponent = whenActive( {
+			moduleName: slug,
+		} )( TestComponent );
+
+		const { queryByTestID } = render(
+			<WhenActiveComponent WidgetNull={ FakeWidgetNull } />,
+			{
+				registry,
+			}
+		);
+
+		expect( queryByTestID( 'component' ) ).not.toBeInTheDocument();
+		// `WidgetNull` does not actually render anything,
+		// a fake implementation is used here just for testing.
+		expect( queryByTestID( 'widget-null' ) ).toBeInTheDocument();
+	} );
+} );


### PR DESCRIPTION
## Summary

Addresses issue #4125 

## Relevant technical choices

* Added a few enhancements to `whenActive` to make it safer in the case that a fallback component is not provided

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
