### PR TITLE
Add filter to toggle modules programmatically.

### DIFF
--- a/includes/Core/Modules/Module.php
+++ b/includes/Core/Modules/Module.php
@@ -794,11 +794,11 @@ abstract class Module {
 	}
 
 	/**
-	 * Default behavior for all the modules, is not to be forced to be active.
+	 * Determines whether the current module is forced to be active or not.
 	 *
 	 * @since n.e.x.t
 	 *
-	 * @return bool Modules are not forced to be active by default. `false` is returned by default.
+	 * @return bool TRUE if the module forced to be active, otherwise FALSE.
 	 */
 	public static function is_force_active() {
 		return false;

--- a/includes/Core/Modules/Module.php
+++ b/includes/Core/Modules/Module.php
@@ -687,7 +687,7 @@ abstract class Module {
 				'homepage'     => '',
 				'feature'      => '',
 				'depends_on'   => array(),
-				'force_active' => false,
+				'force_active' => static::is_force_active(),
 				'internal'     => false,
 			)
 		);
@@ -793,4 +793,14 @@ abstract class Module {
 		return $items;
 	}
 
+	/**
+	 * Default behavior for all the modules, is not to be forced to be active.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @return bool Modules are not forced to be active by default. `false` is returned by default.
+	 */
+	public static function is_force_active() {
+		return false;
+	}
 }

