### PR TITLE
Refactor codebase to rely on Grid, Row, and Cell components.

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -34,6 +34,7 @@ import { resetGlobals } from './utils/resetGlobals';
 import { bootstrapFetchMocks } from './fetch-mocks';
 import { WithTestRegistry } from '../tests/js/utils';
 import { enabledFeatures } from '../assets/js/features';
+import { Cell, Grid, Row } from '../assets/js/material-components';
 
 bootstrapFetchMocks();
 
@@ -48,16 +49,13 @@ export const decorators = [
 		}
 
 		return (
-			<div
-				className="googlesitekit-plugin-preview js mdc-layout-grid"
-				style={ styles }
-			>
-				<div className="mdc-layout-grid__inner">
-					<div className="googlesitekit-plugin mdc-layout-grid__cell mdc-layout-grid__cell--span-12">
+			<Grid className="googlesitekit-plugin-preview js" style={ styles }>
+				<Row>
+					<Cell size={ 12 } className="googlesitekit-plugin">
 						<Story />
-					</div>
-				</div>
-			</div>
+					</Cell>
+				</Row>
+			</Grid>
 		);
 	},
 	// Features must be set up before test registry is initialized.

--- a/assets/js/components/PageHeader.js
+++ b/assets/js/components/PageHeader.js
@@ -21,6 +21,11 @@
 import classnames from 'classnames';
 import PropTypes from 'prop-types';
 
