### PR TITLE
adds default class appendix to WidgetAreaRenderer

### DIFF
--- a/assets/js/googlesitekit/widgets/components/WidgetAreaRenderer.js
+++ b/assets/js/googlesitekit/widgets/components/WidgetAreaRenderer.js
@@ -43,7 +43,7 @@ import InViewProvider from '../../../components/InViewProvider';
 const { useSelect } = Data;
 const DEFAULT_CLASS_APPENDIX = '--boxes'
 
-export default function WidgetAreaRenderer( { slug, totalAreas } ) {
+export default function WidgetAreaRenderer( { slug = DEFAULT_CLASS_APPENDIX, totalAreas } ) {
 	const widgetAreaRef = useRef();
 	const intersectionEntry = useIntersection( widgetAreaRef, {
 		rootMargin: '0px',
@@ -185,5 +185,5 @@ export default function WidgetAreaRenderer( { slug, totalAreas } ) {
 }
 
 WidgetAreaRenderer.propTypes = {
-	slug: PropTypes.string.isRequired ?? DEFAULT_CLASS_APPENDIX,
+	slug: PropTypes.string.isRequired,
 };

--- a/assets/js/googlesitekit/widgets/components/WidgetAreaRenderer.js
+++ b/assets/js/googlesitekit/widgets/components/WidgetAreaRenderer.js
@@ -41,6 +41,7 @@ import WidgetCellWrapper from './WidgetCellWrapper';
 import { isInactiveWidgetState } from '../util/is-inactive-widget-state';
 import InViewProvider from '../../../components/InViewProvider';
 const { useSelect } = Data;
+const DEFAULT_CLASS_APPENDIX = '--boxes'
 
 export default function WidgetAreaRenderer( { slug, totalAreas } ) {
 	const widgetAreaRef = useRef();
@@ -184,5 +185,5 @@ export default function WidgetAreaRenderer( { slug, totalAreas } ) {
 }
 
 WidgetAreaRenderer.propTypes = {
-	slug: PropTypes.string.isRequired,
+	slug: PropTypes.string.isRequired ?? DEFAULT_CLASS_APPENDIX,
 };


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #4329 

## Relevant technical choices

<!-- Please describe your changes. -->
I added a default value for the class appendix that will take place if the slug is undefined like described in the issue
## Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
