### PR TITLE
Update entity search loading indicator to match design.

### DIFF
--- a/assets/js/components/EntitySearchInput.js
+++ b/assets/js/components/EntitySearchInput.js
@@ -103,6 +103,12 @@ function EntitySearchInput() {
 					/* eslint-disable-next-line jsx-a11y/no-autofocus */
 					autoFocus
 				/>
+				{ isLoading && (
+					<ProgressBar
+						className="googlesitekit-entity-search__loading"
+						compress
+					/>
+				) }
 
 				<div className="googlesitekit-entity-search__actions">
 					<Button
@@ -111,13 +117,6 @@ function EntitySearchInput() {
 						className="googlesitekit-entity-search__close"
 						text
 					/>
-					{ isLoading && (
-						<ProgressBar
-							className="googlesitekit-entity-search__loading"
-							small
-							compress
-						/>
-					) }
 				</div>
 			</div>
 		);

--- a/assets/sass/components/global/_googlesitekit-entity-search.scss
+++ b/assets/sass/components/global/_googlesitekit-entity-search.scss
@@ -46,13 +46,17 @@
 		}
 
 		.googlesitekit-entity-search__loading {
-			bottom: 0;
+			border-radius: 4px 4px 0 0;
+			bottom: -4px;
 			position: absolute;
-			right: 1px;
+			right: 4px;
+			width: calc(100% - 8px);
 			z-index: 4;
 
 			@media ( min-width: $bp-wpAdminBarTablet ) {
-				border-bottom-right-radius: 4px;
+				bottom: -6px;
+				right: 0;
+				width: 100%;
 			}
 		}
 


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #4336 

## Relevant technical choices

The IB was missing a couple of details which I have implemented:

* The `ProgressBar` component needed to be moved out of the `.googlesitekit-entity-search__actions` container in order to achieve the desired width.
* Some tweaks were needed to `bottom`, `height` and `width` to accommodate the view at the small breakpoint.

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
