### PR TITLE
Hide any section of the dashboard that has zero widgets.

### DIFF
--- a/assets/js/components/dashboard-details/DashboardDetailsApp.js
+++ b/assets/js/components/dashboard-details/DashboardDetailsApp.js
@@ -31,6 +31,7 @@ import Header from '../Header';
 import DateRangeSelector from '../DateRangeSelector';
 import { CORE_SITE } from '../../googlesitekit/datastore/site/constants';
 import HelpMenu from '../help/HelpMenu';
+import { Grid, Row, Cell } from '../../material-components';
 const { useSelect } = Data;
 
 export default function DashboardDetailsApp() {
@@ -52,13 +53,23 @@ export default function DashboardDetailsApp() {
 				{ currentEntityURL && <DateRangeSelector /> }
 			</Header>
 
-			<WidgetContextRenderer
-				slug={
-					currentEntityURL ? 'pageDashboard' : 'pageDashboardNotFound'
-				}
-				className="googlesitekit-module-page googlesitekit-dashboard-single-url"
-				Header={ DashboardDetailsHeader }
-			/>
+			{ currentEntityURL ? (
+				<WidgetContextRenderer
+					slug={ 'pageDashboard' }
+					className="googlesitekit-module-page googlesitekit-dashboard-single-url"
+					Header={ DashboardDetailsHeader }
+				/>
+			) : (
+				<div className="googlesitekit-widget-context googlesitekit-module-page googlesitekit-dashboard-single-url">
+					<Grid>
+						<Row>
+							<Cell size={ 12 }>
+								<DashboardDetailsHeader />
+							</Cell>
+						</Row>
+					</Grid>
+				</div>
+			) }
 		</Fragment>
 	);
 }

--- a/assets/js/googlesitekit/widgets/components/WidgetAreaRenderer.js
+++ b/assets/js/googlesitekit/widgets/components/WidgetAreaRenderer.js
@@ -48,17 +48,17 @@ export default function WidgetAreaRenderer( { slug, totalAreas } ) {
 		threshold: 0, // Trigger "in-view" as soon as one pixel is visible.
 	} );
 
-	const { widgetArea, widgets, widgetStates, isActive } = useSelect(
-		( select ) => {
-			const store = select( CORE_WIDGETS );
-
-			return {
-				widgetArea: store.getWidgetArea( slug ),
-				widgets: store.getWidgets( slug ),
-				widgetStates: store.getWidgetStates(),
-				isActive: store.isWidgetAreaActive( slug ),
-			};
-		}
+	const widgetArea = useSelect( ( select ) =>
+		select( CORE_WIDGETS ).getWidgetArea( slug )
+	);
+	const widgets = useSelect( ( select ) =>
+		select( CORE_WIDGETS ).getWidgets( slug )
+	);
+	const widgetStates = useSelect( ( select ) =>
+		select( CORE_WIDGETS ).getWidgetStates()
+	);
+	const isActive = useSelect( ( select ) =>
+		select( CORE_WIDGETS ).isWidgetAreaActive( slug )
 	);
 
 	// Compute the layout.

--- a/assets/js/googlesitekit/widgets/components/WidgetAreaRenderer.js
+++ b/assets/js/googlesitekit/widgets/components/WidgetAreaRenderer.js
@@ -38,7 +38,6 @@ import WidgetRenderer from './WidgetRenderer';
 import { getWidgetLayout, combineWidgets } from '../util';
 import { Cell, Grid, Row } from '../../../material-components';
 import WidgetCellWrapper from './WidgetCellWrapper';
-import { isInactiveWidgetState } from '../util/is-inactive-widget-state';
 import InViewProvider from '../../../components/InViewProvider';
 const { useSelect } = Data;
 
@@ -49,22 +48,17 @@ export default function WidgetAreaRenderer( { slug, totalAreas } ) {
 		threshold: 0, // Trigger "in-view" as soon as one pixel is visible.
 	} );
 
