### PR TITLE
Update singular `tab` to `tabs` for idea hub module.

### DIFF
--- a/assets/js/modules/idea-hub/components/dashboard/DashboardIdeasWidget/DraftIdeas.js
+++ b/assets/js/modules/idea-hub/components/dashboard/DashboardIdeasWidget/DraftIdeas.js
@@ -78,7 +78,7 @@ export default function DraftIdeas( { WidgetReportError } ) {
 				Icon={ <EmptyIcon /> }
 				title={ __( 'No drafts here yet', 'google-site-kit' ) }
 				subtitle={ __(
-					'Ideas will appear here by starting a draft from the New or Saved tab',
+					'Ideas will appear here by starting a draft from the New or Saved tabs',
 					'google-site-kit'
 				) }
 			/>


### PR DESCRIPTION
## Summary
The following change updates the label `tab` to `tabs` for the Idea Hub module, according to #4276 where no available drafts are available.

![2021-11-28_20-34](https://user-images.githubusercontent.com/3921289/143802841-7164c7a5-1ac8-42a9-9e2e-aba4c09bde92.png)


<!-- Please reference the issue this PR addresses. -->
Addresses issue 

- #4276

## Relevant technical choices

<!-- Please describe your changes. -->

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
