### PR TITLE
Update DataBlock component usage to use the "Gathering data" prop.

### DIFF
--- a/assets/js/components/DataBlock.js
+++ b/assets/js/components/DataBlock.js
@@ -33,7 +33,7 @@ import { sprintf } from '@wordpress/i18n';
  */
 import ChangeArrow from './ChangeArrow';
 import SourceLink from './SourceLink';
-import GatheringDataNotice from './GatheringDataNotice';
+import GatheringDataNotice, { NOTICE_STYLE } from './GatheringDataNotice';
 import { isFeatureEnabled } from '../features';
 import { numFmt } from '../util';
 
@@ -74,6 +74,7 @@ class DataBlock extends Component {
 			sparkline,
 			invertChangeColor,
 			gatheringData,
+			gatheringDataNoticeStyle,
 		} = this.props;
 
 		const role = 'button' === context ? 'button' : '';
@@ -122,7 +123,10 @@ class DataBlock extends Component {
 					'googlesitekit-data-block',
 					className,
 					`googlesitekit-data-block--${ context }`,
-					{ 'googlesitekit-data-block--selected': selected }
+					{
+						'googlesitekit-data-block--selected': selected,
+						'googlesitekit-data-block--is-gathering-data': gatheringData,
+					}
 				) }
 				tabIndex={ 'button' === context ? '0' : '-1' }
 				role={ handleStatSelection && role }
@@ -198,7 +202,7 @@ class DataBlock extends Component {
 				) }
 
 				{ gatheringData && zeroDataStatesEnabled && (
-					<GatheringDataNotice />
+					<GatheringDataNotice style={ gatheringDataNoticeStyle } />
 				) }
 			</div>
 		);
