### PR TITLE
Fix website url for no Details Page Stats message.

### DIFF
--- a/assets/js/components/DashboardEntityApp.js
+++ b/assets/js/components/DashboardEntityApp.js
@@ -111,7 +111,7 @@ function DashboardEntityApp() {
 															),
 															link2: (
 																<Link
-																	href="https://sitekit.withgoogle.com/documentation/dashboard/#url-not-part-of-site"
+																	href="https://sitekit.withgoogle.com/documentation/troubleshooting/dashboard/#url-not-part-of-this-site"
 																	external
 																	inherit
 																/>

--- a/assets/js/components/dashboard-details/DashboardDetailsHeader.js
+++ b/assets/js/components/dashboard-details/DashboardDetailsHeader.js
@@ -112,7 +112,7 @@ export default function DashboardDetailsHeader() {
 											),
 											link2: (
 												<Link
-													href="https://sitekit.withgoogle.com/documentation/dashboard/#url-not-part-of-site"
+													href="https://sitekit.withgoogle.com/documentation/troubleshooting/dashboard/#url-not-part-of-this-site"
 													external
 													inherit
 												/>


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #4097

## Relevant technical choices

<!-- Please describe your changes. -->

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
