### PR TITLE
Bug/4385 phpunit tests on local

### DIFF
--- a/tests/phpunit/wp-tests-config.php
+++ b/tests/phpunit/wp-tests-config.php
@@ -23,15 +23,33 @@ define( 'ABSPATH', dirname( dirname( __DIR__ ) ) . '/vendor/roots/wordpress/' );
  * DO NOT use a production database or one that is shared with something else.
  */
 
+/**
+ * Returns an environment variable value if it exists, otherwise the default value.
+ *
+ * @since n.e.x.t
+ *
+ * @param string $name Environment variable name.
+ * @param mixed $default A default value to use if the env variable is not set.
+ * @return mixed The environment variable value if it exsits, otherwise the default value.
+ */
+function get_env( $name, $default ) {
+	$value = getenv( $name );
+	if ( false === $value ) {
+		$value = $default;
+	}
+
+	return $value;
+}
+
 /*
  * These database credentials refer to the `mysql` service in the Site Kit local
  * environment docker configuration. Run `npm run env:start` before running the
  * PHPUnit tests using this file.
  */
 define( 'DB_NAME', 'wordpress_test' );
-define( 'DB_USER', 'root' );
-define( 'DB_PASSWORD', 'example' );
-define( 'DB_HOST', '127.0.0.1:9306' );
+define( 'DB_USER', get_env( 'WORDPRESS_DB_USER', 'root' ) );
+define( 'DB_PASSWORD', get_env( 'WORDPRESS_DB_PASSWORD', 'example' ) );
+define( 'DB_HOST', get_env( 'WORDPRESS_DB_HOST', '127.0.0.1:9306' ) );
 define( 'DB_CHARSET', 'utf8' );
 define( 'DB_COLLATE', '' );
 

--- a/tests/phpunit/wp-tests-config.php
+++ b/tests/phpunit/wp-tests-config.php
@@ -32,14 +32,14 @@ define( 'ABSPATH', dirname( dirname( __DIR__ ) ) . '/vendor/roots/wordpress/' );
  * @param mixed $default A default value to use if the env variable is not set.
  * @return mixed The environment variable value if it exsits, otherwise the default value.
  */
-function get_env( $name, $default ) {
+$get_env = function( $name, $default ) {
 	$value = getenv( $name );
 	if ( false === $value ) {
 		$value = $default;
 	}
 
 	return $value;
-}
+};
 
 /*
  * These database credentials refer to the `mysql` service in the Site Kit local
@@ -47,9 +47,9 @@ function get_env( $name, $default ) {
  * PHPUnit tests using this file.
  */
 define( 'DB_NAME', 'wordpress_test' );
-define( 'DB_USER', get_env( 'WORDPRESS_DB_USER', 'root' ) );
-define( 'DB_PASSWORD', get_env( 'WORDPRESS_DB_PASSWORD', 'example' ) );
-define( 'DB_HOST', get_env( 'WORDPRESS_DB_HOST', '127.0.0.1:9306' ) );
+define( 'DB_USER', $get_env( 'WORDPRESS_DB_USER', 'root' ) );
+define( 'DB_PASSWORD', $get_env( 'WORDPRESS_DB_PASSWORD', 'example' ) );
+define( 'DB_HOST', $get_env( 'WORDPRESS_DB_HOST', '127.0.0.1:9306' ) );
 define( 'DB_CHARSET', 'utf8' );
 define( 'DB_COLLATE', '' );
 

--- a/tests/phpunit/wp-tests-config.php
+++ b/tests/phpunit/wp-tests-config.php
@@ -62,8 +62,8 @@ define( 'SECURE_AUTH_SALT', 'put your unique phrase here' );
 define( 'LOGGED_IN_SALT', 'put your unique phrase here' );
 define( 'NONCE_SALT', 'put your unique phrase here' );
 
-define( 'WP_TESTS_DOMAIN', 'example.com' );
-define( 'WP_TESTS_EMAIL', 'admin@example.com' );
+define( 'WP_TESTS_DOMAIN', 'example.org' );
+define( 'WP_TESTS_EMAIL', 'admin@example.org' );
 define( 'WP_TESTS_TITLE', 'Test Blog' );
 
 define( 'WP_PHP_BINARY', 'php' );


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #4385 

## Relevant technical choices

* Also updated the phpunit setup script to allow it to read the database connection information from environment variables used to run a wordpress container.

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
