### PR TITLE
Enhance/4709 follow up - Restore `useExistingTagEffect` hook

### DIFF
--- a/assets/js/modules/tagmanager/components/settings/SettingsEdit.js
+++ b/assets/js/modules/tagmanager/components/settings/SettingsEdit.js
@@ -46,7 +46,7 @@ export default function SettingsEdit() {
 	);
 	const isCreateAccount = ACCOUNT_CREATE === accountID;
 
-	// Set useSnippet to `true` if there is an existing tag and selectrf container ID matches it.
+	// Set useSnippet to `false` if there is an existing tag and it is the same as the selected container ID.
 	useExistingTagEffect();
 	// Synchronize the gaPropertyID setting with the singular GA property ID in selected containers.
 	useGAPropertyIDEffect();

--- a/assets/js/modules/tagmanager/components/settings/SettingsEdit.js
+++ b/assets/js/modules/tagmanager/components/settings/SettingsEdit.js
@@ -22,6 +22,7 @@
 import Data from 'googlesitekit-data';
 import ProgressBar from '../../../../components/ProgressBar';
 import { MODULES_TAGMANAGER, ACCOUNT_CREATE } from '../../datastore/constants';
+import useExistingTagEffect from '../../hooks/useExistingTagEffect';
 import useGAPropertyIDEffect from '../../hooks/useGAPropertyIDEffect';
 import { AccountCreate } from '../common';
 import SettingsForm from './SettingsForm';
@@ -45,6 +46,8 @@ export default function SettingsEdit() {
 	);
 	const isCreateAccount = ACCOUNT_CREATE === accountID;
 
+	// Set useSnippet to `true` if there is an existing tag and selectrf container ID matches it.
+	useExistingTagEffect();
 	// Synchronize the gaPropertyID setting with the singular GA property ID in selected containers.
 	useGAPropertyIDEffect();
 

--- a/assets/js/modules/tagmanager/components/setup/SetupMain.js
+++ b/assets/js/modules/tagmanager/components/setup/SetupMain.js
@@ -69,7 +69,7 @@ export default function SetupMain( { finishSetup } ) {
 	);
 	const isCreateAccount = ACCOUNT_CREATE === accountID;
 
-	// Set useSnippet to `true` if there is an existing tag and selectrf container ID matches it.
+	// Set useSnippet to `false` if there is an existing tag and it is the same as the selected container ID.
 	useExistingTagEffect();
 	// Synchronize the gaPropertyID setting with the singular GA property ID in selected containers.
 	useGAPropertyIDEffect();

--- a/assets/js/modules/tagmanager/components/setup/SetupMain.js
+++ b/assets/js/modules/tagmanager/components/setup/SetupMain.js
@@ -40,6 +40,7 @@ import {
 } from '../../datastore/constants';
 import { CORE_FORMS } from '../../../../googlesitekit/datastore/forms/constants';
 import { CORE_LOCATION } from '../../../../googlesitekit/datastore/location/constants';
+import useExistingTagEffect from '../../hooks/useExistingTagEffect';
 import { AccountCreate } from '../common';
 import useGAPropertyIDEffect from '../../hooks/useGAPropertyIDEffect';
 const { useSelect } = Data;
@@ -68,6 +69,8 @@ export default function SetupMain( { finishSetup } ) {
 	);
 	const isCreateAccount = ACCOUNT_CREATE === accountID;
 
+	// Set useSnippet to `true` if there is an existing tag and selectrf container ID matches it.
+	useExistingTagEffect();
 	// Synchronize the gaPropertyID setting with the singular GA property ID in selected containers.
 	useGAPropertyIDEffect();
 

