### PR TITLE
Remove `Module_Sharing_Settings->register()` from `Modules` class.

### DIFF
--- a/includes/Core/Modules/Modules.php
+++ b/includes/Core/Modules/Modules.php
@@ -218,8 +218,6 @@ final class Modules {
 			}
 		);
 
-		$this->sharing_settings->register();
-
 		add_filter(
 			'googlesitekit_assets',
 			function( $assets ) use ( $available_modules ) {

--- a/includes/Core/Modules/Modules.php
+++ b/includes/Core/Modules/Modules.php
@@ -218,6 +218,8 @@ final class Modules {
 			}
 		);
 
+		$this->sharing_settings->register();
+
 		add_filter(
 			'googlesitekit_assets',
 			function( $assets ) use ( $available_modules ) {

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -197,7 +197,6 @@ final class Plugin {
 				( new Core\User_Surveys\REST_User_Surveys_Controller( $authentication ) )->register();
 				( new Core\Util\Migration_1_3_0( $this->context, $options, $user_options ) )->register();
 				( new Core\Util\Migration_1_8_1( $this->context, $options, $user_options, $authentication ) )->register();
-				( new Core\Modules\Module_Sharing_Settings( $options ) )->register();
 
 				// If a login is happening (runs after 'init'), update current user in dependency chain.
 				add_action(


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #4736

## Relevant technical choices

<!-- Please describe your changes. -->

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
