### PR TITLE
Roll back react-google-charts version and provide alternative fix for gathering data notice sync.

### DIFF
--- a/assets/js/components/GoogleChart.js
+++ b/assets/js/components/GoogleChart.js
@@ -241,10 +241,10 @@ export default function GoogleChart( props ) {
 				data={ modifiedData }
 				loader={ loader }
 				height={ height }
-				onLoad={ () => {
-					setIsChartLoaded( true );
-				} }
 				getChartWrapper={ ( chartWrapper, google ) => {
+					if ( ! isChartLoaded ) {
+						setIsChartLoaded( true );
+					}
 					// Remove all the event listeners on the old chart before we draw
 					// a new one. Only run this if the old chart and the new chart aren't
 					// the same reference though, otherwise we'll remove existing `onReady`

--- a/assets/js/components/GoogleChart.js
+++ b/assets/js/components/GoogleChart.js
@@ -242,9 +242,15 @@ export default function GoogleChart( props ) {
 				loader={ loader }
 				height={ height }
 				getChartWrapper={ ( chartWrapper, google ) => {
+					// An issue with `react-google-charts` v4 causes the chart to
+					// render the overlay before the chart in some cases when using
+					// their own `onLoad` callback. This is a workaround to prevent
+					// that issue but still provide notice that the chart is loaded.
+					// See: https://github.com/google/site-kit-wp/issues/4945
 					if ( ! isChartLoaded ) {
 						setIsChartLoaded( true );
 					}
+
 					// Remove all the event listeners on the old chart before we draw
 					// a new one. Only run this if the old chart and the new chart aren't
 					// the same reference though, otherwise we'll remove existing `onReady`

--- a/package-lock.json
+++ b/package-lock.json
@@ -44224,9 +44224,12 @@
       }
     },
     "react-google-charts": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/react-google-charts/-/react-google-charts-4.0.0.tgz",
-      "integrity": "sha512-9OG0EkBb9JerKEPQYdhmAXnhGLzOdOHOPS9j7l+P1a3z1kcmq9mGDa7PUoX/VQUY4IjZl2/81nsO4o+1cuYsuw=="
+      "version": "3.0.15",
+      "resolved": "https://registry.npmjs.org/react-google-charts/-/react-google-charts-3.0.15.tgz",
+      "integrity": "sha512-78s5xOQOJvL+jIewrWQZEHtlVk+5Yh4zZy+ODA1on1o1FaRjKWXxoo4n4JQl1XuqkF/A9NWque3KqM6pMggjzQ==",
+      "requires": {
+        "react-load-script": "^0.0.6"
+      }
     },
     "react-helmet-async": {
       "version": "1.0.9",
@@ -44291,6 +44294,11 @@
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==",
       "dev": true
+    },
+    "react-load-script": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/react-load-script/-/react-load-script-0.0.6.tgz",
+      "integrity": "sha512-aRGxDGP9VoLxcsaYvKWIW+LRrMOzz2eEcubTS4NvQPPugjk2VvMhow0wWTkSl7RxookomD1MwcP4l5UStg5ShQ=="
     },
     "react-moment-proptypes": {
       "version": "1.7.0",

--- a/package.json
+++ b/package.json
@@ -147,7 +147,7 @@
 		"psl": "^1.8.0",
 		"punycode": "^2.1.1",
 		"query-string": "^7.0.1",
-		"react-google-charts": "^4.0.0",
+		"react-google-charts": "^3.0.15",
 		"react-joyride": "^2.3.0",
 		"react-router-dom": "^5.2.0",
 		"react-use": "^15.3.4",


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #4945 

## Relevant technical choices

Due to a [problem](https://github.com/google/site-kit-wp/issues/4945#issuecomment-1093147413) with upgrading `react-google-charts` to v4, roll back the version and provide an alternative fix for #4945, making use of the `getChartWrapper` callback instead of `onLoad` that v4 of `react-google-charts` provides.

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
