### PR TITLE
Disable Header and Navigation Sticky Positioning when Feature Tour is Active

### DIFF
--- a/assets/js/components/TourTooltips.js
+++ b/assets/js/components/TourTooltips.js
@@ -110,10 +110,16 @@ export default function TourTooltips( {
 		setValue( stepKey, index + ( action === ACTIONS.PREV ? -1 : 1 ) );
 
 	const startTour = () => {
+		global.document.body.classList.add(
+			'googlesitekit-showing-feature-tour'
+		);
 		setValue( runKey, true );
 	};
 
 	const endTour = () => {
+		global.document.body.classList.remove(
+			'googlesitekit-showing-feature-tour'
+		);
 		// Dismiss tour to avoid unwanted repeat viewing.
 		dismissTour( tourID );
 	};

--- a/assets/js/components/TourTooltips.test.js
+++ b/assets/js/components/TourTooltips.test.js
@@ -168,6 +168,36 @@ describe( 'TourTooltips', () => {
 		).not.toBeInTheDocument();
 	} );
 
+	it( 'should add `googlesitekit-showing-feature-tour` class to `body`', async () => {
+		const { baseElement } = renderTourTooltipsWithMockUI( registry );
+
+		expect(
+			baseElement.classList.contains(
+				'googlesitekit-showing-feature-tour'
+			)
+		).toBe( true );
+	} );
+
+	it( 'should remove `googlesitekit-showing-feature-tour` class from `body` when tour ends', async () => {
+		const { baseElement, getByRole } = renderTourTooltipsWithMockUI(
+			registry
+		);
+
+		expect(
+			baseElement.classList.contains(
+				'googlesitekit-showing-feature-tour'
+			)
+		).toBe( true );
+
+		fireEvent.click( getByRole( 'button', { name: /close/i } ) );
+
+		expect(
+			baseElement.classList.contains(
+				'googlesitekit-showing-feature-tour'
+			)
+		).toBe( false );
+	} );
+
 	it( 'should end tour when close icon is clicked', async () => {
 		const { getByRole, queryByRole } = renderTourTooltipsWithMockUI(
 			registry

--- a/assets/sass/components/global/_googlesitekit-dashboard-navigation.scss
+++ b/assets/sass/components/global/_googlesitekit-dashboard-navigation.scss
@@ -29,6 +29,10 @@
 		top: 68px;
 		z-index: 10;
 
+		body.googlesitekit-showing-feature-tour & {
+			position: static;
+		}
+
 		body.admin-bar & {
 
 			@media ( min-width: $width-tablet + 1 + px ) {

--- a/assets/sass/components/global/_googlesitekit-entity-header.scss
+++ b/assets/sass/components/global/_googlesitekit-entity-header.scss
@@ -30,6 +30,10 @@
 		top: 132px;
 		z-index: 9; // Should be below _googlesitekit-dashboard-navigation.
 
+		body.googlesitekit-showing-feature-tour & {
+			position: static;
+		}
+
 		body.admin-bar & {
 
 			@media ( min-width: $width-tablet + 1 + px ) {

--- a/assets/sass/components/global/_googlesitekit-header.scss
+++ b/assets/sass/components/global/_googlesitekit-header.scss
@@ -34,6 +34,10 @@
 			padding-left: 28px;
 		}
 
+		body.googlesitekit-showing-feature-tour & {
+			position: static;
+		}
+
 		body.admin-bar & {
 
 			@media (min-width: $width-tablet + 1 + px) {


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #4453

## Relevant technical choices

<!-- Please describe your changes. -->

## Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
