### PR TITLE
Bug/4492 fix layout inconsistencies

### DIFF
--- a/assets/js/modules/search-console/components/dashboard/SearchFunnelWidget/Overview.js
+++ b/assets/js/modules/search-console/components/dashboard/SearchFunnelWidget/Overview.js
@@ -136,7 +136,7 @@ const Overview = ( {
 	};
 
 	const halfCellProps = {
-		smSize: 2,
+		smSize: 4,
 		mdSize: 4,
 		lgSize: 6,
 	};

--- a/assets/sass/components/global/_googlesitekit-data-block.scss
+++ b/assets/sass/components/global/_googlesitekit-data-block.scss
@@ -46,7 +46,7 @@
 		display: flex;
 		flex-direction: column;
 		height: 100%;
-		justify-content: flex-end;
+		justify-content: flex-start;
 		padding-bottom: $grid-gap-phone;
 		padding-top: $grid-gap-phone + 4px;
 		text-align: center;

--- a/assets/sass/vendor/_mdc-button.scss
+++ b/assets/sass/vendor/_mdc-button.scss
@@ -53,7 +53,7 @@
 
 	&--dropdown .mdc-button__label {
 
-		@media (max-width: $bp-tablet) {
+		@media (max-width: $bp-mobileOnly) {
 
 			@include screen-reader-only;
 		}


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #4492 

## Relevant technical choices

Regarding this AC point, I found that the proposed IB introduced an unexpected layout change at the medium viewport, and it appears only the change to `halfCellProps.smSize` is necessary to fix the issue.

> On viewports where the Analytics CTA in the new Search Funnel "Overview for the last 28 days" widget is displayed below the two DataBlocks (see screenshot above), it should span the full width to not have that empty whitespace.

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
