### PR TITLE
Enhance Idea Hub's internal mechanism for fetching and caching ideas

### DIFF
--- a/tests/phpunit/includes/TestCase.php
+++ b/tests/phpunit/includes/TestCase.php
@@ -231,6 +231,20 @@ class TestCase extends \WP_UnitTestCase {
 		);
 	}
 
+	protected function assertTransientNotExists( $transient ) {
+		$this->assertNull(
+			$this->queryOption( "_transient_$transient" ),
+			"Failed to assert that transient '$transient' does not exist."
+		);
+	}
+
+	protected function assertTransientExists( $transient ) {
+		$this->assertNotNull(
+			$this->queryOption( "_transient_$transient" ),
+			"Failed to assert that transient '$transient' exists."
+		);
+	}
+
 	protected function assertWPErrorWithMessage( $expected_message, $actual ) {
 		$this->assertWPError( $actual );
 		$this->assertEquals( $expected_message, $actual->get_error_message() );

--- a/tests/phpunit/integration/Modules/Idea_HubTest.php
+++ b/tests/phpunit/integration/Modules/Idea_HubTest.php
@@ -17,6 +17,7 @@ use Google\Site_Kit\Core\Authentication\Clients\OAuth_Client;
 use Google\Site_Kit\Core\Modules\Module_With_Scopes;
 use Google\Site_Kit\Core\Modules\Module_With_Settings;
 use Google\Site_Kit\Core\Storage\Options;
+use Google\Site_Kit\Core\Storage\Transients;
 use Google\Site_Kit\Core\Storage\User_Options;
 use Google\Site_Kit\Modules\Idea_Hub\Settings;
 use Google\Site_Kit\Modules\Idea_Hub\Post_Idea_Name;
@@ -245,11 +246,16 @@ class Idea_HubTest extends TestCase {
 	public function test_on_deactivation() {
 		$options = new Options( $this->context );
 		$options->set( Settings::OPTION, 'test-value' );
+		$transients = new Transients( $this->context );
+		$transients->set( Idea_Hub::TRANSIENT_NEW_IDEAS, array() );
+		$transients->set( Idea_Hub::TRANSIENT_SAVED_IDEAS, array() );
 
 		$idea_hub = new Idea_Hub( $this->context, $options );
 		$idea_hub->on_deactivation();
 
 		$this->assertOptionNotExists( Settings::OPTION );
+		$this->assertTransientNotExists( Idea_Hub::TRANSIENT_NEW_IDEAS );
+		$this->assertTransientNotExists( Idea_Hub::TRANSIENT_SAVED_IDEAS );
 	}
 
 	public function test_get_datapoints() {

--- a/tests/phpunit/integration/Modules/Idea_HubTest.php
+++ b/tests/phpunit/integration/Modules/Idea_HubTest.php
@@ -15,6 +15,7 @@ use Google\Site_Kit\Core\Admin\Notice;
 use Google\Site_Kit\Core\Modules\Module_With_Scopes;
 use Google\Site_Kit\Core\Modules\Module_With_Settings;
 use Google\Site_Kit\Core\Storage\Options;
+use Google\Site_Kit\Core\Storage\User_Options;
 use Google\Site_Kit\Modules\Idea_Hub\Settings;
 use Google\Site_Kit\Modules\Idea_Hub\Post_Idea_Name;
 use Google\Site_Kit\Modules\Idea_Hub\Post_Idea_Text;
@@ -37,6 +38,13 @@ class Idea_HubTest extends TestCase {
 	private $context;
 
 	/**
+	 * User_Options instance.
+	 *
+	 * @var User_Options
+	 */
+	private $user_options;
+
+	/**
 	 * Idea_Hub instance.
 	 *
 	 * @var Idea_Hub
@@ -46,8 +54,9 @@ class Idea_HubTest extends TestCase {
 	public function setUp() {
 		parent::setUp();
 
-		$this->context  = new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE );
-		$this->idea_hub = new Idea_Hub( $this->context );
+		$this->context      = new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE );
+		$this->user_options = new User_Options( $this->context );
+		$this->idea_hub     = new Idea_Hub( $this->context, null, $this->user_options );
 	}
 
 	public function test_register() {


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #4738

## Relevant technical choices

* I opted to add more thorough coverage of the new `get_cached_ideas` method rather than the Notices themselves which would have been much more complicated to do at the same time. The remaining logic in the notice `active_callback` functions is rather simple now so this seemed to be unnecessary for now.

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