--- a/includes/Core/Modules/Modules.php
+++ b/includes/Core/Modules/Modules.php
@@ -576,13 +576,13 @@ final class Modules {
 		 *
 		 * @since n.e.x.t
 		 *
-		 * @retun array An array of filtered module slugs.
+		 * @return array An array of filtered module slugs.
 		 */
 		$available_modules = (array) apply_filters( 'googlesitekit_available_modules', array_keys( $this->core_modules ) );
 		$modules           = array_fill_keys( $available_modules, true );
 
 		foreach ( $this->core_modules as $slug => $module ) {
-			if ( isset( $modules[ $slug ] ) ) {
+			if ( isset( $modules[ $slug ] ) || call_user_func( array( $module, 'is_force_active' ) ) ) {
 				$registry->register( $module );
 			}
 		}

--- a/includes/Core/Modules/Modules.php
+++ b/includes/Core/Modules/Modules.php
@@ -566,7 +566,18 @@ final class Modules {
 	 * @return Module_Registry
 	 */
 	protected function setup_registry() {
-		$registry          = new Module_Registry();
+		$registry = new Module_Registry();
+		/**
+		 * Filters an array with the list of all the available modules slugs, each slug present on this array would
+		 * be registered for inclusion. If a module is `force_activate` it would be included even if the module is
+		 * removed from this filter.
+		 *
+		 * @param array $available_modules An array with list of module's slug available on this installation.
+		 *
+		 * @since n.e.x.t
+		 *
+		 * @retun array<string> An array with the list of available slugs.
+		 */
 		$available_modules = (array) apply_filters( 'googlesitekit_available_modules', array_keys( $this->core_modules ) );
 
 		foreach ( $this->core_modules as $slug => $module ) {

--- a/includes/Core/Modules/Modules.php
+++ b/includes/Core/Modules/Modules.php
@@ -126,13 +126,13 @@ final class Modules {
 	 * @var string[] Core module class names.
 	 */
 	private $core_modules = array(
-		'site-verification'  => Site_Verification::class,
-		'search-console'     => Search_Console::class,
-		'analytics'          => Analytics::class,
-		'optimize'           => Optimize::class,
-		'tagmanager'         => Tag_Manager::class,
-		'adsense'            => AdSense::class,
-		'pagespeed-insights' => PageSpeed_Insights::class,
+		'site-verification'             => Site_Verification::class,
+		'search-console'                => Search_Console::class,
+		Analytics::MODULE_SLUG          => Analytics::class,
+		Optimize::MODULE_SLUG           => Optimize::class,
+		Tag_Manager::MODULE_SLUG        => Tag_Manager::class,
+		AdSense::MODULE_SLUG            => AdSense::class,
+		PageSpeed_Insights::MODULE_SLUG => PageSpeed_Insights::class,
 	);
 
 	/**

--- a/includes/Core/Modules/Modules.php
+++ b/includes/Core/Modules/Modules.php
@@ -126,8 +126,8 @@ final class Modules {
 	 * @var string[] Core module class names.
 	 */
 	private $core_modules = array(
-		'site-verification'             => Site_Verification::class,
-		'search-console'                => Search_Console::class,
+		Site_Verification::MODULE_SLUG  => Site_Verification::class,
+		Search_Console::MODULE_SLUG     => Search_Console::class,
 		Analytics::MODULE_SLUG          => Analytics::class,
 		Optimize::MODULE_SLUG           => Optimize::class,
 		Tag_Manager::MODULE_SLUG        => Tag_Manager::class,
@@ -165,7 +165,7 @@ final class Modules {
 			$this->core_modules[ Idea_Hub::MODULE_SLUG ] = Idea_Hub::class;
 		}
 		if ( Feature_Flags::enabled( 'swgModule' ) ) {
-			$this->core_modules['subscribe-with-google'] = Subscribe_With_Google::class;
+			$this->core_modules[ Subscribe_With_Google::MODULE_SLUG ] = Subscribe_With_Google::class;
 		}
 	}
 

--- a/includes/Core/Modules/Modules.php
+++ b/includes/Core/Modules/Modules.php
@@ -130,7 +130,7 @@ final class Modules {
 		'search-console'     => Search_Console::class,
 		'analytics'          => Analytics::class,
 		'optimize'           => Optimize::class,
-		'tag-manager'        => Tag_Manager::class,
+		'tagmanager'         => Tag_Manager::class,
 		'adsense'            => AdSense::class,
 		'pagespeed-insights' => PageSpeed_Insights::class,
 	);

--- a/includes/Core/Modules/Modules.php
+++ b/includes/Core/Modules/Modules.php
@@ -159,10 +159,10 @@ final class Modules {
 		$this->authentication = $authentication ?: new Authentication( $this->context, $this->options, $this->user_options );
 		$this->assets         = $assets ?: new Assets( $this->context );
 
-		$this->core_modules['analytics-4'] = Analytics_4::class;
+		$this->core_modules[ Analytics_4::MODULE_SLUG ] = Analytics_4::class;
 
 		if ( Feature_Flags::enabled( 'ideaHubModule' ) ) {
-			$this->core_modules['idea-hub'] = Idea_Hub::class;
+			$this->core_modules[ Idea_Hub::MODULE_SLUG ] = Idea_Hub::class;
 		}
 		if ( Feature_Flags::enabled( 'swgModule' ) ) {
 			$this->core_modules['subscribe-with-google'] = Subscribe_With_Google::class;

--- a/includes/Core/Modules/Modules.php
+++ b/includes/Core/Modules/Modules.php
@@ -126,13 +126,13 @@ final class Modules {
 	 * @var string[] Core module class names.
 	 */
 	private $core_modules = array(
-		Site_Verification::class,
-		Search_Console::class,
-		Analytics::class,
-		Optimize::class,
-		Tag_Manager::class,
-		AdSense::class,
-		PageSpeed_Insights::class,
+		'site-verification'  => Site_Verification::class,
+		'search-console'     => Search_Console::class,
+		'analytics'          => Analytics::class,
+		'optimize'           => Optimize::class,
+		'tag-manager'        => Tag_Manager::class,
+		'adsense'            => AdSense::class,
+		'pagespeed-insights' => PageSpeed_Insights::class,
 	);
 
 	/**
@@ -159,13 +159,13 @@ final class Modules {
 		$this->authentication = $authentication ?: new Authentication( $this->context, $this->options, $this->user_options );
 		$this->assets         = $assets ?: new Assets( $this->context );
 
-		$this->core_modules[] = Analytics_4::class;
+		$this->core_modules['analytics-4'] = Analytics_4::class;
 
 		if ( Feature_Flags::enabled( 'ideaHubModule' ) ) {
-			$this->core_modules[] = Idea_Hub::class;
+			$this->core_modules['idea-hub'] = Idea_Hub::class;
 		}
 		if ( Feature_Flags::enabled( 'swgModule' ) ) {
-			$this->core_modules[] = Subscribe_With_Google::class;
+			$this->core_modules['subscribe-with-google'] = Subscribe_With_Google::class;
 		}
 	}
 
@@ -566,10 +566,13 @@ final class Modules {
 	 * @return Module_Registry
 	 */
 	protected function setup_registry() {
-		$registry = new Module_Registry();
+		$registry          = new Module_Registry();
+		$available_modules = (array) apply_filters( 'googlesitekit_available_modules', array_keys( $this->core_modules ) );
 
-		foreach ( $this->core_modules as $core_module ) {
-			$registry->register( $core_module );
+		foreach ( $this->core_modules as $slug => $module ) {
+			if ( in_array( $slug, $available_modules, true ) ) {
+				$registry->register( $module );
+			}
 		}
 
 		return $registry;

--- a/includes/Core/Modules/Modules.php
+++ b/includes/Core/Modules/Modules.php
@@ -579,9 +579,10 @@ final class Modules {
 		 * @retun array<string> An array with the list of available slugs.
 		 */
 		$available_modules = (array) apply_filters( 'googlesitekit_available_modules', array_keys( $this->core_modules ) );
+		$modules           = array_fill_keys( $available_modules, true );
 
 		foreach ( $this->core_modules as $slug => $module ) {
-			if ( in_array( $slug, $available_modules, true ) ) {
+			if ( isset( $modules[ $slug ] ) ) {
 				$registry->register( $module );
 			}
 		}

--- a/includes/Modules/Search_Console.php
+++ b/includes/Modules/Search_Console.php
@@ -559,8 +559,7 @@ final class Search_Console extends Module
 	}
 
 	/**
-	 * Flag to indicate this module should be force activated regardless
-	 * if a user removes the module by filters.
+	 * Returns TRUE to indicate that this module should be always active.
 	 *
 	 * @since n.e.x.t
 	 *

--- a/includes/Modules/Search_Console.php
+++ b/includes/Modules/Search_Console.php
@@ -558,4 +558,15 @@ final class Search_Console extends Module
 		);
 	}
 
+	/**
+	 * Flag to indicate this module should be force activated regardless
+	 * if a user removes the module by filters.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @return bool Returns `true` indicating that this module should be activated all the time.
+	 */
+	public static function is_force_active() {
+		return true;
+	}
 }

--- a/includes/Modules/Search_Console.php
+++ b/includes/Modules/Search_Console.php
@@ -55,6 +55,11 @@ final class Search_Console extends Module
 	use Module_With_Screen_Trait, Module_With_Scopes_Trait, Module_With_Settings_Trait, Google_URL_Matcher_Trait, Module_With_Assets_Trait, Module_With_Owner_Trait;
 
 	/**
+	 * Module slug name.
+	 */
+	const MODULE_SLUG = 'search-console';
+
+	/**
 	 * Registers functionality through WordPress hooks.
 	 *
 	 * @since 1.0.0

--- a/includes/Modules/Site_Verification.php
+++ b/includes/Modules/Site_Verification.php
@@ -47,6 +47,11 @@ final class Site_Verification extends Module implements Module_With_Scopes {
 	use Google_URL_Matcher_Trait;
 
 	/**
+	 * Module slug name.
+	 */
+	const MODULE_SLUG = 'site-verification';
+
+	/**
 	 * Meta site verification type.
 	 */
 	const VERIFICATION_TYPE_META = 'META';

--- a/includes/Modules/Site_Verification.php
+++ b/includes/Modules/Site_Verification.php
@@ -507,8 +507,7 @@ final class Site_Verification extends Module implements Module_With_Scopes {
 
 
 	/**
-	 * Flag to indicate this module should be force activated regardless
-	 * if a user removes the module by filters.
+	 * Returns TRUE to indicate that this module should be always active.
 	 *
 	 * @since n.e.x.t
 	 *

--- a/includes/Modules/Site_Verification.php
+++ b/includes/Modules/Site_Verification.php
@@ -504,4 +504,17 @@ final class Site_Verification extends Module implements Module_With_Scopes {
 
 		// If the user does not have the necessary permissions then let the request pass through.
 	}
+
+
+	/**
+	 * Flag to indicate this module should be force activated regardless
+	 * if a user removes the module by filters.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @return bool Returns `true` indicating that this module should be activated all the time.
+	 */
+	public static function is_force_active() {
+		return true;
+	}
 }

--- a/includes/Modules/Subscribe_With_Google.php
+++ b/includes/Modules/Subscribe_With_Google.php
@@ -39,6 +39,11 @@ final class Subscribe_With_Google extends Module
 	use Module_With_Settings_Trait;
 
 	/**
+	 * Module slug name.
+	 */
+	const MODULE_SLUG = 'subscribe-with-google';
+
+	/**
 	 * Registers functionality through WordPress hooks.
 	 *
 	 * @since 1.41.0

--- a/tests/phpunit/integration/Core/Modules/ModulesTest.php
+++ b/tests/phpunit/integration/Core/Modules/ModulesTest.php
@@ -292,8 +292,18 @@ class ModulesTest extends TestCase {
 		add_filter( 'googlesitekit_available_modules', $filter );
 
 		$modules = new Modules( new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE ) );
-		// Review only the keys as the values from the array are objects.
-		$this->assertEquals( $expected, array_keys( $modules->get_available_modules() ) );
+
+		$this->assertCount( count( $expected ), array_keys( $modules->get_available_modules() ) );
+
+		if ( empty( $expected ) ) {
+			$this->assertTrue( is_array( $modules->get_available_modules() ) );
+			$this->assertEmpty( $modules->get_available_modules() );
+			return;
+		}
+
+		foreach ( $expected as $module_slug ) {
+			$this->assertArrayHasKey( $module_slug, $modules->get_available_modules() );
+		}
 	}
 
 	public function provider_googlesitekit_available_modules_filter() {
@@ -399,8 +409,11 @@ class ModulesTest extends TestCase {
 		);
 
 		$modules = new Modules( new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE ) );
-		// Review only the keys as the values from the array are objects.
-		$this->assertEquals( $expected, array_keys( $modules->get_available_modules() ) );
+
+		$this->assertCount( count( $expected ), array_keys( $modules->get_available_modules() ) );
+		foreach ( $expected as $slug ) {
+			$this->assertArrayHasKey( $slug, $modules->get_available_modules() );
+		}
 	}
 
 	public function provider_feature_flag_modules() {

--- a/tests/phpunit/integration/Core/Modules/ModulesTest.php
+++ b/tests/phpunit/integration/Core/Modules/ModulesTest.php
@@ -239,7 +239,7 @@ class ModulesTest extends TestCase {
 		$fake_module            = new FakeModule( new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE ) );
 		$fake_module->set_on_activation_callback(
 			function () use ( &$activation_invocations ) {
-				$activation_invocations ++;
+				$activation_invocations++;
 			}
 		);
 
@@ -267,7 +267,7 @@ class ModulesTest extends TestCase {
 		$fake_module              = new FakeModule( new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE ) );
 		$fake_module->set_on_deactivation_callback(
 			function () use ( &$deactivation_invocations ) {
-				$deactivation_invocations ++;
+				$deactivation_invocations++;
 			}
 		);
 

--- a/tests/phpunit/integration/Core/Modules/ModulesTest.php
+++ b/tests/phpunit/integration/Core/Modules/ModulesTest.php
@@ -13,6 +13,16 @@ namespace Google\Site_Kit\Tests\Core\Modules;
 use Google\Site_Kit\Context;
 use Google\Site_Kit\Core\Modules\Modules;
 use Google\Site_Kit\Core\REST_API\REST_Routes;
+use Google\Site_Kit\Modules\AdSense;
+use Google\Site_Kit\Modules\Analytics;
+use Google\Site_Kit\Modules\Analytics_4;
+use Google\Site_Kit\Modules\Idea_Hub;
+use Google\Site_Kit\Modules\Optimize;
+use Google\Site_Kit\Modules\PageSpeed_Insights;
+use Google\Site_Kit\Modules\Search_Console;
+use Google\Site_Kit\Modules\Site_Verification;
+use Google\Site_Kit\Modules\Subscribe_With_Google;
+use Google\Site_Kit\Modules\Tag_Manager;
 use Google\Site_Kit\Tests\TestCase;
 
 /**
@@ -295,12 +305,6 @@ class ModulesTest extends TestCase {
 
 		$this->assertCount( count( $expected ), array_keys( $modules->get_available_modules() ) );
 
-		if ( empty( $expected ) ) {
-			$this->assertTrue( is_array( $modules->get_available_modules() ) );
-			$this->assertEmpty( $modules->get_available_modules() );
-			return;
-		}
-
 		foreach ( $expected as $module_slug ) {
 			$this->assertArrayHasKey( $module_slug, $modules->get_available_modules() );
 		}
@@ -308,14 +312,14 @@ class ModulesTest extends TestCase {
 
 	public function provider_googlesitekit_available_modules_filter() {
 		$default_modules = array(
-			'site-verification',
-			'search-console',
-			'adsense',
-			'analytics',
-			'analytics-4',
-			'pagespeed-insights',
-			'optimize',
-			'tagmanager',
+			Site_Verification::MODULE_SLUG,
+			Search_Console::MODULE_SLUG,
+			AdSense::MODULE_SLUG,
+			Analytics::MODULE_SLUG,
+			Analytics_4::MODULE_SLUG,
+			PageSpeed_Insights::MODULE_SLUG,
+			Optimize::MODULE_SLUG,
+			Tag_Manager::MODULE_SLUG,
 		);
 
 		yield 'should return all the modules if filter does not change the modules keys' => array(
@@ -325,53 +329,53 @@ class ModulesTest extends TestCase {
 			$default_modules,
 		);
 
-		yield 'should remove all the modules from the register' => array(
+		yield 'should remove all the modules from the register, except the ones flagged as force active' => array(
 			function ( $modules ) {
 				return array();
 			},
-			array(),
+			array( Site_Verification::MODULE_SLUG, Search_Console::MODULE_SLUG ),
 		);
 
-		yield 'should remove all module if `false` is used on the filter' => array(
+		yield 'should remove all module if `false` is used on the filter, except the ones flagged as force active' => array(
 			function ( $modules ) {
 				return false;
 			},
-			array(),
+			array( Site_Verification::MODULE_SLUG, Search_Console::MODULE_SLUG ),
 		);
 
-		yield 'should remove all module if `null` is used on the filter' => array(
+		yield 'should remove all module if `null` is used on the filter, except the ones flagged as force active' => array(
 			function ( $modules ) {
 				return null;
 			},
-			array(),
+			array( Site_Verification::MODULE_SLUG, Search_Console::MODULE_SLUG ),
 		);
 
-		yield 'should remove all module if `0` is used on the filter' => array(
+		yield 'should remove all module if `0` is used on the filter,  except the ones flagged as force active' => array(
 			function ( $modules ) {
 				return 0;
 			},
-			array(),
+			array( Site_Verification::MODULE_SLUG, Search_Console::MODULE_SLUG ),
 		);
 
-		yield "should remove all module if `''` is used on the filter" => array(
+		yield "should remove all module if `''` is used on the filter,  except the ones flagged as force active" => array(
 			function ( $modules ) {
 				return '';
 			},
-			array(),
+			array( Site_Verification::MODULE_SLUG, Search_Console::MODULE_SLUG ),
 		);
 
-		yield 'should enable only analytics and search console module' => array(
+		yield 'should enable only analytics, search console and forced active modules' => array(
 			function ( $modules ) {
-				return array( 'analytics', 'search-console' );
+				return array( Analytics::MODULE_SLUG, Search_Console::MODULE_SLUG );
 			},
-			array( 'search-console', 'analytics' ),
+			array( Site_Verification::MODULE_SLUG, Analytics::MODULE_SLUG, Search_Console::MODULE_SLUG ),
 		);
 
-		yield 'should ignore non existing modules' => array(
+		yield 'should ignore non existing modules, and include modules flagged as forced active' => array(
 			function ( $modules ) {
 				return array( 'apollo-landing', 'orbital-phase' );
 			},
-			array(),
+			array( Site_Verification::MODULE_SLUG, Search_Console::MODULE_SLUG ),
 		);
 	}
 
@@ -418,14 +422,14 @@ class ModulesTest extends TestCase {
 
 	public function provider_feature_flag_modules() {
 		$default_modules = array(
-			'site-verification',
-			'search-console',
-			'adsense',
-			'analytics',
-			'analytics-4',
-			'pagespeed-insights',
-			'optimize',
-			'tagmanager',
+			Site_Verification::MODULE_SLUG,
+			Search_Console::MODULE_SLUG,
+			AdSense::MODULE_SLUG,
+			Analytics::MODULE_SLUG,
+			Analytics_4::MODULE_SLUG,
+			PageSpeed_Insights::MODULE_SLUG,
+			Optimize::MODULE_SLUG,
+			Tag_Manager::MODULE_SLUG,
 		);
 
 		yield 'should include the `idea-hub` module when enabled' => array(
@@ -433,10 +437,9 @@ class ModulesTest extends TestCase {
 			'ideaHubModule',
 			// Module enabled or disabled
 			true,
-			// Module slug
-			'idea-hub',
+			Idea_Hub::MODULE_SLUG,
 			// Expected
-			array_merge( $default_modules, array( 'idea-hub' ) ),
+			array_merge( $default_modules, array( Idea_Hub::MODULE_SLUG ) ),
 		);
 
 		yield 'should not include the `idea-hub` module when enabled' => array(
@@ -444,8 +447,7 @@ class ModulesTest extends TestCase {
 			'ideaHubModule',
 			// Module enabled or disabled
 			false,
-			// Module slug
-			'idea-hub',
+			Idea_Hub::MODULE_SLUG,
 			// Expected
 			$default_modules,
 		);
@@ -455,10 +457,9 @@ class ModulesTest extends TestCase {
 			'swgModule',
 			// Module enabled or disabled
 			true,
-			// Module slug
-			'subscribe-with-google',
+			Subscribe_With_Google::MODULE_SLUG,
 			// Expected
-			array_merge( $default_modules, array( 'subscribe-with-google' ) ),
+			array_merge( $default_modules, array( Subscribe_With_Google::MODULE_SLUG ) ),
 		);
 
 		yield 'should not include the `subscribe-with-google` module when enabled' => array(
@@ -466,8 +467,7 @@ class ModulesTest extends TestCase {
 			'swgModule',
 			// Module enabled or disabled
 			false,
-			// Module slug
-			'subscribe-with-google',
+			Subscribe_With_Google::MODULE_SLUG,
 			// Expected
 			$default_modules,
 		);


### PR DESCRIPTION
## Summary

A new filter was added `googlesitekit_available_modules` the filter allow customizing programmatically which modules are present on the site.

Each module now has a unique key in order to identify each module during the filter just by passing a slug of the module.

<!-- Please reference the issue this PR addresses. -->
Addresses issue #3993

## Relevant technical choices

<!-- Please describe your changes. -->

## Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
