### PR TITLE
Delete function argument type hint and return early if the function a…

### DIFF
--- a/includes/Core/Admin/Screens.php
+++ b/includes/Core/Admin/Screens.php
@@ -151,7 +151,10 @@ final class Screens {
 		add_filter( 'custom_menu_order', '__return_true' );
 		add_filter(
 			'menu_order',
-			function( array $menu_order ) {
+			function( $menu_order ) {
+				if ( ! is_array( $menu_order ) ) {
+					return $menu_order;
+				}
 				// Move the Site Kit dashboard menu item to be one after the index.php item if it exists.
 				$dashboard_index = array_search( 'index.php', $menu_order, true );
 


### PR DESCRIPTION
…rgument is not an array

## Summary

Addresses issue #4485 

## Relevant technical choices

This change removes the type hint applied to the argument passed to the menu_order callback. A check is applied to the argument inside the anonymous function definition. If the passed argument isn't an array as expected, the function will return early.

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [X] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [X] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [X] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [X] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
