### PR TITLE
Fix strip hash pattern in compressed-size workflow

### DIFF
--- a/.github/workflows/compressed-size.yml
+++ b/.github/workflows/compressed-size.yml
@@ -53,4 +53,4 @@ jobs:
           pattern: './dist/assets/**/*.{css,js}'
           # The sub-match below will be replaced by asterisks.
           # The length of 20 corresponds to webpack's `output.hashDigestLength`.
-          strip-hash: "([a-f0-9]{20})\\.(?:css|js)$"
+          strip-hash: "([a-f0-9]{20})(?:\\.min)?\\.(?:css|js)$"


### PR DESCRIPTION
## Summary

Addresses issue #4436 (follow-up)

## Relevant technical choices

Fixes the `strip-hash` pattern used in the Compressed Size workflow that runs in GitHub actions which no longer matches due to the added `.min`.

This does not affect the build/source or anything in a release.

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
