### PR TITLE
Update `useInViewSelect` to return latest value while it is out of view

### DIFF
--- a/assets/js/hooks/useInViewSelect.js
+++ b/assets/js/hooks/useInViewSelect.js
@@ -20,7 +20,7 @@
  * WordPress dependencies
  */
 import { useSelect } from '@wordpress/data';
-import { useCallback } from '@wordpress/element';
+import { useCallback, useRef } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -39,6 +39,7 @@ import { useInView } from './useInView';
  */
 export const useInViewSelect = ( mapSelect, deps = [] ) => {
 	const isInView = useInView( { sticky: true } );
+	const latestSelectorResult = useRef();
 
 	const mapSelectCallback = useCallback( mapSelect, [ ...deps, mapSelect ] );
 
@@ -50,5 +51,9 @@ export const useInViewSelect = ( mapSelect, deps = [] ) => {
 			  }
 	);
 
-	return selectorResult;
+	if ( isInView ) {
+		latestSelectorResult.current = selectorResult;
+	}
+
+	return latestSelectorResult.current;
 };

--- a/assets/js/hooks/useInViewSelect.test.js
+++ b/assets/js/hooks/useInViewSelect.test.js
@@ -128,7 +128,7 @@ describe( 'useInViewSelect', () => {
 		await act( () =>
 			registry.dispatch( CORE_UI ).setValue( 'test', '999' )
 		);
-		rerender(); // just to be sure.
+		rerender();
 
 		// The result is the same because the inView state is false.
 		expect( result.current ).toBe( '123' );


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #4642 

## Relevant technical choices

<!-- Please describe your changes. -->

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
