### PR TITLE
Add GA Tracking Event to Cancel Button in Module Settings.

### DIFF
--- a/assets/js/components/settings/SettingsActiveModule/Footer.js
+++ b/assets/js/components/settings/SettingsActiveModule/Footer.js
@@ -157,7 +157,7 @@ export default function Footer( props ) {
 					<Link
 						className="googlesitekit-settings-module__footer-cancel"
 						inherit
-						to={ `/connected-services/${ slug }` }
+						onClick={ handleClose }
 					>
 						{ __( 'Cancel', 'google-site-kit' ) }
 					</Link>

--- a/assets/js/components/settings/SettingsActiveModule/index.test.js
+++ b/assets/js/components/settings/SettingsActiveModule/index.test.js
@@ -154,9 +154,12 @@ describe( 'SettingsModule', () => {
 		const {
 			getByRole,
 			queryByTestID,
+			findByTestID,
 		} = render( <SettingsModuleWithWrapper />, { history, registry } );
 
-		fireEvent.click( getByRole( 'link', { name: /cancel/i } ) );
+		fireEvent.click( getByRole( 'button', { name: /cancel/i } ) );
+
+		await findByTestID( 'view-component' );
 
 		expect( global.location.hash ).toEqual(
 			'#/connected-services/analytics'


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #4007

## Relevant technical choices

<!-- Please describe your changes. -->

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