+/**
+ * Internal dependencies
+ */
+import { Cell, Row } from '../material-components';
+
 export default function PageHeader( props ) {
 	const {
 		title,
@@ -49,7 +54,7 @@ export default function PageHeader( props ) {
 
 	return (
 		<header className="googlesitekit-page-header">
-			<div className="mdc-layout-grid__inner">
+			<Row>
 				{ title && (
 					<div className={ widthClasses }>
 						{ icon }
@@ -89,7 +94,7 @@ export default function PageHeader( props ) {
 						</div>
 					</div>
 				) }
-			</div>
+			</Row>
 		</header>
 	);
 }

--- a/assets/js/components/PageHeader.js
+++ b/assets/js/components/PageHeader.js
@@ -69,10 +69,10 @@ export default function PageHeader( props ) {
 				{ hasDetails && (
 					<Cell
 						alignBottom
+						mdAlignRight
 						smSize={ 4 }
 						mdSize={ 4 }
 						lgSize={ 6 }
-						className="mdc-layout-grid__cell--align-right-tablet"
 					>
 						<div className="googlesitekit-page-header__details">
 							{ status && (

--- a/assets/js/components/PageHeader.js
+++ b/assets/js/components/PageHeader.js
@@ -24,7 +24,7 @@ import PropTypes from 'prop-types';
 /**
  * Internal dependencies
  */
-import { Cell } from '../material-components';
+import { Cell, Row } from '../material-components';
 
 export default function PageHeader( props ) {
 	const {
@@ -52,7 +52,7 @@ export default function PageHeader( props ) {
 
 	return (
 		<header className="googlesitekit-page-header">
-			<Cell>
+			<Row>
 				{ title && (
 					<Cell { ...titleCellProps }>
 						{ icon }
@@ -89,7 +89,7 @@ export default function PageHeader( props ) {
 						</div>
 					</Cell>
 				) }
-			</Cell>
+			</Row>
 		</header>
 	);
 }

--- a/assets/js/components/PageHeader.js
+++ b/assets/js/components/PageHeader.js
@@ -24,7 +24,7 @@ import PropTypes from 'prop-types';
 /**
  * Internal dependencies
  */
-import { Cell, Row } from '../material-components';
+import { Cell } from '../material-components';
 
 export default function PageHeader( props ) {
 	const {
@@ -37,26 +37,24 @@ export default function PageHeader( props ) {
 		children,
 	} = props;
 
-	const widthClasses = fullWidth
-		? `
-		mdc-layout-grid__cell
-		mdc-layout-grid__cell--span-12
-		`
-		: `
-		mdc-layout-grid__cell
-		mdc-layout-grid__cell--span-4-phone
-		mdc-layout-grid__cell--span-4-tablet
-		mdc-layout-grid__cell--span-6-desktop
-		`;
+	const titleCellProps = fullWidth
+		? {
+				size: 12,
+		  }
+		: {
+				smSize: 4,
+				mdSize: 4,
+				lgSize: 6,
+		  };
 
 	// Determine whether the details cell should display.
 	const hasDetails = '' !== status || Boolean( children );
 
 	return (
 		<header className="googlesitekit-page-header">
-			<Row>
+			<Cell>
 				{ title && (
-					<div className={ widthClasses }>
+					<Cell { ...titleCellProps }>
 						{ icon }
 						<h1
 							className={ classnames(
@@ -66,18 +64,15 @@ export default function PageHeader( props ) {
 						>
 							{ title }
 						</h1>
-					</div>
+					</Cell>
 				) }
 				{ hasDetails && (
-					<div
-						className="
-						mdc-layout-grid__cell
-						mdc-layout-grid__cell--align-bottom
-						mdc-layout-grid__cell--align-right-tablet
-						mdc-layout-grid__cell--span-4-phone
-						mdc-layout-grid__cell--span-4-tablet
-						mdc-layout-grid__cell--span-6-desktop
-					"
+					<Cell
+						alignBottom
+						smSize={ 4 }
+						mdSize={ 4 }
+						lgSize={ 6 }
+						className="mdc-layout-grid__cell--align-right-tablet"
 					>
 						<div className="googlesitekit-page-header__details">
 							{ status && (
@@ -92,9 +87,9 @@ export default function PageHeader( props ) {
 							) }
 							{ children }
 						</div>
-					</div>
+					</Cell>
 				) }
-			</Row>
+			</Cell>
 		</header>
 	);
 }

--- a/assets/js/components/adminbar/AdminBarApp.js
+++ b/assets/js/components/adminbar/AdminBarApp.js
@@ -65,13 +65,7 @@ export default function AdminBarApp() {
 		<Fragment>
 			<Grid>
 				<Row>
-					<div
-						className="
-						mdc-layout-grid__cell
-						mdc-layout-grid__cell--span-3
-						mdc-layout-grid__cell--align-middle
-					"
-					>
+					<Cell alignMiddle size={ 3 }>
 						<div className="googlesitekit-adminbar__subtitle">
 							{ __( 'Stats for', 'google-site-kit' ) }
 						</div>
@@ -92,26 +86,13 @@ export default function AdminBarApp() {
 								) }
 							</p>
 						</div>
-					</div>
+					</Cell>
 
-					<div
-						className="
-						mdc-layout-grid__cell
-						mdc-layout-grid__cell--span-8-tablet
-						mdc-layout-grid__cell--span-7-desktop
-						mdc-layout-grid__cell--align-middle
-					"
-					>
+					<Cell alignMiddle mdSize={ 8 } lgSize={ 7 }>
 						<AdminBarWidgets />
-					</div>
+					</Cell>
 
-					<div
-						className="
-						mdc-layout-grid__cell
-						mdc-layout-grid__cell--span-2
-						mdc-layout-grid__cell--align-middle
-					"
-					>
+					<Cell alignMiddle size={ 2 }>
 						<Link
 							className="googlesitekit-adminbar__link"
 							href="#"
@@ -119,7 +100,7 @@ export default function AdminBarApp() {
 						>
 							{ __( 'More details', 'google-site-kit' ) }
 						</Link>
-					</div>
+					</Cell>
 				</Row>
 			</Grid>
 			<Link

--- a/assets/js/components/adminbar/AdminBarApp.js
+++ b/assets/js/components/adminbar/AdminBarApp.js
@@ -27,6 +27,7 @@ import { __, sprintf, _n } from '@wordpress/i18n';
  */
 import Data from 'googlesitekit-data';
 import Link from '../Link';
+import { Cell, Grid, Row } from '../../material-components';
 import { CORE_SITE } from '../../googlesitekit/datastore/site/constants';
 import { CORE_USER } from '../../googlesitekit/datastore/user/constants';
 import { decodeHTMLEntity, trackEvent } from '../../util';
@@ -62,7 +63,7 @@ export default function AdminBarApp() {
 
 	return (
 		<Fragment>
-			<div className="mdc-layout-grid">
+			<Grid>
 				<div className="mdc-layout-grid__inner">
 					<div
 						className="
@@ -120,7 +121,7 @@ export default function AdminBarApp() {
 						</Link>
 					</div>
 				</div>
-			</div>
+			</Grid>
 			<Link
 				className="googlesitekit-adminbar__link googlesitekit-adminbar__link--mobile"
 				href="#"

--- a/assets/js/components/adminbar/AdminBarApp.js
+++ b/assets/js/components/adminbar/AdminBarApp.js
@@ -64,7 +64,7 @@ export default function AdminBarApp() {
 	return (
 		<Fragment>
 			<Grid>
-				<div className="mdc-layout-grid__inner">
+				<Row>
 					<div
 						className="
 						mdc-layout-grid__cell
@@ -120,7 +120,7 @@ export default function AdminBarApp() {
 							{ __( 'More details', 'google-site-kit' ) }
 						</Link>
 					</div>
-				</div>
+				</Row>
 			</Grid>
 			<Link
 				className="googlesitekit-adminbar__link googlesitekit-adminbar__link--mobile"

--- a/assets/js/components/layout/LayoutFooter.js
+++ b/assets/js/components/layout/LayoutFooter.js
@@ -39,7 +39,7 @@ class LayoutFooter extends Component {
 			<footer className="googlesitekit-layout__footer">
 				<Grid>
 					<Row>
-						<div className="mdc-layout-grid__cell mdc-layout-grid__cell--span-12">
+						<Cell size={ 12 }>
 							{ ctaLink && ctaLabel && (
 								<SourceLink
 									className="googlesitekit-data-block__source"
@@ -49,7 +49,7 @@ class LayoutFooter extends Component {
 								/>
 							) }
 							{ footerContent }
-						</div>
+						</Cell>
 					</Row>
 				</Grid>
 			</footer>

--- a/assets/js/components/layout/LayoutFooter.js
+++ b/assets/js/components/layout/LayoutFooter.js
@@ -29,6 +29,7 @@ import { Component } from '@wordpress/element';
 /**
  * Internal dependencies
  */
+import { Cell, Grid, Row } from '../../material-components';
 import SourceLink from '../SourceLink';
 
 class LayoutFooter extends Component {
@@ -36,7 +37,7 @@ class LayoutFooter extends Component {
 		const { ctaLabel, ctaLink, footerContent } = this.props;
 		return (
 			<footer className="googlesitekit-layout__footer">
-				<div className="mdc-layout-grid">
+				<Grid>
 					<div className="mdc-layout-grid__inner">
 						<div className="mdc-layout-grid__cell mdc-layout-grid__cell--span-12">
 							{ ctaLink && ctaLabel && (
@@ -50,7 +51,7 @@ class LayoutFooter extends Component {
 							{ footerContent }
 						</div>
 					</div>
-				</div>
+				</Grid>
 			</footer>
 		);
 	}

--- a/assets/js/components/layout/LayoutFooter.js
+++ b/assets/js/components/layout/LayoutFooter.js
@@ -38,7 +38,7 @@ class LayoutFooter extends Component {
 		return (
 			<footer className="googlesitekit-layout__footer">
 				<Grid>
-					<div className="mdc-layout-grid__inner">
+					<Row>
 						<div className="mdc-layout-grid__cell mdc-layout-grid__cell--span-12">
 							{ ctaLink && ctaLabel && (
 								<SourceLink
@@ -50,7 +50,7 @@ class LayoutFooter extends Component {
 							) }
 							{ footerContent }
 						</div>
-					</div>
+					</Row>
 				</Grid>
 			</footer>
 		);

--- a/assets/js/components/layout/LayoutHeader.js
+++ b/assets/js/components/layout/LayoutHeader.js
@@ -39,7 +39,7 @@ class LayoutHeader extends Component {
 		return (
 			<header className="googlesitekit-layout__header">
 				<Grid>
-					<div className="mdc-layout-grid__inner">
+					<Row>
 						{ title && (
 							<div
 								className={ classnames(
@@ -73,7 +73,7 @@ class LayoutHeader extends Component {
 								</Link>
 							</div>
 						) }
-					</div>
+					</Row>
 				</Grid>
 			</header>
 		);

--- a/assets/js/components/layout/LayoutHeader.js
+++ b/assets/js/components/layout/LayoutHeader.js
@@ -64,9 +64,9 @@ class LayoutHeader extends Component {
 						{ ctaLink && (
 							<Cell
 								alignMiddle
+								mdAlignRight
 								smSize={ 4 }
 								lgSize={ 6 }
-								className="mdc-layout-grid__cell--align-right-tablet"
 							>
 								<Link href={ ctaLink } external inherit>
 									{ ctaLabel }

--- a/assets/js/components/layout/LayoutHeader.js
+++ b/assets/js/components/layout/LayoutHeader.js
@@ -36,42 +36,42 @@ import Link from '../Link';
 class LayoutHeader extends Component {
 	render() {
 		const { title, ctaLabel, ctaLink } = this.props;
+
+		const titleCellProps = ctaLink
+			? {
+					alignMiddle: true,
+					smSize: 4,
+					lgSize: 6,
+			  }
+			: {
+					alignMiddle: true,
+					smSize: 4,
+					mdSize: 8,
+					lgSize: 12,
+			  };
+
 		return (
 			<header className="googlesitekit-layout__header">
 				<Grid>
 					<Row>
 						{ title && (
-							<div
-								className={ classnames(
-									'mdc-layout-grid__cell',
-									'mdc-layout-grid__cell--align-middle',
-									'mdc-layout-grid__cell--span-4-phone',
-									{
-										'mdc-layout-grid__cell--span-6-desktop': ctaLink,
-										'mdc-layout-grid__cell--span-12-desktop': ! ctaLink,
-										'mdc-layout-grid__cell--span-8-tablet': ! ctaLink,
-									}
-								) }
-							>
+							<Cell { ...titleCellProps }>
 								<h3 className="googlesitekit-subheading-1 googlesitekit-layout__header-title">
 									{ title }
 								</h3>
-							</div>
+							</Cell>
 						) }
 						{ ctaLink && (
-							<div
-								className="
-								mdc-layout-grid__cell
-								mdc-layout-grid__cell--span-6-desktop
-								mdc-layout-grid__cell--span-4-phone
-								mdc-layout-grid__cell--align-middle
-								mdc-layout-grid__cell--align-right-tablet
-							"
+							<Cell
+								alignMiddle
+								smSize={ 4 }
+								lgSize={ 6 }
+								className="mdc-layout-grid__cell--align-right-tablet"
 							>
 								<Link href={ ctaLink } external inherit>
 									{ ctaLabel }
 								</Link>
-							</div>
+							</Cell>
 						) }
 					</Row>
 				</Grid>

--- a/assets/js/components/layout/LayoutHeader.js
+++ b/assets/js/components/layout/LayoutHeader.js
@@ -20,7 +20,6 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
-import classnames from 'classnames';
 
 /**
  * WordPress dependencies

--- a/assets/js/components/layout/LayoutHeader.js
+++ b/assets/js/components/layout/LayoutHeader.js
@@ -30,6 +30,7 @@ import { Component } from '@wordpress/element';
 /**
  * Internal dependencies
  */
+import { Cell, Grid, Row } from '../../material-components';
 import Link from '../Link';
 
 class LayoutHeader extends Component {
@@ -37,7 +38,7 @@ class LayoutHeader extends Component {
 		const { title, ctaLabel, ctaLink } = this.props;
 		return (
 			<header className="googlesitekit-layout__header">
-				<div className="mdc-layout-grid">
+				<Grid>
 					<div className="mdc-layout-grid__inner">
 						{ title && (
 							<div
@@ -73,7 +74,7 @@ class LayoutHeader extends Component {
 							</div>
 						) }
 					</div>
-				</div>
+				</Grid>
 			</header>
 		);
 	}

--- a/assets/js/components/legacy-setup/SetupUsingGCP.js
+++ b/assets/js/components/legacy-setup/SetupUsingGCP.js
@@ -39,6 +39,7 @@ import {
 	PERMISSION_SETUP,
 	CORE_USER,
 } from '../../googlesitekit/datastore/user/constants';
+import { Cell, Grid, Row } from '../../material-components';
 import Header from '../Header';
 import Button from '../Button';
 import Layout from '../layout/Layout';
@@ -269,7 +270,7 @@ class SetupUsingGCP extends Component {
 					<HelpMenu />
 				</Header>
 				<div className="googlesitekit-wizard">
-					<div className="mdc-layout-grid">
+					<Grid>
 						<div className="mdc-layout-grid__inner">
 							<div
 								className="
@@ -279,7 +280,7 @@ class SetupUsingGCP extends Component {
 							>
 								<Layout>
 									<section className="googlesitekit-wizard-progress">
-										<div className="mdc-layout-grid">
+										<Grid>
 											<div className="mdc-layout-grid__inner">
 												{ showVerificationSteps && (
 													<div
@@ -345,10 +346,10 @@ class SetupUsingGCP extends Component {
 													</div>
 												) }
 											</div>
-										</div>
+										</Grid>
 										{ showAuthenticateButton && (
 											<div className="googlesitekit-setup__footer">
-												<div className="mdc-layout-grid">
+												<Grid>
 													<div className="mdc-layout-grid__inner">
 														<div
 															className="
@@ -382,7 +383,7 @@ class SetupUsingGCP extends Component {
 															</Button>
 														</div>
 													</div>
-												</div>
+												</Grid>
 											</div>
 										) }
 									</section>
@@ -391,7 +392,7 @@ class SetupUsingGCP extends Component {
 								</Layout>
 							</div>
 						</div>
-					</div>
+					</Grid>
 				</div>
 			</Fragment>
 		);

--- a/assets/js/components/legacy-setup/SetupUsingGCP.js
+++ b/assets/js/components/legacy-setup/SetupUsingGCP.js
@@ -271,7 +271,7 @@ class SetupUsingGCP extends Component {
 				</Header>
 				<div className="googlesitekit-wizard">
 					<Grid>
-						<div className="mdc-layout-grid__inner">
+						<Row>
 							<div
 								className="
 								mdc-layout-grid__cell
@@ -281,7 +281,7 @@ class SetupUsingGCP extends Component {
 								<Layout>
 									<section className="googlesitekit-wizard-progress">
 										<Grid>
-											<div className="mdc-layout-grid__inner">
+											<Row>
 												{ showVerificationSteps && (
 													<div
 														className="
@@ -345,12 +345,12 @@ class SetupUsingGCP extends Component {
 														</div>
 													</div>
 												) }
-											</div>
+											</Row>
 										</Grid>
 										{ showAuthenticateButton && (
 											<div className="googlesitekit-setup__footer">
 												<Grid>
-													<div className="mdc-layout-grid__inner">
+													<Row>
 														<div
 															className="
 															mdc-layout-grid__cell
@@ -382,7 +382,7 @@ class SetupUsingGCP extends Component {
 																) }
 															</Button>
 														</div>
-													</div>
+													</Row>
 												</Grid>
 											</div>
 										) }
@@ -391,7 +391,7 @@ class SetupUsingGCP extends Component {
 										wizardStepComponent }
 								</Layout>
 							</div>
-						</div>
+						</Row>
 					</Grid>
 				</div>
 			</Fragment>

--- a/assets/js/components/legacy-setup/SetupUsingGCP.js
+++ b/assets/js/components/legacy-setup/SetupUsingGCP.js
@@ -272,23 +272,13 @@ class SetupUsingGCP extends Component {
 				<div className="googlesitekit-wizard">
 					<Grid>
 						<Row>
-							<div
-								className="
-								mdc-layout-grid__cell
-								mdc-layout-grid__cell--span-12
-							"
-							>
+							<Cell size={ 12 }>
 								<Layout>
 									<section className="googlesitekit-wizard-progress">
 										<Grid>
 											<Row>
 												{ showVerificationSteps && (
-													<div
-														className="
-														mdc-layout-grid__cell
-														mdc-layout-grid__cell--span-12
-													"
-													>
+													<Cell size={ 12 }>
 														<div className="googlesitekit-wizard-progress__steps">
 															{ Object.keys(
 																progressSteps
@@ -343,7 +333,7 @@ class SetupUsingGCP extends Component {
 																}
 															) }
 														</div>
-													</div>
+													</Cell>
 												) }
 											</Row>
 										</Grid>
@@ -351,12 +341,7 @@ class SetupUsingGCP extends Component {
 											<div className="googlesitekit-setup__footer">
 												<Grid>
 													<Row>
-														<div
-															className="
-															mdc-layout-grid__cell
-															mdc-layout-grid__cell--span-12
-														"
-														>
+														<Cell size={ 12 }>
 															<h1 className="googlesitekit-setup__title">
 																{ __(
 																	'Authenticate Site Kit',
@@ -381,7 +366,7 @@ class SetupUsingGCP extends Component {
 																	'google-site-kit'
 																) }
 															</Button>
-														</div>
+														</Cell>
 													</Row>
 												</Grid>
 											</div>
@@ -390,7 +375,7 @@ class SetupUsingGCP extends Component {
 									{ showVerificationSteps &&
 										wizardStepComponent }
 								</Layout>
-							</div>
+							</Cell>
 						</Row>
 					</Grid>
 				</div>

--- a/assets/js/components/legacy-setup/wizard-step-authentication.js
+++ b/assets/js/components/legacy-setup/wizard-step-authentication.js
@@ -43,12 +43,7 @@ class WizardStepAuthentication extends Component {
 			<section className="googlesitekit-wizard-step googlesitekit-wizard-step--two">
 				<Grid>
 					<Row>
-						<div
-							className="
-							mdc-layout-grid__cell
-							mdc-layout-grid__cell--span-12
-						"
-						>
+						<Cell size={ 12 }>
 							<h2
 								className="
 								googlesitekit-heading-3
@@ -97,7 +92,7 @@ class WizardStepAuthentication extends Component {
 							<div className="googlesitekit-wizard-step__action googlesitekit-wizard-step__action--justify">
 								<OptIn />
 							</div>
-						</div>
+						</Cell>
 					</Row>
 				</Grid>
 			</section>

--- a/assets/js/components/legacy-setup/wizard-step-authentication.js
+++ b/assets/js/components/legacy-setup/wizard-step-authentication.js
@@ -42,7 +42,7 @@ class WizardStepAuthentication extends Component {
 		return (
 			<section className="googlesitekit-wizard-step googlesitekit-wizard-step--two">
 				<Grid>
-					<div className="mdc-layout-grid__inner">
+					<Row>
 						<div
 							className="
 							mdc-layout-grid__cell
@@ -98,7 +98,7 @@ class WizardStepAuthentication extends Component {
 								<OptIn />
 							</div>
 						</div>
-					</div>
+					</Row>
 				</Grid>
 			</section>
 		);

--- a/assets/js/components/legacy-setup/wizard-step-authentication.js
+++ b/assets/js/components/legacy-setup/wizard-step-authentication.js
@@ -30,6 +30,7 @@ import { Component } from '@wordpress/element';
 /**
  * Internal dependencies
  */
+import { Cell, Grid, Row } from '../../material-components';
 import Button from '../Button';
 import Link from '../Link';
 import OptIn from '../OptIn';
@@ -40,7 +41,7 @@ class WizardStepAuthentication extends Component {
 
 		return (
 			<section className="googlesitekit-wizard-step googlesitekit-wizard-step--two">
-				<div className="mdc-layout-grid">
+				<Grid>
 					<div className="mdc-layout-grid__inner">
 						<div
 							className="
@@ -98,7 +99,7 @@ class WizardStepAuthentication extends Component {
 							</div>
 						</div>
 					</div>
-				</div>
+				</Grid>
 			</section>
 		);
 	}

--- a/assets/js/components/legacy-setup/wizard-step-complete-setup.js
+++ b/assets/js/components/legacy-setup/wizard-step-complete-setup.js
@@ -54,12 +54,7 @@ class WizardStepCompleteSetup extends Component {
 			<section className="googlesitekit-wizard-step googlesitekit-wizard-step--five">
 				<Grid>
 					<Row>
-						<div
-							className="
-							mdc-layout-grid__cell
-							mdc-layout-grid__cell--span-12
-						"
-						>
+						<Cell size={ 12 }>
 							<h2
 								className="
 									googlesitekit-heading-3
@@ -85,7 +80,7 @@ class WizardStepCompleteSetup extends Component {
 									) }
 								</Button>
 							</div>
-						</div>
+						</Cell>
 					</Row>
 				</Grid>
 			</section>

--- a/assets/js/components/legacy-setup/wizard-step-complete-setup.js
+++ b/assets/js/components/legacy-setup/wizard-step-complete-setup.js
@@ -30,6 +30,7 @@ import { Component } from '@wordpress/element';
 /**
  * Internal dependencies
  */
+import { Cell, Grid, Row } from '../../material-components';
 import { trackEvent } from '../../util';
 import Button from '../Button';
 
@@ -51,7 +52,7 @@ class WizardStepCompleteSetup extends Component {
 	render() {
 		return (
 			<section className="googlesitekit-wizard-step googlesitekit-wizard-step--five">
-				<div className="mdc-layout-grid">
+				<Grid>
 					<div className="mdc-layout-grid__inner">
 						<div
 							className="
@@ -86,7 +87,7 @@ class WizardStepCompleteSetup extends Component {
 							</div>
 						</div>
 					</div>
-				</div>
+				</Grid>
 			</section>
 		);
 	}

--- a/assets/js/components/legacy-setup/wizard-step-complete-setup.js
+++ b/assets/js/components/legacy-setup/wizard-step-complete-setup.js
@@ -53,7 +53,7 @@ class WizardStepCompleteSetup extends Component {
 		return (
 			<section className="googlesitekit-wizard-step googlesitekit-wizard-step--five">
 				<Grid>
-					<div className="mdc-layout-grid__inner">
+					<Row>
 						<div
 							className="
 							mdc-layout-grid__cell
@@ -86,7 +86,7 @@ class WizardStepCompleteSetup extends Component {
 								</Button>
 							</div>
 						</div>
-					</div>
+					</Row>
 				</Grid>
 			</section>
 		);

--- a/assets/js/components/legacy-setup/wizard-step-search-console-property.js
+++ b/assets/js/components/legacy-setup/wizard-step-search-console-property.js
@@ -40,7 +40,7 @@ class WizardStepSearchConsoleProperty extends Component {
 		return (
 			<section className="googlesitekit-wizard-step googlesitekit-wizard-step--four">
 				<Grid>
-					<div className="mdc-layout-grid__inner">
+					<Row>
 						<div
 							className="
 							mdc-layout-grid__cell
@@ -56,7 +56,7 @@ class WizardStepSearchConsoleProperty extends Component {
 								SearchConsole.connected()
 							) }
 						</div>
-					</div>
+					</Row>
 				</Grid>
 			</section>
 		);

--- a/assets/js/components/legacy-setup/wizard-step-search-console-property.js
+++ b/assets/js/components/legacy-setup/wizard-step-search-console-property.js
@@ -41,12 +41,7 @@ class WizardStepSearchConsoleProperty extends Component {
 			<section className="googlesitekit-wizard-step googlesitekit-wizard-step--four">
 				<Grid>
 					<Row>
-						<div
-							className="
-							mdc-layout-grid__cell
-							mdc-layout-grid__cell--span-12
-						"
-						>
+						<Cell size={ 12 }>
 							{ shouldSetup ? (
 								<SearchConsole
 									shouldSetup={ shouldSetup }
@@ -55,7 +50,7 @@ class WizardStepSearchConsoleProperty extends Component {
 							) : (
 								SearchConsole.connected()
 							) }
-						</div>
+						</Cell>
 					</Row>
 				</Grid>
 			</section>

--- a/assets/js/components/legacy-setup/wizard-step-search-console-property.js
+++ b/assets/js/components/legacy-setup/wizard-step-search-console-property.js
@@ -29,6 +29,7 @@ import { Component } from '@wordpress/element';
 /**
  * Internal dependencies
  */
+import { Cell, Grid, Row } from '../../material-components';
 import SearchConsole from './search-console';
 
 class WizardStepSearchConsoleProperty extends Component {
@@ -38,7 +39,7 @@ class WizardStepSearchConsoleProperty extends Component {
 
 		return (
 			<section className="googlesitekit-wizard-step googlesitekit-wizard-step--four">
-				<div className="mdc-layout-grid">
+				<Grid>
 					<div className="mdc-layout-grid__inner">
 						<div
 							className="
@@ -56,7 +57,7 @@ class WizardStepSearchConsoleProperty extends Component {
 							) }
 						</div>
 					</div>
-				</div>
+				</Grid>
 			</section>
 		);
 	}

--- a/assets/js/components/legacy-setup/wizard-step-verification.js
+++ b/assets/js/components/legacy-setup/wizard-step-verification.js
@@ -40,7 +40,7 @@ class WizardStepVerification extends Component {
 		return (
 			<section className="googlesitekit-wizard-step googlesitekit-wizard-step--three">
 				<Grid>
-					<div className="mdc-layout-grid__inner">
+					<Row>
 						<div
 							className="
 							mdc-layout-grid__cell
@@ -52,7 +52,7 @@ class WizardStepVerification extends Component {
 								{ ...this.props }
 							/>
 						</div>
-					</div>
+					</Row>
 				</Grid>
 			</section>
 		);

--- a/assets/js/components/legacy-setup/wizard-step-verification.js
+++ b/assets/js/components/legacy-setup/wizard-step-verification.js
@@ -29,6 +29,7 @@ import { Component } from '@wordpress/element';
 /**
  * Internal dependencies
  */
+import { Cell, Grid, Row } from '../../material-components';
 import SiteVerification from './site-verification';
 
 class WizardStepVerification extends Component {
@@ -38,7 +39,7 @@ class WizardStepVerification extends Component {
 
 		return (
 			<section className="googlesitekit-wizard-step googlesitekit-wizard-step--three">
-				<div className="mdc-layout-grid">
+				<Grid>
 					<div className="mdc-layout-grid__inner">
 						<div
 							className="
@@ -52,7 +53,7 @@ class WizardStepVerification extends Component {
 							/>
 						</div>
 					</div>
-				</div>
+				</Grid>
 			</section>
 		);
 	}

--- a/assets/js/components/legacy-setup/wizard-step-verification.js
+++ b/assets/js/components/legacy-setup/wizard-step-verification.js
@@ -41,17 +41,12 @@ class WizardStepVerification extends Component {
 			<section className="googlesitekit-wizard-step googlesitekit-wizard-step--three">
 				<Grid>
 					<Row>
-						<div
-							className="
-							mdc-layout-grid__cell
-							mdc-layout-grid__cell--span-12
-						"
-						>
+						<Cell size={ 12 }>
 							<SiteVerification
 								shouldSetup={ shouldSetup }
 								{ ...this.props }
 							/>
-						</div>
+						</Cell>
 					</Row>
 				</Grid>
 			</section>

--- a/assets/js/components/notifications/BannerNotification.js
+++ b/assets/js/components/notifications/BannerNotification.js
@@ -38,6 +38,7 @@ import {
 /*
  * Internal dependencies
  */
+import { Cell, Grid, Row } from '../../material-components';
 import GoogleLogoIcon from '../../../svg/logo-g.svg';
 import { getContextScrollTop } from '../../util/scroll';
 import { isHashOnly } from '../../util/urls';
@@ -355,7 +356,7 @@ function BannerNotification( {
 				[ `googlesitekit-publisher-win--${ closedClass }` ]: closedClass,
 			} ) }
 		>
-			<div className="mdc-layout-grid">
+			<Grid>
 				<div className="mdc-layout-grid__inner">
 					{ logo && (
 						<div
@@ -458,7 +459,7 @@ function BannerNotification( {
 						</div>
 					) }
 				</div>
-			</div>
+			</Grid>
 		</section>
 	);
 }

--- a/assets/js/components/notifications/BannerNotification.js
+++ b/assets/js/components/notifications/BannerNotification.js
@@ -254,7 +254,7 @@ function BannerNotification( {
 	const dataBlockMarkup = (
 		<Fragment>
 			{ blockData && (
-				<div className="mdc-layout-grid__inner">
+				<Row>
 					{ map( blockData, ( block, i ) => {
 						return (
 							<div
@@ -273,7 +273,7 @@ function BannerNotification( {
 							</div>
 						);
 					} ) }
-				</div>
+				</Row>
 			) }
 		</Fragment>
 	);
@@ -357,7 +357,7 @@ function BannerNotification( {
 			} ) }
 		>
 			<Grid>
-				<div className="mdc-layout-grid__inner">
+				<Row>
 					{ logo && (
 						<div
 							className={ classnames(
@@ -399,14 +399,14 @@ function BannerNotification( {
 						) }
 					>
 						{ inlineLayout ? (
-							<div className="mdc-layout-grid__inner">
+							<Row>
 								<div className="mdc-layout-grid__cell mdc-layout-grid__cell--span-5-desktop mdc-layout-grid__cell--span-8-tablet">
 									{ inlineMarkup }
 								</div>
 								<div className="mdc-layout-grid__cell mdc-layout-grid__cell--span-7-desktop mdc-layout-grid__cell--span-8-tablet mdc-layout-grid__cell--align-bottom">
 									{ dataBlockMarkup }
 								</div>
-							</div>
+							</Row>
 						) : (
 							<Fragment>
 								{ inlineMarkup }
@@ -458,7 +458,7 @@ function BannerNotification( {
 							</div>
 						</div>
 					) }
-				</div>
+				</Row>
 			</Grid>
 		</section>
 	);

--- a/assets/js/components/notifications/BannerNotification.js
+++ b/assets/js/components/notifications/BannerNotification.js
@@ -220,26 +220,31 @@ function BannerNotification( {
 	const closedClass = isClosed ? 'is-closed' : 'is-open';
 	const inlineLayout = 'large' === format && 'win-stats-increase' === type;
 
-	let layout = 'mdc-layout-grid__cell--span-12';
+	let layoutCellProps;
 	if ( 'large' === format ) {
-		layout =
-			'mdc-layout-grid__cell--order-2-phone ' +
-			'mdc-layout-grid__cell--order-1-tablet ' +
-			'mdc-layout-grid__cell--span-6-tablet ' +
-			'mdc-layout-grid__cell--span-8-desktop ';
-
-		if ( inlineLayout ) {
-			layout =
-				'mdc-layout-grid__cell--order-2-phone ' +
-				'mdc-layout-grid__cell--order-1-tablet ' +
-				'mdc-layout-grid__cell--span-5-tablet ' +
-				'mdc-layout-grid__cell--span-8-desktop ';
-		}
+		layoutCellProps = inlineLayout
+			? {
+					mdSize: 5,
+					lgSize: 8,
+					smOrder: 2,
+					mdOrder: 1,
+			  }
+			: {
+					mdSize: 6,
+					lgSize: 8,
+					smOrder: 2,
+					mdOrder: 1,
+			  };
 	} else if ( 'small' === format ) {
-		layout =
-			'mdc-layout-grid__cell--span-11-desktop ' +
-			'mdc-layout-grid__cell--span-7-tablet ' +
-			'mdc-layout-grid__cell--span-3-phone';
+		layoutCellProps = {
+			smSize: 3,
+			mdSize: 7,
+			lgSize: 11,
+		};
+	} else {
+		layoutCellProps = {
+			size: 12,
+		};
 	}
 
 	let icon;
@@ -257,20 +262,11 @@ function BannerNotification( {
 				<Row>
 					{ map( blockData, ( block, i ) => {
 						return (
-							<div
-								key={ i }
-								className={ classnames(
-									'mdc-layout-grid__cell',
-									{
-										'mdc-layout-grid__cell--span-5-desktop': inlineLayout,
-										'mdc-layout-grid__cell--span-4-desktop': ! inlineLayout,
-									}
-								) }
-							>
+							<Cell key={ i } lgSize={ inlineLayout ? 5 : 4 }>
 								<div className="googlesitekit-publisher-win__stats">
 									<DataBlock { ...block } />
 								</div>
-							</div>
+							</Cell>
 						);
 					} ) }
 				</Row>
@@ -346,6 +342,14 @@ function BannerNotification( {
 		<GoogleLogoIcon height="34" width="32" />
 	);
 
+	const logoCellProps = inlineLayout
+		? {
+				size: 12,
+				smOrder: 2,
+				mdOrder: 1,
+		  }
+		: { size: 12 };
+
 	return (
 		<section
 			id={ id }
@@ -359,16 +363,7 @@ function BannerNotification( {
 			<Grid>
 				<Row>
 					{ logo && (
-						<div
-							className={ classnames(
-								'mdc-layout-grid__cell',
-								'mdc-layout-grid__cell--span-12',
-								{
-									'mdc-layout-grid__cell--order-2-phone': inlineLayout,
-									'mdc-layout-grid__cell--order-1-tablet': inlineLayout,
-								}
-							) }
-						>
+						<Cell { ...logoCellProps }>
 							<div className="googlesitekit-publisher-win__logo">
 								{ logoSVG }
 							</div>
@@ -377,35 +372,27 @@ function BannerNotification( {
 									{ moduleName }
 								</div>
 							) }
-						</div>
+						</Cell>
 					) }
 
 					{ SmallImageSVG && (
-						<div
-							className="
-								mdc-layout-grid__cell
-								mdc-layout-grid__cell--span-1
-								googlesitekit-publisher-win__small-media
-							"
+						<Cell
+							size={ 1 }
+							className="googlesitekit-publisher-win__small-media"
 						>
 							<SmallImageSVG />
-						</div>
+						</Cell>
 					) }
 
-					<div
-						className={ classnames(
-							'mdc-layout-grid__cell',
-							layout
-						) }
-					>
+					<Cell { ...layoutCellProps }>
 						{ inlineLayout ? (
 							<Row>
-								<div className="mdc-layout-grid__cell mdc-layout-grid__cell--span-5-desktop mdc-layout-grid__cell--span-8-tablet">
+								<Cell mdSize={ 8 } lgSize={ 5 }>
 									{ inlineMarkup }
-								</div>
-								<div className="mdc-layout-grid__cell mdc-layout-grid__cell--span-7-desktop mdc-layout-grid__cell--span-8-tablet mdc-layout-grid__cell--align-bottom">
+								</Cell>
+								<Cell alignBottom mdSize={ 8 } lgSize={ 7 }>
 									{ dataBlockMarkup }
-								</div>
+								</Cell>
 							</Row>
 						) : (
 							<Fragment>
@@ -428,35 +415,27 @@ function BannerNotification( {
 						{ isDismissible && dismiss && (
 							<Link onClick={ handleDismiss }>{ dismiss }</Link>
 						) }
-					</div>
+					</Cell>
 
 					{ WinImageSVG && (
-						<div
-							className="
-								mdc-layout-grid__cell
-								mdc-layout-grid__cell--order-1-phone
-								mdc-layout-grid__cell--order-2-tablet
-								mdc-layout-grid__cell--span-2-tablet
-								mdc-layout-grid__cell--span-4-desktop
-							"
+						<Cell
+							mdSize={ 2 }
+							lgSize={ 4 }
+							smOrder={ 1 }
+							mdOrder={ 2 }
 						>
 							<div className="googlesitekit-publisher-win__image-large">
 								<WinImageSVG />
 							</div>
-						</div>
+						</Cell>
 					) }
 
 					{ ( 'win-error' === type || 'win-warning' === type ) && (
-						<div
-							className="
-								mdc-layout-grid__cell
-								mdc-layout-grid__cell--span-1
-							"
-						>
+						<Cell size={ 1 }>
 							<div className="googlesitekit-publisher-win__icons">
 								{ icon }
 							</div>
-						</div>
+						</Cell>
 					) }
 				</Row>
 			</Grid>

--- a/assets/js/components/settings/SettingsActiveModule/Footer.js
+++ b/assets/js/components/settings/SettingsActiveModule/Footer.js
@@ -238,11 +238,11 @@ export default function Footer( props ) {
 						{ primaryColumn }
 					</Cell>
 					<Cell
-						className="mdc-layout-grid__cell--align-right-desktop"
 						lgSize={ 6 }
 						mdSize={ 8 }
 						smSize={ 4 }
 						alignMiddle
+						lgAlignRight
 					>
 						{ secondaryColumn }
 					</Cell>

--- a/assets/js/components/settings/SettingsActiveModule/Header.js
+++ b/assets/js/components/settings/SettingsActiveModule/Header.js
@@ -109,11 +109,11 @@ export default function Header( { slug } ) {
 					</Cell>
 
 					<Cell
-						className="mdc-layout-grid__cell--align-right-tablet"
 						lgSize={ 6 }
 						mdSize={ 4 }
 						smSize={ 4 }
 						alignMiddle
+						mdAlignRight
 					>
 						<p className="googlesitekit-settings-module__status">
 							{ connected

--- a/assets/js/components/setup/CompatibilityChecks/index.js
+++ b/assets/js/components/setup/CompatibilityChecks/index.js
@@ -66,7 +66,7 @@ export default function CompatibilityChecks( { children, ...props } ) {
 	);
 
 	const ctaFeedback = error && (
-		<Grid className="googlesitekit-setup-compat mdc-layout-grid--align-left">
+		<Grid alignLeft className="googlesitekit-setup-compat">
 			<div className="googlesitekit-setup__warning">
 				<Warning />
 

--- a/assets/js/components/setup/CompatibilityChecks/index.js
+++ b/assets/js/components/setup/CompatibilityChecks/index.js
@@ -31,7 +31,7 @@ import PropTypes from 'prop-types';
  */
 import Data from 'googlesitekit-data';
 const { useRegistry } = Data;
-import { Cell, Grid, Row } from '../../../material-components';
+import { Grid } from '../../../material-components';
 import Warning from '../../../../svg/warning.svg';
 import ProgressBar from '../../ProgressBar';
 import { useChecks } from '../../../hooks/useChecks';

--- a/assets/js/components/setup/CompatibilityChecks/index.js
+++ b/assets/js/components/setup/CompatibilityChecks/index.js
@@ -31,6 +31,7 @@ import PropTypes from 'prop-types';
  */
 import Data from 'googlesitekit-data';
 const { useRegistry } = Data;
+import { Cell, Grid, Row } from '../../../material-components';
 import Warning from '../../../../svg/warning.svg';
 import ProgressBar from '../../ProgressBar';
 import { useChecks } from '../../../hooks/useChecks';
@@ -65,7 +66,7 @@ export default function CompatibilityChecks( { children, ...props } ) {
 	);
 
 	const ctaFeedback = error && (
-		<div className="googlesitekit-setup-compat mdc-layout-grid mdc-layout-grid--align-left">
+		<Grid className="googlesitekit-setup-compat mdc-layout-grid--align-left">
 			<div className="googlesitekit-setup__warning">
 				<Warning />
 
@@ -77,7 +78,7 @@ export default function CompatibilityChecks( { children, ...props } ) {
 				</div>
 			</div>
 			<CompatibilityErrorNotice error={ error } />
-		</div>
+		</Grid>
 	);
 
 	const inProgressFeedback = ! complete && (

--- a/assets/js/components/setup/ModuleSetup.js
+++ b/assets/js/components/setup/ModuleSetup.js
@@ -103,7 +103,7 @@ export default function ModuleSetup( { moduleSlug } ) {
 			<Header />
 			<div className="googlesitekit-setup">
 				<Grid>
-					<div className="mdc-layout-grid__inner">
+					<Row>
 						<div
 							className="
 							mdc-layout-grid__cell
@@ -112,7 +112,7 @@ export default function ModuleSetup( { moduleSlug } ) {
 						>
 							<section className="googlesitekit-setup__wrapper">
 								<Grid>
-									<div className="mdc-layout-grid__inner">
+									<Row>
 										<div
 											className="
 											mdc-layout-grid__cell
@@ -135,11 +135,11 @@ export default function ModuleSetup( { moduleSlug } ) {
 												finishSetup={ finishSetup }
 											/>
 										</div>
-									</div>
+									</Row>
 								</Grid>
 								<div className="googlesitekit-setup__footer">
 									<Grid>
-										<div className="mdc-layout-grid__inner">
+										<Row>
 											<div
 												className="
 													mdc-layout-grid__cell
@@ -161,12 +161,12 @@ export default function ModuleSetup( { moduleSlug } ) {
 													) }
 												</Link>
 											</div>
-										</div>
+										</Row>
 									</Grid>
 								</div>
 							</section>
 						</div>
-					</div>
+					</Row>
 				</Grid>
 			</div>
 		</Fragment>

--- a/assets/js/components/setup/ModuleSetup.js
+++ b/assets/js/components/setup/ModuleSetup.js
@@ -36,6 +36,7 @@ import { CORE_SITE } from '../../googlesitekit/datastore/site/constants';
 import { CORE_MODULES } from '../../googlesitekit/modules/datastore/constants';
 import { CORE_LOCATION } from '../../googlesitekit/datastore/location/constants';
 import { trackEvent } from '../../util';
+import { Cell, Grid, Row } from '../../material-components';
 import Header from '../Header';
 import Link from '../Link';
 const { useSelect, useDispatch } = Data;
@@ -101,7 +102,7 @@ export default function ModuleSetup( { moduleSlug } ) {
 		<Fragment>
 			<Header />
 			<div className="googlesitekit-setup">
-				<div className="mdc-layout-grid">
+				<Grid>
 					<div className="mdc-layout-grid__inner">
 						<div
 							className="
@@ -110,7 +111,7 @@ export default function ModuleSetup( { moduleSlug } ) {
 						"
 						>
 							<section className="googlesitekit-setup__wrapper">
-								<div className="mdc-layout-grid">
+								<Grid>
 									<div className="mdc-layout-grid__inner">
 										<div
 											className="
@@ -135,9 +136,9 @@ export default function ModuleSetup( { moduleSlug } ) {
 											/>
 										</div>
 									</div>
-								</div>
+								</Grid>
 								<div className="googlesitekit-setup__footer">
-									<div className="mdc-layout-grid">
+									<Grid>
 										<div className="mdc-layout-grid__inner">
 											<div
 												className="
@@ -161,12 +162,12 @@ export default function ModuleSetup( { moduleSlug } ) {
 												</Link>
 											</div>
 										</div>
-									</div>
+									</Grid>
 								</div>
 							</section>
 						</div>
 					</div>
-				</div>
+				</Grid>
 			</div>
 		</Fragment>
 	);

--- a/assets/js/components/setup/ModuleSetup.js
+++ b/assets/js/components/setup/ModuleSetup.js
@@ -104,21 +104,11 @@ export default function ModuleSetup( { moduleSlug } ) {
 			<div className="googlesitekit-setup">
 				<Grid>
 					<Row>
-						<div
-							className="
-							mdc-layout-grid__cell
-							mdc-layout-grid__cell--span-12
-						"
-						>
+						<Cell size={ 12 }>
 							<section className="googlesitekit-setup__wrapper">
 								<Grid>
 									<Row>
-										<div
-											className="
-											mdc-layout-grid__cell
-											mdc-layout-grid__cell--span-12
-										"
-										>
+										<Cell size={ 12 }>
 											<p
 												className="
 												googlesitekit-setup__intro-title
@@ -134,19 +124,16 @@ export default function ModuleSetup( { moduleSlug } ) {
 												module={ module }
 												finishSetup={ finishSetup }
 											/>
-										</div>
+										</Cell>
 									</Row>
 								</Grid>
 								<div className="googlesitekit-setup__footer">
 									<Grid>
 										<Row>
-											<div
-												className="
-													mdc-layout-grid__cell
-													mdc-layout-grid__cell--span-2-phone
-													mdc-layout-grid__cell--span-4-tablet
-													mdc-layout-grid__cell--span-6-desktop
-												"
+											<Cell
+												smSize={ 2 }
+												mdSize={ 4 }
+												lgSize={ 6 }
 											>
 												<Link
 													id={ `setup-${ module.slug }-cancel` }
@@ -160,12 +147,12 @@ export default function ModuleSetup( { moduleSlug } ) {
 														'google-site-kit'
 													) }
 												</Link>
-											</div>
+											</Cell>
 										</Row>
 									</Grid>
 								</div>
 							</section>
-						</div>
+						</Cell>
 					</Row>
 				</Grid>
 			</div>

--- a/assets/js/googlesitekit/widgets/components/URLSearchWidget.js
+++ b/assets/js/googlesitekit/widgets/components/URLSearchWidget.js
@@ -26,6 +26,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import Data from 'googlesitekit-data';
+import { Cell, Grid, Row } from '../../../material-components';
 import ViewContextContext from '../../../components/Root/ViewContextContext';
 import { trackEvent } from '../../../util/tracking';
 import { CORE_SITE } from '../../datastore/site/constants';
@@ -70,7 +71,7 @@ function URLSearchWidget( { Widget } ) {
 				) }
 				noPadding
 			>
-				<div className="mdc-layout-grid">
+				<Grid>
 					<div className="mdc-layout-grid__inner">
 						<div className="mdc-layout-grid__cell mdc-layout-grid__cell--span-12">
 							<div className="googlesitekit-post-searcher">
@@ -97,7 +98,7 @@ function URLSearchWidget( { Widget } ) {
 							</div>
 						</div>
 					</div>
-				</div>
+				</Grid>
 			</Widget>
 		</div>
 	);

--- a/assets/js/googlesitekit/widgets/components/URLSearchWidget.js
+++ b/assets/js/googlesitekit/widgets/components/URLSearchWidget.js
@@ -72,7 +72,7 @@ function URLSearchWidget( { Widget } ) {
 				noPadding
 			>
 				<Grid>
-					<div className="mdc-layout-grid__inner">
+					<Row>
 						<div className="mdc-layout-grid__cell mdc-layout-grid__cell--span-12">
 							<div className="googlesitekit-post-searcher">
 								<label
@@ -97,7 +97,7 @@ function URLSearchWidget( { Widget } ) {
 								</div>
 							</div>
 						</div>
-					</div>
+					</Row>
 				</Grid>
 			</Widget>
 		</div>

--- a/assets/js/googlesitekit/widgets/components/URLSearchWidget.js
+++ b/assets/js/googlesitekit/widgets/components/URLSearchWidget.js
@@ -59,7 +59,7 @@ function URLSearchWidget( { Widget } ) {
 	}, [ detailsURL, match, navigateTo, viewContext ] );
 
 	return (
-		<div className="mdc-layout-grid__cell">
+		<Cell>
 			<Widget
 				Header={ () => (
 					<h3 className="googlesitekit-subheading-1 googlesitekit-widget__header-title">
@@ -73,7 +73,7 @@ function URLSearchWidget( { Widget } ) {
 			>
 				<Grid>
 					<Row>
-						<div className="mdc-layout-grid__cell mdc-layout-grid__cell--span-12">
+						<Cell size={ 12 }>
 							<div className="googlesitekit-post-searcher">
 								<label
 									className="googlesitekit-post-searcher__label"
@@ -96,11 +96,11 @@ function URLSearchWidget( { Widget } ) {
 									</Button>
 								</div>
 							</div>
-						</div>
+						</Cell>
 					</Row>
 				</Grid>
 			</Widget>
-		</div>
+		</Cell>
 	);
 }
 

--- a/assets/js/material-components/layout/Cell.js
+++ b/assets/js/material-components/layout/Cell.js
@@ -32,10 +32,13 @@ export default function Cell( props ) {
 		alignLeft,
 		smSize,
 		smStart,
+		smOrder,
 		mdSize,
 		mdStart,
+		mdOrder,
 		lgSize,
 		lgStart,
+		lgOrder,
 		size,
 		children,
 		...otherProps
@@ -56,14 +59,20 @@ export default function Cell( props ) {
 					12 >= lgSize && lgSize > 0,
 				[ `mdc-layout-grid__cell--start-${ lgStart }-desktop` ]:
 					12 >= lgStart && lgStart > 0,
+				[ `mdc-layout-grid__cell--order-${ lgOrder }-desktop` ]:
+					12 >= lgOrder && lgOrder > 0,
 				[ `mdc-layout-grid__cell--span-${ mdSize }-tablet` ]:
 					8 >= mdSize && mdSize > 0,
 				[ `mdc-layout-grid__cell--start-${ mdStart }-tablet` ]:
 					8 >= mdStart && mdStart > 0,
+				[ `mdc-layout-grid__cell--order-${ mdOrder }-tablet` ]:
+					8 >= mdOrder && mdOrder > 0,
 				[ `mdc-layout-grid__cell--span-${ smSize }-phone` ]:
 					4 >= smSize && smSize > 0,
 				[ `mdc-layout-grid__cell--start-${ smStart }-phone` ]:
 					4 >= smStart && smStart > 0,
+				[ `mdc-layout-grid__cell--order-${ smOrder }-phone` ]:
+					4 >= smOrder && smOrder > 0,
 			} ) }
 		>
 			{ children }
@@ -74,10 +83,13 @@ export default function Cell( props ) {
 Cell.propTypes = {
 	smSize: PropTypes.number,
 	smStart: PropTypes.number,
+	smOrder: PropTypes.number,
 	mdSize: PropTypes.number,
 	mdStart: PropTypes.number,
+	mdOrder: PropTypes.number,
 	lgSize: PropTypes.number,
 	lgStart: PropTypes.number,
+	lgOrder: PropTypes.number,
 	size: PropTypes.number,
 	alignTop: PropTypes.bool,
 	alignMiddle: PropTypes.bool,
@@ -93,8 +105,11 @@ Cell.defaultProps = {
 	size: 0,
 	smSize: 0,
 	smStart: 0,
+	smOrder: 0,
 	mdSize: 0,
 	mdStart: 0,
+	mdOrder: 0,
 	lgSize: 0,
 	lgStart: 0,
+	lgOrder: 0,
 };

--- a/assets/js/material-components/layout/Cell.js
+++ b/assets/js/material-components/layout/Cell.js
@@ -30,6 +30,9 @@ export default function Cell( props ) {
 		alignBottom,
 		alignRight,
 		alignLeft,
+		smAlignRight,
+		mdAlignRight,
+		lgAlignRight,
 		smSize,
 		smStart,
 		smOrder,
@@ -53,6 +56,9 @@ export default function Cell( props ) {
 				'mdc-layout-grid__cell--align-bottom': alignBottom,
 				'mdc-layout-grid__cell--align-right': alignRight,
 				'mdc-layout-grid__cell--align-left': alignLeft,
+				'mdc-layout-grid__cell--align-right-phone': smAlignRight,
+				'mdc-layout-grid__cell--align-right-tablet': mdAlignRight,
+				'mdc-layout-grid__cell--align-right-desktop': lgAlignRight,
 				[ `mdc-layout-grid__cell--span-${ size }` ]:
 					12 >= size && size > 0,
 				[ `mdc-layout-grid__cell--span-${ lgSize }-desktop` ]:
@@ -96,6 +102,9 @@ Cell.propTypes = {
 	alignBottom: PropTypes.bool,
 	alignRight: PropTypes.bool,
 	alignLeft: PropTypes.bool,
+	smAlignRight: PropTypes.bool,
+	mdAlignRight: PropTypes.bool,
+	lgAlignRight: PropTypes.bool,
 	className: PropTypes.string,
 	children: PropTypes.node,
 };

--- a/assets/js/material-components/layout/Grid.js
+++ b/assets/js/material-components/layout/Grid.js
@@ -28,10 +28,11 @@ import classnames from 'classnames';
 import { forwardRef } from '@wordpress/element';
 
 const Grid = forwardRef(
-	( { fill, className, children, ...otherProps }, ref ) => {
+	( { alignLeft, fill, className, children, ...otherProps }, ref ) => {
 		return (
 			<div
 				className={ classnames( 'mdc-layout-grid', className, {
+					'mdc-layout-grid--align-left': alignLeft,
 					'mdc-layout-grid--fill': fill,
 				} ) }
 				{ ...otherProps }
@@ -44,6 +45,7 @@ const Grid = forwardRef(
 );
 
 Grid.propTypes = {
+	alignLeft: PropTypes.bool,
 	fill: PropTypes.bool,
 	className: PropTypes.string,
 	children: PropTypes.node,

--- a/assets/js/material-components/layout/Grid.js
+++ b/assets/js/material-components/layout/Grid.js
@@ -27,19 +27,24 @@ import classnames from 'classnames';
  */
 import { forwardRef } from '@wordpress/element';
 
-const Grid = forwardRef( ( { className, children, ...otherProps }, ref ) => {
-	return (
-		<div
-			className={ classnames( 'mdc-layout-grid', className ) }
-			{ ...otherProps }
-			ref={ ref }
-		>
-			{ children }
-		</div>
-	);
-} );
+const Grid = forwardRef(
+	( { fill, className, children, ...otherProps }, ref ) => {
+		return (
+			<div
+				className={ classnames( 'mdc-layout-grid', className, {
+					'mdc-layout-grid--fill': fill,
+				} ) }
+				{ ...otherProps }
+				ref={ ref }
+			>
+				{ children }
+			</div>
+		);
+	}
+);
 
 Grid.propTypes = {
+	fill: PropTypes.bool,
 	className: PropTypes.string,
 	children: PropTypes.node,
 };

--- a/assets/js/modules/adsense/components/dashboard/DashboardSummaryWidget.js
+++ b/assets/js/modules/adsense/components/dashboard/DashboardSummaryWidget.js
@@ -177,7 +177,7 @@ function DashboardSummaryWidget( {
 	return (
 		<Widget className="googlesitekit-dashboard-adsense-stats" noPadding>
 			<Grid>
-				<div className="mdc-layout-grid__inner">
+				<Row>
 					<div className="mdc-layout-grid__cell mdc-layout-grid__cell--span-12">
 						<DataBlock
 							className="overview-adsense-rpm"
@@ -284,7 +284,7 @@ function DashboardSummaryWidget( {
 							context="compact"
 						/>
 					</div>
-				</div>
+				</Row>
 			</Grid>
 		</Widget>
 	);

--- a/assets/js/modules/adsense/components/dashboard/DashboardSummaryWidget.js
+++ b/assets/js/modules/adsense/components/dashboard/DashboardSummaryWidget.js
@@ -178,7 +178,7 @@ function DashboardSummaryWidget( {
 		<Widget className="googlesitekit-dashboard-adsense-stats" noPadding>
 			<Grid>
 				<Row>
-					<div className="mdc-layout-grid__cell mdc-layout-grid__cell--span-12">
+					<Cell size={ 12 }>
 						<DataBlock
 							className="overview-adsense-rpm"
 							title={ __( 'Page RPM', 'google-site-kit' ) }
@@ -212,9 +212,9 @@ function DashboardSummaryWidget( {
 							}
 							context="compact"
 						/>
-					</div>
+					</Cell>
 
-					<div className="mdc-layout-grid__cell mdc-layout-grid__cell--span-12">
+					<Cell size={ 12 }>
 						<DataBlock
 							className="overview-adsense-earnings"
 							title={ __( 'Total Earnings', 'google-site-kit' ) }
@@ -248,9 +248,9 @@ function DashboardSummaryWidget( {
 							}
 							context="compact"
 						/>
-					</div>
+					</Cell>
 
-					<div className="mdc-layout-grid__cell mdc-layout-grid__cell--span-12">
+					<Cell size={ 12 }>
 						<DataBlock
 							className="overview-adsense-impressions"
 							title={ __( 'Ad Impressions', 'google-site-kit' ) }
@@ -283,7 +283,7 @@ function DashboardSummaryWidget( {
 							}
 							context="compact"
 						/>
-					</div>
+					</Cell>
 				</Row>
 			</Grid>
 		</Widget>

--- a/assets/js/modules/adsense/components/dashboard/DashboardSummaryWidget.js
+++ b/assets/js/modules/adsense/components/dashboard/DashboardSummaryWidget.js
@@ -30,6 +30,7 @@ import { CORE_USER } from '../../../../googlesitekit/datastore/user/constants';
 import { isZeroReport, reduceAdSenseData } from '../../util';
 import extractForSparkline from '../../../../util/extract-for-sparkline';
 import whenActive from '../../../../util/when-active';
+import { Cell, Grid, Row } from '../../../../material-components';
 import PreviewBlock from '../../../../components/PreviewBlock';
 import DataBlock from '../../../../components/DataBlock';
 import Sparkline from '../../../../components/Sparkline';
@@ -174,115 +175,117 @@ function DashboardSummaryWidget( {
 	const currencyCode = currencyHeader ? currencyHeader.currencyCode : false;
 
 	return (
-		<Widget className="googlesitekit-dashboard-adsense-stats mdc-layout-grid">
-			<div className="mdc-layout-grid__inner">
-				<div className="mdc-layout-grid__cell mdc-layout-grid__cell--span-12">
-					<DataBlock
-						className="overview-adsense-rpm"
-						title={ __( 'Page RPM', 'google-site-kit' ) }
-						datapoint={ period.totals?.cells[ 1 ].value || 0 }
-						datapointUnit={ currencyCode }
-						change={
-							period.totals?.cells[ 1 ].value ||
-							0 - previousPeriod.totals?.cells[ 1 ].value ||
-							0
-						}
-						changeDataUnit={ currencyCode }
-						source={ {
-							name: _x(
-								'AdSense',
-								'Service name',
-								'google-site-kit'
-							),
-							link: rpmReportURL,
-							external: true,
-						} }
-						sparkline={
-							daily && (
-								<Sparkline
-									data={ extractForSparkline(
-										processedData.dataMap,
-										2
-									) }
-									change={ 1 }
-								/>
-							)
-						}
-						context="compact"
-					/>
-				</div>
+		<Widget className="googlesitekit-dashboard-adsense-stats" noPadding>
+			<Grid>
+				<div className="mdc-layout-grid__inner">
+					<div className="mdc-layout-grid__cell mdc-layout-grid__cell--span-12">
+						<DataBlock
+							className="overview-adsense-rpm"
+							title={ __( 'Page RPM', 'google-site-kit' ) }
+							datapoint={ period.totals?.cells[ 1 ].value || 0 }
+							datapointUnit={ currencyCode }
+							change={
+								period.totals?.cells[ 1 ].value ||
+								0 - previousPeriod.totals?.cells[ 1 ].value ||
+								0
+							}
+							changeDataUnit={ currencyCode }
+							source={ {
+								name: _x(
+									'AdSense',
+									'Service name',
+									'google-site-kit'
+								),
+								link: rpmReportURL,
+								external: true,
+							} }
+							sparkline={
+								daily && (
+									<Sparkline
+										data={ extractForSparkline(
+											processedData.dataMap,
+											2
+										) }
+										change={ 1 }
+									/>
+								)
+							}
+							context="compact"
+						/>
+					</div>
 
-				<div className="mdc-layout-grid__cell mdc-layout-grid__cell--span-12">
-					<DataBlock
-						className="overview-adsense-earnings"
-						title={ __( 'Total Earnings', 'google-site-kit' ) }
-						datapoint={ period.totals?.cells[ 0 ].value || 0 }
-						datapointUnit={ currencyCode }
-						source={ {
-							name: _x(
-								'AdSense',
-								'Service name',
-								'google-site-kit'
-							),
-							link: earningsURL,
-							external: true,
-						} }
-						change={
-							period.totals?.cells[ 0 ].value ||
-							0 - previousPeriod.totals?.cells[ 0 ].value ||
-							0
-						}
-						changeDataUnit={ currencyCode }
-						sparkline={
-							daily && (
-								<Sparkline
-									data={ extractForSparkline(
-										processedData.dataMap,
-										1
-									) }
-									change={ 1 }
-								/>
-							)
-						}
-						context="compact"
-					/>
-				</div>
+					<div className="mdc-layout-grid__cell mdc-layout-grid__cell--span-12">
+						<DataBlock
+							className="overview-adsense-earnings"
+							title={ __( 'Total Earnings', 'google-site-kit' ) }
+							datapoint={ period.totals?.cells[ 0 ].value || 0 }
+							datapointUnit={ currencyCode }
+							source={ {
+								name: _x(
+									'AdSense',
+									'Service name',
+									'google-site-kit'
+								),
+								link: earningsURL,
+								external: true,
+							} }
+							change={
+								period.totals?.cells[ 0 ].value ||
+								0 - previousPeriod.totals?.cells[ 0 ].value ||
+								0
+							}
+							changeDataUnit={ currencyCode }
+							sparkline={
+								daily && (
+									<Sparkline
+										data={ extractForSparkline(
+											processedData.dataMap,
+											1
+										) }
+										change={ 1 }
+									/>
+								)
+							}
+							context="compact"
+						/>
+					</div>
 
-				<div className="mdc-layout-grid__cell mdc-layout-grid__cell--span-12">
-					<DataBlock
-						className="overview-adsense-impressions"
-						title={ __( 'Ad Impressions', 'google-site-kit' ) }
-						datapoint={ period.totals?.cells[ 2 ].value || 0 }
-						change={
-							period.totals?.cells[ 2 ].value ||
-							0 - previousPeriod.totals?.cells[ 2 ].value ||
-							0
-						}
-						changeDataUnit
-						source={ {
-							name: _x(
-								'AdSense',
-								'Service name',
-								'google-site-kit'
-							),
-							link: impressionsURL,
-							external: true,
-						} }
-						sparkline={
-							daily && (
-								<Sparkline
-									data={ extractForSparkline(
-										processedData.dataMap,
-										3
-									) }
-									change={ 1 }
-								/>
-							)
-						}
-						context="compact"
-					/>
+					<div className="mdc-layout-grid__cell mdc-layout-grid__cell--span-12">
+						<DataBlock
+							className="overview-adsense-impressions"
+							title={ __( 'Ad Impressions', 'google-site-kit' ) }
+							datapoint={ period.totals?.cells[ 2 ].value || 0 }
+							change={
+								period.totals?.cells[ 2 ].value ||
+								0 - previousPeriod.totals?.cells[ 2 ].value ||
+								0
+							}
+							changeDataUnit
+							source={ {
+								name: _x(
+									'AdSense',
+									'Service name',
+									'google-site-kit'
+								),
+								link: impressionsURL,
+								external: true,
+							} }
+							sparkline={
+								daily && (
+									<Sparkline
+										data={ extractForSparkline(
+											processedData.dataMap,
+											3
+										) }
+										change={ 1 }
+									/>
+								)
+							}
+							context="compact"
+						/>
+					</div>
 				</div>
-			</div>
+			</Grid>
 		</Widget>
 	);
 }

--- a/assets/js/modules/adsense/components/dashboard/DashboardZeroData.js
+++ b/assets/js/modules/adsense/components/dashboard/DashboardZeroData.js
@@ -36,7 +36,7 @@ import SiteSteps from '../common/SiteSteps';
  */
 export default function DashboardZeroData() {
 	return (
-		<Grid className="mdc-layout-grid--fill">
+		<Grid fill>
 			<Row>
 				<Cell size={ 12 }>
 					<h3 className="googlesitekit-heading-4 googlesitekit-setup-module__title">

--- a/assets/js/modules/adsense/components/dashboard/DashboardZeroData.js
+++ b/assets/js/modules/adsense/components/dashboard/DashboardZeroData.js
@@ -38,7 +38,7 @@ export default function DashboardZeroData() {
 	return (
 		<Grid className="mdc-layout-grid--fill">
 			<Row>
-				<div className="mdc-layout-grid__cell mdc-layout-grid__cell--span-12">
+				<Cell size={ 12 }>
 					<h3 className="googlesitekit-heading-4 googlesitekit-setup-module__title">
 						{ __( 'No ad impressions yet', 'google-site-kit' ) }
 					</h3>
@@ -51,7 +51,7 @@ export default function DashboardZeroData() {
 					</p>
 
 					<SiteSteps />
-				</div>
+				</Cell>
 			</Row>
 		</Grid>
 	);

--- a/assets/js/modules/adsense/components/dashboard/DashboardZeroData.js
+++ b/assets/js/modules/adsense/components/dashboard/DashboardZeroData.js
@@ -24,6 +24,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
+import { Cell, Grid, Row } from '../../../../material-components';
 import SiteSteps from '../common/SiteSteps';
 
 /*
@@ -35,7 +36,7 @@ import SiteSteps from '../common/SiteSteps';
  */
 export default function DashboardZeroData() {
 	return (
-		<div className="mdc-layout-grid mdc-layout-grid--fill">
+		<Grid className="mdc-layout-grid--fill">
 			<div className="mdc-layout-grid__inner">
 				<div className="mdc-layout-grid__cell mdc-layout-grid__cell--span-12">
 					<h3 className="googlesitekit-heading-4 googlesitekit-setup-module__title">
@@ -52,6 +53,6 @@ export default function DashboardZeroData() {
 					<SiteSteps />
 				</div>
 			</div>
-		</div>
+		</Grid>
 	);
 }

--- a/assets/js/modules/adsense/components/dashboard/DashboardZeroData.js
+++ b/assets/js/modules/adsense/components/dashboard/DashboardZeroData.js
@@ -37,7 +37,7 @@ import SiteSteps from '../common/SiteSteps';
 export default function DashboardZeroData() {
 	return (
 		<Grid className="mdc-layout-grid--fill">
-			<div className="mdc-layout-grid__inner">
+			<Row>
 				<div className="mdc-layout-grid__cell mdc-layout-grid__cell--span-12">
 					<h3 className="googlesitekit-heading-4 googlesitekit-setup-module__title">
 						{ __( 'No ad impressions yet', 'google-site-kit' ) }
@@ -52,7 +52,7 @@ export default function DashboardZeroData() {
 
 					<SiteSteps />
 				</div>
-			</div>
+			</Row>
 		</Grid>
 	);
 }

--- a/assets/js/modules/analytics/components/common/AccountCreate/index.js
+++ b/assets/js/modules/analytics/components/common/AccountCreate/index.js
@@ -44,6 +44,7 @@ import { CORE_LOCATION } from '../../../../../googlesitekit/datastore/location/c
 import { ERROR_CODE_MISSING_REQUIRED_SCOPE } from '../../../../../util/errors';
 import { trackEvent } from '../../../../../util';
 import { getAccountDefaults } from '../../../util/account';
+import { Cell } from '../../../../../material-components';
 import Button from '../../../../../components/Button';
 import Link from '../../../../../components/Link';
 import ProgressBar from '../../../../../components/ProgressBar';
@@ -220,15 +221,15 @@ export default function AccountCreate() {
 			</p>
 
 			<div className="googlesitekit-setup-module__inputs">
-				<div className="mdc-layout-grid__cell mdc-layout-grid__cell--span-6">
+				<Cell size={ 6 }>
 					<AccountField />
-				</div>
-				<div className="mdc-layout-grid__cell mdc-layout-grid__cell--span-6">
+				</Cell>
+				<Cell size={ 6 }>
 					<PropertyField />
-				</div>
-				<div className="mdc-layout-grid__cell mdc-layout-grid__cell--span-6">
+				</Cell>
+				<Cell size={ 6 }>
 					<ProfileField />
-				</div>
+				</Cell>
 			</div>
 
 			<div className="googlesitekit-setup-module__inputs">

--- a/assets/js/modules/analytics/components/settings/SettingsForm.stories.js
+++ b/assets/js/modules/analytics/components/settings/SettingsForm.stories.js
@@ -20,7 +20,7 @@
  * Internal dependencies
  */
 import SettingsForm from './SettingsForm';
-import { Cell, Grid } from '../../../../material-components';
+import { Cell, Grid, Row } from '../../../../material-components';
 import { MODULES_ANALYTICS } from '../../datastore/constants';
 import { MODULES_ANALYTICS_4 } from '../../../analytics-4/datastore/constants';
 import {
@@ -39,11 +39,11 @@ function Template() {
 				<div className="googlesitekit-setup-module">
 					<div className="googlesitekit-settings-module__content googlesitekit-settings-module__content--open">
 						<Grid>
-							<div className="mdc-layout-inner">
+							<Row>
 								<Cell size={ 12 }>
 									<SettingsForm />
 								</Cell>
-							</div>
+							</Row>
 						</Grid>
 					</div>
 				</div>

--- a/assets/js/modules/analytics/components/settings/SettingsForm.stories.js
+++ b/assets/js/modules/analytics/components/settings/SettingsForm.stories.js
@@ -20,7 +20,7 @@
  * Internal dependencies
  */
 import SettingsForm from './SettingsForm';
-import { Cell, Grid, Row } from '../../../../material-components';
+import { Cell, Grid } from '../../../../material-components';
 import { MODULES_ANALYTICS } from '../../datastore/constants';
 import { MODULES_ANALYTICS_4 } from '../../../analytics-4/datastore/constants';
 import {

--- a/assets/js/modules/analytics/components/settings/SettingsForm.stories.js
+++ b/assets/js/modules/analytics/components/settings/SettingsForm.stories.js
@@ -20,6 +20,7 @@
  * Internal dependencies
  */
 import SettingsForm from './SettingsForm';
+import { Cell, Grid, Row } from '../../../../material-components';
 import { MODULES_ANALYTICS } from '../../datastore/constants';
 import { MODULES_ANALYTICS_4 } from '../../../analytics-4/datastore/constants';
 import {
@@ -37,13 +38,13 @@ function Template() {
 			<div className="googlesitekit-settings-module googlesitekit-settings-module--active googlesitekit-settings-module--analytics">
 				<div className="googlesitekit-setup-module">
 					<div className="googlesitekit-settings-module__content googlesitekit-settings-module__content--open">
-						<div className="mdc-layout-grid">
+						<Grid>
 							<div className="mdc-layout-inner">
 								<div className="mdc-layout-grid__cell mdc-layout-grid__cell--span-12">
 									<SettingsForm />
 								</div>
 							</div>
-						</div>
+						</Grid>
 					</div>
 				</div>
 			</div>

--- a/assets/js/modules/analytics/components/settings/SettingsForm.stories.js
+++ b/assets/js/modules/analytics/components/settings/SettingsForm.stories.js
@@ -40,9 +40,9 @@ function Template() {
 					<div className="googlesitekit-settings-module__content googlesitekit-settings-module__content--open">
 						<Grid>
 							<div className="mdc-layout-inner">
-								<div className="mdc-layout-grid__cell mdc-layout-grid__cell--span-12">
+								<Cell size={ 12 }>
 									<SettingsForm />
-								</div>
+								</Cell>
 							</div>
 						</Grid>
 					</div>

--- a/assets/js/modules/analytics/components/settings/SettingsView.stories.js
+++ b/assets/js/modules/analytics/components/settings/SettingsView.stories.js
@@ -20,7 +20,7 @@
  * Internal dependencies
  */
 import SettingsView from './SettingsView';
-import { Cell, Grid } from '../../../../material-components';
+import { Cell, Grid, Row } from '../../../../material-components';
 import { MODULES_ANALYTICS } from '../../datastore/constants';
 import { MODULES_ANALYTICS_4 } from '../../../analytics-4/datastore/constants';
 import {
@@ -39,11 +39,11 @@ function Template( { setupRegistry = () => {}, ...args } ) {
 				<div className="googlesitekit-settings-module googlesitekit-settings-module--active googlesitekit-settings-module--analytics">
 					<div className="googlesitekit-settings-module__content googlesitekit-settings-module__content--open">
 						<Grid>
-							<div className="mdc-layout-inner">
+							<Row>
 								<Cell size={ 12 }>
 									<SettingsView { ...args } />
 								</Cell>
-							</div>
+							</Row>
 						</Grid>
 					</div>
 				</div>

--- a/assets/js/modules/analytics/components/settings/SettingsView.stories.js
+++ b/assets/js/modules/analytics/components/settings/SettingsView.stories.js
@@ -40,9 +40,9 @@ function Template( { setupRegistry = () => {}, ...args } ) {
 					<div className="googlesitekit-settings-module__content googlesitekit-settings-module__content--open">
 						<Grid>
 							<div className="mdc-layout-inner">
-								<div className="mdc-layout-grid__cell mdc-layout-grid__cell--span-12">
+								<Cell size={ 12 }>
 									<SettingsView { ...args } />
-								</div>
+								</Cell>
 							</div>
 						</Grid>
 					</div>

--- a/assets/js/modules/analytics/components/settings/SettingsView.stories.js
+++ b/assets/js/modules/analytics/components/settings/SettingsView.stories.js
@@ -20,6 +20,7 @@
  * Internal dependencies
  */
 import SettingsView from './SettingsView';
+import { Cell, Grid, Row } from '../../../../material-components';
 import { MODULES_ANALYTICS } from '../../datastore/constants';
 import { MODULES_ANALYTICS_4 } from '../../../analytics-4/datastore/constants';
 import {
@@ -37,13 +38,13 @@ function Template( { setupRegistry = () => {}, ...args } ) {
 			<div className="googlesitekit-layout">
 				<div className="googlesitekit-settings-module googlesitekit-settings-module--active googlesitekit-settings-module--analytics">
 					<div className="googlesitekit-settings-module__content googlesitekit-settings-module__content--open">
-						<div className="mdc-layout-grid">
+						<Grid>
 							<div className="mdc-layout-inner">
 								<div className="mdc-layout-grid__cell mdc-layout-grid__cell--span-12">
 									<SettingsView { ...args } />
 								</div>
 							</div>
-						</div>
+						</Grid>
 					</div>
 				</div>
 			</div>

--- a/assets/js/modules/analytics/components/settings/SettingsView.stories.js
+++ b/assets/js/modules/analytics/components/settings/SettingsView.stories.js
@@ -20,7 +20,7 @@
  * Internal dependencies
  */
 import SettingsView from './SettingsView';
-import { Cell, Grid, Row } from '../../../../material-components';
+import { Cell, Grid } from '../../../../material-components';
 import { MODULES_ANALYTICS } from '../../datastore/constants';
 import { MODULES_ANALYTICS_4 } from '../../../analytics-4/datastore/constants';
 import {

--- a/assets/js/modules/idea-hub/components/setup/Setup.stories.js
+++ b/assets/js/modules/idea-hub/components/setup/Setup.stories.js
@@ -33,9 +33,9 @@ function Template() {
 			<section className="googlesitekit-setup__wrapper">
 				<Grid>
 					<Row>
-						<div className=" mdc-layout-grid__cell mdc-layout-grid__cell--span-12 ">
+						<Cell size={ 12 }>
 							<SetupMain />
-						</div>
+						</Cell>
 					</Row>
 				</Grid>
 			</section>

--- a/assets/js/modules/idea-hub/components/setup/Setup.stories.js
+++ b/assets/js/modules/idea-hub/components/setup/Setup.stories.js
@@ -32,11 +32,11 @@ function Template() {
 		<div className="googlesitekit-setup">
 			<section className="googlesitekit-setup__wrapper">
 				<Grid>
-					<div className="mdc-layout-grid__inner">
+					<Row>
 						<div className=" mdc-layout-grid__cell mdc-layout-grid__cell--span-12 ">
 							<SetupMain />
 						</div>
-					</div>
+					</Row>
 				</Grid>
 			</section>
 		</div>

--- a/assets/js/modules/idea-hub/components/setup/Setup.stories.js
+++ b/assets/js/modules/idea-hub/components/setup/Setup.stories.js
@@ -22,6 +22,7 @@
 import { MODULES_IDEA_HUB } from '../../datastore/constants';
 import { CORE_MODULES } from '../../../../googlesitekit/modules/datastore/constants';
 import WithRegistrySetup from '../../../../../../tests/js/WithRegistrySetup';
+import { Cell, Grid, Row } from '../../../../material-components';
 import SetupMain from './SetupMain';
 
 const features = [ 'ideaHubModule' ];
@@ -30,13 +31,13 @@ function Template() {
 	return (
 		<div className="googlesitekit-setup">
 			<section className="googlesitekit-setup__wrapper">
-				<div className="mdc-layout-grid">
+				<Grid>
 					<div className="mdc-layout-grid__inner">
 						<div className=" mdc-layout-grid__cell mdc-layout-grid__cell--span-12 ">
 							<SetupMain />
 						</div>
 					</div>
-				</div>
+				</Grid>
 			</section>
 		</div>
 	);

--- a/assets/js/modules/pagespeed-insights/components/dashboard/DashboardPageSpeed.js
+++ b/assets/js/modules/pagespeed-insights/components/dashboard/DashboardPageSpeed.js
@@ -271,7 +271,7 @@ export default function DashboardPageSpeed() {
 			<Grid
 				id="googlesitekit-pagespeed-header" // Used by jump link.
 			>
-				<div className="mdc-layout-grid__inner">
+				<Row>
 					<div className=" mdc-layout-grid__cell mdc-layout-grid__cell--span-12">
 						<ProgressBar />
 						<p className="googlesitekit-text-align-center">
@@ -281,7 +281,7 @@ export default function DashboardPageSpeed() {
 							) }
 						</p>
 					</div>
-				</div>
+				</Row>
 			</Grid>
 		);
 	}

--- a/assets/js/modules/pagespeed-insights/components/dashboard/DashboardPageSpeed.js
+++ b/assets/js/modules/pagespeed-insights/components/dashboard/DashboardPageSpeed.js
@@ -272,7 +272,7 @@ export default function DashboardPageSpeed() {
 				id="googlesitekit-pagespeed-header" // Used by jump link.
 			>
 				<Row>
-					<div className=" mdc-layout-grid__cell mdc-layout-grid__cell--span-12">
+					<Cell size={ 12 }>
 						<ProgressBar />
 						<p className="googlesitekit-text-align-center">
 							{ __(
@@ -280,7 +280,7 @@ export default function DashboardPageSpeed() {
 								'google-site-kit'
 							) }
 						</p>
-					</div>
+					</Cell>
 				</Row>
 			</Grid>
 		);

--- a/assets/js/modules/pagespeed-insights/components/dashboard/DashboardPageSpeed.js
+++ b/assets/js/modules/pagespeed-insights/components/dashboard/DashboardPageSpeed.js
@@ -42,6 +42,7 @@ import { __ } from '@wordpress/i18n';
  */
 import API from 'googlesitekit-api';
 import Data from 'googlesitekit-data';
+import { Cell, Grid, Row } from '../../../../material-components';
 import ViewContextContext from '../../../../components/Root/ViewContextContext';
 import DeviceSizeTabBar from '../../../../components/DeviceSizeTabBar';
 import ProgressBar from '../../../../components/ProgressBar';
@@ -267,9 +268,8 @@ export default function DashboardPageSpeed() {
 
 	if ( ! referenceURL || ( isFetching && ! reportData ) || ! dataSrc ) {
 		return (
-			<div
+			<Grid
 				id="googlesitekit-pagespeed-header" // Used by jump link.
-				className="mdc-layout-grid"
 			>
 				<div className="mdc-layout-grid__inner">
 					<div className=" mdc-layout-grid__cell mdc-layout-grid__cell--span-12">
@@ -282,7 +282,7 @@ export default function DashboardPageSpeed() {
 						</p>
 					</div>
 				</div>
-			</div>
+			</Grid>
 		);
 	}
 

--- a/assets/js/modules/subscribe-with-google/components/settings/SettingsForm.stories.js
+++ b/assets/js/modules/subscribe-with-google/components/settings/SettingsForm.stories.js
@@ -20,7 +20,7 @@
  * Internal dependencies
  */
 import SettingsForm from './SettingsForm';
-import { Cell, Grid } from '../../../../material-components';
+import { Cell, Grid, Row } from '../../../../material-components';
 import { MODULES_SUBSCRIBE_WITH_GOOGLE } from '../../datastore/constants';
 import {
 	provideModules,
@@ -38,11 +38,11 @@ function Template() {
 				<div className="googlesitekit-setup-module">
 					<div className="googlesitekit-settings-module__content googlesitekit-settings-module__content--open">
 						<Grid>
-							<div className="mdc-layout-inner">
+							<Row>
 								<Cell size={ 12 }>
 									<SettingsForm />
 								</Cell>
-							</div>
+							</Row>
 						</Grid>
 					</div>
 				</div>

--- a/assets/js/modules/subscribe-with-google/components/settings/SettingsForm.stories.js
+++ b/assets/js/modules/subscribe-with-google/components/settings/SettingsForm.stories.js
@@ -39,9 +39,9 @@ function Template() {
 					<div className="googlesitekit-settings-module__content googlesitekit-settings-module__content--open">
 						<Grid>
 							<div className="mdc-layout-inner">
-								<div className="mdc-layout-grid__cell mdc-layout-grid__cell--span-12">
+								<Cell size={ 12 }>
 									<SettingsForm />
-								</div>
+								</Cell>
 							</div>
 						</Grid>
 					</div>

--- a/assets/js/modules/subscribe-with-google/components/settings/SettingsForm.stories.js
+++ b/assets/js/modules/subscribe-with-google/components/settings/SettingsForm.stories.js
@@ -20,6 +20,7 @@
  * Internal dependencies
  */
 import SettingsForm from './SettingsForm';
+import { Cell, Grid, Row } from '../../../../material-components';
 import { MODULES_SUBSCRIBE_WITH_GOOGLE } from '../../datastore/constants';
 import {
 	provideModules,
@@ -36,13 +37,13 @@ function Template() {
 			<div className="googlesitekit-settings-module googlesitekit-settings-module--active googlesitekit-settings-module--subscribe-with-google">
 				<div className="googlesitekit-setup-module">
 					<div className="googlesitekit-settings-module__content googlesitekit-settings-module__content--open">
-						<div className="mdc-layout-grid">
+						<Grid>
 							<div className="mdc-layout-inner">
 								<div className="mdc-layout-grid__cell mdc-layout-grid__cell--span-12">
 									<SettingsForm />
 								</div>
 							</div>
-						</div>
+						</Grid>
 					</div>
 				</div>
 			</div>

--- a/assets/js/modules/subscribe-with-google/components/settings/SettingsForm.stories.js
+++ b/assets/js/modules/subscribe-with-google/components/settings/SettingsForm.stories.js
@@ -20,7 +20,7 @@
  * Internal dependencies
  */
 import SettingsForm from './SettingsForm';
-import { Cell, Grid, Row } from '../../../../material-components';
+import { Cell, Grid } from '../../../../material-components';
 import { MODULES_SUBSCRIBE_WITH_GOOGLE } from '../../datastore/constants';
 import {
 	provideModules,

--- a/assets/js/modules/subscribe-with-google/components/settings/SettingsView.stories.js
+++ b/assets/js/modules/subscribe-with-google/components/settings/SettingsView.stories.js
@@ -20,7 +20,7 @@
  * Internal dependencies
  */
 import SettingsView from './SettingsView';
-import { Cell, Grid } from '../../../../material-components';
+import { Cell, Grid, Row } from '../../../../material-components';
 import { MODULES_SUBSCRIBE_WITH_GOOGLE } from '../../datastore/constants';
 import {
 	provideModules,
@@ -37,11 +37,11 @@ function Template() {
 			<div className="googlesitekit-settings-module googlesitekit-settings-module--active googlesitekit-settings-module--subscribe-with-google">
 				<div className="googlesitekit-settings-module__content googlesitekit-settings-module__content--open">
 					<Grid>
-						<div className="mdc-layout-inner">
+						<Row>
 							<Cell size={ 12 }>
 								<SettingsView />
 							</Cell>
-						</div>
+						</Row>
 					</Grid>
 				</div>
 			</div>

--- a/assets/js/modules/subscribe-with-google/components/settings/SettingsView.stories.js
+++ b/assets/js/modules/subscribe-with-google/components/settings/SettingsView.stories.js
@@ -38,9 +38,9 @@ function Template() {
 				<div className="googlesitekit-settings-module__content googlesitekit-settings-module__content--open">
 					<Grid>
 						<div className="mdc-layout-inner">
-							<div className="mdc-layout-grid__cell mdc-layout-grid__cell--span-12">
+							<Cell size={ 12 }>
 								<SettingsView />
-							</div>
+							</Cell>
 						</div>
 					</Grid>
 				</div>

--- a/assets/js/modules/subscribe-with-google/components/settings/SettingsView.stories.js
+++ b/assets/js/modules/subscribe-with-google/components/settings/SettingsView.stories.js
@@ -20,7 +20,7 @@
  * Internal dependencies
  */
 import SettingsView from './SettingsView';
-import { Cell, Grid, Row } from '../../../../material-components';
+import { Cell, Grid } from '../../../../material-components';
 import { MODULES_SUBSCRIBE_WITH_GOOGLE } from '../../datastore/constants';
 import {
 	provideModules,

--- a/assets/js/modules/subscribe-with-google/components/settings/SettingsView.stories.js
+++ b/assets/js/modules/subscribe-with-google/components/settings/SettingsView.stories.js
@@ -20,6 +20,7 @@
  * Internal dependencies
  */
 import SettingsView from './SettingsView';
+import { Cell, Grid, Row } from '../../../../material-components';
 import { MODULES_SUBSCRIBE_WITH_GOOGLE } from '../../datastore/constants';
 import {
 	provideModules,
@@ -35,13 +36,13 @@ function Template() {
 		<div className="googlesitekit-layout">
 			<div className="googlesitekit-settings-module googlesitekit-settings-module--active googlesitekit-settings-module--subscribe-with-google">
 				<div className="googlesitekit-settings-module__content googlesitekit-settings-module__content--open">
-					<div className="mdc-layout-grid">
+					<Grid>
 						<div className="mdc-layout-inner">
 							<div className="mdc-layout-grid__cell mdc-layout-grid__cell--span-12">
 								<SettingsView />
 							</div>
 						</div>
-					</div>
+					</Grid>
 				</div>
 			</div>
 		</div>

--- a/stories/settings.stories.js
+++ b/stories/settings.stories.js
@@ -36,7 +36,7 @@ import { __ } from '@wordpress/i18n';
 import SettingsModules from '../assets/js/components/settings/SettingsModules';
 import Layout from '../assets/js/components/layout/Layout';
 import SettingsAdmin from '../assets/js/components/settings/SettingsAdmin';
-import { Cell, Grid, Row } from '../assets/js/material-components';
+import { Grid } from '../assets/js/material-components';
 import {
 	provideModuleRegistrations,
 	provideSiteInfo,

--- a/stories/settings.stories.js
+++ b/stories/settings.stories.js
@@ -36,6 +36,7 @@ import { __ } from '@wordpress/i18n';
 import SettingsModules from '../assets/js/components/settings/SettingsModules';
 import Layout from '../assets/js/components/layout/Layout';
 import SettingsAdmin from '../assets/js/components/settings/SettingsAdmin';
+import { Cell, Grid, Row } from '../assets/js/material-components';
 import {
 	provideModuleRegistrations,
 	provideSiteInfo,
@@ -167,9 +168,9 @@ storiesOf( 'Settings', module )
 
 			return (
 				<WithTestRegistry callback={ setupRegistry }>
-					<div className="mdc-layout-grid">
+					<Grid>
 						<SettingsAdmin />
-					</div>
+					</Grid>
 				</WithTestRegistry>
 			);
 		},

--- a/stories/widgets.stories.js
+++ b/stories/widgets.stories.js
@@ -43,9 +43,9 @@ const { HALF, QUARTER, FULL } = WIDGET_WIDTHS;
 function BoxesWidgets( { children } ) {
 	return (
 		<Grid className="googlesitekit-widget-area googlesitekit-widget-area--boxes">
-			<div className="googlesitekit-widget-area-widgets">
-				<Row>{ children }</Row>
-			</div>
+			<Row className="googlesitekit-widget-area-widgets">
+				{ children }
+			</Row>
 		</Grid>
 	);
 }
@@ -53,15 +53,13 @@ function BoxesWidgets( { children } ) {
 function CompositeWidgets( { children } ) {
 	return (
 		<Grid className="googlesitekit-widget-area googlesitekit-widget-area--composite">
-			<div className="googlesitekit-widget-area-widgets">
-				<Row>
-					<Cell size={ 12 }>
-						<Grid>
-							<Row>{ children }</Row>
-						</Grid>
-					</Cell>
-				</Row>
-			</div>
+			<Row className="googlesitekit-widget-area-widgets">
+				<Cell size={ 12 }>
+					<Grid>
+						<Row>{ children }</Row>
+					</Grid>
+				</Cell>
+			</Row>
 		</Grid>
 	);
 }

--- a/stories/widgets.stories.js
+++ b/stories/widgets.stories.js
@@ -55,11 +55,11 @@ function CompositeWidgets( { children } ) {
 		<Grid className="googlesitekit-widget-area googlesitekit-widget-area--composite">
 			<div className="googlesitekit-widget-area-widgets">
 				<Row>
-					<div className="mdc-layout-grid__cell mdc-layout-grid__cell--span-12">
+					<Cell size={ 12 }>
 						<Grid>
 							<Row>{ children }</Row>
 						</Grid>
-					</div>
+					</Cell>
 				</Row>
 			</div>
 		</Grid>
@@ -68,9 +68,9 @@ function CompositeWidgets( { children } ) {
 
 function QuarterWidgetInGrid( props ) {
 	return (
-		<div className="mdc-layout-grid__cell mdc-layout-grid__cell--span-3-desktop mdc-layout-grid__cell--span-4-tablet">
+		<Cell mdSize={ 4 } lgSize={ 3 }>
 			<Widget { ...props } />
-		</div>
+		</Cell>
 	);
 }
 

--- a/stories/widgets.stories.js
+++ b/stories/widgets.stories.js
@@ -32,6 +32,7 @@ import {
 } from '../tests/js/utils';
 import Widget from '../assets/js/googlesitekit/widgets/components/Widget';
 import WidgetAreaRenderer from '../assets/js/googlesitekit/widgets/components/WidgetAreaRenderer';
+import { Cell, Grid, Row } from '../assets/js/material-components';
 import {
 	CORE_WIDGETS,
 	WIDGET_WIDTHS,
@@ -55,11 +56,11 @@ function CompositeWidgets( { children } ) {
 			<div className="googlesitekit-widget-area-widgets">
 				<div className="mdc-layout-grid__inner">
 					<div className="mdc-layout-grid__cell mdc-layout-grid__cell--span-12">
-						<div className="mdc-layout-grid">
+						<Grid>
 							<div className="mdc-layout-grid__inner">
 								{ children }
 							</div>
-						</div>
+						</Grid>
 					</div>
 				</div>
 			</div>

--- a/stories/widgets.stories.js
+++ b/stories/widgets.stories.js
@@ -44,7 +44,7 @@ function BoxesWidgets( { children } ) {
 	return (
 		<Grid className="googlesitekit-widget-area googlesitekit-widget-area--boxes">
 			<div className="googlesitekit-widget-area-widgets">
-				<div className="mdc-layout-grid__inner">{ children }</div>
+				<Row>{ children }</Row>
 			</div>
 		</Grid>
 	);
@@ -54,15 +54,13 @@ function CompositeWidgets( { children } ) {
 	return (
 		<Grid className="googlesitekit-widget-area googlesitekit-widget-area--composite">
 			<div className="googlesitekit-widget-area-widgets">
-				<div className="mdc-layout-grid__inner">
+				<Row>
 					<div className="mdc-layout-grid__cell mdc-layout-grid__cell--span-12">
 						<Grid>
-							<div className="mdc-layout-grid__inner">
-								{ children }
-							</div>
+							<Row>{ children }</Row>
 						</Grid>
 					</div>
-				</div>
+				</Row>
 			</div>
 		</Grid>
 	);

--- a/stories/widgets.stories.js
+++ b/stories/widgets.stories.js
@@ -42,17 +42,17 @@ const { HALF, QUARTER, FULL } = WIDGET_WIDTHS;
 
 function BoxesWidgets( { children } ) {
 	return (
-		<div className="mdc-layout-grid googlesitekit-widget-area googlesitekit-widget-area--boxes">
+		<Grid className="googlesitekit-widget-area googlesitekit-widget-area--boxes">
 			<div className="googlesitekit-widget-area-widgets">
 				<div className="mdc-layout-grid__inner">{ children }</div>
 			</div>
-		</div>
+		</Grid>
 	);
 }
 
 function CompositeWidgets( { children } ) {
 	return (
-		<div className="mdc-layout-grid googlesitekit-widget-area googlesitekit-widget-area--composite">
+		<Grid className="googlesitekit-widget-area googlesitekit-widget-area--composite">
 			<div className="googlesitekit-widget-area-widgets">
 				<div className="mdc-layout-grid__inner">
 					<div className="mdc-layout-grid__cell mdc-layout-grid__cell--span-12">
@@ -64,7 +64,7 @@ function CompositeWidgets( { children } ) {
 					</div>
 				</div>
 			</div>
-		</div>
+		</Grid>
 	);
 }
 


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #2273 

## Relevant technical choices

Augmented `Cell` component to abstract away remaining `mdc-layout-grid__cell--*` class usage in consumers of `Cell`.

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
