### PR TITLE
Remove fallback component when AdSense module is not complete.

### DIFF
--- a/assets/js/modules/adsense/components/module/ModuleOverviewWidget/index.js
+++ b/assets/js/modules/adsense/components/module/ModuleOverviewWidget/index.js
@@ -189,7 +189,4 @@ ModuleOverviewWidget.metrics = {
 
 export default whenActive( {
 	moduleName: 'adsense',
-	IncompleteComponent: ( { WidgetCompleteModuleActivationCTA } ) => (
-		<WidgetCompleteModuleActivationCTA moduleSlug="adsense" />
-	),
 } )( ModuleOverviewWidget );

--- a/assets/js/modules/adsense/index.js
+++ b/assets/js/modules/adsense/index.js
@@ -112,6 +112,18 @@ export const registerWidgets = ( widgets ) => {
 			},
 			[ AREA_MAIN_DASHBOARD_MONETIZATION_PRIMARY ]
 		);
+
+		widgets.registerWidget(
+			'adsenseConnectCTA',
+			{
+				Component: AdSenseConnectCTAWidget,
+				width: [ widgets.WIDGET_WIDTHS.FULL ],
+				priority: 2,
+				wrapWidget: false,
+			},
+			[ AREA_MAIN_DASHBOARD_MONETIZATION_PRIMARY ]
+		);
+
 		widgets.registerWidget(
 			'adsenseTopEarningPages',
 			{
@@ -180,19 +192,6 @@ export const registerWidgets = ( widgets ) => {
 				wrapWidget: false,
 			},
 			[ AREA_MODULE_ADSENSE_MAIN ]
-		);
-	}
-
-	if ( isFeatureEnabled( 'unifiedDashboard' ) ) {
-		widgets.registerWidget(
-			'adsenseConnectCTA',
-			{
-				Component: AdSenseConnectCTAWidget,
-				width: [ widgets.WIDGET_WIDTHS.FULL ],
-				priority: 2,
-				wrapWidget: false,
-			},
-			[ AREA_MAIN_DASHBOARD_MONETIZATION_PRIMARY ]
 		);
 	}
 };


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #4145

## Relevant technical choices

<!-- Please describe your changes. -->
Removed the `IncompleteComponent` component when `AdSense` setup has not been completed. We have another widget, `AdSenseConnectCTAWidget`, which will be displayed to prompt the user to complete the setup.

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
