### PR TITLE
Only register widgets for the correct feature flag.

### DIFF
--- a/assets/js/modules/adsense/index.js
+++ b/assets/js/modules/adsense/index.js
@@ -49,6 +49,7 @@ import {
 	ERROR_CODE_ADBLOCKER_ACTIVE,
 } from './constants';
 import { WIDGET_AREA_STYLES } from '../../googlesitekit/widgets/datastore/constants';
+import { isFeatureEnabled } from '../../features';
 export { registerStore } from './datastore';
 
 export const registerModule = ( modules ) => {
@@ -101,54 +102,65 @@ export const registerModule = ( modules ) => {
 };
 
 export const registerWidgets = ( widgets ) => {
-	widgets.registerWidget(
-		'adsenseSummary',
-		{
-			Component: DashboardSummaryWidget,
-			width: widgets.WIDGET_WIDTHS.HALF,
-			priority: 1,
-			wrapWidget: false,
-		},
-		[ AREA_DASHBOARD_EARNINGS ]
-	);
-	widgets.registerWidget(
-		'adsenseTopEarningPages',
-		{
-			Component: DashboardTopEarningPagesWidget,
-			width: [ widgets.WIDGET_WIDTHS.HALF, widgets.WIDGET_WIDTHS.FULL ],
-			priority: 2,
-			wrapWidget: false,
-		},
-		[ AREA_DASHBOARD_EARNINGS, AREA_MAIN_DASHBOARD_MONETIZATION_PRIMARY ]
-	);
-	widgets.registerWidget(
-		'adsenseModuleOverview',
-		{
-			Component: ModuleOverviewWidget,
-			width: widgets.WIDGET_WIDTHS.FULL,
-			priority: 1,
-			wrapWidget: false,
-		},
-		[ AREA_MODULE_ADSENSE_MAIN, AREA_MAIN_DASHBOARD_MONETIZATION_PRIMARY ]
-	);
-	widgets.registerWidgetArea(
-		AREA_MODULE_ADSENSE_MAIN,
-		{
-			priority: 1,
-			style: WIDGET_AREA_STYLES.BOXES,
-			title: __( 'Overview', 'google-site-kit' ),
-		},
-		CONTEXT_MODULE_ADSENSE
-	);
+	if ( ! isFeatureEnabled( 'unifiedDashboard' ) ) {
+		widgets.registerWidget(
+			'adsenseSummary',
+			{
+				Component: DashboardSummaryWidget,
+				width: widgets.WIDGET_WIDTHS.HALF,
+				priority: 1,
+				wrapWidget: false,
+			},
+			[ AREA_DASHBOARD_EARNINGS ]
+		);
+		widgets.registerWidget(
+			'adsenseTopEarningPages',
+			{
+				Component: DashboardTopEarningPagesWidget,
+				width: [
+					widgets.WIDGET_WIDTHS.HALF,
+					widgets.WIDGET_WIDTHS.FULL,
+				],
+				priority: 2,
+				wrapWidget: false,
+			},
+			[
+				AREA_DASHBOARD_EARNINGS,
+				AREA_MAIN_DASHBOARD_MONETIZATION_PRIMARY,
+			]
+		);
+		widgets.registerWidget(
+			'adsenseModuleOverview',
+			{
+				Component: ModuleOverviewWidget,
+				width: widgets.WIDGET_WIDTHS.FULL,
+				priority: 1,
+				wrapWidget: false,
+			},
+			[
+				AREA_MODULE_ADSENSE_MAIN,
+				AREA_MAIN_DASHBOARD_MONETIZATION_PRIMARY,
+			]
+		);
+		widgets.registerWidgetArea(
+			AREA_MODULE_ADSENSE_MAIN,
+			{
+				priority: 1,
+				style: WIDGET_AREA_STYLES.BOXES,
+				title: __( 'Overview', 'google-site-kit' ),
+			},
+			CONTEXT_MODULE_ADSENSE
+		);
 
-	widgets.registerWidget(
-		'adsenseModuleTopEarningPages',
-		{
-			Component: ModuleTopEarningPagesWidget,
-			width: widgets.WIDGET_WIDTHS.FULL,
-			priority: 2,
-			wrapWidget: false,
-		},
-		[ AREA_MODULE_ADSENSE_MAIN ]
-	);
+		widgets.registerWidget(
+			'adsenseModuleTopEarningPages',
+			{
+				Component: ModuleTopEarningPagesWidget,
+				width: widgets.WIDGET_WIDTHS.FULL,
+				priority: 2,
+				wrapWidget: false,
+			},
+			[ AREA_MODULE_ADSENSE_MAIN ]
+		);
+	}
 };

--- a/assets/js/modules/analytics/index.js
+++ b/assets/js/modules/analytics/index.js
@@ -73,103 +73,105 @@ export const registerModule = ( modules ) => {
 };
 
 export const registerWidgets = ( widgets ) => {
-	widgets.registerWidget(
-		'analyticsAllTraffic',
-		{
-			Component: DashboardAllTrafficWidget,
-			width: widgets.WIDGET_WIDTHS.FULL,
-			priority: 1,
-			wrapWidget: false,
-		},
-		[ AREA_DASHBOARD_ALL_TRAFFIC, AREA_PAGE_DASHBOARD_ALL_TRAFFIC ]
-	);
+	if ( ! isFeatureEnabled( 'unifiedDashboard' ) ) {
+		widgets.registerWidget(
+			'analyticsAllTraffic',
+			{
+				Component: DashboardAllTrafficWidget,
+				width: widgets.WIDGET_WIDTHS.FULL,
+				priority: 1,
+				wrapWidget: false,
+			},
+			[ AREA_DASHBOARD_ALL_TRAFFIC, AREA_PAGE_DASHBOARD_ALL_TRAFFIC ]
+		);
 
-	widgets.registerWidget(
-		'analyticsUniqueVisitors',
-		{
-			Component: DashboardSearchVisitorsWidget,
-			width: widgets.WIDGET_WIDTHS.QUARTER,
-			priority: 3,
-			wrapWidget: true,
-		},
-		[ AREA_DASHBOARD_SEARCH_FUNNEL, AREA_PAGE_DASHBOARD_SEARCH_FUNNEL ]
-	);
+		widgets.registerWidget(
+			'analyticsUniqueVisitors',
+			{
+				Component: DashboardSearchVisitorsWidget,
+				width: widgets.WIDGET_WIDTHS.QUARTER,
+				priority: 3,
+				wrapWidget: true,
+			},
+			[ AREA_DASHBOARD_SEARCH_FUNNEL, AREA_PAGE_DASHBOARD_SEARCH_FUNNEL ]
+		);
 
-	widgets.registerWidget(
-		'analyticsGoals',
-		{
-			Component: DashboardGoalsWidget,
-			width: widgets.WIDGET_WIDTHS.QUARTER,
-			priority: 4,
-			wrapWidget: true,
-		},
-		[ AREA_DASHBOARD_SEARCH_FUNNEL ]
-	);
+		widgets.registerWidget(
+			'analyticsGoals',
+			{
+				Component: DashboardGoalsWidget,
+				width: widgets.WIDGET_WIDTHS.QUARTER,
+				priority: 4,
+				wrapWidget: true,
+			},
+			[ AREA_DASHBOARD_SEARCH_FUNNEL ]
+		);
 
-	widgets.registerWidget(
-		'analyticsBounceRate',
-		{
-			Component: DashboardBounceRateWidget,
-			width: widgets.WIDGET_WIDTHS.QUARTER,
-			priority: 4,
-			wrapWidget: true,
-		},
-		[ AREA_PAGE_DASHBOARD_SEARCH_FUNNEL ]
-	);
+		widgets.registerWidget(
+			'analyticsBounceRate',
+			{
+				Component: DashboardBounceRateWidget,
+				width: widgets.WIDGET_WIDTHS.QUARTER,
+				priority: 4,
+				wrapWidget: true,
+			},
+			[ AREA_PAGE_DASHBOARD_SEARCH_FUNNEL ]
+		);
 
-	widgets.registerWidget(
-		'analyticsPopularPages',
-		{
-			Component: DashboardPopularPagesWidget,
-			width: widgets.WIDGET_WIDTHS.HALF,
-			priority: 3,
-			wrapWidget: false,
-		},
-		[ AREA_DASHBOARD_ACQUISITION ]
-	);
+		widgets.registerWidget(
+			'analyticsPopularPages',
+			{
+				Component: DashboardPopularPagesWidget,
+				width: widgets.WIDGET_WIDTHS.HALF,
+				priority: 3,
+				wrapWidget: false,
+			},
+			[ AREA_DASHBOARD_ACQUISITION ]
+		);
 
-	widgets.registerWidget(
-		'analyticsModuleAcquisitionChannels',
-		{
-			Component: ModuleAcquisitionChannelsWidget,
-			width: widgets.WIDGET_WIDTHS.FULL,
-			priority: 3,
-			wrapWidget: false,
-		},
-		[ AREA_MODULE_ANALYTICS_MAIN ]
-	);
+		widgets.registerWidget(
+			'analyticsModuleAcquisitionChannels',
+			{
+				Component: ModuleAcquisitionChannelsWidget,
+				width: widgets.WIDGET_WIDTHS.FULL,
+				priority: 3,
+				wrapWidget: false,
+			},
+			[ AREA_MODULE_ANALYTICS_MAIN ]
+		);
 
-	widgets.registerWidgetArea(
-		AREA_MODULE_ANALYTICS_MAIN,
-		{
-			priority: 1,
-			style: WIDGET_AREA_STYLES.BOXES,
-			title: __( 'Overview', 'google-site-kit' ),
-		},
-		CONTEXT_MODULE_ANALYTICS
-	);
+		widgets.registerWidgetArea(
+			AREA_MODULE_ANALYTICS_MAIN,
+			{
+				priority: 1,
+				style: WIDGET_AREA_STYLES.BOXES,
+				title: __( 'Overview', 'google-site-kit' ),
+			},
+			CONTEXT_MODULE_ANALYTICS
+		);
 
-	widgets.registerWidget(
-		'analyticsModuleOverview',
-		{
-			Component: ModuleOverviewWidget,
-			width: widgets.WIDGET_WIDTHS.FULL,
-			priority: 1,
-			wrapWidget: false,
-		},
-		[ AREA_MODULE_ANALYTICS_MAIN ]
-	);
+		widgets.registerWidget(
+			'analyticsModuleOverview',
+			{
+				Component: ModuleOverviewWidget,
+				width: widgets.WIDGET_WIDTHS.FULL,
+				priority: 1,
+				wrapWidget: false,
+			},
+			[ AREA_MODULE_ANALYTICS_MAIN ]
+		);
 
-	widgets.registerWidget(
-		'analyticsModulePopularPages',
-		{
-			Component: ModulePopularPagesWidget,
-			width: widgets.WIDGET_WIDTHS.FULL,
-			priority: 2,
-			wrapWidget: false,
-		},
-		[ AREA_MODULE_ANALYTICS_MAIN ]
-	);
+		widgets.registerWidget(
+			'analyticsModulePopularPages',
+			{
+				Component: ModulePopularPagesWidget,
+				width: widgets.WIDGET_WIDTHS.FULL,
+				priority: 2,
+				wrapWidget: false,
+			},
+			[ AREA_MODULE_ANALYTICS_MAIN ]
+		);
+	}
 
 	if ( isFeatureEnabled( 'unifiedDashboard' ) ) {
 		widgets.registerWidget(

--- a/assets/js/modules/idea-hub/index.js
+++ b/assets/js/modules/idea-hub/index.js
@@ -28,7 +28,6 @@ import { MODULES_IDEA_HUB } from './datastore/constants';
 import { registerStore as registerDataStore } from './datastore';
 import { isFeatureEnabled } from '../../features';
 import { AREA_DASHBOARD_ACQUISITION } from '../../googlesitekit/widgets/default-areas';
-
 import DashboardIdeasWidget from './components/dashboard/DashboardIdeasWidget';
 import IdeaHubIcon from '../../../svg/idea-hub.svg';
 import { SettingsView } from './components/settings';
@@ -62,14 +61,16 @@ export const registerWidgets = ifIdeaHubIsEnabled( ( widgets ) => {
 		return;
 	}
 
-	widgets.registerWidget(
-		'ideaHubIdeas',
-		{
-			Component: DashboardIdeasWidget,
-			width: widgets.WIDGET_WIDTHS.HALF,
-			priority: 2,
-			wrapWidget: false,
-		},
-		[ AREA_DASHBOARD_ACQUISITION ]
-	);
+	if ( ! isFeatureEnabled( 'unifiedDashboard' ) ) {
+		widgets.registerWidget(
+			'ideaHubIdeas',
+			{
+				Component: DashboardIdeasWidget,
+				width: widgets.WIDGET_WIDTHS.HALF,
+				priority: 2,
+				wrapWidget: false,
+			},
+			[ AREA_DASHBOARD_ACQUISITION ]
+		);
+	}
 } );

--- a/assets/js/modules/pagespeed-insights/index.js
+++ b/assets/js/modules/pagespeed-insights/index.js
@@ -32,6 +32,7 @@ import { SettingsView } from './components/settings';
 import DashboardPageSpeedWidget from './components/dashboard/DashboardPageSpeedWidget';
 import PageSpeedInsightsIcon from '../../../svg/pagespeed-insights.svg';
 import { MODULES_PAGESPEED_INSIGHTS } from './datastore/constants';
+import { isFeatureEnabled } from '../../features';
 
 export { registerStore } from './datastore';
 
@@ -50,13 +51,15 @@ export const registerModule = ( modules ) => {
 };
 
 export const registerWidgets = ( widgets ) => {
-	widgets.registerWidget(
-		'pagespeedInsightsWebVitals',
-		{
-			Component: DashboardPageSpeedWidget,
-			width: widgets.WIDGET_WIDTHS.FULL,
-			wrapWidget: false,
-		},
-		[ AREA_DASHBOARD_SPEED, AREA_PAGE_DASHBOARD_SPEED ]
-	);
+	if ( ! isFeatureEnabled( 'unifiedDashboard' ) ) {
+		widgets.registerWidget(
+			'pagespeedInsightsWebVitals',
+			{
+				Component: DashboardPageSpeedWidget,
+				width: widgets.WIDGET_WIDTHS.FULL,
+				wrapWidget: false,
+			},
+			[ AREA_DASHBOARD_SPEED, AREA_PAGE_DASHBOARD_SPEED ]
+		);
+	}
 };

--- a/assets/js/modules/search-console/index.js
+++ b/assets/js/modules/search-console/index.js
@@ -43,6 +43,7 @@ import {
 	AREA_MODULE_SEARCH_CONSOLE_MAIN,
 } from './constants';
 import { WIDGET_AREA_STYLES } from '../../googlesitekit/widgets/datastore/constants';
+import { isFeatureEnabled } from '../../features';
 
 export { registerStore } from './datastore';
 
@@ -57,63 +58,68 @@ export const registerModule = ( modules ) => {
 };
 
 export const registerWidgets = ( widgets ) => {
-	widgets.registerWidget(
-		'searchConsoleImpressions',
-		{
-			Component: DashboardImpressionsWidget,
-			width: widgets.WIDGET_WIDTHS.QUARTER,
-			priority: 1,
-			wrapWidget: true,
-		},
-		[ AREA_DASHBOARD_SEARCH_FUNNEL, AREA_PAGE_DASHBOARD_SEARCH_FUNNEL ]
-	);
-	widgets.registerWidget(
-		'searchConsoleClicks',
-		{
-			Component: DashboardClicksWidget,
-			width: widgets.WIDGET_WIDTHS.QUARTER,
-			priority: 2,
-			wrapWidget: true,
-		},
-		[ AREA_DASHBOARD_SEARCH_FUNNEL, AREA_PAGE_DASHBOARD_SEARCH_FUNNEL ]
-	);
-	widgets.registerWidget(
-		'searchConsolePopularKeywords',
-		{
-			Component: DashboardPopularKeywordsWidget,
-			width: [ widgets.WIDGET_WIDTHS.HALF, widgets.WIDGET_WIDTHS.FULL ],
-			priority: 1,
-			wrapWidget: false,
-		},
-		[ AREA_DASHBOARD_ACQUISITION, AREA_PAGE_DASHBOARD_ACQUISITION ]
-	);
-	widgets.registerWidget(
-		'searchConsoleModuleOverview',
-		{
-			Component: ModuleOverviewWidget,
-			width: widgets.WIDGET_WIDTHS.FULL,
-			priority: 1,
-			wrapWidget: false,
-		},
-		[ AREA_MODULE_SEARCH_CONSOLE_MAIN ]
-	);
-	widgets.registerWidgetArea(
-		AREA_MODULE_SEARCH_CONSOLE_MAIN,
-		{
-			priority: 1,
-			style: WIDGET_AREA_STYLES.BOXES,
-			title: __( 'Overview', 'google-site-kit' ),
-		},
-		CONTEXT_MODULE_SEARCH_CONSOLE
-	);
-	widgets.registerWidget(
-		'searchConsoleModulePopularKeywords',
-		{
-			Component: ModulePopularKeywordsWidget,
-			width: [ widgets.WIDGET_WIDTHS.FULL ],
-			priority: 2,
-			wrapWidget: false,
-		},
-		[ AREA_MODULE_SEARCH_CONSOLE_MAIN ]
-	);
+	if ( ! isFeatureEnabled( 'unifiedDashboard' ) ) {
+		widgets.registerWidget(
+			'searchConsoleImpressions',
+			{
+				Component: DashboardImpressionsWidget,
+				width: widgets.WIDGET_WIDTHS.QUARTER,
+				priority: 1,
+				wrapWidget: true,
+			},
+			[ AREA_DASHBOARD_SEARCH_FUNNEL, AREA_PAGE_DASHBOARD_SEARCH_FUNNEL ]
+		);
+		widgets.registerWidget(
+			'searchConsoleClicks',
+			{
+				Component: DashboardClicksWidget,
+				width: widgets.WIDGET_WIDTHS.QUARTER,
+				priority: 2,
+				wrapWidget: true,
+			},
+			[ AREA_DASHBOARD_SEARCH_FUNNEL, AREA_PAGE_DASHBOARD_SEARCH_FUNNEL ]
+		);
+		widgets.registerWidget(
+			'searchConsolePopularKeywords',
+			{
+				Component: DashboardPopularKeywordsWidget,
+				width: [
+					widgets.WIDGET_WIDTHS.HALF,
+					widgets.WIDGET_WIDTHS.FULL,
+				],
+				priority: 1,
+				wrapWidget: false,
+			},
+			[ AREA_DASHBOARD_ACQUISITION, AREA_PAGE_DASHBOARD_ACQUISITION ]
+		);
+		widgets.registerWidget(
+			'searchConsoleModuleOverview',
+			{
+				Component: ModuleOverviewWidget,
+				width: widgets.WIDGET_WIDTHS.FULL,
+				priority: 1,
+				wrapWidget: false,
+			},
+			[ AREA_MODULE_SEARCH_CONSOLE_MAIN ]
+		);
+		widgets.registerWidgetArea(
+			AREA_MODULE_SEARCH_CONSOLE_MAIN,
+			{
+				priority: 1,
+				style: WIDGET_AREA_STYLES.BOXES,
+				title: __( 'Overview', 'google-site-kit' ),
+			},
+			CONTEXT_MODULE_SEARCH_CONSOLE
+		);
+		widgets.registerWidget(
+			'searchConsoleModulePopularKeywords',
+			{
+				Component: ModulePopularKeywordsWidget,
+				width: [ widgets.WIDGET_WIDTHS.FULL ],
+				priority: 2,
+				wrapWidget: false,
+			},
+			[ AREA_MODULE_SEARCH_CONSOLE_MAIN ]
+		);
+	}
 };


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #4149.

## Relevant technical choices

We should only register the same widget slug once, to prevent the error encountered here: https://github.com/google/site-kit-wp/issues/4149#issuecomment-937611939

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
