### PR TITLE
Bug/4257 Prevent AdSense greying out while checks are performed

### DIFF
--- a/assets/js/components/settings/SetupModule.js
+++ b/assets/js/components/settings/SetupModule.js
@@ -82,7 +82,8 @@ export default function SetupModule( { slug, name, description } ) {
 				'googlesitekit-settings-connect-module',
 				`googlesitekit-settings-connect-module--${ slug }`,
 				{
-					'googlesitekit-settings-connect-module--disabled': ! canActivateModule,
+					'googlesitekit-settings-connect-module--disabled':
+						canActivateModule === false,
 				}
 			) }
 			key={ slug }


### PR DESCRIPTION
## Summary

Addresses issue #4257 

## Relevant technical choices

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
