### PR TITLE
Ensure the report total is always evaluated as a number.

### DIFF
--- a/assets/js/modules/analytics/components/dashboard/DashboardAllTrafficWidget/UserCountGraph.js
+++ b/assets/js/modules/analytics/components/dashboard/DashboardAllTrafficWidget/UserCountGraph.js
@@ -185,7 +185,12 @@ export default function UserCountGraph( { loaded, error, report } ) {
 
 	// Set the `max` height of the chart to `undefined` so that the chart will
 	// show all content, but only if the report is loaded/has data.
-	if ( ! report?.[ 0 ]?.data?.totals?.[ 0 ]?.values?.[ 0 ] ) {
+	if (
+		! report?.[ 0 ]?.data?.totals?.[ 0 ]?.values?.[ 0 ] ||
+		// The total returned by the API can be a string, so make sure we cast it
+		// to a number.
+		parseInt( report?.[ 0 ]?.data?.totals?.[ 0 ]?.values?.[ 0 ], 10 ) === 0
+	) {
 		chartOptions.vAxis.viewWindow.max = 100;
 	} else {
 		chartOptions.vAxis.viewWindow.max = undefined;


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #4226.

## Relevant technical choices

The value of the report total seems to be returned as a string sometimes; this prevents the negative numbers in the vertical axis being shown when there is zero data:


<img width="299" alt="Screenshot 2021-10-22 at 22 26 29" src="https://user-images.githubusercontent.com/90871/138524841-60c327a3-1b1f-4347-afef-50bf242efe6f.png">

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
