### PR TITLE
Enhance/4478 - Fix check-access endpoint body params (follow-up)

### DIFF
--- a/includes/Core/Modules/Modules.php
+++ b/includes/Core/Modules/Modules.php
@@ -818,7 +818,8 @@ final class Modules {
 					array(
 						'methods'             => WP_REST_Server::EDITABLE,
 						'callback'            => function( WP_REST_Request $request ) {
-							$slug = $request['slug'];
+							$data = $request['data'];
+							$slug = isset( $data['slug'] ) ? $data['slug'] : '';
 
 							try {
 								$module = $this->get_module( $slug );

--- a/tests/phpunit/integration/Core/Modules/ModulesTest.php
+++ b/tests/phpunit/integration/Core/Modules/ModulesTest.php
@@ -703,7 +703,13 @@ class ModulesTest extends TestCase {
 		$modules->register();
 
 		$request = new WP_REST_Request( 'POST', '/' . REST_Routes::REST_ROOT . '/core/modules/data/check-access' );
-		$request->set_param( 'slug', 'analytics' );
+		$request->set_body_params(
+			array(
+				'data' => array(
+					'slug' => 'analytics',
+				),
+			)
+		);
 		$response = rest_get_server()->dispatch( $request );
 
 		$this->assertEquals( 'module_not_connected', $response->get_data()['code'] );
@@ -736,7 +742,13 @@ class ModulesTest extends TestCase {
 		);
 
 		$request = new WP_REST_Request( 'POST', '/' . REST_Routes::REST_ROOT . '/core/modules/data/check-access' );
-		$request->set_param( 'slug', 'analytics' );
+		$request->set_body_params(
+			array(
+				'data' => array(
+					'slug' => 'analytics',
+				),
+			)
+		);
 		$response = rest_get_server()->dispatch( $request );
 
 		$this->assertArrayIntersection(


### PR DESCRIPTION
## Summary

Addresses issue:

- #4478 

## Relevant technical choices

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
