### PR TITLE
Add missing colons `:` to bug template.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -25,8 +25,8 @@ about: Create a report to help us improve
 <!-- Please complete the following information. -->
  - PHP Version: 
  - OS: [e.g. iOS]
- - Browser [e.g. chrome, safari]
- - Plugin Version [e.g. 22]
+ - Browser: [e.g. chrome, safari]
+ - Plugin Version: [e.g. 22]
  - Device: [e.g. iPhone6]
 
 <!-- Please add any additional information about the bug. -->


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #

The following PR updates the bug template adding missing colons `:` for the bug template.

## Relevant technical choices

<!-- Please describe your changes. -->

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [ ] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
