### PR TITLE
Modify service setup URL method to rely on its v2 version.

### DIFF
--- a/includes/Core/Authentication/Authentication.php
+++ b/includes/Core/Authentication/Authentication.php
@@ -1090,10 +1090,9 @@ final class Authentication {
 
 					$access_code = $this->user_options->get( OAuth_Client::OPTION_PROXY_ACCESS_CODE );
 
+					$is_using_proxy = $this->credentials->using_proxy();
 					if ( Feature_Flags::enabled( 'serviceSetupV2' ) ) {
-						$is_using_proxy = $this->credentials->using_proxy() && $access_code;
-					} else {
-						$is_using_proxy = $this->credentials->using_proxy();
+						$is_using_proxy = $is_using_proxy && ! empty( $access_code );
 					}
 
 					if ( $is_using_proxy ) {

--- a/includes/Core/Authentication/Authentication.php
+++ b/includes/Core/Authentication/Authentication.php
@@ -1097,9 +1097,10 @@ final class Authentication {
 
 					if ( $is_using_proxy ) {
 						if ( Feature_Flags::enabled( 'serviceSetupV2' ) ) {
+							$credentials = $this->credentials->get();
 							$params = array(
 								'code'    => $access_code,
-								'site_id' => $this->credentials->get()['oauth2_client_id'],
+								'site_id' => ! empty( $credentials['oauth2_client_id'] ) ? $credentials['oauth2_client_id'] : '',
 							);
 							$setup_url = $this->google_proxy->setup_url_v2( $params );
 						} else {

--- a/includes/Core/Authentication/Authentication.php
+++ b/includes/Core/Authentication/Authentication.php
@@ -1062,6 +1062,7 @@ final class Authentication {
 	 * Gets OAuth error notice.
 	 *
 	 * @since 1.0.0
+	 * @since n.e.x.t Uses the new `Google_Proxy::setup_url_v2` method when the `serviceSetupV2` feature flag is enabled.
 	 *
 	 * @return Notice Notice object.
 	 */
@@ -1087,12 +1088,27 @@ final class Authentication {
 
 					$message = $auth_client->get_error_message( $error_code );
 
-					if ( $this->is_authenticated() ) {
-						$setup_url = $this->get_connect_url();
-					} elseif ( $this->credentials->using_proxy() ) {
-						$access_code = $this->user_options->get( OAuth_Client::OPTION_PROXY_ACCESS_CODE );
-						$setup_url = $auth_client->get_proxy_setup_url( $access_code );
+					$access_code = $this->user_options->get( OAuth_Client::OPTION_PROXY_ACCESS_CODE );
+
+					if ( Feature_Flags::enabled( 'serviceSetupV2' ) ) {
+						$is_using_proxy = $this->credentials->using_proxy() && $access_code;
+					} else {
+						$is_using_proxy = $this->credentials->using_proxy();
+					}
+
+					if ( $is_using_proxy ) {
+						if ( Feature_Flags::enabled( 'serviceSetupV2' ) ) {
+							$params = array(
+								'code'    => $access_code,
+								'site_id' => $this->credentials->get()['oauth2_client_id'],
+							);
+							$setup_url = $this->google_proxy->setup_url_v2( $params );
+						} else {
+							$setup_url = $auth_client->get_proxy_setup_url( $access_code );
+						}
 						$this->user_options->delete( OAuth_Client::OPTION_PROXY_ACCESS_CODE );
+					} elseif ( $this->is_authenticated() ) {
+						$setup_url = $this->get_connect_url();
 					} else {
 						$setup_url = $this->context->admin_url( 'splash' );
 					}

--- a/includes/Core/Authentication/Clients/OAuth_Client.php
+++ b/includes/Core/Authentication/Clients/OAuth_Client.php
@@ -388,12 +388,13 @@ final class OAuth_Client extends OAuth_Client_Base {
 		} catch ( Google_Proxy_Code_Exception $e ) {
 			// Redirect back to proxy immediately with the access code.
 			if ( Feature_Flags::enabled( 'serviceSetupV2' ) ) {
-				$params = array(
+				$credentials = $this->credentials->get();
+				$params      = array(
 					'code'    => $e->getAccessCode(),
-					'site_id' => $this->credentials->get()['oauth2_client_id'],
+					'site_id' => ! empty( $credentials['oauth2_client_id'] ) ? $credentials['oauth2_client_id'] : '',
 				);
-				$params = $this->google_proxy->add_setup_step_from_error_code( $params, $e->getMessage() );
-				$url    = $this->google_proxy->setup_url_v2( $params );
+				$params      = $this->google_proxy->add_setup_step_from_error_code( $params, $e->getMessage() );
+				$url         = $this->google_proxy->setup_url_v2( $params );
 			} else {
 				$url = $this->get_proxy_setup_url( $e->getAccessCode(), $e->getMessage() );
 			}

--- a/includes/Core/Authentication/Clients/OAuth_Client.php
+++ b/includes/Core/Authentication/Clients/OAuth_Client.php
@@ -21,6 +21,7 @@ use Google\Site_Kit\Core\Authentication\Token;
 use Google\Site_Kit\Core\Permissions\Permissions;
 use Google\Site_Kit\Core\Storage\Options;
 use Google\Site_Kit\Core\Storage\User_Options;
+use Google\Site_Kit\Core\Util\Feature_Flags;
 use Google\Site_Kit\Core\Util\Scopes;
 use Google\Site_Kit_Dependencies\Google\Service\PeopleService as Google_Service_PeopleService;
 
@@ -364,6 +365,7 @@ final class OAuth_Client extends OAuth_Client_Base {
 	 * screen if present.
 	 *
 	 * @since 1.0.0
+	 * @since n.e.x.t Uses the new `Google_Proxy::setup_url_v2` method when the `serviceSetupV2` feature flag is enabled.
 	 */
 	public function authorize_user() {
 		$code       = $this->context->input()->filter( INPUT_GET, 'code', FILTER_SANITIZE_STRING );
@@ -385,7 +387,17 @@ final class OAuth_Client extends OAuth_Client_Base {
 			$token_response = $this->get_client()->fetchAccessTokenWithAuthCode( $code );
 		} catch ( Google_Proxy_Code_Exception $e ) {
 			// Redirect back to proxy immediately with the access code.
-			wp_safe_redirect( $this->get_proxy_setup_url( $e->getAccessCode(), $e->getMessage() ) );
+			if ( Feature_Flags::enabled( 'serviceSetupV2' ) ) {
+				$params = array(
+					'code'    => $e->getAccessCode(),
+					'site_id' => $this->credentials->get()['oauth2_client_id'],
+				);
+				$params = $this->google_proxy->add_setup_step_from_error_code( $params, $e->getMessage() );
+				$url    = $this->google_proxy->setup_url_v2( $params );
+			} else {
+				$url = $this->get_proxy_setup_url( $e->getAccessCode(), $e->getMessage() );
+			}
+			wp_safe_redirect( $url );
 			exit();
 		} catch ( Exception $e ) {
 			$this->handle_fetch_token_exception( $e );
@@ -538,8 +550,15 @@ final class OAuth_Client extends OAuth_Client_Base {
 	 *
 	 * @param string $access_code Optional. Temporary access code for an undelegated access token. Default empty string.
 	 * @return string URL to the setup page on the authentication proxy.
+	 *
+	 * @since n.e.x.t
+	 * @throws Exception Thrown if called when the `serviceSetupV2` feature flag is enabled.
 	 */
 	public function get_proxy_setup_url( $access_code = '' ) {
+		if ( Feature_Flags::enabled( 'serviceSetupV2' ) ) {
+			throw new Exception( __( 'Unexpected method call: get_proxy_setup_url should not be called when the serviceSetupV2 feature flag is enabled.', 'google-site-kit' ) );
+		}
+
 		$scope = rawurlencode( implode( ' ', $this->get_required_scopes() ) );
 
 		$query_params = array( 'scope' => $scope );

--- a/includes/Core/Authentication/Google_Proxy.php
+++ b/includes/Core/Authentication/Google_Proxy.php
@@ -153,7 +153,7 @@ class Google_Proxy {
 	/**
 	 * Returns the setup URL to the authentication proxy.
 	 *
-	 * This should be renamed to replace `setup_url` once the `serviceSetupV2` feature is fully developed and the feature flag is removed.
+	 * TODO: Rename this function to replace `setup_url` once the `serviceSetupV2` feature is fully developed and the feature flag is removed.
 	 *
 	 * @since n.e.x.t
 	 *

--- a/includes/Core/Authentication/Google_Proxy.php
+++ b/includes/Core/Authentication/Google_Proxy.php
@@ -12,6 +12,7 @@ namespace Google\Site_Kit\Core\Authentication;
 
 use Google\Site_Kit\Context;
 use Google\Site_Kit\Core\Util\Feature_Flags;
+use Exception;
 use WP_Error;
 
 /**
@@ -31,6 +32,7 @@ class Google_Proxy {
 	const OAUTH2_AUTH_URI           = '/o/oauth2/auth/';
 	const OAUTH2_DELETE_SITE_URI    = '/o/oauth2/delete-site/';
 	const SETUP_URI                 = '/site-management/setup/';
+	const SETUP_URI_V2              = '/v2/site-management/setup/';
 	const PERMISSIONS_URI           = '/site-management/permissions/';
 	const USER_INPUT_SETTINGS_URI   = '/site-management/settings/';
 	const FEATURES_URI              = '/site-management/features/';
@@ -146,6 +148,53 @@ class Google_Proxy {
 		$params['hl']               = $this->context->get_locale( 'user' );
 
 		return add_query_arg( $params, $this->url( self::SETUP_URI ) );
+	}
+
+	/**
+	 * Returns the setup URL to the authentication proxy.
+	 *
+	 * This should be renamed to replace `setup_url` once the `serviceSetupV2` feature is fully developed and the feature flag is removed.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param array $query_params Query parameters to include in the URL.
+	 * @return string URL to the setup page on the authentication proxy.
+	 *
+	 * @throws Exception Thrown if called without the required query parameters.
+	 */
+	public function setup_url_v2( array $query_params = array() ) {
+		if ( empty( $query_params['code'] ) ) {
+			throw new Exception( __( 'Missing code parameter for setup URL.', 'google-site-kit' ) );
+		}
+		if ( empty( $query_params['site_id'] ) && empty( $query_params['site_code'] ) ) {
+			throw new Exception( __( 'Missing site_id or site_code parameter for setup URL.', 'google-site-kit' ) );
+		}
+
+		return add_query_arg( $query_params, $this->url( self::SETUP_URI_V2 ) );
+	}
+
+	/**
+	 * Conditionally adds the `step` parameter to the passed query parameters, depending on the given error code.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param array  $query_params Query parameters.
+	 * @param string $error_code Error code.
+	 * @return array Query parameters with `step` included, depending on the error code.
+	 */
+	public function add_setup_step_from_error_code( $query_params, $error_code ) {
+		switch ( $error_code ) {
+			case 'missing_verification':
+				$query_params['step'] = 'verification';
+				break;
+			case 'missing_delegation_consent':
+				$query_params['step'] = 'delegation_consent';
+				break;
+			case 'missing_search_console_property':
+				$query_params['step'] = 'search_console_property';
+				break;
+		}
+		return $query_params;
 	}
 
 	/**

--- a/includes/Core/Authentication/Setup.php
+++ b/includes/Core/Authentication/Setup.php
@@ -15,6 +15,7 @@ use Google\Site_Kit\Core\Authentication\Clients\OAuth_Client;
 use Google\Site_Kit\Core\Authentication\Exception\Exchange_Site_Code_Exception;
 use Google\Site_Kit\Core\Authentication\Exception\Missing_Verification_Exception;
 use Google\Site_Kit\Core\Storage\User_Options;
+use Google\Site_Kit\Core\Util\Feature_Flags;
 
 /**
  * Base class for authentication setup.
@@ -177,13 +178,19 @@ abstract class Setup {
 	 * proxy, based on which action was received.
 	 *
 	 * @since 1.48.0
+	 * @since n.e.x.t Uses the new `Google_Proxy::setup_url_v2` method when the `serviceSetupV2` feature flag is enabled.
 	 *
 	 * @param string $code   Code ('googlesitekit_code') provided by proxy.
 	 * @param array  $params Additional query parameters to include in the proxy redirect URL.
 	 */
 	protected function redirect_to_proxy( $code = '', $params = array() ) {
-		$url = $this->authentication->get_oauth_client()->get_proxy_setup_url( $code );
-		$url = add_query_arg( $params, $url );
+		if ( Feature_Flags::enabled( 'serviceSetupV2' ) ) {
+			$params['code'] = $code;
+			$url            = $this->authentication->get_google_proxy()->setup_url_v2( $params );
+		} else {
+			$url = $this->authentication->get_oauth_client()->get_proxy_setup_url( $code );
+			$url = add_query_arg( $params, $url );
+		}
 
 		wp_safe_redirect( $url );
 		exit;

--- a/includes/Core/Authentication/Setup_V1.php
+++ b/includes/Core/Authentication/Setup_V1.php
@@ -88,6 +88,7 @@ class Setup_V1 extends Setup {
 			wp_die( esc_html__( 'Invalid request.', 'google-site-kit' ), 400 );
 		}
 
+		$proxy_query_params = array();
 		if ( $verification_token && $verification_method ) {
 			$this->handle_verification( $verification_token, $verification_method );
 
@@ -95,8 +96,6 @@ class Setup_V1 extends Setup {
 				'verify'              => 'true',
 				'verification_method' => $verification_method,
 			);
-		} else {
-			$proxy_query_params = array();
 		}
 
 		if ( $site_code ) {

--- a/includes/Core/Authentication/Setup_V1.php
+++ b/includes/Core/Authentication/Setup_V1.php
@@ -68,6 +68,7 @@ class Setup_V1 extends Setup {
 	 * Handles the setup action, which is used for all intermediate proxy redirect requests.
 	 *
 	 * @since 1.48.0
+	 * @since n.e.x.t Sets the `verify` and `verification_method` query params.
 	 */
 	public function handle_action_setup() {
 		$input               = $this->context->input();
@@ -89,18 +90,26 @@ class Setup_V1 extends Setup {
 
 		if ( $verification_token && $verification_method ) {
 			$this->handle_verification( $verification_token, $verification_method );
+
+			$proxy_query_params = array(
+				'verify'              => 'true',
+				'verification_method' => $verification_method,
+			);
+		} else {
+			$proxy_query_params = array();
 		}
 
 		if ( $site_code ) {
 			try {
 				$this->handle_site_code( $code, $site_code );
 			} catch ( Missing_Verification_Exception $exception ) {
-				$this->redirect_to_proxy( $code, compact( 'site_code' ) );
+				$proxy_query_params['site_code'] = $site_code;
+				$this->redirect_to_proxy( $code, $proxy_query_params );
 			} catch ( Exchange_Site_Code_Exception $exception ) {
 				$this->redirect_to_splash();
 			}
 		}
 
-		$this->redirect_to_proxy( $code );
+		$this->redirect_to_proxy( $code, $proxy_query_params );
 	}
 }

--- a/includes/Core/Authentication/Setup_V2.php
+++ b/includes/Core/Authentication/Setup_V2.php
@@ -116,7 +116,8 @@ class Setup_V2 extends Setup {
 			}
 		}
 
-		$proxy_query_params['site_id'] = $this->credentials->get()['oauth2_client_id'];
+		$credentials                   = $this->credentials->get();
+		$proxy_query_params['site_id'] = ! empty( $credentials['oauth2_client_id'] ) ? $credentials['oauth2_client_id'] : '';
 
 		$this->redirect_to_proxy( $code, $proxy_query_params );
 	}

--- a/includes/Core/Authentication/Setup_V2.php
+++ b/includes/Core/Authentication/Setup_V2.php
@@ -116,6 +116,8 @@ class Setup_V2 extends Setup {
 			}
 		}
 
+		$proxy_query_params['site_id'] = $this->credentials->get()['oauth2_client_id'];
+
 		$this->redirect_to_proxy( $code, $proxy_query_params );
 	}
 

--- a/includes/Core/Authentication/Setup_V2.php
+++ b/includes/Core/Authentication/Setup_V2.php
@@ -69,6 +69,7 @@ class Setup_V2 extends Setup {
 	 * Handles the action for verifying site ownership.
 	 *
 	 * @since 1.48.0
+	 * @since n.e.x.t Sets the `verify` and `verification_method` and `site_id` query params.
 	 */
 	public function handle_action_verify() {
 		$input               = $this->context->input();
@@ -95,19 +96,27 @@ class Setup_V2 extends Setup {
 
 		$this->handle_verification( $verification_token, $verification_method );
 
+		$proxy_query_params = array(
+			'step'                => $step,
+			'verify'              => 'true',
+			'verification_method' => $verification_method,
+		);
+
 		// If the site does not have a site ID yet, a site code will be passed.
 		// Handling the site code here will save the extra redirect from the proxy if successful.
 		if ( $site_code ) {
 			try {
 				$this->handle_site_code( $code, $site_code );
 			} catch ( Missing_Verification_Exception $exception ) {
-				$this->redirect_to_proxy( $code, compact( 'site_code', 'step' ) );
+				$proxy_query_params['site_code'] = $site_code;
+
+				$this->redirect_to_proxy( $code, $proxy_query_params );
 			} catch ( Exchange_Site_Code_Exception $exception ) {
 				$this->redirect_to_splash();
 			}
 		}
 
-		$this->redirect_to_proxy( $code, compact( 'step' ) );
+		$this->redirect_to_proxy( $code, $proxy_query_params );
 	}
 
 	/**

--- a/includes/Core/Modules/Module.php
+++ b/includes/Core/Modules/Module.php
@@ -739,9 +739,10 @@ abstract class Module {
 			$message     = $auth_client->get_error_message( $code );
 			if ( Feature_Flags::enabled( 'serviceSetupV2' ) ) {
 				$google_proxy  = $this->authentication->get_google_proxy();
+				$credentials   = $this->credentials->get();
 				$params        = array(
 					'code'    => $e->getAccessCode(),
-					'site_id' => $this->authentication->credentials()->get()['oauth2_client_id'],
+					'site_id' => ! empty( $credentials['oauth2_client_id'] ) ? $credentials['oauth2_client_id'] : '',
 				);
 				$params        = $google_proxy->add_setup_step_from_error_code( $params, $code );
 				$reconnect_url = $google_proxy->setup_url_v2( $params );

--- a/includes/Core/Modules/Module.php
+++ b/includes/Core/Modules/Module.php
@@ -25,6 +25,7 @@ use Google\Site_Kit\Core\Authentication\Authentication;
 use Google\Site_Kit\Core\Authentication\Clients\Google_Site_Kit_Client;
 use Google\Site_Kit\Core\REST_API\Exception\Invalid_Datapoint_Exception;
 use Google\Site_Kit\Core\REST_API\Data_Request;
+use Google\Site_Kit\Core\Util\Feature_Flags;
 use Google\Site_Kit_Dependencies\Google\Service as Google_Service;
 use Google\Site_Kit_Dependencies\Google_Service_Exception;
 use Google\Site_Kit_Dependencies\Psr\Http\Message\RequestInterface;
@@ -705,6 +706,7 @@ abstract class Module {
 	 * Transforms an exception into a WP_Error object.
 	 *
 	 * @since 1.0.0
+	 * @since n.e.x.t Uses the new `Google_Proxy::setup_url_v2` method when the `serviceSetupV2` feature flag is enabled.
 	 *
 	 * @param Exception $e         Exception object.
 	 * @param string    $datapoint Datapoint originally requested.
@@ -731,11 +733,21 @@ abstract class Module {
 				$reason = $errors[0]['reason'];
 			}
 		} elseif ( $e instanceof Google_Proxy_Code_Exception ) {
-			$status        = 401;
-			$code          = $message;
-			$auth_client   = $this->authentication->get_oauth_client();
-			$message       = $auth_client->get_error_message( $code );
-			$reconnect_url = $auth_client->get_proxy_setup_url( $e->getAccessCode(), $code );
+			$status      = 401;
+			$code        = $message;
+			$auth_client = $this->authentication->get_oauth_client();
+			$message     = $auth_client->get_error_message( $code );
+			if ( Feature_Flags::enabled( 'serviceSetupV2' ) ) {
+				$google_proxy  = $this->authentication->get_google_proxy();
+				$params        = array(
+					'code'    => $e->getAccessCode(),
+					'site_id' => $this->authentication->credentials()->get()['oauth2_client_id'],
+				);
+				$params        = $google_proxy->add_setup_step_from_error_code( $params, $code );
+				$reconnect_url = $google_proxy->setup_url_v2( $params );
+			} else {
+				$reconnect_url = $auth_client->get_proxy_setup_url( $e->getAccessCode(), $code );
+			}
 		}
 
 		if ( empty( $code ) ) {

--- a/includes/Modules/Site_Verification.php
+++ b/includes/Modules/Site_Verification.php
@@ -396,6 +396,7 @@ final class Site_Verification extends Module implements Module_With_Scopes {
 	 * @since 1.1.0
 	 * @since 1.1.2 Runs on `admin_action_googlesitekit_proxy_setup` and no longer redirects directly.
 	 * @since 1.48.0 Token and method are now passed as arguments.
+	 * @since n.e.x.t No longer uses the `googlesitekit_proxy_setup_url_params` filter to set the `verify` and `verification_method` query params.
 	 *
 	 * @param string $token  Verification token.
 	 * @param string $method Verification method type.
@@ -408,19 +409,6 @@ final class Site_Verification extends Module implements Module_With_Scopes {
 			case self::VERIFICATION_TYPE_META:
 				$this->authentication->verification_meta()->set( $token );
 		}
-
-		add_filter(
-			'googlesitekit_proxy_setup_url_params',
-			function ( $params ) use ( $method ) {
-				return array_merge(
-					$params,
-					array(
-						'verify'              => 'true',
-						'verification_method' => $method,
-					)
-				);
-			}
-		);
 	}
 
 	/**

--- a/tests/phpunit/integration/Core/Authentication/Setup_V2Test.php
+++ b/tests/phpunit/integration/Core/Authentication/Setup_V2Test.php
@@ -183,6 +183,8 @@ class Setup_V2Test extends TestCase {
 			$location = $redirect->get_location();
 			$this->assertStringStartsWith( 'https://sitekit.withgoogle.com/site-management/setup/', $location );
 			$this->assertContains( '&step=test-step', $location );
+			$this->assertContains( '&verify=true', $location );
+			$this->assertContains( '&verification_method=FILE', $location );
 		} catch ( WPDieException $exception ) {
 			$this->assertContains(
 				'Verifying site ownership requires a token and verification method',

--- a/tests/phpunit/integration/Modules/Site_VerificationTest.php
+++ b/tests/phpunit/integration/Modules/Site_VerificationTest.php
@@ -142,14 +142,6 @@ class Site_VerificationTest extends TestCase {
 		do_action( 'googlesitekit_verify_site_ownership', 'testtoken', 'FILE' );
 
 		$this->assertEquals( 'testtoken', $user_options->get( Verification_File::OPTION ) );
-
-		$this->assertEqualSetsWithIndex(
-			array(
-				'verification_method' => 'FILE',
-				'verify'              => 'true',
-			),
-			apply_filters( 'googlesitekit_proxy_setup_url_params', array(), '', '' )
-		);
 	}
 
 	public function test_get_module_scopes() {


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #4376 

## Relevant technical choices

<!-- Please describe your changes. -->

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
