### PR TITLE
Fix mobile view Google Analytics setup notice blue box overflow

### DIFF
--- a/assets/sass/components/settings/_googlesitekit-settings-notice.scss
+++ b/assets/sass/components/settings/_googlesitekit-settings-notice.scss
@@ -33,6 +33,7 @@
 
 	.googlesitekit-settings-notice__body {
 		flex-grow: 1;
+		min-width: 0;
 
 		@media (min-width: $bp-tablet) {
 			display: flex;


### PR DESCRIPTION
## Summary

Addresses issue #4494 

## Relevant technical choices

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

## Screenshot

<img width="267" alt="Screenshot 2021-12-10 at 8 08 54 PM" src="https://user-images.githubusercontent.com/24408261/145592827-4fd311da-3ae0-40d2-ab7c-aba7bccde943.png">

