### PR TITLE
Fix odd-looking lines below Search traffic and Overall page metrics widget numbers.

### DIFF
--- a/assets/sass/components/global/_googlesitekit-gathering-data-notice.scss
+++ b/assets/sass/components/global/_googlesitekit-gathering-data-notice.scss
@@ -23,7 +23,7 @@
 		display: block;
 		font-size: 16px;
 		line-height: 19px;
-		padding: 0 0 20px;
+		padding: 0;
 
 		@media (min-width: $bp-tablet) {
 			font-size: 28px;
@@ -55,14 +55,6 @@
 
 			position: relative;
 			text-align: inherit;
-
-			&::after {
-				background-color: $c-jumbo;
-				content: "";
-				display: inline-block;
-				height: 2px;
-				width: 96px;
-			}
 		}
 
 		&.googlesitekit-gathering-data-notice--has-style-overlay {


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #5010 

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [x] Run the code.
- [x] Ensure the acceptance criteria are satisfied.
- [x] Reassess the implementation with the IB.
- [x] Ensure no unrelated changes are included.
- [x] Ensure CI checks pass.
- [x] Check Storybook where applicable.
- [x] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
