### PR TITLE
Update basic modules to use same file naming convention for consistency

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -368,7 +368,10 @@ function* webpackConfig( env, argv ) {
 		},
 		externals,
 		output: {
-			filename: '[name].js',
+			filename:
+				mode === 'production'
+					? '[name]-[contenthash].min.js'
+					: '[name].js',
 			path: __dirname + '/dist/assets/js',
 			publicPath: '',
 		},
@@ -379,6 +382,12 @@ function* webpackConfig( env, argv ) {
 			new WebpackBar( {
 				name: 'Basic Modules',
 				color: '#fb1105',
+			} ),
+			new ManifestPlugin( {
+				...manifestArgs( mode ),
+				filter( file ) {
+					return ( file.name || '' ).match( /\.js$/ );
+				},
 			} ),
 		],
 		optimization: {


### PR DESCRIPTION
## Summary

Addresses issue #4436

## Relevant technical choices

<!-- Please describe your changes. -->

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
