### PR TITLE
Bug/4398 Add async attribute to AdSense snippet 

### DIFF
--- a/includes/Modules/AdSense/Web_Tag.php
+++ b/includes/Modules/AdSense/Web_Tag.php
@@ -59,6 +59,7 @@ class Web_Tag extends Module_Web_Tag {
 		);
 
 		$adsense_script_attributes = array(
+			'async'       => true,
 			'src'         => $adsense_script_src,
 			'crossorigin' => 'anonymous',
 		);


### PR DESCRIPTION
## Summary

Addresses issue #4398

## Relevant technical choices

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
