### PR TITLE
Enhance/4699 - Disable `PieChart` for gathering data state (follow-up)

### DIFF
--- a/assets/js/modules/analytics/components/dashboard/DashboardAllTrafficWidget/UserDimensionsPieChart.js
+++ b/assets/js/modules/analytics/components/dashboard/DashboardAllTrafficWidget/UserDimensionsPieChart.js
@@ -22,6 +22,7 @@
 import classnames from 'classnames';
 import PropTypes from 'prop-types';
 import isNull from 'lodash/isNull';
+import cloneDeep from 'lodash/cloneDeep';
 
 /**
  * WordPress dependencies
@@ -483,7 +484,7 @@ export default function UserDimensionsPieChart( props ) {
 		}
 	};
 
-	const options = { ...UserDimensionsPieChart.chartOptions };
+	const options = cloneDeep( UserDimensionsPieChart.chartOptions );
 
 	let labels = {
 		'ga:channelGrouping': __(

--- a/assets/js/modules/analytics/components/dashboard/DashboardAllTrafficWidget/UserDimensionsPieChart.js
+++ b/assets/js/modules/analytics/components/dashboard/DashboardAllTrafficWidget/UserDimensionsPieChart.js
@@ -483,7 +483,9 @@ export default function UserDimensionsPieChart( props ) {
 		}
 	};
 
-	const labels = {
+	const options = { ...UserDimensionsPieChart.chartOptions };
+
+	let labels = {
 		'ga:channelGrouping': __(
 			'<span>By</span> channels',
 			'google-site-kit'
@@ -491,6 +493,15 @@ export default function UserDimensionsPieChart( props ) {
 		'ga:country': __( '<span>By</span> locations', 'google-site-kit' ),
 		'ga:deviceCategory': __( '<span>By</span> devices', 'google-site-kit' ),
 	};
+
+	if ( gatheringData ) {
+		labels = {
+			'ga:channelGrouping': __( 'gathering data…', 'google-site-kit' ),
+		};
+		options.pieSliceText = 'none';
+		options.tooltip.trigger = 'none';
+		options.sliceVisibilityThreshold = 1;
+	}
 
 	const sanitizeArgs = {
 		ALLOWED_TAGS: [ 'span' ],
@@ -500,8 +511,6 @@ export default function UserDimensionsPieChart( props ) {
 	const title = loaded
 		? sanitizeHTML( labels[ dimensionName ] || '', sanitizeArgs )
 		: { __html: '' };
-
-	const options = { ...UserDimensionsPieChart.chartOptions };
 
 	const isSingleSliceReport = isSingleSlice( report );
 	if ( isSingleSliceReport ) {
@@ -547,7 +556,10 @@ export default function UserDimensionsPieChart( props ) {
 					width="100%"
 				>
 					<div
-						className="googlesitekit-widget--analyticsAllTraffic__dimensions-chart-title"
+						className={ classnames( {
+							'googlesitekit-widget--analyticsAllTraffic__dimensions-chart-gathering-data': gatheringData,
+							'googlesitekit-widget--analyticsAllTraffic__dimensions-chart-title': ! gatheringData,
+						} ) }
 						dangerouslySetInnerHTML={ title }
 					/>
 				</GoogleChart>

--- a/assets/sass/config/_variables.scss
+++ b/assets/sass/config/_variables.scss
@@ -25,6 +25,7 @@ $c-white: #fff;
 $c-alabaster: #f9f9f9;
 $c-mercury: #e6e6e6;
 $c-silver: #bbb;
+$c-silver-2: #ccc;
 $c-header-gray: #fafafa;
 $c-jumbo: #828286; // 3.82 contrast
 $c-boulder: #757575;

--- a/assets/sass/widgets/_googlesitekit-widget-analyticsAllTraffic.scss
+++ b/assets/sass/widgets/_googlesitekit-widget-analyticsAllTraffic.scss
@@ -204,7 +204,6 @@
 	.googlesitekit-widget--analyticsAllTraffic__dimensions-chart-gathering-data {
 		color: $c-silver-2;
 		font-size: 18px;
-		font-weight: 400;
 		left: 50%;
 		line-height: 21px;
 		max-width: 80px;

--- a/assets/sass/widgets/_googlesitekit-widget-analyticsAllTraffic.scss
+++ b/assets/sass/widgets/_googlesitekit-widget-analyticsAllTraffic.scss
@@ -201,6 +201,19 @@
 		}
 	}
 
+	.googlesitekit-widget--analyticsAllTraffic__dimensions-chart-gathering-data {
+		color: $c-silver-2;
+		font-size: 18px;
+		font-weight: 400;
+		left: 50%;
+		line-height: 21px;
+		max-width: 80px;
+		position: absolute;
+		text-align: center;
+		top: 50%;
+		transform: translate(-50%, -50%);
+	}
+
 	.googlesitekit-widget--analyticsAllTraffic__tabs--small {
 		text-align: center;
 


### PR DESCRIPTION
## Summary

Addresses issue:

- #4699 

## Relevant technical choices

This is a follow-up PR that addresses disabling the `PieChart` while the state is gathering data.

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [x] Run the code.
- [x] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
