### PR TITLE
Remove individual module pages.

### DIFF
--- a/assets/js/components/DashboardEntryPoint.js
+++ b/assets/js/components/DashboardEntryPoint.js
@@ -1,0 +1,25 @@
+import { Fragment } from '@wordpress/element';
+import { useFeature } from '../hooks/useFeature';
+import ModuleSetup from './setup/ModuleSetup';
+import DashboardApp from './dashboard/DashboardApp';
+import DashboardMainApp from './DashboardMainApp';
+import NotificationCounter from './legacy-notifications/notification-counter';
+
+export default function DashboardEntryPoint( { setupModuleSlug } ) {
+	const unifiedDashboardEnabled = useFeature( 'unifiedDashboard' );
+
+	if ( unifiedDashboardEnabled ) {
+		return <DashboardMainApp />;
+	}
+
+	if ( !! setupModuleSlug ) {
+		return <ModuleSetup moduleSlug={ setupModuleSlug } />;
+	}
+
+	return (
+		<Fragment>
+			<NotificationCounter />
+			<DashboardApp />
+		</Fragment>
+	);
+}

--- a/assets/js/components/DashboardEntryPoint.js
+++ b/assets/js/components/DashboardEntryPoint.js
@@ -1,4 +1,29 @@
+/**
+ * DashboardEntryPoint component.
+ *
+ * Site Kit by Google, Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * WordPress dependencies
+ */
 import { Fragment } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
 import { useFeature } from '../hooks/useFeature';
 import ModuleSetup from './setup/ModuleSetup';
 import DashboardApp from './dashboard/DashboardApp';

