### PR TITLE
Add HelpMenu back in the adsense module.

### DIFF
--- a/assets/js/components/module/ModuleApp.js
+++ b/assets/js/components/module/ModuleApp.js
@@ -36,6 +36,7 @@ import Alert from '../Alert';
 import ModuleHeader from './ModuleHeader';
 import WidgetContextRenderer from '../../googlesitekit/widgets/components/WidgetContextRenderer';
 import DateRangeSelector from '../DateRangeSelector';
+import HelpMenu from '../help/HelpMenu';
 import { CORE_MODULES } from '../../googlesitekit/modules/datastore/constants';
 
 const { useSelect } = Data;
@@ -51,7 +52,10 @@ function ModuleApp( { moduleSlug } ) {
 
 	return (
 		<Fragment>
-			<Header>{ moduleConnected && <DateRangeSelector /> }</Header>
+			<Header>
+				<HelpMenu />
+				{ moduleConnected && <DateRangeSelector /> }
+			</Header>
 			<Alert module={ moduleSlug } />
 			<WidgetContextRenderer
 				slug={ screenWidgetContext }

--- a/assets/js/components/setup/ModuleSetup.js
+++ b/assets/js/components/setup/ModuleSetup.js
@@ -36,6 +36,7 @@ import { CORE_SITE } from '../../googlesitekit/datastore/site/constants';
 import { CORE_MODULES } from '../../googlesitekit/modules/datastore/constants';
 import { CORE_LOCATION } from '../../googlesitekit/datastore/location/constants';
 import { trackEvent } from '../../util';
+import HelpMenu from '../help/HelpMenu';
 import { Cell, Grid, Row } from '../../material-components';
 import Header from '../Header';
 import Link from '../Link';
@@ -100,7 +101,9 @@ export default function ModuleSetup( { moduleSlug } ) {
 
 	return (
 		<Fragment>
-			<Header />
+			<Header>
+				<HelpMenu />
+			</Header>
 			<div className="googlesitekit-setup">
 				<Grid>
 					<Row>


### PR DESCRIPTION
## Summary

Addresses issue #4423 

## Relevant technical choices

## Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

This is a follow-up PR for [4578](https://github.com/google/site-kit-wp/pull/4578)

