### PR TITLE
Move Search Funnel Widget below other widgets.

### DIFF
--- a/assets/js/modules/search-console/index.js
+++ b/assets/js/modules/search-console/index.js
@@ -151,7 +151,7 @@ export const registerWidgets = ( widgets ) => {
 			{
 				Component: SearchFunnelWidget,
 				width: [ widgets.WIDGET_WIDTHS.FULL ],
-				priority: 1,
+				priority: 3,
 				wrapWidget: false,
 			},
 			[


### PR DESCRIPTION
This fixes the priority of the Search Funnel widget on the Unified Dashboard. See: https://github.com/google/site-kit-wp/issues/4123#issuecomment-959092647

## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #4123.

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
