### PR TITLE
Enhancement/4373 Fix close icon overlapping search box border on hover

### DIFF
--- a/assets/sass/components/global/_googlesitekit-entity-search.scss
+++ b/assets/sass/components/global/_googlesitekit-entity-search.scss
@@ -35,7 +35,7 @@
 			z-index: 3;
 
 			@media ( min-width: $bp-wpAdminBarTablet ) {
-				right: 0;
+				right: 1px;
 			}
 		}
 


### PR DESCRIPTION
## Summary

Addresses issue #4373 

## Relevant technical choices

<!-- Please describe your changes. -->

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
