### PR TITLE
Update WP dashboard popular pages widget to skip rendering table if no rows

### DIFF
--- a/assets/js/components/wp-dashboard/WPDashboardPopularPages.js
+++ b/assets/js/components/wp-dashboard/WPDashboardPopularPages.js
@@ -37,7 +37,6 @@ import {
 import { CORE_USER } from '../../googlesitekit/datastore/user/constants';
 import PreviewTable from '../../components/PreviewTable';
 import TableOverflowContainer from '../../components/TableOverflowContainer';
-import { isZeroReport } from '../../modules/analytics/util/is-zero-report';
 import ReportTable from '../ReportTable';
 import DetailsPermaLinks from '../DetailsPermaLinks';
 import { numFmt } from '../../util';
@@ -110,8 +109,13 @@ export default function WPDashboardPopularPages( props ) {
 		return <WidgetReportError moduleSlug="analytics" error={ error } />;
 	}
 
-	if ( isZeroReport( report ) && ! zeroDataStatesEnabled ) {
+	if ( isGatheringData && ! zeroDataStatesEnabled ) {
 		return <WidgetReportZero moduleSlug="analytics" />;
+	}
+
+	// Skip rendering the table if there are no rows.
+	if ( ! report[ 0 ].data?.rows?.length ) {
+		return null;
 	}
 
 	const rows = cloneDeep( report[ 0 ].data.rows );


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #4908

## Relevant technical choices

_See inline comments below_

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
