### PR TITLE
Don't show loading indicator when selecting an Entity in the entity search results using the keyboard.

### DIFF
--- a/assets/js/components/EntitySearchInput.js
+++ b/assets/js/components/EntitySearchInput.js
@@ -116,6 +116,7 @@ function EntitySearchInput() {
 					id={ instanceID }
 					setIsActive={ setIsActive }
 					setMatch={ setMatch }
+					match={ match }
 					placeholder={ __(
 						'Enter title or URL…',
 						'google-site-kit'

--- a/assets/js/components/PostSearcherAutoSuggest.js
+++ b/assets/js/components/PostSearcherAutoSuggest.js
@@ -48,6 +48,7 @@ const { useSelect } = Data;
 
 export default function PostSearcherAutoSuggest( {
 	id,
+	match,
 	setMatch,
 	isLoading,
 	showDropdown = true,
@@ -117,8 +118,14 @@ export default function PostSearcherAutoSuggest( {
 	);
 
 	useEffect( () => {
-		if ( debouncedValue !== '' && debouncedValue !== currentEntityTitle ) {
+		if (
+			debouncedValue !== '' &&
+			debouncedValue !== currentEntityTitle &&
+			// eslint-disable-next-line camelcase
+			debouncedValue !== match?.post_title
+		) {
 			setIsLoading?.( true );
+
 			/**
 			 * Create AbortController instance to pass
 			 * the signal property to the API.get() method.
@@ -141,7 +148,7 @@ export default function PostSearcherAutoSuggest( {
 			// Clean-up abort
 			return () => controller?.abort();
 		}
-	}, [ debouncedValue, setIsLoading, currentEntityTitle ] );
+	}, [ debouncedValue, setIsLoading, currentEntityTitle, match ] );
 
 	useEffect( () => {
 		if ( ! searchTerm ) {


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #4562.

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
