### PR TITLE
Set defaults when selecting a post ID from widgets page.

### DIFF
--- a/assets/js/googlesitekit-idea-hub-notice.js
+++ b/assets/js/googlesitekit-idea-hub-notice.js
@@ -47,8 +47,13 @@ const loadIdeaHubNotices = async ( _global = global ) => {
 	};
 
 	const listener = async () => {
+		// Added a no operation function as default value if the function does not exist on the store.
+		const noOperation = () => {};
+		const editorData = wp.data.select( 'core/editor' ) || {};
 		// eslint-disable-next-line sitekit/acronym-case
-		const postID = wp.data.select( 'core/editor' ).getCurrentPostId();
+		const { getCurrentPostId = noOperation } = editorData;
+		// eslint-disable-next-line sitekit/acronym-case
+		const postID = getCurrentPostId();
 
 		if ( ! postID ) {
 			return;

--- a/assets/js/googlesitekit-idea-hub-notice.js
+++ b/assets/js/googlesitekit-idea-hub-notice.js
@@ -47,13 +47,8 @@ const loadIdeaHubNotices = async ( _global = global ) => {
 	};
 
 	const listener = async () => {
-		// Added a no operation function as default value if the function does not exist on the store.
-		const noOperation = () => {};
-		const editorData = wp.data.select( 'core/editor' ) || {};
 		// eslint-disable-next-line sitekit/acronym-case
-		const { getCurrentPostId = noOperation } = editorData;
-		// eslint-disable-next-line sitekit/acronym-case
-		const postID = getCurrentPostId();
+		const postID = wp.data.select( 'core/editor' )?.getCurrentPostId();
 
 		if ( ! postID ) {
 			return;


### PR DESCRIPTION
## Summary

When selecting the function `getCurrentPostId` from the`wp.data.select( 'core/editor' )` make sure that a default value is set to the store in case it returns `null` or `undefined` in this case an object is set to the default value, and a no operation value is set to the function `getCurrentPostId` if does not exists on the object.

<!-- Please reference the issue this PR addresses. -->
Addresses issue #4466 

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
