### PR TITLE
Reduce spacing for optimize setup.

### DIFF
--- a/assets/js/modules/optimize/components/common/OptimizeIDField.js
+++ b/assets/js/modules/optimize/components/common/OptimizeIDField.js
@@ -24,7 +24,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { Fragment, useCallback } from '@wordpress/element';
+import { useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -50,29 +50,32 @@ export default function OptimizeIDField() {
 		[ setOptimizeID ]
 	);
 
+	const isInvalidValue = ! isValidOptimizeID( optimizeID ) && optimizeID;
+
 	return (
-		<Fragment>
+		<div className="googlesitekit-optimize__container-id">
 			<TextField
 				className={ classnames( 'mdc-text-field', {
-					'mdc-text-field--error':
-						! isValidOptimizeID( optimizeID ) && optimizeID,
+					'mdc-text-field--error': isInvalidValue,
 				} ) }
 				label={ __( 'Optimize Container ID', 'google-site-kit' ) }
 				name="optimizeID"
 				onChange={ onChange }
 				helperText={
-					<HelperText persistent>
-						{ __(
-							'Format: GTM-XXXXXXX or OPT-XXXXXXX',
-							'google-site-kit'
-						) }
-					</HelperText>
+					isInvalidValue && (
+						<HelperText persistent>
+							{ __(
+								'Format: GTM-XXXXXXX or OPT-XXXXXXX',
+								'google-site-kit'
+							) }
+						</HelperText>
+					)
 				}
 				outlined
 				required
 			>
 				<Input value={ optimizeID } />
 			</TextField>
-		</Fragment>
+		</div>
 	);
 }

--- a/assets/js/modules/optimize/components/common/OptimizeIDField.js
+++ b/assets/js/modules/optimize/components/common/OptimizeIDField.js
@@ -61,7 +61,7 @@ export default function OptimizeIDField() {
 				name="optimizeID"
 				onChange={ onChange }
 				helperText={
-					<HelperText>
+					<HelperText persistent>
 						{ __(
 							'Format: GTM-XXXXXXX or OPT-XXXXXXX',
 							'google-site-kit'

--- a/assets/sass/components/setup/_googlesitekit-setup-module.scss
+++ b/assets/sass/components/setup/_googlesitekit-setup-module.scss
@@ -112,6 +112,25 @@
 			@media (min-width: $bp-desktop) {
 				margin: $grid-gap-desktop $grid-gap-desktop $grid-gap-desktop 0;
 			}
+
+			&.googlesitekit-optimize__container-id {
+				margin-right: 0;
+				width: 100%;
+
+				@media (min-width: $bp-tablet) {
+					align-items: center;
+					display: flex;
+					flex-wrap: nowrap;
+				}
+
+				.mdc-text-field-helper-line {
+					margin: $grid-gap-phone/2 0 0;
+
+					@media (min-width: $bp-tablet) {
+						margin: 0;
+					}
+				}
+			}
 		}
 
 		&--collapsed > div {
@@ -128,7 +147,11 @@
 		}
 
 		+ .googlesitekit-error-text {
-			margin-top: -24px;
+			margin-top: $grid-gap-phone * -1;
+
+			@media (min-width: $bp-desktop) {
+				margin-top: $grid-gap-desktop * -1;
+			}
 		}
 	}
 

--- a/assets/sass/components/setup/_googlesitekit-setup.scss
+++ b/assets/sass/components/setup/_googlesitekit-setup.scss
@@ -114,6 +114,26 @@
 		padding-left: 10px;
 		padding-right: 10px;
 	}
+
+	.googlesitekit-optimize-setup__form {
+
+		.googlesitekit-setup-module__inputs {
+			display: block;
+
+			@media (min-width: $bp-tablet) {
+				display: flex;
+				flex-wrap: nowrap;
+			}
+
+			.mdc-text-field-helper-line {
+				margin-top: 0;
+
+				@media (min-width: $bp-tablet) {
+					margin: 0;
+				}
+			}
+		}
+	}
 }
 
 .googlesitekit-setup-compat {

--- a/assets/sass/components/setup/_googlesitekit-setup.scss
+++ b/assets/sass/components/setup/_googlesitekit-setup.scss
@@ -114,26 +114,6 @@
 		padding-left: 10px;
 		padding-right: 10px;
 	}
-
-	.googlesitekit-optimize-setup__form {
-
-		.googlesitekit-setup-module__inputs {
-			display: block;
-
-			@media (min-width: $bp-tablet) {
-				display: flex;
-				flex-wrap: nowrap;
-			}
-
-			.mdc-text-field-helper-line {
-				margin-top: 0;
-
-				@media (min-width: $bp-tablet) {
-					margin: 0;
-				}
-			}
-		}
-	}
 }
 
 .googlesitekit-setup-compat {


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #4028 

## Relevant technical choices
The styling is pretty specific to the Optimize setup form since we have `flex-wrap: wrap` on the flex items. This means we don't have much control over when the elements are stacked in order to remove the extra margin.

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