--- a/assets/js/modules/tagmanager/hooks/useExistingTagEffect.js
+++ b/assets/js/modules/tagmanager/hooks/useExistingTagEffect.js
@@ -29,9 +29,6 @@ import { MODULES_TAGMANAGER } from '../datastore/constants';
 const { useSelect, useDispatch } = Data;
 
 export default function useExistingTagEffect() {
-	const hasExistingTag = useSelect( ( select ) =>
-		select( MODULES_TAGMANAGER ).hasExistingTag()
-	);
 	const existingTag = useSelect( ( select ) =>
 		select( MODULES_TAGMANAGER ).getExistingTag()
 	);
@@ -42,12 +39,12 @@ export default function useExistingTagEffect() {
 	const { setUseSnippet } = useDispatch( MODULES_TAGMANAGER );
 
 	useEffect( () => {
-		if ( hasExistingTag ) {
+		if ( containerID && existingTag ) {
 			if ( existingTag === containerID ) {
 				setUseSnippet( false );
 			} else {
 				setUseSnippet( true );
 			}
 		}
-	}, [ containerID, existingTag, hasExistingTag, setUseSnippet ] );
+	}, [ containerID, existingTag, setUseSnippet ] );
 }

--- a/assets/js/modules/tagmanager/hooks/useExistingTagEffect.js
+++ b/assets/js/modules/tagmanager/hooks/useExistingTagEffect.js
@@ -1,0 +1,51 @@
+/**
+ * Tag Manager useExistingTag custom hook.
+ *
+ * Site Kit by Google, Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { useEffect } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import Data from 'googlesitekit-data';
+import { MODULES_TAGMANAGER } from '../datastore/constants';
+const { useSelect, useDispatch } = Data;
+
+export default function useExistingTagEffect() {
+	const hasExistingTag = useSelect( ( select ) =>
+		select( MODULES_TAGMANAGER ).hasExistingTag()
+	);
+	const existingTag = useSelect( ( select ) =>
+		select( MODULES_TAGMANAGER ).getExistingTag()
+	);
+	const containerID = useSelect( ( select ) =>
+		select( MODULES_TAGMANAGER ).getContainerID()
+	);
+
+	// Set the accountID and containerID if there is an existing tag.
+	const { setUseSnippet } = useDispatch( MODULES_TAGMANAGER );
+
+	useEffect( () => {
+		if ( hasExistingTag && existingTag === containerID ) {
+			// Disable the plugin snippet to avoid duplicate tagging.
+			setUseSnippet( false );
+		}
+	}, [ containerID, existingTag, hasExistingTag, setUseSnippet ] );
+}

--- a/assets/js/modules/tagmanager/hooks/useExistingTagEffect.js
+++ b/assets/js/modules/tagmanager/hooks/useExistingTagEffect.js
@@ -39,13 +39,15 @@ export default function useExistingTagEffect() {
 		select( MODULES_TAGMANAGER ).getContainerID()
 	);
 
-	// Set the accountID and containerID if there is an existing tag.
 	const { setUseSnippet } = useDispatch( MODULES_TAGMANAGER );
 
 	useEffect( () => {
-		if ( hasExistingTag && existingTag === containerID ) {
-			// Disable the plugin snippet to avoid duplicate tagging.
-			setUseSnippet( false );
+		if ( hasExistingTag ) {
+			if ( existingTag === containerID ) {
+				setUseSnippet( false );
+			} else {
+				setUseSnippet( true );
+			}
 		}
 	}, [ containerID, existingTag, hasExistingTag, setUseSnippet ] );
 }

--- a/assets/js/modules/tagmanager/hooks/useExistingTagEffect.test.js
+++ b/assets/js/modules/tagmanager/hooks/useExistingTagEffect.test.js
@@ -1,0 +1,102 @@
+/**
+ * Tag Manager useExistingTagEffect hook tests.
+ *
+ * Site Kit by Google, Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import { renderHook, actHook as act } from '../../../../../tests/js/test-utils';
+import { createTestRegistry } from '../../../../../tests/js/utils';
+import { MODULES_TAGMANAGER, CONTEXT_WEB } from '../datastore/constants';
+import * as factories from '../datastore/__factories__';
+import useExistingTagEffect from './useExistingTagEffect';
+
+describe( 'useExistingTagEffect', () => {
+	let registry;
+	beforeEach( () => {
+		registry = createTestRegistry();
+		// Set settings to prevent fetch in resolver.
+		registry.dispatch( MODULES_TAGMANAGER ).receiveGetSettings( {} );
+		// Set set no existing tag.
+		registry.dispatch( MODULES_TAGMANAGER ).receiveGetExistingTag( null );
+	} );
+
+	it( 'sets useSnippet value based on existing tag and selected container', async () => {
+		const account = factories.accountBuilder();
+		// eslint-disable-next-line sitekit/acronym-case
+		const accountID = account.accountId;
+		const containers = factories.buildContainers(
+			3,
+			// eslint-disable-next-line sitekit/acronym-case
+			{ accountId: account.accountId, usageContext: [ CONTEXT_WEB ] }
+		);
+		const [ existingContainer, firstContainer ] = containers;
+
+		registry
+			.dispatch( MODULES_TAGMANAGER )
+			// eslint-disable-next-line sitekit/acronym-case
+			.receiveGetExistingTag( existingContainer.publicId );
+
+		registry
+			.dispatch( MODULES_TAGMANAGER )
+			.receiveGetAccounts( [ account ] );
+		registry
+			.dispatch( MODULES_TAGMANAGER )
+			.receiveGetContainers( containers, { accountID } );
+		registry.dispatch( MODULES_TAGMANAGER ).setAccountID( accountID );
+
+		const { rerender } = renderHook( () => useExistingTagEffect(), {
+			registry,
+		} );
+
+		expect(
+			registry.select( MODULES_TAGMANAGER ).getUseSnippet()
+		).toBeUndefined();
+
+		act( () => {
+			registry
+				.dispatch( MODULES_TAGMANAGER )
+				// eslint-disable-next-line sitekit/acronym-case
+				.setContainerID( existingContainer.publicId );
+			registry.dispatch( MODULES_TAGMANAGER ).setInternalContainerID(
+				// eslint-disable-next-line sitekit/acronym-case
+				existingContainer.containerId
+			);
+			rerender();
+		} );
+
+		expect( registry.select( MODULES_TAGMANAGER ).getUseSnippet() ).toBe(
+			false
+		);
+
+		act( () => {
+			registry
+				.dispatch( MODULES_TAGMANAGER )
+				// eslint-disable-next-line sitekit/acronym-case
+				.setContainerID( firstContainer.publicId );
+			registry.dispatch( MODULES_TAGMANAGER ).setInternalContainerID(
+				// eslint-disable-next-line sitekit/acronym-case
+				firstContainer.containerId
+			);
+			rerender();
+		} );
+
+		expect( registry.select( MODULES_TAGMANAGER ).getUseSnippet() ).toBe(
+			true
+		);
+	} );
+} );

--- a/assets/js/modules/tagmanager/hooks/useExistingTagEffect.test.js
+++ b/assets/js/modules/tagmanager/hooks/useExistingTagEffect.test.js
@@ -44,7 +44,7 @@ describe( 'useExistingTagEffect', () => {
 			// eslint-disable-next-line sitekit/acronym-case
 			{ accountId: account.accountId, usageContext: [ CONTEXT_WEB ] }
 		);
-		const [ existingContainer, firstContainer ] = containers;
+		const [ existingContainer, anotherContainer ] = containers;
 
 		registry
 			.dispatch( MODULES_TAGMANAGER )
@@ -87,10 +87,10 @@ describe( 'useExistingTagEffect', () => {
 			registry
 				.dispatch( MODULES_TAGMANAGER )
 				// eslint-disable-next-line sitekit/acronym-case
-				.setContainerID( firstContainer.publicId );
+				.setContainerID( anotherContainer.publicId );
 			registry.dispatch( MODULES_TAGMANAGER ).setInternalContainerID(
 				// eslint-disable-next-line sitekit/acronym-case
-				firstContainer.containerId
+				anotherContainer.containerId
 			);
 			rerender();
 		} );


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #4709 

## Relevant technical choices

<!-- Please describe your changes. -->

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [ ] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [x] Run the code.
- [x] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [x] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [x] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
