### PR TITLE
Update PHP tests for compatibility with PHP 8 and WP 5.9+ and WP < 5.2

### DIFF
--- a/.github/workflows/php-tests-wp-4-7-php-5-6.yml
+++ b/.github/workflows/php-tests-wp-4-7-php-5-6.yml
@@ -78,4 +78,4 @@ jobs:
       - name: Set up PHP test data
         run: tests/bin/install-wp-tests.sh ${MYSQL_DATABASE} ${MYSQL_USER} ${MYSQL_PASSWORD} ${DB_HOST}:${DB_PORT} ${WP_VERSION}
       - name: Run Unit Tests
-        run: composer test
+        run: composer test -- --verbose

--- a/.github/workflows/php-tests-wp-4-7-php-5-6.yml
+++ b/.github/workflows/php-tests-wp-4-7-php-5-6.yml
@@ -75,6 +75,7 @@ jobs:
         with:
           extensions: mysqli, runkit, uopz
           php-version: '5.6'
+          tools: phpunit-polyfills
       - name: Set up PHP test data
         run: tests/bin/install-wp-tests.sh ${MYSQL_DATABASE} ${MYSQL_USER} ${MYSQL_PASSWORD} ${DB_HOST}:${DB_PORT} ${WP_VERSION}
       - name: Run Unit Tests

--- a/.github/workflows/php-tests-wp-4-7-php-5-6.yml
+++ b/.github/workflows/php-tests-wp-4-7-php-5-6.yml
@@ -75,7 +75,6 @@ jobs:
         with:
           extensions: mysqli, runkit, uopz
           php-version: '5.6'
-          tools: phpunit-polyfills
       - name: Set up PHP test data
         run: tests/bin/install-wp-tests.sh ${MYSQL_DATABASE} ${MYSQL_USER} ${MYSQL_PASSWORD} ${DB_HOST}:${DB_PORT} ${WP_VERSION}
       - name: Run Unit Tests

--- a/.github/workflows/php-tests-wp-4-7-php-5-6.yml
+++ b/.github/workflows/php-tests-wp-4-7-php-5-6.yml
@@ -51,7 +51,7 @@ jobs:
       MYSQL_USER: root
       MYSQL_PASSWORD: wordpress
       MYSQL_DATABASE: wordpress_test
-      WP_VERSION: '4.7'
+      WP_VERSION: '4.9'
     steps:
       - uses: styfle/cancel-workflow-action@0.8.0
       - uses: actions/checkout@v2

--- a/.github/workflows/php-tests-wp-4-7-php-5-6.yml
+++ b/.github/workflows/php-tests-wp-4-7-php-5-6.yml
@@ -51,7 +51,7 @@ jobs:
       MYSQL_USER: root
       MYSQL_PASSWORD: wordpress
       MYSQL_DATABASE: wordpress_test
-      WP_VERSION: '4.9'
+      WP_VERSION: '4.7'
     steps:
       - uses: styfle/cancel-workflow-action@0.8.0
       - uses: actions/checkout@v2

--- a/.github/workflows/php-tests-wp-latest-multisite-php-7-4.yml
+++ b/.github/workflows/php-tests-wp-latest-multisite-php-7-4.yml
@@ -59,7 +59,7 @@ jobs:
       - uses: shivammathur/setup-php@v2
         with:
           extensions: mysqli, runkit7, uopz
-          tools: composer:2.1, phpunit-polyfills
+          tools: composer:2.1
           php-version: '7.4'
       - name: Get Composer Cache Directory
         id: composer-cache

--- a/.github/workflows/php-tests-wp-latest-multisite-php-7-4.yml
+++ b/.github/workflows/php-tests-wp-latest-multisite-php-7-4.yml
@@ -76,4 +76,4 @@ jobs:
       - name: Set up PHP test data
         run: tests/bin/install-wp-tests.sh ${MYSQL_DATABASE} ${MYSQL_USER} ${MYSQL_PASSWORD} ${DB_HOST}:${DB_PORT} ${WP_VERSION}
       - name: Run Unit Tests
-        run: composer test:multisite
+        run: composer test:multisite -- --verbose

--- a/.github/workflows/php-tests-wp-latest-multisite-php-7-4.yml
+++ b/.github/workflows/php-tests-wp-latest-multisite-php-7-4.yml
@@ -59,7 +59,7 @@ jobs:
       - uses: shivammathur/setup-php@v2
         with:
           extensions: mysqli, runkit7, uopz
-          tools: composer:2.1
+          tools: composer:2.1, phpunit-polyfills
           php-version: '7.4'
       - name: Get Composer Cache Directory
         id: composer-cache

--- a/.github/workflows/php-tests-wp-latest-php-7-4.yml
+++ b/.github/workflows/php-tests-wp-latest-php-7-4.yml
@@ -58,7 +58,7 @@ jobs:
       - uses: shivammathur/setup-php@v2
         with:
           extensions: mysqli, runkit7, uopz
-          tools: composer:2.1
+          tools: composer:2.1, phpunit-polyfills
           php-version: '7.4'
       - name: Get Composer Cache Directory
         id: composer-cache

--- a/.github/workflows/php-tests-wp-latest-php-7-4.yml
+++ b/.github/workflows/php-tests-wp-latest-php-7-4.yml
@@ -58,7 +58,7 @@ jobs:
       - uses: shivammathur/setup-php@v2
         with:
           extensions: mysqli, runkit7, uopz
-          tools: composer:2.1, phpunit-polyfills
+          tools: composer:2.1
           php-version: '7.4'
       - name: Get Composer Cache Directory
         id: composer-cache

--- a/.github/workflows/php-tests-wp-latest-php-7-4.yml
+++ b/.github/workflows/php-tests-wp-latest-php-7-4.yml
@@ -75,4 +75,4 @@ jobs:
       - name: Set up PHP test data
         run: tests/bin/install-wp-tests.sh ${MYSQL_DATABASE} ${MYSQL_USER} ${MYSQL_PASSWORD} ${DB_HOST}:${DB_PORT} ${WP_VERSION}
       - name: Run Unit Tests
-        run: composer test
+        run: composer test -- --verbose

--- a/.github/workflows/php-tests-wp-latest-php-8-0.yml
+++ b/.github/workflows/php-tests-wp-latest-php-8-0.yml
@@ -58,7 +58,7 @@ jobs:
       - uses: shivammathur/setup-php@v2
         with:
           extensions: mysqli, runkit7, uopz
-          tools: composer
+          tools: composer, phpunit-polyfills
           php-version: '8.0'
       - name: Get Composer Cache Directory
         id: composer-cache

--- a/.github/workflows/php-tests-wp-latest-php-8-0.yml
+++ b/.github/workflows/php-tests-wp-latest-php-8-0.yml
@@ -77,4 +77,4 @@ jobs:
       - name: Set up PHP test data
         run: tests/bin/install-wp-tests.sh ${MYSQL_DATABASE} ${MYSQL_USER} ${MYSQL_PASSWORD} ${DB_HOST}:${DB_PORT} ${WP_VERSION}
       - name: Run Unit Tests
-        run: composer test
+        run: composer test -- --verbose

--- a/.github/workflows/php-tests-wp-latest-php-8-0.yml
+++ b/.github/workflows/php-tests-wp-latest-php-8-0.yml
@@ -58,7 +58,7 @@ jobs:
       - uses: shivammathur/setup-php@v2
         with:
           extensions: mysqli, runkit7, uopz
-          tools: composer, phpunit-polyfills
+          tools: composer
           php-version: '8.0'
       - name: Get Composer Cache Directory
         id: composer-cache

--- a/.github/workflows/php-tests-wp-nightly-php-7-4.yml
+++ b/.github/workflows/php-tests-wp-nightly-php-7-4.yml
@@ -58,7 +58,7 @@ jobs:
       - uses: shivammathur/setup-php@v2
         with:
           extensions: mysqli, runkit7, uopz
-          tools: composer:2.1
+          tools: composer:2.1, phpunit-polyfills
           php-version: '7.4'
       - name: Get Composer Cache Directory
         id: composer-cache

--- a/.github/workflows/php-tests-wp-nightly-php-7-4.yml
+++ b/.github/workflows/php-tests-wp-nightly-php-7-4.yml
@@ -58,7 +58,7 @@ jobs:
       - uses: shivammathur/setup-php@v2
         with:
           extensions: mysqli, runkit7, uopz
-          tools: composer:2.1, phpunit-polyfills
+          tools: composer:2.1
           php-version: '7.4'
       - name: Get Composer Cache Directory
         id: composer-cache

--- a/.github/workflows/php-tests-wp-nightly-php-7-4.yml
+++ b/.github/workflows/php-tests-wp-nightly-php-7-4.yml
@@ -75,4 +75,4 @@ jobs:
       - name: Set up PHP test data
         run: tests/bin/install-wp-tests.sh ${MYSQL_DATABASE} ${MYSQL_USER} ${MYSQL_PASSWORD} ${DB_HOST}:${DB_PORT} ${WP_VERSION}
       - name: Run Unit Tests
-        run: composer test
+        run: composer test -- --verbose

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ npm-debug.log
 /languages
 /storybook-static
 google-site-kit*.zip
+.phpunit.result.cache
 
 # Editors
 *.esproj

