### PR TITLE
Update PageSpeed and Idea Hub to be modules with owners.

### DIFF
--- a/includes/Modules/Idea_Hub.php
+++ b/includes/Modules/Idea_Hub.php
@@ -24,6 +24,8 @@ use Google\Site_Kit\Core\Modules\Module_With_Deactivation;
 use Google\Site_Kit\Core\Modules\Module_With_Debug_Fields;
 use Google\Site_Kit\Core\Modules\Module_With_Assets;
 use Google\Site_Kit\Core\Modules\Module_With_Assets_Trait;
+use Google\Site_Kit\Core\Modules\Module_With_Owner;
+use Google\Site_Kit\Core\Modules\Module_With_Owner_Trait;
 use Google\Site_Kit\Core\Modules\Module_With_Persistent_Registration;
 use Google\Site_Kit\Core\Modules\Module_With_Scopes;
 use Google\Site_Kit\Core\Modules\Module_With_Scopes_Trait;
@@ -60,9 +62,10 @@ use WP_Post;
  * @ignore
  */
 final class Idea_Hub extends Module
-	implements Module_With_Scopes, Module_With_Settings, Module_With_Debug_Fields, Module_With_Assets, Module_With_Deactivation, Module_With_Persistent_Registration {
+	implements Module_With_Scopes, Module_With_Settings, Module_With_Debug_Fields, Module_With_Assets, Module_With_Deactivation, Module_With_Owner, Module_With_Persistent_Registration {
 
 	use Module_With_Assets_Trait;
+	use Module_With_Owner_Trait;
 	use Module_With_Scopes_Trait;
 	use Module_With_Settings_Trait;
 	use Method_Proxy_Trait;

--- a/includes/Modules/Idea_Hub/Settings.php
+++ b/includes/Modules/Idea_Hub/Settings.php
@@ -31,6 +31,9 @@ class Settings extends Module_Settings {
 	 * @return array
 	 */
 	protected function get_default() {
-		return array( 'tosAccepted' => false );
+		return array(
+			'tosAccepted' => false,
+			'ownerID'     => 0,
+		);
 	}
 }

--- a/includes/Modules/PageSpeed_Insights.php
+++ b/includes/Modules/PageSpeed_Insights.php
@@ -15,12 +15,17 @@ use Google\Site_Kit\Core\Modules\Module;
 use Google\Site_Kit\Core\Modules\Module_With_Assets;
 use Google\Site_Kit\Core\Modules\Module_With_Assets_Trait;
 use Google\Site_Kit\Core\Modules\Module_With_Deactivation;
+use Google\Site_Kit\Core\Modules\Module_With_Owner;
+use Google\Site_Kit\Core\Modules\Module_With_Owner_Trait;
+use Google\Site_Kit\Core\Modules\Module_With_Settings;
+use Google\Site_Kit\Core\Modules\Module_With_Settings_Trait;
 use Google\Site_Kit\Core\Modules\Module_With_Scopes;
 use Google\Site_Kit\Core\Modules\Module_With_Scopes_Trait;
 use Google\Site_Kit\Core\REST_API\Exception\Invalid_Datapoint_Exception;
 use Google\Site_Kit\Core\Authentication\Clients\Google_Site_Kit_Client;
 use Google\Site_Kit\Core\REST_API\Data_Request;
 use Google\Site_Kit\Core\Util\Feature_Flags;
+use Google\Site_Kit\Modules\PageSpeed_Insights\Settings;
 use Google\Site_Kit_Dependencies\Google\Service\PagespeedInsights as Google_Service_PagespeedInsights;
 use Google\Site_Kit_Dependencies\Psr\Http\Message\RequestInterface;
 use WP_Error;
@@ -33,8 +38,8 @@ use WP_Error;
  * @ignore
  */
 final class PageSpeed_Insights extends Module
-	implements Module_With_Scopes, Module_With_Assets, Module_With_Deactivation {
-	use Module_With_Scopes_Trait, Module_With_Assets_Trait;
+	implements Module_With_Scopes, Module_With_Assets, Module_With_Deactivation, Module_With_Settings, Module_With_Owner {
+	use Module_With_Scopes_Trait, Module_With_Assets_Trait, Module_With_Settings_Trait, Module_With_Owner_Trait;
 
 	/**
 	 * Module slug name.
@@ -54,8 +59,7 @@ final class PageSpeed_Insights extends Module
 	 * @since 1.0.0
 	 */
 	public function on_deactivation() {
-		// TODO: Remove in a future release.
-		$this->options->delete( 'googlesitekit_pagespeed_insights_settings' );
+		$this->get_settings()->delete();
 	}
 
 	/**
@@ -177,6 +181,17 @@ final class PageSpeed_Insights extends Module
 			'order'       => 4,
 			'homepage'    => __( 'https://pagespeed.web.dev', 'google-site-kit' ),
 		);
+	}
+
+	/**
+	 * Sets up the module's settings instance.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @return Module_Settings
+	 */
+	protected function setup_settings() {
+		return new Settings( $this->options );
 	}
 
 	/**

--- a/includes/Modules/PageSpeed_Insights/Settings.php
+++ b/includes/Modules/PageSpeed_Insights/Settings.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Class Google\Site_Kit\Modules\PageSpeed_Insights\Settings
+ *
+ * @package   Google\Site_Kit\Modules\PageSpeed_Insights
+ * @copyright 2021 Google LLC
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
+ * @link      https://sitekit.withgoogle.com
+ */
+
+namespace Google\Site_Kit\Modules\PageSpeed_Insights;
+
+use Google\Site_Kit\Core\Modules\Module_Settings;
+
+/**
+ * Class for PageSpeed Insights settings.
+ *
+ * @since n.e.x.t
+ * @access private
+ * @ignore
+ */
+class Settings extends Module_Settings {
+
+	const OPTION = 'googlesitekit_pagespeed-insights_settings';
+
+	/**
+	 * Gets the default value.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @return array
+	 */
+	protected function get_default() {
+		return array( 'ownerID' => 0 );
+	}
+}

--- a/tests/phpunit/integration/Modules/Idea_Hub/SettingsTest.php
+++ b/tests/phpunit/integration/Modules/Idea_Hub/SettingsTest.php
@@ -26,7 +26,10 @@ class SettingsTest extends SettingsTestCase {
 		$settings->register();
 
 		$this->assertEqualSetsWithIndex(
-			array( 'tosAccepted' => false ),
+			array(
+				'tosAccepted' => false,
+				'ownerID'     => 0,
+			),
 			get_option( Settings::OPTION )
 		);
 	}

--- a/tests/phpunit/integration/Modules/PageSpeed_Insights/SettingsTest.php
+++ b/tests/phpunit/integration/Modules/PageSpeed_Insights/SettingsTest.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Class Google\Site_Kit\Tests\Modules\PageSpeed_Insights\SettingsTest
+ *
+ * @package   Google\Site_Kit\Tests\Modules\PageSpeed_Insights
+ * @copyright 2021 Google LLC
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
+ * @link      https://sitekit.withgoogle.com
+ */
+
+namespace Google\Site_Kit\Tests\Modules\PageSpeed_Insights;
+
+use Google\Site_Kit\Context;
+use Google\Site_Kit\Core\Storage\Options;
+use Google\Site_Kit\Modules\PageSpeed_Insights\Settings;
+use Google\Site_Kit\Tests\Modules\SettingsTestCase;
+
+/**
+ * @group Modules
+ * @group PageSpeed_Insights
+ */
+class SettingsTest extends SettingsTestCase {
+
+	public function test_get_default() {
+		$settings = new Settings( new Options( new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE ) ) );
+		$settings->register();
+
+		$this->assertEqualSetsWithIndex(
+			array( 'ownerID' => 0 ),
+			get_option( Settings::OPTION )
+		);
+	}
+
+	protected function get_testcase() {
+		return $this;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	protected function get_option_name() {
+		return Settings::OPTION;
+	}
+}


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #4476 

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