@@ -220,6 +224,7 @@ DataBlock.propTypes = {
 	handleStatSelection: PropTypes.func,
 	invertChangeColor: PropTypes.bool,
 	gatheringData: PropTypes.bool,
+	gatheringDataNoticeStyle: PropTypes.oneOf( Object.values( NOTICE_STYLE ) ),
 };
 
 DataBlock.defaultProps = {
@@ -237,6 +242,7 @@ DataBlock.defaultProps = {
 	handleStatSelection: null,
 	invertChangeColor: false,
 	gatheringData: false,
+	gatheringDataNoticeStyle: NOTICE_STYLE.DEFAULT,
 };
 
 export default DataBlock;

--- a/assets/js/components/GatheringDataNotice.js
+++ b/assets/js/components/GatheringDataNotice.js
@@ -26,7 +26,13 @@ import PropTypes from 'prop-types';
  */
 import { __ } from '@wordpress/i18n';
 
-function GatheringDataNotice( { style = 'default' } ) {
+export const NOTICE_STYLE = {
+	DEFAULT: 'default',
+	OVERLAY: 'overlay',
+	SMALL: 'small',
+};
+
+function GatheringDataNotice( { style = NOTICE_STYLE.DEFAULT } ) {
 	return (
 		<div
 			className={ `googlesitekit-gathering-data-notice googlesitekit-gathering-data-notice--has-style-${ style }` }
@@ -37,7 +43,7 @@ function GatheringDataNotice( { style = 'default' } ) {
 }
 
 GatheringDataNotice.propTypes = {
-	style: PropTypes.oneOf( [ 'small', 'default', 'overlay' ] ),
+	style: PropTypes.oneOf( Object.values( NOTICE_STYLE ) ),
 };
 
 export default GatheringDataNotice;

--- a/assets/js/components/GatheringDataNotice.stories.js
+++ b/assets/js/components/GatheringDataNotice.stories.js
@@ -19,7 +19,7 @@
 /**
  * Internal dependencies
  */
-import GatheringDataNotice from './GatheringDataNotice';
+import GatheringDataNotice, { NOTICE_STYLE } from './GatheringDataNotice';
 
 const Template = ( args ) => <GatheringDataNotice { ...args } />;
 
@@ -29,13 +29,13 @@ DefaultGatheringDataNotice.storyName = 'Default';
 export const GatheringDataNoticeOverlay = Template.bind( {} );
 GatheringDataNoticeOverlay.storyName = 'Overlay';
 GatheringDataNoticeOverlay.args = {
-	style: 'overlay',
+	style: NOTICE_STYLE.OVERLAY,
 };
 
 export const GatheringDataNoticeSmall = Template.bind( {} );
 GatheringDataNoticeSmall.storyName = 'Small';
 GatheringDataNoticeSmall.args = {
-	style: 'small',
+	style: NOTICE_STYLE.SMALL,
 };
 
 export default {

--- a/assets/js/components/adminbar/AdminBarApp.stories.js
+++ b/assets/js/components/adminbar/AdminBarApp.stories.js
@@ -20,7 +20,9 @@
  * Internal dependencies
  */
 import {
+	setupAnalyticsGatheringData,
 	setupBaseRegistry,
+	setupSearchConsoleGatheringData,
 	setupSearchConsoleAnalyticsMockReports,
 } from './common.stories';
 import WithRegistrySetup from '../../../../tests/js/WithRegistrySetup';
@@ -45,6 +47,18 @@ Ready.scenario = {
 
 export const DataUnavailable = Template.bind( {} );
 DataUnavailable.storyName = 'Data Unavailable';
+
+export const GatheringData = Template.bind( {} );
+GatheringData.storyName = 'Gathering Data';
+GatheringData.args = {
+	setupRegistry( registry ) {
+		setupSearchConsoleGatheringData( registry );
+		setupAnalyticsGatheringData( registry );
+	},
+};
+GatheringData.parameters = {
+	features: [ 'zeroDataStates' ],
+};
 
 export default {
 	title: 'Views/AdminBarApp/AdminBarApp',

--- a/assets/js/components/adminbar/AdminBarApp.stories.js
+++ b/assets/js/components/adminbar/AdminBarApp.stories.js
@@ -51,7 +51,7 @@ DataUnavailable.storyName = 'Data Unavailable';
 export const GatheringData = Template.bind( {} );
 GatheringData.storyName = 'Gathering Data';
 GatheringData.args = {
-	setupRegistry( registry ) {
+	setupRegistry: ( registry ) => {
 		setupSearchConsoleGatheringData( registry );
 		setupAnalyticsGatheringData( registry );
 	},

--- a/assets/js/components/adminbar/AdminBarClicks.js
+++ b/assets/js/components/adminbar/AdminBarClicks.js
@@ -91,9 +91,8 @@ function AdminBarClicks( { WidgetReportZero, WidgetReportError } ) {
 	}
 
 	if (
-		! zeroDataStatesEnabled &&
 		isZeroReport( searchConsoleData ) &&
-		isGatheringData
+		( zeroDataStatesEnabled ? isGatheringData === false : isGatheringData )
 	) {
 		return <WidgetReportZero moduleSlug="search-console" />;
 	}
@@ -105,15 +104,6 @@ function AdminBarClicks( { WidgetReportZero, WidgetReportError } ) {
 	const totalOlderClicks = sumObjectListValue( compareRange, 'clicks' );
 	const totalClicksChange = calculateChange( totalOlderClicks, totalClicks );
 
-	// TODO: Check for zeroDataStatesEnabled probably not needed here as it's checked in DataBlock.
-	// But - IB says check unifiedDashboard so leave as placeholder for now.
-	const gatheringDataProps = zeroDataStatesEnabled
-		? {
-				gatheringData: isGatheringData,
-				gatheringDataNoticeStyle: NOTICE_STYLE.SMALL,
-		  }
-		: {};
-
 	return (
 		<DataBlock
 			className="overview-total-clicks"
@@ -121,7 +111,8 @@ function AdminBarClicks( { WidgetReportZero, WidgetReportError } ) {
 			datapoint={ totalClicks }
 			change={ totalClicksChange }
 			changeDataUnit="%"
-			{ ...gatheringDataProps }
+			gatheringData={ isGatheringData }
+			gatheringDataNoticeStyle={ NOTICE_STYLE.SMALL }
 		/>
 	);
 }

--- a/assets/js/components/adminbar/AdminBarClicks.js
+++ b/assets/js/components/adminbar/AdminBarClicks.js
@@ -104,6 +104,13 @@ function AdminBarClicks( { WidgetReportZero, WidgetReportError } ) {
 	const totalOlderClicks = sumObjectListValue( compareRange, 'clicks' );
 	const totalClicksChange = calculateChange( totalOlderClicks, totalClicks );
 
+	const gatheringDataProps = zeroDataStatesEnabled
+		? {
+				gatheringData: isGatheringData,
+				gatheringDataNoticeStyle: NOTICE_STYLE.SMALL,
+		  }
+		: {};
+
 	return (
 		<DataBlock
 			className="overview-total-clicks"
@@ -111,8 +118,7 @@ function AdminBarClicks( { WidgetReportZero, WidgetReportError } ) {
 			datapoint={ totalClicks }
 			change={ totalClicksChange }
 			changeDataUnit="%"
-			gatheringData={ isGatheringData }
-			gatheringDataNoticeStyle={ NOTICE_STYLE.SMALL }
+			{ ...gatheringDataProps }
 		/>
 	);
 }

--- a/assets/js/components/adminbar/AdminBarClicks.js
+++ b/assets/js/components/adminbar/AdminBarClicks.js
@@ -35,11 +35,15 @@ import { calculateChange } from '../../util';
 import { isZeroReport } from '../../modules/search-console/util';
 import PreviewBlock from '../PreviewBlock';
 import DataBlock from '../DataBlock';
+import { NOTICE_STYLE } from '../GatheringDataNotice';
 import sumObjectListValue from '../../util/sum-object-list-value';
 import { partitionReport } from '../../util/partition-report';
+import { useFeature } from '../../hooks/useFeature';
 const { useSelect } = Data;
 
 function AdminBarClicks( { WidgetReportZero, WidgetReportError } ) {
+	const zeroDataStatesEnabled = useFeature( 'zeroDataStates' );
+
 	const isGatheringData = useSelect( ( select ) =>
 		select( MODULES_SEARCH_CONSOLE ).isGatheringData()
 	);
@@ -86,7 +90,11 @@ function AdminBarClicks( { WidgetReportZero, WidgetReportError } ) {
 		);
 	}
 
-	if ( isZeroReport( searchConsoleData ) && isGatheringData ) {
+	if (
+		! zeroDataStatesEnabled &&
+		isZeroReport( searchConsoleData ) &&
+		isGatheringData
+	) {
 		return <WidgetReportZero moduleSlug="search-console" />;
 	}
 
@@ -97,6 +105,15 @@ function AdminBarClicks( { WidgetReportZero, WidgetReportError } ) {
 	const totalOlderClicks = sumObjectListValue( compareRange, 'clicks' );
 	const totalClicksChange = calculateChange( totalOlderClicks, totalClicks );
 
+	// TODO: Check for zeroDataStatesEnabled probably not needed here as it's checked in DataBlock.
+	// But - IB says check unifiedDashboard so leave as placeholder for now.
+	const gatheringDataProps = zeroDataStatesEnabled
+		? {
+				gatheringData: isGatheringData,
+				gatheringDataNoticeStyle: NOTICE_STYLE.SMALL,
+		  }
+		: {};
+
 	return (
 		<DataBlock
 			className="overview-total-clicks"
@@ -104,6 +121,7 @@ function AdminBarClicks( { WidgetReportZero, WidgetReportError } ) {
 			datapoint={ totalClicks }
 			change={ totalClicksChange }
 			changeDataUnit="%"
+			{ ...gatheringDataProps }
 		/>
 	);
 }

--- a/assets/js/components/adminbar/AdminBarClicks.stories.js
+++ b/assets/js/components/adminbar/AdminBarClicks.stories.js
@@ -21,6 +21,7 @@
  */
 import { withWidgetComponentProps } from '../../googlesitekit/widgets/util';
 import {
+	setupSearchConsoleGatheringData,
 	setupSearchConsoleMockReports,
 	widgetDecorators,
 } from './common.stories';
@@ -45,6 +46,15 @@ Ready.args = {
 
 export const DataUnavailable = Template.bind( {} );
 DataUnavailable.storyName = 'Data Unavailable';
+
+export const GatheringData = Template.bind( {} );
+GatheringData.storyName = 'Gathering Data';
+GatheringData.args = {
+	setupRegistry: setupSearchConsoleGatheringData,
+};
+GatheringData.parameters = {
+	features: [ 'zeroDataStates' ],
+};
 
 export default {
 	title: 'Views/AdminBarApp/AdminBarClicks',

--- a/assets/js/components/adminbar/AdminBarImpressions.js
+++ b/assets/js/components/adminbar/AdminBarImpressions.js
@@ -111,6 +111,13 @@ function AdminBarImpressions( { WidgetReportZero, WidgetReportError } ) {
 		totalImpressions
 	);
 
+	const gatheringDataProps = zeroDataStatesEnabled
+		? {
+				gatheringData: isGatheringData,
+				gatheringDataNoticeStyle: NOTICE_STYLE.SMALL,
+		  }
+		: {};
+
 	return (
 		<DataBlock
 			className="overview-total-impressions"
@@ -118,8 +125,7 @@ function AdminBarImpressions( { WidgetReportZero, WidgetReportError } ) {
 			datapoint={ totalImpressions }
 			change={ totalImpressionsChange }
 			changeDataUnit="%"
-			gatheringData={ isGatheringData }
-			gatheringDataNoticeStyle={ NOTICE_STYLE.SMALL }
+			{ ...gatheringDataProps }
 		/>
 	);
 }

--- a/assets/js/components/adminbar/AdminBarImpressions.js
+++ b/assets/js/components/adminbar/AdminBarImpressions.js
@@ -42,7 +42,6 @@ import { useFeature } from '../../hooks/useFeature';
 const { useSelect } = Data;
 
 function AdminBarImpressions( { WidgetReportZero, WidgetReportError } ) {
-	// const unifiedDashboardEnabled = useFeature( 'unifiedDashboard' );
 	const zeroDataStatesEnabled = useFeature( 'zeroDataStates' );
 
 	const isGatheringData = useSelect( ( select ) =>

--- a/assets/js/components/adminbar/AdminBarImpressions.js
+++ b/assets/js/components/adminbar/AdminBarImpressions.js
@@ -91,11 +91,9 @@ function AdminBarImpressions( { WidgetReportZero, WidgetReportError } ) {
 		);
 	}
 
-	// TODO: How can isZeroReport be false when isGatheringData is true? Adding ! zeroDataStatesEnabled for now.
 	if (
-		! zeroDataStatesEnabled &&
 		isZeroReport( searchConsoleData ) &&
-		isGatheringData
+		( zeroDataStatesEnabled ? isGatheringData === false : isGatheringData )
 	) {
 		return <WidgetReportZero moduleSlug="search-console" />;
 	}
@@ -113,15 +111,6 @@ function AdminBarImpressions( { WidgetReportZero, WidgetReportError } ) {
 		totalImpressions
 	);
 
-	// TODO: Check for zeroDataStatesEnabled probably not needed here as it's checked in DataBlock.
-	// But - IB says check unifiedDashboard so leave as placeholder for now.
-	const gatheringDataProps = zeroDataStatesEnabled
-		? {
-				gatheringData: isGatheringData,
-				gatheringDataNoticeStyle: NOTICE_STYLE.SMALL,
-		  }
-		: {};
-
 	return (
 		<DataBlock
 			className="overview-total-impressions"
@@ -129,7 +118,8 @@ function AdminBarImpressions( { WidgetReportZero, WidgetReportError } ) {
 			datapoint={ totalImpressions }
 			change={ totalImpressionsChange }
 			changeDataUnit="%"
-			{ ...gatheringDataProps }
+			gatheringData={ isGatheringData }
+			gatheringDataNoticeStyle={ NOTICE_STYLE.SMALL }
 		/>
 	);
 }

--- a/assets/js/components/adminbar/AdminBarImpressions.js
+++ b/assets/js/components/adminbar/AdminBarImpressions.js
@@ -27,6 +27,7 @@ import { __ } from '@wordpress/i18n';
 import Data from 'googlesitekit-data';
 import DataBlock from '../DataBlock';
 import PreviewBlock from '../PreviewBlock';
+import { NOTICE_STYLE } from '../GatheringDataNotice';
 import { CORE_USER } from '../../googlesitekit/datastore/user/constants';
 import { CORE_SITE } from '../../googlesitekit/datastore/site/constants';
 import {
@@ -37,9 +38,13 @@ import { calculateChange } from '../../util';
 import { isZeroReport } from '../../modules/search-console/util';
 import sumObjectListValue from '../../util/sum-object-list-value';
 import { partitionReport } from '../../util/partition-report';
+import { useFeature } from '../../hooks/useFeature';
 const { useSelect } = Data;
 
 function AdminBarImpressions( { WidgetReportZero, WidgetReportError } ) {
+	// const unifiedDashboardEnabled = useFeature( 'unifiedDashboard' );
+	const zeroDataStatesEnabled = useFeature( 'zeroDataStates' );
+
 	const isGatheringData = useSelect( ( select ) =>
 		select( MODULES_SEARCH_CONSOLE ).isGatheringData()
 	);
@@ -86,7 +91,12 @@ function AdminBarImpressions( { WidgetReportZero, WidgetReportError } ) {
 		);
 	}
 
-	if ( isZeroReport( searchConsoleData ) && isGatheringData ) {
+	// TODO: How can isZeroReport be false when isGatheringData is true? Adding ! zeroDataStatesEnabled for now.
+	if (
+		! zeroDataStatesEnabled &&
+		isZeroReport( searchConsoleData ) &&
+		isGatheringData
+	) {
 		return <WidgetReportZero moduleSlug="search-console" />;
 	}
 
@@ -103,6 +113,15 @@ function AdminBarImpressions( { WidgetReportZero, WidgetReportError } ) {
 		totalImpressions
 	);
 
+	// TODO: Check for zeroDataStatesEnabled probably not needed here as it's checked in DataBlock.
+	// But - IB says check unifiedDashboard so leave as placeholder for now.
+	const gatheringDataProps = zeroDataStatesEnabled
+		? {
+				gatheringData: isGatheringData,
+				gatheringDataNoticeStyle: NOTICE_STYLE.SMALL,
+		  }
+		: {};
+
 	return (
 		<DataBlock
 			className="overview-total-impressions"
@@ -110,6 +129,7 @@ function AdminBarImpressions( { WidgetReportZero, WidgetReportError } ) {
 			datapoint={ totalImpressions }
 			change={ totalImpressionsChange }
 			changeDataUnit="%"
+			{ ...gatheringDataProps }
 		/>
 	);
 }

--- a/assets/js/components/adminbar/AdminBarImpressions.stories.js
+++ b/assets/js/components/adminbar/AdminBarImpressions.stories.js
@@ -21,6 +21,7 @@
  */
 import { withWidgetComponentProps } from '../../googlesitekit/widgets/util';
 import {
+	setupSearchConsoleGatheringData,
 	setupSearchConsoleMockReports,
 	widgetDecorators,
 } from './common.stories';
@@ -45,6 +46,15 @@ Ready.args = {
 
 export const DataUnavailable = Template.bind( {} );
 DataUnavailable.storyName = 'Data Unavailable';
+
+export const GatheringData = Template.bind( {} );
+GatheringData.storyName = 'Gathering Data';
+GatheringData.args = {
+	setupRegistry: setupSearchConsoleGatheringData,
+};
+GatheringData.parameters = {
+	features: [ 'zeroDataStates' ],
+};
 
 export default {
 	title: 'Views/AdminBarApp/AdminBarImpressions',

--- a/assets/js/components/adminbar/AdminBarSessions.js
+++ b/assets/js/components/adminbar/AdminBarSessions.js
@@ -90,9 +90,8 @@ const AdminBarSessions = ( { WidgetReportZero, WidgetReportError } ) => {
 	}
 
 	if (
-		! zeroDataStatesEnabled &&
 		isZeroReport( analyticsData ) &&
-		isGatheringData
+		( zeroDataStatesEnabled ? isGatheringData === false : isGatheringData )
 	) {
 		return <WidgetReportZero moduleSlug="analytics" />;
 	}
@@ -106,15 +105,6 @@ const AdminBarSessions = ( { WidgetReportZero, WidgetReportError } ) => {
 		lastMonth[ 0 ]
 	);
 
-	// TODO: Check for zeroDataStatesEnabled probably not needed here as it's checked in DataBlock.
-	// But - IB says check unifiedDashboard so leave as placeholder for now.
-	const gatheringDataProps = zeroDataStatesEnabled
-		? {
-				gatheringData: isGatheringData,
-				gatheringDataNoticeStyle: NOTICE_STYLE.SMALL,
-		  }
-		: {};
-
 	return (
 		<DataBlock
 			className="overview-total-sessions"
@@ -122,7 +112,8 @@ const AdminBarSessions = ( { WidgetReportZero, WidgetReportError } ) => {
 			datapoint={ totalSessions }
 			change={ totalSessionsChange }
 			changeDataUnit="%"
-			{ ...gatheringDataProps }
+			gatheringData={ isGatheringData }
+			gatheringDataNoticeStyle={ NOTICE_STYLE.SMALL }
 		/>
 	);
 };

--- a/assets/js/components/adminbar/AdminBarSessions.js
+++ b/assets/js/components/adminbar/AdminBarSessions.js
@@ -105,6 +105,13 @@ const AdminBarSessions = ( { WidgetReportZero, WidgetReportError } ) => {
 		lastMonth[ 0 ]
 	);
 
+	const gatheringDataProps = zeroDataStatesEnabled
+		? {
+				gatheringData: isGatheringData,
+				gatheringDataNoticeStyle: NOTICE_STYLE.SMALL,
+		  }
+		: {};
+
 	return (
 		<DataBlock
 			className="overview-total-sessions"
@@ -112,8 +119,7 @@ const AdminBarSessions = ( { WidgetReportZero, WidgetReportError } ) => {
 			datapoint={ totalSessions }
 			change={ totalSessionsChange }
 			changeDataUnit="%"
-			gatheringData={ isGatheringData }
-			gatheringDataNoticeStyle={ NOTICE_STYLE.SMALL }
+			{ ...gatheringDataProps }
 		/>
 	);
 };

--- a/assets/js/components/adminbar/AdminBarSessions.js
+++ b/assets/js/components/adminbar/AdminBarSessions.js
@@ -27,6 +27,7 @@ import { __ } from '@wordpress/i18n';
 import Data from 'googlesitekit-data';
 import DataBlock from '../DataBlock';
 import PreviewBlock from '../PreviewBlock';
+import { NOTICE_STYLE } from '../GatheringDataNotice';
 import { CORE_USER } from '../../googlesitekit/datastore/user/constants';
 import { CORE_SITE } from '../../googlesitekit/datastore/site/constants';
 import {
@@ -35,9 +36,12 @@ import {
 } from '../../modules/analytics/datastore/constants';
 import { calculateChange } from '../../util';
 import { isZeroReport } from '../../modules/analytics/util/is-zero-report';
+import { useFeature } from '../../hooks/useFeature';
 const { useSelect } = Data;
 
 const AdminBarSessions = ( { WidgetReportZero, WidgetReportError } ) => {
+	const zeroDataStatesEnabled = useFeature( 'zeroDataStates' );
+
 	const isGatheringData = useSelect( ( select ) =>
 		select( MODULES_ANALYTICS ).isGatheringData()
 	);
@@ -85,7 +89,11 @@ const AdminBarSessions = ( { WidgetReportZero, WidgetReportError } ) => {
 		return <WidgetReportError moduleSlug="analytics" error={ error } />;
 	}
 
-	if ( isZeroReport( analyticsData ) && isGatheringData ) {
+	if (
+		! zeroDataStatesEnabled &&
+		isZeroReport( analyticsData ) &&
+		isGatheringData
+	) {
 		return <WidgetReportZero moduleSlug="analytics" />;
 	}
 
@@ -98,6 +106,15 @@ const AdminBarSessions = ( { WidgetReportZero, WidgetReportError } ) => {
 		lastMonth[ 0 ]
 	);
 
+	// TODO: Check for zeroDataStatesEnabled probably not needed here as it's checked in DataBlock.
+	// But - IB says check unifiedDashboard so leave as placeholder for now.
+	const gatheringDataProps = zeroDataStatesEnabled
+		? {
+				gatheringData: isGatheringData,
+				gatheringDataNoticeStyle: NOTICE_STYLE.SMALL,
+		  }
+		: {};
+
 	return (
 		<DataBlock
 			className="overview-total-sessions"
@@ -105,6 +122,7 @@ const AdminBarSessions = ( { WidgetReportZero, WidgetReportError } ) => {
 			datapoint={ totalSessions }
 			change={ totalSessionsChange }
 			changeDataUnit="%"
+			{ ...gatheringDataProps }
 		/>
 	);
 };

--- a/assets/js/components/adminbar/AdminBarSessions.stories.js
+++ b/assets/js/components/adminbar/AdminBarSessions.stories.js
@@ -21,6 +21,7 @@
  */
 import { withWidgetComponentProps } from '../../googlesitekit/widgets/util';
 import {
+	setupAnalyticsGatheringData,
 	setupSearchConsoleAnalyticsMockReports,
 	widgetDecorators,
 } from './common.stories';
@@ -45,6 +46,15 @@ Ready.args = {
 
 export const DataUnavailable = Template.bind( {} );
 DataUnavailable.storyName = 'Data Unavailable';
+
+export const GatheringData = Template.bind( {} );
+GatheringData.storyName = 'GatheringData';
+GatheringData.args = {
+	setupRegistry: setupAnalyticsGatheringData,
+};
+GatheringData.parameters = {
+	features: [ 'zeroDataStates' ],
+};
 
 export default {
 	title: 'Views/AdminBarApp/AdminBarSessions',

--- a/assets/js/components/adminbar/AdminBarUniqueVisitors.js
+++ b/assets/js/components/adminbar/AdminBarUniqueVisitors.js
@@ -88,9 +88,8 @@ const AdminBarUniqueVisitors = ( { WidgetReportZero, WidgetReportError } ) => {
 	}
 
 	if (
-		! zeroDataStatesEnabled &&
 		isZeroReport( analyticsData ) &&
-		isGatheringData
+		( zeroDataStatesEnabled ? isGatheringData === false : isGatheringData )
 	) {
 		return <WidgetReportZero moduleSlug="analytics" />;
 	}
@@ -101,15 +100,6 @@ const AdminBarUniqueVisitors = ( { WidgetReportZero, WidgetReportError } ) => {
 	const totalUsers = lastMonth[ 0 ];
 	const previousTotalUsers = previousMonth[ 0 ];
 
-	// TODO: Check for zeroDataStatesEnabled probably not needed here as it's checked in DataBlock.
-	// But - IB says check unifiedDashboard so leave as placeholder for now.
-	const gatheringDataProps = zeroDataStatesEnabled
-		? {
-				gatheringData: isGatheringData,
-				gatheringDataNoticeStyle: NOTICE_STYLE.SMALL,
-		  }
-		: {};
-
 	return (
 		<DataBlock
 			className="overview-total-users"
@@ -117,7 +107,8 @@ const AdminBarUniqueVisitors = ( { WidgetReportZero, WidgetReportError } ) => {
 			datapoint={ totalUsers }
 			change={ calculateChange( previousTotalUsers, totalUsers ) }
 			changeDataUnit="%"
-			{ ...gatheringDataProps }
+			gatheringData={ isGatheringData }
+			gatheringDataNoticeStyle={ NOTICE_STYLE.SMALL }
 		/>
 	);
 };

--- a/assets/js/components/adminbar/AdminBarUniqueVisitors.js
+++ b/assets/js/components/adminbar/AdminBarUniqueVisitors.js
@@ -27,6 +27,7 @@ import { __ } from '@wordpress/i18n';
 import DataBlock from '../DataBlock';
 import Data from 'googlesitekit-data';
 import PreviewBlock from '../PreviewBlock';
+import { NOTICE_STYLE } from '../GatheringDataNotice';
 import { CORE_USER } from '../../googlesitekit/datastore/user/constants';
 import { CORE_SITE } from '../../googlesitekit/datastore/site/constants';
 import {
@@ -35,9 +36,12 @@ import {
 } from '../../modules/analytics/datastore/constants';
 import { calculateChange } from '../../util';
 import { isZeroReport } from '../../modules/analytics/util/is-zero-report';
+import { useFeature } from '../../hooks/useFeature';
 const { useSelect } = Data;
 
 const AdminBarUniqueVisitors = ( { WidgetReportZero, WidgetReportError } ) => {
+	const zeroDataStatesEnabled = useFeature( 'zeroDataStates' );
+
 	const isGatheringData = useSelect( ( select ) =>
 		select( MODULES_ANALYTICS ).isGatheringData()
 	);
@@ -83,7 +87,11 @@ const AdminBarUniqueVisitors = ( { WidgetReportZero, WidgetReportError } ) => {
 		return <WidgetReportError moduleSlug="analytics" error={ error } />;
 	}
 
-	if ( isZeroReport( analyticsData ) && isGatheringData ) {
+	if (
+		! zeroDataStatesEnabled &&
+		isZeroReport( analyticsData ) &&
+		isGatheringData
+	) {
 		return <WidgetReportZero moduleSlug="analytics" />;
 	}
 
@@ -93,6 +101,15 @@ const AdminBarUniqueVisitors = ( { WidgetReportZero, WidgetReportError } ) => {
 	const totalUsers = lastMonth[ 0 ];
 	const previousTotalUsers = previousMonth[ 0 ];
 
+	// TODO: Check for zeroDataStatesEnabled probably not needed here as it's checked in DataBlock.
+	// But - IB says check unifiedDashboard so leave as placeholder for now.
+	const gatheringDataProps = zeroDataStatesEnabled
+		? {
+				gatheringData: isGatheringData,
+				gatheringDataNoticeStyle: NOTICE_STYLE.SMALL,
+		  }
+		: {};
+
 	return (
 		<DataBlock
 			className="overview-total-users"
@@ -100,6 +117,7 @@ const AdminBarUniqueVisitors = ( { WidgetReportZero, WidgetReportError } ) => {
 			datapoint={ totalUsers }
 			change={ calculateChange( previousTotalUsers, totalUsers ) }
 			changeDataUnit="%"
+			{ ...gatheringDataProps }
 		/>
 	);
 };

--- a/assets/js/components/adminbar/AdminBarUniqueVisitors.js
+++ b/assets/js/components/adminbar/AdminBarUniqueVisitors.js
@@ -100,6 +100,13 @@ const AdminBarUniqueVisitors = ( { WidgetReportZero, WidgetReportError } ) => {
 	const totalUsers = lastMonth[ 0 ];
 	const previousTotalUsers = previousMonth[ 0 ];
 
+	const gatheringDataProps = zeroDataStatesEnabled
+		? {
+				gatheringData: isGatheringData,
+				gatheringDataNoticeStyle: NOTICE_STYLE.SMALL,
+		  }
+		: {};
+
 	return (
 		<DataBlock
 			className="overview-total-users"
@@ -107,8 +114,7 @@ const AdminBarUniqueVisitors = ( { WidgetReportZero, WidgetReportError } ) => {
 			datapoint={ totalUsers }
 			change={ calculateChange( previousTotalUsers, totalUsers ) }
 			changeDataUnit="%"
-			gatheringData={ isGatheringData }
-			gatheringDataNoticeStyle={ NOTICE_STYLE.SMALL }
+			{ ...gatheringDataProps }
 		/>
 	);
 };

--- a/assets/js/components/adminbar/AdminBarUniqueVisitors.stories.js
+++ b/assets/js/components/adminbar/AdminBarUniqueVisitors.stories.js
@@ -20,7 +20,11 @@
  * Internal dependencies
  */
 import { withWidgetComponentProps } from '../../googlesitekit/widgets/util';
-import { setupAnalyticsMockReports, widgetDecorators } from './common.stories';
+import {
+	setupAnalyticsGatheringData,
+	setupAnalyticsMockReports,
+	widgetDecorators,
+} from './common.stories';
 import WithRegistrySetup from '../../../../tests/js/WithRegistrySetup';
 import AdminBarUniqueVisitors from './AdminBarUniqueVisitors';
 
@@ -42,6 +46,15 @@ Ready.args = {
 
 export const DataUnavailable = Template.bind( {} );
 DataUnavailable.storyName = 'Data Unavailable';
+
+export const GatheringData = Template.bind( {} );
+GatheringData.storyName = 'GatheringData';
+GatheringData.args = {
+	setupRegistry: setupAnalyticsGatheringData,
+};
+GatheringData.parameters = {
+	features: [ 'zeroDataStates' ],
+};
 
 export default {
 	title: 'Views/AdminBarApp/AdminBarUniqueVisitors',

--- a/assets/js/components/adminbar/AdminBarWidgets.stories.js
+++ b/assets/js/components/adminbar/AdminBarWidgets.stories.js
@@ -24,6 +24,8 @@ import {
 	setupSearchConsoleAnalyticsMockReports,
 	setupAnalyticsMockReports,
 	setupSearchConsoleMockReports,
+	setupAnalyticsGatheringData,
+	setupSearchConsoleGatheringData,
 } from './common.stories';
 import WithRegistrySetup from '../../../../tests/js/WithRegistrySetup';
 import AdminBarWidgets from './AdminBarWidgets';
@@ -173,6 +175,39 @@ SearchConsoleDataUnavailable.decorators = [
 		);
 	},
 ];
+
+export const GatheringData = Template.bind( {} );
+GatheringData.storyName = 'Gathering Data';
+GatheringData.decorators = [
+	( Story ) => {
+		const setupRegistry = ( registry ) => {
+			provideModules( registry, [
+				{
+					slug: 'search-console',
+					active: true,
+					connected: true,
+				},
+				{
+					slug: 'analytics',
+					active: true,
+					connected: true,
+				},
+			] );
+
+			setupSearchConsoleGatheringData( registry );
+			setupAnalyticsGatheringData( registry );
+		};
+
+		return (
+			<WithRegistrySetup func={ setupRegistry }>
+				<Story />
+			</WithRegistrySetup>
+		);
+	},
+];
+GatheringData.parameters = {
+	features: [ 'zeroDataStates' ],
+};
 
 export default {
 	title: 'Views/AdminBarApp/AdminBarWidgets',

--- a/assets/js/components/adminbar/common.stories.js
+++ b/assets/js/components/adminbar/common.stories.js
@@ -148,3 +148,32 @@ export const widgetDecorators = [
 		);
 	},
 ];
+
+export function setupSearchConsoleGatheringData( registry ) {
+	registry.dispatch( CORE_USER ).setReferenceDate( '2021-01-28' );
+	registry.dispatch( MODULES_SEARCH_CONSOLE ).receiveGetReport( [], {
+		options: adminbarSearchConsoleOptions,
+	} );
+}
+
+export const setupAnalyticsGatheringData = (
+	registry,
+	data = adminbarAnalyticsMockData
+) => {
+	registry.dispatch( CORE_USER ).setReferenceDate( '2021-01-28' );
+	data.forEach( ( options ) => {
+		registry.dispatch( MODULES_ANALYTICS ).receiveGetReport(
+			[
+				{
+					data: {
+						rows: [],
+						totals: [ { values: [] }, { values: [] } ],
+					},
+				},
+			],
+			{
+				options,
+			}
+		);
+	} );
+};

--- a/assets/js/components/wp-dashboard/WPDashboardClicks.js
+++ b/assets/js/components/wp-dashboard/WPDashboardClicks.js
@@ -37,9 +37,13 @@ import sumObjectListValue from '../../util/sum-object-list-value';
 import { partitionReport } from '../../util/partition-report';
 import DataBlock from '../DataBlock';
 import PreviewBlock from '../PreviewBlock';
+import { NOTICE_STYLE } from '../GatheringDataNotice';
+import { useFeature } from '../../hooks/useFeature';
 const { useSelect, useInViewSelect } = Data;
 
 const WPDashboardClicks = ( { WidgetReportZero, WidgetReportError } ) => {
+	const zeroDataStatesEnabled = useFeature( 'zeroDataStates' );
+
 	const isGatheringData = useInViewSelect( ( select ) =>
 		select( MODULES_SEARCH_CONSOLE ).isGatheringData()
 	);
@@ -90,7 +94,7 @@ const WPDashboardClicks = ( { WidgetReportZero, WidgetReportError } ) => {
 		);
 	}
 
-	if ( isZeroReport( data ) && isGatheringData ) {
+	if ( ! zeroDataStatesEnabled && isZeroReport( data ) && isGatheringData ) {
 		return <WidgetReportZero moduleSlug="search-console" />;
 	}
 
@@ -101,6 +105,15 @@ const WPDashboardClicks = ( { WidgetReportZero, WidgetReportError } ) => {
 	const totalOlderClicks = sumObjectListValue( compareRange, 'clicks' );
 	const totalClicksChange = calculateChange( totalOlderClicks, totalClicks );
 
+	// TODO: Check for zeroDataStatesEnabled probably not needed here as it's checked in DataBlock.
+	// But - IB says check unifiedDashboard so leave as placeholder for now.
+	const gatheringDataProps = zeroDataStatesEnabled
+		? {
+				gatheringData: isGatheringData,
+				gatheringDataNoticeStyle: NOTICE_STYLE.SMALL,
+		  }
+		: {};
+
 	return (
 		<DataBlock
 			className="googlesitekit-wp-dashboard-stats__data-table overview-total-clicks"
@@ -108,6 +121,7 @@ const WPDashboardClicks = ( { WidgetReportZero, WidgetReportError } ) => {
 			datapoint={ totalClicks }
 			change={ totalClicksChange }
 			changeDataUnit="%"
+			{ ...gatheringDataProps }
 		/>
 	);
 };

--- a/assets/js/components/wp-dashboard/WPDashboardClicks.js
+++ b/assets/js/components/wp-dashboard/WPDashboardClicks.js
@@ -108,6 +108,13 @@ const WPDashboardClicks = ( { WidgetReportZero, WidgetReportError } ) => {
 	const totalOlderClicks = sumObjectListValue( compareRange, 'clicks' );
 	const totalClicksChange = calculateChange( totalOlderClicks, totalClicks );
 
+	const gatheringDataProps = zeroDataStatesEnabled
+		? {
+				gatheringData: isGatheringData,
+				gatheringDataNoticeStyle: NOTICE_STYLE.SMALL,
+		  }
+		: {};
+
 	return (
 		<DataBlock
 			className="googlesitekit-wp-dashboard-stats__data-table overview-total-clicks"
@@ -115,8 +122,7 @@ const WPDashboardClicks = ( { WidgetReportZero, WidgetReportError } ) => {
 			datapoint={ totalClicks }
 			change={ totalClicksChange }
 			changeDataUnit="%"
-			gatheringData={ isGatheringData }
-			gatheringDataNoticeStyle={ NOTICE_STYLE.SMALL }
+			{ ...gatheringDataProps }
 		/>
 	);
 };

--- a/assets/js/components/wp-dashboard/WPDashboardClicks.js
+++ b/assets/js/components/wp-dashboard/WPDashboardClicks.js
@@ -94,7 +94,10 @@ const WPDashboardClicks = ( { WidgetReportZero, WidgetReportError } ) => {
 		);
 	}
 
-	if ( ! zeroDataStatesEnabled && isZeroReport( data ) && isGatheringData ) {
+	if (
+		isZeroReport( data ) &&
+		( zeroDataStatesEnabled ? isGatheringData === false : isGatheringData )
+	) {
 		return <WidgetReportZero moduleSlug="search-console" />;
 	}
 
@@ -105,15 +108,6 @@ const WPDashboardClicks = ( { WidgetReportZero, WidgetReportError } ) => {
 	const totalOlderClicks = sumObjectListValue( compareRange, 'clicks' );
 	const totalClicksChange = calculateChange( totalOlderClicks, totalClicks );
 
-	// TODO: Check for zeroDataStatesEnabled probably not needed here as it's checked in DataBlock.
-	// But - IB says check unifiedDashboard so leave as placeholder for now.
-	const gatheringDataProps = zeroDataStatesEnabled
-		? {
-				gatheringData: isGatheringData,
-				gatheringDataNoticeStyle: NOTICE_STYLE.SMALL,
-		  }
-		: {};
-
 	return (
 		<DataBlock
 			className="googlesitekit-wp-dashboard-stats__data-table overview-total-clicks"
@@ -121,7 +115,8 @@ const WPDashboardClicks = ( { WidgetReportZero, WidgetReportError } ) => {
 			datapoint={ totalClicks }
 			change={ totalClicksChange }
 			changeDataUnit="%"
-			{ ...gatheringDataProps }
+			gatheringData={ isGatheringData }
+			gatheringDataNoticeStyle={ NOTICE_STYLE.SMALL }
 		/>
 	);
 };

--- a/assets/js/components/wp-dashboard/WPDashboardClicks.stories.js
+++ b/assets/js/components/wp-dashboard/WPDashboardClicks.stories.js
@@ -1,0 +1,62 @@
+/**
+ * WP Dashboard Clicks Component Stories.
+ *
+ * Site Kit by Google, Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import { withWidgetComponentProps } from '../../googlesitekit/widgets/util';
+import {
+	setupSearchConsoleGatheringData,
+	setupSearchConsoleMockReports,
+	widgetDecorators,
+} from './common.stories';
+import WPDashboardClicks from './WPDashboardClicks';
+import WithRegistrySetup from '../../../../tests/js/WithRegistrySetup';
+
+const WidgetWithComponentProps = withWidgetComponentProps( 'widget-slug' )(
+	WPDashboardClicks
+);
+
+const Template = ( { setupRegistry = () => {}, ...args } ) => (
+	<WithRegistrySetup func={ setupRegistry }>
+		<WidgetWithComponentProps { ...args } />
+	</WithRegistrySetup>
+);
+
+export const Ready = Template.bind( {} );
+Ready.storyName = 'Ready';
+Ready.args = {
+	setupRegistry: setupSearchConsoleMockReports,
+};
+
+export const DataUnavailable = Template.bind( {} );
+DataUnavailable.storyName = 'Data Unavailable';
+
+export const GatheringData = Template.bind( {} );
+GatheringData.storyName = 'Gathering Data';
+GatheringData.args = {
+	setupRegistry: setupSearchConsoleGatheringData,
+};
+GatheringData.parameters = {
+	features: [ 'zeroDataStates' ],
+};
+
+export default {
+	title: 'Views/WPDashboardApp/WPDashboardClicks',
+	decorators: widgetDecorators,
+};

--- a/assets/js/components/wp-dashboard/WPDashboardIdeaHub.stories.js
+++ b/assets/js/components/wp-dashboard/WPDashboardIdeaHub.stories.js
@@ -66,7 +66,7 @@ Ready.parameters = {
 };
 
 export default {
-	title: 'Views/WPDashboardApp',
+	title: 'Views/WPDashboardApp/WPDashboardIdeaHub',
 	decorators: [
 		( Story ) => {
 			mockEndpoints();

--- a/assets/js/components/wp-dashboard/WPDashboardImpressions.js
+++ b/assets/js/components/wp-dashboard/WPDashboardImpressions.js
@@ -94,7 +94,10 @@ const WPDashboardImpressions = ( { WidgetReportZero, WidgetReportError } ) => {
 		);
 	}
 
-	if ( ! zeroDataStatesEnabled && isZeroReport( data ) && isGatheringData ) {
+	if (
+		isZeroReport( data ) &&
+		( zeroDataStatesEnabled ? isGatheringData === false : isGatheringData )
+	) {
 		return <WidgetReportZero moduleSlug="search-console" />;
 	}
 
@@ -111,13 +114,6 @@ const WPDashboardImpressions = ( { WidgetReportZero, WidgetReportError } ) => {
 		totalImpressions
 	);
 
-	const gatheringDataProps = zeroDataStatesEnabled
-		? {
-				gatheringData: isGatheringData,
-				gatheringDataNoticeStyle: NOTICE_STYLE.SMALL,
-		  }
-		: {};
-
 	return (
 		<DataBlock
 			className="googlesitekit-wp-dashboard-stats__data-table overview-total-impressions"
@@ -125,7 +121,8 @@ const WPDashboardImpressions = ( { WidgetReportZero, WidgetReportError } ) => {
 			datapoint={ totalImpressions }
 			change={ totalImpressionsChange }
 			changeDataUnit="%"
-			{ ...gatheringDataProps }
+			gatheringData={ isGatheringData }
+			gatheringDataNoticeStyle={ NOTICE_STYLE.SMALL }
 		/>
 	);
 };

--- a/assets/js/components/wp-dashboard/WPDashboardImpressions.js
+++ b/assets/js/components/wp-dashboard/WPDashboardImpressions.js
@@ -114,6 +114,13 @@ const WPDashboardImpressions = ( { WidgetReportZero, WidgetReportError } ) => {
 		totalImpressions
 	);
 
+	const gatheringDataProps = zeroDataStatesEnabled
+		? {
+				gatheringData: isGatheringData,
+				gatheringDataNoticeStyle: NOTICE_STYLE.SMALL,
+		  }
+		: {};
+
 	return (
 		<DataBlock
 			className="googlesitekit-wp-dashboard-stats__data-table overview-total-impressions"
@@ -121,8 +128,7 @@ const WPDashboardImpressions = ( { WidgetReportZero, WidgetReportError } ) => {
 			datapoint={ totalImpressions }
 			change={ totalImpressionsChange }
 			changeDataUnit="%"
-			gatheringData={ isGatheringData }
-			gatheringDataNoticeStyle={ NOTICE_STYLE.SMALL }
+			{ ...gatheringDataProps }
 		/>
 	);
 };

--- a/assets/js/components/wp-dashboard/WPDashboardImpressions.js
+++ b/assets/js/components/wp-dashboard/WPDashboardImpressions.js
@@ -34,12 +34,16 @@ import { CORE_USER } from '../../googlesitekit/datastore/user/constants';
 import { isZeroReport } from '../../modules/search-console/util';
 import DataBlock from '../DataBlock';
 import PreviewBlock from '../PreviewBlock';
+import { NOTICE_STYLE } from '../GatheringDataNotice';
 import { calculateChange, trackEvent } from '../../util';
 import sumObjectListValue from '../../util/sum-object-list-value';
 import { partitionReport } from '../../util/partition-report';
+import { useFeature } from '../../hooks/useFeature';
 const { useSelect, useInViewSelect } = Data;
 
 const WPDashboardImpressions = ( { WidgetReportZero, WidgetReportError } ) => {
+	const zeroDataStatesEnabled = useFeature( 'zeroDataStates' );
+
 	const isGatheringData = useInViewSelect( ( select ) =>
 		select( MODULES_SEARCH_CONSOLE ).isGatheringData()
 	);
@@ -90,7 +94,7 @@ const WPDashboardImpressions = ( { WidgetReportZero, WidgetReportError } ) => {
 		);
 	}
 
-	if ( isZeroReport( data ) && isGatheringData ) {
+	if ( ! zeroDataStatesEnabled && isZeroReport( data ) && isGatheringData ) {
 		return <WidgetReportZero moduleSlug="search-console" />;
 	}
 
@@ -107,6 +111,13 @@ const WPDashboardImpressions = ( { WidgetReportZero, WidgetReportError } ) => {
 		totalImpressions
 	);
 
+	const gatheringDataProps = zeroDataStatesEnabled
+		? {
+				gatheringData: isGatheringData,
+				gatheringDataNoticeStyle: NOTICE_STYLE.SMALL,
+		  }
+		: {};
+
 	return (
 		<DataBlock
 			className="googlesitekit-wp-dashboard-stats__data-table overview-total-impressions"
@@ -114,6 +125,7 @@ const WPDashboardImpressions = ( { WidgetReportZero, WidgetReportError } ) => {
 			datapoint={ totalImpressions }
 			change={ totalImpressionsChange }
 			changeDataUnit="%"
+			{ ...gatheringDataProps }
 		/>
 	);
 };

--- a/assets/js/components/wp-dashboard/WPDashboardImpressions.stories.js
+++ b/assets/js/components/wp-dashboard/WPDashboardImpressions.stories.js
@@ -1,0 +1,62 @@
+/**
+ * WP Dashboard Impressions Component Stories.
+ *
+ * Site Kit by Google, Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import { withWidgetComponentProps } from '../../googlesitekit/widgets/util';
+import {
+	setupSearchConsoleGatheringData,
+	setupSearchConsoleMockReports,
+	widgetDecorators,
+} from './common.stories';
+import WPDashboardImpressions from './WPDashboardImpressions';
+import WithRegistrySetup from '../../../../tests/js/WithRegistrySetup';
+
+const WidgetWithComponentProps = withWidgetComponentProps( 'widget-slug' )(
+	WPDashboardImpressions
+);
+
+const Template = ( { setupRegistry = () => {}, ...args } ) => (
+	<WithRegistrySetup func={ setupRegistry }>
+		<WidgetWithComponentProps { ...args } />
+	</WithRegistrySetup>
+);
+
+export const Ready = Template.bind( {} );
+Ready.storyName = 'Ready';
+Ready.args = {
+	setupRegistry: setupSearchConsoleMockReports,
+};
+
+export const DataUnavailable = Template.bind( {} );
+DataUnavailable.storyName = 'Data Unavailable';
+
+export const GatheringData = Template.bind( {} );
+GatheringData.storyName = 'Gathering Data';
+GatheringData.args = {
+	setupRegistry: setupSearchConsoleGatheringData,
+};
+GatheringData.parameters = {
+	features: [ 'zeroDataStates' ],
+};
+
+export default {
+	title: 'Views/WPDashboardApp/WPDashboardImpressions',
+	decorators: widgetDecorators,
+};

--- a/assets/js/components/wp-dashboard/WPDashboardSessionDuration.js
+++ b/assets/js/components/wp-dashboard/WPDashboardSessionDuration.js
@@ -89,7 +89,10 @@ const WPDashboardSessionDuration = ( {
 		return <WidgetReportError moduleSlug="analytics" error={ error } />;
 	}
 
-	if ( ! zeroDataStatesEnabled && isZeroReport( data ) && isGatheringData ) {
+	if (
+		isZeroReport( data ) &&
+		( zeroDataStatesEnabled ? isGatheringData === false : isGatheringData )
+	) {
 		return <WidgetReportZero moduleSlug="analytics" />;
 	}
 
@@ -102,15 +105,6 @@ const WPDashboardSessionDuration = ( {
 		lastMonth[ 0 ]
 	);
 
-	// TODO: Check for zeroDataStatesEnabled probably not needed here as it's checked in DataBlock.
-	// But - IB says check unifiedDashboard so leave as placeholder for now.
-	const gatheringDataProps = zeroDataStatesEnabled
-		? {
-				gatheringData: isGatheringData,
-				gatheringDataNoticeStyle: NOTICE_STYLE.SMALL,
-		  }
-		: {};
-
 	return (
 		<DataBlock
 			className="googlesitekit-wp-dashboard-stats__data-table overview-average-session-duration"
@@ -119,7 +113,8 @@ const WPDashboardSessionDuration = ( {
 			datapointUnit="s"
 			change={ averageSessionDurationChange }
 			changeDataUnit="%"
-			{ ...gatheringDataProps }
+			gatheringData={ isGatheringData }
+			gatheringDataNoticeStyle={ NOTICE_STYLE.SMALL }
 		/>
 	);
 };

--- a/assets/js/components/wp-dashboard/WPDashboardSessionDuration.js
+++ b/assets/js/components/wp-dashboard/WPDashboardSessionDuration.js
@@ -105,6 +105,13 @@ const WPDashboardSessionDuration = ( {
 		lastMonth[ 0 ]
 	);
 
+	const gatheringDataProps = zeroDataStatesEnabled
+		? {
+				gatheringData: isGatheringData,
+				gatheringDataNoticeStyle: NOTICE_STYLE.SMALL,
+		  }
+		: {};
+
 	return (
 		<DataBlock
 			className="googlesitekit-wp-dashboard-stats__data-table overview-average-session-duration"
@@ -113,8 +120,7 @@ const WPDashboardSessionDuration = ( {
 			datapointUnit="s"
 			change={ averageSessionDurationChange }
 			changeDataUnit="%"
-			gatheringData={ isGatheringData }
-			gatheringDataNoticeStyle={ NOTICE_STYLE.SMALL }
+			{ ...gatheringDataProps }
 		/>
 	);
 };

--- a/assets/js/components/wp-dashboard/WPDashboardSessionDuration.js
+++ b/assets/js/components/wp-dashboard/WPDashboardSessionDuration.js
@@ -33,13 +33,17 @@ import { CORE_USER } from '../../googlesitekit/datastore/user/constants';
 import { calculateChange } from '../../util';
 import DataBlock from '../DataBlock';
 import PreviewBlock from '../PreviewBlock';
+import { NOTICE_STYLE } from '../GatheringDataNotice';
 import { isZeroReport } from '../../modules/analytics/util/is-zero-report';
+import { useFeature } from '../../hooks/useFeature';
 const { useSelect, useInViewSelect } = Data;
 
 const WPDashboardSessionDuration = ( {
 	WidgetReportZero,
 	WidgetReportError,
 } ) => {
+	const zeroDataStatesEnabled = useFeature( 'zeroDataStates' );
+
 	const isGatheringData = useInViewSelect( ( select ) =>
 		select( MODULES_ANALYTICS ).isGatheringData()
 	);
@@ -85,7 +89,7 @@ const WPDashboardSessionDuration = ( {
 		return <WidgetReportError moduleSlug="analytics" error={ error } />;
 	}
 
-	if ( isZeroReport( data ) && isGatheringData ) {
+	if ( ! zeroDataStatesEnabled && isZeroReport( data ) && isGatheringData ) {
 		return <WidgetReportZero moduleSlug="analytics" />;
 	}
 
@@ -98,6 +102,15 @@ const WPDashboardSessionDuration = ( {
 		lastMonth[ 0 ]
 	);
 
+	// TODO: Check for zeroDataStatesEnabled probably not needed here as it's checked in DataBlock.
+	// But - IB says check unifiedDashboard so leave as placeholder for now.
+	const gatheringDataProps = zeroDataStatesEnabled
+		? {
+				gatheringData: isGatheringData,
+				gatheringDataNoticeStyle: NOTICE_STYLE.SMALL,
+		  }
+		: {};
+
 	return (
 		<DataBlock
 			className="googlesitekit-wp-dashboard-stats__data-table overview-average-session-duration"
@@ -106,6 +119,7 @@ const WPDashboardSessionDuration = ( {
 			datapointUnit="s"
 			change={ averageSessionDurationChange }
 			changeDataUnit="%"
+			{ ...gatheringDataProps }
 		/>
 	);
 };

--- a/assets/js/components/wp-dashboard/WPDashboardSessionDuration.stories.js
+++ b/assets/js/components/wp-dashboard/WPDashboardSessionDuration.stories.js
@@ -1,0 +1,62 @@
+/**
+ * WP Dashboard Session Duration Component Stories.
+ *
+ * Site Kit by Google, Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import { withWidgetComponentProps } from '../../googlesitekit/widgets/util';
+import {
+	setupAnalyticsGatheringData,
+	setupSearchConsoleAnalyticsMockReports,
+	widgetDecorators,
+} from './common.stories';
+import WithRegistrySetup from '../../../../tests/js/WithRegistrySetup';
+import WPDashboardSessionDuration from './WPDashboardSessionDuration';
+
+const WidgetWithComponentProps = withWidgetComponentProps( 'widget-slug' )(
+	WPDashboardSessionDuration
+);
+
+const Template = ( { setupRegistry = () => {}, ...args } ) => (
+	<WithRegistrySetup func={ setupRegistry }>
+		<WidgetWithComponentProps { ...args } />
+	</WithRegistrySetup>
+);
+
+export const Ready = Template.bind( {} );
+Ready.storyName = 'Ready';
+Ready.args = {
+	setupRegistry: setupSearchConsoleAnalyticsMockReports,
+};
+
+export const DataUnavailable = Template.bind( {} );
+DataUnavailable.storyName = 'Data Unavailable';
+
+export const GatheringData = Template.bind( {} );
+GatheringData.storyName = 'GatheringData';
+GatheringData.args = {
+	setupRegistry: setupAnalyticsGatheringData,
+};
+GatheringData.parameters = {
+	features: [ 'zeroDataStates' ],
+};
+
+export default {
+	title: 'Views/WPDashboardApp/WPDashboardSessionDuration',
+	decorators: widgetDecorators,
+};

--- a/assets/js/components/wp-dashboard/WPDashboardUniqueVisitors.js
+++ b/assets/js/components/wp-dashboard/WPDashboardUniqueVisitors.js
@@ -100,6 +100,13 @@ const WPDashboardUniqueVisitors = ( {
 	const totalUsers = lastMonth[ 0 ];
 	const previousTotalUsers = previousMonth[ 0 ];
 
+	const gatheringDataProps = zeroDataStatesEnabled
+		? {
+				gatheringData: isGatheringData,
+				gatheringDataNoticeStyle: NOTICE_STYLE.SMALL,
+		  }
+		: {};
+
 	return (
 		<DataBlock
 			className="googlesitekit-wp-dashboard-stats__data-table overview-total-users"
@@ -107,8 +114,7 @@ const WPDashboardUniqueVisitors = ( {
 			datapoint={ totalUsers }
 			change={ calculateChange( previousTotalUsers, totalUsers ) }
 			changeDataUnit="%"
-			gatheringData={ isGatheringData }
-			gatheringDataNoticeStyle={ NOTICE_STYLE.SMALL }
+			{ ...gatheringDataProps }
 		/>
 	);
 };

--- a/assets/js/components/wp-dashboard/WPDashboardUniqueVisitors.js
+++ b/assets/js/components/wp-dashboard/WPDashboardUniqueVisitors.js
@@ -87,7 +87,10 @@ const WPDashboardUniqueVisitors = ( {
 		return <WidgetReportError moduleSlug="analytics" error={ error } />;
 	}
 
-	if ( ! zeroDataStatesEnabled && isZeroReport( data ) && isGatheringData ) {
+	if (
+		isZeroReport( data ) &&
+		( zeroDataStatesEnabled ? isGatheringData === false : isGatheringData )
+	) {
 		return <WidgetReportZero moduleSlug="analytics" />;
 	}
 
@@ -97,15 +100,6 @@ const WPDashboardUniqueVisitors = ( {
 	const totalUsers = lastMonth[ 0 ];
 	const previousTotalUsers = previousMonth[ 0 ];
 
-	// TODO: Check for zeroDataStatesEnabled probably not needed here as it's checked in DataBlock.
-	// But - IB says check unifiedDashboard so leave as placeholder for now.
-	const gatheringDataProps = zeroDataStatesEnabled
-		? {
-				gatheringData: isGatheringData,
-				gatheringDataNoticeStyle: NOTICE_STYLE.SMALL,
-		  }
-		: {};
-
 	return (
 		<DataBlock
 			className="googlesitekit-wp-dashboard-stats__data-table overview-total-users"
@@ -113,7 +107,8 @@ const WPDashboardUniqueVisitors = ( {
 			datapoint={ totalUsers }
 			change={ calculateChange( previousTotalUsers, totalUsers ) }
 			changeDataUnit="%"
-			{ ...gatheringDataProps }
+			gatheringData={ isGatheringData }
+			gatheringDataNoticeStyle={ NOTICE_STYLE.SMALL }
 		/>
 	);
 };

--- a/assets/js/components/wp-dashboard/WPDashboardUniqueVisitors.js
+++ b/assets/js/components/wp-dashboard/WPDashboardUniqueVisitors.js
@@ -33,13 +33,17 @@ import { CORE_USER } from '../../googlesitekit/datastore/user/constants';
 import PreviewBlock from '../PreviewBlock';
 import { calculateChange } from '../../util';
 import DataBlock from '../DataBlock';
+import { NOTICE_STYLE } from '../GatheringDataNotice';
 import { isZeroReport } from '../../modules/analytics/util/is-zero-report';
+import { useFeature } from '../../hooks/useFeature';
 const { useSelect, useInViewSelect } = Data;
 
 const WPDashboardUniqueVisitors = ( {
 	WidgetReportZero,
 	WidgetReportError,
 } ) => {
+	const zeroDataStatesEnabled = useFeature( 'zeroDataStates' );
+
 	const isGatheringData = useInViewSelect( ( select ) =>
 		select( MODULES_ANALYTICS ).isGatheringData()
 	);
@@ -83,7 +87,7 @@ const WPDashboardUniqueVisitors = ( {
 		return <WidgetReportError moduleSlug="analytics" error={ error } />;
 	}
 
-	if ( isZeroReport( data ) && isGatheringData ) {
+	if ( ! zeroDataStatesEnabled && isZeroReport( data ) && isGatheringData ) {
 		return <WidgetReportZero moduleSlug="analytics" />;
 	}
 
@@ -93,6 +97,15 @@ const WPDashboardUniqueVisitors = ( {
 	const totalUsers = lastMonth[ 0 ];
 	const previousTotalUsers = previousMonth[ 0 ];
 
+	// TODO: Check for zeroDataStatesEnabled probably not needed here as it's checked in DataBlock.
+	// But - IB says check unifiedDashboard so leave as placeholder for now.
+	const gatheringDataProps = zeroDataStatesEnabled
+		? {
+				gatheringData: isGatheringData,
+				gatheringDataNoticeStyle: NOTICE_STYLE.SMALL,
+		  }
+		: {};
+
 	return (
 		<DataBlock
 			className="googlesitekit-wp-dashboard-stats__data-table overview-total-users"
@@ -100,6 +113,7 @@ const WPDashboardUniqueVisitors = ( {
 			datapoint={ totalUsers }
 			change={ calculateChange( previousTotalUsers, totalUsers ) }
 			changeDataUnit="%"
+			{ ...gatheringDataProps }
 		/>
 	);
 };

--- a/assets/js/components/wp-dashboard/WPDashboardUniqueVisitors.stories.js
+++ b/assets/js/components/wp-dashboard/WPDashboardUniqueVisitors.stories.js
@@ -1,0 +1,62 @@
+/**
+ * WP Dashboard Unique Visitors Component Stories.
+ *
+ * Site Kit by Google, Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import { withWidgetComponentProps } from '../../googlesitekit/widgets/util';
+import {
+	setupAnalyticsGatheringData,
+	setupAnalyticsMockReports,
+	widgetDecorators,
+} from './common.stories';
+import WithRegistrySetup from '../../../../tests/js/WithRegistrySetup';
+import WPDashboardUniqueVisitors from './WPDashboardUniqueVisitors';
+
+const WidgetWithComponentProps = withWidgetComponentProps( 'widget-slug' )(
+	WPDashboardUniqueVisitors
+);
+
+const Template = ( { setupRegistry = () => {}, ...args } ) => (
+	<WithRegistrySetup func={ setupRegistry }>
+		<WidgetWithComponentProps { ...args } />
+	</WithRegistrySetup>
+);
+
+export const Ready = Template.bind( {} );
+Ready.storyName = 'Ready';
+Ready.args = {
+	setupRegistry: setupAnalyticsMockReports,
+};
+
+export const DataUnavailable = Template.bind( {} );
+DataUnavailable.storyName = 'Data Unavailable';
+
+export const GatheringData = Template.bind( {} );
+GatheringData.storyName = 'GatheringData';
+GatheringData.args = {
+	setupRegistry: setupAnalyticsGatheringData,
+};
+GatheringData.parameters = {
+	features: [ 'zeroDataStates' ],
+};
+
+export default {
+	title: 'Views/WPDashboardApp/WPDashboardUniqueVisitors',
+	decorators: widgetDecorators,
+};

--- a/assets/js/components/wp-dashboard/common.stories.js
+++ b/assets/js/components/wp-dashboard/common.stories.js
@@ -1,0 +1,170 @@
+/**
+ * Shared exports among WPDashboard Stories.
+ *
+ * Site Kit by Google, Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import { provideModules } from '../../../../tests/js/utils';
+import { CORE_USER } from '../../googlesitekit/datastore/user/constants';
+import { MODULES_SEARCH_CONSOLE } from '../../modules/search-console/datastore/constants';
+import { MODULES_ANALYTICS } from '../../modules/analytics/datastore/constants';
+import { getAnalyticsMockResponse } from '../../modules/analytics/util/data-mock';
+import WithRegistrySetup from '../../../../tests/js/WithRegistrySetup';
+import { provideSearchConsoleMockReport } from '../../modules/search-console/util/data-mock';
+
+const adminbarSearchConsoleOptions = {
+	startDate: '2020-12-03',
+	endDate: '2021-01-27',
+	dimensions: 'date',
+};
+
+const adminbarAnalyticsMockData = [
+	// Mock Total Users widget data
+	{
+		startDate: '2020-12-31',
+		endDate: '2021-01-27',
+		compareStartDate: '2020-12-03',
+		compareEndDate: '2020-12-30',
+		metrics: [
+			{
+				expression: 'ga:users',
+				alias: 'Total Users',
+			},
+		],
+	},
+
+	// Mock Sessions widget data
+	{
+		startDate: '2020-12-31',
+		endDate: '2021-01-27',
+		compareStartDate: '2020-12-03',
+		compareEndDate: '2020-12-30',
+		dimensions: 'ga:date',
+		limit: 10,
+		metrics: [
+			{
+				expression: 'ga:avgSessionDuration',
+				alias: 'Average Session Duration',
+			},
+		],
+	},
+];
+export const setupBaseRegistry = ( registry, args ) => {
+	// Set up the search console and analytics modules stores but provide no data.
+	provideModules( registry, [
+		{
+			slug: 'search-console',
+			active: true,
+			connected: true,
+		},
+		{
+			slug: 'analytics',
+			active: true,
+			connected: true,
+		},
+	] );
+
+	// Call story-specific setup.
+	if ( typeof args?.setupRegistry === 'function' ) {
+		args.setupRegistry( registry );
+	}
+};
+
+export function setupSearchConsoleMockReports( registry, data ) {
+	registry.dispatch( CORE_USER ).setReferenceDate( '2021-01-28' );
+
+	if ( data ) {
+		registry.dispatch( MODULES_SEARCH_CONSOLE ).receiveGetReport( data, {
+			options: adminbarSearchConsoleOptions,
+		} );
+	} else {
+		provideSearchConsoleMockReport(
+			registry,
+			adminbarSearchConsoleOptions
+		);
+	}
+}
+
+export const setupAnalyticsMockReports = (
+	registry,
+	data = adminbarAnalyticsMockData
+) => {
+	registry.dispatch( CORE_USER ).setReferenceDate( '2021-01-28' );
+	data.forEach( ( options ) => {
+		registry
+			.dispatch( MODULES_ANALYTICS )
+			.receiveGetReport( getAnalyticsMockResponse( options ), {
+				options,
+			} );
+	} );
+};
+
+export const setupSearchConsoleAnalyticsMockReports = ( registry ) => {
+	setupSearchConsoleMockReports( registry );
+	setupAnalyticsMockReports( registry );
+};
+
+export const widgetDecorators = [
+	( Story ) => (
+		<div className="googlesitekit-widget">
+			<div className="googlesitekit-widget__body">
+				<Story />
+			</div>
+		</div>
+	),
+	( Story, { args } ) => {
+		const setupRegistry = ( registry ) => {
+			setupBaseRegistry( registry, args );
+		};
+
+		return (
+			<WithRegistrySetup func={ setupRegistry }>
+				<Story />
+			</WithRegistrySetup>
+		);
+	},
+];
+
+export function setupSearchConsoleGatheringData( registry ) {
+	registry.dispatch( CORE_USER ).setReferenceDate( '2021-01-28' );
+	registry.dispatch( MODULES_SEARCH_CONSOLE ).receiveGetReport( [], {
+		options: adminbarSearchConsoleOptions,
+	} );
+}
+
+export const setupAnalyticsGatheringData = (
+	registry,
+	data = adminbarAnalyticsMockData
+) => {
+	registry.dispatch( CORE_USER ).setReferenceDate( '2021-01-28' );
+	data.forEach( ( options ) => {
+		registry.dispatch( MODULES_ANALYTICS ).receiveGetReport(
+			[
+				{
+					data: {
+						rows: [],
+						totals: [ { values: [] }, { values: [] } ],
+					},
+				},
+			],
+			{
+				options,
+			}
+		);
+	} );
+};

--- a/assets/sass/adminbar.scss
+++ b/assets/sass/adminbar.scss
@@ -48,6 +48,7 @@
 @import "components/global/googlesitekit-cta";
 @import "components/global/googlesitekit-cta-link";
 @import "components/global/googlesitekit-data-block";
+@import "components/global/googlesitekit-gathering-data-notice";
 @import "components/global/googlesitekit-notifications-counter";
 @import "components/global/googlesitekit-preview-block";
 @import "components/global/googlesitekit-noscript";

--- a/assets/sass/components/global/_googlesitekit-gathering-data-notice.scss
+++ b/assets/sass/components/global/_googlesitekit-gathering-data-notice.scss
@@ -70,3 +70,20 @@
 		}
 	}
 }
+
+#wpadminbar {
+
+	.googlesitekit-plugin {
+
+		.googlesitekit-gathering-data-notice {
+
+			p {
+
+				color: $c-jumbo;
+				font-size: 11px;
+				line-height: 13px;
+				text-transform: lowercase;
+			}
+		}
+	}
+}

--- a/assets/sass/components/wp-dashboard/_googlesitekit-wp-dashboard-stats.scss
+++ b/assets/sass/components/wp-dashboard/_googlesitekit-wp-dashboard-stats.scss
@@ -28,7 +28,7 @@
 	}
 
 	> .googlesitekit-wp-dashboard-stats__data-table {
-		align-self: flex-end;
+		align-self: stretch;
 		width: 48%;
 
 		@media (min-width: $bp-tablet) {
@@ -101,5 +101,9 @@
 	// Regular CTA shows up when data is zero
 	.googlesitekit-cta + .googlesitekit-wp-dashboard-stats__cta {
 		width: 100%;
+	}
+
+	> .googlesitekit-data-block--is-gathering-data {
+		margin-bottom: $grid-gap-phone;
 	}
 }

--- a/assets/sass/wpdashboard.scss
+++ b/assets/sass/wpdashboard.scss
@@ -37,6 +37,7 @@
 @import "components/global/googlesitekit-cta-link";
 @import "components/global/googlesitekit-data-block";
 @import "components/global/googlesitekit-error-text";
+@import "components/global/googlesitekit-gathering-data-notice";
 @import "components/global/googlesitekit-logo";
 @import "components/global/googlesitekit-notifications-counter";
 @import "components/global/googlesitekit-preview-block";


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #4711 

## Relevant technical choices

As [discussed](https://github.com/google/site-kit-wp/issues/4711#issuecomment-1056633326), the conditions for showing `WidgetReportZero` have been tweaked in order that the `GatheringDataNotice` can actually be shown via `DataBlock` rather than the display of `WidgetReportZero` taking precedence.


Also, added components for the `WPDashboard*` components which contain `DataBlock`s in order to provide Gathering Data variants.

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