--- a/composer.json
+++ b/composer.json
@@ -7,13 +7,14 @@
   "require-dev": {
     "automattic/vipwpcs": "^2",
     "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
+    "google/site-kit-wp-phpunit-polyfill": "^0.1.0",
     "phpcompatibility/phpcompatibility-wp": "^2.1",
     "phpunit/phpunit": "^5 || ^6 || ^7",
     "roave/security-advisories": "dev-latest",
-    "roots/wordpress": ">=4.7",
+    "roots/wordpress": "5.9.*",
     "squizlabs/php_codesniffer": "^3.3",
     "wp-coding-standards/wpcs": "^2",
-    "wp-phpunit/wp-phpunit": ">=4.7",
+    "wp-phpunit/wp-phpunit": "5.9.*",
     "yoast/phpunit-polyfills": "^1.0"
   },
   "require": {
@@ -51,6 +52,12 @@
   "extra": {
     "wordpress-install-dir": "vendor/roots/wordpress"
   },
+  "repositories": [
+    {
+      "type": "path",
+      "url": "packages/wp-phpunit-polyfill"
+    }
+  ],
   "scripts": {
     "post-install-cmd": [
       "@prefix-dependencies"

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     "automattic/vipwpcs": "^2",
     "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
     "phpcompatibility/phpcompatibility-wp": "^2.1",
-		"phpunit/phpunit": "^5 || ^6 || ^7 || ^8",
+    "phpunit/phpunit": "^5 || ^6 || ^7 || ^8",
     "roave/security-advisories": "dev-latest",
     "roots/wordpress": ">=4.7",
     "squizlabs/php_codesniffer": "^3.3",
@@ -83,7 +83,7 @@
     ],
     "lint": "phpcs",
     "lint-fix": "phpcbf",
-    "test":  "phpunit",
+    "test": "phpunit",
     "test:multisite": "@test --configuration=phpunit.multisite.xml"
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -11,10 +11,10 @@
     "phpcompatibility/phpcompatibility-wp": "^2.1",
     "phpunit/phpunit": "^5 || ^6 || ^7",
     "roave/security-advisories": "dev-latest",
-    "roots/wordpress": "5.9.*",
+    "roots/wordpress": ">=4.7",
     "squizlabs/php_codesniffer": "^3.3",
     "wp-coding-standards/wpcs": "^2",
-    "wp-phpunit/wp-phpunit": "5.9.*",
+    "wp-phpunit/wp-phpunit": ">=4.7",
     "yoast/phpunit-polyfills": "^1.0"
   },
   "require": {

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     "automattic/vipwpcs": "^2",
     "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
     "phpcompatibility/phpcompatibility-wp": "^2.1",
-    "phpunit/phpunit": "^5 || ^6 || ^7 || ^8",
+    "phpunit/phpunit": "^5 || ^6 || ^7",
     "roave/security-advisories": "dev-latest",
     "roots/wordpress": ">=4.7",
     "squizlabs/php_codesniffer": "^3.3",

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
     "google/site-kit-wp-phpunit-polyfill": "^0.1.0",
     "phpcompatibility/phpcompatibility-wp": "^2.1",
-    "phpunit/phpunit": "^5 || ^6 || ^7",
+    "phpunit/phpunit": "^5 || ^6 || ^7 || ^8",
     "roave/security-advisories": "dev-latest",
     "roots/wordpress": ">=4.7",
     "squizlabs/php_codesniffer": "^3.3",

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     "automattic/vipwpcs": "^2",
     "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
     "phpcompatibility/phpcompatibility-wp": "^2.1",
-    "phpunit/phpunit": "^5 || ^6 || ^7",
+		"phpunit/phpunit": "^5 || ^6 || ^7 || ^8",
     "roave/security-advisories": "dev-latest",
     "roots/wordpress": ">=4.7",
     "squizlabs/php_codesniffer": "^3.3",

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
     "google/site-kit-wp-phpunit-polyfill": "^0.1.0",
     "phpcompatibility/phpcompatibility-wp": "^2.1",
-    "phpunit/phpunit": "^5 || ^6 || ^7 || ^8",
+    "phpunit/phpunit": "^5 || ^6 || ^7 || ^8 || ^9",
     "roave/security-advisories": "dev-latest",
     "roots/wordpress": ">=4.7",
     "squizlabs/php_codesniffer": "^3.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f2b08c0ba37bbc6cb8526c13258784c8",
+    "content-hash": "ef9aa8d722909f0c571a212d8f1c9ad3",
     "packages": [
         {
             "name": "firebase/php-jwt",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b8359897ea5dea6e5fab64e94be7dc43",
+    "content-hash": "d67cd63673a4ac5933103f0f2da0cf3b",
     "packages": [
         {
             "name": "firebase/php-jwt",
@@ -986,6 +986,25 @@
                 "source": "https://github.com/doctrine/instantiator/tree/master"
             },
             "time": "2015-06-14T21:17:01+00:00"
+        },
+        {
+            "name": "google/site-kit-wp-phpunit-polyfill",
+            "version": "v0.1",
+            "dist": {
+                "type": "path",
+                "url": "packages/wp-phpunit-polyfill",
+                "reference": "636f6e16f77f326c852049d9f8751cc26a31e85a"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "autoloader.php"
+                ]
+            },
+            "description": "A library for polyfilling changes to core's WP_UnitTestCase below WP 5.2",
+            "transport-options": {
+                "relative": true
+            }
         },
         {
             "name": "myclabs/deep-copy",
@@ -2287,6 +2306,10 @@
             "keywords": [
                 "wordpress"
             ],
+            "support": {
+                "issues": "https://github.com/roots/wordpress-core-installer/issues",
+                "source": "https://github.com/roots/wordpress-core-installer/tree/master"
+            },
             "funding": [
                 {
                     "url": "https://github.com/roots",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "09cf4543398af87915f28ca20147f7b6",
+    "content-hash": "b8359897ea5dea6e5fab64e94be7dc43",
     "packages": [
         {
             "name": "firebase/php-jwt",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ef9aa8d722909f0c571a212d8f1c9ad3",
+    "content-hash": "30131f03995ac4cf954a84be8e0ff8c0",
     "packages": [
         {
             "name": "firebase/php-jwt",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d67cd63673a4ac5933103f0f2da0cf3b",
+    "content-hash": "f2b08c0ba37bbc6cb8526c13258784c8",
     "packages": [
         {
             "name": "firebase/php-jwt",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b8359897ea5dea6e5fab64e94be7dc43",
+    "content-hash": "09cf4543398af87915f28ca20147f7b6",
     "packages": [
         {
             "name": "firebase/php-jwt",
@@ -981,6 +981,10 @@
                 "constructor",
                 "instantiate"
             ],
+            "support": {
+                "issues": "https://github.com/doctrine/instantiator/issues",
+                "source": "https://github.com/doctrine/instantiator/tree/master"
+            },
             "time": "2015-06-14T21:17:01+00:00"
         },
         {
@@ -1026,6 +1030,10 @@
                 "object",
                 "object graph"
             ],
+            "support": {
+                "issues": "https://github.com/myclabs/DeepCopy/issues",
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.x"
+            },
             "time": "2017-10-19T19:58:43+00:00"
         },
         {
@@ -1240,6 +1248,10 @@
                 "reflection",
                 "static analysis"
             ],
+            "support": {
+                "issues": "https://github.com/phpDocumentor/ReflectionCommon/issues",
+                "source": "https://github.com/phpDocumentor/ReflectionCommon/tree/master"
+            },
             "time": "2017-09-11T18:02:19+00:00"
         },
         {
@@ -1285,6 +1297,10 @@
                 }
             ],
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
+            "support": {
+                "issues": "https://github.com/phpDocumentor/ReflectionDocBlock/issues",
+                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/release/3.x"
+            },
             "time": "2017-11-10T14:09:06+00:00"
         },
         {
@@ -1332,6 +1348,10 @@
                     "email": "me@mikevanriel.com"
                 }
             ],
+            "support": {
+                "issues": "https://github.com/phpDocumentor/TypeResolver/issues",
+                "source": "https://github.com/phpDocumentor/TypeResolver/tree/master"
+            },
             "time": "2017-07-14T14:27:02+00:00"
         },
         {
@@ -1395,6 +1415,10 @@
                 "spy",
                 "stub"
             ],
+            "support": {
+                "issues": "https://github.com/phpspec/prophecy/issues",
+                "source": "https://github.com/phpspec/prophecy/tree/v1.10.3"
+            },
             "time": "2020-03-05T15:02:03+00:00"
         },
         {
@@ -1458,6 +1482,11 @@
                 "testing",
                 "xunit"
             ],
+            "support": {
+                "irc": "irc://irc.freenode.net/phpunit",
+                "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/4.0"
+            },
             "time": "2017-04-02T07:44:40+00:00"
         },
         {
@@ -1505,6 +1534,11 @@
                 "filesystem",
                 "iterator"
             ],
+            "support": {
+                "irc": "irc://irc.freenode.net/phpunit",
+                "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/1.4.5"
+            },
             "time": "2017-11-27T13:52:08+00:00"
         },
         {
@@ -1546,6 +1580,10 @@
             "keywords": [
                 "template"
             ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
+                "source": "https://github.com/sebastianbergmann/php-text-template/tree/1.2.1"
+            },
             "time": "2015-06-21T13:50:34+00:00"
         },
         {
@@ -1595,6 +1633,10 @@
             "keywords": [
                 "timer"
             ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-timer/issues",
+                "source": "https://github.com/sebastianbergmann/php-timer/tree/master"
+            },
             "time": "2017-02-26T11:10:40+00:00"
         },
         {
@@ -1644,6 +1686,10 @@
             "keywords": [
                 "tokenizer"
             ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-token-stream/issues",
+                "source": "https://github.com/sebastianbergmann/php-token-stream/tree/1.4"
+            },
             "abandoned": true,
             "time": "2017-12-04T08:55:13+00:00"
         },
@@ -1727,6 +1773,10 @@
                 "testing",
                 "xunit"
             ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/phpunit/issues",
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/5.7.27"
+            },
             "time": "2018-02-01T05:50:59+00:00"
         },
         {
@@ -1786,6 +1836,11 @@
                 "mock",
                 "xunit"
             ],
+            "support": {
+                "irc": "irc://irc.freenode.net/phpunit",
+                "issues": "https://github.com/sebastianbergmann/phpunit-mock-objects/issues",
+                "source": "https://github.com/sebastianbergmann/phpunit-mock-objects/tree/3.4"
+            },
             "abandoned": true,
             "time": "2017-06-30T09:13:00+00:00"
         },
@@ -2121,19 +2176,22 @@
         },
         {
             "name": "roots/wordpress",
-            "version": "5.8",
+            "version": "5.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress/WordPress.git",
-                "reference": "5.8"
+                "reference": "5.9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress/WordPress/zipball/refs/tags/5.8"
+                "url": "https://api.github.com/repos/WordPress/WordPress/zipball/refs/tags/5.9"
             },
             "require": {
                 "php": ">=5.3.2",
                 "roots/wordpress-core-installer": ">=1.0.0"
+            },
+            "provide": {
+                "wordpress/core-implementation": "5.9"
             },
             "type": "wordpress-core",
             "notification-url": "https://packagist.org/downloads/",
@@ -2172,7 +2230,7 @@
                     "type": "patreon"
                 }
             ],
-            "time": "2021-07-20T16:24:55+00:00"
+            "time": "2022-01-25T19:50:55+00:00"
         },
         {
             "name": "roots/wordpress-core-installer",
@@ -2284,6 +2342,10 @@
             ],
             "description": "Looks up which function or method a line of code belongs to",
             "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/issues",
+                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/1.0.2"
+            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
@@ -2354,6 +2416,10 @@
                 "compare",
                 "equality"
             ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/comparator/issues",
+                "source": "https://github.com/sebastianbergmann/comparator/tree/1.2"
+            },
             "time": "2017-01-29T09:50:25+00:00"
         },
         {
@@ -2406,6 +2472,10 @@
             "keywords": [
                 "diff"
             ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/diff/issues",
+                "source": "https://github.com/sebastianbergmann/diff/tree/1.4"
+            },
             "time": "2017-05-22T07:24:03+00:00"
         },
         {
@@ -2456,6 +2526,10 @@
                 "environment",
                 "hhvm"
             ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/environment/issues",
+                "source": "https://github.com/sebastianbergmann/environment/tree/master"
+            },
             "time": "2016-11-26T07:53:53+00:00"
         },
         {
@@ -2523,6 +2597,10 @@
                 "export",
                 "exporter"
             ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/exporter/issues",
+                "source": "https://github.com/sebastianbergmann/exporter/tree/master"
+            },
             "time": "2016-11-19T08:54:04+00:00"
         },
         {
@@ -2574,6 +2652,10 @@
             "keywords": [
                 "global state"
             ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/global-state/issues",
+                "source": "https://github.com/sebastianbergmann/global-state/tree/1.1.1"
+            },
             "time": "2015-10-12T03:26:01+00:00"
         },
         {
@@ -2620,6 +2702,10 @@
             ],
             "description": "Traverses array structures and object graphs to enumerate all referenced objects",
             "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
+                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/master"
+            },
             "time": "2017-02-18T15:18:39+00:00"
         },
         {
@@ -2673,6 +2759,10 @@
             ],
             "description": "Provides functionality to recursively process PHP variables",
             "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/master"
+            },
             "time": "2016-11-19T07:33:16+00:00"
         },
         {
@@ -2715,6 +2805,10 @@
             ],
             "description": "Provides a list of PHP built-in functions that operate on resources",
             "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/resource-operations/issues",
+                "source": "https://github.com/sebastianbergmann/resource-operations/tree/master"
+            },
             "time": "2015-07-28T20:34:47+00:00"
         },
         {
@@ -2758,6 +2852,10 @@
             ],
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/version/issues",
+                "source": "https://github.com/sebastianbergmann/version/tree/master"
+            },
             "time": "2016-10-03T07:35:21+00:00"
         },
         {
@@ -2919,6 +3017,9 @@
                 "polyfill",
                 "portable"
             ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.19.0"
+            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -2987,6 +3088,9 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/yaml/tree/v3.4.47"
+            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -3050,6 +3154,10 @@
                 "check",
                 "validate"
             ],
+            "support": {
+                "issues": "https://github.com/webmozarts/assert/issues",
+                "source": "https://github.com/webmozarts/assert/tree/1.9.1"
+            },
             "time": "2020-07-08T17:02:28+00:00"
         },
         {
@@ -3100,16 +3208,16 @@
         },
         {
             "name": "wp-phpunit/wp-phpunit",
-            "version": "5.8.0",
+            "version": "5.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-phpunit/wp-phpunit.git",
-                "reference": "da3f6fc3bc5cae2c76af6f9a260620fc4f8d9f90"
+                "reference": "02d98f9d5f15442489b5d98c1f4c486901e3e110"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-phpunit/wp-phpunit/zipball/da3f6fc3bc5cae2c76af6f9a260620fc4f8d9f90",
-                "reference": "da3f6fc3bc5cae2c76af6f9a260620fc4f8d9f90",
+                "url": "https://api.github.com/repos/wp-phpunit/wp-phpunit/zipball/02d98f9d5f15442489b5d98c1f4c486901e3e110",
+                "reference": "02d98f9d5f15442489b5d98c1f4c486901e3e110",
                 "shasum": ""
             },
             "type": "library",
@@ -3144,20 +3252,20 @@
                 "issues": "https://github.com/wp-phpunit/issues",
                 "source": "https://github.com/wp-phpunit/wp-phpunit"
             },
-            "time": "2021-07-27T09:32:49+00:00"
+            "time": "2022-01-25T20:37:14+00:00"
         },
         {
             "name": "yoast/phpunit-polyfills",
-            "version": "1.0.1",
+            "version": "1.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Yoast/PHPUnit-Polyfills.git",
-                "reference": "f014fb21c2b0038fd329515d59025af42fb98715"
+                "reference": "5ea3536428944955f969bc764bbe09738e151ada"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/f014fb21c2b0038fd329515d59025af42fb98715",
-                "reference": "f014fb21c2b0038fd329515d59025af42fb98715",
+                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/5ea3536428944955f969bc764bbe09738e151ada",
+                "reference": "5ea3536428944955f969bc764bbe09738e151ada",
                 "shasum": ""
             },
             "require": {
@@ -3165,9 +3273,7 @@
                 "phpunit/phpunit": "^4.8.36 || ^5.7.21 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
             },
             "require-dev": {
-                "php-parallel-lint/php-console-highlighter": "^0.5",
-                "php-parallel-lint/php-parallel-lint": "^1.3.0",
-                "yoast/yoastcs": "^2.1.0"
+                "yoast/yoastcs": "^2.2.0"
             },
             "type": "library",
             "extra": {
@@ -3207,7 +3313,7 @@
                 "issues": "https://github.com/Yoast/PHPUnit-Polyfills/issues",
                 "source": "https://github.com/Yoast/PHPUnit-Polyfills"
             },
-            "time": "2021-08-09T16:28:08+00:00"
+            "time": "2021-11-23T01:37:03+00:00"
         }
     ],
     "aliases": [],

--- a/packages/wp-phpunit-polyfill/autoloader.php
+++ b/packages/wp-phpunit-polyfill/autoloader.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Google\Site_Kit\Tests\Polyfill;
+
+use ReflectionClass;
+use ReflectionException;
+
+spl_autoload_register(
+	function ( $class_name ) {
+		switch ( $class_name ) {
+			case WP_UnitTestCase_Adapter::class:
+				require_once __DIR__ . '/src/WP_UnitTestCase_Adapter.php';
+				return true;
+
+			case WP_UnitTestCase_Polyfill::class:
+				try {
+					$reflection_class = new ReflectionClass( 'WP_UnitTestCase' );
+
+					if ( $reflection_class->hasMethod( 'set_up' ) ) {
+						require_once __DIR__ . '/src/WP_UnitTestCase_Passthru.php';
+					} else {
+						require_once __DIR__ . '/src/WP_UnitTestCase_Polyfill.php';
+					}
+
+					return true;
+				} catch ( ReflectionException $exception ) {
+					return false;
+				}
+		}
+
+		return false;
+	}
+);

--- a/packages/wp-phpunit-polyfill/autoloader.php
+++ b/packages/wp-phpunit-polyfill/autoloader.php
@@ -1,4 +1,12 @@
 <?php
+/**
+ * Polyfill autoloader.
+ *
+ * @package   Google\Site_Kit\Tests\Polyfill
+ * @copyright 2022 Google LLC
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
+ * @link      https://sitekit.withgoogle.com
+ */
 
 namespace Google\Site_Kit\Tests\Polyfill;
 