-	const widgetArea = useSelect( ( select ) =>
-		select( CORE_WIDGETS ).getWidgetArea( slug )
-	);
-	const widgets = useSelect( ( select ) =>
-		select( CORE_WIDGETS ).getWidgets( slug )
-	);
-	const widgetStates = useSelect( ( select ) =>
-		select( CORE_WIDGETS ).getWidgetStates()
-	);
+	const { widgetArea, widgets, widgetStates, isActive } = useSelect(
+		( select ) => {
+			const store = select( CORE_WIDGETS );
 
-	const activeWidgets = widgets.filter(
-		( widget ) =>
-			! (
-				widgetStates[ widget.slug ] &&
-				isInactiveWidgetState( widgetStates[ widget.slug ] )
-			)
+			return {
+				widgetArea: store.getWidgetArea( slug ),
+				widgets: store.getWidgets( slug ),
+				widgetStates: store.getWidgetStates(),
+				isActive: store.isWidgetAreaActive( slug ),
+			};
+		}
 	);
 
 	// Compute the layout.
@@ -116,7 +110,7 @@ export default function WidgetAreaRenderer( { slug, totalAreas } ) {
 	// can maybe render later if conditions change for widgets to become active.
 	// Returning `null` here however would have the side-effect of making
 	// all widgets active again, which is why we must return the "null" output.
-	if ( ! activeWidgets.length ) {
+	if ( ! isActive ) {
 		return (
 			<Grid
 				className={ classnames(

--- a/assets/js/googlesitekit/widgets/components/WidgetContextRenderer.js
+++ b/assets/js/googlesitekit/widgets/components/WidgetContextRenderer.js
@@ -56,7 +56,9 @@ const WidgetContextRenderer = ( props ) => {
 			id={ id }
 			className={ classnames(
 				'googlesitekit-widget-context',
-				! isActive && 'googlesitekit-hidden',
+				{
+					'googlesitekit-hidden': ! isActive,
+				},
 				className
 			) }
 		>

--- a/assets/js/googlesitekit/widgets/components/WidgetContextRenderer.js
+++ b/assets/js/googlesitekit/widgets/components/WidgetContextRenderer.js
@@ -35,11 +35,20 @@ const { useSelect } = Data;
 const WidgetContextRenderer = ( props ) => {
 	const { id, slug, className, Header, Footer } = props;
 
-	const widgetAreas = useSelect( ( select ) => {
-		if ( slug ) {
-			return select( CORE_WIDGETS ).getWidgetAreas( slug );
+	const { widgetAreas, isActive } = useSelect( ( select ) => {
+		if ( ! slug ) {
+			return {
+				widgetAreas: null,
+				isActive: false,
+			};
 		}
-		return null;
+
+		const store = select( CORE_WIDGETS );
+
+		return {
+			widgetAreas: store.getWidgetAreas( slug ),
+			isActive: store.isWidgetContextActive( slug ),
+		};
 	} );
 
 	return (
@@ -47,10 +56,11 @@ const WidgetContextRenderer = ( props ) => {
 			id={ id }
 			className={ classnames(
 				'googlesitekit-widget-context',
+				! isActive && 'googlesitekit-hidden',
 				className
 			) }
 		>
-			{ Header && (
+			{ Header && isActive && (
 				<Grid>
 					<Row>
 						<Cell size={ 12 }>
@@ -69,7 +79,7 @@ const WidgetContextRenderer = ( props ) => {
 						/>
 					);
 				} ) }
-			{ Footer && (
+			{ Footer && isActive && (
 				<Grid>
 					<Row>
 						<Cell size={ 12 }>

--- a/assets/js/googlesitekit/widgets/components/WidgetContextRenderer.js
+++ b/assets/js/googlesitekit/widgets/components/WidgetContextRenderer.js
@@ -35,21 +35,17 @@ const { useSelect } = Data;
 const WidgetContextRenderer = ( props ) => {
 	const { id, slug, className, Header, Footer } = props;
 
-	const { widgetAreas, isActive } = useSelect( ( select ) => {
-		if ( ! slug ) {
-			return {
-				widgetAreas: null,
-				isActive: false,
-			};
+	const widgetAreas = useSelect( ( select ) => {
+		if ( slug ) {
+			return select( CORE_WIDGETS ).getWidgetAreas( slug );
 		}
-
-		const store = select( CORE_WIDGETS );
-
-		return {
-			widgetAreas: store.getWidgetAreas( slug ),
-			isActive: store.isWidgetContextActive( slug ),
-		};
+		return null;
 	} );
+
+	const isActive = useSelect(
+		( select ) =>
+			!! slug && select( CORE_WIDGETS ).isWidgetContextActive( slug )
+	);
 
 	return (
 		<div

--- a/assets/js/googlesitekit/widgets/components/WidgetContextRenderer.test.js
+++ b/assets/js/googlesitekit/widgets/components/WidgetContextRenderer.test.js
@@ -37,43 +37,49 @@ const WidgetComponentEmpty = ( { WidgetNull } ) => {
 
 describe( 'WidgetContextRenderer', () => {
 	let registry;
-	let actions;
 
 	beforeEach( () => {
 		registry = createTestRegistry();
-		actions = registry.dispatch( CORE_WIDGETS );
 
 		// Register a widget area.
-		actions.registerWidgetArea( 'TestArea1', {
+		registry.dispatch( CORE_WIDGETS ).registerWidgetArea( 'TestArea1', {
 			title: 'Dashboard Header',
 			subtitle: 'Cool stuff for yoursite.com',
 			style: 'composite',
 		} );
 
-		actions.assignWidgetArea( 'TestArea1', 'TestContext' );
+		registry
+			.dispatch( CORE_WIDGETS )
+			.assignWidgetArea( 'TestArea1', 'TestContext' );
 	} );
 
 	it( 'should render the registered widget areas', async () => {
 		// Register a second widget area.
-		actions.registerWidgetArea( 'TestArea2', {
+		registry.dispatch( CORE_WIDGETS ).registerWidgetArea( 'TestArea2', {
 			title: 'Dashboard Body',
 			subtitle: 'More cool stuff for yoursite.com',
 			style: 'composite',
 		} );
-		actions.assignWidgetArea( 'TestArea2', 'TestContext' );
+		registry
+			.dispatch( CORE_WIDGETS )
+			.assignWidgetArea( 'TestArea2', 'TestContext' );
 
 		// Register active widgets in the areas.
-		actions.registerWidget( 'TestWidget1', {
+		registry.dispatch( CORE_WIDGETS ).registerWidget( 'TestWidget1', {
 			Component: WidgetComponent,
 			width: 'full',
 		} );
-		actions.registerWidget( 'TestWidget2', {
+		registry.dispatch( CORE_WIDGETS ).registerWidget( 'TestWidget2', {
 			Component: WidgetComponent,
 			width: 'full',
 		} );
 
-		actions.assignWidget( 'TestWidget1', 'TestArea1' );
-		actions.assignWidget( 'TestWidget2', 'TestArea2' );
+		registry
+			.dispatch( CORE_WIDGETS )
+			.assignWidget( 'TestWidget1', 'TestArea1' );
+		registry
+			.dispatch( CORE_WIDGETS )
+			.assignWidget( 'TestWidget2', 'TestArea2' );
 
 		const { container } = render(
 			<WidgetContextRenderer slug={ 'TestContext' } />,
@@ -92,12 +98,14 @@ describe( 'WidgetContextRenderer', () => {
 
 	it( 'should render a hidden widget context when it has no active area', async () => {
 		// Register an inactive widget in the area.
-		actions.registerWidget( 'TestWidget1', {
+		registry.dispatch( CORE_WIDGETS ).registerWidget( 'TestWidget1', {
 			Component: WidgetComponentEmpty,
 			width: 'full',
 		} );
 
-		actions.assignWidget( 'TestWidget1', 'TestArea1' );
+		registry
+			.dispatch( CORE_WIDGETS )
+			.assignWidget( 'TestWidget1', 'TestArea1' );
 
 		const { container } = render(
 			<WidgetContextRenderer slug={ 'TestContext' } />,

--- a/assets/js/googlesitekit/widgets/components/WidgetContextRenderer.test.js
+++ b/assets/js/googlesitekit/widgets/components/WidgetContextRenderer.test.js
@@ -1,0 +1,116 @@
+/**
+ * WidgetContextRenderer component tests.
+ *
+ * Site Kit by Google, Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import WidgetContextRenderer from './WidgetContextRenderer';
+import { CORE_WIDGETS } from '../datastore/constants';
+import {
+	createTestRegistry,
+	render,
+	waitFor,
+} from '../../../../../tests/js/test-utils';
+
+const WidgetComponent = () => {
+	return <div>Foo bar!</div>;
+};
+
+const WidgetComponentEmpty = ( { WidgetNull } ) => {
+	return <WidgetNull />;
+};
+
+describe( 'WidgetContextRenderer', () => {
+	let registry;
+	let actions;
+
+	beforeEach( () => {
+		registry = createTestRegistry();
+		actions = registry.dispatch( CORE_WIDGETS );
+
+		// Register a widget area.
+		actions.registerWidgetArea( 'TestArea1', {
+			title: 'Dashboard Header',
+			subtitle: 'Cool stuff for yoursite.com',
+			style: 'composite',
+		} );
+
+		actions.assignWidgetArea( 'TestArea1', 'TestContext' );
+	} );
+
+	it( 'should render the registered widget areas', async () => {
+		// Register a second widget area.
+		actions.registerWidgetArea( 'TestArea2', {
+			title: 'Dashboard Body',
+			subtitle: 'More cool stuff for yoursite.com',
+			style: 'composite',
+		} );
+		actions.assignWidgetArea( 'TestArea2', 'TestContext' );
+
+		// Register active widgets in the areas.
+		actions.registerWidget( 'TestWidget1', {
+			Component: WidgetComponent,
+			width: 'full',
+		} );
+		actions.registerWidget( 'TestWidget2', {
+			Component: WidgetComponent,
+			width: 'full',
+		} );
+
+		actions.assignWidget( 'TestWidget1', 'TestArea1' );
+		actions.assignWidget( 'TestWidget2', 'TestArea2' );
+
+		const { container } = render(
+			<WidgetContextRenderer slug={ 'TestContext' } />,
+			{ registry }
+		);
+
+		await waitFor( () => {
+			expect(
+				container.querySelectorAll( '.googlesitekit-widget-context' )
+			).toHaveLength( 1 );
+			expect(
+				container.querySelector( '.googlesitekit-widget-context' )
+			).toMatchSnapshot();
+		} );
+	} );
+
+	it( 'should render a hidden widget context when it has no active area', async () => {
+		// Register an inactive widget in the area.
+		actions.registerWidget( 'TestWidget1', {
+			Component: WidgetComponentEmpty,
+			width: 'full',
+		} );
+
+		actions.assignWidget( 'TestWidget1', 'TestArea1' );
+
+		const { container } = render(
+			<WidgetContextRenderer slug={ 'TestContext' } />,
+			{ registry }
+		);
+
+		await waitFor( () => {
+			expect(
+				container.querySelectorAll( '.googlesitekit-widget-context' )
+			).toHaveLength( 1 );
+			expect(
+				container.querySelector( '.googlesitekit-widget-context' )
+			).toHaveClass( 'googlesitekit-hidden' );
+		} );
+	} );
+} );

--- a/assets/js/googlesitekit/widgets/components/__snapshots__/WidgetContextRenderer.test.js.snap
+++ b/assets/js/googlesitekit/widgets/components/__snapshots__/WidgetContextRenderer.test.js.snap
@@ -1,0 +1,122 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`WidgetContextRenderer should render the registered widget areas 1`] = `
+<div
+  class="googlesitekit-widget-context"
+>
+  <div
+    class="mdc-layout-grid googlesitekit-widget-area googlesitekit-widget-area--TestArea1 googlesitekit-widget-area--composite"
+  >
+    <div
+      class="mdc-layout-grid__inner"
+    >
+      <div
+        class="googlesitekit-widget-area-header mdc-layout-grid__cell mdc-layout-grid__cell--span-12"
+      >
+        <h3
+          class="googlesitekit-widget-area-header__title googlesitekit-heading-3"
+        >
+          Dashboard Header
+        </h3>
+        <h4
+          class="googlesitekit-widget-area-header__subtitle"
+        >
+          Cool stuff for yoursite.com
+        </h4>
+      </div>
+    </div>
+    <div
+      class="googlesitekit-widget-area-widgets"
+    >
+      <div
+        class="mdc-layout-grid__inner"
+      >
+        <div
+          class="mdc-layout-grid__cell mdc-layout-grid__cell--span-12"
+        >
+          <div
+            class="mdc-layout-grid"
+          >
+            <div
+              class="mdc-layout-grid__inner"
+            >
+              <div
+                class="mdc-layout-grid__cell mdc-layout-grid__cell--span-12"
+              >
+                <div
+                  class="googlesitekit-widget googlesitekit-widget--TestWidget1"
+                >
+                  <div
+                    class="googlesitekit-widget__body"
+                  >
+                    <div>
+                      Foo bar!
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    class="mdc-layout-grid googlesitekit-widget-area googlesitekit-widget-area--TestArea2 googlesitekit-widget-area--composite"
+  >
+    <div
+      class="mdc-layout-grid__inner"
+    >
+      <div
+        class="googlesitekit-widget-area-header mdc-layout-grid__cell mdc-layout-grid__cell--span-12"
+      >
+        <h3
+          class="googlesitekit-widget-area-header__title googlesitekit-heading-3"
+        >
+          Dashboard Body
+        </h3>
+        <h4
+          class="googlesitekit-widget-area-header__subtitle"
+        >
+          More cool stuff for yoursite.com
+        </h4>
+      </div>
+    </div>
+    <div
+      class="googlesitekit-widget-area-widgets"
+    >
+      <div
+        class="mdc-layout-grid__inner"
+      >
+        <div
+          class="mdc-layout-grid__cell mdc-layout-grid__cell--span-12"
+        >
+          <div
+            class="mdc-layout-grid"
+          >
+            <div
+              class="mdc-layout-grid__inner"
+            >
+              <div
+                class="mdc-layout-grid__cell mdc-layout-grid__cell--span-12"
+              >
+                <div
+                  class="googlesitekit-widget googlesitekit-widget--TestWidget2"
+                >
+                  <div
+                    class="googlesitekit-widget__body"
+                  >
+                    <div>
+                      Foo bar!
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/assets/js/googlesitekit/widgets/datastore/areas.js
+++ b/assets/js/googlesitekit/widgets/datastore/areas.js
@@ -188,11 +188,11 @@ export const selectors = {
 				'widgetAreaSlug is required to check a widget area is active.'
 			);
 
-			const store = select( CORE_WIDGETS );
-
-			return store
+			return select( CORE_WIDGETS )
 				.getWidgets( widgetAreaSlug )
-				.some( ( widget ) => store.isWidgetActive( widget.slug ) );
+				.some( ( widget ) =>
+					select( CORE_WIDGETS ).isWidgetActive( widget.slug )
+				);
 		}
 	),
 

--- a/assets/js/googlesitekit/widgets/datastore/areas.js
+++ b/assets/js/googlesitekit/widgets/datastore/areas.js
@@ -24,8 +24,11 @@ import invariant from 'invariant';
 /**
  * Internal dependencies
  */
-import { WIDGET_AREA_STYLES } from './constants';
+import Data from 'googlesitekit-data';
+import { CORE_WIDGETS, WIDGET_AREA_STYLES } from './constants';
 import { sortByProperty } from '../../../util/sort-by-property';
+
+const { createRegistrySelector } = Data;
 
 const ASSIGN_WIDGET_AREA = 'ASSIGN_WIDGET_AREA';
 const REGISTER_WIDGET_AREA = 'REGISTER_WIDGET_AREA';
@@ -166,6 +169,33 @@ export const reducer = ( state, { type, payload } ) => {
 export const resolvers = {};
 
 export const selectors = {
+	/**
+	 * Checks if a widget area is active.
+	 *
+	 * Returns `true` if the widget area is active.
+	 * Returns `false` if the widget area is NOT active.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param {Object} state Data store's state.
+	 * @param {string} slug  Widget area's slug.
+	 * @return {boolean} `true`/`false` based on whether widget area is active.
+	 */
+	isWidgetAreaActive: createRegistrySelector(
+		( select ) => ( state, widgetAreaSlug ) => {
+			invariant(
+				widgetAreaSlug,
+				'widgetAreaSlug is required to check a widget area is active.'
+			);
+
+			const store = select( CORE_WIDGETS );
+
+			return store
+				.getWidgets( widgetAreaSlug )
+				.some( ( widget ) => store.isWidgetActive( widget.slug ) );
+		}
+	),
+
 	/**
 	 * Checks if a widget area has been registered.
 	 *

--- a/assets/js/googlesitekit/widgets/datastore/areas.test.js
+++ b/assets/js/googlesitekit/widgets/datastore/areas.test.js
@@ -24,6 +24,7 @@ import {
 	unsubscribeFromAll,
 } from '../../../../../tests/js/utils';
 import { CORE_WIDGETS } from './constants';
+import Null from '../../../components/Null';
 import SiteKitLogo from '../../../../svg/logo-sitekit.svg';
 
 describe( 'core/widgets Widget areas', () => {
@@ -490,6 +491,103 @@ describe( 'core/widgets Widget areas', () => {
 						.select( CORE_WIDGETS )
 						.getWidgetArea( 'NotRealArea' )
 				).toEqual( null );
+			} );
+		} );
+
+		describe( 'isWidgetAreaActive', () => {
+			beforeEach( () => {
+				registry
+					.dispatch( CORE_WIDGETS )
+					.registerWidgetArea( 'TestArea', {
+						title: 'Test Header',
+						subtitle: 'Cool stuff for yoursite.com',
+						style: 'composite',
+					} );
+			} );
+
+			it( 'requires a widgetAreaSlug', () => {
+				expect( () => {
+					registry.select( CORE_WIDGETS ).isWidgetAreaActive();
+				} ).toThrow(
+					'widgetAreaSlug is required to check a widget area is active.'
+				);
+			} );
+
+			it( 'returns false if there are no widgets registered for the area', () => {
+				expect(
+					registry
+						.select( CORE_WIDGETS )
+						.isWidgetAreaActive( 'TestArea' )
+				).toEqual( false );
+			} );
+
+			describe( 'when there are widgets registered for the area', () => {
+				beforeEach( () => {
+					// Register an active widget with default widget state.
+					registry
+						.dispatch( CORE_WIDGETS )
+						.registerWidget( 'TestWidget1', {
+							Component: () => <div>Test Widget 1</div>,
+						} );
+
+					const Component = () => <div>Test Widget 2</div>;
+
+					// Register an active widget with state set to a component other than the `Null` component.
+					registry
+						.dispatch( CORE_WIDGETS )
+						.registerWidget( 'TestWidget2', {
+							Component,
+						} );
+
+					registry
+						.dispatch( CORE_WIDGETS )
+						.setWidgetState( 'TestWidget2', Component, {} );
+
+					// Assign the widgets to the widget area.
+					registry
+						.dispatch( CORE_WIDGETS )
+						.assignWidget( 'TestWidget1', 'TestArea' );
+
+					registry
+						.dispatch( CORE_WIDGETS )
+						.assignWidget( 'TestWidget2', 'TestArea' );
+				} );
+
+				it( 'returns true when the area widgets are active', () => {
+					expect(
+						registry
+							.select( CORE_WIDGETS )
+							.isWidgetAreaActive( 'TestArea' )
+					).toEqual( true );
+				} );
+
+				it( 'returns true when at least one area widget is active', () => {
+					registry
+						.dispatch( CORE_WIDGETS )
+						.setWidgetState( 'TestWidget1', Null, {} );
+
+					expect(
+						registry
+							.select( CORE_WIDGETS )
+							.isWidgetAreaActive( 'TestArea' )
+					).toEqual( true );
+				} );
+
+				it( 'returns false when none of the area widgets are active', () => {
+					registry
+						.dispatch( CORE_WIDGETS )
+						.setWidgetState( 'TestWidget1', Null, {} );
+
+					registry
+						.dispatch( CORE_WIDGETS )
+						.setWidgetState( 'TestWidget2', Null, {} );
+
+					expect(
+						registry
+							.select( CORE_WIDGETS )
+							.isWidgetAreaActive( 'TestArea' )
+					).toEqual( false );
+				} );
 			} );
 		} );
 

--- a/assets/js/googlesitekit/widgets/datastore/areas.test.js
+++ b/assets/js/googlesitekit/widgets/datastore/areas.test.js
@@ -96,7 +96,7 @@ describe( 'core/widgets Widget areas', () => {
 				expect( testareaAreas ).toHaveLength( 1 );
 				expect(
 					testareaAreas.some( ( area ) => area.slug === slug )
-				).toEqual( true );
+				).toBe( true );
 			} );
 		} );
 
@@ -119,7 +119,7 @@ describe( 'core/widgets Widget areas', () => {
 					registry
 						.select( CORE_WIDGETS )
 						.isWidgetAreaRegistered( slug )
-				).toEqual( true );
+				).toBe( true );
 				// There is no selector for unassigned widget areas, so we inspect the store directly for
 				// this test.
 				expect( state.areas ).toMatchObject( {
@@ -203,12 +203,12 @@ describe( 'core/widgets Widget areas', () => {
 					registry
 						.select( CORE_WIDGETS )
 						.isWidgetAreaRegistered( slugOne )
-				).toEqual( true );
+				).toBe( true );
 				expect(
 					registry
 						.select( CORE_WIDGETS )
 						.isWidgetAreaRegistered( slugTwo )
-				).toEqual( true );
+				).toBe( true );
 				// There is no selector for unassigned widget areas, so we inspect the store directly for
 				// this test.
 				expect( state.areas ).toMatchObject( {
@@ -234,7 +234,7 @@ describe( 'core/widgets Widget areas', () => {
 					registry
 						.select( CORE_WIDGETS )
 						.isWidgetAreaRegistered( slug )
-				).toEqual( true );
+				).toBe( true );
 				// There is no selector for unassigned widget areas, so we inspect the store directly for
 				// this test.
 				expect( state.areas ).toMatchObject( {
@@ -490,7 +490,7 @@ describe( 'core/widgets Widget areas', () => {
 					registry
 						.select( CORE_WIDGETS )
 						.getWidgetArea( 'NotRealArea' )
-				).toEqual( null );
+				).toBe( null );
 			} );
 		} );
 
@@ -518,7 +518,7 @@ describe( 'core/widgets Widget areas', () => {
 					registry
 						.select( CORE_WIDGETS )
 						.isWidgetAreaActive( 'TestArea' )
-				).toEqual( false );
+				).toBe( false );
 			} );
 
 			describe( 'when there are widgets registered for the area', () => {
@@ -558,7 +558,7 @@ describe( 'core/widgets Widget areas', () => {
 						registry
 							.select( CORE_WIDGETS )
 							.isWidgetAreaActive( 'TestArea' )
-					).toEqual( true );
+					).toBe( true );
 				} );
 
 				it( 'returns true when at least one area widget is active', () => {
@@ -570,7 +570,7 @@ describe( 'core/widgets Widget areas', () => {
 						registry
 							.select( CORE_WIDGETS )
 							.isWidgetAreaActive( 'TestArea' )
-					).toEqual( true );
+					).toBe( true );
 				} );
 
 				it( 'returns false when none of the area widgets are active', () => {
@@ -586,7 +586,7 @@ describe( 'core/widgets Widget areas', () => {
 						registry
 							.select( CORE_WIDGETS )
 							.isWidgetAreaActive( 'TestArea' )
-					).toEqual( false );
+					).toBe( false );
 				} );
 			} );
 		} );
@@ -605,7 +605,7 @@ describe( 'core/widgets Widget areas', () => {
 					registry
 						.select( CORE_WIDGETS )
 						.isWidgetAreaRegistered( 'TestArea' )
-				).toEqual( true );
+				).toBe( true );
 			} );
 
 			it( 'returns false if the widget area is not registered', () => {
@@ -613,7 +613,7 @@ describe( 'core/widgets Widget areas', () => {
 					registry
 						.select( CORE_WIDGETS )
 						.isWidgetAreaRegistered( 'NotRealArea' )
-				).toEqual( false );
+				).toBe( false );
 			} );
 		} );
 	} );

--- a/assets/js/googlesitekit/widgets/datastore/areas.test.js
+++ b/assets/js/googlesitekit/widgets/datastore/areas.test.js
@@ -496,13 +496,52 @@ describe( 'core/widgets Widget areas', () => {
 
 		describe( 'isWidgetAreaActive', () => {
 			beforeEach( () => {
+				// Register a test area which will remain empty.
 				registry
 					.dispatch( CORE_WIDGETS )
-					.registerWidgetArea( 'TestArea', {
-						title: 'Test Header',
+					.registerWidgetArea( 'EmptyTestArea', {
+						title: 'Test Header 1',
 						subtitle: 'Cool stuff for yoursite.com',
 						style: 'composite',
 					} );
+
+				// Register a test area to populate with widgets.
+				registry
+					.dispatch( CORE_WIDGETS )
+					.registerWidgetArea( 'TestArea', {
+						title: 'Test Header 2',
+						subtitle: 'More cool stuff for yoursite.com',
+						style: 'composite',
+					} );
+
+				// Register an active widget with default widget state.
+				registry
+					.dispatch( CORE_WIDGETS )
+					.registerWidget( 'TestWidget1', {
+						Component: () => <div>Test Widget 1</div>,
+					} );
+
+				const Component = () => <div>Test Widget 2</div>;
+
+				// Register an active widget with state set to a component other than the `Null` component.
+				registry
+					.dispatch( CORE_WIDGETS )
+					.registerWidget( 'TestWidget2', {
+						Component,
+					} );
+
+				registry
+					.dispatch( CORE_WIDGETS )
+					.setWidgetState( 'TestWidget2', Component, {} );
+
+				// Assign the widgets to the widget area.
+				registry
+					.dispatch( CORE_WIDGETS )
+					.assignWidget( 'TestWidget1', 'TestArea' );
+
+				registry
+					.dispatch( CORE_WIDGETS )
+					.assignWidget( 'TestWidget2', 'TestArea' );
 			} );
 
 			it( 'requires a widgetAreaSlug', () => {
@@ -517,77 +556,44 @@ describe( 'core/widgets Widget areas', () => {
 				expect(
 					registry
 						.select( CORE_WIDGETS )
-						.isWidgetAreaActive( 'TestArea' )
+						.isWidgetAreaActive( 'EmptyTestArea' )
 				).toBe( false );
 			} );
 
-			describe( 'when there are widgets registered for the area', () => {
-				beforeEach( () => {
-					// Register an active widget with default widget state.
+			it( 'returns true when the area widgets are active', () => {
+				expect(
 					registry
-						.dispatch( CORE_WIDGETS )
-						.registerWidget( 'TestWidget1', {
-							Component: () => <div>Test Widget 1</div>,
-						} );
+						.select( CORE_WIDGETS )
+						.isWidgetAreaActive( 'TestArea' )
+				).toBe( true );
+			} );
 
-					const Component = () => <div>Test Widget 2</div>;
+			it( 'returns true when at least one area widget is active', () => {
+				registry
+					.dispatch( CORE_WIDGETS )
+					.setWidgetState( 'TestWidget1', Null, {} );
 
-					// Register an active widget with state set to a component other than the `Null` component.
+				expect(
 					registry
-						.dispatch( CORE_WIDGETS )
-						.registerWidget( 'TestWidget2', {
-							Component,
-						} );
+						.select( CORE_WIDGETS )
+						.isWidgetAreaActive( 'TestArea' )
+				).toBe( true );
+			} );
 
+			it( 'returns false when none of the area widgets are active', () => {
+				registry
+					.dispatch( CORE_WIDGETS )
+					.setWidgetState( 'TestWidget1', Null, {} );
+
+				registry
+					.dispatch( CORE_WIDGETS )
+					.setWidgetState( 'TestWidget2', Null, {} );
+
+				expect(
 					registry
-						.dispatch( CORE_WIDGETS )
-						.setWidgetState( 'TestWidget2', Component, {} );
-
-					// Assign the widgets to the widget area.
-					registry
-						.dispatch( CORE_WIDGETS )
-						.assignWidget( 'TestWidget1', 'TestArea' );
-
-					registry
-						.dispatch( CORE_WIDGETS )
-						.assignWidget( 'TestWidget2', 'TestArea' );
-				} );
-
-				it( 'returns true when the area widgets are active', () => {
-					expect(
-						registry
-							.select( CORE_WIDGETS )
-							.isWidgetAreaActive( 'TestArea' )
-					).toBe( true );
-				} );
-
-				it( 'returns true when at least one area widget is active', () => {
-					registry
-						.dispatch( CORE_WIDGETS )
-						.setWidgetState( 'TestWidget1', Null, {} );
-
-					expect(
-						registry
-							.select( CORE_WIDGETS )
-							.isWidgetAreaActive( 'TestArea' )
-					).toBe( true );
-				} );
-
-				it( 'returns false when none of the area widgets are active', () => {
-					registry
-						.dispatch( CORE_WIDGETS )
-						.setWidgetState( 'TestWidget1', Null, {} );
-
-					registry
-						.dispatch( CORE_WIDGETS )
-						.setWidgetState( 'TestWidget2', Null, {} );
-
-					expect(
-						registry
-							.select( CORE_WIDGETS )
-							.isWidgetAreaActive( 'TestArea' )
-					).toBe( false );
-				} );
+						.select( CORE_WIDGETS )
+						.isWidgetAreaActive( 'TestArea' )
+				).toBe( false );
 			} );
 		} );
 

--- a/assets/js/googlesitekit/widgets/datastore/contexts.js
+++ b/assets/js/googlesitekit/widgets/datastore/contexts.js
@@ -49,11 +49,11 @@ export const selectors = {
 				'contextSlug is required to check a widget context is active.'
 			);
 
-			const store = select( CORE_WIDGETS );
-
-			return store
+			return select( CORE_WIDGETS )
 				.getWidgetAreas( contextSlug )
-				.some( ( area ) => store.isWidgetAreaActive( area.slug ) );
+				.some( ( area ) =>
+					select( CORE_WIDGETS ).isWidgetAreaActive( area.slug )
+				);
 		}
 	),
 };

--- a/assets/js/googlesitekit/widgets/datastore/contexts.js
+++ b/assets/js/googlesitekit/widgets/datastore/contexts.js
@@ -1,0 +1,63 @@
+/**
+ * `core/widgets` data store: contexts.
+ *
+ * Site Kit by Google, Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import invariant from 'invariant';
+
+/**
+ * Internal dependencies
+ */
+import Data from 'googlesitekit-data';
+import { CORE_WIDGETS } from './constants';
+
+const { createRegistrySelector } = Data;
+
+export const selectors = {
+	/**
+	 * Checks if a widget context is active.
+	 *
+	 * Returns `true` if the widget context is active.
+	 * Returns `false` if the widget context is NOT active.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param {Object} state Data store's state.
+	 * @param {string} slug  Widget context's slug.
+	 * @return {boolean} `true`/`false` based on whether widget context is active.
+	 */
+	isWidgetContextActive: createRegistrySelector(
+		( select ) => ( state, contextSlug ) => {
+			invariant(
+				contextSlug,
+				'contextSlug is required to check a widget context is active.'
+			);
+
+			const store = select( CORE_WIDGETS );
+
+			return store
+				.getWidgetAreas( contextSlug )
+				.some( ( area ) => store.isWidgetAreaActive( area.slug ) );
+		}
+	),
+};
+
+export default {
+	selectors,
+};

--- a/assets/js/googlesitekit/widgets/datastore/contexts.test.js
+++ b/assets/js/googlesitekit/widgets/datastore/contexts.test.js
@@ -1,0 +1,136 @@
+/**
+ * `core/widgets` data store: widget context tests.
+ *
+ * Site Kit by Google, Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import { createTestRegistry } from '../../../../../tests/js/utils';
+import { CORE_WIDGETS } from './constants';
+import Null from '../../../components/Null';
+
+describe( 'core/widgets Widget context selectors', () => {
+	let registry;
+
+	beforeEach( () => {
+		registry = createTestRegistry();
+	} );
+
+	describe( 'isWidgetContextActive', () => {
+		it( 'requires a contextSlug', () => {
+			expect( () => {
+				registry.select( CORE_WIDGETS ).isWidgetContextActive();
+			} ).toThrow(
+				'contextSlug is required to check a widget context is active.'
+			);
+		} );
+
+		it( 'returns false if there are no areas registered for the context', () => {
+			expect(
+				registry
+					.select( CORE_WIDGETS )
+					.isWidgetContextActive( 'TestContext' )
+			).toEqual( false );
+		} );
+
+		describe( 'when there are areas registered for the context', () => {
+			beforeEach( () => {
+				// Setup the first test area.
+				registry
+					.dispatch( CORE_WIDGETS )
+					.registerWidgetArea( 'TestArea1', {
+						title: 'Test Header 1',
+						subtitle: 'Cool stuff for yoursite.com',
+						style: 'composite',
+					} );
+
+				registry
+					.dispatch( CORE_WIDGETS )
+					.assignWidgetArea( 'TestArea1', 'TestContext' );
+
+				registry
+					.dispatch( CORE_WIDGETS )
+					.registerWidget( 'TestWidget1', {
+						Component: () => <div>Test Widget 1</div>,
+					} );
+
+				registry
+					.dispatch( CORE_WIDGETS )
+					.assignWidget( 'TestWidget1', 'TestArea1' );
+
+				// Setup the second test area.
+				registry
+					.dispatch( CORE_WIDGETS )
+					.registerWidgetArea( 'TestArea2', {
+						title: 'Test Header 2',
+						subtitle: 'More cool stuff for yoursite.com',
+						style: 'composite',
+					} );
+
+				registry
+					.dispatch( CORE_WIDGETS )
+					.assignWidgetArea( 'TestArea2', 'TestContext' );
+
+				registry
+					.dispatch( CORE_WIDGETS )
+					.registerWidget( 'TestWidget2', {
+						Component: () => <div>Test Widget 2</div>,
+					} );
+
+				registry
+					.dispatch( CORE_WIDGETS )
+					.assignWidget( 'TestWidget2', 'TestArea2' );
+			} );
+
+			it( 'returns true when the areas are active', () => {
+				expect(
+					registry
+						.select( CORE_WIDGETS )
+						.isWidgetContextActive( 'TestContext' )
+				).toEqual( true );
+			} );
+
+			it( 'returns true when at least one area is active', () => {
+				registry
+					.dispatch( CORE_WIDGETS )
+					.setWidgetState( 'TestWidget1', Null, {} );
+
+				expect(
+					registry
+						.select( CORE_WIDGETS )
+						.isWidgetContextActive( 'TestContext' )
+				).toEqual( true );
+			} );
+
+			it( 'returns false when none of the areas are active', () => {
+				registry
+					.dispatch( CORE_WIDGETS )
+					.setWidgetState( 'TestWidget1', Null, {} );
+
+				registry
+					.dispatch( CORE_WIDGETS )
+					.setWidgetState( 'TestWidget2', Null, {} );
+
+				expect(
+					registry
+						.select( CORE_WIDGETS )
+						.isWidgetContextActive( 'TestContext' )
+				).toEqual( false );
+			} );
+		} );
+	} );
+} );

--- a/assets/js/googlesitekit/widgets/datastore/contexts.test.js
+++ b/assets/js/googlesitekit/widgets/datastore/contexts.test.js
@@ -44,7 +44,7 @@ describe( 'core/widgets Widget context selectors', () => {
 				registry
 					.select( CORE_WIDGETS )
 					.isWidgetContextActive( 'TestContext' )
-			).toEqual( false );
+			).toBe( false );
 		} );
 
 		describe( 'when there are areas registered for the context', () => {
@@ -101,7 +101,7 @@ describe( 'core/widgets Widget context selectors', () => {
 					registry
 						.select( CORE_WIDGETS )
 						.isWidgetContextActive( 'TestContext' )
-				).toEqual( true );
+				).toBe( true );
 			} );
 
 			it( 'returns true when at least one area is active', () => {
@@ -113,7 +113,7 @@ describe( 'core/widgets Widget context selectors', () => {
 					registry
 						.select( CORE_WIDGETS )
 						.isWidgetContextActive( 'TestContext' )
-				).toEqual( true );
+				).toBe( true );
 			} );
 
 			it( 'returns false when none of the areas are active', () => {
@@ -129,7 +129,7 @@ describe( 'core/widgets Widget context selectors', () => {
 					registry
 						.select( CORE_WIDGETS )
 						.isWidgetContextActive( 'TestContext' )
-				).toEqual( false );
+				).toBe( false );
 			} );
 		} );
 	} );

--- a/assets/js/googlesitekit/widgets/datastore/contexts.test.js
+++ b/assets/js/googlesitekit/widgets/datastore/contexts.test.js
@@ -31,6 +31,46 @@ describe( 'core/widgets Widget context selectors', () => {
 	} );
 
 	describe( 'isWidgetContextActive', () => {
+		beforeEach( () => {
+			// Setup the first test area.
+			registry.dispatch( CORE_WIDGETS ).registerWidgetArea( 'TestArea1', {
+				title: 'Test Header 1',
+				subtitle: 'Cool stuff for yoursite.com',
+				style: 'composite',
+			} );
+
+			registry
+				.dispatch( CORE_WIDGETS )
+				.assignWidgetArea( 'TestArea1', 'TestContext' );
+
+			registry.dispatch( CORE_WIDGETS ).registerWidget( 'TestWidget1', {
+				Component: () => <div>Test Widget 1</div>,
+			} );
+
+			registry
+				.dispatch( CORE_WIDGETS )
+				.assignWidget( 'TestWidget1', 'TestArea1' );
+
+			// Setup the second test area.
+			registry.dispatch( CORE_WIDGETS ).registerWidgetArea( 'TestArea2', {
+				title: 'Test Header 2',
+				subtitle: 'More cool stuff for yoursite.com',
+				style: 'composite',
+			} );
+
+			registry
+				.dispatch( CORE_WIDGETS )
+				.assignWidgetArea( 'TestArea2', 'TestContext' );
+
+			registry.dispatch( CORE_WIDGETS ).registerWidget( 'TestWidget2', {
+				Component: () => <div>Test Widget 2</div>,
+			} );
+
+			registry
+				.dispatch( CORE_WIDGETS )
+				.assignWidget( 'TestWidget2', 'TestArea2' );
+		} );
+
 		it( 'requires a contextSlug', () => {
 			expect( () => {
 				registry.select( CORE_WIDGETS ).isWidgetContextActive();
@@ -43,94 +83,44 @@ describe( 'core/widgets Widget context selectors', () => {
 			expect(
 				registry
 					.select( CORE_WIDGETS )
-					.isWidgetContextActive( 'TestContext' )
+					.isWidgetContextActive( 'UnregisteredTestContext' )
 			).toBe( false );
 		} );
 
-		describe( 'when there are areas registered for the context', () => {
-			beforeEach( () => {
-				// Setup the first test area.
+		it( 'returns true when the context areas are active', () => {
+			expect(
 				registry
-					.dispatch( CORE_WIDGETS )
-					.registerWidgetArea( 'TestArea1', {
-						title: 'Test Header 1',
-						subtitle: 'Cool stuff for yoursite.com',
-						style: 'composite',
-					} );
+					.select( CORE_WIDGETS )
+					.isWidgetContextActive( 'TestContext' )
+			).toBe( true );
+		} );
 
+		it( 'returns true when at least one context area is active', () => {
+			registry
+				.dispatch( CORE_WIDGETS )
+				.setWidgetState( 'TestWidget1', Null, {} );
+
+			expect(
 				registry
-					.dispatch( CORE_WIDGETS )
-					.assignWidgetArea( 'TestArea1', 'TestContext' );
+					.select( CORE_WIDGETS )
+					.isWidgetContextActive( 'TestContext' )
+			).toBe( true );
+		} );
 
+		it( 'returns false when none of the context areas are active', () => {
+			registry
+				.dispatch( CORE_WIDGETS )
+				.setWidgetState( 'TestWidget1', Null, {} );
+
+			registry
+				.dispatch( CORE_WIDGETS )
+				.setWidgetState( 'TestWidget2', Null, {} );
+
+			expect(
 				registry
-					.dispatch( CORE_WIDGETS )
-					.registerWidget( 'TestWidget1', {
-						Component: () => <div>Test Widget 1</div>,
-					} );
-
-				registry
-					.dispatch( CORE_WIDGETS )
-					.assignWidget( 'TestWidget1', 'TestArea1' );
-
-				// Setup the second test area.
-				registry
-					.dispatch( CORE_WIDGETS )
-					.registerWidgetArea( 'TestArea2', {
-						title: 'Test Header 2',
-						subtitle: 'More cool stuff for yoursite.com',
-						style: 'composite',
-					} );
-
-				registry
-					.dispatch( CORE_WIDGETS )
-					.assignWidgetArea( 'TestArea2', 'TestContext' );
-
-				registry
-					.dispatch( CORE_WIDGETS )
-					.registerWidget( 'TestWidget2', {
-						Component: () => <div>Test Widget 2</div>,
-					} );
-
-				registry
-					.dispatch( CORE_WIDGETS )
-					.assignWidget( 'TestWidget2', 'TestArea2' );
-			} );
-
-			it( 'returns true when the areas are active', () => {
-				expect(
-					registry
-						.select( CORE_WIDGETS )
-						.isWidgetContextActive( 'TestContext' )
-				).toBe( true );
-			} );
-
-			it( 'returns true when at least one area is active', () => {
-				registry
-					.dispatch( CORE_WIDGETS )
-					.setWidgetState( 'TestWidget1', Null, {} );
-
-				expect(
-					registry
-						.select( CORE_WIDGETS )
-						.isWidgetContextActive( 'TestContext' )
-				).toBe( true );
-			} );
-
-			it( 'returns false when none of the areas are active', () => {
-				registry
-					.dispatch( CORE_WIDGETS )
-					.setWidgetState( 'TestWidget1', Null, {} );
-
-				registry
-					.dispatch( CORE_WIDGETS )
-					.setWidgetState( 'TestWidget2', Null, {} );
-
-				expect(
-					registry
-						.select( CORE_WIDGETS )
-						.isWidgetContextActive( 'TestContext' )
-				).toBe( false );
-			} );
+					.select( CORE_WIDGETS )
+					.isWidgetContextActive( 'TestContext' )
+			).toBe( false );
 		} );
 	} );
 } );

--- a/assets/js/googlesitekit/widgets/datastore/contexts.test.js
+++ b/assets/js/googlesitekit/widgets/datastore/contexts.test.js
@@ -23,104 +23,114 @@ import { createTestRegistry } from '../../../../../tests/js/utils';
 import { CORE_WIDGETS } from './constants';
 import Null from '../../../components/Null';
 
-describe( 'core/widgets Widget context selectors', () => {
+describe( 'core/widgets Widget context', () => {
 	let registry;
 
 	beforeEach( () => {
 		registry = createTestRegistry();
 	} );
 
-	describe( 'isWidgetContextActive', () => {
-		beforeEach( () => {
-			// Setup the first test area.
-			registry.dispatch( CORE_WIDGETS ).registerWidgetArea( 'TestArea1', {
-				title: 'Test Header 1',
-				subtitle: 'Cool stuff for yoursite.com',
-				style: 'composite',
+	describe( 'selectors', () => {
+		describe( 'isWidgetContextActive', () => {
+			beforeEach( () => {
+				// Setup the first test area.
+				registry
+					.dispatch( CORE_WIDGETS )
+					.registerWidgetArea( 'TestArea1', {
+						title: 'Test Header 1',
+						subtitle: 'Cool stuff for yoursite.com',
+						style: 'composite',
+					} );
+
+				registry
+					.dispatch( CORE_WIDGETS )
+					.assignWidgetArea( 'TestArea1', 'TestContext' );
+
+				registry
+					.dispatch( CORE_WIDGETS )
+					.registerWidget( 'TestWidget1', {
+						Component: () => <div>Test Widget 1</div>,
+					} );
+
+				registry
+					.dispatch( CORE_WIDGETS )
+					.assignWidget( 'TestWidget1', 'TestArea1' );
+
+				// Setup the second test area.
+				registry
+					.dispatch( CORE_WIDGETS )
+					.registerWidgetArea( 'TestArea2', {
+						title: 'Test Header 2',
+						subtitle: 'More cool stuff for yoursite.com',
+						style: 'composite',
+					} );
+
+				registry
+					.dispatch( CORE_WIDGETS )
+					.assignWidgetArea( 'TestArea2', 'TestContext' );
+
+				registry
+					.dispatch( CORE_WIDGETS )
+					.registerWidget( 'TestWidget2', {
+						Component: () => <div>Test Widget 2</div>,
+					} );
+
+				registry
+					.dispatch( CORE_WIDGETS )
+					.assignWidget( 'TestWidget2', 'TestArea2' );
 			} );
 
-			registry
-				.dispatch( CORE_WIDGETS )
-				.assignWidgetArea( 'TestArea1', 'TestContext' );
-
-			registry.dispatch( CORE_WIDGETS ).registerWidget( 'TestWidget1', {
-				Component: () => <div>Test Widget 1</div>,
+			it( 'requires a contextSlug', () => {
+				expect( () => {
+					registry.select( CORE_WIDGETS ).isWidgetContextActive();
+				} ).toThrow(
+					'contextSlug is required to check a widget context is active.'
+				);
 			} );
 
-			registry
-				.dispatch( CORE_WIDGETS )
-				.assignWidget( 'TestWidget1', 'TestArea1' );
-
-			// Setup the second test area.
-			registry.dispatch( CORE_WIDGETS ).registerWidgetArea( 'TestArea2', {
-				title: 'Test Header 2',
-				subtitle: 'More cool stuff for yoursite.com',
-				style: 'composite',
+			it( 'returns false if there are no areas registered for the context', () => {
+				expect(
+					registry
+						.select( CORE_WIDGETS )
+						.isWidgetContextActive( 'UnregisteredTestContext' )
+				).toBe( false );
 			} );
 
-			registry
-				.dispatch( CORE_WIDGETS )
-				.assignWidgetArea( 'TestArea2', 'TestContext' );
-
-			registry.dispatch( CORE_WIDGETS ).registerWidget( 'TestWidget2', {
-				Component: () => <div>Test Widget 2</div>,
+			it( 'returns true when the context areas are active', () => {
+				expect(
+					registry
+						.select( CORE_WIDGETS )
+						.isWidgetContextActive( 'TestContext' )
+				).toBe( true );
 			} );
 
-			registry
-				.dispatch( CORE_WIDGETS )
-				.assignWidget( 'TestWidget2', 'TestArea2' );
-		} );
-
-		it( 'requires a contextSlug', () => {
-			expect( () => {
-				registry.select( CORE_WIDGETS ).isWidgetContextActive();
-			} ).toThrow(
-				'contextSlug is required to check a widget context is active.'
-			);
-		} );
-
-		it( 'returns false if there are no areas registered for the context', () => {
-			expect(
+			it( 'returns true when at least one context area is active', () => {
 				registry
-					.select( CORE_WIDGETS )
-					.isWidgetContextActive( 'UnregisteredTestContext' )
-			).toBe( false );
-		} );
+					.dispatch( CORE_WIDGETS )
+					.setWidgetState( 'TestWidget1', Null, {} );
 
-		it( 'returns true when the context areas are active', () => {
-			expect(
+				expect(
+					registry
+						.select( CORE_WIDGETS )
+						.isWidgetContextActive( 'TestContext' )
+				).toBe( true );
+			} );
+
+			it( 'returns false when none of the context areas are active', () => {
 				registry
-					.select( CORE_WIDGETS )
-					.isWidgetContextActive( 'TestContext' )
-			).toBe( true );
-		} );
+					.dispatch( CORE_WIDGETS )
+					.setWidgetState( 'TestWidget1', Null, {} );
 
-		it( 'returns true when at least one context area is active', () => {
-			registry
-				.dispatch( CORE_WIDGETS )
-				.setWidgetState( 'TestWidget1', Null, {} );
-
-			expect(
 				registry
-					.select( CORE_WIDGETS )
-					.isWidgetContextActive( 'TestContext' )
-			).toBe( true );
-		} );
+					.dispatch( CORE_WIDGETS )
+					.setWidgetState( 'TestWidget2', Null, {} );
 
-		it( 'returns false when none of the context areas are active', () => {
-			registry
-				.dispatch( CORE_WIDGETS )
-				.setWidgetState( 'TestWidget1', Null, {} );
-
-			registry
-				.dispatch( CORE_WIDGETS )
-				.setWidgetState( 'TestWidget2', Null, {} );
-
-			expect(
-				registry
-					.select( CORE_WIDGETS )
-					.isWidgetContextActive( 'TestContext' )
-			).toBe( false );
+				expect(
+					registry
+						.select( CORE_WIDGETS )
+						.isWidgetContextActive( 'TestContext' )
+				).toBe( false );
+			} );
 		} );
 	} );
 } );

--- a/assets/js/googlesitekit/widgets/datastore/contexts.test.js
+++ b/assets/js/googlesitekit/widgets/datastore/contexts.test.js
@@ -23,7 +23,7 @@ import { createTestRegistry } from '../../../../../tests/js/utils';
 import { CORE_WIDGETS } from './constants';
 import Null from '../../../components/Null';
 
-describe( 'core/widgets Widget context', () => {
+describe( 'core/widgets Widget contexts', () => {
 	let registry;
 
 	beforeEach( () => {

--- a/assets/js/googlesitekit/widgets/datastore/index.js
+++ b/assets/js/googlesitekit/widgets/datastore/index.js
@@ -22,6 +22,7 @@
 import Data from 'googlesitekit-data';
 import areas from './areas';
 import widgets from './widgets';
+import contexts from './contexts';
 import { createErrorStore } from '../../data/create-error-store';
 import { CORE_WIDGETS } from './constants';
 
@@ -29,6 +30,7 @@ const store = Data.combineStores(
 	Data.commonStore,
 	areas,
 	widgets,
+	contexts,
 	createErrorStore()
 );
 

--- a/assets/js/googlesitekit/widgets/datastore/widgets.js
+++ b/assets/js/googlesitekit/widgets/datastore/widgets.js
@@ -24,6 +24,7 @@ import invariant from 'invariant';
 /**
  * Internal dependencies
  */
+import { isInactiveWidgetState } from '../util/is-inactive-widget-state';
 import { WIDGET_WIDTHS } from './constants';
 
 const ASSIGN_WIDGET = 'ASSIGN_WIDGET';
@@ -254,6 +255,24 @@ export const reducer = ( state, { type, payload } ) => {
 export const resolvers = {};
 
 export const selectors = {
+	/**
+	 * Checks if a widget with a given slug is active.
+	 *
+	 * Returns `true` if the widget area is active.
+	 * Returns `false` if the widget area is NOT active.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param {Object} state Data store's state.
+	 * @param {string} slug  Widget's slug.
+	 * @return {boolean} `true`/`false` based on whether widget is active.
+	 */
+	isWidgetActive( state, slug ) {
+		invariant( slug, 'slug is required to check a widget is active.' );
+
+		return ! isInactiveWidgetState( state.widgetStates[ slug ] );
+	},
+
 	/**
 	 * Checks if a widget has been registered with a given slug.
 	 *

--- a/assets/js/googlesitekit/widgets/datastore/widgets.js
+++ b/assets/js/googlesitekit/widgets/datastore/widgets.js
@@ -24,8 +24,11 @@ import invariant from 'invariant';
 /**
  * Internal dependencies
  */
+import Data from 'googlesitekit-data';
 import { isInactiveWidgetState } from '../util/is-inactive-widget-state';
-import { WIDGET_WIDTHS } from './constants';
+import { CORE_WIDGETS, WIDGET_WIDTHS } from './constants';
+
+const { createRegistrySelector } = Data;
 
 const ASSIGN_WIDGET = 'ASSIGN_WIDGET';
 const REGISTER_WIDGET = 'REGISTER_WIDGET';
@@ -267,11 +270,13 @@ export const selectors = {
 	 * @param {string} slug  Widget's slug.
 	 * @return {boolean} `true`/`false` based on whether widget is active.
 	 */
-	isWidgetActive( state, slug ) {
+	isWidgetActive: createRegistrySelector( ( select ) => ( state, slug ) => {
 		invariant( slug, 'slug is required to check a widget is active.' );
 
-		return ! isInactiveWidgetState( state.widgetStates[ slug ] );
-	},
+		return ! isInactiveWidgetState(
+			select( CORE_WIDGETS ).getWidgetState( slug )
+		);
+	} ),
 
 	/**
 	 * Checks if a widget has been registered with a given slug.

--- a/assets/js/googlesitekit/widgets/datastore/widgets.test.js
+++ b/assets/js/googlesitekit/widgets/datastore/widgets.test.js
@@ -204,12 +204,10 @@ describe( 'core/widgets Widgets', () => {
 					priority: 11,
 				} );
 
-				expect( store.getState().widgets[ slug ].Component ).toEqual(
+				expect( store.getState().widgets[ slug ].Component ).toBe(
 					WidgetComponent
 				);
-				expect( store.getState().widgets[ slug ].priority ).toEqual(
-					11
-				);
+				expect( store.getState().widgets[ slug ].priority ).toBe( 11 );
 
 				// Ensure we can render a component with the widget's component, verifying it's still a
 				// usable React component.
@@ -237,7 +235,7 @@ describe( 'core/widgets Widgets', () => {
 				);
 
 				// Ensure original widget's component is registered.
-				expect( store.getState().widgets[ slug ].Component ).toEqual(
+				expect( store.getState().widgets[ slug ].Component ).toBe(
 					WidgetOne
 				);
 			} );
@@ -340,10 +338,10 @@ describe( 'core/widgets Widgets', () => {
 					.getWidgets( 'dashboard-header' );
 
 				expect( widgets ).toHaveLength( 4 );
-				expect( widgets[ 0 ].slug ).toEqual( 'lowest' );
-				expect( widgets[ 1 ].slug ).toEqual( 'mediumOne' );
-				expect( widgets[ 2 ].slug ).toEqual( 'mediumTwo' );
-				expect( widgets[ 3 ].slug ).toEqual( 'highest' );
+				expect( widgets[ 0 ].slug ).toBe( 'lowest' );
+				expect( widgets[ 1 ].slug ).toBe( 'mediumOne' );
+				expect( widgets[ 2 ].slug ).toBe( 'mediumTwo' );
+				expect( widgets[ 3 ].slug ).toBe( 'highest' );
 			} );
 
 			it( 'should not return widgets that have been assigned but not registered', () => {

--- a/assets/js/googlesitekit/widgets/datastore/widgets.test.js
+++ b/assets/js/googlesitekit/widgets/datastore/widgets.test.js
@@ -140,17 +140,17 @@ describe( 'core/widgets Widgets', () => {
 					state.areaAssignments[ 'dashboard-header' ].includes(
 						'slugOne'
 					)
-				).toEqual( true );
+				).toBe( true );
 				expect(
 					state.areaAssignments[ 'dashboard-header' ].includes(
 						'slugTwo'
 					)
-				).toEqual( true );
+				).toBe( true );
 				expect(
 					state.areaAssignments[ 'dashboard-header' ].includes(
 						'slugThree'
 					)
-				).toEqual( true );
+				).toBe( true );
 			} );
 
 			it( 'should allow assignment of non-registered widget areas', () => {
@@ -168,12 +168,12 @@ describe( 'core/widgets Widgets', () => {
 					state.areaAssignments[ 'dashboard-header' ].includes(
 						'testOne'
 					)
-				).toEqual( true );
+				).toBe( true );
 				expect(
 					state.areaAssignments[ 'dashboard-header' ].includes(
 						'testTwo'
 					)
-				).toEqual( true );
+				).toBe( true );
 			} );
 		} );
 
@@ -409,7 +409,7 @@ describe( 'core/widgets Widgets', () => {
 					registry
 						.select( CORE_WIDGETS )
 						.isWidgetActive( 'TestWidget' )
-				).toEqual( true );
+				).toBe( true );
 			} );
 
 			it( 'returns true if the widget is active when the widget state has been set', () => {
@@ -421,7 +421,7 @@ describe( 'core/widgets Widgets', () => {
 					registry
 						.select( CORE_WIDGETS )
 						.isWidgetActive( 'TestWidget' )
-				).toEqual( true );
+				).toBe( true );
 			} );
 
 			it( 'returns false if the widget is not active', () => {
@@ -433,7 +433,7 @@ describe( 'core/widgets Widgets', () => {
 					registry
 						.select( CORE_WIDGETS )
 						.isWidgetActive( 'TestWidget' )
-				).toEqual( false );
+				).toBe( false );
 			} );
 		} );
 
@@ -451,7 +451,7 @@ describe( 'core/widgets Widgets', () => {
 					registry
 						.select( CORE_WIDGETS )
 						.isWidgetRegistered( 'TestWidget' )
-				).toEqual( true );
+				).toBe( true );
 			} );
 
 			it( 'returns false if the widget is not registered', () => {
@@ -459,7 +459,7 @@ describe( 'core/widgets Widgets', () => {
 					registry
 						.select( CORE_WIDGETS )
 						.isWidgetAreaRegistered( 'NotRealWidget' )
-				).toEqual( false );
+				).toBe( false );
 			} );
 		} );
 
@@ -481,7 +481,7 @@ describe( 'core/widgets Widgets', () => {
 			it( 'returns null if the widget is not registered', () => {
 				expect(
 					registry.select( CORE_WIDGETS ).getWidget( 'NotRealWidget' )
-				).toEqual( null );
+				).toBe( null );
 			} );
 		} );
 	} );

--- a/assets/js/googlesitekit/widgets/datastore/widgets.test.js
+++ b/assets/js/googlesitekit/widgets/datastore/widgets.test.js
@@ -25,6 +25,7 @@ import {
 } from '../../../../../tests/js/utils';
 import { render } from '../../../../../tests/js/test-utils';
 import { CORE_WIDGETS } from './constants';
+import Null from '../../../components/Null';
 
 describe( 'core/widgets Widgets', () => {
 	let registry;
@@ -383,6 +384,56 @@ describe( 'core/widgets Widgets', () => {
 					.getWidgets( 'dashboard-header' );
 
 				expect( widgets ).toHaveLength( 1 );
+			} );
+		} );
+
+		describe( 'isWidgetActive', () => {
+			const Component = () => <div>Hello test.</div>;
+
+			beforeEach( () => {
+				registry
+					.dispatch( CORE_WIDGETS )
+					.registerWidget( 'TestWidget', {
+						Component,
+					} );
+			} );
+
+			it( 'requires a slug', () => {
+				expect( () => {
+					registry.select( CORE_WIDGETS ).isWidgetActive();
+				} ).toThrow( 'slug is required to check a widget is active.' );
+			} );
+
+			it( 'returns true if the widget is active with default widget state', () => {
+				expect(
+					registry
+						.select( CORE_WIDGETS )
+						.isWidgetActive( 'TestWidget' )
+				).toEqual( true );
+			} );
+
+			it( 'returns true if the widget is active when the widget state has been set', () => {
+				registry
+					.dispatch( CORE_WIDGETS )
+					.setWidgetState( 'TestWidget', Component, {} );
+
+				expect(
+					registry
+						.select( CORE_WIDGETS )
+						.isWidgetActive( 'TestWidget' )
+				).toEqual( true );
+			} );
+
+			it( 'returns false if the widget is not active', () => {
+				registry
+					.dispatch( CORE_WIDGETS )
+					.setWidgetState( 'TestWidget', Null, {} );
+
+				expect(
+					registry
+						.select( CORE_WIDGETS )
+						.isWidgetActive( 'TestWidget' )
+				).toEqual( false );
 			} );
 		} );
 


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #4136 

## Relevant technical choices

##### `assets/js/components/dashboard-details/DashboardDetailsApp.js`:
Added an additional `div` with some reused classes to ensure the styling is correct on the entity dashboard error page, as discussed in the comments on the ticket - see https://github.com/google/site-kit-wp/issues/4136#issuecomment-968886245.

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
