### PR TITLE
Bug/5008 - Incorrect dashboard notification briefly shows before correct one is loaded

### DIFF
--- a/assets/js/components/notifications/ZeroDataStateNotifications.js
+++ b/assets/js/components/notifications/ZeroDataStateNotifications.js
@@ -55,6 +55,15 @@ export default function ZeroDataStateNotifications() {
 	);
 
 	if (
+		analyticsGatheringData === undefined ||
+		searchConsoleGatheringData === undefined ||
+		analyticsHasZeroData === undefined ||
+		searchConsoleHasZeroData === undefined
+	) {
+		return null;
+	}
+
+	if (
 		! analyticsGatheringData &&
 		! searchConsoleGatheringData &&
 		! analyticsHasZeroData &&
@@ -99,26 +108,28 @@ export default function ZeroDataStateNotifications() {
 				/>
 			) }
 
-			{ ( analyticsHasZeroData || searchConsoleHasZeroData ) && (
-				<BannerNotification
-					id="zero-data-notification"
-					title={ __(
-						'Not enough traffic yet to display stats',
-						'google-site-kit'
-					) }
-					description={ __(
-						'Site Kit will start showing stats on the dashboard as soon as enough people have visited your site. Keep working on your site to attract more visitors.',
-						'google-site-kit'
-					) }
-					format="small"
-					learnMoreLabel={ __( 'Learn more', 'google-site-kit' ) }
-					learnMoreURL="https://sitekit.withgoogle.com/documentation/using-site-kit/dashboard-data-display/"
-					dismiss={ __( 'Remind me later', 'google-site-kit' ) }
-					isDismissible
-					dismissExpires={ getTimeInSeconds( 'day' ) }
-					SmallImageSVG={ ZeroStateIcon }
-				/>
-			) }
+			{ ( analyticsGatheringData === false ||
+				searchConsoleGatheringData === false ) &&
+				( analyticsHasZeroData || searchConsoleHasZeroData ) && (
+					<BannerNotification
+						id="zero-data-notification"
+						title={ __(
+							'Not enough traffic yet to display stats',
+							'google-site-kit'
+						) }
+						description={ __(
+							'Site Kit will start showing stats on the dashboard as soon as enough people have visited your site. Keep working on your site to attract more visitors.',
+							'google-site-kit'
+						) }
+						format="small"
+						learnMoreLabel={ __( 'Learn more', 'google-site-kit' ) }
+						learnMoreURL="https://sitekit.withgoogle.com/documentation/using-site-kit/dashboard-data-display/"
+						dismiss={ __( 'Remind me later', 'google-site-kit' ) }
+						isDismissible
+						dismissExpires={ getTimeInSeconds( 'day' ) }
+						SmallImageSVG={ ZeroStateIcon }
+					/>
+				) }
 		</Fragment>
 	);
 }

--- a/assets/js/components/notifications/ZeroDataStateNotifications.js
+++ b/assets/js/components/notifications/ZeroDataStateNotifications.js
@@ -108,8 +108,8 @@ export default function ZeroDataStateNotifications() {
 				/>
 			) }
 
-			{ ( analyticsGatheringData === false ||
-				searchConsoleGatheringData === false ) &&
+			{ analyticsGatheringData === false &&
+				searchConsoleGatheringData === false &&
 				( analyticsHasZeroData || searchConsoleHasZeroData ) && (
 					<BannerNotification
 						id="zero-data-notification"

--- a/assets/js/components/notifications/ZeroDataStateNotifications.js
+++ b/assets/js/components/notifications/ZeroDataStateNotifications.js
@@ -55,7 +55,7 @@ export default function ZeroDataStateNotifications() {
 	);
 
 	// If any of the checks for gathering data or zero data states have
-	// no finished loading, we don't show any notifications. This
+	// not finished loading, we don't show any notifications. This
 	// prevents one notification from briefly showing while the other
 	// notification loads and then replaces the first one.
 	// See: https://github.com/google/site-kit-wp/issues/5008


### PR DESCRIPTION
## Summary

Addresses issue:

- #5008 

## Relevant technical choices

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
