### PR TITLE
Remove date selector chevron for Unified Dashboard mobile viewport.

### DIFF
--- a/assets/js/components/DateRangeSelector.js
+++ b/assets/js/components/DateRangeSelector.js
@@ -94,7 +94,9 @@ export default function DateRangeSelector() {
 		>
 			<Button
 				className={ classnames(
-					'googlesitekit-header__date-range-selector-menu mdc-button--dropdown googlesitekit-header__dropdown',
+					'googlesitekit-header__date-range-selector-menu',
+					'mdc-button--dropdown',
+					'googlesitekit-header__dropdown',
 					{
 						'googlesitekit-header__date-range-selector-menu--has-unified-dashboard': unifiedDashboardEnabled,
 					}

--- a/assets/js/components/DateRangeSelector.js
+++ b/assets/js/components/DateRangeSelector.js
@@ -20,6 +20,7 @@
  * External dependencies
  */
 import { useClickAway } from 'react-use';
+import classnames from 'classnames';
 
 /**
  * WordPress dependencies
@@ -39,9 +40,12 @@ import ViewContextContext from './Root/ViewContextContext';
 import Menu from './Menu';
 import Button from './Button';
 import { trackEvent } from '../util';
+import { useFeature } from '../hooks/useFeature';
 const { useSelect, useDispatch } = Data;
 
 export default function DateRangeSelector() {
+	const unifiedDashboardEnabled = useFeature( 'unifiedDashboard' );
+
 	const ranges = getAvailableDateRanges();
 	const dateRange = useSelect( ( select ) =>
 		select( CORE_USER ).getDateRange()
@@ -89,7 +93,12 @@ export default function DateRangeSelector() {
 			className="googlesitekit-date-range-selector googlesitekit-dropdown-menu mdc-menu-surface--anchor"
 		>
 			<Button
-				className="googlesitekit-header__date-range-selector-menu mdc-button--dropdown googlesitekit-header__dropdown"
+				className={ classnames(
+					'googlesitekit-header__date-range-selector-menu mdc-button--dropdown googlesitekit-header__dropdown',
+					{
+						'googlesitekit-header__date-range-selector-menu--has-unified-dashboard': unifiedDashboardEnabled,
+					}
+				) }
 				text
 				onClick={ handleMenu }
 				icon={ <DateRangeIcon width="18" height="20" /> }

--- a/assets/js/components/DateRangeSelector.js
+++ b/assets/js/components/DateRangeSelector.js
@@ -94,9 +94,9 @@ export default function DateRangeSelector() {
 		>
 			<Button
 				className={ classnames(
-					'googlesitekit-header__date-range-selector-menu',
 					'mdc-button--dropdown',
 					'googlesitekit-header__dropdown',
+					'googlesitekit-header__date-range-selector-menu',
 					{
 						'googlesitekit-header__date-range-selector-menu--has-unified-dashboard': unifiedDashboardEnabled,
 					}

--- a/assets/sass/components/global/_googlesitekit-header.scss
+++ b/assets/sass/components/global/_googlesitekit-header.scss
@@ -117,6 +117,19 @@
 				padding-right: $grid-gap-desktop;
 			}
 
+
+			.googlesitekit-header__date-range-selector-menu--has-unified-dashboard {
+
+				&.mdc-button--dropdown {
+
+					@media (max-width: $bp-mobileOnly) {
+
+						background: none;
+						padding: 8px;
+					}
+				}
+			}
+
 			.mdc-menu-surface {
 				right: 0;
 			}

--- a/assets/sass/components/global/_googlesitekit-header.scss
+++ b/assets/sass/components/global/_googlesitekit-header.scss
@@ -117,7 +117,6 @@
 				padding-right: $grid-gap-desktop;
 			}
 
-
 			.googlesitekit-header__date-range-selector-menu--has-unified-dashboard {
 
 				&.mdc-button--dropdown {
@@ -125,7 +124,7 @@
 					@media (max-width: $bp-mobileOnly) {
 
 						background: none;
-						padding: 8px;
+						padding-right: 8px;
 					}
 				}
 			}

--- a/assets/sass/components/global/_googlesitekit-header.scss
+++ b/assets/sass/components/global/_googlesitekit-header.scss
@@ -124,7 +124,7 @@
 					@media (max-width: $bp-mobileOnly) {
 
 						background: none;
-						padding-right: 8px;
+						padding-right: $grid-gap-phone / 2;
 					}
 				}
 			}


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #4377 

## Relevant technical choices

Used `--has-unified-dashboard` suffix for the new class to be consistent with other classes within the same file.

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
