### PR TITLE
Improve reauthenticate message for 'access_denied' error.

### DIFF
--- a/includes/Core/Authentication/Authentication.php
+++ b/includes/Core/Authentication/Authentication.php
@@ -1080,19 +1080,13 @@ final class Authentication {
 					$message = $auth_client->get_error_message( $error_code );
 
 					if ( $this->is_authenticated() ) {
-
 						$setup_url = $this->get_connect_url();
-
 					} elseif ( $this->credentials->using_proxy() ) {
-
 						$access_code = $this->user_options->get( OAuth_Client::OPTION_PROXY_ACCESS_CODE );
 						$setup_url = $auth_client->get_proxy_setup_url( $access_code );
 						$this->user_options->delete( OAuth_Client::OPTION_PROXY_ACCESS_CODE );
-
 					} else {
-
 						$setup_url = $this->context->admin_url( 'splash' );
-
 					}
 
 					if ( 'access_denied' === $error_code ) {


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #3970

## Relevant technical choices

<!-- Please describe your changes. -->

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
