### PR TITLE
Fix AdSense widget registration.

### DIFF
--- a/assets/js/modules/adsense/index.js
+++ b/assets/js/modules/adsense/index.js
@@ -97,11 +97,7 @@ export const registerWidgets = ( widgets ) => {
 			priority: 1,
 			wrapWidget: false,
 		},
-		[
-			isFeatureEnabled( 'unifiedDashboard' )
-				? AREA_MAIN_DASHBOARD_MONETIZATION_PRIMARY
-				: AREA_MODULE_ADSENSE_MAIN,
-		]
+		[ AREA_MAIN_DASHBOARD_MONETIZATION_PRIMARY, AREA_MODULE_ADSENSE_MAIN ]
 	);
 
 	if ( isFeatureEnabled( 'unifiedDashboard' ) ) {

--- a/assets/js/modules/adsense/index.js
+++ b/assets/js/modules/adsense/index.js
@@ -104,7 +104,43 @@ export const registerWidgets = ( widgets ) => {
 		]
 	);
 
+	if ( isFeatureEnabled( 'unifiedDashboard' ) ) {
+		widgets.registerWidget(
+			'adsenseTopEarningPages',
+			{
+				Component: DashboardTopEarningPagesWidget,
+				width: [
+					widgets.WIDGET_WIDTHS.HALF,
+					widgets.WIDGET_WIDTHS.FULL,
+				],
+				priority: 2,
+				wrapWidget: false,
+			},
+			[ AREA_MAIN_DASHBOARD_MONETIZATION_PRIMARY ]
+		);
+		widgets.registerWidget(
+			'adsenseModuleOverview',
+			{
+				Component: ModuleOverviewWidget,
+				width: widgets.WIDGET_WIDTHS.FULL,
+				priority: 2,
+				wrapWidget: false,
+			},
+			[ AREA_MAIN_DASHBOARD_MONETIZATION_PRIMARY ]
+		);
+	}
+
 	if ( ! isFeatureEnabled( 'unifiedDashboard' ) ) {
+		widgets.registerWidgetArea(
+			AREA_MODULE_ADSENSE_MAIN,
+			{
+				priority: 1,
+				style: WIDGET_AREA_STYLES.BOXES,
+				title: __( 'Overview', 'google-site-kit' ),
+			},
+			CONTEXT_MODULE_ADSENSE
+		);
+
 		widgets.registerWidget(
 			'adsenseSummary',
 			{
@@ -126,10 +162,7 @@ export const registerWidgets = ( widgets ) => {
 				priority: 2,
 				wrapWidget: false,
 			},
-			[
-				AREA_DASHBOARD_EARNINGS,
-				AREA_MAIN_DASHBOARD_MONETIZATION_PRIMARY,
-			]
+			[ AREA_DASHBOARD_EARNINGS ]
 		);
 		widgets.registerWidget(
 			'adsenseModuleOverview',
@@ -139,21 +172,8 @@ export const registerWidgets = ( widgets ) => {
 				priority: 2,
 				wrapWidget: false,
 			},
-			[
-				AREA_MODULE_ADSENSE_MAIN,
-				AREA_MAIN_DASHBOARD_MONETIZATION_PRIMARY,
-			]
+			[ AREA_MODULE_ADSENSE_MAIN ]
 		);
-		widgets.registerWidgetArea(
-			AREA_MODULE_ADSENSE_MAIN,
-			{
-				priority: 1,
-				style: WIDGET_AREA_STYLES.BOXES,
-				title: __( 'Overview', 'google-site-kit' ),
-			},
-			CONTEXT_MODULE_ADSENSE
-		);
-
 		widgets.registerWidget(
 			'adsenseModuleTopEarningPages',
 			{


### PR DESCRIPTION
## Summary

Addresses issue #4348.

This ensures the AdSense widgets are registered when the Unified Dashboard feature flag is enabled.

Note: This diverges from the IB in that the `unifiedDashboard` feature flag checks are still intact. The reason for this is that some widgets share the same slug in both the Unified and "old" dashboard: https://github.com/google/site-kit-wp/blob/53a768c6a3bc353966f95371e6c03c816a61ec79/assets/js/modules/adsense/index.js#L164

Separating out the registrations allows us to change the sizes, priorities, etc. easier if needed for only one "kind" of dashboard, plus it makes the code _much_ more scannable/readable so we know which widgets should appear in which dashboard. It'll also make refactoring/removal of old dashboard code easier when the feature flag is removed.

So I've opted to keep the feature checks for everything except the adblocker, because it doesn't cause any harm now that the registration is fixed.

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
