### PR TITLE
Remove `.min` from js extension in production

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -247,14 +247,10 @@ function* webpackConfig( env, argv ) {
 		externals,
 		output: {
 			filename:
-				mode === 'production'
-					? '[name]-[contenthash].min.js'
-					: '[name].js',
+				mode === 'production' ? '[name]-[contenthash].js' : '[name].js',
 			path: path.join( __dirname, 'dist/assets/js' ),
 			chunkFilename:
-				mode === 'production'
-					? '[name]-[chunkhash].min.js'
-					: '[name].js',
+				mode === 'production' ? '[name]-[chunkhash].js' : '[name].js',
 			publicPath: '',
 			/*
 				If multiple webpack runtimes (from different compilations) are used on the
@@ -343,7 +339,7 @@ function* webpackConfig( env, argv ) {
 						name: 'googlesitekit-vendor',
 						filename:
 							mode === 'production'
-								? 'googlesitekit-vendor-[contenthash].min.js'
+								? 'googlesitekit-vendor-[contenthash].js'
 								: 'googlesitekit-vendor.js',
 						enforce: true,
 						test: /[\\/]node_modules[\\/]/,
@@ -369,9 +365,7 @@ function* webpackConfig( env, argv ) {
 		externals,
 		output: {
 			filename:
-				mode === 'production'
-					? '[name]-[contenthash].min.js'
-					: '[name].js',
+				mode === 'production' ? '[name]-[contenthash].js' : '[name].js',
 			path: __dirname + '/dist/assets/js',
 			publicPath: '',
 		},


### PR DESCRIPTION
## Summary

Addresses issue #4592

**Note this targets `main` for the 1.48.1 hotfix**

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
