### PR TITLE
Fix expose recoverable modules incorrect condition - Follow up

### DIFF
--- a/includes/Core/Modules/Modules.php
+++ b/includes/Core/Modules/Modules.php
@@ -1131,14 +1131,14 @@ final class Modules {
 	 *
 	 * @since 1.50.0
 	 *
-	 * @return array List of recoverable modules.
+	 * @return Module_With_Owner[] array List of recoverable modules.
 	 */
 	public function get_recoverable_modules() {
 		$recoverable_modules = array();
 		$shareable_modules   = $this->get_shareable_modules();
 
 		foreach ( $shareable_modules as $module ) {
-			$owner_id = $module instanceof Module_With_Owner && $module->get_owner_id();
+			$owner_id = $module->get_owner_id();
 
 			// 1. If no owner identified by its owner_id
 			// 2. Lacks the AUTHENTICATE Permissions


### PR DESCRIPTION
## Summary

Addresses issue:

- #4527 

## Relevant technical choices

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
