### PR TITLE
Add event tracking for Search Console property setting.

### DIFF
--- a/assets/js/modules/search-console/components/common/PropertySelect.js
+++ b/assets/js/modules/search-console/components/common/PropertySelect.js
@@ -19,7 +19,7 @@
 /**
  * WordPress dependencies
  */
-import { useCallback } from '@wordpress/element';
+import { useCallback, useContext } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 
 /**
@@ -29,9 +29,13 @@ import Data from 'googlesitekit-data';
 import { MODULES_SEARCH_CONSOLE } from '../../datastore/constants';
 import ProgressBar from '../../../../components/ProgressBar';
 import { Select, Option } from '../../../../material-components';
+import { trackEvent } from '../../../../util/tracking';
+import ViewContextContext from '../../../../components/Root/ViewContextContext';
 const { useSelect, useDispatch } = Data;
 
 export default function PropertySelect() {
+	const viewContext = useContext( ViewContextContext );
+
 	const propertyID = useSelect( ( select ) =>
 		select( MODULES_SEARCH_CONSOLE ).getPropertyID()
 	);
@@ -50,9 +54,14 @@ export default function PropertySelect() {
 			const newPropertyID = item.dataset.value;
 			if ( propertyID !== newPropertyID ) {
 				setPropertyID( newPropertyID );
+
+				trackEvent(
+					`${ viewContext }_search-console`,
+					'change_property'
+				);
 			}
 		},
-		[ propertyID, setPropertyID ]
+		[ propertyID, setPropertyID, viewContext ]
 	);
 
 	if ( ! hasResolvedProperties ) {


### PR DESCRIPTION
## Summary

Addresses issue #4215

## Relevant technical choices

Implemented as per IB.

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
