### PR TITLE
Only show AdSense module when it is active.

### DIFF
--- a/assets/js/modules/adsense/components/module/ModuleOverviewWidget/index.js
+++ b/assets/js/modules/adsense/components/module/ModuleOverviewWidget/index.js
@@ -190,6 +190,6 @@ ModuleOverviewWidget.metrics = {
 export default whenActive( {
 	moduleName: 'adsense',
 	IncompleteComponent: ( { WidgetCompleteModuleActivationCTA } ) => (
-		<WidgetCompleteModuleActivationCTA />
+		<WidgetCompleteModuleActivationCTA moduleSlug="adsense" />
 	),
 } )( ModuleOverviewWidget );


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #4149.

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
