### PR TITLE
Reset `viewWindow.max` when data is non-zero.

### DIFF
--- a/assets/js/modules/adsense/components/module/ModuleOverviewWidget/Stats.js
+++ b/assets/js/modules/adsense/components/module/ModuleOverviewWidget/Stats.js
@@ -133,6 +133,8 @@ export default function Stats( props ) {
 		isZeroReport( previousRangeData )
 	) {
 		options.vAxis.viewWindow.max = 100;
+	} else {
+		options.vAxis.viewWindow.max = undefined;
 	}
 
 	return (

--- a/assets/js/modules/analytics/components/dashboard/DashboardAllTrafficWidget/UserCountGraph.js
+++ b/assets/js/modules/analytics/components/dashboard/DashboardAllTrafficWidget/UserCountGraph.js
@@ -182,8 +182,13 @@ export default function UserCountGraph( { loaded, error, report } ) {
 
 	chartOptions.series[ 0 ].color = graphLineColor;
 	chartOptions.hAxis.ticks = [ startTick, ...midTicks, endTick ];
+
+	// Set the `max` height of the chart to `undefined` so that the chart will
+	// show all content, but only if the report is loaded/has data.
 	if ( ! report?.[ 0 ]?.data?.totals?.[ 0 ]?.values?.[ 0 ] ) {
 		chartOptions.vAxis.viewWindow.max = 100;
+	} else {
+		chartOptions.vAxis.viewWindow.max = undefined;
 	}
 
 	return (

--- a/assets/js/modules/analytics/components/module/ModuleOverviewWidget/SiteStats.js
+++ b/assets/js/modules/analytics/components/module/ModuleOverviewWidget/SiteStats.js
@@ -80,6 +80,8 @@ export default function SiteStats( { selectedStat, report } ) {
 
 	if ( isZeroReport( report ) ) {
 		options.vAxis.viewWindow.max = 100;
+	} else {
+		options.vAxis.viewWindow.max = undefined;
 	}
 
 	return (

--- a/assets/js/modules/search-console/components/module/ModuleOverviewWidget/Stats.js
+++ b/assets/js/modules/search-console/components/module/ModuleOverviewWidget/Stats.js
@@ -129,6 +129,8 @@ export default function Stats( props ) {
 
 	if ( isZeroReport( data ) ) {
 		options.vAxis.viewWindow.max = 100;
+	} else {
+		options.vAxis.viewWindow.max = undefined;
 	}
 
 	return (


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #4226.

## Relevant technical choices

On first load of these chart components, the report data is `undefined` (eg false-y) while they load, so it sets the `viewWindow.max` to `100`. But after the data loads it seems if that key isn't preset and set the old value passed to `options` remains.

So if data is available we need to "reset" the `viewWindow.max` attribute.

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
