### PR TITLE
Fix useIntersection not working on WordPress dashboard.

### DIFF
--- a/assets/js/components/wp-dashboard/WPDashboardIdeaHub.js
+++ b/assets/js/components/wp-dashboard/WPDashboardIdeaHub.js
@@ -40,7 +40,6 @@ import { trackEvent } from '../../util';
 import GoogleLogoIcon from '../../../svg/logo-g.svg';
 import Link from '../Link';
 import whenActive from '../../util/when-active';
-
 const { useSelect } = Data;
 
 function WPDashboardIdeaHub() {
@@ -75,6 +74,13 @@ function WPDashboardIdeaHub() {
 		);
 	}, [] );
 
+	// If the saved ideas from Idea Hub haven't finished loading yet,
+	// show an empty div. This allows `useIntersection` to work as expected.
+	if ( savedIdeas === undefined ) {
+		return <div ref={ trackingRef } />;
+	}
+
+	// If the saved ideas from Idea Hub are empty, don't show the notice.
 	if ( ! savedIdeas?.length ) {
 		return null;
 	}

--- a/assets/js/googlesitekit/widgets/components/WidgetAreaRenderer.js
+++ b/assets/js/googlesitekit/widgets/components/WidgetAreaRenderer.js
@@ -58,6 +58,7 @@ export default function WidgetAreaRenderer( { slug, totalAreas } ) {
 	const widgetStates = useSelect( ( select ) =>
 		select( CORE_WIDGETS ).getWidgetStates()
 	);
+
 	const activeWidgets = widgets.filter(
 		( widget ) =>
 			! (

--- a/assets/js/modules/idea-hub/components/dashboard/DashboardCTA.js
+++ b/assets/js/modules/idea-hub/components/dashboard/DashboardCTA.js
@@ -116,8 +116,6 @@ export default function DashboardCTA( { Widget, WidgetNull } ) {
 		);
 	}, [ dismissItem ] );
 
-	global.console.log( 'trackingRef', trackingRef );
-
 	// Don't render this component if it has been dismissed or the dismissed
 	// flag hasn't loaded yet.
 	if ( dismissed || dismissed === undefined ) {

--- a/assets/js/modules/idea-hub/components/dashboard/DashboardCTA.js
+++ b/assets/js/modules/idea-hub/components/dashboard/DashboardCTA.js
@@ -116,7 +116,10 @@ export default function DashboardCTA( { Widget, WidgetNull } ) {
 		);
 	}, [ dismissItem ] );
 
-	// Don't render this component if it has been dismissed or dismissed items aren't loaded yet.
+	global.console.log( 'trackingRef', trackingRef );
+
+	// Don't render this component if it has been dismissed or the dismissed
+	// flag hasn't loaded yet.
 	if ( dismissed || dismissed === undefined ) {
 		return <WidgetNull />;
 	}


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #4120.

## Relevant technical choices

This ensures the WordPress dashboard component always has a `ref` set during loading so the `useInteraction` hook works properly. After a fair bit of testing—this is only needed in this component.

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
