### PR TITLE
Use non-widget ReportZero when Analytics is gathering data.

### DIFF
--- a/assets/js/modules/search-console/components/dashboard/SearchFunnelWidget/Overview.js
+++ b/assets/js/modules/search-console/components/dashboard/SearchFunnelWidget/Overview.js
@@ -334,7 +334,6 @@ Overview.propTypes = {
 	selectedStats: PropTypes.number.isRequired,
 	handleStatsSelection: PropTypes.func.isRequired,
 	error: PropTypes.object,
-	WidgetReportZero: PropTypes.elementType.isRequired,
 	WidgetReportError: PropTypes.elementType.isRequired,
 };
 

--- a/assets/js/modules/search-console/components/dashboard/SearchFunnelWidget/Overview.js
+++ b/assets/js/modules/search-console/components/dashboard/SearchFunnelWidget/Overview.js
@@ -48,6 +48,7 @@ import CTA from '../../../../../components/notifications/CTA';
 import ViewContextContext from '../../../../../components/Root/ViewContextContext';
 import DataBlock from '../../../../../components/DataBlock';
 import ProgressBar from '../../../../../components/ProgressBar';
+import ReportZero from '../../../../../components/ReportZero';
 const { useSelect, useInViewSelect } = Data;
 
 function getDatapointAndChange( [ report ], selectedStat, divider = 1 ) {
@@ -70,7 +71,6 @@ const Overview = ( {
 	handleStatsSelection,
 	dateRangeLength,
 	error,
-	WidgetReportZero,
 	WidgetReportError,
 } ) => {
 	const viewContext = useContext( ViewContextContext );
@@ -220,7 +220,8 @@ const Overview = ( {
 
 				{ isAnalyticsGatheringData && ! error && (
 					<Cell { ...halfCellProps }>
-						<WidgetReportZero moduleSlug="analytics" />
+						{ /* We need to use ReportZero rather than WidgetReportZero to not associate a zero state for the whole widget. */ }
+						<ReportZero moduleSlug="analytics" />
 					</Cell>
 				) }
 

--- a/assets/js/modules/search-console/components/dashboard/SearchFunnelWidget/index.js
+++ b/assets/js/modules/search-console/components/dashboard/SearchFunnelWidget/index.js
@@ -352,7 +352,6 @@ const SearchFunnelWidget = ( {
 					analyticsVisitorsStatsError ||
 					analyticsGoalsError
 				}
-				WidgetReportZero={ WidgetReportZero }
 				WidgetReportError={ WidgetReportError }
 			/>
 


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #4571 

## Relevant technical choices

- Removes `WidgetReportZero` from being used in the inner `Overview` component as this causes the entire Traffic section to be hidden due to the widgets collapsing into the same zero-data state
- `WidgetReportZero` should only be used in this widget when Search Console is zero data which is already handled before `Overview` is rendered

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
