### PR TITLE
Fix Tag Manager account and container dropdown pre-selection.

### DIFF
--- a/assets/js/modules/tagmanager/datastore/accounts.js
+++ b/assets/js/modules/tagmanager/datastore/accounts.js
@@ -125,40 +125,46 @@ export const baseActions = {
 				const webContainers = select(
 					MODULES_TAGMANAGER
 				).getWebContainers( accountID );
-				const webContainer = webContainers[ 0 ] || {
-					// eslint-disable-next-line sitekit/acronym-case
-					publicId: CONTAINER_CREATE,
-					// eslint-disable-next-line sitekit/acronym-case
-					containerId: '',
-				};
-				dispatch( MODULES_TAGMANAGER ).setContainerID(
-					// eslint-disable-next-line sitekit/acronym-case
-					webContainer.publicId
-				);
-				dispatch( MODULES_TAGMANAGER ).setInternalContainerID(
-					// eslint-disable-next-line sitekit/acronym-case
-					webContainer.containerId
-				);
+
+				if ( ! webContainers.length ) {
+					dispatch( MODULES_TAGMANAGER ).setContainerID(
+						CONTAINER_CREATE
+					);
+					dispatch( MODULES_TAGMANAGER ).setInternalContainerID( '' );
+				} else if ( webContainers.length === 1 ) {
+					dispatch( MODULES_TAGMANAGER ).setContainerID(
+						// eslint-disable-next-line sitekit/acronym-case
+						webContainers[ 0 ].publicId
+					);
+					dispatch( MODULES_TAGMANAGER ).setInternalContainerID(
+						// eslint-disable-next-line sitekit/acronym-case
+						webContainers[ 0 ].containerId
+					);
+				}
 			}
 
 			if ( isAMP() ) {
 				const ampContainers = select(
 					MODULES_TAGMANAGER
 				).getAMPContainers( accountID );
-				const ampContainer = ampContainers[ 0 ] || {
-					// eslint-disable-next-line sitekit/acronym-case
-					publicId: CONTAINER_CREATE,
-					// eslint-disable-next-line sitekit/acronym-case
-					containerId: '',
-				};
-				dispatch( MODULES_TAGMANAGER ).setAMPContainerID(
-					// eslint-disable-next-line sitekit/acronym-case
-					ampContainer.publicId
-				);
-				dispatch( MODULES_TAGMANAGER ).setInternalAMPContainerID(
-					// eslint-disable-next-line sitekit/acronym-case
-					ampContainer.containerId
-				);
+
+				if ( ! ampContainers.length ) {
+					dispatch( MODULES_TAGMANAGER ).setAMPContainerID(
+						CONTAINER_CREATE
+					);
+					dispatch( MODULES_TAGMANAGER ).setInternalAMPContainerID(
+						''
+					);
+				} else if ( ampContainers.length === 1 ) {
+					dispatch( MODULES_TAGMANAGER ).setAMPContainerID(
+						// eslint-disable-next-line sitekit/acronym-case
+						ampContainers[ 0 ].publicId
+					);
+					dispatch( MODULES_TAGMANAGER ).setInternalAMPContainerID(
+						// eslint-disable-next-line sitekit/acronym-case
+						ampContainers[ 0 ].containerId
+					);
+				}
 			}
 		}
 	),
