### PR TITLE
Add `Session Duration` to Most Pupular Content Widget in Unified DAshboard

### DIFF
--- a/assets/js/modules/analytics/components/module/ModulePopularPagesWidget/index.js
+++ b/assets/js/modules/analytics/components/module/ModulePopularPagesWidget/index.js
@@ -45,6 +45,7 @@ import ReportTable from '../../../../../components/ReportTable';
 import PreviewTable from '../../../../../components/PreviewTable';
 import Header from './Header';
 import Footer from './Footer';
+import { useFeature } from '../../../../../hooks/useFeature';
 const { useSelect } = Data;
 
 export default function ModulePopularPagesWidget( props ) {
@@ -59,6 +60,8 @@ export default function ModulePopularPagesWidget( props ) {
 			offsetDays: DATE_RANGE_OFFSET,
 		} )
 	);
+
+	const unifiedDashboardEnabled = useFeature( 'unifiedDashboard' );
 
 	const args = {
 		...dates,
@@ -75,6 +78,10 @@ export default function ModulePopularPagesWidget( props ) {
 			{
 				expression: 'ga:bounceRate',
 				alias: 'Bounce rate',
+			},
+			{
+				expression: 'ga:avgSessionDuration',
+				alias: 'Session Duration',
 			},
 		],
 		orderby: [
@@ -188,10 +195,21 @@ export default function ModulePopularPagesWidget( props ) {
 		},
 	];
 
+	if ( unifiedDashboardEnabled ) {
+		tableColumns.push( {
+			title: __( 'Session Duration', 'google-site-kit' ),
+			description: __( 'Session Duration', 'google-site-kit' ),
+			hideOnMobile: true,
+			field: 'metrics.0.values.3',
+			Component: ( { fieldValue } ) => (
+				<span>{ numFmt( fieldValue, 's' ) }</span>
+			),
+		} );
+	}
+
 	const rows = report?.[ 0 ]?.data?.rows?.length
 		? cloneDeep( report[ 0 ].data.rows )
 		: [];
-
 	// Combine the titles from the pageTitles with the rows from the metrics report.
 	rows.forEach( ( row ) => {
 		const url = row.dimensions[ 0 ];


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #4124

## Relevant technical choices

<!-- Please describe your changes. -->

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
