### PR TITLE
Feature/4208 auto configure analytics

### DIFF
--- a/includes/Core/Authentication/Clients/OAuth_Client.php
+++ b/includes/Core/Authentication/Clients/OAuth_Client.php
@@ -409,7 +409,6 @@ final class OAuth_Client extends OAuth_Client_Base {
 		$previous_scopes = $this->get_granted_scopes();
 
 		// Update granted scopes.
-		$analytics_required = ! empty( $token_response['analytics_configuration'] );
 		if ( isset( $token_response['scope'] ) ) {
 			$scopes = explode( ' ', sanitize_text_field( $token_response['scope'] ) );
 		} elseif ( $this->context->input()->filter( INPUT_GET, 'scope' ) ) {
@@ -430,7 +429,7 @@ final class OAuth_Client extends OAuth_Client_Base {
 				return 0 === strpos( $scope, 'https://www.googleapis.com/auth/' );
 			}
 		);
-		$this->set_granted_scopes( $scopes, $analytics_required );
+		$this->set_granted_scopes( $scopes, ! empty( $token_response['analytics_configuration'] ) );
 
 		$this->refresh_profile_data( 2 * MINUTE_IN_SECONDS );
 

--- a/includes/Core/Modules/Modules.php
+++ b/includes/Core/Modules/Modules.php
@@ -262,6 +262,25 @@ final class Modules {
 				return $data;
 			}
 		);
+
+		// Automatic Analytics setup.
+		add_action(
+			'googlesitekit_authorize_user',
+			function( array $token_response ) {
+				$module = $this->get_module( Analytics::MODULE_SLUG );
+				$option = $this->get_active_modules_option();
+
+				if ( in_array( Analytics::MODULE_SLUG, $option, true )
+					|| empty( $token_response['analytics_configuration'] ) ) {
+					// Ignore automatic analytics setup if module is already
+					// active or analytics information is missing.
+					return;
+				}
+				$this->activate_module( Analytics::MODULE_SLUG );
+				$module->handle_token_response_data( $token_response );
+			},
+			1 // Ensure this hook happens before Analytics hook.
+		);
 	}
 
 	/**

--- a/includes/Core/Modules/Modules.php
+++ b/includes/Core/Modules/Modules.php
@@ -270,13 +270,17 @@ final class Modules {
 				$module = $this->get_module( Analytics::MODULE_SLUG );
 				$option = $this->get_active_modules_option();
 
-				if ( in_array( Analytics::MODULE_SLUG, $option, true )
-					|| empty( $token_response['analytics_configuration'] ) ) {
-					// Ignore automatic analytics setup if module is already
-					// active or analytics information is missing.
+				if ( empty( $token_response['analytics_configuration'] ) ) {
+					// Ignore automatic analytics setup if analytics
+					// information is missing.
 					return;
 				}
-				$this->activate_module( Analytics::MODULE_SLUG );
+
+				if ( ! in_array( Analytics::MODULE_SLUG, $option, true ) ) {
+					// Activate Analytics module if it's not already active.
+					$this->activate_module( Analytics::MODULE_SLUG );
+				}
+
 				$module->handle_token_response_data( $token_response );
 			},
 			1 // Ensure this hook happens before Analytics hook.

--- a/includes/Modules/Analytics.php
+++ b/includes/Modules/Analytics.php
@@ -111,6 +111,14 @@ final class Analytics extends Module
 		// Analytics tag placement logic.
 		add_action( 'template_redirect', $this->get_method_proxy( 'register_tag' ) );
 
+		// Automatic Analytics setup.
+		add_action(
+			'googlesitekit_authorize_user',
+			function( array $token_response ) {
+				$this->handle_token_response_data( $token_response );
+			}
+		);
+
 		( new Advanced_Tracking( $this->context ) )->register();
 	}
 
@@ -226,6 +234,32 @@ final class Analytics extends Module
 				'value' => $settings['useSnippet'] ? __( 'Yes', 'google-site-kit' ) : __( 'No', 'google-site-kit' ),
 				'debug' => $settings['useSnippet'] ? 'yes' : 'no',
 			),
+		);
+	}
+
+	/**
+	 * Handles the token response data by configuring Analytics if an analytics
+	 * configuration exists in the given token response.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param array $token_response The OAuth token response.
+	 */
+	public function handle_token_response_data( $token_response ) {
+		if ( $this->is_connected()
+			|| empty( $token_response['analytics_configuration'] ) ) {
+			// Ignore automatic analytics setup if module is already
+			// connected or analytics information is missing.
+			return;
+		}
+		$configuration = $token_response['analytics_configuration'];
+		$this->get_settings()->merge(
+			array(
+				'accountID'             => $configuration['ga_account_id'],
+				'propertyID'            => $configuration['ua_property_id'],
+				'internalWebPropertyID' => $configuration['ua_internal_web_property_id'],
+				'profileID'             => $configuration['ua_profile_id'],
+			)
 		);
 	}
 

--- a/tests/phpunit/integration/Core/Modules/ModulesTest.php
+++ b/tests/phpunit/integration/Core/Modules/ModulesTest.php
@@ -311,7 +311,7 @@ class ModulesTest extends TestCase {
 
 		do_action( 'googlesitekit_authorize_user', $token_response );
 
-		// Analytics is configured with the correct data
+		// Analytics is configured with the correct data.
 		$option     = $reflected_get_active_modules_option_method->invoke( $modules );
 		$connection = $analytics->get_settings()->get();
 		$this->assertTrue( in_array( Analytics::MODULE_SLUG, $option, true ) );

--- a/tests/phpunit/integration/Modules/AnalyticsTest.php
+++ b/tests/phpunit/integration/Modules/AnalyticsTest.php
@@ -746,9 +746,7 @@ class AnalyticsTest extends TestCase {
 		$reflected_handle_token_response_data_method = new ReflectionMethod( 'Google\Site_Kit\Modules\Analytics', 'handle_token_response_data' );
 		$reflected_handle_token_response_data_method->setAccessible( true );
 
-		$configuration = array();
-
-		$reflected_handle_token_response_data_method->invoke( $analytics, array( 'analytics_configuration' => $configuration ) );
+		$reflected_handle_token_response_data_method->invoke( $analytics, array( 'analytics_configuration' => array() ) );
 
 		$connection = $analytics->get_settings()->get();
 		$this->assertFalse( $analytics->is_connected() );
@@ -798,5 +796,4 @@ class AnalyticsTest extends TestCase {
 		$this->assertEquals( $connection['internalWebPropertyID'], $ua_internal_web_property_id );
 		$this->assertEquals( $connection['profileID'], $ua_profile_id );
 	}
-
 }


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #4208

## Relevant technical choices

<!-- Please describe your changes. -->
The Analytics module will be automatically activated and configured if an `analytics_configuration` is present in the token response from the Site Kit Service.

## Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
