### PR TITLE
Remove hover on autocomplete no results found.

### DIFF
--- a/assets/js/components/PostSearcherAutoSuggest.js
+++ b/assets/js/components/PostSearcherAutoSuggest.js
@@ -174,7 +174,7 @@ export default function PostSearcherAutoSuggest( {
 						<ComboboxList className="autocomplete__menu autocomplete__menu--inline">
 							<ComboboxOption
 								value={ noResultsMessage }
-								className="autocomplete__option"
+								className="autocomplete__option autocomplete__option--no-results"
 							/>
 						</ComboboxList>
 					</ComboboxPopover>

--- a/assets/sass/components/global/_googlesitekit-entity-search.scss
+++ b/assets/sass/components/global/_googlesitekit-entity-search.scss
@@ -112,6 +112,14 @@
 			cursor: pointer;
 		}
 
+		// Removes hover effect for `No results found`
+		.autocomplete__option--no-results,
+		.autocomplete__option--no-results:hover,
+		.autocomplete__option--no-results[data-highlighted] {
+			background: none;
+			cursor: default;
+		}
+
 		.mdc-button__label {
 			display: none;
 


### PR DESCRIPTION
## Summary

Addresses issue #4503 

## Relevant technical choices

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
