### PR TITLE
Update PHP tests for compatibility with PHP 8 and WP 5.9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ npm-debug.log
 /languages
 /storybook-static
 google-site-kit*.zip
+.phpunit.result.cache
 
 # Editors
 *.esproj

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     "automattic/vipwpcs": "^2",
     "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
     "phpcompatibility/phpcompatibility-wp": "^2.1",
-		"phpunit/phpunit": "^5 || ^6 || ^7 || ^8",
+    "phpunit/phpunit": "^5 || ^6 || ^7 || ^8",
     "roave/security-advisories": "dev-latest",
     "roots/wordpress": ">=4.7",
     "squizlabs/php_codesniffer": "^3.3",
@@ -83,7 +83,7 @@
     ],
     "lint": "phpcs",
     "lint-fix": "phpcbf",
-    "test":  "phpunit",
+    "test": "phpunit",
     "test:multisite": "@test --configuration=phpunit.multisite.xml"
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     "automattic/vipwpcs": "^2",
     "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
     "phpcompatibility/phpcompatibility-wp": "^2.1",
-    "phpunit/phpunit": "^5 || ^6 || ^7",
+		"phpunit/phpunit": "^5 || ^6 || ^7 || ^8",
     "roave/security-advisories": "dev-latest",
     "roots/wordpress": ">=4.7",
     "squizlabs/php_codesniffer": "^3.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b8359897ea5dea6e5fab64e94be7dc43",
+    "content-hash": "09cf4543398af87915f28ca20147f7b6",
     "packages": [
         {
             "name": "firebase/php-jwt",
@@ -981,6 +981,10 @@
                 "constructor",
                 "instantiate"
             ],
+            "support": {
+                "issues": "https://github.com/doctrine/instantiator/issues",
+                "source": "https://github.com/doctrine/instantiator/tree/master"
+            },
             "time": "2015-06-14T21:17:01+00:00"
         },
         {
@@ -1026,6 +1030,10 @@
                 "object",
                 "object graph"
             ],
+            "support": {
+                "issues": "https://github.com/myclabs/DeepCopy/issues",
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.x"
+            },
             "time": "2017-10-19T19:58:43+00:00"
         },
         {
@@ -1240,6 +1248,10 @@
                 "reflection",
                 "static analysis"
             ],
+            "support": {
+                "issues": "https://github.com/phpDocumentor/ReflectionCommon/issues",
+                "source": "https://github.com/phpDocumentor/ReflectionCommon/tree/master"
+            },
             "time": "2017-09-11T18:02:19+00:00"
         },
         {
@@ -1285,6 +1297,10 @@
                 }
             ],
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
+            "support": {
+                "issues": "https://github.com/phpDocumentor/ReflectionDocBlock/issues",
+                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/release/3.x"
+            },
             "time": "2017-11-10T14:09:06+00:00"
         },
         {
@@ -1332,6 +1348,10 @@
                     "email": "me@mikevanriel.com"
                 }
             ],
+            "support": {
+                "issues": "https://github.com/phpDocumentor/TypeResolver/issues",
+                "source": "https://github.com/phpDocumentor/TypeResolver/tree/master"
+            },
             "time": "2017-07-14T14:27:02+00:00"
         },
         {
@@ -1395,6 +1415,10 @@
                 "spy",
                 "stub"
             ],
+            "support": {
+                "issues": "https://github.com/phpspec/prophecy/issues",
+                "source": "https://github.com/phpspec/prophecy/tree/v1.10.3"
+            },
             "time": "2020-03-05T15:02:03+00:00"
         },
         {
@@ -1458,6 +1482,11 @@
                 "testing",
                 "xunit"
             ],
+            "support": {
+                "irc": "irc://irc.freenode.net/phpunit",
+                "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/4.0"
+            },
             "time": "2017-04-02T07:44:40+00:00"
         },
         {
@@ -1505,6 +1534,11 @@
                 "filesystem",
                 "iterator"
             ],
+            "support": {
+                "irc": "irc://irc.freenode.net/phpunit",
+                "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/1.4.5"
+            },
             "time": "2017-11-27T13:52:08+00:00"
         },
         {
@@ -1546,6 +1580,10 @@
             "keywords": [
                 "template"
             ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
+                "source": "https://github.com/sebastianbergmann/php-text-template/tree/1.2.1"
+            },
             "time": "2015-06-21T13:50:34+00:00"
         },
         {
@@ -1595,6 +1633,10 @@
             "keywords": [
                 "timer"
             ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-timer/issues",
+                "source": "https://github.com/sebastianbergmann/php-timer/tree/master"
+            },
             "time": "2017-02-26T11:10:40+00:00"
         },
         {
@@ -1644,6 +1686,10 @@
             "keywords": [
                 "tokenizer"
             ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-token-stream/issues",
+                "source": "https://github.com/sebastianbergmann/php-token-stream/tree/1.4"
+            },
             "abandoned": true,
             "time": "2017-12-04T08:55:13+00:00"
         },
