### PR TITLE
Fix search input text overflow into the close button

### DIFF
--- a/assets/sass/components/global/_googlesitekit-entity-search.scss
+++ b/assets/sass/components/global/_googlesitekit-entity-search.scss
@@ -69,13 +69,11 @@
 			font-size: 14px;
 			height: 34px;
 			margin: 0;
-			padding: 0;
-			padding-right: 32px;
+			padding: 0 32px 0 0;
 
 			@media ( min-width: $bp-wpAdminBarTablet ) {
 				border: 1px solid $c-entity-search-input-border;
-				padding: 0 16px;
-				padding-right: 32px;
+				padding: 0 32px 0 16px;
 			}
 
 			&:focus {

--- a/assets/sass/components/global/_googlesitekit-entity-search.scss
+++ b/assets/sass/components/global/_googlesitekit-entity-search.scss
@@ -70,10 +70,12 @@
 			height: 34px;
 			margin: 0;
 			padding: 0;
+			padding-right: 32px;
 
 			@media ( min-width: $bp-wpAdminBarTablet ) {
 				border: 1px solid $c-entity-search-input-border;
 				padding: 0 16px;
+				padding-right: 32px;
 			}
 
 			&:focus {


### PR DESCRIPTION
## Summary

Addresses issue #4500 

## Relevant technical choices

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

## Screenshots

<img width="800" alt="Screenshot 2021-12-10 at 6 17 53 PM" src="https://user-images.githubusercontent.com/24408261/145585993-778f712e-5e06-4b8a-89e0-27ee3edb6b68.png">

<img width="258" alt="Screenshot 2021-12-10 at 6 18 16 PM" src="https://user-images.githubusercontent.com/24408261/145586015-7197b099-3701-4263-af1d-3fc8cd637d33.png">

