### PR TITLE
Implement the new module sharing settings class.

### DIFF
--- a/includes/Core/Modules/Module_Sharing_Settings.php
+++ b/includes/Core/Modules/Module_Sharing_Settings.php
@@ -13,7 +13,7 @@ namespace Google\Site_Kit\Core\Modules;
 use Google\Site_Kit\Core\Storage\Setting;
 
 /**
- * Base class for module sharing settings.
+ * Class for module sharing settings.
  *
  * @since n.e.x.t
  * @access private
@@ -50,7 +50,7 @@ class Module_Sharing_Settings extends Setting {
 	 *
 	 * @since n.e.x.t
 	 *
-	 * @return callable|null
+	 * @return callable Callback method that filters or type casts invalid setting values.
 	 */
 	protected function get_sanitize_callback() {
 		return function( $option ) {
@@ -75,7 +75,7 @@ class Module_Sharing_Settings extends Setting {
 	}
 
 	/**
-	 * Filter empty or non-string elements from a given array.
+	 * Filters empty or non-string elements from a given array.
 	 *
 	 * @since n.e.x.t
 	 *

--- a/includes/Core/Modules/Module_Sharing_Settings.php
+++ b/includes/Core/Modules/Module_Sharing_Settings.php
@@ -97,4 +97,23 @@ class Module_Sharing_Settings extends Setting {
 		return array_values( $filtered_elements );
 	}
 
+	/**
+	 * Gets the settings after filling in default values.
+	 *
+	 * {@inheritDoc}
+	 *
+	 * @since n.e.x.t
+	 */
+	public function get() {
+		$settings = parent::get();
+
+		foreach ( $settings as $module_slug => $sharing_settings ) {
+			if ( ! isset( $sharing_settings['management'] ) || ! in_array( $sharing_settings['management'], array( 'all_admins', 'owner' ), true ) ) {
+				$settings[ $module_slug ]['management'] = 'owner';
+			}
+		}
+
+		return $settings;
+	}
+
 }

--- a/includes/Core/Modules/Module_Sharing_Settings.php
+++ b/includes/Core/Modules/Module_Sharing_Settings.php
@@ -59,7 +59,11 @@ class Module_Sharing_Settings extends Setting {
 			}
 			$sanitized_option = array();
 			foreach ( $option as $module_slug => $sharing_settings ) {
-				$sanitized_option[ $module_slug ]['sharedRoles'] = $this->sanitize_string_list( $sharing_settings['sharedRoles'] );
+				$sanitized_option[ $module_slug ] = array();
+
+				if ( isset( $sharing_settings['sharedRoles'] ) ) {
+					$sanitized_option[ $module_slug ]['sharedRoles'] = $this->sanitize_string_list( $sharing_settings['sharedRoles'] );
+				}
 
 				if ( isset( $sharing_settings['management'] ) ) {
 					$sanitized_option[ $module_slug ]['management'] = (string) $sharing_settings['management'];
@@ -108,6 +112,9 @@ class Module_Sharing_Settings extends Setting {
 		$settings = parent::get();
 
 		foreach ( $settings as $module_slug => $sharing_settings ) {
+			if ( ! isset( $sharing_settings['sharedRoles'] ) || ! is_array( $sharing_settings['sharedRoles'] ) ) {
+				$settings[ $module_slug ]['sharedRoles'] = array();
+			}
 			if ( ! isset( $sharing_settings['management'] ) || ! in_array( $sharing_settings['management'], array( 'all_admins', 'owner' ), true ) ) {
 				$settings[ $module_slug ]['management'] = 'owner';
 			}

--- a/includes/Core/Modules/Module_Sharing_Settings.php
+++ b/includes/Core/Modules/Module_Sharing_Settings.php
@@ -104,9 +104,9 @@ class Module_Sharing_Settings extends Setting {
 	/**
 	 * Gets the settings after filling in default values.
 	 *
-	 * {@inheritDoc}
-	 *
 	 * @since n.e.x.t
+	 *
+	 * @return array Value set for the option, or registered default if not set.
 	 */
 	public function get() {
 		$settings = parent::get();

--- a/includes/Core/Modules/Module_Sharing_Settings.php
+++ b/includes/Core/Modules/Module_Sharing_Settings.php
@@ -54,46 +54,47 @@ class Module_Sharing_Settings extends Setting {
 	 */
 	protected function get_sanitize_callback() {
 		return function( $option ) {
-			if ( is_array( $option ) ) {
-				foreach ( $option as &$sharing_settings ) {
-					if ( isset( $sharing_settings['sharedRoles'] ) ) {
-						$sharing_settings['sharedRoles'] = $this->filter_valid_roles( $sharing_settings['sharedRoles'] );
-					}
-					if ( isset( $sharing_settings['management'] ) ) {
-						$sharing_settings['management'] = (string) $sharing_settings['management'];
-					}
+			if ( ! is_array( $option ) ) {
+				return array();
+			}
+			$sanitized_option = array();
+			foreach ( $option as $module_slug => $sharing_settings ) {
+				$sanitized_option[ $module_slug ]['sharedRoles'] = $this->sanitize_string_list( $sharing_settings['sharedRoles'] );
+
+				if ( isset( $sharing_settings['management'] ) ) {
+					$sanitized_option[ $module_slug ]['management'] = (string) $sharing_settings['management'];
 				}
 			}
-			return $option;
+
+			return $sanitized_option;
 		};
 	}
 
 	/**
-	 * Removes invalid roles from a given array.
+	 * Filter empty or non-string elements from a given array.
 	 *
 	 * @since n.e.x.t
 	 *
-	 * @param array $roles Array of roles to check.
-	 * @return array Filtered array of roles that exist in the current site.
+	 * @param array $elements Array to check.
+	 * @return array Empty array or a filtered array containing only non-empty strings.
 	 */
-	private function filter_valid_roles( $roles = array() ) {
-		if ( ! is_array( $roles ) ) {
-			$roles = array( $roles );
+	private function sanitize_string_list( $elements = array() ) {
+		if ( ! is_array( $elements ) ) {
+			$elements = array( $elements );
 		}
 
-		if ( empty( $roles ) ) {
+		if ( empty( $elements ) ) {
 			return array();
 		}
 
-		$valid_roles    = wp_roles()->role_names;
-		$filtered_roles = array_filter(
-			$roles,
-			function( $role ) use ( $valid_roles ) {
-				return in_array( $role, array_keys( $valid_roles ), true );
+		$filtered_elements = array_filter(
+			$elements,
+			function( $element ) {
+				return is_string( $element ) && ! empty( $element );
 			}
 		);
 		// Avoid index gaps for filtered values.
-		return array_values( $filtered_roles );
+		return array_values( $filtered_elements );
 	}
 
 }

--- a/includes/Core/Modules/Module_Sharing_Settings.php
+++ b/includes/Core/Modules/Module_Sharing_Settings.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * Class Google\Site_Kit\Core\Modules\Module_Sharing_Settings
+ *
+ * @package   Google\Site_Kit\Core\Modules
+ * @copyright 2022 Google LLC
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
+ * @link      https://sitekit.withgoogle.com
+ */
+
+namespace Google\Site_Kit\Core\Modules;
+
+use Google\Site_Kit\Core\Storage\Setting;
+
+/**
+ * Base class for module sharing settings.
+ *
+ * @since n.e.x.t
+ * @access private
+ * @ignore
+ */
+class Module_Sharing_Settings extends Setting {
+
+	const OPTION = 'googlesitekit_dashboard_sharing';
+
+	/**
+	 * Gets the default value.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @return array
+	 */
+	protected function get_default() {
+		return array();
+	}
+
+	/**
+	 * Gets the expected value type.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @return string The type name.
+	 */
+	protected function get_type() {
+		return 'object';
+	}
+
+	/**
+	 * Gets the callback for sanitizing the setting's value before saving.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @return callable|null
+	 */
+	protected function get_sanitize_callback() {
+		return function( $option ) {
+			if ( is_array( $option ) ) {
+				foreach ( $option as &$sharing_settings ) {
+					if ( isset( $sharing_settings['sharedRoles'] ) ) {
+						$sharing_settings['sharedRoles'] = $this->filter_valid_roles( $sharing_settings['sharedRoles'] );
+					}
+					if ( isset( $sharing_settings['management'] ) ) {
+						$sharing_settings['management'] = (string) $sharing_settings['management'];
+					}
+				}
+			}
+			return $option;
+		};
+	}
+
+	/**
+	 * Removes invalid roles from a given array.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param array $roles Array of roles to check.
+	 * @return array Filtered array of roles that exist in the current site.
+	 */
+	private function filter_valid_roles( $roles = array() ) {
+		if ( ! is_array( $roles ) ) {
+			$roles = array( $roles );
+		}
+
+		if ( empty( $roles ) ) {
+			return array();
+		}
+
+		$valid_roles    = wp_roles()->role_names;
+		$filtered_roles = array_filter(
+			$roles,
+			function( $role ) use ( $valid_roles ) {
+				return in_array( $role, array_keys( $valid_roles ), true );
+			}
+		);
+		// Avoid index gaps for filtered values.
+		return array_values( $filtered_roles );
+	}
+
+}

--- a/tests/phpunit/integration/Core/Modules/Module_Sharing_SettingsTest.php
+++ b/tests/phpunit/integration/Core/Modules/Module_Sharing_SettingsTest.php
@@ -29,7 +29,7 @@ class Module_Sharing_SettingsTest extends SettingsTestCase {
 		$settings->register();
 
 		$this->assertEmpty(
-			get_option( Module_Sharing_Settings::OPTION )
+			get_option( $this->get_option_name() )
 		);
 	}
 
@@ -67,9 +67,46 @@ class Module_Sharing_SettingsTest extends SettingsTestCase {
 			),
 		);
 		$settings->set( $test_sharing_settings );
-		$this->assertEquals( $expected, get_option( Module_Sharing_Settings::OPTION ) );
+		// Use get_option() instead of $settings->get() to test sanitization and set() in isolation.
+		$this->assertEquals( $expected, get_option( $this->get_option_name() ) );
 	}
 
+	public function test_get() {
+		$settings = new Module_Sharing_Settings( new Options( new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE ) ) );
+		$settings->register();
 
+		// Test invalid management setting.
+		$test_sharing_settings = array(
+			'analytics'          => array(
+				'sharedRoles' => array( 'editor', 'subscriber' ),
+				'management'  => '',
+			),
+			'pagespeed-insights' => array(
+				'sharedRoles' => array( 'editor', 'subscriber' ),
+				'management'  => null,
+			),
+			'search-console'     => array(
+				'sharedRoles' => array( 'editor', 'subscriber' ),
+				'management'  => 'all_admins',
+			),
+		);
+		$expected              = array(
+			'analytics'          => array(
+				'sharedRoles' => array( 'editor', 'subscriber' ),
+				'management'  => 'owner',
+			),
+			'pagespeed-insights' => array(
+				'sharedRoles' => array( 'editor', 'subscriber' ),
+				'management'  => 'owner',
+			),
+			'search-console'     => array(
+				'sharedRoles' => array( 'editor', 'subscriber' ),
+				'management'  => 'all_admins',
+			),
+		);
+		$settings->set( $test_sharing_settings );
+		// Use get_option() instead of $settings->get() to test sanitization and set() in isolation.
+		$this->assertEquals( $expected, $settings->get() );
+	}
 
 }

--- a/tests/phpunit/integration/Core/Modules/Module_Sharing_SettingsTest.php
+++ b/tests/phpunit/integration/Core/Modules/Module_Sharing_SettingsTest.php
@@ -3,7 +3,7 @@
  * Module_Sharing_SettingsTest
  *
  * @package   Google\Site_Kit\Tests\Core\Modules
- * @copyright 2021 Google LLC
+ * @copyright 2022 Google LLC
  * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
  * @link      https://sitekit.withgoogle.com
  */
@@ -40,11 +40,15 @@ class Module_Sharing_SettingsTest extends SettingsTestCase {
 		// Test invalid sharedRoles.
 		$test_sharing_settings = array(
 			'analytics'          => array(
-				'sharedRoles' => array( 'invalidrole', 'editor' ),
+				'sharedRoles' => array( '', 'editor', array( 'edit' ) ),
 				'management'  => 'owner',
 			),
 			'pagespeed-insights' => array(
-				'sharedRoles' => 'invalidrole',
+				'sharedRoles' => '',
+				'management'  => 'all_admins',
+			),
+			'search-console'     => array(
+				'sharedRoles' => null,
 				'management'  => 'all_admins',
 			),
 		);
@@ -54,6 +58,10 @@ class Module_Sharing_SettingsTest extends SettingsTestCase {
 				'management'  => 'owner',
 			),
 			'pagespeed-insights' => array(
+				'sharedRoles' => array(),
+				'management'  => 'all_admins',
+			),
+			'search-console'     => array(
 				'sharedRoles' => array(),
 				'management'  => 'all_admins',
 			),

--- a/tests/phpunit/integration/Core/Modules/Module_Sharing_SettingsTest.php
+++ b/tests/phpunit/integration/Core/Modules/Module_Sharing_SettingsTest.php
@@ -18,6 +18,22 @@ use Google\Site_Kit\Tests\Modules\SettingsTestCase;
 class Module_Sharing_SettingsTest extends SettingsTestCase {
 
 	/**
+	 * Module Sharing Settings instance.
+	 *
+	 * @var Module_Sharing_Settings
+	 */
+	private $settings;
+
+	public function setUp() {
+		parent::setUp();
+
+		$context        = new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE );
+		$options        = new Options( $context );
+		$this->settings = new Module_Sharing_Settings( $options );
+		$this->settings->register();
+	}
+
+	/**
 	 * @inheritDoc
 	 */
 	protected function get_option_name() {
@@ -25,17 +41,12 @@ class Module_Sharing_SettingsTest extends SettingsTestCase {
 	}
 
 	public function test_get_default() {
-		$settings = new Module_Sharing_Settings( new Options( new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE ) ) );
-		$settings->register();
-
 		$this->assertEmpty(
 			get_option( $this->get_option_name() )
 		);
 	}
 
 	public function test_get_sanitize_callback() {
-		$settings = new Module_Sharing_Settings( new Options( new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE ) ) );
-		$settings->register();
 		$this->assertEmpty( get_option( $this->get_option_name() ) );
 
 		// Test sanitizing invalid sharedRoles.
@@ -66,15 +77,13 @@ class Module_Sharing_SettingsTest extends SettingsTestCase {
 				'management' => 'all_admins',
 			),
 		);
-		$settings->set( $test_sharing_settings );
+		$this->settings->set( $test_sharing_settings );
 		// Use get_option() instead of $settings->get() to test sanitization and set() in isolation.
 		$this->assertEquals( $expected, get_option( $this->get_option_name() ) );
 	}
 
 	public function test_get() {
-		$settings = new Module_Sharing_Settings( new Options( new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE ) ) );
-		$settings->register();
-		$defaultSettings = $settings->get();
+		$defaultSettings = $this->settings->get();
 		$this->assertTrue( is_array( $defaultSettings ) );
 		$this->assertEmpty( $defaultSettings );
 
@@ -115,8 +124,8 @@ class Module_Sharing_SettingsTest extends SettingsTestCase {
 				'management'  => 'all_admins',
 			),
 		);
-		$settings->set( $test_sharing_settings );
-		$this->assertEquals( $expected, $settings->get() );
+		$this->settings->set( $test_sharing_settings );
+		$this->assertEquals( $expected, $this->settings->get() );
 	}
 
 }

--- a/tests/phpunit/integration/Core/Modules/Module_Sharing_SettingsTest.php
+++ b/tests/phpunit/integration/Core/Modules/Module_Sharing_SettingsTest.php
@@ -37,7 +37,7 @@ class Module_Sharing_SettingsTest extends SettingsTestCase {
 		$settings = new Module_Sharing_Settings( new Options( new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE ) ) );
 		$settings->register();
 
-		// Test invalid sharedRoles.
+		// Test sanitizing invalid sharedRoles.
 		$test_sharing_settings = array(
 			'analytics'          => array(
 				'sharedRoles' => array( '', 'editor', array( 'edit' ) ),
@@ -62,8 +62,7 @@ class Module_Sharing_SettingsTest extends SettingsTestCase {
 				'management'  => 'all_admins',
 			),
 			'search-console'     => array(
-				'sharedRoles' => array(),
-				'management'  => 'all_admins',
+				'management' => 'all_admins',
 			),
 		);
 		$settings->set( $test_sharing_settings );
@@ -75,14 +74,18 @@ class Module_Sharing_SettingsTest extends SettingsTestCase {
 		$settings = new Module_Sharing_Settings( new Options( new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE ) ) );
 		$settings->register();
 
-		// Test invalid management setting.
+		// Test invalid settings when we get settings.
 		$test_sharing_settings = array(
 			'analytics'          => array(
-				'sharedRoles' => array( 'editor', 'subscriber' ),
+				'sharedRoles' => '',
 				'management'  => '',
 			),
 			'pagespeed-insights' => array(
-				'sharedRoles' => array( 'editor', 'subscriber' ),
+				'sharedRoles' => null,
+				'management'  => 'all_admins',
+			),
+			'adsense'            => array(
+				'sharedRoles' => array( 'editor' ),
 				'management'  => null,
 			),
 			'search-console'     => array(
@@ -92,11 +95,15 @@ class Module_Sharing_SettingsTest extends SettingsTestCase {
 		);
 		$expected              = array(
 			'analytics'          => array(
-				'sharedRoles' => array( 'editor', 'subscriber' ),
+				'sharedRoles' => array(),
 				'management'  => 'owner',
 			),
 			'pagespeed-insights' => array(
-				'sharedRoles' => array( 'editor', 'subscriber' ),
+				'sharedRoles' => array(),
+				'management'  => 'all_admins',
+			),
+			'adsense'            => array(
+				'sharedRoles' => array( 'editor' ),
 				'management'  => 'owner',
 			),
 			'search-console'     => array(

--- a/tests/phpunit/integration/Core/Modules/Module_Sharing_SettingsTest.php
+++ b/tests/phpunit/integration/Core/Modules/Module_Sharing_SettingsTest.php
@@ -36,6 +36,7 @@ class Module_Sharing_SettingsTest extends SettingsTestCase {
 	public function test_get_sanitize_callback() {
 		$settings = new Module_Sharing_Settings( new Options( new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE ) ) );
 		$settings->register();
+		$this->assertEmpty( get_option( $this->get_option_name() ) );
 
 		// Test sanitizing invalid sharedRoles.
 		$test_sharing_settings = array(
@@ -73,6 +74,9 @@ class Module_Sharing_SettingsTest extends SettingsTestCase {
 	public function test_get() {
 		$settings = new Module_Sharing_Settings( new Options( new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE ) ) );
 		$settings->register();
+		$defaultSettings = $settings->get();
+		$this->assertTrue( is_array( $defaultSettings ) );
+		$this->assertEmpty( $defaultSettings );
 
 		// Test invalid settings when we get settings.
 		$test_sharing_settings = array(

--- a/tests/phpunit/integration/Core/Modules/Module_Sharing_SettingsTest.php
+++ b/tests/phpunit/integration/Core/Modules/Module_Sharing_SettingsTest.php
@@ -105,7 +105,6 @@ class Module_Sharing_SettingsTest extends SettingsTestCase {
 			),
 		);
 		$settings->set( $test_sharing_settings );
-		// Use get_option() instead of $settings->get() to test sanitization and set() in isolation.
 		$this->assertEquals( $expected, $settings->get() );
 	}
 

--- a/tests/phpunit/integration/Core/Modules/Module_Sharing_SettingsTest.php
+++ b/tests/phpunit/integration/Core/Modules/Module_Sharing_SettingsTest.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Module_Sharing_SettingsTest
+ *
+ * @package   Google\Site_Kit\Tests\Core\Modules
+ * @copyright 2021 Google LLC
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
+ * @link      https://sitekit.withgoogle.com
+ */
+
+namespace Google\Site_Kit\Tests\Core\Modules;
+
+use Google\Site_Kit\Context;
+use Google\Site_Kit\Core\Modules\Module_Sharing_Settings;
+use Google\Site_Kit\Core\Storage\Options;
+use Google\Site_Kit\Tests\Modules\SettingsTestCase;
+
+class Module_Sharing_SettingsTest extends SettingsTestCase {
+
+	/**
+	 * @inheritDoc
+	 */
+	protected function get_option_name() {
+		return Module_Sharing_Settings::OPTION;
+	}
+
+	public function test_get_default() {
+		$settings = new Module_Sharing_Settings( new Options( new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE ) ) );
+		$settings->register();
+
+		$this->assertEmpty(
+			get_option( Module_Sharing_Settings::OPTION )
+		);
+	}
+
+	public function test_get_sanitize_callback() {
+		$settings = new Module_Sharing_Settings( new Options( new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE ) ) );
+		$settings->register();
+
+		// Test invalid sharedRoles.
+		$test_sharing_settings = array(
+			'analytics'          => array(
+				'sharedRoles' => array( 'invalidrole', 'editor' ),
+				'management'  => 'owner',
+			),
+			'pagespeed-insights' => array(
+				'sharedRoles' => 'invalidrole',
+				'management'  => 'all_admins',
+			),
+		);
+		$expected              = array(
+			'analytics'          => array(
+				'sharedRoles' => array( 'editor' ),
+				'management'  => 'owner',
+			),
+			'pagespeed-insights' => array(
+				'sharedRoles' => array(),
+				'management'  => 'all_admins',
+			),
+		);
+		$settings->set( $test_sharing_settings );
+		$this->assertEquals( $expected, get_option( Module_Sharing_Settings::OPTION ) );
+	}
+
+
+
+}

--- a/tests/phpunit/integration/Core/Modules/Module_Sharing_SettingsTest.php
+++ b/tests/phpunit/integration/Core/Modules/Module_Sharing_SettingsTest.php
@@ -33,9 +33,6 @@ class Module_Sharing_SettingsTest extends SettingsTestCase {
 		$this->settings->register();
 	}
 
-	/**
-	 * @inheritDoc
-	 */
 	protected function get_option_name() {
 		return Module_Sharing_Settings::OPTION;
 	}


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue: #4475 

## Relevant technical choices
- Sanitize callback method prevents the addition of invalid wordpress roles.

## Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
