### PR TITLE
Amend Analytics setup copy for when a non-SiteKit placed snippet is evident.

### DIFF
--- a/assets/js/modules/analytics/components/common/ExistingTagNotice.js
+++ b/assets/js/modules/analytics/components/common/ExistingTagNotice.js
@@ -51,7 +51,7 @@ export default function ExistingTagNotice() {
 			notice = sprintf(
 				/* translators: %s: Analytics tag ID */
 				__(
-					'An existing Universal Analytics tag was found on your site with the ID %s. Since this tag refers to the same property you have selected here, Site Kit will not place its own tag and rely on the existing one. If later on you decide to remove this tag, Site Kit can place a new tag for you.',
+					'An existing Universal Analytics tag was found on your site with the ID %s. Since this tag refers to the same property selected here, Site Kit will not place its own tag and rely on the existing one. If later on you decide to remove this tag, Site Kit can place a new tag for you.',
 					'google-site-kit'
 				),
 				ua.existingTag
@@ -71,7 +71,7 @@ export default function ExistingTagNotice() {
 			notice = sprintf(
 				/* translators: %s: Analytics 4 measurement ID */
 				__(
-					'An existing Google Analytics 4 tag was found on your site with the ID %s. Since this tag refers to the same property you have selected here, Site Kit will not place its own tag and rely on the existing one. If later on you decide to remove this tag, Site Kit can place a new tag for you.',
+					'An existing Google Analytics 4 tag was found on your site with the ID %s. Since this tag refers to the same property selected here, Site Kit will not place its own tag and rely on the existing one. If later on you decide to remove this tag, Site Kit can place a new tag for you.',
 					'google-site-kit'
 				),
 				ga4.existingTag
@@ -94,7 +94,7 @@ export default function ExistingTagNotice() {
 			notice = sprintf(
 				/* translators: %1$s: Analytics tag ID, %2$s: Analytics 4 measurement ID */
 				__(
-					'An existing Universal Analytics tag with the ID %1$s and an existing Google Analytics 4 tag with the ID %2$s were found on your site. Since these tags refer to the same properties you have selected here, Site Kit will not place its own tags and rely on the existing ones. If later on you decide to remove these tags, Site Kit can place new tags for you.',
+					'An existing Universal Analytics tag with the ID %1$s and an existing Google Analytics 4 tag with the ID %2$s were found on your site. Since these tags refer to the same properties selected here, Site Kit will not place its own tags and rely on the existing ones. If later on you decide to remove these tags, Site Kit can place new tags for you.',
 					'google-site-kit'
 				),
 				ua.existingTag,
@@ -107,7 +107,7 @@ export default function ExistingTagNotice() {
 			notice = sprintf(
 				/* translators: %1$s: Analytics tag ID, %2$s: Analytics 4 measurement ID */
 				__(
-					'An existing Universal Analytics tag with the ID %1$s and an existing Google Analytics 4 tag with the ID %2$s were found on your site. Since the Universal Analytics tag refers to the same property you have selected here, Site Kit will not place its own tag and rely on the existing one.',
+					'An existing Universal Analytics tag with the ID %1$s and an existing Google Analytics 4 tag with the ID %2$s were found on your site. Since the Universal Analytics tag refers to the same property selected here, Site Kit will not place its own tag and rely on the existing one.',
 					'google-site-kit'
 				),
 				ua.existingTag,
@@ -120,7 +120,7 @@ export default function ExistingTagNotice() {
 			notice = sprintf(
 				/* translators: %1$s: Analytics tag ID, %2$s: Analytics 4 measurement ID */
 				__(
-					'An existing Universal Analytics tag with the ID %1$s and an existing Google Analytics 4 tag with the ID %2$s were found on your site. Since the Google Analytics 4 tag refers to the same property you have selected here, Site Kit will not place its own tag and rely on the existing one. If later on you decide to remove this tag, Site Kit can place a new tag for you.',
+					'An existing Universal Analytics tag with the ID %1$s and an existing Google Analytics 4 tag with the ID %2$s were found on your site. Since the Google Analytics 4 tag refers to the same property selected here, Site Kit will not place its own tag and rely on the existing one. If later on you decide to remove this tag, Site Kit can place a new tag for you.',
 					'google-site-kit'
 				),
 				ua.existingTag,


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #4151

## Relevant technical choices

Implemented as per IB.

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
