### PR TITLE
Fix PHPScoper running on PHP tests for 5.6.

### DIFF
--- a/.github/workflows/php-tests-wp-4-7-php-5-6.yml
+++ b/.github/workflows/php-tests-wp-4-7-php-5-6.yml
@@ -57,9 +57,8 @@ jobs:
       - uses: actions/checkout@v2
       - uses: shivammathur/setup-php@v2
         with:
-          extensions: mysqli, runkit, uopz
           tools: composer
-          php-version: '5.6'
+          php-version: '7.4' # Necessary for `composer install`
       - name: Get Composer Cache Directory
         id: composer-cache
         run: |
@@ -71,7 +70,11 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-composer-
       - name: Composer Install
-        run: docker run --rm -v "$PWD:/app" -v "${{ steps.composer-cache.outputs.dir }}:/tmp/cache" composer install --no-interaction --no-progress # Run inside docker so composer install doesn't error...
+        run: composer install --no-interaction --no-progress
+      - uses: shivammathur/setup-php@v2
+        with:
+          extensions: mysqli, runkit, uopz
+          php-version: '5.6'
       - name: Set up PHP test data
         run: tests/bin/install-wp-tests.sh ${MYSQL_DATABASE} ${MYSQL_USER} ${MYSQL_PASSWORD} ${DB_HOST}:${DB_PORT} ${WP_VERSION}
       - name: Run Unit Tests


### PR DESCRIPTION
## Summary

Addresses issue #4455

**Note: targets `main`**

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
