### PR TITLE
Add verbose option to E2E tests.

### DIFF
--- a/tests/e2e/jest.config.js
+++ b/tests/e2e/jest.config.js
@@ -18,4 +18,5 @@ module.exports = {
 	},
 	transformIgnorePatterns: [ 'node_modules' ],
 	testPathIgnorePatterns: [ '.git', 'node_modules' ],
+	verbose: true,
 };


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #4201 

## Relevant technical choices

<!-- Please describe your changes. -->

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
