### PR TITLE
Enhance/5008 - Render zero notification if either one of the modules are in zero state

### DIFF
--- a/assets/js/components/notifications/ZeroDataStateNotifications.js
+++ b/assets/js/components/notifications/ZeroDataStateNotifications.js
@@ -113,28 +113,26 @@ export default function ZeroDataStateNotifications() {
 				/>
 			) }
 
-			{ analyticsGatheringData === false &&
-				searchConsoleGatheringData === false &&
-				( analyticsHasZeroData || searchConsoleHasZeroData ) && (
-					<BannerNotification
-						id="zero-data-notification"
-						title={ __(
-							'Not enough traffic yet to display stats',
-							'google-site-kit'
-						) }
-						description={ __(
-							'Site Kit will start showing stats on the dashboard as soon as enough people have visited your site. Keep working on your site to attract more visitors.',
-							'google-site-kit'
-						) }
-						format="small"
-						learnMoreLabel={ __( 'Learn more', 'google-site-kit' ) }
-						learnMoreURL="https://sitekit.withgoogle.com/documentation/using-site-kit/dashboard-data-display/"
-						dismiss={ __( 'Remind me later', 'google-site-kit' ) }
-						isDismissible
-						dismissExpires={ getTimeInSeconds( 'day' ) }
-						SmallImageSVG={ ZeroStateIcon }
-					/>
-				) }
+			{ ( analyticsHasZeroData || searchConsoleHasZeroData ) && (
+				<BannerNotification
+					id="zero-data-notification"
+					title={ __(
+						'Not enough traffic yet to display stats',
+						'google-site-kit'
+					) }
+					description={ __(
+						'Site Kit will start showing stats on the dashboard as soon as enough people have visited your site. Keep working on your site to attract more visitors.',
+						'google-site-kit'
+					) }
+					format="small"
+					learnMoreLabel={ __( 'Learn more', 'google-site-kit' ) }
+					learnMoreURL="https://sitekit.withgoogle.com/documentation/using-site-kit/dashboard-data-display/"
+					dismiss={ __( 'Remind me later', 'google-site-kit' ) }
+					isDismissible
+					dismissExpires={ getTimeInSeconds( 'day' ) }
+					SmallImageSVG={ ZeroStateIcon }
+				/>
+			) }
 		</Fragment>
 	);
 }

--- a/assets/js/components/notifications/ZeroDataStateNotifications.js
+++ b/assets/js/components/notifications/ZeroDataStateNotifications.js
@@ -95,6 +95,10 @@ export default function ZeroDataStateNotifications() {
 		);
 	}
 
+	const showZeroDataNotification =
+		( analyticsGatheringData === false && analyticsHasZeroData ) ||
+		( searchConsoleGatheringData === false && searchConsoleHasZeroData );
+
 	return (
 		<Fragment>
 			{ ( analyticsGatheringData || searchConsoleGatheringData ) && (
@@ -113,7 +117,7 @@ export default function ZeroDataStateNotifications() {
 				/>
 			) }
 
-			{ ( analyticsHasZeroData || searchConsoleHasZeroData ) && (
+			{ showZeroDataNotification && (
 				<BannerNotification
 					id="zero-data-notification"
 					title={ __(


### PR DESCRIPTION
## Summary

Addresses issue:

- #5008 

## Relevant technical choices

In this PR I have removed the condition that prevents rendering the `zero` data notification if one of the modules is in the `gathering` data state and the other is in the `zero` data state.

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [x] Run the code.
- [x] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [x] Ensure no unrelated changes are included.
- [x] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [x] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [x] Ensure the PR has the correct target branch.
- [x] Double-check that the PR is okay to be merged.
- [x] Ensure the corresponding issue has a ZenHub release assigned.
- [x] Add a changelog message to the issue.
