### PR TITLE
Conditionally select Analytics data for Search Funnel widget.

### DIFF
--- a/assets/js/modules/search-console/components/dashboard/SearchFunnelWidget/index.js
+++ b/assets/js/modules/search-console/components/dashboard/SearchFunnelWidget/index.js
@@ -49,6 +49,7 @@ import Header from './Header';
 import Overview from './Overview';
 import SearchConsoleStats from './SearchConsoleStats';
 import AnalyticsStats from './AnalyticsStats';
+import { CORE_MODULES } from '../../../../../googlesitekit/modules/datastore/constants';
 const { useSelect } = Data;
 
 const SearchFunnelWidget = ( {
@@ -57,6 +58,10 @@ const SearchFunnelWidget = ( {
 	WidgetReportError,
 } ) => {
 	const [ selectedStats, setSelectedStats ] = useState( 0 );
+
+	const isAnalyticsConnected = useSelect( ( select ) =>
+		select( CORE_MODULES ).isModuleConnected( 'analytics' )
+	);
 
 	const dateRangeLength = useSelect( ( select ) =>
 		select( CORE_USER ).getDateRangeNumberOfDays()
@@ -140,65 +145,117 @@ const SearchFunnelWidget = ( {
 			).hasFinishedResolution( 'getReport', [ searchConsoleReportArgs ] )
 	);
 
-	const analyticsOverviewLoading = useSelect(
-		( select ) =>
-			! select( MODULES_ANALYTICS ).hasFinishedResolution( 'getReport', [
-				analyticsOverviewArgs,
-			] )
-	);
-	const analyticsOverviewData = useSelect( ( select ) =>
-		select( MODULES_ANALYTICS ).getReport( analyticsOverviewArgs )
-	);
-	const analyticsOverviewError = useSelect( ( select ) =>
-		select( MODULES_ANALYTICS ).getErrorForSelector( 'getReport', [
+	const analyticsOverviewLoading = useSelect( ( select ) => {
+		if ( ! isAnalyticsConnected ) {
+			return false;
+		}
+
+		return ! select( MODULES_ANALYTICS ).hasFinishedResolution(
+			'getReport',
+			[ analyticsOverviewArgs ]
+		);
+	} );
+	const analyticsOverviewData = useSelect( ( select ) => {
+		if ( ! isAnalyticsConnected ) {
+			return null;
+		}
+
+		return select( MODULES_ANALYTICS ).getReport( analyticsOverviewArgs );
+	} );
+	const analyticsOverviewError = useSelect( ( select ) => {
+		if ( ! isAnalyticsConnected ) {
+			return false;
+		}
+
+		return select( MODULES_ANALYTICS ).getErrorForSelector( 'getReport', [
 			analyticsOverviewArgs,
-		] )
-	);
+		] );
+	} );
 
-	const analyticsStatsLoading = useSelect(
-		( select ) =>
-			! select( MODULES_ANALYTICS ).hasFinishedResolution( 'getReport', [
-				analyticsStatsArgs,
-			] )
-	);
-	const analyticsStatsData = useSelect( ( select ) =>
-		select( MODULES_ANALYTICS ).getReport( analyticsStatsArgs )
-	);
-	const analyticsStatsError = useSelect( ( select ) =>
-		select( MODULES_ANALYTICS ).getErrorForSelector( 'getReport', [
+	const analyticsStatsLoading = useSelect( ( select ) => {
+		if ( ! isAnalyticsConnected ) {
+			return false;
+		}
+
+		return ! select( MODULES_ANALYTICS ).hasFinishedResolution(
+			'getReport',
+			[ analyticsStatsArgs ]
+		);
+	} );
+	const analyticsStatsData = useSelect( ( select ) => {
+		if ( ! isAnalyticsConnected ) {
+			return null;
+		}
+
+		return select( MODULES_ANALYTICS ).getReport( analyticsStatsArgs );
+	} );
+	const analyticsStatsError = useSelect( ( select ) => {
+		if ( ! isAnalyticsConnected ) {
+			return false;
+		}
+
+		return select( MODULES_ANALYTICS ).getErrorForSelector( 'getReport', [
 			analyticsStatsArgs,
-		] )
-	);
+		] );
+	} );
 
-	const analyticsVisitorsOverviewLoading = useSelect(
-		( select ) =>
-			! select( MODULES_ANALYTICS ).hasFinishedResolution( 'getReport', [
-				analyticsVisitorsOverviewArgs,
-			] )
-	);
-	const analyticsVisitorsOverviewData = useSelect( ( select ) =>
-		select( MODULES_ANALYTICS ).getReport( analyticsVisitorsOverviewArgs )
-	);
-	const analyticsVisitorsOverviewError = useSelect( ( select ) =>
-		select( MODULES_ANALYTICS ).getErrorForSelector( 'getReport', [
+	const analyticsVisitorsOverviewLoading = useSelect( ( select ) => {
+		if ( ! isAnalyticsConnected ) {
+			return false;
+		}
+
+		return ! select( MODULES_ANALYTICS ).hasFinishedResolution(
+			'getReport',
+			[ analyticsVisitorsOverviewArgs ]
+		);
+	} );
+	const analyticsVisitorsOverviewData = useSelect( ( select ) => {
+		if ( ! isAnalyticsConnected ) {
+			return null;
+		}
+
+		return select( MODULES_ANALYTICS ).getReport(
+			analyticsVisitorsOverviewArgs
+		);
+	} );
+	const analyticsVisitorsOverviewError = useSelect( ( select ) => {
+		if ( ! isAnalyticsConnected ) {
+			return false;
+		}
+
+		return select( MODULES_ANALYTICS ).getErrorForSelector( 'getReport', [
 			analyticsVisitorsOverviewArgs,
-		] )
-	);
+		] );
+	} );
 
-	const analyticsVisitorsStatsLoading = useSelect(
-		( select ) =>
-			! select( MODULES_ANALYTICS ).hasFinishedResolution( 'getReport', [
-				analyticsVisitorsStatsArgs,
-			] )
-	);
-	const analyticsVisitorsStatsData = useSelect( ( select ) =>
-		select( MODULES_ANALYTICS ).getReport( analyticsVisitorsStatsArgs )
-	);
-	const analyticsVisitorsStatsError = useSelect( ( select ) =>
-		select( MODULES_ANALYTICS ).getErrorForSelector( 'getReport', [
+	const analyticsVisitorsStatsLoading = useSelect( ( select ) => {
+		if ( ! isAnalyticsConnected ) {
+			return false;
+		}
+
+		return ! select( MODULES_ANALYTICS ).hasFinishedResolution(
+			'getReport',
+			[ analyticsVisitorsStatsArgs ]
+		);
+	} );
+	const analyticsVisitorsStatsData = useSelect( ( select ) => {
+		if ( ! isAnalyticsConnected ) {
+			return null;
+		}
+
+		return select( MODULES_ANALYTICS ).getReport(
+			analyticsVisitorsStatsArgs
+		);
+	} );
+	const analyticsVisitorsStatsError = useSelect( ( select ) => {
+		if ( ! isAnalyticsConnected ) {
+			return null;
+		}
+
+		return select( MODULES_ANALYTICS ).getErrorForSelector( 'getReport', [
 			analyticsVisitorsStatsArgs,
-		] )
-	);
+		] );
+	} );
 
 	const WidgetHeader = () => (
 		<Header


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #4123.

This PR exposes a potential desire for a `useSelectIfModulesActivated` hook that returns `null` or similar when a module isn't activated. Might be worth doing in a future issue, because this PR adds a fair bit of boilerplate to fix the issue encountered here: https://github.com/google/site-kit-wp/issues/4123#issuecomment-956281336.

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
