### PR TITLE
Only load Analytics widget when Analytics is active.

### DIFF
--- a/assets/js/modules/analytics/components/module/ModulePopularPagesWidget/index.js
+++ b/assets/js/modules/analytics/components/module/ModulePopularPagesWidget/index.js
@@ -43,11 +43,12 @@ import TableOverflowContainer from '../../../../../components/TableOverflowConta
 import DetailsPermaLinks from '../../../../../components/DetailsPermaLinks';
 import ReportTable from '../../../../../components/ReportTable';
 import PreviewTable from '../../../../../components/PreviewTable';
+import whenActive from '../../../../../util/when-active';
 import Header from './Header';
 import Footer from './Footer';
 const { useSelect } = Data;
 
-export default function ModulePopularPagesWidget( props ) {
+function ModulePopularPagesWidget( props ) {
 	const { Widget, WidgetReportError, WidgetReportZero } = props;
 
 	const isGatheringData = useSelect( ( select ) =>
@@ -212,3 +213,7 @@ ModulePopularPagesWidget.propTypes = {
 	WidgetReportError: PropTypes.elementType.isRequired,
 	WidgetReportZero: PropTypes.elementType.isRequired,
 };
+
+export default whenActive( { moduleName: 'analytics' } )(
+	ModulePopularPagesWidget
+);


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #4048. Adds a `whenActive` HOC to prevent the issue mentioned here: https://github.com/google/site-kit-wp/issues/4048#issuecomment-946784395

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