@@ -8,10 +16,6 @@ use ReflectionException;
 spl_autoload_register(
 	function ( $class_name ) {
 		switch ( $class_name ) {
-			case WP_UnitTestCase_Adapter::class:
-				require_once __DIR__ . '/src/WP_UnitTestCase_Adapter.php';
-				return true;
-
 			case WP_UnitTestCase_Polyfill::class:
 				try {
 					$reflection_class = new ReflectionClass( 'WP_UnitTestCase' );

--- a/packages/wp-phpunit-polyfill/composer.json
+++ b/packages/wp-phpunit-polyfill/composer.json
@@ -1,0 +1,8 @@
+{
+  "name": "google/site-kit-wp-phpunit-polyfill",
+  "description": "A library for polyfilling changes to core's WP_UnitTestCase below WP 5.2",
+  "version": "v0.1",
+  "autoload": {
+    "files": ["autoloader.php"]
+  }
+}

--- a/packages/wp-phpunit-polyfill/src/WP_UnitTestCase_Adapter.php
+++ b/packages/wp-phpunit-polyfill/src/WP_UnitTestCase_Adapter.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace Google\Site_Kit\Tests\Polyfill;
+
+abstract class WP_UnitTestCase_Adapter extends WP_UnitTestCase_Polyfill {}

--- a/packages/wp-phpunit-polyfill/src/WP_UnitTestCase_Adapter.php
+++ b/packages/wp-phpunit-polyfill/src/WP_UnitTestCase_Adapter.php
@@ -1,5 +1,0 @@
-<?php
-
-namespace Google\Site_Kit\Tests\Polyfill;
-
-abstract class WP_UnitTestCase_Adapter extends WP_UnitTestCase_Polyfill {}

--- a/packages/wp-phpunit-polyfill/src/WP_UnitTestCase_Passthru.php
+++ b/packages/wp-phpunit-polyfill/src/WP_UnitTestCase_Passthru.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Google\Site_Kit\Tests\Polyfill;
+
+use WP_UnitTestCase;
+
+class WP_UnitTestCase_Polyfill extends WP_UnitTestCase {}

--- a/packages/wp-phpunit-polyfill/src/WP_UnitTestCase_Passthru.php
+++ b/packages/wp-phpunit-polyfill/src/WP_UnitTestCase_Passthru.php
@@ -1,7 +1,18 @@
 <?php
+/**
+ * Class Google\Site_Kit\Tests\Polyfill\WP_UnitTestCase_Polyfill.
+ *
+ * @package   Google\Site_Kit\Tests\Polyfill
+ * @copyright 2022 Google LLC
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
+ * @link      https://sitekit.withgoogle.com
+ */
 
 namespace Google\Site_Kit\Tests\Polyfill;
 
 use WP_UnitTestCase;
 
-class WP_UnitTestCase_Polyfill extends WP_UnitTestCase {}
+/**
+ * Passthrough implementation for WP >= 5.2
+ */
+class WP_UnitTestCase_Polyfill extends WP_UnitTestCase {} // phpcs:ignore Generic.Classes.DuplicateClassName.Found

--- a/packages/wp-phpunit-polyfill/src/WP_UnitTestCase_Polyfill.php
+++ b/packages/wp-phpunit-polyfill/src/WP_UnitTestCase_Polyfill.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace Google\Site_Kit\Tests\Polyfill;
+
+use WP_UnitTestCase;
+use Yoast\PHPUnitPolyfills\Helpers\AssertAttributeHelper;
+use Yoast\PHPUnitPolyfills\Polyfills\AssertClosedResource;
+use Yoast\PHPUnitPolyfills\Polyfills\AssertEqualsSpecializations;
+use Yoast\PHPUnitPolyfills\Polyfills\AssertFileDirectory;
+use Yoast\PHPUnitPolyfills\Polyfills\AssertFileEqualsSpecializations;
+use Yoast\PHPUnitPolyfills\Polyfills\AssertionRenames;
+use Yoast\PHPUnitPolyfills\Polyfills\AssertIsType;
+use Yoast\PHPUnitPolyfills\Polyfills\AssertNumericType;
+use Yoast\PHPUnitPolyfills\Polyfills\AssertObjectEquals;
+use Yoast\PHPUnitPolyfills\Polyfills\AssertStringContains;
+use Yoast\PHPUnitPolyfills\Polyfills\EqualToSpecializations;
+use Yoast\PHPUnitPolyfills\Polyfills\ExpectException;
+use Yoast\PHPUnitPolyfills\Polyfills\ExpectExceptionMessageMatches;
+use Yoast\PHPUnitPolyfills\Polyfills\ExpectExceptionObject;
+use Yoast\PHPUnitPolyfills\Polyfills\ExpectPHPException;
+
+/**
+ * Defines a basic fixture to run multiple tests.
+ *
+ * Resets the state of the WordPress installation before and after every test.
+ *
+ * Includes utility functions and assertions useful for testing WordPress.
+ *
+ * All WordPress unit tests should inherit from this class.
+ */
+class WP_UnitTestCase_Polyfill extends WP_UnitTestCase {
+
+	use AssertAttributeHelper;
+	use AssertClosedResource;
+	use AssertEqualsSpecializations;
+	use AssertFileDirectory;
+	use AssertFileEqualsSpecializations;
+	use AssertionRenames;
+	use AssertIsType;
+	use AssertNumericType;
+	use AssertObjectEquals;
+	use AssertStringContains;
+	use EqualToSpecializations;
+	use ExpectException;
+	use ExpectExceptionMessageMatches;
+	use ExpectExceptionObject;
+	use ExpectPHPException;
+
+	/**
+	 * Wrapper method for the `set_up_before_class()` method for forward-compatibility with WP 5.9.
+	 */
+	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
+		static::set_up_before_class();
+	}
+
+	/**
+	 * Wrapper method for the `tear_down_after_class()` method for forward-compatibility with WP 5.9.
+	 */
+	public static function tearDownAfterClass() {
+		static::tear_down_after_class();
+		parent::tearDownAfterClass();
+	}
+
+	/**
+	 * Wrapper method for the `set_up()` method for forward-compatibility with WP 5.9.
+	 */
+	public function setUp() {
+		parent::setUp();
+		$this->set_up();
+	}
+
+	/**
+	 * Wrapper method for the `tear_down()` method for forward-compatibility with WP 5.9.
+	 */
+	public function tearDown() {
+		$this->tear_down();
+		parent::tearDown();
+	}
+
+	/**
+	 * Wrapper method for the `assert_pre_conditions()` method for forward-compatibility with WP 5.9.
+	 */
+	protected function assertPreConditions() {
+		parent::assertPreConditions();
+		$this->assert_pre_conditions();
+	}
+
+	/**
+	 * Wrapper method for the `assert_post_conditions()` method for forward-compatibility with WP 5.9.
+	 */
+	protected function assertPostConditions() {
+		parent::assertPostConditions();
+		$this->assert_post_conditions();
+	}
+
+	/**
+	 * Placeholder method for forward-compatibility with WP 5.9.
+	 */
+	public static function set_up_before_class() {
+	}
+
+	/**
+	 * Placeholder method for forward-compatibility with WP 5.9.
+	 */
+	public static function tear_down_after_class() {
+	}
+
+	/**
+	 * Placeholder method for forward-compatibility with WP 5.9.
+	 */
+	protected function set_up() {
+	}
+
+	/**
+	 * Placeholder method for forward-compatibility with WP 5.9.
+	 */
+	protected function tear_down() {
+	}
+
+	/**
+	 * Placeholder method for forward-compatibility with WP 5.9.
+	 */
+	protected function assert_pre_conditions() {
+	}
+
+	/**
+	 * Placeholder method for forward-compatibility with WP 5.9.
+	 */
+	protected function assert_post_conditions() {
+	}
+}

--- a/packages/wp-phpunit-polyfill/src/WP_UnitTestCase_Polyfill.php
+++ b/packages/wp-phpunit-polyfill/src/WP_UnitTestCase_Polyfill.php
@@ -1,4 +1,12 @@
 <?php
+/**
+ * Class Google\Site_Kit\Tests\Polyfill\WP_UnitTestCase_Polyfill.
+ *
+ * @package   Google\Site_Kit\Tests\Polyfill
+ * @copyright 2022 Google LLC
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
+ * @link      https://sitekit.withgoogle.com
+ */
 
 namespace Google\Site_Kit\Tests\Polyfill;
 
@@ -19,14 +27,12 @@ use Yoast\PHPUnitPolyfills\Polyfills\ExpectExceptionMessageMatches;
 use Yoast\PHPUnitPolyfills\Polyfills\ExpectExceptionObject;
 use Yoast\PHPUnitPolyfills\Polyfills\ExpectPHPException;
 
+/* phpcs:disable Generic.Classes.DuplicateClassName.Found */
+
 /**
- * Defines a basic fixture to run multiple tests.
+ * Compatibility layer for WP_UnitTestCase < WP 5.2.
  *
- * Resets the state of the WordPress installation before and after every test.
- *
- * Includes utility functions and assertions useful for testing WordPress.
- *
- * All WordPress unit tests should inherit from this class.
+ * @link https://github.com/WordPress/wordpress-develop/blob/f5e9419fd60ece7818820e7b1aecea1658964492/tests/phpunit/includes/testcase.php
  */
 class WP_UnitTestCase_Polyfill extends WP_UnitTestCase {
 

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -85,20 +85,6 @@
 	<rule ref="WordPressVIPMinimum.Functions.RestrictedFunctions">
 		<exclude-pattern>tests/*</exclude-pattern>
 	</rule>
-	<rule ref="Squiz.Commenting.PostStatementComment">
-		<exclude-pattern>tests/*</exclude-pattern>
-	</rule>
-	<rule ref="Squiz.Commenting.LongConditionClosingComment">
-		<exclude-pattern>tests/*</exclude-pattern>
-	</rule>
-
-	<!-- wp-phpunit-polyfill exclusions -->
-	<rule ref="Generic.Classes.DuplicateClassName">
-		<exclude-pattern>packages/wp-phpunit-polyfill/*</exclude-pattern>
-	</rule>
-	<rule ref="Squiz.Commenting">
-		<exclude-pattern>packages/wp-phpunit-polyfill/*</exclude-pattern>
-	</rule>
 
 	<!-- Third-party and generated code -->
 	<exclude-pattern>dist/*</exclude-pattern>

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -85,6 +85,12 @@
 	<rule ref="WordPressVIPMinimum.Functions.RestrictedFunctions">
 		<exclude-pattern>tests/*</exclude-pattern>
 	</rule>
+	<rule ref="Squiz.Commenting.PostStatementComment">
+		<exclude-pattern>tests/*</exclude-pattern>
+	</rule>
+	<rule ref="Squiz.Commenting.LongConditionClosingComment">
+		<exclude-pattern>tests/*</exclude-pattern>
+	</rule>
 
 	<!-- wp-phpunit-polyfill exclusions -->
 	<rule ref="Generic.Classes.DuplicateClassName">

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -86,6 +86,14 @@
 		<exclude-pattern>tests/*</exclude-pattern>
 	</rule>
 
+	<!-- wp-phpunit-polyfill exclusions -->
+	<rule ref="Generic.Classes.DuplicateClassName">
+		<exclude-pattern>packages/wp-phpunit-polyfill/*</exclude-pattern>
+	</rule>
+	<rule ref="Squiz.Commenting">
+		<exclude-pattern>packages/wp-phpunit-polyfill/*</exclude-pattern>
+	</rule>
+
 	<!-- Third-party and generated code -->
 	<exclude-pattern>dist/*</exclude-pattern>
 	<exclude-pattern>node_modules/*</exclude-pattern>

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -9,8 +9,6 @@
  */
 
 define( 'TESTS_PLUGIN_DIR', dirname( dirname( __DIR__ ) ) );
-// Ensure Composer autoloader is available.
-require_once TESTS_PLUGIN_DIR . '/vendor/autoload.php';
 
 if ( false !== getenv( 'WP_PLUGIN_DIR' ) ) {
 	define( 'WP_PLUGIN_DIR', getenv( 'WP_PLUGIN_DIR' ) );

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -9,6 +9,8 @@
  */
 
 define( 'TESTS_PLUGIN_DIR', dirname( dirname( __DIR__ ) ) );
+// Ensure Composer autoloader is available.
+require_once TESTS_PLUGIN_DIR . '/vendor/autoload.php';
 
 if ( false !== getenv( 'WP_PLUGIN_DIR' ) ) {
 	define( 'WP_PLUGIN_DIR', getenv( 'WP_PLUGIN_DIR' ) );
@@ -24,9 +26,6 @@ if ( false !== getenv( 'WP_TESTS_DIR' ) ) {
 } elseif ( file_exists( '/tmp/wordpress-tests-lib/includes/bootstrap.php' ) ) {
 	$_test_root = '/tmp/wordpress-tests-lib';
 } else {
-	// Ensure Composer autoloader is available.
-	require_once TESTS_PLUGIN_DIR . '/vendor/autoload.php';
-
 	if ( ! getenv( 'WP_PHPUNIT__DIR' ) ) {
 		printf( '%s is not defined. Run `composer install` to install the WordPress tests library.' . "\n", 'WP_PHPUNIT__DIR' );
 		exit;

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -42,23 +42,6 @@ $GLOBALS['wp_tests_options'] = array(
 	'active_plugins' => array( basename( TESTS_PLUGIN_DIR ) . '/google-site-kit.php' ),
 );
 
-/**
- * PHP 8 Compatibility with PHPUnit 7.
- *
- * WordPress core loads these via the main autoloader but these files
- * aren't installed via Composer (yet) so we need to require them manually
- * before PHPUnit's bundled versions are autoloaded to use the compatible versions.
- *
- * @see https://core.trac.wordpress.org/ticket/50902
- * @see https://core.trac.wordpress.org/ticket/50913
- */
-if ( version_compare( '8.0', phpversion(), '<=' ) ) {
-	require_once $_test_root . '/includes/phpunit7/MockObject/Builder/NamespaceMatch.php';
-	require_once $_test_root . '/includes/phpunit7/MockObject/Builder/ParametersMatch.php';
-	require_once $_test_root . '/includes/phpunit7/MockObject/InvocationMocker.php';
-	require_once $_test_root . '/includes/phpunit7/MockObject/MockMethod.php';
-}
-
 // Give access to tests_add_filter() function.
 require $_test_root . '/includes/functions.php';
 

--- a/tests/phpunit/includes/Core/Modules/Module_With_Scopes_ContractTests.php
+++ b/tests/phpunit/includes/Core/Modules/Module_With_Scopes_ContractTests.php
@@ -28,7 +28,7 @@ trait Module_With_Scopes_ContractTests {
 
 		$scopes = $module->get_scopes();
 
-		$testcase->assertInternalType( 'array', $scopes );
+		$testcase->assertIsArray( $scopes );
 
 		// Test that anything else is only a Google scope.
 		$scopes = array_diff( $scopes, array( 'openid', 'profile', 'email' ) );

--- a/tests/phpunit/includes/Modules/SettingsTestCase.php
+++ b/tests/phpunit/includes/Modules/SettingsTestCase.php
@@ -19,8 +19,8 @@ abstract class SettingsTestCase extends TestCase {
 	 */
 	abstract protected function get_option_name();
 
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 
 		$option_name = $this->get_option_name();
 

--- a/tests/phpunit/includes/TestCase.php
+++ b/tests/phpunit/includes/TestCase.php
@@ -16,10 +16,10 @@ use Google\Site_Kit\Core\Util\Build_Mode;
 use Google\Site_Kit\Core\Util\Feature_Flags;
 use Google\Site_Kit\Core\Util\Input;
 use Google\Site_Kit\Tests\Exception\RedirectException;
-use Google\Site_Kit\Tests\Polyfill\WP_UnitTestCase_Adapter;
+use Google\Site_Kit\Tests\Polyfill\WP_UnitTestCase_Polyfill;
 use PHPUnit_Framework_MockObject_MockObject;
 
-class TestCase extends WP_UnitTestCase_Adapter {
+class TestCase extends WP_UnitTestCase_Polyfill {
 	// Do not preserve global state since it doesn't support closures within globals.
 	protected $preserveGlobalState = false;
 

--- a/tests/phpunit/includes/TestCase.php
+++ b/tests/phpunit/includes/TestCase.php
@@ -218,6 +218,21 @@ class TestCase extends WP_UnitTestCase_Adapter {
 		);
 	}
 
+	/**
+	 * Asserts that the associative array subset is within the given array.
+	 *
+	 * Replacement for PHPUnit's deprecated assertArraySubset in PHPUnit 8.
+	 *
+	 * @param array  $subset  Partial array.
+	 * @param array  $array   Array to check includes the partial.
+	 * @param string $message Optional. Message to display when the assertion fails.
+	 */
+	protected function assertArrayIntersection( array $subset, array $array, $message = '' ) {
+		$intersection = array_intersect_key( $subset, $array );
+
+		$this->assertEqualSetsWithIndex( $subset, $intersection, $message );
+	}
+
 	protected function assertOptionNotExists( $option ) {
 		$this->assertNull(
 			$this->queryOption( $option ),

--- a/tests/phpunit/includes/TestCase.php
+++ b/tests/phpunit/includes/TestCase.php
@@ -16,9 +16,10 @@ use Google\Site_Kit\Core\Util\Build_Mode;
 use Google\Site_Kit\Core\Util\Feature_Flags;
 use Google\Site_Kit\Core\Util\Input;
 use Google\Site_Kit\Tests\Exception\RedirectException;
+use Google\Site_Kit\Tests\Polyfill\WP_UnitTestCase_Adapter;
 use PHPUnit_Framework_MockObject_MockObject;
 
-class TestCase extends \WP_UnitTestCase {
+class TestCase extends WP_UnitTestCase_Adapter {
 	// Do not preserve global state since it doesn't support closures within globals.
 	protected $preserveGlobalState = false;
 

--- a/tests/phpunit/includes/TestCase.php
+++ b/tests/phpunit/includes/TestCase.php
@@ -24,8 +24,8 @@ class TestCase extends \WP_UnitTestCase {
 
 	protected static $featureFlagsConfig;
 
-	public static function setUpBeforeClass() {
-		parent::setUpBeforeClass();
+	public static function set_up_before_class() {
+		parent::set_up_before_class();
 
 		if ( ! self::$featureFlagsConfig ) {
 			self::$featureFlagsConfig = json_decode(
@@ -37,8 +37,8 @@ class TestCase extends \WP_UnitTestCase {
 		self::reset_feature_flags();
 	}
 
-	public static function tearDownAfterClass() {
-		parent::tearDownAfterClass();
+	public static function tear_down_after_class() {
+		parent::tear_down_after_class();
 		self::reset_feature_flags();
 		self::reset_build_mode();
 	}
@@ -54,8 +54,8 @@ class TestCase extends \WP_UnitTestCase {
 	/**
 	 * Runs the routine before each test is executed.
 	 */
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 
 		// At this point all hooks are isolated between tests.
 
@@ -79,8 +79,8 @@ class TestCase extends \WP_UnitTestCase {
 	/**
 	 * After a test method runs, reset any state in WordPress the test method might have changed.
 	 */
-	public function tearDown() {
-		parent::tearDown();
+	public function tear_down() {
+		parent::tear_down();
 		// Clear screen related globals.
 		unset( $GLOBALS['current_screen'], $GLOBALS['taxnow'], $GLOBALS['typenow'] );
 	}

--- a/tests/phpunit/integration/Core/Admin/NoticeTest.php
+++ b/tests/phpunit/integration/Core/Admin/NoticeTest.php
@@ -96,8 +96,8 @@ class NoticeTest extends TestCase {
 		$notice->render();
 		$output = ob_get_clean();
 
-		$this->assertContains( '<div id="googlesitekit-notice-test-slug" class="notice notice-success">', $output );
-		$this->assertContains( '<p>Successfully saved.</p>', $output );
+		$this->assertStringContainsString( '<div id="googlesitekit-notice-test-slug" class="notice notice-success">', $output );
+		$this->assertStringContainsString( '<p>Successfully saved.</p>', $output );
 	}
 
 	public function test_render_with_callable() {
@@ -116,7 +116,7 @@ class NoticeTest extends TestCase {
 		$notice->render();
 		$output = ob_get_clean();
 
-		$this->assertContains( '<div id="googlesitekit-notice-test-slug" class="notice notice-warning is-dismissible">', $output );
-		$this->assertContains( '<p>Successfully saved<script>document.write(" just now");</script>.</p>', $output );
+		$this->assertStringContainsString( '<div id="googlesitekit-notice-test-slug" class="notice notice-warning is-dismissible">', $output );
+		$this->assertStringContainsString( '<p>Successfully saved<script>document.write(" just now");</script>.</p>', $output );
 	}
 }

--- a/tests/phpunit/integration/Core/Admin/ScreensTest.php
+++ b/tests/phpunit/integration/Core/Admin/ScreensTest.php
@@ -29,8 +29,8 @@ class ScreensTest extends TestCase {
 	 */
 	private $screens;
 
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 
 		$context = new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE );
 		$assets  = new Assets( $context );

--- a/tests/phpunit/integration/Core/Assets/AssetsTest.php
+++ b/tests/phpunit/integration/Core/Assets/AssetsTest.php
@@ -144,6 +144,6 @@ class AssetsTest extends TestCase {
 
 		// Ensure that before_print callback for 'googlesitekit-commons' was run (its localized script should be there).
 		$localized_script = wp_scripts()->get_data( 'googlesitekit-commons', 'data' );
-		$this->assertContains( 'var _googlesitekitLegacyData = ', $localized_script );
+		$this->assertStringContainsString( 'var _googlesitekitLegacyData = ', $localized_script );
 	}
 }

--- a/tests/phpunit/integration/Core/Assets/AssetsTest.php
+++ b/tests/phpunit/integration/Core/Assets/AssetsTest.php
@@ -19,8 +19,8 @@ use Google\Site_Kit\Tests\TestCase;
  */
 class AssetsTest extends TestCase {
 
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 
 		wp_scripts()->registered = array();
 		wp_scripts()->queue      = array();

--- a/tests/phpunit/integration/Core/Assets/ScriptTest.php
+++ b/tests/phpunit/integration/Core/Assets/ScriptTest.php
@@ -19,8 +19,8 @@ use Google\Site_Kit\Tests\TestCase;
  */
 class ScriptTest extends TestCase {
 
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 
 		wp_scripts()->registered = array();
 		wp_scripts()->queue      = array();

--- a/tests/phpunit/integration/Core/Assets/Script_DataTest.php
+++ b/tests/phpunit/integration/Core/Assets/Script_DataTest.php
@@ -19,8 +19,8 @@ use Google\Site_Kit\Tests\TestCase;
  */
 class Script_DataTest extends TestCase {
 
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 
 		wp_scripts()->registered = array();
 		wp_scripts()->queue      = array();

--- a/tests/phpunit/integration/Core/Assets/Script_DataTest.php
+++ b/tests/phpunit/integration/Core/Assets/Script_DataTest.php
@@ -48,7 +48,7 @@ class Script_DataTest extends TestCase {
 
 		$script->before_print();
 
-		$this->assertContains(
+		$this->assertStringContainsString(
 			'var testGlobal = ' . wp_json_encode( $data ),
 			wp_scripts()->get_data( 'test-handle', 'data' )
 		);

--- a/tests/phpunit/integration/Core/Assets/StylesheetTest.php
+++ b/tests/phpunit/integration/Core/Assets/StylesheetTest.php
@@ -19,8 +19,8 @@ use Google\Site_Kit\Tests\TestCase;
  */
 class StylesheetTest extends TestCase {
 
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 
 		wp_styles()->registered = array();
 		wp_styles()->queue      = array();

--- a/tests/phpunit/integration/Core/Authentication/AuthenticationTest.php
+++ b/tests/phpunit/integration/Core/Authentication/AuthenticationTest.php
@@ -468,7 +468,7 @@ class AuthenticationTest extends TestCase {
 			do_action( $connect_action );
 			$this->fail( 'Expected WPDieException to be thrown' );
 		} catch ( WPDieException $e ) {
-			$this->assertContains( 'have permissions to authenticate', $e->getMessage() );
+			$this->assertStringContainsString( 'have permissions to authenticate', $e->getMessage() );
 		}
 
 		$editor_id = $this->factory()->user->create( array( 'role' => 'editor' ) );
@@ -479,7 +479,7 @@ class AuthenticationTest extends TestCase {
 			do_action( $connect_action );
 			$this->fail( 'Expected WPDieException to be thrown' );
 		} catch ( WPDieException $e ) {
-			$this->assertContains( 'have permissions to authenticate', $e->getMessage() );
+			$this->assertStringContainsString( 'have permissions to authenticate', $e->getMessage() );
 		}
 
 		// Administrators can authenticate.
@@ -533,7 +533,7 @@ class AuthenticationTest extends TestCase {
 			do_action( $disconnect_action );
 			$this->fail( 'Expected WPDieException to be thrown' );
 		} catch ( WPDieException $e ) {
-			$this->assertContains( 'have permissions to authenticate', $e->getMessage() );
+			$this->assertStringContainsString( 'have permissions to authenticate', $e->getMessage() );
 		}
 
 		$editor_id = $this->factory()->user->create( array( 'role' => 'editor' ) );
@@ -544,7 +544,7 @@ class AuthenticationTest extends TestCase {
 			do_action( $disconnect_action );
 			$this->fail( 'Expected WPDieException to be thrown' );
 		} catch ( WPDieException $e ) {
-			$this->assertContains( 'have permissions to authenticate', $e->getMessage() );
+			$this->assertStringContainsString( 'have permissions to authenticate', $e->getMessage() );
 		}
 
 		// Administrators can authenticate.
@@ -680,7 +680,7 @@ class AuthenticationTest extends TestCase {
 			do_action( $action );
 			$this->fail( 'Expected WPDieException to be thrown' );
 		} catch ( Exception $e ) {
-			$this->assertContains( 'insufficient permissions to manage Site Kit permissions', $e->getMessage() );
+			$this->assertStringContainsString( 'insufficient permissions to manage Site Kit permissions', $e->getMessage() );
 		}
 
 		wp_set_current_user( $admin_id );
@@ -694,7 +694,7 @@ class AuthenticationTest extends TestCase {
 			do_action( $action );
 			$this->fail( 'Expected WPDieException to be thrown' );
 		} catch ( Exception $e ) {
-			$this->assertContains( 'Site Kit is not configured to use the authentication proxy', $e->getMessage() );
+			$this->assertStringContainsString( 'Site Kit is not configured to use the authentication proxy', $e->getMessage() );
 		}
 
 		list( $site_id ) = $this->fake_proxy_site_connection();

--- a/tests/phpunit/integration/Core/Authentication/Clients/OAuth_ClientTest.php
+++ b/tests/phpunit/integration/Core/Authentication/Clients/OAuth_ClientTest.php
@@ -419,7 +419,7 @@ class OAuth_ClientTest extends TestCase {
 			$client->authorize_user();
 		} catch ( RedirectException $redirect ) {
 			$this->assertStringStartsWith( "$success_redirect?", $redirect->get_location() );
-			$this->assertContains( 'notification=authentication_success', $redirect->get_location() );
+			$this->assertStringContainsString( 'notification=authentication_success', $redirect->get_location() );
 		}
 
 		$profile = $user_options->get( Profile::OPTION );
@@ -585,35 +585,35 @@ class OAuth_ClientTest extends TestCase {
 		// If no site ID, pass site registration args.
 		$client = new OAuth_Client( $context );
 		$url    = $client->get_proxy_setup_url();
-		$this->assertContains( 'name=', $url );
-		$this->assertContains( 'url=', $url );
-		$this->assertContains( 'scope=', $url );
-		$this->assertContains( 'nonce=', $url );
-		$this->assertContains( 'redirect_uri=', $url );
-		$this->assertContains( 'action_uri=', $url );
-		$this->assertContains( 'return_uri=', $url );
-		$this->assertContains( 'analytics_redirect_uri=', $url );
-		$this->assertContains( 'user_roles=', $url );
-		$this->assertContains( 'application_name=', $url );
-		$this->assertContains( 'hl=', $url );
-		$this->assertNotContains( 'site_id=', $url );
+		$this->assertStringContainsString( 'name=', $url );
+		$this->assertStringContainsString( 'url=', $url );
+		$this->assertStringContainsString( 'scope=', $url );
+		$this->assertStringContainsString( 'nonce=', $url );
+		$this->assertStringContainsString( 'redirect_uri=', $url );
+		$this->assertStringContainsString( 'action_uri=', $url );
+		$this->assertStringContainsString( 'return_uri=', $url );
+		$this->assertStringContainsString( 'analytics_redirect_uri=', $url );
+		$this->assertStringContainsString( 'user_roles=', $url );
+		$this->assertStringContainsString( 'application_name=', $url );
+		$this->assertStringContainsString( 'hl=', $url );
+		$this->assertStringNotContainsString( 'site_id=', $url );
 
 		// Otherwise, pass site ID and given temporary access code.
 		list( $site_id ) = $this->fake_proxy_site_connection();
 		$client          = new OAuth_Client( $context );
 		$url             = $client->get_proxy_setup_url( 'temp-code' );
-		$this->assertContains( 'site_id=' . $site_id, $url );
-		$this->assertContains( 'code=temp-code', $url );
-		$this->assertContains( 'scope=', $url );
-		$this->assertContains( 'nonce=', $url );
-		$this->assertContains( 'user_roles=', $url );
-		$this->assertContains( 'application_name=', $url );
-		$this->assertNotContains( '&name=', $url );
-		$this->assertNotContains( 'url=', $url );
-		$this->assertNotContains( 'redirect_uri=', $url );
-		$this->assertNotContains( 'action_uri=', $url );
-		$this->assertNotContains( 'return_uri=', $url );
-		$this->assertNotContains( 'analytics_redirect_uri=', $url );
+		$this->assertStringContainsString( 'site_id=' . $site_id, $url );
+		$this->assertStringContainsString( 'code=temp-code', $url );
+		$this->assertStringContainsString( 'scope=', $url );
+		$this->assertStringContainsString( 'nonce=', $url );
+		$this->assertStringContainsString( 'user_roles=', $url );
+		$this->assertStringContainsString( 'application_name=', $url );
+		$this->assertStringNotContainsString( '&name=', $url );
+		$this->assertStringNotContainsString( 'url=', $url );
+		$this->assertStringNotContainsString( 'redirect_uri=', $url );
+		$this->assertStringNotContainsString( 'action_uri=', $url );
+		$this->assertStringNotContainsString( 'return_uri=', $url );
+		$this->assertStringNotContainsString( 'analytics_redirect_uri=', $url );
 	}
 
 	public function test_get_proxy_permissions_url() {
@@ -631,19 +631,19 @@ class OAuth_ClientTest extends TestCase {
 		$client = new OAuth_Client( $context );
 		$client->set_token( array( 'access_token' => 'test-access-token' ) );
 		$url = $client->get_proxy_permissions_url();
-		$this->assertContains( 'token=test-access-token', $url );
-		$this->assertContains( 'application_name=', $url );
-		$this->assertContains( 'hl=', $url );
+		$this->assertStringContainsString( 'token=test-access-token', $url );
+		$this->assertStringContainsString( 'application_name=', $url );
+		$this->assertStringContainsString( 'hl=', $url );
 
 		// If there is a site ID, it should also include that.
 		list( $site_id ) = $this->fake_proxy_site_connection();
 		$client          = new OAuth_Client( $context );
 		$client->set_token( array( 'access_token' => 'test-access-token' ) );
 		$url = $client->get_proxy_permissions_url();
-		$this->assertContains( 'token=test-access-token', $url );
-		$this->assertContains( 'site_id=' . $site_id, $url );
-		$this->assertContains( 'application_name=', $url );
-		$this->assertContains( 'hl=', $url );
+		$this->assertStringContainsString( 'token=test-access-token', $url );
+		$this->assertStringContainsString( 'site_id=' . $site_id, $url );
+		$this->assertStringContainsString( 'application_name=', $url );
+		$this->assertStringContainsString( 'hl=', $url );
 	}
 
 	protected function get_user_credential_keys() {

--- a/tests/phpunit/integration/Core/Authentication/Clients/OAuth_Client_BaseTest.php
+++ b/tests/phpunit/integration/Core/Authentication/Clients/OAuth_Client_BaseTest.php
@@ -149,9 +149,9 @@ class OAuth_Client_BaseTest extends TestCase {
 			->setConstructorArgs( array( new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE ) ) )
 			->getMockForAbstractClass();
 
-		$this->assertContains( 'Unknown Error (code: unknown_code)', $oauth_client->get_error_message( 'unknown_code' ) );
-		$this->assertContains( 'Unknown Error (code: )', $oauth_client->get_error_message( '' ) );
-		$this->assertContains( 'Unknown Error (code: 123)', $oauth_client->get_error_message( 123 ) );
+		$this->assertStringContainsString( 'Unknown Error (code: unknown_code)', $oauth_client->get_error_message( 'unknown_code' ) );
+		$this->assertStringContainsString( 'Unknown Error (code: )', $oauth_client->get_error_message( '' ) );
+		$this->assertStringContainsString( 'Unknown Error (code: 123)', $oauth_client->get_error_message( 123 ) );
 	}
 
 	/**
@@ -165,7 +165,7 @@ class OAuth_Client_BaseTest extends TestCase {
 		$message = $oauth_client->get_error_message( $error_code );
 
 		$this->assertRegExp( '/unable|invalid|failed/i', $message );
-		$this->assertNotContains( 'Unknown Error', $message );
+		$this->assertStringNotContainsString( 'Unknown Error', $message );
 	}
 
 	public function error_message_provider() {

--- a/tests/phpunit/integration/Core/Authentication/Clients/OAuth_Client_BaseTest.php
+++ b/tests/phpunit/integration/Core/Authentication/Clients/OAuth_Client_BaseTest.php
@@ -164,7 +164,7 @@ class OAuth_Client_BaseTest extends TestCase {
 
 		$message = $oauth_client->get_error_message( $error_code );
 
-		$this->assertRegExp( '/unable|invalid|failed/i', $message );
+		$this->assertMatchesRegularExpression( '/unable|invalid|failed/i', $message );
 		$this->assertStringNotContainsString( 'Unknown Error', $message );
 	}
 

--- a/tests/phpunit/integration/Core/Authentication/Connected_Proxy_URLTest.php
+++ b/tests/phpunit/integration/Core/Authentication/Connected_Proxy_URLTest.php
@@ -29,8 +29,8 @@ class Connected_Proxy_URLTest extends SettingsTestCase {
 	 */
 	private $options;
 
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 		$this->options = new Options( new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE ) );
 	}
 

--- a/tests/phpunit/integration/Core/Authentication/Disconnected_ReasonTest.php
+++ b/tests/phpunit/integration/Core/Authentication/Disconnected_ReasonTest.php
@@ -29,8 +29,8 @@ class Disconnected_ReasonTest extends SettingsTestCase {
 	 */
 	private $options;
 
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 		$this->options = new User_Options( new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE ) );
 	}
 

--- a/tests/phpunit/integration/Core/Authentication/Google_ProxyTest.php
+++ b/tests/phpunit/integration/Core/Authentication/Google_ProxyTest.php
@@ -56,8 +56,8 @@ class Google_ProxyTest extends TestCase {
 	 */
 	private $request_args;
 
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 
 		$this->context      = new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE );
 		$this->google_proxy = new Google_Proxy( $this->context );

--- a/tests/phpunit/integration/Core/Authentication/Has_Connected_AdminsTest.php
+++ b/tests/phpunit/integration/Core/Authentication/Has_Connected_AdminsTest.php
@@ -37,8 +37,8 @@ class Has_Connected_AdminsTest extends TestCase {
 	 */
 	protected $user_options;
 
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 		$this->context      = new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE );
 		$this->options      = new Options( $this->context );
 		$this->user_options = new User_Options( $this->context );

--- a/tests/phpunit/integration/Core/Authentication/Has_Multiple_AdminsTest.php
+++ b/tests/phpunit/integration/Core/Authentication/Has_Multiple_AdminsTest.php
@@ -30,8 +30,8 @@ class Has_Multiple_AdminsTest extends TestCase {
 	 */
 	protected $transients;
 
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 		$this->context    = new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE );
 		$this->transients = new Transients( $this->context );
 	}

--- a/tests/phpunit/integration/Core/Authentication/Owner_IDTest.php
+++ b/tests/phpunit/integration/Core/Authentication/Owner_IDTest.php
@@ -46,14 +46,14 @@ class Owner_IDTest extends SettingsTestCase {
 
 	public function test_get() {
 		$this->assertEquals( 0, $this->owner_id->get() );
-		$this->assertInternalType( 'int', $this->owner_id->get() );
+		$this->assertIsInt( $this->owner_id->get() );
 
 		$this->options->set( Owner_ID::OPTION, 1 );
-		$this->assertInternalType( 'int', $this->owner_id->get() );
+		$this->assertIsInt( $this->owner_id->get() );
 		$this->assertEquals( 1, $this->owner_id->get() );
 
 		$this->options->set( Owner_ID::OPTION, 'xxx' );
-		$this->assertInternalType( 'int', $this->owner_id->get() );
+		$this->assertIsInt( $this->owner_id->get() );
 		$this->assertEquals( 0, $this->owner_id->get() );
 
 		// When setting with a string, WP sanitizes it before caching.
@@ -61,7 +61,7 @@ class Owner_IDTest extends SettingsTestCase {
 		// from the DB with a cold cache will result in a string return value.
 		$this->options->set( Owner_ID::OPTION, '3' );
 		wp_cache_flush(); // The option value is cached on set, so we have to flush after.
-		$this->assertInternalType( 'int', $this->owner_id->get() );
+		$this->assertIsInt( $this->owner_id->get() );
 		$this->assertEquals( 3, $this->owner_id->get() );
 	}
 

--- a/tests/phpunit/integration/Core/Authentication/Owner_IDTest.php
+++ b/tests/phpunit/integration/Core/Authentication/Owner_IDTest.php
@@ -36,8 +36,8 @@ class Owner_IDTest extends SettingsTestCase {
 	 */
 	private $options;
 
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 
 		$this->options  = new Options( new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE ) );
 		$this->owner_id = new Owner_ID( $this->options );

--- a/tests/phpunit/integration/Core/Authentication/Setup_V2Test.php
+++ b/tests/phpunit/integration/Core/Authentication/Setup_V2Test.php
@@ -182,11 +182,11 @@ class Setup_V2Test extends TestCase {
 		} catch ( RedirectException $redirect ) {
 			$location = $redirect->get_location();
 			$this->assertStringStartsWith( 'https://sitekit.withgoogle.com/site-management/setup/', $location );
-			$this->assertContains( '&step=test-step', $location );
-			$this->assertContains( '&verify=true', $location );
-			$this->assertContains( '&verification_method=FILE', $location );
+			$this->assertStringContainsString( '&step=test-step', $location );
+			$this->assertStringContainsString( '&verify=true', $location );
+			$this->assertStringContainsString( '&verification_method=FILE', $location );
 		} catch ( WPDieException $exception ) {
-			$this->assertContains(
+			$this->assertStringContainsString(
 				'Verifying site ownership requires a token and verification method',
 				$exception->getMessage()
 			);
@@ -273,7 +273,7 @@ class Setup_V2Test extends TestCase {
 			do_action( 'admin_action_' . Google_Proxy::ACTION_EXCHANGE_SITE_CODE );
 			$this->fail( 'Expected redirection to proxy setup URL!' );
 		} catch ( WPDieException $exception ) {
-			$this->assertContains(
+			$this->assertStringContainsString(
 				'Invalid request',
 				$exception->getMessage()
 			);
@@ -284,7 +284,7 @@ class Setup_V2Test extends TestCase {
 		} catch ( RedirectException $redirect ) {
 			$location = $redirect->get_location();
 			$this->assertStringStartsWith( 'https://sitekit.withgoogle.com/site-management/setup/', $location );
-			$this->assertContains( '&step=test-step', $location );
+			$this->assertStringContainsString( '&step=test-step', $location );
 			$this->assertArrayHasKey( $sync_url, $http_requests );
 			$sync_request = $http_requests[ $sync_url ];
 			$this->assertEquals( $code, $sync_request['body']['code'] );

--- a/tests/phpunit/integration/Core/Authentication/Setup_V2Test.php
+++ b/tests/phpunit/integration/Core/Authentication/Setup_V2Test.php
@@ -21,8 +21,8 @@ use WPDieException;
 class Setup_V2Test extends TestCase {
 	use Fake_Site_Connection_Trait;
 
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 
 		// Remove hooked actions for V1 during bootstrap.
 		remove_all_actions( 'admin_action_' . Google_Proxy::ACTION_SETUP_START );

--- a/tests/phpunit/integration/Core/Authentication/TokenTest.php
+++ b/tests/phpunit/integration/Core/Authentication/TokenTest.php
@@ -25,8 +25,8 @@ class TokenTest extends TestCase {
 	private $user_options;
 	private $encrypted_user_options;
 
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 
 		$user_id = $this->factory()->user->create();
 		$context = new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE );

--- a/tests/phpunit/integration/Core/Authentication/User_Input_StateTest.php
+++ b/tests/phpunit/integration/Core/Authentication/User_Input_StateTest.php
@@ -30,8 +30,8 @@ class User_Input_StateTest extends TestCase {
 	/**
 	 * Set Up Test.
 	 */
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 		$user_id                = $this->factory()->user->create();
 		$context                = new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE );
 		$this->user_options     = new User_Options( $context, $user_id );

--- a/tests/phpunit/integration/Core/Authentication/VerificationTest.php
+++ b/tests/phpunit/integration/Core/Authentication/VerificationTest.php
@@ -54,8 +54,8 @@ class VerificationTest extends TestCase {
 	/**
 	 * Set Up Test.
 	 */
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 		wp_set_current_user( self::$user_id );
 		$this->user_options = new User_Options( new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE ) );
 	}

--- a/tests/phpunit/integration/Core/Dismissals/Dismissed_ItemsTest.php
+++ b/tests/phpunit/integration/Core/Dismissals/Dismissed_ItemsTest.php
@@ -27,8 +27,8 @@ class Dismissed_ItemsTest extends TestCase {
 	 */
 	private $dismissed_items;
 
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 
 		$user_id = $this->factory()->user->create();
 		$context = new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE );

--- a/tests/phpunit/integration/Core/Dismissals/REST_Dismissals_ControllerTest.php
+++ b/tests/phpunit/integration/Core/Dismissals/REST_Dismissals_ControllerTest.php
@@ -34,8 +34,8 @@ class REST_Dismissals_ControllerTest extends TestCase {
 	 */
 	private $controller;
 
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 
 		$user_id = $this->factory()->user->create( array( 'role' => 'administrator' ) );
 		wp_set_current_user( $user_id );
@@ -46,8 +46,8 @@ class REST_Dismissals_ControllerTest extends TestCase {
 		$this->controller      = new REST_Dismissals_Controller( $this->dismissed_items );
 	}
 
-	public function tearDown() {
-		parent::tearDown();
+	public function tear_down() {
+		parent::tear_down();
 		// This ensures the REST server is initialized fresh for each test using it.
 		unset( $GLOBALS['wp_rest_server'] );
 	}

--- a/tests/phpunit/integration/Core/Feature_Tours/Dismissed_ToursTest.php
+++ b/tests/phpunit/integration/Core/Feature_Tours/Dismissed_ToursTest.php
@@ -22,8 +22,8 @@ class Dismissed_ToursTest extends TestCase {
 	 */
 	protected $user_options;
 
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 		$user_id            = $this->factory()->user->create();
 		$context            = new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE );
 		$this->user_options = new User_Options( $context, $user_id );

--- a/tests/phpunit/integration/Core/Feature_Tours/REST_Feature_Tours_ControllerTest.php
+++ b/tests/phpunit/integration/Core/Feature_Tours/REST_Feature_Tours_ControllerTest.php
@@ -36,8 +36,8 @@ class REST_Feature_Tours_ControllerTest extends TestCase {
 	 */
 	private $controller;
 
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 
 		$user_id = $this->factory()->user->create( array( 'role' => 'administrator' ) );
 		wp_set_current_user( $user_id );
@@ -48,8 +48,8 @@ class REST_Feature_Tours_ControllerTest extends TestCase {
 		$this->controller      = new REST_Feature_Tours_Controller( $this->dismissed_tours );
 	}
 
-	public function tearDown() {
-		parent::tearDown();
+	public function tear_down() {
+		parent::tear_down();
 		// This ensures the REST server is initialized fresh for each test using it.
 		unset( $GLOBALS['wp_rest_server'] );
 	}

--- a/tests/phpunit/integration/Core/Modules/ModuleTest.php
+++ b/tests/phpunit/integration/Core/Modules/ModuleTest.php
@@ -99,7 +99,7 @@ class ModuleTest extends TestCase {
 
 		$module   = new FakeModule( new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE ) );
 		$response = $module->get_data( 'test-request', array( 'foo' => 'bar' ) );
-		$this->assertInternalType( 'object', $response );
+		$this->assertIsObject( $response );
 		$this->assertEquals( 'GET', $response->method );
 		$this->assertEquals( 'test-request', $response->datapoint );
 		$this->assertEquals( array( 'foo' => 'bar' ), (array) $response->data );
@@ -112,7 +112,7 @@ class ModuleTest extends TestCase {
 				'asArray' => true,
 			)
 		);
-		$this->assertInternalType( 'array', $response );
+		$this->assertIsArray( $response );
 		$this->assertEquals( 'GET', $response['method'] );
 		$this->assertEquals( 'test-request', $response['datapoint'] );
 		$this->assertEquals(

--- a/tests/phpunit/integration/Core/Modules/Module_Sharing_SettingsTest.php
+++ b/tests/phpunit/integration/Core/Modules/Module_Sharing_SettingsTest.php
@@ -24,8 +24,8 @@ class Module_Sharing_SettingsTest extends SettingsTestCase {
 	 */
 	private $settings;
 
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 
 		$context        = new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE );
 		$options        = new Options( $context );

--- a/tests/phpunit/integration/Core/Modules/ModulesTest.php
+++ b/tests/phpunit/integration/Core/Modules/ModulesTest.php
@@ -134,7 +134,7 @@ class ModulesTest extends TestCase {
 			$modules->get_module( $module_slug );
 		} catch ( \Exception $exception ) {
 			// We expect an exception to be thrown, let's make sure it's the right one.
-			$this->assertContains( $module_slug, $exception->getMessage() );
+			$this->assertStringContainsString( $module_slug, $exception->getMessage() );
 
 			return;
 		}
@@ -161,7 +161,7 @@ class ModulesTest extends TestCase {
 			$modules->get_module_dependencies( $module_slug );
 		} catch ( \Exception $exception ) {
 			// We expect an exception to be thrown, let's make sure it's the right one.
-			$this->assertContains( $module_slug, $exception->getMessage() );
+			$this->assertStringContainsString( $module_slug, $exception->getMessage() );
 
 			return;
 		}
@@ -188,7 +188,7 @@ class ModulesTest extends TestCase {
 			$modules->get_module_dependants( $module_slug );
 		} catch ( \Exception $exception ) {
 			// We expect an exception to be thrown, let's make sure it's the right one.
-			$this->assertContains( $module_slug, $exception->getMessage() );
+			$this->assertStringContainsString( $module_slug, $exception->getMessage() );
 
 			return;
 		}

--- a/tests/phpunit/integration/Core/Modules/Tags/Module_AMP_TagTest.php
+++ b/tests/phpunit/integration/Core/Modules/Tags/Module_AMP_TagTest.php
@@ -19,8 +19,8 @@ class Module_AMP_TagTest extends TestCase {
 
 	private $module_slug;
 
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 
 		$this->module_slug = 'fake-module';
 		$this->amp_tag     = new FakeModule_AMP_Tag( 'test-tag-id', $this->module_slug );

--- a/tests/phpunit/integration/Core/Modules/Tags/Module_Web_TagTest.php
+++ b/tests/phpunit/integration/Core/Modules/Tags/Module_Web_TagTest.php
@@ -19,8 +19,8 @@ class Module_Web_TagTest extends TestCase {
 
 	private $module_slug;
 
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 
 		$this->module_slug = 'fake-module';
 		$this->web_tag     = new FakeModule_Web_Tag( 'test-tag-id', $this->module_slug );

--- a/tests/phpunit/integration/Core/Permissions/PermissionsTest.php
+++ b/tests/phpunit/integration/Core/Permissions/PermissionsTest.php
@@ -24,8 +24,8 @@ use Google\Site_Kit\Tests\TestCase;
 class PermissionsTest extends TestCase {
 	use Fake_Site_Connection_Trait;
 
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 
 		// Unhook all actions and filters added during Permissions::register
 		// to avoid interference with "main" instance setup during plugin bootstrap.

--- a/tests/phpunit/integration/Core/Storage/SettingTest.php
+++ b/tests/phpunit/integration/Core/Storage/SettingTest.php
@@ -25,8 +25,8 @@ class SettingTest extends TestCase {
 	 */
 	protected $context;
 
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 		$this->context = new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE );
 	}
 

--- a/tests/phpunit/integration/Core/Storage/User_TransientsTest.php
+++ b/tests/phpunit/integration/Core/Storage/User_TransientsTest.php
@@ -42,8 +42,8 @@ class User_TransientsTest extends TestCase {
 		wp_using_ext_object_cache( self::$old_wp_using_ext_object_cache );
 	}
 
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 		$this->context = new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE );
 	}
 

--- a/tests/phpunit/integration/Core/Tags/Guards/Tag_Verify_GuardTest.php
+++ b/tests/phpunit/integration/Core/Tags/Guards/Tag_Verify_GuardTest.php
@@ -21,8 +21,8 @@ class Tag_Verify_GuardTest extends TestCase {
 	 */
 	private $tagverify;
 
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 		$this->tagverify = new Tag_Verify_Guard( new MutableInput() );
 	}
 

--- a/tests/phpunit/integration/Core/Tracking/REST_Tracking_Consent_ControllerTest.php
+++ b/tests/phpunit/integration/Core/Tracking/REST_Tracking_Consent_ControllerTest.php
@@ -27,8 +27,8 @@ use WP_REST_Server;
 class REST_Tracking_Consent_ControllerTest extends TestCase {
 	use Fake_Site_Connection_Trait;
 
-	public function tearDown() {
-		parent::tearDown();
+	public function tear_down() {
+		parent::tear_down();
 		// This ensures the REST server is initialized fresh for each test using it.
 		unset( $GLOBALS['wp_rest_server'] );
 		unset( $GLOBALS['current_user'] );

--- a/tests/phpunit/integration/Core/Tracking/Tracking_ConsentTest.php
+++ b/tests/phpunit/integration/Core/Tracking/Tracking_ConsentTest.php
@@ -20,8 +20,8 @@ use Google\Site_Kit\Tests\TestCase;
  */
 class Tracking_ConsentTest extends TestCase {
 
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 		// Unregister all registered user meta.
 		global $wp_meta_keys;
 		unset( $wp_meta_keys['user'] );

--- a/tests/phpunit/integration/Core/User_Surveys/REST_User_Surveys_ControllerTest.php
+++ b/tests/phpunit/integration/Core/User_Surveys/REST_User_Surveys_ControllerTest.php
@@ -24,8 +24,8 @@ class REST_User_Surveys_ControllerTest extends TestCase {
 	 */
 	private $controller;
 
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 
 		$context          = new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE );
 		$authentication   = new Authentication( $context );

--- a/tests/phpunit/integration/Core/Util/Feature_FlagsTest.php
+++ b/tests/phpunit/integration/Core/Util/Feature_FlagsTest.php
@@ -16,8 +16,8 @@ use ReflectionMethod;
 
 class Feature_FlagsTest extends TestCase {
 
-	public function tearDown() {
-		parent::tearDown();
+	public function tear_down() {
+		parent::tear_down();
 		static::reset_feature_flags();
 	}
 

--- a/tests/phpunit/integration/Core/Util/Google_URL_Matcher_TraitTest.php
+++ b/tests/phpunit/integration/Core/Util/Google_URL_Matcher_TraitTest.php
@@ -20,8 +20,8 @@ class Google_URL_Matcher_TraitTest extends TestCase {
 
 	private $matcher;
 
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 
 		$this->matcher = new Google_URL_Matcher();
 	}

--- a/tests/phpunit/integration/Core/Util/Google_URL_NormalizerTest.php
+++ b/tests/phpunit/integration/Core/Util/Google_URL_NormalizerTest.php
@@ -20,8 +20,8 @@ class Google_URL_NormalizerTest extends TestCase {
 
 	private $url_normalizer;
 
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 
 		$this->url_normalizer = new Google_URL_Normalizer();
 	}

--- a/tests/phpunit/integration/Core/Util/Migration_1_3_0Test.php
+++ b/tests/phpunit/integration/Core/Util/Migration_1_3_0Test.php
@@ -29,8 +29,8 @@ class Migration_1_3_0Test extends TestCase {
 	 */
 	protected $user_options;
 
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 		$this->context      = new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE );
 		$this->user_options = new User_Options( $this->context );
 		$this->delete_db_version();

--- a/tests/phpunit/integration/Core/Util/Migration_1_8_1Test.php
+++ b/tests/phpunit/integration/Core/Util/Migration_1_8_1Test.php
@@ -57,8 +57,8 @@ class Migration_1_8_1Test extends TestCase {
 	private $temp_api_request_issued;
 	private $temp_received_identifiers;
 
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 
 		$this->context        = new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE );
 		$this->options        = new Options( $this->context );

--- a/tests/phpunit/integration/Core/Util/REST_Entity_Search_ControllerTest.php
+++ b/tests/phpunit/integration/Core/Util/REST_Entity_Search_ControllerTest.php
@@ -26,15 +26,15 @@ class REST_Entity_Search_ControllerTest extends TestCase {
 	 */
 	private $controller;
 
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 
 		$context          = new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE );
 		$this->controller = new REST_Entity_Search_Controller( $context );
 	}
 
-	public function tearDown() {
-		parent::tearDown();
+	public function tear_down() {
+		parent::tear_down();
 		// This ensures the REST server is initialized fresh for each test using it.
 		unset( $GLOBALS['wp_rest_server'] );
 		unset( $GLOBALS['current_user'] );

--- a/tests/phpunit/integration/Core/Util/ResetTest.php
+++ b/tests/phpunit/integration/Core/Util/ResetTest.php
@@ -34,8 +34,8 @@ class ResetTest extends TestCase {
 	 */
 	protected $context_with_mutable_input;
 
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 
 		// Set up a test option as a way to check if reset ran or not.
 		// When the reset runs, this option will no longer exist.

--- a/tests/phpunit/integration/Core/Util/ResetTest.php
+++ b/tests/phpunit/integration/Core/Util/ResetTest.php
@@ -107,7 +107,7 @@ class ResetTest extends TestCase {
 			do_action( 'admin_action_' . Reset::ACTION );
 			$this->fail( 'Expected insufficient permissions exception' );
 		} catch ( WPDieException $die_exception ) {
-			$this->assertContains( 'permissions to set up Site Kit', $die_exception->getMessage() );
+			$this->assertStringContainsString( 'permissions to set up Site Kit', $die_exception->getMessage() );
 		}
 		$this->assertOptionExists( self::TEST_OPTION );
 	}
@@ -127,8 +127,8 @@ class ResetTest extends TestCase {
 		} catch ( RedirectException $redirect ) {
 			$redirect_url = $redirect->get_location();
 			$this->assertStringStartsWith( $this->context_with_mutable_input->admin_url( 'splash' ), $redirect_url );
-			$this->assertContains( '&googlesitekit_reset_session=1', $redirect_url );
-			$this->assertContains( '&notification=reset_success', $redirect_url );
+			$this->assertStringContainsString( '&googlesitekit_reset_session=1', $redirect_url );
+			$this->assertStringContainsString( '&notification=reset_success', $redirect_url );
 
 		}
 		// Reset ran and option no longer exists.

--- a/tests/phpunit/integration/Core/Util/UninstallationTest.php
+++ b/tests/phpunit/integration/Core/Util/UninstallationTest.php
@@ -28,8 +28,8 @@ class UninstallationTest extends TestCase {
 	private $uninstallation;
 	private $issued_delete_site_request;
 
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 
 		$context              = new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE );
 		$this->google_proxy   = new Google_Proxy( $context );

--- a/tests/phpunit/integration/Core/Util/User_Input_SettingsTest.php
+++ b/tests/phpunit/integration/Core/Util/User_Input_SettingsTest.php
@@ -48,8 +48,8 @@ class User_Input_SettingsTest extends TestCase {
 		wp_using_ext_object_cache( self::$old_wp_using_ext_object_cache );
 	}
 
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 		$this->context = new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE );
 	}
 

--- a/tests/phpunit/integration/Modules/AdSense/SettingsTest.php
+++ b/tests/phpunit/integration/Modules/AdSense/SettingsTest.php
@@ -29,9 +29,9 @@ class SettingsTest extends SettingsTestCase {
 		$settings->register();
 
 		update_option( Settings::OPTION, array( 'accountID' => 'saved-account-id' ) );
-		$this->assertArraySubset( array( 'accountID' => 'saved-account-id' ), get_option( Settings::OPTION ) );
+		$this->assertArrayIntersection( array( 'accountID' => 'saved-account-id' ), get_option( Settings::OPTION ) );
 		add_filter( 'googlesitekit_adsense_account_id', '__return_empty_string' );
-		$this->assertArraySubset( array( 'accountID' => 'saved-account-id' ), get_option( Settings::OPTION ) );
+		$this->assertArrayIntersection( array( 'accountID' => 'saved-account-id' ), get_option( Settings::OPTION ) );
 		remove_filter( 'googlesitekit_adsense_account_id', '__return_empty_string' );
 
 		add_filter(
@@ -40,13 +40,13 @@ class SettingsTest extends SettingsTestCase {
 				return 'filtered-adsense-account-id';
 			}
 		);
-		$this->assertArraySubset( array( 'accountID' => 'filtered-adsense-account-id' ), get_option( Settings::OPTION ) );
+		$this->assertArrayIntersection( array( 'accountID' => 'filtered-adsense-account-id' ), get_option( Settings::OPTION ) );
 
 		// Default value filtered into saved value.
-		$this->assertArraySubset( array( 'useSnippet' => true ), get_option( Settings::OPTION ) );
+		$this->assertArrayIntersection( array( 'useSnippet' => true ), get_option( Settings::OPTION ) );
 		update_option( Settings::OPTION, array( 'useSnippet' => false ) );
 		// Default respects saved value.
-		$this->assertArraySubset( array( 'useSnippet' => false ), get_option( Settings::OPTION ) );
+		$this->assertArrayIntersection( array( 'useSnippet' => false ), get_option( Settings::OPTION ) );
 	}
 
 	public function test_get_default() {
@@ -83,7 +83,7 @@ class SettingsTest extends SettingsTestCase {
 		$settings->register();
 
 		$option = $settings->get();
-		$this->assertArraySubset(
+		$this->assertArrayIntersection(
 			array(
 				'accountID'            => 'test-account-id',
 				'accountStatus'        => 'test-account-status',

--- a/tests/phpunit/integration/Modules/AdSense/Tag_GuardTest.php
+++ b/tests/phpunit/integration/Modules/AdSense/Tag_GuardTest.php
@@ -36,8 +36,8 @@ class Tag_GuardTest extends TestCase {
 	 */
 	private $guard;
 
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 
 		update_option(
 			Settings::OPTION,

--- a/tests/phpunit/integration/Modules/AdSenseTest.php
+++ b/tests/phpunit/integration/Modules/AdSenseTest.php
@@ -174,9 +174,9 @@ class AdSenseTest extends TestCase {
 
 		$output = $this->capture_action( 'wp_head' );
 
-		$this->assertContains( 'Google AdSense snippet added by Site Kit', $output );
+		$this->assertStringContainsString( 'Google AdSense snippet added by Site Kit', $output );
 
-		$this->assertContains( 'pagead2.googlesyndication.com/pagead/js/adsbygoogle.js', $output );
+		$this->assertStringContainsString( 'pagead2.googlesyndication.com/pagead/js/adsbygoogle.js', $output );
 
 		if ( $enabled ) {
 			$this->assertRegExp( '/\sdata-block-on-consent\b/', $output );
@@ -197,11 +197,11 @@ class AdSenseTest extends TestCase {
 
 		$output = $this->capture_action( 'wp_head' );
 
-		$this->assertContains( 'google-adsense-platform-account', $output );
-		$this->assertContains( 'ca-host-pub-2644536267352236', $output );
+		$this->assertStringContainsString( 'google-adsense-platform-account', $output );
+		$this->assertStringContainsString( 'ca-host-pub-2644536267352236', $output );
 
-		$this->assertContains( 'google-adsense-platform-domain', $output );
-		$this->assertContains( 'sitekit.withgoogle.com', $output );
+		$this->assertStringContainsString( 'google-adsense-platform-domain', $output );
+		$this->assertStringContainsString( 'sitekit.withgoogle.com', $output );
 
 	}
 
@@ -230,9 +230,9 @@ class AdSenseTest extends TestCase {
 
 		$output = $this->capture_action( 'wp_body_open' );
 
-		$this->assertContains( 'Google AdSense AMP snippet added by Site Kit', $output );
+		$this->assertStringContainsString( 'Google AdSense AMP snippet added by Site Kit', $output );
 
-		$this->assertContains( 'data-ad-client="ca-pub-12345678"', $output );
+		$this->assertStringContainsString( 'data-ad-client="ca-pub-12345678"', $output );
 
 		if ( $enabled ) {
 			$this->assertRegExp( '/\sdata-block-on-consent\b/', $output );
@@ -270,9 +270,9 @@ class AdSenseTest extends TestCase {
 
 		$output = apply_filters( 'the_content', 'test content' );
 
-		$this->assertContains( 'Google AdSense AMP snippet added by Site Kit', $output );
+		$this->assertStringContainsString( 'Google AdSense AMP snippet added by Site Kit', $output );
 
-		$this->assertContains( 'data-ad-client="ca-pub-12345678"', $output );
+		$this->assertStringContainsString( 'data-ad-client="ca-pub-12345678"', $output );
 
 		if ( $enabled ) {
 			$this->assertRegExp( '/\sdata-block-on-consent\b/', $output );
@@ -313,7 +313,7 @@ class AdSenseTest extends TestCase {
 
 		// Confirm that the tag is not added if we're not in the loop.
 		$output = apply_filters( 'the_content', 'test content' );
-		$this->assertNotContains( 'data-ad-client="ca-pub-12345678"', $output );
+		$this->assertStringNotContainsString( 'data-ad-client="ca-pub-12345678"', $output );
 
 		// We need to fake the global to allow the hook to add the tag.
 		global $wp_query;
@@ -321,7 +321,7 @@ class AdSenseTest extends TestCase {
 
 		// Confirm that the tag is added when in the loop.
 		$output = apply_filters( 'the_content', 'test content' );
-		$this->assertContains( 'data-ad-client="ca-pub-12345678"', $output );
+		$this->assertStringContainsString( 'data-ad-client="ca-pub-12345678"', $output );
 	}
 
 	public function data_amp_auto_ads_tag_in_the_loop() {

--- a/tests/phpunit/integration/Modules/AdSenseTest.php
+++ b/tests/phpunit/integration/Modules/AdSenseTest.php
@@ -179,9 +179,9 @@ class AdSenseTest extends TestCase {
 		$this->assertStringContainsString( 'pagead2.googlesyndication.com/pagead/js/adsbygoogle.js', $output );
 
 		if ( $enabled ) {
-			$this->assertRegExp( '/\sdata-block-on-consent\b/', $output );
+			$this->assertMatchesRegularExpression( '/\sdata-block-on-consent\b/', $output );
 		} else {
-			$this->assertNotRegExp( '/\sdata-block-on-consent\b/', $output );
+			$this->assertDoesNotMatchRegularExpression( '/\sdata-block-on-consent\b/', $output );
 		}
 	}
 
@@ -235,9 +235,9 @@ class AdSenseTest extends TestCase {
 		$this->assertStringContainsString( 'data-ad-client="ca-pub-12345678"', $output );
 
 		if ( $enabled ) {
-			$this->assertRegExp( '/\sdata-block-on-consent\b/', $output );
+			$this->assertMatchesRegularExpression( '/\sdata-block-on-consent\b/', $output );
 		} else {
-			$this->assertNotRegExp( '/\sdata-block-on-consent\b/', $output );
+			$this->assertDoesNotMatchRegularExpression( '/\sdata-block-on-consent\b/', $output );
 		}
 	}
 
@@ -275,9 +275,9 @@ class AdSenseTest extends TestCase {
 		$this->assertStringContainsString( 'data-ad-client="ca-pub-12345678"', $output );
 
 		if ( $enabled ) {
-			$this->assertRegExp( '/\sdata-block-on-consent\b/', $output );
+			$this->assertMatchesRegularExpression( '/\sdata-block-on-consent\b/', $output );
 		} else {
-			$this->assertNotRegExp( '/\sdata-block-on-consent\b/', $output );
+			$this->assertDoesNotMatchRegularExpression( '/\sdata-block-on-consent\b/', $output );
 		}
 	}
 

--- a/tests/phpunit/integration/Modules/Analytics/Advanced_Tracking/Script_InjectorTest.php
+++ b/tests/phpunit/integration/Modules/Analytics/Advanced_Tracking/Script_InjectorTest.php
@@ -64,7 +64,7 @@ class Script_InjectorTest extends TestCase {
 		$output = ob_get_clean();
 
 		$expected_json = '[{"action":"test_event_without_metadata","selector":".some-button","on":"click","metadata":null},{"action":"test_event_with_metadata","selector":".a-very-specific-button","on":"click","metadata":{"event_category":"test_event_category"}},{"action":"test_event_onload","on":"DOMContentLoaded","metadata":null,"selector":""}]';
-		$this->assertRegExp( '/<script( [^>]*)?>.+<\/script>/ms', trim( $output ) );
+		$this->assertMatchesRegularExpression( '/<script( [^>]*)?>.+<\/script>/ms', trim( $output ) );
 		$this->assertStringContainsString( $expected_json, $output );
 	}
 

--- a/tests/phpunit/integration/Modules/Analytics/Advanced_Tracking/Script_InjectorTest.php
+++ b/tests/phpunit/integration/Modules/Analytics/Advanced_Tracking/Script_InjectorTest.php
@@ -65,7 +65,7 @@ class Script_InjectorTest extends TestCase {
 
 		$expected_json = '[{"action":"test_event_without_metadata","selector":".some-button","on":"click","metadata":null},{"action":"test_event_with_metadata","selector":".a-very-specific-button","on":"click","metadata":{"event_category":"test_event_category"}},{"action":"test_event_onload","on":"DOMContentLoaded","metadata":null,"selector":""}]';
 		$this->assertRegExp( '/<script( [^>]*)?>.+<\/script>/ms', trim( $output ) );
-		$this->assertContains( $expected_json, $output );
+		$this->assertStringContainsString( $expected_json, $output );
 	}
 
 	public function test_inject_event_script_no_events() {

--- a/tests/phpunit/integration/Modules/Analytics/SettingsTest.php
+++ b/tests/phpunit/integration/Modules/Analytics/SettingsTest.php
@@ -125,7 +125,7 @@ class SettingsTest extends SettingsTestCase {
 		$settings->register();
 
 		$option = $settings->get();
-		$this->assertArraySubset(
+		$this->assertArrayIntersection(
 			array(
 				'accountID'             => 'test-account-id',
 				'profileID'             => 'test-profile-id',

--- a/tests/phpunit/integration/Modules/AnalyticsTest.php
+++ b/tests/phpunit/integration/Modules/AnalyticsTest.php
@@ -213,7 +213,7 @@ class AnalyticsTest extends TestCase {
 
 		$output = $this->capture_action( '__test_print_scripts' );
 
-		$this->assertContains( 'https://www.googletagmanager.com/gtag/js?id=UA-12345678-1', $output );
+		$this->assertStringContainsString( 'https://www.googletagmanager.com/gtag/js?id=UA-12345678-1', $output );
 
 		if ( $enabled ) {
 			$this->assertRegExp( '/\sdata-block-on-consent\b/', $output );
@@ -247,7 +247,7 @@ class AnalyticsTest extends TestCase {
 
 		$output = $this->capture_action( 'wp_footer' );
 
-		$this->assertContains( '<amp-analytics', $output );
+		$this->assertStringContainsString( '<amp-analytics', $output );
 
 		if ( $enabled ) {
 			$this->assertRegExp( '/\sdata-block-on-consent\b/', $output );
@@ -480,9 +480,9 @@ class AnalyticsTest extends TestCase {
 		$this->assertNotEmpty( $head_html );
 		// Whether or not tracking is disabled does not affect output of snippet.
 		if ( $settings['useSnippet'] ) {
-			$this->assertContains( "id={$settings['propertyID']}", $head_html );
+			$this->assertStringContainsString( "id={$settings['propertyID']}", $head_html );
 		} else {
-			$this->assertNotContains( "id={$settings['propertyID']}", $head_html );
+			$this->assertStringNotContainsString( "id={$settings['propertyID']}", $head_html );
 		}
 
 		$assert_opt_out_presence( $head_html );
@@ -499,10 +499,10 @@ class AnalyticsTest extends TestCase {
 		);
 
 		$assert_contains_opt_out     = function ( $html ) {
-			$this->assertContains( 'window["ga-disable-UA-21234567-8"] = true', $html );
+			$this->assertStringContainsString( 'window["ga-disable-UA-21234567-8"] = true', $html );
 		};
 		$assert_not_contains_opt_out = function ( $html ) {
-			$this->assertNotContains( 'window["ga-disable-UA-21234567-8"] = true', $html );
+			$this->assertStringNotContainsString( 'window["ga-disable-UA-21234567-8"] = true', $html );
 		};
 
 		return array(

--- a/tests/phpunit/integration/Modules/AnalyticsTest.php
+++ b/tests/phpunit/integration/Modules/AnalyticsTest.php
@@ -216,9 +216,9 @@ class AnalyticsTest extends TestCase {
 		$this->assertStringContainsString( 'https://www.googletagmanager.com/gtag/js?id=UA-12345678-1', $output );
 
 		if ( $enabled ) {
-			$this->assertRegExp( '/\sdata-block-on-consent\b/', $output );
+			$this->assertMatchesRegularExpression( '/\sdata-block-on-consent\b/', $output );
 		} else {
-			$this->assertNotRegExp( '/\sdata-block-on-consent\b/', $output );
+			$this->assertDoesNotMatchRegularExpression( '/\sdata-block-on-consent\b/', $output );
 		}
 	}
 
@@ -250,9 +250,9 @@ class AnalyticsTest extends TestCase {
 		$this->assertStringContainsString( '<amp-analytics', $output );
 
 		if ( $enabled ) {
-			$this->assertRegExp( '/\sdata-block-on-consent\b/', $output );
+			$this->assertMatchesRegularExpression( '/\sdata-block-on-consent\b/', $output );
 		} else {
-			$this->assertNotRegExp( '/\sdata-block-on-consent\b/', $output );
+			$this->assertDoesNotMatchRegularExpression( '/\sdata-block-on-consent\b/', $output );
 		}
 	}
 

--- a/tests/phpunit/integration/Modules/Analytics_4/Tag_GuardTest.php
+++ b/tests/phpunit/integration/Modules/Analytics_4/Tag_GuardTest.php
@@ -27,8 +27,8 @@ class Tag_GuardTest extends TestCase {
 	 */
 	protected $guard;
 
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 
 		$context     = new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE );
 		$options     = new Options( $context );

--- a/tests/phpunit/integration/Modules/Analytics_4Test.php
+++ b/tests/phpunit/integration/Modules/Analytics_4Test.php
@@ -51,8 +51,8 @@ class Analytics_4Test extends TestCase {
 	 */
 	private $analytics;
 
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 
 		$this->context   = new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE );
 		$this->analytics = new Analytics_4( $this->context );

--- a/tests/phpunit/integration/Modules/Idea_Hub/Idea_Interaction_CountTest.php
+++ b/tests/phpunit/integration/Modules/Idea_Hub/Idea_Interaction_CountTest.php
@@ -31,8 +31,8 @@ class Idea_Interaction_CountTest extends TestCase {
 	 */
 	private $interaction_count;
 
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 
 		$user_id = $this->factory()->user->create();
 		$context = new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE );

--- a/tests/phpunit/integration/Modules/Idea_HubTest.php
+++ b/tests/phpunit/integration/Modules/Idea_HubTest.php
@@ -42,8 +42,8 @@ class Idea_HubTest extends TestCase {
 	 */
 	private $idea_hub;
 
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 
 		$this->context  = new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE );
 		$this->idea_hub = new Idea_Hub( $this->context );

--- a/tests/phpunit/integration/Modules/Optimize/SettingsTest.php
+++ b/tests/phpunit/integration/Modules/Optimize/SettingsTest.php
@@ -51,7 +51,7 @@ class SettingsTest extends SettingsTestCase {
 		$settings->register();
 
 		$option = $settings->get();
-		$this->assertArraySubset(
+		$this->assertArrayIntersection(
 			array(
 				// The first legacy key for the same new key wins.
 				'ampExperimentJSON' => 'test-amp-experiment-json-1',
@@ -83,7 +83,7 @@ class SettingsTest extends SettingsTestCase {
 		$settings->register();
 
 		$option = $settings->get();
-		$this->assertArraySubset(
+		$this->assertArrayIntersection(
 			array(
 				// The value exposed should be a JSON string.
 				// phpcs:ignore WordPressVIPMinimum.Security.Mustache
@@ -102,7 +102,7 @@ class SettingsTest extends SettingsTestCase {
 		$settings->register();
 
 		$option = $settings->get();
-		$this->assertArraySubset(
+		$this->assertArrayIntersection(
 			array(
 				// The value exposed should be a JSON string.
 				'ampExperimentJSON' => '',

--- a/tests/phpunit/integration/Modules/Site_VerificationTest.php
+++ b/tests/phpunit/integration/Modules/Site_VerificationTest.php
@@ -75,14 +75,14 @@ class Site_VerificationTest extends TestCase {
 		add_user_meta( $user_id, $meta_key, $verification_meta );
 
 		$this->assertFalse( $transients->get( Site_Verification::TRANSIENT_VERIFICATION_META_TAGS ) );
-		$this->assertContains( $verification_meta, $this->capture_action( 'wp_head' ) );
+		$this->assertStringContainsString( $verification_meta, $this->capture_action( 'wp_head' ) );
 		$this->assertContains( $verification_meta, $transients->get( Site_Verification::TRANSIENT_VERIFICATION_META_TAGS ) );
 
 		$updated_verification_meta = $verification_meta . '-updated';
 		update_user_meta( $user_id, $meta_key, $updated_verification_meta );
 
 		$this->assertFalse( $transients->get( Site_Verification::TRANSIENT_VERIFICATION_META_TAGS ) );
-		$this->assertContains( $updated_verification_meta, $this->capture_action( 'wp_head' ) );
+		$this->assertStringContainsString( $updated_verification_meta, $this->capture_action( 'wp_head' ) );
 		$this->assertContains( $updated_verification_meta, $transients->get( Site_Verification::TRANSIENT_VERIFICATION_META_TAGS ) );
 
 		delete_user_meta( $user_id, $meta_key );
@@ -102,12 +102,12 @@ class Site_VerificationTest extends TestCase {
 
 		( new Transients( $context ) )->set( Site_Verification::TRANSIENT_VERIFICATION_META_TAGS, array( $saved_tag ) );
 
-		$this->assertContains(
+		$this->assertStringContainsString(
 			$expected_output,
 			$this->capture_action( 'wp_head' )
 		);
 
-		$this->assertContains(
+		$this->assertStringContainsString(
 			$expected_output,
 			$this->capture_action( 'login_head' )
 		);
@@ -166,7 +166,7 @@ class Site_VerificationTest extends TestCase {
 
 		// Ensure no verification file response if the user does not have one.
 		$this->go_to( '/google1234.html' );
-		$this->assertNotContains( 'google-site-verification', $this->capture_action( 'init' ) );
+		$this->assertStringNotContainsString( 'google-site-verification', $this->capture_action( 'init' ) );
 
 		// Set correct verification for user
 		$user_options->set( Verification_File::OPTION, '1234' );

--- a/tests/phpunit/integration/Modules/Subscribe_With_GoogleTest.php
+++ b/tests/phpunit/integration/Modules/Subscribe_With_GoogleTest.php
@@ -35,8 +35,8 @@ class Subscribe_With_GoogleTest extends TestCase {
 	 */
 	private $subscribe_with_google;
 
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 
 		$this->context               = new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE );
 		$this->subscribe_with_google = new Subscribe_With_Google( $this->context );

--- a/tests/phpunit/integration/Modules/Tag_Manager/SettingsTest.php
+++ b/tests/phpunit/integration/Modules/Tag_Manager/SettingsTest.php
@@ -55,7 +55,7 @@ class SettingsTest extends SettingsTestCase {
 		$settings->register();
 
 		$option = $settings->get();
-		$this->assertArraySubset(
+		$this->assertArrayIntersection(
 			array(
 				// The first legacy key for the same new key wins.
 				'accountID'   => 'test-account-id-snake',

--- a/tests/phpunit/integration/Modules/Tag_ManagerTest.php
+++ b/tests/phpunit/integration/Modules/Tag_ManagerTest.php
@@ -199,7 +199,7 @@ class Tag_ManagerTest extends TestCase {
 
 		$output = $this->capture_action( 'wp_footer' );
 
-		$this->assertContains( 'Google Tag Manager AMP snippet added by Site Kit', $output );
+		$this->assertStringContainsString( 'Google Tag Manager AMP snippet added by Site Kit', $output );
 
 		if ( $enabled ) {
 			$this->assertRegExp( '/\sdata-block-on-consent\b/', $output );
@@ -236,15 +236,15 @@ class Tag_ManagerTest extends TestCase {
 		$header = $this->capture_action( 'wp_head' );
 		$footer = $this->capture_action( 'wp_footer' );
 
-		$this->assertContains( 'Google Tag Manager snippet added by Site Kit', $header );
+		$this->assertStringContainsString( 'Google Tag Manager snippet added by Site Kit', $header );
 
 		if ( $enabled ) {
 			$this->assertRegExp( '/\sdata-block-on-consent\b/', $header );
 			// If enabled, the no-JS fallback must not be output.
-			$this->assertNotContains( '<noscript>', $footer );
+			$this->assertStringNotContainsString( '<noscript>', $footer );
 		} else {
 			$this->assertNotRegExp( '/\sdata-block-on-consent\b/', $header );
-			$this->assertContains( '<noscript>', $footer );
+			$this->assertStringContainsString( '<noscript>', $footer );
 		}
 	}
 

--- a/tests/phpunit/integration/Modules/Tag_ManagerTest.php
+++ b/tests/phpunit/integration/Modules/Tag_ManagerTest.php
@@ -202,9 +202,9 @@ class Tag_ManagerTest extends TestCase {
 		$this->assertStringContainsString( 'Google Tag Manager AMP snippet added by Site Kit', $output );
 
 		if ( $enabled ) {
-			$this->assertRegExp( '/\sdata-block-on-consent\b/', $output );
+			$this->assertMatchesRegularExpression( '/\sdata-block-on-consent\b/', $output );
 		} else {
-			$this->assertNotRegExp( '/\sdata-block-on-consent\b/', $output );
+			$this->assertDoesNotMatchRegularExpression( '/\sdata-block-on-consent\b/', $output );
 		}
 	}
 
@@ -239,11 +239,11 @@ class Tag_ManagerTest extends TestCase {
 		$this->assertStringContainsString( 'Google Tag Manager snippet added by Site Kit', $header );
 
 		if ( $enabled ) {
-			$this->assertRegExp( '/\sdata-block-on-consent\b/', $header );
+			$this->assertMatchesRegularExpression( '/\sdata-block-on-consent\b/', $header );
 			// If enabled, the no-JS fallback must not be output.
 			$this->assertStringNotContainsString( '<noscript>', $footer );
 		} else {
-			$this->assertNotRegExp( '/\sdata-block-on-consent\b/', $header );
+			$this->assertDoesNotMatchRegularExpression( '/\sdata-block-on-consent\b/', $header );
 			$this->assertStringContainsString( '<noscript>', $footer );
 		}
 	}

--- a/tests/phpunit/integration/PluginTest.php
+++ b/tests/phpunit/integration/PluginTest.php
@@ -25,13 +25,13 @@ class PluginTest extends TestCase {
 	 */
 	protected static $backup_instance;
 
-	public static function setUpBeforeClass() {
-		parent::setUpBeforeClass();
+	public static function set_upBeforeClass() {
+		parent::set_upBeforeClass();
 		self::$backup_instance = Plugin::instance();
 	}
 
-	public function tearDown() {
-		parent::tearDown();
+	public function tear_down() {
+		parent::tear_down();
 		// Restore the main instance after each test.
 		$this->force_set_property( 'Google\Site_Kit\Plugin', 'instance', self::$backup_instance );
 	}

--- a/tests/phpunit/integration/PluginTest.php
+++ b/tests/phpunit/integration/PluginTest.php
@@ -72,7 +72,7 @@ class PluginTest extends TestCase {
 		do_action( $action );
 		$output = ob_get_clean();
 
-		$this->assertContains(
+		$this->assertStringContainsString(
 			'<meta name="generator" content="Site Kit by Google ' . GOOGLESITEKIT_VERSION . '"',
 			$output
 		);

--- a/tests/phpunit/integration/PluginTest.php
+++ b/tests/phpunit/integration/PluginTest.php
@@ -25,8 +25,7 @@ class PluginTest extends TestCase {
 	 */
 	protected static $backup_instance;
 
-	public static function set_upBeforeClass() {
-		parent::set_upBeforeClass();
+	public static function wpSetUpBeforeClass() {
 		self::$backup_instance = Plugin::instance();
 	}
 

--- a/tests/phpunit/integration/PluginTest.php
+++ b/tests/phpunit/integration/PluginTest.php
@@ -94,7 +94,7 @@ class PluginTest extends TestCase {
 		$network_admin_notices = ob_get_clean();
 
 		// Regex is case-insensitive and dotall (s) to match over multiple lines.
-		$this->assertRegExp( '#<div class="notice notice-warning.*?not yet compatible.*?</div>#is', $network_admin_notices );
+		$this->assertMatchesRegularExpression( '#<div class="notice notice-warning.*?not yet compatible.*?</div>#is', $network_admin_notices );
 	}
 
 	public function test_load_and_instance() {


### PR DESCRIPTION
## Summary

Addresses issue:

- #4729 

The "wp-phpunit" portion of WordPress core changed with WP 5.9 to allow for compatibility with newer versions of PHPUnit which are incompatible with PHP below PHP 7 due to the addition of return types on fixture methods (e.g. `setUp`, `tearDown` etc). Omitting these return types raises errors due to incompatible definitions which forced WP core to adopt the [PHPUnit Polyfills](https://github.com/Yoast/PHPUnit-Polyfills) library. This allows for authoring test cases that are forward-compatible with newer versions of PHPUnit.

This does not come for free however and requires us to rewrite our fixture methods to match the snake-case (cross-version compatible) names used by WordPress core's base test case.

This is further complicated by the changes made to the WP core base test case only being back ported to WP 5.2 which leaves the new methods uncalled in tests based on wp-phpunit for WP below 5.2.

The solution here was to introduce an additional polyfill layer between Site Kit's base test case and the `WP_UnitTestCase` by using a new `WP_UnitTestCase_Polyfill` class which works very similar to way the PHPUnit polyfill test case works only a bit simpler. If the `WP_UnitTestCase` class does not have the newer methods, we load a polyfill version of the class which is basically a copy of the same class used in WP 5.2 of the library. Otherwise, we load an empty "pass-through" version of the class; both then extend the `WP_UnitTestCase` class. This allows us to restore the same functionality for our test case while maintaining support for wp-phpunit with our current minimum supported version of WP (4.7).

The added polyfill has been implemented as a local path-type Composer package, to make it easier to extract/replace later.

The rest of the changes here are to fix deprecation warnings with v8 and v9 of PHPUnit which otherwise fail, even though no test failures occur. Using PHPUnit 8 seemed to be required as PHPUnit 7 was failing with parse errors ("unexpected token match"). The lift for compatibility from PHPUnit 8 to 9 was trivial so this was included as well. 


## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