@@ -1727,6 +1773,10 @@
                 "testing",
                 "xunit"
             ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/phpunit/issues",
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/5.7.27"
+            },
             "time": "2018-02-01T05:50:59+00:00"
         },
         {
@@ -1786,6 +1836,11 @@
                 "mock",
                 "xunit"
             ],
+            "support": {
+                "irc": "irc://irc.freenode.net/phpunit",
+                "issues": "https://github.com/sebastianbergmann/phpunit-mock-objects/issues",
+                "source": "https://github.com/sebastianbergmann/phpunit-mock-objects/tree/3.4"
+            },
             "abandoned": true,
             "time": "2017-06-30T09:13:00+00:00"
         },
@@ -2121,19 +2176,22 @@
         },
         {
             "name": "roots/wordpress",
-            "version": "5.8",
+            "version": "5.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress/WordPress.git",
-                "reference": "5.8"
+                "reference": "5.9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress/WordPress/zipball/refs/tags/5.8"
+                "url": "https://api.github.com/repos/WordPress/WordPress/zipball/refs/tags/5.9"
             },
             "require": {
                 "php": ">=5.3.2",
                 "roots/wordpress-core-installer": ">=1.0.0"
+            },
+            "provide": {
+                "wordpress/core-implementation": "5.9"
             },
             "type": "wordpress-core",
             "notification-url": "https://packagist.org/downloads/",
@@ -2172,7 +2230,7 @@
                     "type": "patreon"
                 }
             ],
-            "time": "2021-07-20T16:24:55+00:00"
+            "time": "2022-01-25T19:50:55+00:00"
         },
         {
             "name": "roots/wordpress-core-installer",
@@ -2284,6 +2342,10 @@
             ],
             "description": "Looks up which function or method a line of code belongs to",
             "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/issues",
+                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/1.0.2"
+            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
@@ -2354,6 +2416,10 @@
                 "compare",
                 "equality"
             ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/comparator/issues",
+                "source": "https://github.com/sebastianbergmann/comparator/tree/1.2"
+            },
             "time": "2017-01-29T09:50:25+00:00"
         },
         {
@@ -2406,6 +2472,10 @@
             "keywords": [
                 "diff"
             ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/diff/issues",
+                "source": "https://github.com/sebastianbergmann/diff/tree/1.4"
+            },
             "time": "2017-05-22T07:24:03+00:00"
         },
         {
@@ -2456,6 +2526,10 @@
                 "environment",
                 "hhvm"
             ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/environment/issues",
+                "source": "https://github.com/sebastianbergmann/environment/tree/master"
+            },
             "time": "2016-11-26T07:53:53+00:00"
         },
         {
@@ -2523,6 +2597,10 @@
                 "export",
                 "exporter"
             ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/exporter/issues",
+                "source": "https://github.com/sebastianbergmann/exporter/tree/master"
+            },
             "time": "2016-11-19T08:54:04+00:00"
         },
         {
@@ -2574,6 +2652,10 @@
             "keywords": [
                 "global state"
             ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/global-state/issues",
+                "source": "https://github.com/sebastianbergmann/global-state/tree/1.1.1"
+            },
             "time": "2015-10-12T03:26:01+00:00"
         },
         {
@@ -2620,6 +2702,10 @@
             ],
             "description": "Traverses array structures and object graphs to enumerate all referenced objects",
             "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
+                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/master"
+            },
             "time": "2017-02-18T15:18:39+00:00"
         },
         {
@@ -2673,6 +2759,10 @@
             ],
             "description": "Provides functionality to recursively process PHP variables",
             "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/master"
+            },
             "time": "2016-11-19T07:33:16+00:00"
         },
         {
@@ -2715,6 +2805,10 @@
             ],
             "description": "Provides a list of PHP built-in functions that operate on resources",
             "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/resource-operations/issues",
