### PR TITLE
Enhancement/3201 full reset

### DIFF
--- a/includes/Core/Util/Reset.php
+++ b/includes/Core/Util/Reset.php
@@ -288,6 +288,18 @@ class Reset {
 	 * @since n.e.x.t
 	 */
 	public function maybe_hard_reset() {
+		/**
+		 * Filters the hard reset option, which is `false` by default.
+		 *
+		 * By default, when Site Kit is reset it does not delete "persistent" data
+		 * (options prefixed with `googlesitekitpersistent_`). If this filter returns `true`,
+		 * all options belonging to Site Kit, including those with the above "persistent"
+		 * prefix, will be deleted.
+		 *
+		 * @since n.e.x.t
+		 *
+		 * @param bool $hard_reset_enabled If a hard reset is enabled. `false` by default.
+		 */
 		$hard_reset_enabled = apply_filters( 'googlesitekit_hard_reset_enabled', false );
 		if ( ! $hard_reset_enabled ) {
 			return;

--- a/includes/Core/Util/Reset.php
+++ b/includes/Core/Util/Reset.php
@@ -278,4 +278,20 @@ class Reset {
 		);
 		exit;
 	}
+
+	/**
+	 * Performs hard reset if it is enabled programmatically.
+	 *
+	 * @since n.e.x.t
+	 */
+	public function maybe_hard_reset() {
+		$hard_reset_enabled = apply_filters( 'googlesitekit_hard_reset_enabled', false );
+		if ( ! $hard_reset_enabled ) {
+			return;
+		}
+
+		$reset_persistent = new Reset_Persistent( $this->context );
+		$reset_persistent->all();
+	}
+
 }

--- a/includes/Core/Util/Reset.php
+++ b/includes/Core/Util/Reset.php
@@ -239,6 +239,8 @@ class Reset {
 						'methods'             => WP_REST_Server::EDITABLE,
 						'callback'            => function( WP_REST_Request $request ) {
 							$this->all();
+							$this->maybe_hard_reset();
+
 							return new WP_REST_Response( true );
 						},
 						'permission_callback' => $can_setup,
@@ -264,6 +266,7 @@ class Reset {
 		}
 
 		$this->all();
+		$this->maybe_hard_reset();
 
 		wp_safe_redirect(
 			$this->context->admin_url(


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #3201

## Relevant technical choices

<!-- Please describe your changes. -->

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [ ] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
