### PR TITLE
`Learn More` links on the Adsense modules opens in a new window.

### DIFF
--- a/assets/js/components/notifications/CTA.js
+++ b/assets/js/components/notifications/CTA.js
@@ -76,6 +76,7 @@ CTA.propTypes = {
 	'aria-label': PropTypes.string,
 	error: PropTypes.bool,
 	onClick: PropTypes.func,
+	ctaLinkExternal: PropTypes.bool,
 };
 
 CTA.defaultProps = {
@@ -85,6 +86,7 @@ CTA.defaultProps = {
 	ctaLabel: '',
 	error: false,
 	onClick: () => {},
+	ctaLinkExternal: false,
 };
 
 export default CTA;

--- a/assets/js/components/notifications/CTA.js
+++ b/assets/js/components/notifications/CTA.js
@@ -72,11 +72,11 @@ CTA.propTypes = {
 	title: PropTypes.string.isRequired,
 	description: PropTypes.oneOfType( [ PropTypes.string, PropTypes.node ] ),
 	ctaLink: PropTypes.string,
+	ctaLinkExternal: PropTypes.bool,
 	ctaLabel: PropTypes.string,
 	'aria-label': PropTypes.string,
 	error: PropTypes.bool,
 	onClick: PropTypes.func,
-	ctaLinkExternal: PropTypes.bool,
 };
 
 CTA.defaultProps = {
@@ -86,7 +86,6 @@ CTA.defaultProps = {
 	ctaLabel: '',
 	error: false,
 	onClick: () => {},
-	ctaLinkExternal: false,
 };
 
 export default CTA;

--- a/assets/js/modules/analytics/components/common/AdSenseLinkCTA.js
+++ b/assets/js/modules/analytics/components/common/AdSenseLinkCTA.js
@@ -45,6 +45,7 @@ export default function AdSenseLinkCTA() {
 			) }
 			ctaLink={ supportURL }
 			ctaLabel={ __( 'Learn more', 'google-site-kit' ) }
+			ctaLinkExternal={ true }
 		/>
 	);
 }

--- a/assets/js/modules/analytics/components/common/AdSenseLinkCTA.js
+++ b/assets/js/modules/analytics/components/common/AdSenseLinkCTA.js
@@ -45,7 +45,7 @@ export default function AdSenseLinkCTA() {
 			) }
 			ctaLink={ supportURL }
 			ctaLabel={ __( 'Learn more', 'google-site-kit' ) }
-			ctaLinkExternal={ true }
+			ctaLinkExternal
 		/>
 	);
 }


### PR DESCRIPTION
## Summary

Add property `ctaLinkExternal` to open the link in a separate window.

<!-- Please reference the issue this PR addresses. -->
Addresses issue #4286 

## Relevant technical choices

- Updated the `CTA` component in order to register the property `ctaLinkExternal` for external callers.
- Added a default value for the property `ctaLinkExternal`  as `false` in order to be backwards compatible.

<!-- Please describe your changes. -->

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