@@ -200,7 +206,7 @@ export const baseResolvers = {
 		}
 
 		if (
-			accounts?.length &&
+			accounts?.length === 1 &&
 			! select( MODULES_TAGMANAGER ).getAccountID()
 		) {
 			dispatch( MODULES_TAGMANAGER ).selectAccount(

--- a/assets/js/modules/tagmanager/datastore/accounts.test.js
+++ b/assets/js/modules/tagmanager/datastore/accounts.test.js
@@ -231,10 +231,10 @@ describe( 'modules/tagmanager accounts', () => {
 					containers,
 				} = factories.buildAccountWithContainers( {
 					container: { usageContext: [ CONTEXT_WEB ] },
-					count: 3,
+					count: 1,
 				} );
 				const accountID = account.accountId; // eslint-disable-line sitekit/acronym-case
-				const [ firstContainer ] = containers;
+				const { publicId, containerId } = containers[ 0 ]; // eslint-disable-line sitekit/acronym-case
 				let resolveResponse;
 				const responsePromise = new Promise( ( resolve ) => {
 					resolveResponse = () => resolve( containers );
@@ -281,12 +281,12 @@ describe( 'modules/tagmanager accounts', () => {
 				).toBe( accountID );
 				expect(
 					registry.select( MODULES_TAGMANAGER ).getContainerID()
-				).toBe( firstContainer.publicId ); // eslint-disable-line sitekit/acronym-case
+				).toBe( publicId ); // eslint-disable-line sitekit/acronym-case
 				expect(
 					registry
 						.select( MODULES_TAGMANAGER )
 						.getInternalContainerID()
-				).toBe( firstContainer.containerId ); // eslint-disable-line sitekit/acronym-case
+				).toBe( containerId ); // eslint-disable-line sitekit/acronym-case
 				expect(
 					registry.select( MODULES_TAGMANAGER ).getAMPContainerID()
 				).toBe( '' );
@@ -308,16 +308,16 @@ describe( 'modules/tagmanager accounts', () => {
 			} );
 
 			describe( 'with no AMP', () => {
-				it( 'selects the first web container for the selected account', async () => {
+				it( 'selects the web container for the selected account when there is only one web container', async () => {
 					const {
 						account,
 						containers,
 					} = factories.buildAccountWithContainers( {
 						container: { usageContext: [ CONTEXT_WEB ] },
-						count: 3,
+						count: 1,
 					} );
 					const accountID = account.accountId; // eslint-disable-line sitekit/acronym-case
-					const [ firstContainer ] = containers;
+					const { publicId, containerId } = containers[ 0 ]; // eslint-disable-line sitekit/acronym-case
 					registry
 						.dispatch( MODULES_TAGMANAGER )
 						.receiveGetContainers( containers, { accountID } );
@@ -328,12 +328,49 @@ describe( 'modules/tagmanager accounts', () => {
 
 					expect(
 						registry.select( MODULES_TAGMANAGER ).getContainerID()
-					).toBe( firstContainer.publicId ); // eslint-disable-line sitekit/acronym-case
+					).toBe( publicId ); // eslint-disable-line sitekit/acronym-case
 					expect(
 						registry
 							.select( MODULES_TAGMANAGER )
 							.getInternalContainerID()
-					).toBe( firstContainer.containerId ); // eslint-disable-line sitekit/acronym-case
+					).toBe( containerId ); // eslint-disable-line sitekit/acronym-case
+					expect(
+						registry
+							.select( MODULES_TAGMANAGER )
+							.getAMPContainerID()
+					).toBe( '' );
+					expect(
+						registry
+							.select( MODULES_TAGMANAGER )
+							.getInternalAMPContainerID()
+					).toBe( '' );
+				} );
+
+				it( 'does not select a web container for the selected account when there are multiple web containers', async () => {
+					const {
+						account,
+						containers,
+					} = factories.buildAccountWithContainers( {
+						container: { usageContext: [ CONTEXT_WEB ] },
+						count: 3,
+					} );
+					const accountID = account.accountId; // eslint-disable-line sitekit/acronym-case
+					registry
+						.dispatch( MODULES_TAGMANAGER )
+						.receiveGetContainers( containers, { accountID } );
+
+					await registry
+						.dispatch( MODULES_TAGMANAGER )
+						.selectAccount( accountID );
+
+					expect(
+						registry.select( MODULES_TAGMANAGER ).getContainerID()
+					).toBe( '' );
+					expect(
+						registry
+							.select( MODULES_TAGMANAGER )
+							.getInternalContainerID()
+					).toBe( '' );
 					expect(
 						registry
 							.select( MODULES_TAGMANAGER )
@@ -384,16 +421,16 @@ describe( 'modules/tagmanager accounts', () => {
 						.receiveSiteInfo( { ampMode: AMP_MODE_PRIMARY } )
 				);
 
-				it( 'selects the first AMP container for the selected account', async () => {
+				it( 'selects the AMP container for the selected account when there is only one AMP container', async () => {
 					const {
 						account,
 						containers,
 					} = factories.buildAccountWithContainers( {
 						container: { usageContext: [ CONTEXT_AMP ] },
-						count: 3,
+						count: 1,
 					} );
 					const accountID = account.accountId; // eslint-disable-line sitekit/acronym-case
-					const [ firstContainer ] = containers;
+					const { publicId, containerId } = containers[ 0 ]; // eslint-disable-line sitekit/acronym-case
 					registry
 						.dispatch( MODULES_TAGMANAGER )
 						.receiveGetContainers( containers, { accountID } );
@@ -414,12 +451,49 @@ describe( 'modules/tagmanager accounts', () => {
 						registry
 							.select( MODULES_TAGMANAGER )
 							.getAMPContainerID()
-					).toBe( firstContainer.publicId ); // eslint-disable-line sitekit/acronym-case
+					).toBe( publicId ); // eslint-disable-line sitekit/acronym-case
 					expect(
 						registry
 							.select( MODULES_TAGMANAGER )
 							.getInternalAMPContainerID()
-					).toBe( firstContainer.containerId ); // eslint-disable-line sitekit/acronym-case
+					).toBe( containerId ); // eslint-disable-line sitekit/acronym-case
+				} );
+
+				it( 'does not select an AMP container for the selected account when there are multiple AMP containers', async () => {
+					const {
+						account,
+						containers,
+					} = factories.buildAccountWithContainers( {
+						container: { usageContext: [ CONTEXT_AMP ] },
+						count: 3,
+					} );
+					const accountID = account.accountId; // eslint-disable-line sitekit/acronym-case
+					registry
+						.dispatch( MODULES_TAGMANAGER )
+						.receiveGetContainers( containers, { accountID } );
+
+					await registry
+						.dispatch( MODULES_TAGMANAGER )
+						.selectAccount( accountID );
+
+					expect(
+						registry.select( MODULES_TAGMANAGER ).getContainerID()
+					).toBe( '' );
+					expect(
+						registry
+							.select( MODULES_TAGMANAGER )
+							.getInternalContainerID()
+					).toBe( '' );
+					expect(
+						registry
+							.select( MODULES_TAGMANAGER )
+							.getAMPContainerID()
+					).toBe( '' );
+					expect(
+						registry
+							.select( MODULES_TAGMANAGER )
+							.getInternalAMPContainerID()
+					).toBe( '' );
 				} );
 
 				it( 'selects "set up a new container" if there are none', async () => {
@@ -460,17 +534,17 @@ describe( 'modules/tagmanager accounts', () => {
 						.receiveSiteInfo( { ampMode: AMP_MODE_SECONDARY } )
 				);
 
-				it( 'selects both first containers for the selected account', async () => {
+				it( 'selects both first containers for the selected account when there is one web and one AMP container', async () => {
 					// eslint-disable-next-line sitekit/acronym-case
 					const { accountId } = factories.accountBuilder();
 					// eslint-disable-next-line sitekit/acronym-case
 					const accountID = accountId;
-					const webContainers = factories.buildContainers( 3, {
+					const webContainers = factories.buildContainers( 1, {
 						// eslint-disable-next-line sitekit/acronym-case
 						accountId,
 						usageContext: [ CONTEXT_WEB ],
 					} );
-					const ampContainers = factories.buildContainers( 3, {
+					const ampContainers = factories.buildContainers( 1, {
 						// eslint-disable-next-line sitekit/acronym-case
 						accountId,
 						usageContext: [ CONTEXT_AMP ],
@@ -502,6 +576,50 @@ describe( 'modules/tagmanager accounts', () => {
 							.select( MODULES_TAGMANAGER )
 							.getInternalAMPContainerID()
 					).toBe( ampContainers[ 0 ].containerId ); // eslint-disable-line sitekit/acronym-case
+				} );
+
+				it( 'does not select a container for the selected account when there are multiple web and AMP containers', async () => {
+					// eslint-disable-next-line sitekit/acronym-case
+					const { accountId } = factories.accountBuilder();
+					// eslint-disable-next-line sitekit/acronym-case
+					const accountID = accountId;
+					const webContainers = factories.buildContainers( 3, {
+						// eslint-disable-next-line sitekit/acronym-case
+						accountId,
+						usageContext: [ CONTEXT_WEB ],
+					} );
+					const ampContainers = factories.buildContainers( 3, {
+						// eslint-disable-next-line sitekit/acronym-case
+						accountId,
+						usageContext: [ CONTEXT_AMP ],
+					} );
+					const containers = [ ...webContainers, ...ampContainers ];
+					registry
+						.dispatch( MODULES_TAGMANAGER )
+						.receiveGetContainers( containers, { accountID } );
+
+					await registry
+						.dispatch( MODULES_TAGMANAGER )
+						.selectAccount( accountID );
+
+					expect(
+						registry.select( MODULES_TAGMANAGER ).getContainerID()
+					).toBe( '' );
+					expect(
+						registry
+							.select( MODULES_TAGMANAGER )
+							.getInternalContainerID()
+					).toBe( '' );
+					expect(
+						registry
+							.select( MODULES_TAGMANAGER )
+							.getAMPContainerID()
+					).toBe( '' );
+					expect(
+						registry
+							.select( MODULES_TAGMANAGER )
+							.getInternalAMPContainerID()
+					).toBe( '' );
 				} );
 
 				it( 'selects "set up a new container" if there are none', async () => {

--- a/tests/e2e/specs/modules/tagmanager/setup.test.js
+++ b/tests/e2e/specs/modules/tagmanager/setup.test.js
@@ -248,21 +248,21 @@ describe( 'Tag Manager module setup', () => {
 				'.googlesitekit-tagmanager__select-container--amp'
 			);
 
-			// Ensure account and container are selected by default.
+			// Ensure account and container are not yet selected.
 			await expect(
 				page
 			).toMatchElement(
 				'.googlesitekit-tagmanager__select-account .mdc-select__selected-text',
-				{ text: /test account a/i }
+				{ text: '' }
 			);
 			await expect(
 				page
 			).toMatchElement(
 				'.googlesitekit-tagmanager__select-container .mdc-select__selected-text',
-				{ text: /test container x/i }
+				{ text: '' }
 			);
 
-			// Ensure choosing a different account loads the proper values.
+			// Ensure choosing an account loads the proper values.
 			await expect( page ).toClick(
 				'.googlesitekit-tagmanager__select-account'
 			);
@@ -424,42 +424,44 @@ describe( 'Tag Manager module setup', () => {
 				);
 			} );
 
-			it( 'validates homepage AMP for logged-in users', async () => {
-				await expect( page ).toClick( 'button:not(:disabled)', {
-					text: /confirm \& continue/i,
+			describe( 'when validating', () => {
+				beforeEach( async () => {
+					await page.waitForSelector(
+						'.googlesitekit-tagmanager__select-account'
+					);
+					await expect( page ).toClick(
+						'.googlesitekit-tagmanager__select-account'
+					);
+					await expect( page ).toClick(
+						'.mdc-menu-surface--open .mdc-list-item',
+						{
+							text: /test account a/i,
+						}
+					);
+					await expect( page ).toClick( 'button:not(:disabled)', {
+						text: /confirm \& continue/i,
+					} );
+					await page.waitForSelector(
+						'.googlesitekit-publisher-win--win-success'
+					);
+					await expect( page ).toMatchElement(
+						'.googlesitekit-publisher-win__title',
+						{
+							text: /Congrats on completing the setup for Tag Manager!/i,
+						}
+					);
+					await page.goto( createURL( '/', 'amp' ), {
+						waitUntil: 'load',
+					} );
 				} );
-				await page.waitForSelector(
-					'.googlesitekit-publisher-win--win-success'
-				);
-				await expect( page ).toMatchElement(
-					'.googlesitekit-publisher-win__title',
-					{
-						text: /Congrats on completing the setup for Tag Manager!/i,
-					}
-				);
-				await page.goto( createURL( '/', 'amp' ), {
-					waitUntil: 'load',
-				} );
-				await expect( page ).toHaveValidAMPForUser();
-			} );
 
-			it( 'validates homepage AMP for non-logged-in users', async () => {
-				await expect( page ).toClick( 'button:not(:disabled)', {
-					text: /confirm \& continue/i,
+				it( 'validates homepage AMP for logged-in users', async () => {
+					await expect( page ).toHaveValidAMPForUser();
 				} );
-				await page.waitForSelector(
-					'.googlesitekit-publisher-win--win-success'
-				);
-				await expect( page ).toMatchElement(
-					'.googlesitekit-publisher-win__title',
-					{
-						text: /Congrats on completing the setup for Tag Manager!/i,
-					}
-				);
-				await page.goto( createURL( '/', 'amp' ), {
-					waitUntil: 'load',
+
+				it( 'validates homepage AMP for non-logged-in users', async () => {
+					await expect( page ).toHaveValidAMPForVisitor();
 				} );
-				await expect( page ).toHaveValidAMPForVisitor();
 			} );
 		} );
 	} );


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #4209 

## Relevant technical choices

Although not mentioned in the IB, it's necessary to still dispatch

```js
setContainerID( CONTAINER_CREATE )
setInternalContainerID( '' )

// Or, for AMP containers:

setAMPContainerID( CONTAINER_CREATE )
setInternalAMPContainerID( '' )
```

when the related container arrays are empty.

Additionally, a number of tests needed to be fixed, and a couple of test cases added.

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [ ] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
