### PR TITLE
Use negative margin to position error text correctly.

### DIFF
--- a/assets/sass/components/setup/_googlesitekit-setup-module.scss
+++ b/assets/sass/components/setup/_googlesitekit-setup-module.scss
@@ -127,12 +127,8 @@
 			margin: 1em 0;
 		}
 
-		div[name="optimizeID"] {
-			margin-bottom: 0;
-
-			+ .mdc-text-field-helper-line {
-				margin-bottom: 0;
-			}
+		+ .googlesitekit-error-text {
+			margin-top: -24px;
 		}
 	}
 


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #4028 

## Relevant technical choices
If we set `margin-bottom: 0` to the elements as per the IB, this causes UI issues since there might be other elements besides the input which we removed the margin as noted by QA. The solution is to use negative margin on the error text to make sure we are not introducing regressions.

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [z] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
