### PR TITLE
Update unified dashboard tab bar pills to scroll to an area instead of relying on the browser anchor targets.

### DIFF
--- a/assets/js/components/DashboardNavigation.js
+++ b/assets/js/components/DashboardNavigation.js
@@ -26,6 +26,7 @@ import { ChipSet, Chip } from '@material/react-chips';
  */
 import { useCallback, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { removeQueryArgs } from '@wordpress/url';
 
 /**
  * Internal dependencies
@@ -37,13 +38,49 @@ import {
 	ANCHOR_ID_TRAFFIC,
 } from '../googlesitekit/constants';
 
+/**
+ * Get the y coordinate to scroll to the top of a context element, taking the sticky header and navigation height into account.
+ *
+ * @since n.e.x.t
+ *
+ * @param {string} contextID The ID of the context element to scroll to.
+ * @return {number} The offset to scroll to.
+ */
+
+const getContextScrollTop = ( contextID ) => {
+	if ( contextID === 'traffic' ) {
+		return 0;
+	}
+
+	const contextTop = document
+		.getElementById( contextID )
+		.getBoundingClientRect().top;
+
+	const navigationBottom = document
+		.querySelector( '.googlesitekit-navigation' )
+		.getBoundingClientRect().bottom;
+
+	return contextTop + global.scrollY - navigationBottom;
+};
+
 export default function DashboardNavigation() {
 	const [ selectedIds, setSelectedIds ] = useState( [] );
 
 	const handleSelect = useCallback( ( selections ) => {
 		const [ hash ] = selections;
 		if ( hash ) {
-			global.location.hash = hash;
+			global.history.replaceState( {}, '', `#${ hash }` );
+
+			global.scrollTo( {
+				top: getContextScrollTop( hash ),
+				behavior: 'smooth',
+			} );
+		} else {
+			global.history.replaceState(
+				{},
+				'',
+				removeQueryArgs( global.location.href )
+			);
 		}
 		setSelectedIds( selections );
 	}, [] );

--- a/assets/js/components/DashboardNavigation.js
+++ b/assets/js/components/DashboardNavigation.js
@@ -46,7 +46,6 @@ import {
  * @param {string} contextID The ID of the context element to scroll to.
  * @return {number} The offset to scroll to.
  */
-
 const getContextScrollTop = ( contextID ) => {
 	if ( contextID === 'traffic' ) {
 		return 0;

--- a/assets/js/components/DashboardNavigation.js
+++ b/assets/js/components/DashboardNavigation.js
@@ -39,7 +39,7 @@ import {
 } from '../googlesitekit/constants';
 
 /**
- * Get the y coordinate to scroll to the top of a context element, taking the sticky header and navigation height into account.
+ * Gets the y coordinate to scroll to the top of a context element, taking the sticky header and navigation height into account.
  *
  * @since n.e.x.t
  *


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #4367 

## Relevant technical choices

<!-- Please describe your changes. -->

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
