### PR TITLE
Fix `commonArgs` to include `url`

### DIFF
--- a/assets/js/modules/analytics/components/dashboard/DashboardSearchVisitorsWidget.js
+++ b/assets/js/modules/analytics/components/dashboard/DashboardSearchVisitorsWidget.js
@@ -48,6 +48,9 @@ function DashboardSearchVisitorsWidget( props ) {
 	const isGatheringData = useInViewSelect( ( select ) =>
 		select( MODULES_ANALYTICS ).isGatheringData()
 	);
+	const url = useSelect( ( select ) =>
+		select( CORE_SITE ).getCurrentEntityURL()
+	);
 
 	const { compareStartDate, compareEndDate, startDate, endDate } = useSelect(
 		( select ) =>
@@ -66,6 +69,7 @@ function DashboardSearchVisitorsWidget( props ) {
 				alias: 'Users',
 			},
 		],
+		...( url && { url } ),
 	};
 
 	const sparklineArgs = {
@@ -87,13 +91,6 @@ function DashboardSearchVisitorsWidget( props ) {
 		compareEndDate,
 		...commonArgs,
 	};
-
-	const url = useSelect( ( select ) =>
-		select( CORE_SITE ).getCurrentEntityURL()
-	);
-	if ( url ) {
-		commonArgs.url = url;
-	}
 
 	const { loading, error, serviceURL } = useSelect( ( select ) => {
 		const store = select( MODULES_ANALYTICS );


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #4361 

## Relevant technical choices

- Fixes a regression where `commonArgs` no longer included `url` until after it was used

## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
