### PR TITLE
Fix dependency prefixing in GHA

### DIFF
--- a/.github/workflows/e2e-tests-wp-4-7.yml
+++ b/.github/workflows/e2e-tests-wp-4-7.yml
@@ -117,7 +117,7 @@ jobs:
       - uses: shivammathur/setup-php@v2
         with:
           php-version: '7.x'
-          tools: composer
+          tools: composer:2.1
 
       - name: Get Composer Cache Directory
         id: composer-cache

--- a/.github/workflows/e2e-tests-wp-4-9-gutenberg.yml
+++ b/.github/workflows/e2e-tests-wp-4-9-gutenberg.yml
@@ -115,7 +115,7 @@ jobs:
       - uses: shivammathur/setup-php@v2
         with:
           php-version: '7.x'
-          tools: composer
+          tools: composer:2.1
 
       - name: Get Composer Cache Directory
         id: composer-cache

--- a/.github/workflows/e2e-tests-wp-latest.yml
+++ b/.github/workflows/e2e-tests-wp-latest.yml
@@ -116,7 +116,7 @@ jobs:
       - uses: shivammathur/setup-php@v2
         with:
           php-version: '7.x'
-          tools: composer
+          tools: composer:2.1
 
       - name: Get Composer Cache Directory
         id: composer-cache

--- a/.github/workflows/e2e-tests-wp-nightly.yml
+++ b/.github/workflows/e2e-tests-wp-nightly.yml
@@ -116,7 +116,7 @@ jobs:
       - uses: shivammathur/setup-php@v2
         with:
           php-version: '7.x'
-          tools: composer
+          tools: composer:2.1
 
       - name: Get Composer Cache Directory
         id: composer-cache

--- a/.github/workflows/php-tests-wp-4-7-php-5-6.yml
+++ b/.github/workflows/php-tests-wp-4-7-php-5-6.yml
@@ -57,7 +57,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: shivammathur/setup-php@v2
         with:
-          tools: composer
+          tools: composer:2.1
           php-version: '7.4' # Necessary for `composer install`
       - name: Get Composer Cache Directory
         id: composer-cache

--- a/.github/workflows/php-tests-wp-latest-multisite-php-7-4.yml
+++ b/.github/workflows/php-tests-wp-latest-multisite-php-7-4.yml
@@ -59,7 +59,7 @@ jobs:
       - uses: shivammathur/setup-php@v2
         with:
           extensions: mysqli, runkit7, uopz
-          tools: composer
+          tools: composer:2.1
           php-version: '7.4'
       - name: Get Composer Cache Directory
         id: composer-cache

--- a/.github/workflows/php-tests-wp-latest-php-7-4.yml
+++ b/.github/workflows/php-tests-wp-latest-php-7-4.yml
@@ -58,7 +58,7 @@ jobs:
       - uses: shivammathur/setup-php@v2
         with:
           extensions: mysqli, runkit7, uopz
-          tools: composer
+          tools: composer:2.1
           php-version: '7.4'
       - name: Get Composer Cache Directory
         id: composer-cache

--- a/.github/workflows/php-tests-wp-nightly-php-7-4.yml
+++ b/.github/workflows/php-tests-wp-nightly-php-7-4.yml
@@ -58,7 +58,7 @@ jobs:
       - uses: shivammathur/setup-php@v2
         with:
           extensions: mysqli, runkit7, uopz
-          tools: composer
+          tools: composer:2.1
           php-version: '7.4'
       - name: Get Composer Cache Directory
         id: composer-cache

--- a/composer.json
+++ b/composer.json
@@ -56,7 +56,7 @@
     ],
     "prefix-dependencies": [
       "@composer --working-dir=php-scoper install",
-      "php-scoper/vendor/bin/php-scoper add --output-dir=./third-party --force -vvv",
+      "php-scoper/vendor/bin/php-scoper add --output-dir=./third-party --force --quiet",
       "@autoload-includes",
       "@autoload-third-party",
       "@composer dump-autoload --no-dev",

--- a/composer.json
+++ b/composer.json
@@ -56,7 +56,7 @@
     ],
     "prefix-dependencies": [
       "@composer --working-dir=php-scoper install",
-      "php-scoper/vendor/bin/php-scoper add --output-dir=./third-party --force --quiet",
+      "php-scoper/vendor/bin/php-scoper add --output-dir=./third-party --force -vvv",
       "@autoload-includes",
       "@autoload-third-party",
       "@composer dump-autoload --no-dev",


### PR DESCRIPTION
## Summary

Addresses issue #4605

## Relevant technical choices

* Tests show that the problem started with the recent release of Composer 2.2.
	* Both 2.2.0 and 2.2.1 fail in this way
	* The latest Composer 2.1.x works as checks will show below
* Only seems to affect PHP 7 so other jobs for 5.6 and 8 were left to use the latest version of Composer

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
