### PR TITLE
Fix reference to credentials in Module

### DIFF
--- a/includes/Core/Modules/Module.php
+++ b/includes/Core/Modules/Module.php
@@ -739,7 +739,7 @@ abstract class Module {
 			$auth_client   = $this->authentication->get_oauth_client();
 			$message       = $auth_client->get_error_message( $code );
 			$google_proxy  = $this->authentication->get_google_proxy();
-			$credentials   = $this->credentials->get();
+			$credentials   = $this->authentication->credentials()->get();
 			$params        = array(
 				'code'    => $e->getAccessCode(),
 				'site_id' => ! empty( $credentials['oauth2_client_id'] ) ? $credentials['oauth2_client_id'] : '',


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #4998

## Relevant technical choices

After making this change, banner + report error show correctly again

![image](https://user-images.githubusercontent.com/1621608/161321780-3f9e5822-8aa3-4c39-855d-2a8280444435.png)

* Added test for this method which raises the same error without the fix

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
