### PR TITLE
Open AdSense Overview Widget source link in a new tab/window.

### DIFF
--- a/assets/js/modules/adsense/components/module/ModuleOverviewWidget/Footer.js
+++ b/assets/js/modules/adsense/components/module/ModuleOverviewWidget/Footer.js
@@ -50,6 +50,7 @@ const Footer = () => {
 		<SourceLink
 			href={ accountSiteURL }
 			name={ _x( 'AdSense', 'Service name', 'google-site-kit' ) }
+			external
 		/>
 	);
 };


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #4570 

## Relevant technical choices

Add missing `external` prop to `SourceLink` in `assets/js/modules/adsense/components/module/ModuleOverviewWidget/Footer.js`.

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
