### PR TITLE
Fix AdSense widget order on Unified Dashboard.

### DIFF
--- a/assets/js/modules/adsense/index.js
+++ b/assets/js/modules/adsense/index.js
@@ -119,7 +119,7 @@ export const registerWidgets = ( widgets ) => {
 					widgets.WIDGET_WIDTHS.HALF,
 					widgets.WIDGET_WIDTHS.FULL,
 				],
-				priority: 2,
+				priority: 3,
 				wrapWidget: false,
 			},
 			[ AREA_MAIN_DASHBOARD_MONETIZATION_PRIMARY ]

--- a/assets/js/modules/adsense/index.js
+++ b/assets/js/modules/adsense/index.js
@@ -102,6 +102,16 @@ export const registerWidgets = ( widgets ) => {
 
 	if ( isFeatureEnabled( 'unifiedDashboard' ) ) {
 		widgets.registerWidget(
+			'adsenseModuleOverview',
+			{
+				Component: ModuleOverviewWidget,
+				width: widgets.WIDGET_WIDTHS.FULL,
+				priority: 2,
+				wrapWidget: false,
+			},
+			[ AREA_MAIN_DASHBOARD_MONETIZATION_PRIMARY ]
+		);
+		widgets.registerWidget(
 			'adsenseTopEarningPages',
 			{
 				Component: DashboardTopEarningPagesWidget,
@@ -109,16 +119,6 @@ export const registerWidgets = ( widgets ) => {
 					widgets.WIDGET_WIDTHS.HALF,
 					widgets.WIDGET_WIDTHS.FULL,
 				],
-				priority: 2,
-				wrapWidget: false,
-			},
-			[ AREA_MAIN_DASHBOARD_MONETIZATION_PRIMARY ]
-		);
-		widgets.registerWidget(
-			'adsenseModuleOverview',
-			{
-				Component: ModuleOverviewWidget,
-				width: widgets.WIDGET_WIDTHS.FULL,
 				priority: 2,
 				wrapWidget: false,
 			},


### PR DESCRIPTION
Move "Performance over the last 28 days" above "Top Earning Pages" on Unified Dasboard.

## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #4348 

Switch the order of the widgets as per this comment: https://github.com/google/site-kit-wp/issues/4348#issuecomment-984825663

## Relevant technical choices

<!-- Please describe your changes. -->

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
