### PR TITLE
Use `useInViewSelect` when selecting `isGatheringData` in `WPDashboardPopularPages`

### DIFF
--- a/assets/js/components/wp-dashboard/WPDashboardPopularPages.js
+++ b/assets/js/components/wp-dashboard/WPDashboardPopularPages.js
@@ -47,7 +47,7 @@ const { useSelect } = Data;
 export default function WPDashboardPopularPages( props ) {
 	const { WidgetReportZero, WidgetReportError } = props;
 
-	const isGatheringData = useSelect( ( select ) =>
+	const isGatheringData = useInViewSelect( ( select ) =>
 		select( MODULES_ANALYTICS ).isGatheringData()
 	);
 


### PR DESCRIPTION
## Summary

Addresses issue #4096

## Relevant technical choices

<!-- Please describe your changes. -->

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
