### PR TITLE
Add datastore partial to get AdSense site information.

### DIFF
--- a/assets/js/modules/adsense/datastore/__fixtures__/index.js
+++ b/assets/js/modules/adsense/datastore/__fixtures__/index.js
@@ -16,13 +16,14 @@
  * limitations under the License.
  */
 
-export { default as accounts } from './accounts';
-export { default as accountsMultiple } from './accounts-multiple';
-export { default as clients } from './clients';
-export { default as clientsNoAFC } from './clients-no-afc';
-export { default as urlchannels } from './urlchannels';
-export { default as adunits } from './adunits';
-export { default as alerts } from './alerts';
-export { default as alertsGraylisted } from './alerts-graylisted';
-export { default as tagPermissionAccess } from './tag-permission-access';
-export { default as tagPermissionNoAccess } from './tag-permission-no-access';
+export { default as accounts } from './accounts.json';
+export { default as accountsMultiple } from './accounts-multiple.json';
+export { default as clients } from './clients.json';
+export { default as clientsNoAFC } from './clients-no-afc.json';
+export { default as urlchannels } from './urlchannels.json';
+export { default as adunits } from './adunits.json';
+export { default as alerts } from './alerts.json';
+export { default as alertsGraylisted } from './alerts-graylisted.json';
+export { default as tagPermissionAccess } from './tag-permission-access.json';
+export { default as tagPermissionNoAccess } from './tag-permission-no-access.json';
+export { default as sites } from './sites.json';

--- a/assets/js/modules/adsense/datastore/__fixtures__/sites.json
+++ b/assets/js/modules/adsense/datastore/__fixtures__/sites.json
@@ -1,0 +1,23 @@
+[
+  {
+    "autoAdsEnabled": null,
+    "domain": "example.com",
+    "name": "accounts/pub-2833782679114991/sites/example.com",
+    "reportingDimensionId": "ca-pub-2833782679114991:example.com",
+    "state": "NEEDS_ATTENTION"
+  },
+  {
+    "autoAdsEnabled": true,
+    "domain": "www.test-site.com",
+    "name": "accounts/pub-2833782679114991/sites/www.test-site.com",
+    "reportingDimensionId": "ca-pub-2833782679114991:www.test-site.com",
+    "state": "REQUIRES_REVIEW"
+  },
+  {
+    "autoAdsEnabled": true,
+    "domain": "some-other-tld.ie",
+    "name": "accounts/pub-2833782679114991/sites/some-other-tld.ie",
+    "reportingDimensionId": "ca-pub-2833782679114991:some-other-tld.ie",
+    "state": "READY"
+  }
+]

--- a/assets/js/modules/adsense/datastore/index.js
+++ b/assets/js/modules/adsense/datastore/index.js
@@ -31,6 +31,7 @@ import urlchannels from './urlchannels';
 import settings from './settings';
 import adblocker from './adblocker';
 import service from './service';