+                "source": "https://github.com/sebastianbergmann/resource-operations/tree/master"
+            },
             "time": "2015-07-28T20:34:47+00:00"
         },
         {
@@ -2758,6 +2852,10 @@
             ],
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/version/issues",
+                "source": "https://github.com/sebastianbergmann/version/tree/master"
+            },
             "time": "2016-10-03T07:35:21+00:00"
         },
         {
@@ -2919,6 +3017,9 @@
                 "polyfill",
                 "portable"
             ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.19.0"
+            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -2987,6 +3088,9 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/yaml/tree/v3.4.47"
+            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -3050,6 +3154,10 @@
                 "check",
                 "validate"
             ],
+            "support": {
+                "issues": "https://github.com/webmozarts/assert/issues",
+                "source": "https://github.com/webmozarts/assert/tree/1.9.1"
+            },
             "time": "2020-07-08T17:02:28+00:00"
         },
         {
@@ -3100,16 +3208,16 @@
         },
         {
             "name": "wp-phpunit/wp-phpunit",
-            "version": "5.8.0",
+            "version": "5.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-phpunit/wp-phpunit.git",
-                "reference": "da3f6fc3bc5cae2c76af6f9a260620fc4f8d9f90"
+                "reference": "02d98f9d5f15442489b5d98c1f4c486901e3e110"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-phpunit/wp-phpunit/zipball/da3f6fc3bc5cae2c76af6f9a260620fc4f8d9f90",
-                "reference": "da3f6fc3bc5cae2c76af6f9a260620fc4f8d9f90",
+                "url": "https://api.github.com/repos/wp-phpunit/wp-phpunit/zipball/02d98f9d5f15442489b5d98c1f4c486901e3e110",
+                "reference": "02d98f9d5f15442489b5d98c1f4c486901e3e110",
                 "shasum": ""
             },
             "type": "library",
@@ -3144,20 +3252,20 @@
                 "issues": "https://github.com/wp-phpunit/issues",
                 "source": "https://github.com/wp-phpunit/wp-phpunit"
             },
-            "time": "2021-07-27T09:32:49+00:00"
+            "time": "2022-01-25T20:37:14+00:00"
         },
         {
             "name": "yoast/phpunit-polyfills",
-            "version": "1.0.1",
+            "version": "1.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Yoast/PHPUnit-Polyfills.git",
-                "reference": "f014fb21c2b0038fd329515d59025af42fb98715"
+                "reference": "5ea3536428944955f969bc764bbe09738e151ada"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/f014fb21c2b0038fd329515d59025af42fb98715",
-                "reference": "f014fb21c2b0038fd329515d59025af42fb98715",
+                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/5ea3536428944955f969bc764bbe09738e151ada",
+                "reference": "5ea3536428944955f969bc764bbe09738e151ada",
                 "shasum": ""
             },
             "require": {
@@ -3165,9 +3273,7 @@
                 "phpunit/phpunit": "^4.8.36 || ^5.7.21 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
             },
             "require-dev": {
-                "php-parallel-lint/php-console-highlighter": "^0.5",
-                "php-parallel-lint/php-parallel-lint": "^1.3.0",
-                "yoast/yoastcs": "^2.1.0"
+                "yoast/yoastcs": "^2.2.0"
             },
             "type": "library",
             "extra": {
@@ -3207,7 +3313,7 @@
                 "issues": "https://github.com/Yoast/PHPUnit-Polyfills/issues",
                 "source": "https://github.com/Yoast/PHPUnit-Polyfills"
             },
-            "time": "2021-08-09T16:28:08+00:00"
+            "time": "2021-11-23T01:37:03+00:00"
         }
     ],
     "aliases": [],

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -42,23 +42,6 @@ $GLOBALS['wp_tests_options'] = array(
 	'active_plugins' => array( basename( TESTS_PLUGIN_DIR ) . '/google-site-kit.php' ),
 );
 
-/**
- * PHP 8 Compatibility with PHPUnit 7.
- *
- * WordPress core loads these via the main autoloader but these files
- * aren't installed via Composer (yet) so we need to require them manually
- * before PHPUnit's bundled versions are autoloaded to use the compatible versions.
- *
- * @see https://core.trac.wordpress.org/ticket/50902
- * @see https://core.trac.wordpress.org/ticket/50913
- */
-if ( version_compare( '8.0', phpversion(), '<=' ) ) {
-	require_once $_test_root . '/includes/phpunit7/MockObject/Builder/NamespaceMatch.php';
-	require_once $_test_root . '/includes/phpunit7/MockObject/Builder/ParametersMatch.php';
-	require_once $_test_root . '/includes/phpunit7/MockObject/InvocationMocker.php';
-	require_once $_test_root . '/includes/phpunit7/MockObject/MockMethod.php';
-}
-
 // Give access to tests_add_filter() function.
 require $_test_root . '/includes/functions.php';
 

