### PR TITLE
Fix unstable unit test on Entity_Search_ControllerTest.

### DIFF
--- a/tests/phpunit/integration/Core/Util/REST_Entity_Search_ControllerTest.php
+++ b/tests/phpunit/integration/Core/Util/REST_Entity_Search_ControllerTest.php
@@ -138,8 +138,11 @@ class REST_Entity_Search_ControllerTest extends TestCase {
 		$this->assertEquals( 'post', $data[0]['type'] );
 		$this->assertArrayHasKey( 'title', $data[0] );
 		$this->assertArrayHasKey( 'url', $data[0] );
-		$this->assertEquals( $earthID, $data[0]['id'] );
-		$this->assertEquals( $marsID, $data[1]['id'] );
+
+		$postIDs = wp_list_pluck( $data, 'id' );
+
+		$this->assertContains( $earthID, $postIDs );
+		$this->assertContains( $marsID, $postIDs );
 	}
 
 	public function test_entity_search() {


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #4855 

## Relevant technical choices

<!-- Please describe your changes. -->

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