+import sites from './sites';
 import { MODULES_ADSENSE } from './constants';
 
 const store = Data.combineStores(
@@ -44,7 +45,8 @@ const store = Data.combineStores(
 	urlchannels,
 	settings,
 	adblocker,
-	service
+	service,
+	sites
 );
 
 export const initialState = store.initialState;

--- a/assets/js/modules/adsense/datastore/sites.js
+++ b/assets/js/modules/adsense/datastore/sites.js
@@ -1,0 +1,215 @@
+/**
+ * `modules/adsense` data store: sites.
+ *
+ * Site Kit by Google, Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import invariant from 'invariant';
+
+/**
+ * Internal dependencies
+ */
+import API from 'googlesitekit-api';
+import Data from 'googlesitekit-data';
+import { MODULES_ADSENSE } from './constants';
+import { isValidAccountID } from '../util';
+import { createFetchStore } from '../../../googlesitekit/data/create-fetch-store';
+import { actions as errorStoreActions } from '../../../googlesitekit/data/create-error-store';
+import { determineSiteFromDomain } from '../util/site';
+import { CORE_SITE } from '../../../googlesitekit/datastore/site/constants';
+
+const { createRegistrySelector } = Data;
+
+// Actions
+const RESET_SITES = 'RESET_SITES';
+
+const fetchGetSitesStore = createFetchStore( {
+	baseName: 'getSites',
+	controlCallback: ( { accountID } ) => {
+		return API.get(
+			'modules',
+			'adsense',
+			'sites',
+			{ accountID },
+			{
+				useCache: false,
+			}
+		);
+	},
+	reducerCallback: ( state, sites, { accountID } ) => {
+		return {
+			...state,
+			sites: {
+				...state.sites,
+				[ accountID ]: [ ...sites ],
+			},
+		};
+	},
+	argsToParams: ( accountID ) => {
+		return { accountID };
+	},
+	validateParams: ( { accountID } = {} ) => {
+		invariant( accountID, 'accountID is required.' );
+	},
+} );
+
+const baseInitialState = {
+	sites: {},
+};
+
+const baseActions = {
+	*resetSites() {
+		const { dispatch } = yield Data.commonActions.getRegistry();
+
+		yield {
+			payload: {},
+			type: RESET_SITES,
+		};
+
+		yield errorStoreActions.clearErrors( 'getSites' );
+
+		return dispatch( MODULES_ADSENSE ).invalidateResolutionForStoreSelector(
+			'getSites'
+		);
+	},
+};
+
+const baseReducer = ( state, { type } ) => {
+	switch ( type ) {
+		case RESET_SITES: {
+			const {
+				siteID,
+				accountStatus,
+				siteStatus,
+				accountSetupComplete,
+				siteSetupComplete,
+			} = state.savedSettings || {};
+			return {
+				...state,
+				sites: initialState.sites,
+				settings: {
+					...( state.settings || {} ),
+					siteID,
+					accountStatus,
+					siteStatus,
+					accountSetupComplete,
+					siteSetupComplete,
+				},
+			};
+		}
+
+		default: {
+			return state;
+		}
+	}
+};
+
+const baseResolvers = {
+	*getSites( accountID ) {
+		if ( undefined === accountID || ! isValidAccountID( accountID ) ) {
+			return;
+		}
+
+		const registry = yield Data.commonActions.getRegistry();
+		const existingSites = registry
+			.select( MODULES_ADSENSE )
+			.getSites( accountID );
+
+		// If there are already sites loaded in state, consider it fulfilled
+		// and don't make an API request.
+		if ( existingSites ) {
+			return;
+		}
+
+		yield fetchGetSitesStore.actions.fetchGetSites( accountID );
+	},
+};
+
+const baseSelectors = {
+	/**
+	 * Gets all Google AdSense sites this account can access.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param {Object} state     Data store's state.
+	 * @param {string} accountID The AdSense Account ID to fetch sites for.
+	 * @return {(Array.<Object>|undefined)} An array of AdSense Sites; `undefined` if not loaded.
+	 */
+	getSites( state, accountID ) {
+		if ( undefined === accountID ) {
+			return undefined;
+		}
+
+		const { sites } = state;
+
+		return sites[ accountID ];
+	},
+	/**
+	 * Gets a Google AdSense site for a given domain, if it exists for the given account.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param {Object} state     Data store's state.
+	 * @param {string} accountID The AdSense Account ID to find a site for.
+	 * @param {string} domain    The domain string to match to a site.
+	 * @return {(Array.<Object>|null|undefined)} An array of AdSense sites; null if no match
+	 * found or `undefined` if not loaded.
+	 */
+	getSite: createRegistrySelector(
+		( select ) => ( state, accountID, domain ) => {
+			const sites = select( MODULES_ADSENSE ).getSites( accountID );
+			return determineSiteFromDomain( sites, domain );
+		}
+	),
+	/**
+	 * Gets the Google AdSense site object for the current site, if it exists for
+	 * the given AdSense account.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param {Object} state     Data store's state.
+	 * @param {string} accountID The AdSense Account ID to find a site for.
+	 * @return {(Array.string|null|undefined)} An array of AdSense sites; null if no match
+	 * found or `undefined` if not loaded.
+	 */
+	getCurrentSite: createRegistrySelector(
+		( select ) => ( state, accountID ) => {
+			const currentSiteURL = select( CORE_SITE ).getReferenceSiteURL();
+			const url = new URL( currentSiteURL );
+
+			return select( MODULES_ADSENSE ).getSite( accountID, url.origin );
+		}
+	),
+};
+
+const store = Data.combineStores( fetchGetSitesStore, {
+	initialState: baseInitialState,
+	actions: baseActions,
+	reducer: baseReducer,
+	resolvers: baseResolvers,
+	selectors: baseSelectors,
+} );
+
+export const initialState = store.initialState;
+export const actions = store.actions;
+export const controls = store.controls;
+export const reducer = store.reducer;
+export const resolvers = store.resolvers;
+export const selectors = store.selectors;
+
+export default store;

--- a/assets/js/modules/adsense/datastore/sites.test.js
+++ b/assets/js/modules/adsense/datastore/sites.test.js
@@ -1,0 +1,218 @@
+/**
+ * `modules/adsense` data store: sites tests.
+ *
+ * Site Kit by Google, Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import API from 'googlesitekit-api';
+import { MODULES_ADSENSE } from './constants';
+import { CORE_SITE } from '../../../googlesitekit/datastore/site/constants';
+import {
+	createTestRegistry,
+	subscribeUntil,
+	unsubscribeFromAll,
+} from '../../../../../tests/js/utils';
+import * as fixtures from './__fixtures__';
+
+describe( 'modules/adsense sites', () => {
+	let registry;
+
+	beforeAll( () => {
+		API.setUsingCache( false );
+	} );
+
+	beforeEach( () => {
+		registry = createTestRegistry();
+	} );
+
+	afterAll( () => {
+		API.setUsingCache( true );
+	} );
+
+	afterEach( () => {
+		unsubscribeFromAll( registry );
+	} );
+
+	describe( 'actions', () => {} );
+
+	describe( 'selectors', () => {
+		describe( 'getSites', () => {
+			it( 'uses a resolver to make a network request', async () => {
+				fetchMock.getOnce(
+					/^\/google-site-kit\/v1\/modules\/adsense\/data\/sites/,
+					{ body: fixtures.sites, status: 200 }
+				);
+
+				const accountID = fixtures.clients[ 0 ]._accountID;
+
+				const initialSites = registry
+					.select( MODULES_ADSENSE )
+					.getSites( accountID );
+
+				expect( initialSites ).toEqual( undefined );
+				await subscribeUntil(
+					registry,
+					() =>
+						registry
+							.select( MODULES_ADSENSE )
+							.getSites( accountID ) !== undefined
+				);
+
+				const sites = registry
+					.select( MODULES_ADSENSE )
+					.getSites( accountID );
+
+				expect( fetchMock ).toHaveFetchedTimes( 1 );
+				expect( sites ).toEqual( fixtures.sites );
+			} );
+
+			it( 'does not make a network request if sites for this account are already present', async () => {
+				const accountID = fixtures.clients[ 0 ]._accountID;
+
+				// Load data into this store so there are matches for the data we're about to select,
+				// even though the selector hasn't fulfilled yet.
+				registry
+					.dispatch( MODULES_ADSENSE )
+					.receiveGetSites( fixtures.sites, { accountID } );
+
+				const sites = registry
+					.select( MODULES_ADSENSE )
+					.getSites( accountID );
+
+				await subscribeUntil( registry, () =>
+					registry
+						.select( MODULES_ADSENSE )
+						.hasFinishedResolution( 'getSites', [ accountID ] )
+				);
+
+				expect( fetchMock ).not.toHaveFetched();
+				expect( sites ).toEqual( fixtures.sites );
+			} );
+
+			it( 'dispatches an error if the request fails', async () => {
+				const response = {
+					code: 'internal_server_error',
+					message: 'Internal server error',
+					data: { status: 500 },
+				};
+				fetchMock.getOnce(
+					/^\/google-site-kit\/v1\/modules\/adsense\/data\/sites/,
+					{ body: response, status: 500 }
+				);
+
+				const fakeAccountID = 'pub-777888999';
+				registry.select( MODULES_ADSENSE ).getSites( fakeAccountID );
+				await subscribeUntil(
+					registry,
+					() =>
+						registry
+							.select( MODULES_ADSENSE )
+							.isFetchingGetSites( fakeAccountID ) === false
+				);
+
+				expect( fetchMock ).toHaveFetchedTimes( 1 );
+
+				const sites = registry
+					.select( MODULES_ADSENSE )
+					.getSites( fakeAccountID );
+				expect( sites ).toEqual( undefined );
+				expect( console ).toHaveErrored();
+			} );
+		} );
+		describe( 'getSite', () => {
+			beforeEach( () => {
+				const accountID = fixtures.clients[ 0 ]._accountID;
+
+				// Load data into this store so there are matches for the data we're about to select,
+				// even though the selector hasn't fulfilled yet.
+				registry
+					.dispatch( MODULES_ADSENSE )
+					.receiveGetSites( fixtures.sites, { accountID } );
+			} );
+			it.each( [
+				[ 'www.example.com', fixtures.sites[ 0 ] ],
+				[ 'othersubdomain.example.com', fixtures.sites[ 0 ] ],
+				[ 'www.test-site.com', fixtures.sites[ 1 ] ],
+				[ 'some-other-tld.ie', fixtures.sites[ 2 ] ],
+			] )(
+				'finds the site in this account that matches the domain: %s',
+				async ( domain, expected ) => {
+					const accountID = fixtures.clients[ 0 ]._accountID;
+					const site = registry
+						.select( MODULES_ADSENSE )
+						.getSite( accountID, domain );
+					expect( site ).toEqual( expected );
+				}
+			);
+			it.each( [
+				[ 'non-existent-site.com' ],
+				[ 'some-other-tld.com' ],
+			] )(
+				'returns null when no site matches the given domain: %s',
+				async ( domain ) => {
+					const accountID = fixtures.clients[ 0 ]._accountID;
+					const site = registry
+						.select( MODULES_ADSENSE )
+						.getSite( accountID, domain );
+					expect( site ).toEqual( null );
+				}
+			);
+			it( 'returns null when no site matches the given domain', async () => {
+				const accountID = fixtures.clients[ 0 ]._accountID;
+
+				const site = registry
+					.select( MODULES_ADSENSE )
+					.getSite( accountID, 'www.non-existent-url.com' );
+				expect( site ).toEqual( null );
+			} );
+		} );
+		describe( 'getCurrentSite', () => {
+			beforeEach( () => {
+				const accountID = fixtures.clients[ 0 ]._accountID;
+
+				// Load data into this store so there are matches for the data we're about to select,
+				// even though the selector hasn't fulfilled yet.
+				registry
+					.dispatch( MODULES_ADSENSE )
+					.receiveGetSites( fixtures.sites, { accountID } );
+			} );
+			it( 'gets the AdSense site which matches the domain of the current site', async () => {
+				const accountID = fixtures.clients[ 0 ]._accountID;
+
+				await registry.dispatch( CORE_SITE ).receiveSiteInfo( {
+					referenceSiteURL: 'http://example.com',
+				} );
+				const site = registry
+					.select( MODULES_ADSENSE )
+					.getCurrentSite( accountID );
+				expect( site ).toEqual( fixtures.sites[ 0 ] );
+			} );
+			it( 'returns null when the current site domain does not matches any site', async () => {
+				const accountID = fixtures.clients[ 0 ]._accountID;
+
+				await registry.dispatch( CORE_SITE ).receiveSiteInfo( {
+					referenceSiteURL: 'http://non-existent-site.com',
+				} );
+				const site = registry
+					.select( MODULES_ADSENSE )
+					.getCurrentSite( accountID );
+				expect( site ).toEqual( null );
+			} );
+		} );
+	} );
+} );

--- a/assets/js/modules/adsense/util/site.js
+++ b/assets/js/modules/adsense/util/site.js
@@ -1,0 +1,46 @@
+/**
+ * Site utlities.
+ *
+ * Site Kit by Google, Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Determines the AdSense site status for given input data.
+ *
+ * This utility function should be used in combination with data retrieved from
+ * the datastore, hence passing undefined (loading state) is supported.
+ *
+ * @since n.e.x.t
+ *
+ * @param {(Array|undefined)}  sites  Array of AdSense site objects retrieved from the API.
+ * @param {(string|undefined)} domain The domain string to match to a site.
+ * @return {(Object|undefined)} AdSense site object that matches the domain, or undefined if
+ * any of the parameters are undefined.
+ */
+export const determineSiteFromDomain = ( sites, domain ) => {
+	if ( undefined === sites || undefined === domain ) {
+		return undefined;
+	}
+
+	const lowerCaseDomain = domain.toLowerCase();
+	const siteIndex = sites.findIndex( ( site ) => {
+		return 0 <= lowerCaseDomain.indexOf( site.domain.toLowerCase() );
+	} );
+	if ( siteIndex === -1 ) {
+		return null;
+	}
+
+	return sites[ siteIndex ];
+};

--- a/assets/js/modules/adsense/util/site.test.js
+++ b/assets/js/modules/adsense/util/site.test.js
@@ -1,0 +1,48 @@
+/**
+ * Site utility tests.
+ *
+ * Site Kit by Google, Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import { determineSiteFromDomain } from './site';
+import * as fixtures from '../datastore/__fixtures__';
+
+describe( 'determineSiteFromDomain', () => {
+	it.each( [
+		[ undefined, undefined ],
+		[ undefined, 'www.example.com' ],
+		[ fixtures.sites, undefined ],
+	] )( 'returns undefined for undefined parameters', ( sites, domain ) => {
+		expect( determineSiteFromDomain( sites, domain ) ).toEqual( undefined );
+	} );
+
+	it.each( [
+		[ 'www.example.com', fixtures.sites[ 0 ] ],
+		[ 'www.eXAmPle.COm', fixtures.sites[ 0 ] ],
+		[ 'othersubdomain.example.com', fixtures.sites[ 0 ] ],
+		[ 'www.test-site.com', fixtures.sites[ 1 ] ],
+		[ 'some-other-tld.ie', fixtures.sites[ 2 ] ],
+	] )(
+		'returns the correct site for a given domain',
+		( domain, expected ) => {
+			expect( determineSiteFromDomain( fixtures.sites, domain ) ).toEqual(
+				expected
+			);
+		}
+	);
+} );


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #4756 

## Relevant technical choices

<!-- Please describe your changes. -->

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