--- a/assets/js/components/DashboardEntryPoint.js
+++ b/assets/js/components/DashboardEntryPoint.js
@@ -8,12 +8,12 @@ import NotificationCounter from './legacy-notifications/notification-counter';
 export default function DashboardEntryPoint( { setupModuleSlug } ) {
 	const unifiedDashboardEnabled = useFeature( 'unifiedDashboard' );
 
-	if ( unifiedDashboardEnabled ) {
-		return <DashboardMainApp />;
-	}
-
 	if ( !! setupModuleSlug ) {
 		return <ModuleSetup moduleSlug={ setupModuleSlug } />;
+	}
+
+	if ( unifiedDashboardEnabled ) {
+		return <DashboardMainApp />;
 	}
 
 	return (

--- a/assets/js/components/DashboardEntryPoint.js
+++ b/assets/js/components/DashboardEntryPoint.js
@@ -17,6 +17,11 @@
  */
 
 /**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+
+/**
  * WordPress dependencies
  */
 import { Fragment } from '@wordpress/element';
@@ -48,3 +53,7 @@ export default function DashboardEntryPoint( { setupModuleSlug } ) {
 		</Fragment>
 	);
 }
+
+DashboardEntryPoint.propTypes = {
+	setupModuleSlug: PropTypes.string,
+};

--- a/assets/js/components/DashboardEntryPoint.test.js
+++ b/assets/js/components/DashboardEntryPoint.test.js
@@ -35,41 +35,33 @@ jest.mock( './legacy-notifications/notification-counter', () =>
 );
 
 describe( 'DashboardEntryPoint', () => {
-	describe( 'when unified dashboard is enabled', () => {
-		const renderOptions = { features: [ 'unifiedDashboard' ] };
+	const unifiedDashboardRenderOptions = { features: [ 'unifiedDashboard' ] };
 
-		it( 'should render the unified dashboard', () => {
-			const { container } = render(
-				<DashboardEntryPoint />,
-				renderOptions
-			);
-			expect( container ).toMatchSnapshot();
-		} );
-
-		describe( 'when passed the setupModuleSlug prop', () => {
-			it( 'should render the module setup component', () => {
-				const { container } = render(
-					<DashboardEntryPoint setupModuleSlug="analytics" />,
-					renderOptions
-				);
-				expect( container ).toMatchSnapshot();
-			} );
-		} );
+	it( 'should render the unified dashboard when unified dashboard is enabled', () => {
+		const { container } = render(
+			<DashboardEntryPoint />,
+			unifiedDashboardRenderOptions
+		);
+		expect( container ).toMatchSnapshot();
 	} );
 
-	describe( 'when unified dashboard is not enabled', () => {
-		it( 'should render the non-unified dashboard', () => {
-			const { container } = render( <DashboardEntryPoint /> );
-			expect( container ).toMatchSnapshot();
-		} );
+	it( 'should render the module setup component when unified dashboard is enabled and passed the setupModuleSlug prop', () => {
+		const { container } = render(
+			<DashboardEntryPoint setupModuleSlug="analytics" />,
+			unifiedDashboardRenderOptions
+		);
+		expect( container ).toMatchSnapshot();
+	} );
 
-		describe( 'when passed the setupModuleSlug prop', () => {
-			it( 'should render the module setup component', () => {
-				const { container } = render(
-					<DashboardEntryPoint setupModuleSlug="analytics" />
-				);
-				expect( container ).toMatchSnapshot();
-			} );
-		} );
+	it( 'should render the non-unified dashboard when unified dashboard is not enabled', () => {
+		const { container } = render( <DashboardEntryPoint /> );
+		expect( container ).toMatchSnapshot();
+	} );
+
+	it( 'should render the module setup component when unified dashboard is not enabled and passed the setupModuleSlug prop', () => {
+		const { container } = render(
+			<DashboardEntryPoint setupModuleSlug="analytics" />
+		);
+		expect( container ).toMatchSnapshot();
 	} );
 } );

--- a/assets/js/components/DashboardEntryPoint.test.js
+++ b/assets/js/components/DashboardEntryPoint.test.js
@@ -1,0 +1,75 @@
+/**
+ * DashboardEntryPoint tests.
+ *
+ * Site Kit by Google, Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import { render } from '../../../tests/js/test-utils';
+import { mockCreateComponent } from '../../../tests/js/mock-component-utils';
+import DashboardEntryPoint from './DashboardEntryPoint';
+
+jest.mock( './setup/ModuleSetup', () => mockCreateComponent( 'ModuleSetup' ) );
+jest.mock( './dashboard/DashboardApp', () =>
+	mockCreateComponent( 'DashboardApp' )
+);
+jest.mock( './DashboardMainApp', () =>
+	mockCreateComponent( 'DashboardMainApp' )
+);
+jest.mock( './legacy-notifications/notification-counter', () =>
+	mockCreateComponent( 'NotificationCounter' )
+);
+
+describe( 'DashboardEntryPoint', () => {
+	describe( 'when unified dashboard is enabled', () => {
+		const renderOptions = { features: [ 'unifiedDashboard' ] };
+
+		it( 'should render the unified dashboard', () => {
+			const { container } = render(
+				<DashboardEntryPoint />,
+				renderOptions
+			);
+			expect( container ).toMatchSnapshot();
+		} );
+
+		describe( 'when passed the setupModuleSlug prop', () => {
+			it( 'should render the module setup component', () => {
+				const { container } = render(
+					<DashboardEntryPoint setupModuleSlug="analytics" />,
+					renderOptions
+				);
+				expect( container ).toMatchSnapshot();
+			} );
+		} );
+	} );
+
+	describe( 'when unified dashboard is not enabled', () => {
+		it( 'should render the non-unified dashboard', () => {
+			const { container } = render( <DashboardEntryPoint /> );
+			expect( container ).toMatchSnapshot();
+		} );
+
+		describe( 'when passed the setupModuleSlug prop', () => {
+			it( 'should render the module setup component', () => {
+				const { container } = render(
+					<DashboardEntryPoint setupModuleSlug="analytics" />
+				);
+				expect( container ).toMatchSnapshot();
+			} );
+		} );
+	} );
+} );

--- a/assets/js/components/__snapshots__/DashboardEntryPoint.test.js.snap
+++ b/assets/js/components/__snapshots__/DashboardEntryPoint.test.js.snap
@@ -1,15 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`DashboardEntryPoint when unified dashboard is enabled should render the unified dashboard 1`] = `
-<div>
-  <div>
-    DashboardMainApp
-    {}
-  </div>
-</div>
-`;
-
-exports[`DashboardEntryPoint when unified dashboard is enabled when passed the setupModuleSlug prop should render the module setup component 1`] = `
+exports[`DashboardEntryPoint should render the module setup component when unified dashboard is enabled and passed the setupModuleSlug prop 1`] = `
 <div>
   <div>
     ModuleSetup
@@ -18,7 +9,16 @@ exports[`DashboardEntryPoint when unified dashboard is enabled when passed the s
 </div>
 `;
 
-exports[`DashboardEntryPoint when unified dashboard is not enabled should render the non-unified dashboard 1`] = `
+exports[`DashboardEntryPoint should render the module setup component when unified dashboard is not enabled and passed the setupModuleSlug prop 1`] = `
+<div>
+  <div>
+    ModuleSetup
+    {"moduleSlug":"analytics"}
+  </div>
+</div>
+`;
+
+exports[`DashboardEntryPoint should render the non-unified dashboard when unified dashboard is not enabled 1`] = `
 <div>
   <div>
     NotificationCounter
@@ -31,11 +31,11 @@ exports[`DashboardEntryPoint when unified dashboard is not enabled should render
 </div>
 `;
 
-exports[`DashboardEntryPoint when unified dashboard is not enabled when passed the setupModuleSlug prop should render the module setup component 1`] = `
+exports[`DashboardEntryPoint should render the unified dashboard when unified dashboard is enabled 1`] = `
 <div>
   <div>
-    ModuleSetup
-    {"moduleSlug":"analytics"}
+    DashboardMainApp
+    {}
   </div>
 </div>
 `;

--- a/assets/js/components/__snapshots__/DashboardEntryPoint.test.js.snap
+++ b/assets/js/components/__snapshots__/DashboardEntryPoint.test.js.snap
@@ -1,0 +1,41 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DashboardEntryPoint when unified dashboard is enabled should render the unified dashboard 1`] = `
+<div>
+  <div>
+    DashboardMainApp
+    {}
+  </div>
+</div>
+`;
+
+exports[`DashboardEntryPoint when unified dashboard is enabled when passed the setupModuleSlug prop should render the module setup component 1`] = `
+<div>
+  <div>
+    ModuleSetup
+    {"moduleSlug":"analytics"}
+  </div>
+</div>
+`;
+
+exports[`DashboardEntryPoint when unified dashboard is not enabled should render the non-unified dashboard 1`] = `
+<div>
+  <div>
+    NotificationCounter
+    {}
+  </div>
+  <div>
+    DashboardApp
+    {}
+  </div>
+</div>
+`;
+
+exports[`DashboardEntryPoint when unified dashboard is not enabled when passed the setupModuleSlug prop should render the module setup component 1`] = `
+<div>
+  <div>
+    ModuleSetup
+    {"moduleSlug":"analytics"}
+  </div>
+</div>
+`;

--- a/assets/js/googlesitekit-dashboard.js
+++ b/assets/js/googlesitekit-dashboard.js
@@ -20,42 +20,19 @@
  * WordPress dependencies
  */
 import domReady from '@wordpress/dom-ready';
-import { render, Fragment } from '@wordpress/element';
+import { render } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import { clearWebStorage } from './util';
-import { useFeature } from './hooks/useFeature';
 import Root from './components/Root';
-import ModuleSetup from './components/setup/ModuleSetup';
-import DashboardApp from './components/dashboard/DashboardApp';
-import DashboardMainApp from './components/DashboardMainApp';
-import NotificationCounter from './components/legacy-notifications/notification-counter';
 import './components/legacy-notifications';
 import {
 	VIEW_CONTEXT_DASHBOARD,
 	VIEW_CONTEXT_MODULE_SETUP,
 } from './googlesitekit/constants';
-
-const GoogleSitekitDashboard = ( { setupModuleSlug } ) => {
-	const unifiedDashboardEnabled = useFeature( 'unifiedDashboard' );
-
-	if ( unifiedDashboardEnabled ) {
-		return <DashboardMainApp />;
-	}
-
-	if ( !! setupModuleSlug ) {
-		return <ModuleSetup moduleSlug={ setupModuleSlug } />;
-	}
-
-	return (
-		<Fragment>
-			<NotificationCounter />
-			<DashboardApp />
-		</Fragment>
-	);
-};
+import DashboardEntryPoint from './components/DashboardEntryPoint';
 
 // Initialize the app once the DOM is ready.
 domReady( () => {
@@ -78,7 +55,7 @@ domReady( () => {
 						: VIEW_CONTEXT_DASHBOARD
 				}
 			>
-				<GoogleSitekitDashboard setupModuleSlug={ setupModuleSlug } />
+				<DashboardEntryPoint setupModuleSlug={ setupModuleSlug } />
 			</Root>,
 			renderTarget
 		);

--- a/assets/js/modules/adsense/datastore/base.js
+++ b/assets/js/modules/adsense/datastore/base.js
@@ -20,6 +20,7 @@
  * Internal dependencies
  */
 import Modules from 'googlesitekit-modules';
+import { isFeatureEnabled } from '../../../features';
 import { MODULES_ADSENSE } from './constants';
 import { validateCanSubmitChanges } from './settings';
 
@@ -37,7 +38,9 @@ const baseModuleStore = Modules.createModuleStore( 'adsense', {
 		'webStoriesAdUnit',
 		'autoAdsDisabled',
 	],
-	adminPage: 'googlesitekit-module-adsense',
+	adminPage: isFeatureEnabled( 'unifiedDashboard' )
+		? undefined
+		: 'googlesitekit-module-adsense',
 	validateCanSubmitChanges,
 } );
 

--- a/assets/js/modules/adsense/datastore/base.test.js
+++ b/assets/js/modules/adsense/datastore/base.test.js
@@ -43,8 +43,8 @@ describe( 'modules/adsense base data store', () => {
 		store = require( './base' ).default;
 		registry.registerStore( MODULES_ADSENSE, store );
 
-		expect( store.selectors.getAdminScreenURL() ).toBe(
-			`http://example.com/wp-admin/admin.php?page=googlesitekit-dashboard`
+		expect( registry.select( MODULES_ADSENSE ).getAdminScreenURL() ).toBe(
+			'http://example.com/wp-admin/admin.php?page=googlesitekit-dashboard'
 		);
 	} );
 
@@ -52,8 +52,8 @@ describe( 'modules/adsense base data store', () => {
 		store = require( './base' ).default;
 		registry.registerStore( MODULES_ADSENSE, store );
 
-		expect( store.selectors.getAdminScreenURL() ).toBe(
-			`http://example.com/wp-admin/admin.php?page=googlesitekit-module-adsense`
+		expect( registry.select( MODULES_ADSENSE ).getAdminScreenURL() ).toBe(
+			'http://example.com/wp-admin/admin.php?page=googlesitekit-module-adsense'
 		);
 	} );
 } );

--- a/assets/js/modules/adsense/datastore/base.test.js
+++ b/assets/js/modules/adsense/datastore/base.test.js
@@ -1,0 +1,69 @@
+/**
+ * `modules/adsense` base data store tests.
+ *
+ * Site Kit by Google, Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import { createTestRegistry } from '../../../../../tests/js/utils';
+import { CORE_SITE } from '../../../googlesitekit/datastore/site/constants';
+import { MODULES_ADSENSE } from './constants';
+
+describe( 'modules/adsense base data store', () => {
+	let registry;
+	let store;
+
+	const adminURL = 'http://something.test/wp-admin';
+
+	beforeEach( () => {
+		jest.resetModules();
+
+		registry = createTestRegistry();
+		registry.dispatch( CORE_SITE ).receiveSiteInfo( {
+			adminURL,
+		} );
+	} );
+
+	describe( 'when unified dashboard is enabled', () => {
+		beforeEach( () => {
+			const { enabledFeatures } = require( '../../../features' );
+			enabledFeatures.add( 'unifiedDashboard' );
+
+			store = require( './base' ).default;
+			registry.registerStore( MODULES_ADSENSE, store );
+		} );
+
+		it( 'does not define the admin page', () => {
+			expect( store.selectors.getAdminScreenURL() ).toBe(
+				`${ adminURL }/admin.php?page=googlesitekit-dashboard`
+			);
+		} );
+	} );
+
+	describe( 'when unified dashboard is not enabled', () => {
+		beforeEach( () => {
+			store = require( './base' ).default;
+			registry.registerStore( MODULES_ADSENSE, store );
+		} );
+
+		it( 'does define the admin page', () => {
+			expect( store.selectors.getAdminScreenURL() ).toBe(
+				`${ adminURL }/admin.php?page=googlesitekit-module-adsense`
+			);
+		} );
+	} );
+} );

--- a/assets/js/modules/adsense/datastore/base.test.js
+++ b/assets/js/modules/adsense/datastore/base.test.js
@@ -19,23 +19,21 @@
 /**
  * Internal dependencies
  */
-import { createTestRegistry } from '../../../../../tests/js/utils';
-import { CORE_SITE } from '../../../googlesitekit/datastore/site/constants';
+import {
+	createTestRegistry,
+	provideSiteInfo,
+} from '../../../../../tests/js/utils';
 import { MODULES_ADSENSE } from './constants';
 
 describe( 'modules/adsense base data store', () => {
 	let registry;
 	let store;
 
-	const adminURL = 'http://something.test/wp-admin';
-
 	beforeEach( () => {
 		jest.resetModules();
 
 		registry = createTestRegistry();
-		registry.dispatch( CORE_SITE ).receiveSiteInfo( {
-			adminURL,
-		} );
+		provideSiteInfo( registry );
 	} );
 
 	it( 'does not define the admin page when unified dashboard is enabled', () => {
@@ -46,7 +44,7 @@ describe( 'modules/adsense base data store', () => {
 		registry.registerStore( MODULES_ADSENSE, store );
 
 		expect( store.selectors.getAdminScreenURL() ).toBe(
-			`${ adminURL }/admin.php?page=googlesitekit-dashboard`
+			`http://example.com/wp-admin/admin.php?page=googlesitekit-dashboard`
 		);
 	} );
 
@@ -55,7 +53,7 @@ describe( 'modules/adsense base data store', () => {
 		registry.registerStore( MODULES_ADSENSE, store );
 
 		expect( store.selectors.getAdminScreenURL() ).toBe(
-			`${ adminURL }/admin.php?page=googlesitekit-module-adsense`
+			`http://example.com/wp-admin/admin.php?page=googlesitekit-module-adsense`
 		);
 	} );
 } );

--- a/assets/js/modules/adsense/datastore/base.test.js
+++ b/assets/js/modules/adsense/datastore/base.test.js
@@ -38,32 +38,24 @@ describe( 'modules/adsense base data store', () => {
 		} );
 	} );
 
-	describe( 'when unified dashboard is enabled', () => {
-		beforeEach( () => {
-			const { enabledFeatures } = require( '../../../features' );
-			enabledFeatures.add( 'unifiedDashboard' );
+	it( 'does not define the admin page when unified dashboard is enabled', () => {
+		const { enabledFeatures } = require( '../../../features' );
+		enabledFeatures.add( 'unifiedDashboard' );
 
-			store = require( './base' ).default;
-			registry.registerStore( MODULES_ADSENSE, store );
-		} );
+		store = require( './base' ).default;
+		registry.registerStore( MODULES_ADSENSE, store );
 
-		it( 'does not define the admin page', () => {
-			expect( store.selectors.getAdminScreenURL() ).toBe(
-				`${ adminURL }/admin.php?page=googlesitekit-dashboard`
-			);
-		} );
+		expect( store.selectors.getAdminScreenURL() ).toBe(
+			`${ adminURL }/admin.php?page=googlesitekit-dashboard`
+		);
 	} );
 
-	describe( 'when unified dashboard is not enabled', () => {
-		beforeEach( () => {
-			store = require( './base' ).default;
-			registry.registerStore( MODULES_ADSENSE, store );
-		} );
+	it( 'does define the admin page when unified dashboard is not enabled', () => {
+		store = require( './base' ).default;
+		registry.registerStore( MODULES_ADSENSE, store );
 
-		it( 'does define the admin page', () => {
-			expect( store.selectors.getAdminScreenURL() ).toBe(
-				`${ adminURL }/admin.php?page=googlesitekit-module-adsense`
-			);
-		} );
+		expect( store.selectors.getAdminScreenURL() ).toBe(
+			`${ adminURL }/admin.php?page=googlesitekit-module-adsense`
+		);
 	} );
 } );

--- a/assets/js/modules/analytics/datastore/base.js
+++ b/assets/js/modules/analytics/datastore/base.js
@@ -20,6 +20,7 @@
  * Internal dependencies
  */
 import Modules from 'googlesitekit-modules';
+import { isFeatureEnabled } from '../../../features';
 import { MODULES_ANALYTICS } from './constants';
 import {
 	rollbackChanges,
@@ -41,7 +42,9 @@ const baseModuleStore = Modules.createModuleStore( 'analytics', {
 		'trackingDisabled',
 		'useSnippet',
 	],
-	adminPage: 'googlesitekit-module-analytics',
+	adminPage: isFeatureEnabled( 'unifiedDashboard' )
+		? undefined
+		: 'googlesitekit-module-analytics',
 	submitChanges,
 	rollbackChanges,
 	validateCanSubmitChanges,

--- a/assets/js/modules/analytics/datastore/base.test.js
+++ b/assets/js/modules/analytics/datastore/base.test.js
@@ -19,23 +19,21 @@
 /**
  * Internal dependencies
  */
-import { createTestRegistry } from '../../../../../tests/js/utils';
-import { CORE_SITE } from '../../../googlesitekit/datastore/site/constants';
+import {
+	createTestRegistry,
+	provideSiteInfo,
+} from '../../../../../tests/js/utils';
 import { MODULES_ANALYTICS } from './constants';
 
 describe( 'modules/analytics base data store', () => {
 	let registry;
 	let store;
 
-	const adminURL = 'http://something.test/wp-admin';
-
 	beforeEach( () => {
 		jest.resetModules();
 
 		registry = createTestRegistry();
-		registry.dispatch( CORE_SITE ).receiveSiteInfo( {
-			adminURL,
-		} );
+		provideSiteInfo( registry );
 	} );
 
 	it( 'does not define the admin page when unified dashboard is enabled', () => {
@@ -46,7 +44,7 @@ describe( 'modules/analytics base data store', () => {
 		registry.registerStore( MODULES_ANALYTICS, store );
 
 		expect( store.selectors.getAdminScreenURL() ).toBe(
-			`${ adminURL }/admin.php?page=googlesitekit-dashboard`
+			`http://example.com/wp-admin/admin.php?page=googlesitekit-dashboard`
 		);
 	} );
 
@@ -55,7 +53,7 @@ describe( 'modules/analytics base data store', () => {
 		registry.registerStore( MODULES_ANALYTICS, store );
 
 		expect( store.selectors.getAdminScreenURL() ).toBe(
-			`${ adminURL }/admin.php?page=googlesitekit-module-analytics`
+			`http://example.com/wp-admin/admin.php?page=googlesitekit-module-analytics`
 		);
 	} );
 } );

--- a/assets/js/modules/analytics/datastore/base.test.js
+++ b/assets/js/modules/analytics/datastore/base.test.js
@@ -38,32 +38,24 @@ describe( 'modules/analytics base data store', () => {
 		} );
 	} );
 
-	describe( 'when unified dashboard is enabled', () => {
-		beforeEach( () => {
-			const { enabledFeatures } = require( '../../../features' );
-			enabledFeatures.add( 'unifiedDashboard' );
+	it( 'does not define the admin page when unified dashboard is enabled', () => {
+		const { enabledFeatures } = require( '../../../features' );
+		enabledFeatures.add( 'unifiedDashboard' );
 
-			store = require( './base' ).default;
-			registry.registerStore( MODULES_ANALYTICS, store );
-		} );
+		store = require( './base' ).default;
+		registry.registerStore( MODULES_ANALYTICS, store );
 
-		it( 'does not define the admin page', () => {
-			expect( store.selectors.getAdminScreenURL() ).toBe(
-				`${ adminURL }/admin.php?page=googlesitekit-dashboard`
-			);
-		} );
+		expect( store.selectors.getAdminScreenURL() ).toBe(
+			`${ adminURL }/admin.php?page=googlesitekit-dashboard`
+		);
 	} );
 
-	describe( 'when unified dashboard is not enabled', () => {
-		beforeEach( () => {
-			store = require( './base' ).default;
-			registry.registerStore( MODULES_ANALYTICS, store );
-		} );
+	it( 'does define the admin page when unified dashboard is not enabled', () => {
+		store = require( './base' ).default;
+		registry.registerStore( MODULES_ANALYTICS, store );
 
-		it( 'does define the admin page', () => {
-			expect( store.selectors.getAdminScreenURL() ).toBe(
-				`${ adminURL }/admin.php?page=googlesitekit-module-analytics`
-			);
-		} );
+		expect( store.selectors.getAdminScreenURL() ).toBe(
+			`${ adminURL }/admin.php?page=googlesitekit-module-analytics`
+		);
 	} );
 } );

--- a/assets/js/modules/analytics/datastore/base.test.js
+++ b/assets/js/modules/analytics/datastore/base.test.js
@@ -43,8 +43,8 @@ describe( 'modules/analytics base data store', () => {
 		store = require( './base' ).default;
 		registry.registerStore( MODULES_ANALYTICS, store );
 
-		expect( store.selectors.getAdminScreenURL() ).toBe(
-			`http://example.com/wp-admin/admin.php?page=googlesitekit-dashboard`
+		expect( registry.select( MODULES_ANALYTICS ).getAdminScreenURL() ).toBe(
+			'http://example.com/wp-admin/admin.php?page=googlesitekit-dashboard'
 		);
 	} );
 
@@ -52,8 +52,8 @@ describe( 'modules/analytics base data store', () => {
 		store = require( './base' ).default;
 		registry.registerStore( MODULES_ANALYTICS, store );
 
-		expect( store.selectors.getAdminScreenURL() ).toBe(
-			`http://example.com/wp-admin/admin.php?page=googlesitekit-module-analytics`
+		expect( registry.select( MODULES_ANALYTICS ).getAdminScreenURL() ).toBe(
+			'http://example.com/wp-admin/admin.php?page=googlesitekit-module-analytics'
 		);
 	} );
 } );

--- a/assets/js/modules/analytics/datastore/base.test.js
+++ b/assets/js/modules/analytics/datastore/base.test.js
@@ -1,0 +1,69 @@
+/**
+ * `modules/analytics` base data store tests.
+ *
+ * Site Kit by Google, Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import { createTestRegistry } from '../../../../../tests/js/utils';
+import { CORE_SITE } from '../../../googlesitekit/datastore/site/constants';
+import { MODULES_ANALYTICS } from './constants';
+
+describe( 'modules/analytics base data store', () => {
+	let registry;
+	let store;
+
+	const adminURL = 'http://something.test/wp-admin';
+
+	beforeEach( () => {
+		jest.resetModules();
+
+		registry = createTestRegistry();
+		registry.dispatch( CORE_SITE ).receiveSiteInfo( {
+			adminURL,
+		} );
+	} );
+
+	describe( 'when unified dashboard is enabled', () => {
+		beforeEach( () => {
+			const { enabledFeatures } = require( '../../../features' );
+			enabledFeatures.add( 'unifiedDashboard' );
+
+			store = require( './base' ).default;
+			registry.registerStore( MODULES_ANALYTICS, store );
+		} );
+
+		it( 'does not define the admin page', () => {
+			expect( store.selectors.getAdminScreenURL() ).toBe(
+				`${ adminURL }/admin.php?page=googlesitekit-dashboard`
+			);
+		} );
+	} );
+
+	describe( 'when unified dashboard is not enabled', () => {
+		beforeEach( () => {
+			store = require( './base' ).default;
+			registry.registerStore( MODULES_ANALYTICS, store );
+		} );
+
+		it( 'does define the admin page', () => {
+			expect( store.selectors.getAdminScreenURL() ).toBe(
+				`${ adminURL }/admin.php?page=googlesitekit-module-analytics`
+			);
+		} );
+	} );
+} );

--- a/assets/js/modules/search-console/datastore/base.js
+++ b/assets/js/modules/search-console/datastore/base.js
@@ -1,5 +1,5 @@
 /**
- * `modules/search-console` data store
+ * `modules/search-console` base data store
  *
  * Site Kit by Google, Copyright 2021 Google LLC
  *
@@ -19,29 +19,17 @@
 /**
  * Internal dependencies
  */
-import Data from 'googlesitekit-data';
+import Modules from 'googlesitekit-modules';
 import { MODULES_SEARCH_CONSOLE } from './constants';
-import baseModuleStore from './base';
-import report from './report';
-import service from './service';
-import properties from './properties';
+import { submitChanges, validateCanSubmitChanges } from './settings';
 
-const store = Data.combineStores(
-	baseModuleStore,
-	report,
-	service,
-	properties
-);
+const baseModuleStore = Modules.createModuleStore( 'search-console', {
+	storeName: MODULES_SEARCH_CONSOLE,
+	settingSlugs: [ 'propertyID', 'ownerID' ],
+	adminPage: 'googlesitekit-module-search-console',
+	requiresSetup: false,
+	submitChanges,
+	validateCanSubmitChanges,
+} );
 
-export const initialState = store.initialState;
-export const actions = store.actions;
-export const controls = store.controls;
-export const reducer = store.reducer;
-export const resolvers = store.resolvers;
-export const selectors = store.selectors;
-
-export const registerStore = ( registry ) => {
-	registry.registerStore( MODULES_SEARCH_CONSOLE, store );
-};
-
-export default store;
+export default baseModuleStore;

--- a/assets/js/modules/search-console/datastore/base.js
+++ b/assets/js/modules/search-console/datastore/base.js
@@ -20,13 +20,16 @@
  * Internal dependencies
  */
 import Modules from 'googlesitekit-modules';
+import { isFeatureEnabled } from '../../../features';
 import { MODULES_SEARCH_CONSOLE } from './constants';
 import { submitChanges, validateCanSubmitChanges } from './settings';
 
 const baseModuleStore = Modules.createModuleStore( 'search-console', {
 	storeName: MODULES_SEARCH_CONSOLE,
 	settingSlugs: [ 'propertyID', 'ownerID' ],
-	adminPage: 'googlesitekit-module-search-console',
+	adminPage: isFeatureEnabled( 'unifiedDashboard' )
+		? undefined
+		: 'googlesitekit-module-search-console',
 	requiresSetup: false,
 	submitChanges,
 	validateCanSubmitChanges,

--- a/assets/js/modules/search-console/datastore/base.test.js
+++ b/assets/js/modules/search-console/datastore/base.test.js
@@ -1,0 +1,69 @@
+/**
+ * `modules/search-console` base data store tests.
+ *
+ * Site Kit by Google, Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import { createTestRegistry } from '../../../../../tests/js/utils';
+import { CORE_SITE } from '../../../googlesitekit/datastore/site/constants';
+import { MODULES_SEARCH_CONSOLE } from './constants';
+
+describe( 'modules/search-console base data store', () => {
+	let registry;
+	let store;
+
+	const adminURL = 'http://something.test/wp-admin';
+
+	beforeEach( () => {
+		jest.resetModules();
+
+		registry = createTestRegistry();
+		registry.dispatch( CORE_SITE ).receiveSiteInfo( {
+			adminURL,
+		} );
+	} );
+
+	describe( 'when unified dashboard is enabled', () => {
+		beforeEach( () => {
+			const { enabledFeatures } = require( '../../../features' );
+			enabledFeatures.add( 'unifiedDashboard' );
+
+			store = require( './base' ).default;
+			registry.registerStore( MODULES_SEARCH_CONSOLE, store );
+		} );
+
+		it( 'does not define the admin page', () => {
+			expect( store.selectors.getAdminScreenURL() ).toBe(
+				`${ adminURL }/admin.php?page=googlesitekit-dashboard`
+			);
+		} );
+	} );
+
+	describe( 'when unified dashboard is not enabled', () => {
+		beforeEach( () => {
+			store = require( './base' ).default;
+			registry.registerStore( MODULES_SEARCH_CONSOLE, store );
+		} );
+
+		it( 'does define the admin page', () => {
+			expect( store.selectors.getAdminScreenURL() ).toBe(
+				`${ adminURL }/admin.php?page=googlesitekit-module-search-console`
+			);
+		} );
+	} );
+} );

--- a/assets/js/modules/search-console/datastore/base.test.js
+++ b/assets/js/modules/search-console/datastore/base.test.js
@@ -19,23 +19,21 @@
 /**
  * Internal dependencies
  */
-import { createTestRegistry } from '../../../../../tests/js/utils';
-import { CORE_SITE } from '../../../googlesitekit/datastore/site/constants';
+import {
+	createTestRegistry,
+	provideSiteInfo,
+} from '../../../../../tests/js/utils';
 import { MODULES_SEARCH_CONSOLE } from './constants';
 
 describe( 'modules/search-console base data store', () => {
 	let registry;
 	let store;
 
-	const adminURL = 'http://something.test/wp-admin';
-
 	beforeEach( () => {
 		jest.resetModules();
 
 		registry = createTestRegistry();
-		registry.dispatch( CORE_SITE ).receiveSiteInfo( {
-			adminURL,
-		} );
+		provideSiteInfo( registry );
 	} );
 
 	it( 'does not define the admin page when unified dashboard is enabled', () => {
@@ -46,7 +44,7 @@ describe( 'modules/search-console base data store', () => {
 		registry.registerStore( MODULES_SEARCH_CONSOLE, store );
 
 		expect( store.selectors.getAdminScreenURL() ).toBe(
-			`${ adminURL }/admin.php?page=googlesitekit-dashboard`
+			`http://example.com/wp-admin/admin.php?page=googlesitekit-dashboard`
 		);
 	} );
 
@@ -55,7 +53,7 @@ describe( 'modules/search-console base data store', () => {
 		registry.registerStore( MODULES_SEARCH_CONSOLE, store );
 
 		expect( store.selectors.getAdminScreenURL() ).toBe(
-			`${ adminURL }/admin.php?page=googlesitekit-module-search-console`
+			`http://example.com/wp-admin/admin.php?page=googlesitekit-module-search-console`
 		);
 	} );
 } );

--- a/assets/js/modules/search-console/datastore/base.test.js
+++ b/assets/js/modules/search-console/datastore/base.test.js
@@ -43,8 +43,10 @@ describe( 'modules/search-console base data store', () => {
 		store = require( './base' ).default;
 		registry.registerStore( MODULES_SEARCH_CONSOLE, store );
 
-		expect( store.selectors.getAdminScreenURL() ).toBe(
-			`http://example.com/wp-admin/admin.php?page=googlesitekit-dashboard`
+		expect(
+			registry.select( MODULES_SEARCH_CONSOLE ).getAdminScreenURL()
+		).toBe(
+			'http://example.com/wp-admin/admin.php?page=googlesitekit-dashboard'
 		);
 	} );
 
@@ -52,8 +54,10 @@ describe( 'modules/search-console base data store', () => {
 		store = require( './base' ).default;
 		registry.registerStore( MODULES_SEARCH_CONSOLE, store );
 
-		expect( store.selectors.getAdminScreenURL() ).toBe(
-			`http://example.com/wp-admin/admin.php?page=googlesitekit-module-search-console`
+		expect(
+			registry.select( MODULES_SEARCH_CONSOLE ).getAdminScreenURL()
+		).toBe(
+			'http://example.com/wp-admin/admin.php?page=googlesitekit-module-search-console'
 		);
 	} );
 } );

--- a/assets/js/modules/search-console/datastore/base.test.js
+++ b/assets/js/modules/search-console/datastore/base.test.js
@@ -38,32 +38,24 @@ describe( 'modules/search-console base data store', () => {
 		} );
 	} );
 
-	describe( 'when unified dashboard is enabled', () => {
-		beforeEach( () => {
-			const { enabledFeatures } = require( '../../../features' );
-			enabledFeatures.add( 'unifiedDashboard' );
+	it( 'does not define the admin page when unified dashboard is enabled', () => {
+		const { enabledFeatures } = require( '../../../features' );
+		enabledFeatures.add( 'unifiedDashboard' );
 
-			store = require( './base' ).default;
-			registry.registerStore( MODULES_SEARCH_CONSOLE, store );
-		} );
+		store = require( './base' ).default;
+		registry.registerStore( MODULES_SEARCH_CONSOLE, store );
 
-		it( 'does not define the admin page', () => {
-			expect( store.selectors.getAdminScreenURL() ).toBe(
-				`${ adminURL }/admin.php?page=googlesitekit-dashboard`
-			);
-		} );
+		expect( store.selectors.getAdminScreenURL() ).toBe(
+			`${ adminURL }/admin.php?page=googlesitekit-dashboard`
+		);
 	} );
 
-	describe( 'when unified dashboard is not enabled', () => {
-		beforeEach( () => {
-			store = require( './base' ).default;
-			registry.registerStore( MODULES_SEARCH_CONSOLE, store );
-		} );
+	it( 'does define the admin page when unified dashboard is not enabled', () => {
+		store = require( './base' ).default;
+		registry.registerStore( MODULES_SEARCH_CONSOLE, store );
 
-		it( 'does define the admin page', () => {
-			expect( store.selectors.getAdminScreenURL() ).toBe(
-				`${ adminURL }/admin.php?page=googlesitekit-module-search-console`
-			);
-		} );
+		expect( store.selectors.getAdminScreenURL() ).toBe(
+			`${ adminURL }/admin.php?page=googlesitekit-module-search-console`
+		);
 	} );
 } );

--- a/includes/Modules/AdSense.php
+++ b/includes/Modules/AdSense.php
@@ -32,6 +32,7 @@ use Google\Site_Kit\Core\REST_API\Data_Request;
 use Google\Site_Kit\Core\Tags\Guards\Tag_Production_Guard;
 use Google\Site_Kit\Core\Tags\Guards\Tag_Verify_Guard;
 use Google\Site_Kit\Core\Util\Debug_Data;
+use Google\Site_Kit\Core\Util\Feature_Flags;
 use Google\Site_Kit\Core\Util\Method_Proxy_Trait;
 use Google\Site_Kit\Modules\AdSense\AMP_Tag;
 use Google\Site_Kit\Modules\AdSense\Settings;
@@ -73,7 +74,9 @@ final class AdSense extends Module
 	public function register() {
 		$this->register_scopes_hook();
 
-		$this->register_screen_hook();
+		if ( ! Feature_Flags::enabled( 'unifiedDashboard' ) ) {
+			$this->register_screen_hook();
+		}
 
 		add_action( 'wp_head', $this->get_method_proxy_once( 'render_platform_meta_tags' ) );
 

--- a/includes/Modules/Analytics.php
+++ b/includes/Modules/Analytics.php
@@ -34,6 +34,7 @@ use Google\Site_Kit\Core\REST_API\Data_Request;
 use Google\Site_Kit\Core\Tags\Guards\Tag_Production_Guard;
 use Google\Site_Kit\Core\Tags\Guards\Tag_Verify_Guard;
 use Google\Site_Kit\Core\Util\Debug_Data;
+use Google\Site_Kit\Core\Util\Feature_Flags;
 use Google\Site_Kit\Core\Util\Method_Proxy_Trait;
 use Google\Site_Kit\Modules\Analytics\Google_Service_AnalyticsProvisioning;
 use Google\Site_Kit\Modules\Analytics\AMP_Tag;
@@ -94,7 +95,9 @@ final class Analytics extends Module
 	public function register() {
 		$this->register_scopes_hook();
 
-		$this->register_screen_hook();
+		if ( ! Feature_Flags::enabled( 'unifiedDashboard' ) ) {
+			$this->register_screen_hook();
+		}
 
 		/**
 		 * This filter only exists to be unhooked by the AdSense module if active.

--- a/includes/Modules/Search_Console.php
+++ b/includes/Modules/Search_Console.php
@@ -28,6 +28,7 @@ use Google\Site_Kit\Core\Permissions\Permissions;
 use Google\Site_Kit\Core\REST_API\Exception\Invalid_Datapoint_Exception;
 use Google\Site_Kit\Core\Assets\Script;
 use Google\Site_Kit\Core\REST_API\Data_Request;
+use Google\Site_Kit\Core\Util\Feature_Flags;
 use Google\Site_Kit\Core\Util\Google_URL_Matcher_Trait;
 use Google\Site_Kit\Core\Util\Google_URL_Normalizer;
 use Google\Site_Kit\Modules\Search_Console\Settings;
@@ -61,7 +62,9 @@ final class Search_Console extends Module
 	public function register() {
 		$this->register_scopes_hook();
 
-		$this->register_screen_hook();
+		if ( ! Feature_Flags::enabled( 'unifiedDashboard' ) ) {
+			$this->register_screen_hook();
+		}
 
 		// Detect and store Search Console property when receiving token for the first time.
 		add_action(

--- a/tests/js/mock-component-utils.js
+++ b/tests/js/mock-component-utils.js
@@ -17,7 +17,7 @@
  */
 
 /**
- * Create a mock component with a given name. The component will render the name and JSON stringified props passed to it.
+ * Creates a mock component with a given name. The component will render the name and JSON stringified props passed to it.
  * The function is prefixed `mock` to allow usage with `jest.mock`. In general we should try to avoid mocking components,
  * but on the odd occasion that it's necessary this function can be used to create them.
  *
@@ -26,7 +26,6 @@
  * @param {string} name The name of the component.
  * @return {WPElement} The mock component.
  */
-
 export function mockCreateComponent( name ) {
 	return ( { children, ...props } ) => (
 		<div>

--- a/tests/js/mock-component-utils.js
+++ b/tests/js/mock-component-utils.js
@@ -1,0 +1,38 @@
+/**
+ * Mock component utils.
+ *
+ * Site Kit by Google, Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Create a mock component with a given name. The component will render the name and JSON stringified props passed to it.
+ * The function is prefixed `mock` to allow usage with `jest.mock`. In general we should try to avoid mocking components,
+ * but on the odd occasion that it's necessary this function can be used to create them.
+ *
+ * @since n.e.x.t
+ *
+ * @param {string} name The name of the component.
+ * @return {WPElement} The mock component.
+ */
+
+export function mockCreateComponent( name ) {
+	return ( { children, ...props } ) => (
+		<div>
+			{ name }
+			{ JSON.stringify( props ) }
+			{ children }
+		</div>
+	);
+}

--- a/tests/phpunit/integration/Modules/AdSenseTest.php
+++ b/tests/phpunit/integration/Modules/AdSenseTest.php
@@ -49,6 +49,20 @@ class AdSenseTest extends TestCase {
 		$this->assertContains( $adsense->get_screen(), apply_filters( 'googlesitekit_module_screens', array() ) );
 	}
 
+	public function test_register_unified_dashboard() {
+		$this->enable_feature( 'unifiedDashboard' );
+
+		$adsense = new AdSense( new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE ) );
+		remove_all_filters( 'googlesitekit_module_screens' );
+
+		$this->assertEmpty( apply_filters( 'googlesitekit_module_screens', array() ) );
+
+		$adsense->register();
+
+		// Verify the screen is not registered.
+		$this->assertEmpty( apply_filters( 'googlesitekit_module_screens', array() ) );
+	}
+
 	public function test_register_template_redirect_amp() {
 		$context = $this->get_amp_primary_context();
 		$adsense = new AdSense( $context );

--- a/tests/phpunit/integration/Modules/AnalyticsTest.php
+++ b/tests/phpunit/integration/Modules/AnalyticsTest.php
@@ -72,6 +72,20 @@ class AnalyticsTest extends TestCase {
 		$this->assertTrue( has_action( 'web_stories_story_head' ) );
 	}
 
+	public function test_register_unified_dashboard() {
+		$this->enable_feature( 'unifiedDashboard' );
+
+		$analytics = new Analytics( new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE ) );
+		remove_all_filters( 'googlesitekit_module_screens' );
+
+		$this->assertEmpty( apply_filters( 'googlesitekit_module_screens', array() ) );
+
+		$analytics->register();
+
+		// Verify the screen is not registered.
+		$this->assertEmpty( apply_filters( 'googlesitekit_module_screens', array() ) );
+	}
+
 	public function test_register_template_redirect_amp() {
 		$context   = $this->get_amp_primary_context();
 		$analytics = new Analytics( $context );

--- a/tests/phpunit/integration/Modules/Search_ConsoleTest.php
+++ b/tests/phpunit/integration/Modules/Search_ConsoleTest.php
@@ -73,6 +73,21 @@ class Search_ConsoleTest extends TestCase {
 		$this->assertTrue( apply_filters( 'googlesitekit_setup_complete', true ) );
 	}
 
+	public function test_register_unified_dashboard() {
+		$this->enable_feature( 'unifiedDashboard' );
+
+		$search_console = new Search_Console( new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE ) );
+		remove_all_filters( 'googlesitekit_module_screens' );
+
+		$this->assertEmpty( apply_filters( 'googlesitekit_module_screens', array() ) );
+
+		$search_console->register();
+
+		// Verify the screen is not registered.
+		$this->assertEmpty( apply_filters( 'googlesitekit_module_screens', array() ) );
+	}
+
+
 	public function test_get_datapoints() {
 		$search_console = new Search_Console( new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE ) );
 


### PR DESCRIPTION
## Summary

Addresses issue #4134

## Relevant technical choices

#### `DashboardEntryPoint` tests

When writing the tests for the `DashboardEntryPoint` component, I decided to mock the components it renders. Although we generally avoid mocking components, in this particular case it seems preferable as the component is a container for a large part, possibly the majority of the app. Scaffolding the tests for a fully integrated `DashboardEntryPoint` would require mocking a significant amount of app state, which would then need to be maintained as the app develops, and could also easily get out of sync.

Given the aim of the test is simply to validate the conditionals within `DashboardEntryPoint`, it seems pragmatic to make use of component mocks in this particular case.

#### `assets/js/modules/search-console/datastore/index.js`

When it came to making the changes to `assets/js/modules/search-console/datastore/index.js`, I extracted the creation of the base store to `assets/js/modules/search-console/datastore/base.js` in order to be consistent with the other modules.

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
