### PR TITLE
Make sure `window.google` is undefined before loading Charts.

### DIFF
--- a/assets/js/components/GoogleChart.js
+++ b/assets/js/components/GoogleChart.js
@@ -17,6 +17,9 @@
  */
 /* eslint-disable react-hooks/exhaustive-deps */
 
+/* Ensures `google` global is undefined before loading `react-google-charts` library */
+import '../util/initialize-google-global';
+
 /**
  * External dependencies
  */

--- a/assets/js/util/initialize-google-global.js
+++ b/assets/js/util/initialize-google-global.js
@@ -1,0 +1,21 @@
+/**
+ * Side Effect to initialize `google` global.
+ *
+ * Site Kit by Google, Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+if ( ! Object.prototype.hasOwnProperty.call( global, 'google' ) ) {
+	global.google = undefined;
+}


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #4074

## Relevant technical choices

<!-- Please describe your changes. -->

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
