### PR TITLE
Disable DimensionTabs when in gatheringData or zeroData state.

### DIFF
--- a/assets/js/modules/analytics/components/dashboard/DashboardAllTrafficWidget/DimensionTabs.js
+++ b/assets/js/modules/analytics/components/dashboard/DashboardAllTrafficWidget/DimensionTabs.js
@@ -138,7 +138,9 @@ export default function DimensionTabs( {
 					onEnhancedChange={ handleTabUpdate }
 					outlined
 					value={ `dimension-name-${ activeTab }` }
-					disabled={ gatheringData }
+					disabled={
+						gatheringData || ( zeroDataStatesEnabled && isZeroData )
+					}
 				>
 					{ tabs.map( ( tab, index ) => (
 						<Option

--- a/assets/js/modules/analytics/components/dashboard/DashboardAllTrafficWidget/DimensionTabs.js
+++ b/assets/js/modules/analytics/components/dashboard/DashboardAllTrafficWidget/DimensionTabs.js
@@ -44,6 +44,7 @@ import {
 import PreviewBlock from '../../../../../components/PreviewBlock';
 import { Select, Option } from '../../../../../material-components';
 import { trackEvent } from '../../../../../util';
+import { useFeature } from '../../../../../hooks/useFeature';
 const { useDispatch } = Data;
 
 const tabs = [
@@ -65,9 +66,12 @@ export default function DimensionTabs( {
 	dimensionName,
 	gatheringData,
 	loaded,
+	isZeroData,
 } ) {
 	const viewContext = useContext( ViewContextContext );
 	const { setValues } = useDispatch( CORE_UI );
+
+	const zeroDataStatesEnabled = useFeature( 'zeroDataStates' );
 
 	const activeTab = tabs.findIndex(
 		( v ) => v.dimensionName === dimensionName
@@ -115,7 +119,10 @@ export default function DimensionTabs( {
 							key={ tab.dimensionName }
 							className="mdc-tab--min-width"
 							focusOnActivate={ false }
-							disabled={ gatheringData }
+							disabled={
+								gatheringData ||
+								( zeroDataStatesEnabled && isZeroData )
+							}
 						>
 							<span className="mdc-tab__text-label">
 								{ tab.tabText }
@@ -150,5 +157,6 @@ export default function DimensionTabs( {
 DimensionTabs.propTypes = {
 	dimensionName: PropTypes.string.isRequired,
 	gatheringData: PropTypes.bool,
+	isZeroData: PropTypes.bool,
 	loaded: PropTypes.bool,
 };

--- a/assets/js/modules/analytics/components/dashboard/DashboardAllTrafficWidget/index.js
+++ b/assets/js/modules/analytics/components/dashboard/DashboardAllTrafficWidget/index.js
@@ -313,6 +313,7 @@ function DashboardAllTrafficWidget( props ) {
 							loaded={ ! firstLoad }
 							dimensionName={ dimensionName }
 							gatheringData={ isGatheringData }
+							isZeroData={ pieChartReportIsZero }
 						/>
 
 						{ ! showEmptyPieChart && (

--- a/assets/sass/widgets/_googlesitekit-widget-analyticsAllTraffic.scss
+++ b/assets/sass/widgets/_googlesitekit-widget-analyticsAllTraffic.scss
@@ -30,20 +30,38 @@
 			height: 4px;
 		}
 
+		.mdc-tab__text-label {
+			letter-spacing: normal;
+			text-transform: none;
+		}
+
 		.mdc-tab {
 			height: 40px;
 			margin: 0 10px;
 			padding: 0 20px;
 
-			@media (min-width: $bp-tablet) and (max-width: $bp-xlarge) {
+			@media ( min-width: $bp-tablet ) and ( max-width: $bp-xlarge ) {
 				margin: 0;
 				padding: 0 10px;
 			}
+
+			&[disabled] {
+				cursor: default;
+			}
+
+			&[disabled] .mdc-tab__ripple {
+				display: none;
+			}
+
+			&[disabled] .mdc-tab__text-label {
+				color: $c-jumbo;
+				opacity: 0.6;
+			}
 		}
 
-		.mdc-tab__text-label {
-			letter-spacing: normal;
-			text-transform: none;
+		.mdc-tab--active[disabled] .mdc-tab-indicator__content--underline {
+			background-color: $c-jumbo;
+			opacity: 0.6;
 		}
 
 		.googlesitekit-widget__footer {
@@ -53,12 +71,12 @@
 
 	.googlesitekit-widget--analyticsAllTraffic__user-count-chart {
 
-		@media (min-width: $bp-desktop) {
+		@media ( min-width: $bp-desktop ) {
 			position: relative;
 			top: 16px;
 		}
 
-		@media (min-width: $bp-xlarge) {
+		@media ( min-width: $bp-xlarge ) {
 			top: 0;
 		}
 	}
@@ -106,7 +124,7 @@
 	.googlesitekit-widget--analyticsAllTraffic__totalcount--loading {
 		margin: 0 0 10px;
 
-		@media (min-width: $bp-xlarge) {
+		@media ( min-width: $bp-xlarge ) {
 			// Override `PreviewBlock` height definition, since it doesn't
 			// support flexible sizes per breakpoint.
 			// TODO: Remove and achieve via `PreviewBlock` extra props instead.
@@ -120,7 +138,8 @@
 		width: 100%;
 	}
 
-	.googlesitekit-widget--analyticsAllTraffic__dimensions-chart .googlesitekit-chart-loading {
+	.googlesitekit-widget--analyticsAllTraffic__dimensions-chart
+	.googlesitekit-chart-loading {
 		padding-bottom: 32px;
 		padding-top: 32px;
 	}
@@ -129,7 +148,7 @@
 		padding: $grid-gap-phone;
 		text-align: center;
 
-		@media (min-width: $bp-desktop) {
+		@media ( min-width: $bp-desktop ) {
 			padding: $grid-gap-desktop;
 		}
 
@@ -137,7 +156,7 @@
 			align-items: center;
 			min-height: 120px;
 
-			@media (min-width: $bp-desktop) {
+			@media ( min-width: $bp-desktop ) {
 				min-height: 270px;
 			}
 		}
@@ -216,7 +235,7 @@
 	.googlesitekit-widget--analyticsAllTraffic__tabs--small {
 		text-align: center;
 
-		@media (min-width: $bp-tablet) {
+		@media ( min-width: $bp-tablet ) {
 			display: none;
 		}
 	}
@@ -233,7 +252,7 @@
 
 	.googlesitekit-widget--analyticsAllTraffic__totals {
 		// HACK: Fixes jumping of widget when a dimension is selected.
-		@media (min-width: $bp-desktop) {
+		@media ( min-width: $bp-desktop ) {
 			margin-bottom: $grid-gap-desktop * -1;
 		}
 
@@ -242,7 +261,7 @@
 			height: auto;
 			margin-top: $grid-gap-phone;
 
-			@media (min-width: $bp-desktop) {
+			@media ( min-width: $bp-desktop ) {
 				margin-top: $grid-gap-desktop;
 			}
 		}

--- a/stories/module-analytics-components.stories.js
+++ b/stories/module-analytics-components.stories.js
@@ -189,11 +189,11 @@ generateAnalyticsWidgetStories( {
 			features: [ 'zeroDataStates' ],
 			storyName: 'Zero Data (zeroDataStates enabled)',
 		},
-		'Gathering Data': {
+		'Gathering Data (zeroDataStates enabled)': {
 			options: allTrafficReports.options,
 			data: allTrafficReports.data.map( () => null ),
 			features: [ 'zeroDataStates' ],
-			storyName: 'Gathering Data',
+			storyName: 'Gathering Data (zeroDataStates enabled)',
 		},
 	},
 	wrapWidget: false,

--- a/stories/module-analytics-components.stories.js
+++ b/stories/module-analytics-components.stories.js
@@ -189,6 +189,12 @@ generateAnalyticsWidgetStories( {
 			features: [ 'zeroDataStates' ],
 			storyName: 'Zero Data (zeroDataStates enabled)',
 		},
+		'Gathering Data': {
+			options: allTrafficReports.options,
+			data: allTrafficReports.data.map( () => null ),
+			features: [ 'zeroDataStates' ],
+			storyName: 'Gathering Data',
+		},
 	},
 	wrapWidget: false,
 } );


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #4961

## Relevant technical choices

I used the existing `pieChartReportIsZero` variable and passed it to the `DimensionTabs` variable here instead of adding another `hasZeroData` selector, which works in testing and I think makes sense over adding another selexctor to the actual `DimensionTabs` component as suggested in the IB.

This also fixes the story at https://google.github.io/site-kit-wp/storybook/develop/?path=/story/analytics-module-components-dashboard-all-traffic-widget--zero-data-zerodatastates-enabled. The story for this PR (https://google.github.io/site-kit-wp/storybook/pull/4999/?path=/story/analytics-module-components-dashboard-all-traffic-widget--zero-data-zerodatastates-enabled) now shows the tabs as disabled, which they should be.

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [x] Run the code.
- [x] Ensure the acceptance criteria are satisfied.
- [x] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [x] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [x] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [x] Ensure the PR has the correct target branch.
- [x] Double-check that the PR is okay to be merged.
- [x] Ensure the corresponding issue has a ZenHub release assigned.
- [x] Add a changelog message to the issue.
