### PR TITLE
Add AdSense link in `Help` dropdown when service connected

### DIFF
--- a/assets/js/components/help/HelpMenu.js
+++ b/assets/js/components/help/HelpMenu.js
@@ -32,6 +32,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
+import Data from 'googlesitekit-data';
 import HelpIcon from '../../../svg/help.svg';
 import { useKeyCodesInside } from '../../hooks/useKeyCodesInside';
 import { trackEvent } from '../../util';
@@ -39,6 +40,8 @@ import ViewContextContext from '../Root/ViewContextContext';
 import Button from '../Button';
 import Menu from '../Menu';
 import HelpMenuLink from './HelpMenuLink';
+import { CORE_MODULES } from '../../googlesitekit/modules/datastore/constants';
+const { useSelect } = Data;
 
 export default function HelpMenu( { children } ) {
 	const [ menuOpen, setMenuOpen ] = useState( false );
@@ -48,6 +51,10 @@ export default function HelpMenu( { children } ) {
 	useClickAway( menuWrapperRef, () => setMenuOpen( false ) );
 	useKeyCodesInside( [ ESCAPE, TAB ], menuWrapperRef, () =>
 		setMenuOpen( false )
+	);
+
+	const adSenseModuleActive = useSelect( ( select ) =>
+		select( CORE_MODULES ).isModuleActive( 'adsense' )
 	);
 
 	const handleMenu = useCallback( () => {
@@ -102,6 +109,14 @@ export default function HelpMenu( { children } ) {
 				>
 					{ __( 'Get support', 'google-site-kit' ) }
 				</HelpMenuLink>
+				{ adSenseModuleActive && (
+					<HelpMenuLink
+						gaEventLabel="adsense_help"
+						href="https://support.google.com/adsense/"
+					>
+						{ __( 'Get help with AdSense', 'google-site-kit' ) }
+					</HelpMenuLink>
+				) }
 			</Menu>
 		</div>
 	);

--- a/assets/js/components/module/ModuleApp.js
+++ b/assets/js/components/module/ModuleApp.js
@@ -20,7 +20,6 @@
  * WordPress dependencies
  */
 import { Fragment } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
 
 /**
  * External dependencies
@@ -36,9 +35,7 @@ import Header from '../Header';
 import Alert from '../Alert';
 import ModuleHeader from './ModuleHeader';
 import WidgetContextRenderer from '../../googlesitekit/widgets/components/WidgetContextRenderer';
-import HelpMenu from '../help/HelpMenu';
 import DateRangeSelector from '../DateRangeSelector';
-import HelpMenuLink from '../help/HelpMenuLink';
 import { CORE_MODULES } from '../../googlesitekit/modules/datastore/constants';
 
 const { useSelect } = Data;
@@ -54,19 +51,7 @@ function ModuleApp( { moduleSlug } ) {
 
 	return (
 		<Fragment>
-			<Header>
-				<HelpMenu>
-					{ moduleSlug === 'adsense' && (
-						<HelpMenuLink
-							gaEventLabel="adsense_help"
-							href="https://support.google.com/adsense/"
-						>
-							{ __( 'Get help with AdSense', 'google-site-kit' ) }
-						</HelpMenuLink>
-					) }
-				</HelpMenu>
-				{ moduleConnected && <DateRangeSelector /> }
-			</Header>
+			<Header>{ moduleConnected && <DateRangeSelector /> }</Header>
 			<Alert module={ moduleSlug } />
 			<WidgetContextRenderer
 				slug={ screenWidgetContext }

--- a/assets/js/components/setup/ModuleSetup.js
+++ b/assets/js/components/setup/ModuleSetup.js
@@ -36,8 +36,6 @@ import { CORE_SITE } from '../../googlesitekit/datastore/site/constants';
 import { CORE_MODULES } from '../../googlesitekit/modules/datastore/constants';
 import { CORE_LOCATION } from '../../googlesitekit/datastore/location/constants';
 import { trackEvent } from '../../util';
-import HelpMenu from '../help/HelpMenu';
-import HelpMenuLink from '../help/HelpMenuLink';
 import Header from '../Header';
 import Link from '../Link';
 const { useSelect, useDispatch } = Data;
@@ -101,15 +99,7 @@ export default function ModuleSetup( { moduleSlug } ) {
 
 	return (
 		<Fragment>
-			<Header>
-				<HelpMenu>
-					{ moduleSlug === 'adsense' && (
-						<HelpMenuLink href="https://support.google.com/adsense/">
-							{ __( 'Get help with AdSense', 'google-site-kit' ) }
-						</HelpMenuLink>
-					) }
-				</HelpMenu>
-			</Header>
+			<Header />
 			<div className="googlesitekit-setup">
 				<div className="mdc-layout-grid">
 					<div className="mdc-layout-grid__inner">


### PR DESCRIPTION
## Summary

Addresses issue #4423 

## Relevant technical choices

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

## Screenshots

<img width="1627" alt="Screenshot 2021-12-17 at 2 58 59 PM" src="https://user-images.githubusercontent.com/24408261/146527428-fc2abd46-0a34-4c67-a49e-eb2c3503e579.png">

<img width="1627" alt="Screenshot 2021-12-17 at 3 01 06 PM" src="https://user-images.githubusercontent.com/24408261/146527451-e0ad7472-41ad-4a49-9f8a-9508c5fb2300.png">

<img width="1627" alt="Screenshot 2021-12-17 at 3 03 37 PM" src="https://user-images.githubusercontent.com/24408261/146527459-fc2ed318-d450-40b5-9386-eb274671039d.png">

<img width="1627" alt="Screenshot 2021-12-17 at 3 04 13 PM" src="https://user-images.githubusercontent.com/24408261/146527466-fcec74cb-f25f-43e1-a669-3cfe80b76467.png">

