### PR TITLE
Fix ManifestPlugin args for Gutenberg Entry Points.

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -519,7 +519,7 @@ function* webpackConfig( env, argv ) {
 				cwd: process.cwd(),
 			} ),
 			new ManifestPlugin( {
-				...manifestArgs,
+				...manifestArgs( mode ),
 				filter( file ) {
 					return ( file.name || '' ).match( /\.js$/ );
 				},


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #4107

## Relevant technical choices

- Fixes the definition of the Webpack manifest plugin in the bundle config for Gutenberg entry points

![image](https://user-images.githubusercontent.com/1621608/149536658-003f54a3-3e70-4304-a421-f8b1ed8a7840.png)

![image](https://user-images.githubusercontent.com/1621608/149536648-ec34c11c-5c53-4264-a389-6a8bacf8b0d5.png)


## Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
