### PR TITLE
Update `useExistingTagEffect` hook to account for accessing the settings form directly.

### DIFF
--- a/assets/js/modules/tagmanager/hooks/useExistingTagEffect.js
+++ b/assets/js/modules/tagmanager/hooks/useExistingTagEffect.js
@@ -42,10 +42,7 @@ export default function useExistingTagEffect() {
 
 	useEffect( () => {
 		if ( existingTag && containerID !== undefined ) {
-			if (
-				containerID === '' ||
-				( skipEffect.current && containerID !== '' )
-			) {
+			if ( containerID === '' || skipEffect.current ) {
 				skipEffect.current = false;
 				return;
 			}

--- a/assets/js/modules/tagmanager/hooks/useExistingTagEffect.js
+++ b/assets/js/modules/tagmanager/hooks/useExistingTagEffect.js
@@ -36,16 +36,19 @@ export default function useExistingTagEffect() {
 		select( MODULES_TAGMANAGER ).getContainerID()
 	);
 
-	const skipEffect = useRef( !! containerID );
+	const skipEffect = useRef( true );
 
 	const { setUseSnippet } = useDispatch( MODULES_TAGMANAGER );
 
 	useEffect( () => {
-		if ( skipEffect.current ) {
-			skipEffect.current = false;
-			return;
-		}
-		if ( existingTag && containerID ) {
+		if ( existingTag && containerID !== undefined ) {
+			if (
+				containerID === '' ||
+				( skipEffect.current && containerID !== '' )
+			) {
+				skipEffect.current = false;
+				return;
+			}
 			if ( existingTag === containerID ) {
 				setUseSnippet( false );
 			} else {

--- a/assets/js/modules/tagmanager/hooks/useExistingTagEffect.test.js
+++ b/assets/js/modules/tagmanager/hooks/useExistingTagEffect.test.js
@@ -67,6 +67,28 @@ describe( 'useExistingTagEffect', () => {
 			registry.select( MODULES_TAGMANAGER ).getUseSnippet()
 		).toBeUndefined();
 
+		expect(
+			registry.select( MODULES_TAGMANAGER ).getContainerID()
+		).toBeUndefined();
+
+		act( () => {
+			registry
+				.dispatch( MODULES_TAGMANAGER )
+				// eslint-disable-next-line sitekit/acronym-case
+				.setContainerID( '' );
+			registry
+				.dispatch( MODULES_TAGMANAGER )
+				.setInternalContainerID( '' );
+			rerender();
+		} );
+
+		expect( registry.select( MODULES_TAGMANAGER ).getUseSnippet() ).toBe(
+			undefined
+		);
+		expect( registry.select( MODULES_TAGMANAGER ).getContainerID() ).toBe(
+			''
+		);
+
 		act( () => {
 			registry
 				.dispatch( MODULES_TAGMANAGER )
@@ -212,17 +234,27 @@ describe( 'useExistingTagEffect', () => {
 		// Manually disable useSnippet.
 		registry.dispatch( MODULES_TAGMANAGER ).setUseSnippet( false );
 
-		registry
-			.dispatch( MODULES_TAGMANAGER )
-			// eslint-disable-next-line sitekit/acronym-case
-			.setContainerID( anotherContainer.publicId );
-		registry.dispatch( MODULES_TAGMANAGER ).setInternalContainerID(
-			// eslint-disable-next-line sitekit/acronym-case
-			anotherContainer.containerId
-		);
-
 		const { rerender } = renderHook( () => useExistingTagEffect(), {
 			registry,
+		} );
+
+		expect( registry.select( MODULES_TAGMANAGER ).getUseSnippet() ).toBe(
+			false
+		);
+		expect(
+			registry.select( MODULES_TAGMANAGER ).getContainerID()
+		).toBeUndefined();
+
+		act( () => {
+			registry
+				.dispatch( MODULES_TAGMANAGER )
+				// eslint-disable-next-line sitekit/acronym-case
+				.setContainerID( anotherContainer.publicId );
+			registry.dispatch( MODULES_TAGMANAGER ).setInternalContainerID(
+				// eslint-disable-next-line sitekit/acronym-case
+				anotherContainer.containerId
+			);
+			rerender();
 		} );
 
 		expect( registry.select( MODULES_TAGMANAGER ).getUseSnippet() ).toBe(


### PR DESCRIPTION

## Summary

Context: https://github.com/google/site-kit-wp/pull/4953#issuecomment-1075735818

cc @techanvil @aaemnnosttv @felixarntz 

- #4713 

## Relevant technical choices

<!-- Please describe your changes. -->

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [x] Run the code.
- [x] Ensure the acceptance criteria are satisfied.
- [x] Reassess the implementation with the IB.
- [x] Ensure no unrelated changes are included.
- [x] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [x] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [x] Ensure the PR has the correct target branch.
- [x] Double-check that the PR is okay to be merged.
- [x] Ensure the corresponding issue has a ZenHub release assigned.
- [x] Add a changelog message to the issue.