--- a/tests/phpunit/includes/Modules/SettingsTestCase.php
+++ b/tests/phpunit/includes/Modules/SettingsTestCase.php
@@ -19,8 +19,8 @@ abstract class SettingsTestCase extends TestCase {
 	 */
 	abstract protected function get_option_name();
 
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 
 		$option_name = $this->get_option_name();
 

--- a/tests/phpunit/includes/TestCase.php
+++ b/tests/phpunit/includes/TestCase.php
@@ -24,8 +24,8 @@ class TestCase extends \WP_UnitTestCase {
 
 	protected static $featureFlagsConfig;
 
-	public static function setUpBeforeClass() {
-		parent::setUpBeforeClass();
+	public static function set_up_before_class() {
+		parent::set_up_before_class();
 
 		if ( ! self::$featureFlagsConfig ) {
 			self::$featureFlagsConfig = json_decode(
@@ -37,8 +37,8 @@ class TestCase extends \WP_UnitTestCase {
 		self::reset_feature_flags();
 	}
 
-	public static function tearDownAfterClass() {
-		parent::tearDownAfterClass();
+	public static function tear_down_after_class() {
+		parent::tear_down_after_class();
 		self::reset_feature_flags();
 		self::reset_build_mode();
 	}
@@ -54,8 +54,8 @@ class TestCase extends \WP_UnitTestCase {
 	/**
 	 * Runs the routine before each test is executed.
 	 */
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 
 		// At this point all hooks are isolated between tests.
 
@@ -79,8 +79,8 @@ class TestCase extends \WP_UnitTestCase {
 	/**
 	 * After a test method runs, reset any state in WordPress the test method might have changed.
 	 */
-	public function tearDown() {
-		parent::tearDown();
+	public function tear_down() {
+		parent::tear_down();
 		// Clear screen related globals.
 		unset( $GLOBALS['current_screen'], $GLOBALS['taxnow'], $GLOBALS['typenow'] );
 	}

--- a/tests/phpunit/integration/Core/Admin/ScreensTest.php
+++ b/tests/phpunit/integration/Core/Admin/ScreensTest.php
@@ -29,8 +29,8 @@ class ScreensTest extends TestCase {
 	 */
 	private $screens;
 
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 
 		$context = new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE );
 		$assets  = new Assets( $context );

--- a/tests/phpunit/integration/Core/Assets/AssetsTest.php
+++ b/tests/phpunit/integration/Core/Assets/AssetsTest.php
@@ -19,8 +19,8 @@ use Google\Site_Kit\Tests\TestCase;
  */
 class AssetsTest extends TestCase {
 
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 
 		wp_scripts()->registered = array();
 		wp_scripts()->queue      = array();

--- a/tests/phpunit/integration/Core/Assets/ScriptTest.php
+++ b/tests/phpunit/integration/Core/Assets/ScriptTest.php
@@ -19,8 +19,8 @@ use Google\Site_Kit\Tests\TestCase;
  */
 class ScriptTest extends TestCase {
 
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 
 		wp_scripts()->registered = array();
 		wp_scripts()->queue      = array();

--- a/tests/phpunit/integration/Core/Assets/Script_DataTest.php
+++ b/tests/phpunit/integration/Core/Assets/Script_DataTest.php
@@ -19,8 +19,8 @@ use Google\Site_Kit\Tests\TestCase;
  */
 class Script_DataTest extends TestCase {
 
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 
 		wp_scripts()->registered = array();
 		wp_scripts()->queue      = array();

--- a/tests/phpunit/integration/Core/Assets/StylesheetTest.php
+++ b/tests/phpunit/integration/Core/Assets/StylesheetTest.php
@@ -19,8 +19,8 @@ use Google\Site_Kit\Tests\TestCase;
  */
 class StylesheetTest extends TestCase {
 
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 
 		wp_styles()->registered = array();
 		wp_styles()->queue      = array();

--- a/tests/phpunit/integration/Core/Authentication/Connected_Proxy_URLTest.php
+++ b/tests/phpunit/integration/Core/Authentication/Connected_Proxy_URLTest.php
@@ -29,8 +29,8 @@ class Connected_Proxy_URLTest extends SettingsTestCase {
 	 */
 	private $options;
 
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 		$this->options = new Options( new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE ) );
 	}
 

--- a/tests/phpunit/integration/Core/Authentication/Disconnected_ReasonTest.php
+++ b/tests/phpunit/integration/Core/Authentication/Disconnected_ReasonTest.php
@@ -29,8 +29,8 @@ class Disconnected_ReasonTest extends SettingsTestCase {
 	 */
 	private $options;
 
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 		$this->options = new User_Options( new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE ) );
 	}
 

--- a/tests/phpunit/integration/Core/Authentication/Google_ProxyTest.php
+++ b/tests/phpunit/integration/Core/Authentication/Google_ProxyTest.php
@@ -56,8 +56,8 @@ class Google_ProxyTest extends TestCase {
 	 */
 	private $request_args;
 
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 
 		$this->context      = new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE );
 		$this->google_proxy = new Google_Proxy( $this->context );

--- a/tests/phpunit/integration/Core/Authentication/Has_Connected_AdminsTest.php
+++ b/tests/phpunit/integration/Core/Authentication/Has_Connected_AdminsTest.php
@@ -37,8 +37,8 @@ class Has_Connected_AdminsTest extends TestCase {
 	 */
 	protected $user_options;
 
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 		$this->context      = new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE );
 		$this->options      = new Options( $this->context );
 		$this->user_options = new User_Options( $this->context );

--- a/tests/phpunit/integration/Core/Authentication/Has_Multiple_AdminsTest.php
+++ b/tests/phpunit/integration/Core/Authentication/Has_Multiple_AdminsTest.php
@@ -30,8 +30,8 @@ class Has_Multiple_AdminsTest extends TestCase {
 	 */
 	protected $transients;
 
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 		$this->context    = new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE );
 		$this->transients = new Transients( $this->context );
 	}

--- a/tests/phpunit/integration/Core/Authentication/Owner_IDTest.php
+++ b/tests/phpunit/integration/Core/Authentication/Owner_IDTest.php
@@ -36,8 +36,8 @@ class Owner_IDTest extends SettingsTestCase {
 	 */
 	private $options;
 
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 
 		$this->options  = new Options( new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE ) );
 		$this->owner_id = new Owner_ID( $this->options );

--- a/tests/phpunit/integration/Core/Authentication/Setup_V2Test.php
+++ b/tests/phpunit/integration/Core/Authentication/Setup_V2Test.php
@@ -21,8 +21,8 @@ use WPDieException;
 class Setup_V2Test extends TestCase {
 	use Fake_Site_Connection_Trait;
 
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 
 		// Remove hooked actions for V1 during bootstrap.
 		remove_all_actions( 'admin_action_' . Google_Proxy::ACTION_SETUP_START );

--- a/tests/phpunit/integration/Core/Authentication/TokenTest.php
+++ b/tests/phpunit/integration/Core/Authentication/TokenTest.php
@@ -25,8 +25,8 @@ class TokenTest extends TestCase {
 	private $user_options;
 	private $encrypted_user_options;
 
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 
 		$user_id = $this->factory()->user->create();
 		$context = new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE );

--- a/tests/phpunit/integration/Core/Authentication/User_Input_StateTest.php
+++ b/tests/phpunit/integration/Core/Authentication/User_Input_StateTest.php
@@ -30,8 +30,8 @@ class User_Input_StateTest extends TestCase {
 	/**
 	 * Set Up Test.
 	 */
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 		$user_id                = $this->factory()->user->create();
 		$context                = new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE );
 		$this->user_options     = new User_Options( $context, $user_id );

--- a/tests/phpunit/integration/Core/Authentication/VerificationTest.php
+++ b/tests/phpunit/integration/Core/Authentication/VerificationTest.php
@@ -54,8 +54,8 @@ class VerificationTest extends TestCase {
 	/**
 	 * Set Up Test.
 	 */
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 		wp_set_current_user( self::$user_id );
 		$this->user_options = new User_Options( new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE ) );
 	}

--- a/tests/phpunit/integration/Core/Dismissals/Dismissed_ItemsTest.php
+++ b/tests/phpunit/integration/Core/Dismissals/Dismissed_ItemsTest.php
@@ -27,8 +27,8 @@ class Dismissed_ItemsTest extends TestCase {
 	 */
 	private $dismissed_items;
 
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 
 		$user_id = $this->factory()->user->create();
 		$context = new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE );

--- a/tests/phpunit/integration/Core/Dismissals/REST_Dismissals_ControllerTest.php
+++ b/tests/phpunit/integration/Core/Dismissals/REST_Dismissals_ControllerTest.php
@@ -34,8 +34,8 @@ class REST_Dismissals_ControllerTest extends TestCase {
 	 */
 	private $controller;
 
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 
 		$user_id = $this->factory()->user->create( array( 'role' => 'administrator' ) );
 		wp_set_current_user( $user_id );
@@ -46,8 +46,8 @@ class REST_Dismissals_ControllerTest extends TestCase {
 		$this->controller      = new REST_Dismissals_Controller( $this->dismissed_items );
 	}
 
-	public function tearDown() {
-		parent::tearDown();
+	public function tear_down() {
+		parent::tear_down();
 		// This ensures the REST server is initialized fresh for each test using it.
 		unset( $GLOBALS['wp_rest_server'] );
 	}

--- a/tests/phpunit/integration/Core/Feature_Tours/Dismissed_ToursTest.php
+++ b/tests/phpunit/integration/Core/Feature_Tours/Dismissed_ToursTest.php
@@ -22,8 +22,8 @@ class Dismissed_ToursTest extends TestCase {
 	 */
 	protected $user_options;
 
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 		$user_id            = $this->factory()->user->create();
 		$context            = new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE );
 		$this->user_options = new User_Options( $context, $user_id );

--- a/tests/phpunit/integration/Core/Feature_Tours/REST_Feature_Tours_ControllerTest.php
+++ b/tests/phpunit/integration/Core/Feature_Tours/REST_Feature_Tours_ControllerTest.php
@@ -36,8 +36,8 @@ class REST_Feature_Tours_ControllerTest extends TestCase {
 	 */
 	private $controller;
 
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 
 		$user_id = $this->factory()->user->create( array( 'role' => 'administrator' ) );
 		wp_set_current_user( $user_id );
@@ -48,8 +48,8 @@ class REST_Feature_Tours_ControllerTest extends TestCase {
 		$this->controller      = new REST_Feature_Tours_Controller( $this->dismissed_tours );
 	}
 
-	public function tearDown() {
-		parent::tearDown();
+	public function tear_down() {
+		parent::tear_down();
 		// This ensures the REST server is initialized fresh for each test using it.
 		unset( $GLOBALS['wp_rest_server'] );
 	}

--- a/tests/phpunit/integration/Core/Modules/Module_Sharing_SettingsTest.php
+++ b/tests/phpunit/integration/Core/Modules/Module_Sharing_SettingsTest.php
@@ -24,8 +24,8 @@ class Module_Sharing_SettingsTest extends SettingsTestCase {
 	 */
 	private $settings;
 
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 
 		$context        = new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE );
 		$options        = new Options( $context );

--- a/tests/phpunit/integration/Core/Modules/Tags/Module_AMP_TagTest.php
+++ b/tests/phpunit/integration/Core/Modules/Tags/Module_AMP_TagTest.php
@@ -19,8 +19,8 @@ class Module_AMP_TagTest extends TestCase {
 
 	private $module_slug;
 
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 
 		$this->module_slug = 'fake-module';
 		$this->amp_tag     = new FakeModule_AMP_Tag( 'test-tag-id', $this->module_slug );

--- a/tests/phpunit/integration/Core/Modules/Tags/Module_Web_TagTest.php
+++ b/tests/phpunit/integration/Core/Modules/Tags/Module_Web_TagTest.php
@@ -19,8 +19,8 @@ class Module_Web_TagTest extends TestCase {
 
 	private $module_slug;
 
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 
 		$this->module_slug = 'fake-module';
 		$this->web_tag     = new FakeModule_Web_Tag( 'test-tag-id', $this->module_slug );

--- a/tests/phpunit/integration/Core/Permissions/PermissionsTest.php
+++ b/tests/phpunit/integration/Core/Permissions/PermissionsTest.php
@@ -24,8 +24,8 @@ use Google\Site_Kit\Tests\TestCase;
 class PermissionsTest extends TestCase {
 	use Fake_Site_Connection_Trait;
 
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 
 		// Unhook all actions and filters added during Permissions::register
 		// to avoid interference with "main" instance setup during plugin bootstrap.

--- a/tests/phpunit/integration/Core/Storage/SettingTest.php
+++ b/tests/phpunit/integration/Core/Storage/SettingTest.php
@@ -25,8 +25,8 @@ class SettingTest extends TestCase {
 	 */
 	protected $context;
 
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 		$this->context = new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE );
 	}
 

--- a/tests/phpunit/integration/Core/Storage/User_TransientsTest.php
+++ b/tests/phpunit/integration/Core/Storage/User_TransientsTest.php
@@ -42,8 +42,8 @@ class User_TransientsTest extends TestCase {
 		wp_using_ext_object_cache( self::$old_wp_using_ext_object_cache );
 	}
 
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 		$this->context = new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE );
 	}
 

--- a/tests/phpunit/integration/Core/Tags/Guards/Tag_Verify_GuardTest.php
+++ b/tests/phpunit/integration/Core/Tags/Guards/Tag_Verify_GuardTest.php
@@ -21,8 +21,8 @@ class Tag_Verify_GuardTest extends TestCase {
 	 */
 	private $tagverify;
 
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 		$this->tagverify = new Tag_Verify_Guard( new MutableInput() );
 	}
 

--- a/tests/phpunit/integration/Core/Tracking/REST_Tracking_Consent_ControllerTest.php
+++ b/tests/phpunit/integration/Core/Tracking/REST_Tracking_Consent_ControllerTest.php
@@ -27,8 +27,8 @@ use WP_REST_Server;
 class REST_Tracking_Consent_ControllerTest extends TestCase {
 	use Fake_Site_Connection_Trait;
 
-	public function tearDown() {
-		parent::tearDown();
+	public function tear_down() {
+		parent::tear_down();
 		// This ensures the REST server is initialized fresh for each test using it.
 		unset( $GLOBALS['wp_rest_server'] );
 		unset( $GLOBALS['current_user'] );

--- a/tests/phpunit/integration/Core/Tracking/Tracking_ConsentTest.php
+++ b/tests/phpunit/integration/Core/Tracking/Tracking_ConsentTest.php
@@ -20,8 +20,8 @@ use Google\Site_Kit\Tests\TestCase;
  */
 class Tracking_ConsentTest extends TestCase {
 
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 		// Unregister all registered user meta.
 		global $wp_meta_keys;
 		unset( $wp_meta_keys['user'] );

--- a/tests/phpunit/integration/Core/User_Surveys/REST_User_Surveys_ControllerTest.php
+++ b/tests/phpunit/integration/Core/User_Surveys/REST_User_Surveys_ControllerTest.php
@@ -24,8 +24,8 @@ class REST_User_Surveys_ControllerTest extends TestCase {
 	 */
 	private $controller;
 
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 
 		$context          = new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE );
 		$authentication   = new Authentication( $context );

--- a/tests/phpunit/integration/Core/Util/Feature_FlagsTest.php
+++ b/tests/phpunit/integration/Core/Util/Feature_FlagsTest.php
@@ -16,8 +16,8 @@ use ReflectionMethod;
 
 class Feature_FlagsTest extends TestCase {
 
-	public function tearDown() {
-		parent::tearDown();
+	public function tear_down() {
+		parent::tear_down();
 		static::reset_feature_flags();
 	}
 

--- a/tests/phpunit/integration/Core/Util/Google_URL_Matcher_TraitTest.php
+++ b/tests/phpunit/integration/Core/Util/Google_URL_Matcher_TraitTest.php
@@ -20,8 +20,8 @@ class Google_URL_Matcher_TraitTest extends TestCase {
 
 	private $matcher;
 
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 
 		$this->matcher = new Google_URL_Matcher();
 	}

--- a/tests/phpunit/integration/Core/Util/Google_URL_NormalizerTest.php
+++ b/tests/phpunit/integration/Core/Util/Google_URL_NormalizerTest.php
@@ -20,8 +20,8 @@ class Google_URL_NormalizerTest extends TestCase {
 
 	private $url_normalizer;
 
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 
 		$this->url_normalizer = new Google_URL_Normalizer();
 	}

--- a/tests/phpunit/integration/Core/Util/Migration_1_3_0Test.php
+++ b/tests/phpunit/integration/Core/Util/Migration_1_3_0Test.php
@@ -29,8 +29,8 @@ class Migration_1_3_0Test extends TestCase {
 	 */
 	protected $user_options;
 
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 		$this->context      = new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE );
 		$this->user_options = new User_Options( $this->context );
 		$this->delete_db_version();

--- a/tests/phpunit/integration/Core/Util/Migration_1_8_1Test.php
+++ b/tests/phpunit/integration/Core/Util/Migration_1_8_1Test.php
@@ -57,8 +57,8 @@ class Migration_1_8_1Test extends TestCase {
 	private $temp_api_request_issued;
 	private $temp_received_identifiers;
 
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 
 		$this->context        = new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE );
 		$this->options        = new Options( $this->context );

--- a/tests/phpunit/integration/Core/Util/ResetTest.php
+++ b/tests/phpunit/integration/Core/Util/ResetTest.php
@@ -34,8 +34,8 @@ class ResetTest extends TestCase {
 	 */
 	protected $context_with_mutable_input;
 
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 
 		// Set up a test option as a way to check if reset ran or not.
 		// When the reset runs, this option will no longer exist.

--- a/tests/phpunit/integration/Core/Util/UninstallationTest.php
+++ b/tests/phpunit/integration/Core/Util/UninstallationTest.php
@@ -28,8 +28,8 @@ class UninstallationTest extends TestCase {
 	private $uninstallation;
 	private $issued_delete_site_request;
 
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 
 		$context              = new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE );
 		$this->google_proxy   = new Google_Proxy( $context );

--- a/tests/phpunit/integration/Core/Util/User_Input_SettingsTest.php
+++ b/tests/phpunit/integration/Core/Util/User_Input_SettingsTest.php
@@ -48,8 +48,8 @@ class User_Input_SettingsTest extends TestCase {
 		wp_using_ext_object_cache( self::$old_wp_using_ext_object_cache );
 	}
 
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 		$this->context = new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE );
 	}
 

--- a/tests/phpunit/integration/Modules/AdSense/Tag_GuardTest.php
+++ b/tests/phpunit/integration/Modules/AdSense/Tag_GuardTest.php
@@ -36,8 +36,8 @@ class Tag_GuardTest extends TestCase {
 	 */
 	private $guard;
 
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 
 		update_option(
 			Settings::OPTION,

--- a/tests/phpunit/integration/Modules/Analytics_4/Tag_GuardTest.php
+++ b/tests/phpunit/integration/Modules/Analytics_4/Tag_GuardTest.php
@@ -27,8 +27,8 @@ class Tag_GuardTest extends TestCase {
 	 */
 	protected $guard;
 
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 
 		$context     = new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE );
 		$options     = new Options( $context );

--- a/tests/phpunit/integration/Modules/Analytics_4Test.php
+++ b/tests/phpunit/integration/Modules/Analytics_4Test.php
@@ -51,8 +51,8 @@ class Analytics_4Test extends TestCase {
 	 */
 	private $analytics;
 
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 
 		$this->context   = new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE );
 		$this->analytics = new Analytics_4( $this->context );

--- a/tests/phpunit/integration/Modules/Idea_Hub/Idea_Interaction_CountTest.php
+++ b/tests/phpunit/integration/Modules/Idea_Hub/Idea_Interaction_CountTest.php
@@ -31,8 +31,8 @@ class Idea_Interaction_CountTest extends TestCase {
 	 */
 	private $interaction_count;
 
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 
 		$user_id = $this->factory()->user->create();
 		$context = new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE );

--- a/tests/phpunit/integration/Modules/Idea_HubTest.php
+++ b/tests/phpunit/integration/Modules/Idea_HubTest.php
@@ -42,8 +42,8 @@ class Idea_HubTest extends TestCase {
 	 */
 	private $idea_hub;
 
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 
 		$this->context  = new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE );
 		$this->idea_hub = new Idea_Hub( $this->context );

--- a/tests/phpunit/integration/Modules/Subscribe_With_GoogleTest.php
+++ b/tests/phpunit/integration/Modules/Subscribe_With_GoogleTest.php
@@ -35,8 +35,8 @@ class Subscribe_With_GoogleTest extends TestCase {
 	 */
 	private $subscribe_with_google;
 
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 
 		$this->context               = new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE );
 		$this->subscribe_with_google = new Subscribe_With_Google( $this->context );

--- a/tests/phpunit/integration/PluginTest.php
+++ b/tests/phpunit/integration/PluginTest.php
@@ -25,13 +25,13 @@ class PluginTest extends TestCase {
 	 */
 	protected static $backup_instance;
 
-	public static function setUpBeforeClass() {
-		parent::setUpBeforeClass();
+	public static function set_upBeforeClass() {
+		parent::set_upBeforeClass();
 		self::$backup_instance = Plugin::instance();
 	}
 
-	public function tearDown() {
-		parent::tearDown();
+	public function tear_down() {
+		parent::tear_down();
 		// Restore the main instance after each test.
 		$this->force_set_property( 'Google\Site_Kit\Plugin', 'instance', self::$backup_instance );
 	}


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #4729 

## Relevant technical choices

<!-- Please describe your changes. -->

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
