### PR TITLE
Enhancement/2908 Add more cases to "Site Not Ready for SK" message

### DIFF
--- a/assets/js/components/setup/CompatibilityChecks/CompatibilityErrorNotice.js
+++ b/assets/js/components/setup/CompatibilityChecks/CompatibilityErrorNotice.js
@@ -131,7 +131,7 @@ export default function CompatibilityErrorNotice( { error } ) {
 			return (
 				<p>
 					{ __(
-						'Looks like you may be using a caching plugin which could interfere with setup. Please deactivate any caching plugins before setting up Site Kit. You may reactivate them once setup has been completed.',
+						"Looks like Site Kit is unable to place or detect tags on your site. This can be caused by using certain caching or maintenance mode plugins or your site's frontend is configured on a different host or infrastructure than your administration dashboard.",
 						'google-site-kit'
 					) }
 				</p>

--- a/assets/js/components/setup/CompatibilityChecks/CompatibilityErrorNotice.js
+++ b/assets/js/components/setup/CompatibilityChecks/CompatibilityErrorNotice.js
@@ -131,7 +131,7 @@ export default function CompatibilityErrorNotice( { error } ) {
 			return (
 				<p>
 					{ __(
-						"Looks like Site Kit is unable to place or detect tags on your site. This can be caused by using certain caching or maintenance mode plugins or your site's frontend is configured on a different host or infrastructure than your administration dashboard.",
+						'Looks like Site Kit is unable to place or detect tags on your site. This can be caused by using certain caching or maintenance mode plugins or your site’s frontend is configured on a different host or infrastructure than your administration dashboard.',
 						'google-site-kit'
 					) }
 				</p>


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #2908 

## Relevant technical choices

<!-- Please describe your changes. -->

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
