### PR TITLE
Add notice for when userSnippet is disabled in GA4/UA.

### DIFF
--- a/assets/js/modules/optimize/components/common/OptimizeSnippetNotice.js
+++ b/assets/js/modules/optimize/components/common/OptimizeSnippetNotice.js
@@ -19,7 +19,6 @@
 /**
  * WordPress dependencies
  */
-import { useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -45,33 +44,27 @@ export default function OptimizeSnippetNotice() {
 		select( MODULES_ANALYTICS ).getUseSnippet()
 	);
 
-	const notice = useMemo( () => {
-		if ( ! useUASnippet && analytics4ModuleConnected && ! useGA4Snippet ) {
-			return __(
-				'Site Kit is currently configured to neither place the Universal Analytics snippet nor the Google Analytics 4 snippet. If you have manually inserted these snippets, you will have to modify them to include the Optimize ID, or alternatively you will need to enable Site Kit to place them.',
-				'google-site-kit'
-			);
-		}
+	let notice = null;
 
-		if (
-			! useUASnippet &&
-			( ! analytics4ModuleConnected || useGA4Snippet )
-		) {
-			return __(
-				'Site Kit is currently configured to not place the Universal Analytics snippet. If you have manually inserted this snippet, you will have to modify it to include the Optimize ID, or alternatively you will need to enable Site Kit to place it.',
-				'google-site-kit'
-			);
-		}
-
-		if ( analytics4ModuleConnected && ! useGA4Snippet && useUASnippet ) {
-			return __(
-				'Site Kit is currently configured to not place the Google Analytics 4 snippet. If you have manually inserted this snippet, you will have to modify it to include the Optimize ID, or alternatively you will need to enable Site Kit to place it.',
-				'google-site-kit'
-			);
-		}
-
-		return null;
-	}, [ analytics4ModuleConnected, useGA4Snippet, useUASnippet ] );
+	if ( ! useUASnippet && analytics4ModuleConnected && ! useGA4Snippet ) {
+		notice = __(
+			'Site Kit is currently configured to neither place the Universal Analytics snippet nor the Google Analytics 4 snippet. If you have manually inserted these snippets, you will have to modify them to include the Optimize ID, or alternatively you will need to enable Site Kit to place them.',
+			'google-site-kit'
+		);
+	} else if (
+		! useUASnippet &&
+		( ! analytics4ModuleConnected || useGA4Snippet )
+	) {
+		notice = __(
+			'Site Kit is currently configured to not place the Universal Analytics snippet. If you have manually inserted this snippet, you will have to modify it to include the Optimize ID, or alternatively you will need to enable Site Kit to place it.',
+			'google-site-kit'
+		);
+	} else if ( analytics4ModuleConnected && ! useGA4Snippet && useUASnippet ) {
+		notice = __(
+			'Site Kit is currently configured to not place the Google Analytics 4 snippet. If you have manually inserted this snippet, you will have to modify it to include the Optimize ID, or alternatively you will need to enable Site Kit to place it.',
+			'google-site-kit'
+		);
+	}
 
 	if ( ! notice ) {
 		return null;

--- a/assets/js/modules/optimize/components/common/OptimizeSnippetNotice.js
+++ b/assets/js/modules/optimize/components/common/OptimizeSnippetNotice.js
@@ -1,0 +1,81 @@
+/**
+ * OptimizeSnippetNotice component.
+ *
+ * Site Kit by Google, Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { useMemo } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import Data from 'googlesitekit-data';
+import { MODULES_ANALYTICS } from '../../../analytics/datastore/constants';
+import { MODULES_ANALYTICS_4 } from '../../../analytics-4/datastore/constants';
+import { CORE_MODULES } from '../../../../googlesitekit/modules/datastore/constants';
+
+const { useSelect } = Data;
+
+export default function OptimizeSnippetNotice() {
+	const analytics4ModuleConnected = useSelect( ( select ) =>
+		select( CORE_MODULES ).isModuleConnected( 'analytics-4' )
+	);
+
+	const useGA4Snippet = useSelect( ( select ) =>
+		select( MODULES_ANALYTICS_4 ).getUseSnippet()
+	);
+
+	const useUASnippet = useSelect( ( select ) =>
+		select( MODULES_ANALYTICS ).getUseSnippet()
+	);
+
+	const notice = useMemo( () => {
+		if ( ! useUASnippet && analytics4ModuleConnected && ! useGA4Snippet ) {
+			return __(
+				'Site Kit is currently configured to neither place the Universal Analytics snippet nor the Google Analytics 4 snippet. If you have manually inserted these snippets, you will have to modify them to include the Optimize ID, or alternatively you will need to enable Site Kit to place them.',
+				'google-site-kit'
+			);
+		}
+
+		if (
+			! useUASnippet &&
+			( ! analytics4ModuleConnected || useGA4Snippet )
+		) {
+			return __(
+				'Site Kit is currently configured to not place the Universal Analytics snippet. If you have manually inserted this snippet, you will have to modify it to include the Optimize ID, or alternatively you will need to enable Site Kit to place it.',
+				'google-site-kit'
+			);
+		}
+
+		if ( analytics4ModuleConnected && ! useGA4Snippet && useUASnippet ) {
+			return __(
+				'Site Kit is currently configured to not place the Google Analytics 4 snippet. If you have manually inserted this snippet, you will have to modify it to include the Optimize ID, or alternatively you will need to enable Site Kit to place it.',
+				'google-site-kit'
+			);
+		}
+
+		return null;
+	}, [ analytics4ModuleConnected, useGA4Snippet, useUASnippet ] );
+
+	if ( ! notice ) {
+		return null;
+	}
+
+	return <p>{ notice }</p>;
+}

--- a/assets/js/modules/optimize/components/common/index.js
+++ b/assets/js/modules/optimize/components/common/index.js
@@ -19,6 +19,7 @@
 export { default as AMPExperimentJSONField } from './AMPExperimentJSONField';
 export { default as OptimizeIDField } from './OptimizeIDField';
 export { default as OptimizeIDFieldInstructions } from './OptimizeIDFieldInstructions';
+export { default as OptimizeSnippetNotice } from './OptimizeSnippetNotice';
 export { default as UseSnippetInstructions } from './UseSnippetInstructions';
 export { default as PlaceAntiFlickerSwitch } from './PlaceAntiFlickerSwitch';
 export { default as AnalyticsNotice } from './AnalyticsNotice';

--- a/assets/js/modules/optimize/components/setup/SetupForm.js
+++ b/assets/js/modules/optimize/components/setup/SetupForm.js
@@ -39,10 +39,11 @@ import ErrorText from '../../../../components/ErrorText';
 import {
 	AMPExperimentJSONField,
 	OptimizeIDField,
+	OptimizeSnippetNotice,
 	UseSnippetInstructions,
 	OptimizeIDFieldInstructions,
 	AnalyticsNotice,
-} from '../common/';
+} from '../common';
 const { useSelect, useDispatch } = Data;
 
 export default function SetupForm( { finishSetup } ) {
@@ -94,6 +95,8 @@ export default function SetupForm( { finishSetup } ) {
 			<AMPExperimentJSONField />
 
 			<UseSnippetInstructions />
+
+			<OptimizeSnippetNotice />
 
 			<div className="googlesitekit-setup-module__action">
 				<Button disabled={ ! canSubmitChanges }>


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #3822

## Relevant technical choices

<!-- Please describe your changes. -->

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
