### PR TITLE
Remove remaining legacy GA event for AdSense.

### DIFF
--- a/assets/js/modules/adsense/components/setup/SetupSiteAdded.js
+++ b/assets/js/modules/adsense/components/setup/SetupSiteAdded.js
@@ -32,7 +32,6 @@ import { __ } from '@wordpress/i18n';
  */
 import Data from 'googlesitekit-data';
 import Button from '../../../../components/Button';
-import { trackEvent } from '../../../../util';
 import { MODULES_ADSENSE } from '../../datastore/constants';
 import SiteSteps from '../common/SiteSteps';
 import { ErrorNotices } from '../common';
@@ -51,7 +50,6 @@ export default function SetupSiteAdded( { finishSetup } ) {
 
 		const success = await completeSiteSetup();
 		if ( success ) {
-			await trackEvent( 'adsense_setup', 'complete_adsense_setup' );
 			finishSetup();
 		}
 	}, [ isDoingSubmitChanges, finishSetup, completeSiteSetup ] );


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #4766 

## Relevant technical choices

<!-- Please describe your changes. -->

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [ ] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
