### PR TITLE
Update webpack configuration for production assets

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -217,10 +217,14 @@ function* webpackConfig( env, argv ) {
 		externals,
 		output: {
 			filename:
-				mode === 'production' ? '[name]-[contenthash].js' : '[name].js',
+				mode === 'production'
+					? '[name]-[contenthash].min.js'
+					: '[name].js',
 			path: path.join( __dirname, 'dist/assets/js' ),
 			chunkFilename:
-				mode === 'production' ? '[name]-[chunkhash].js' : '[name].js',
+				mode === 'production'
+					? '[name]-[chunkhash].min.js'
+					: '[name].js',
 			publicPath: '',
 			/*
 				If multiple webpack runtimes (from different compilations) are used on the
@@ -309,7 +313,7 @@ function* webpackConfig( env, argv ) {
 						name: 'googlesitekit-vendor',
 						filename:
 							mode === 'production'
-								? 'googlesitekit-vendor-[contenthash].js'
+								? 'googlesitekit-vendor-[contenthash].min.js'
 								: 'googlesitekit-vendor.js',
 						enforce: true,
 						test: /[\\/]node_modules[\\/]/,
@@ -389,7 +393,7 @@ function* webpackConfig( env, argv ) {
 			new MiniCssExtractPlugin( {
 				filename:
 					'production' === mode
-						? '/assets/css/[name]-[contenthash].css'
+						? '/assets/css/[name]-[contenthash].min.css'
 						: '/assets/css/[name].css',
 			} ),
 			new WebpackBar( {


### PR DESCRIPTION
## Summary

Update on the webpack config based on the IB from #4436 in order to add the suffix `min.` before the
extension of the file in order to avoid third-party optimization plugins to handle minified files as non modified files.

<!-- Please reference the issue this PR addresses. -->
Addresses issue #4436

## Relevant technical choices

<!-- Please describe your changes. -->

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
