### PR TITLE
Add margin bottom to widget area header title

### DIFF
--- a/assets/sass/widgets/_widget-area.scss
+++ b/assets/sass/widgets/_widget-area.scss
@@ -40,7 +40,7 @@
 	.googlesitekit-widget-area-header__title {
 		color: $c-tertiary;
 		font-weight: 400;
-		margin: 0;
+		margin: 0 0 0.125rem 0;
 	}
 
 	.googlesitekit-widget-area-header__subtitle {


### PR DESCRIPTION
## Summary

Addresses issue #4501 

## Relevant technical choices

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

All the VRTs are passing.

## Screenshot

**Before**

<img width="323" alt="Screenshot 2021-12-15 at 10 53 19 AM" src="https://user-images.githubusercontent.com/24408261/146132934-c2655176-1883-4ff7-94f9-cd1760b49335.png">

**After**

<img width="323" alt="Screenshot 2021-12-15 at 10 53 08 AM" src="https://user-images.githubusercontent.com/24408261/146132916-09761f45-4040-445d-9166-359170f8d7e1.png">

