### PR TITLE
Enhance/4819 auth dependent components

### DIFF
--- a/assets/js/components/PermissionsModal/AuthenticatedPermissionsModal.js
+++ b/assets/js/components/PermissionsModal/AuthenticatedPermissionsModal.js
@@ -1,0 +1,112 @@
+/**
+ * AuthenticatedPermissionsModal component.
+ *
+ * Site Kit by Google, Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { useEffect, useCallback } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import Data from 'googlesitekit-data';
+import { CORE_USER } from '../../googlesitekit/datastore/user/constants';
+import { CORE_LOCATION } from '../../googlesitekit/datastore/location/constants';
+import { snapshotAllStores } from '../../googlesitekit/data/create-snapshot-store';
+import Dialog from '../Dialog';
+import Portal from '../Portal';
+const { useSelect, useDispatch, useRegistry } = Data;
+
+const AuthenticatedPermissionsModal = () => {
+	const registry = useRegistry();
+	const permissionsError = useSelect( ( select ) =>
+		select( CORE_USER ).getPermissionScopeError()
+	);
+	const connectURL = useSelect( ( select ) =>
+		select( CORE_USER ).getConnectURL( {
+			additionalScopes: permissionsError?.data?.scopes,
+			redirectURL: global.location.href,
+		} )
+	);
+
+	const { clearPermissionScopeError } = useDispatch( CORE_USER );
+	const { navigateTo } = useDispatch( CORE_LOCATION );
+
+	const onCancel = useCallback( () => {
+		clearPermissionScopeError();
+	}, [ clearPermissionScopeError ] );
+
+	const onConfirm = useCallback( async () => {
+		// If we have a datastores to snapshot before navigating away to the
+		// authorization page, do that first.
+		await snapshotAllStores( registry );
+		navigateTo( connectURL );
+	}, [ registry, connectURL, navigateTo ] );
+
+	useEffect( () => {
+		// If error has flag to skip the modal, redirect to the authorization
+		// page immediately without prompting the user, essentially short-
+		// circuiting to the confirm step.
+		const confirmIfSkipModal = async () => {
+			if (
+				permissionsError?.data?.skipModal &&
+				permissionsError?.data?.scopes?.length
+			) {
+				await onConfirm();
+			}
+		};
+		confirmIfSkipModal();
+	}, [ onConfirm, permissionsError ] );
+
+	if ( ! permissionsError ) {
+		return null;
+	}
+
+	// If there aren't any scopes for us to request, there's no reason to show
+	// the modal. Log a console warning if this happens and return `null`.
+	if ( ! permissionsError?.data?.scopes?.length ) {
+		global.console.warn(
+			'permissionsError lacks scopes array to use for redirect, so not showing the PermissionsModal. permissionsError was:',
+			permissionsError
+		);
+		return null;
+	}
+
+	if ( permissionsError?.data?.skipModal ) {
+		return null;
+	}
+
+	return (
+		<Portal>
+			<Dialog
+				title={ __(
+					'Additional Permissions Required',
+					'google-site-kit'
+				) }
+				subtitle={ permissionsError.message }
+				confirmButton={ __( 'Proceed', 'google-site-kit' ) }
+				dialogActive={ true }
+				handleConfirm={ onConfirm }
+				handleDialog={ onCancel }
+			/>
+		</Portal>
+	);
+};
+
+export default AuthenticatedPermissionsModal;

--- a/assets/js/components/PermissionsModal/index.js
+++ b/assets/js/components/PermissionsModal/index.js
@@ -17,97 +17,12 @@
  */
 
 /**
- * WordPress dependencies
- */
-import { __ } from '@wordpress/i18n';
-import { useEffect, useCallback } from '@wordpress/element';
-
-/**
  * Internal dependencies
  */
 import Data from 'googlesitekit-data';
+import AuthenticatedPermissionsModal from './AuthenticatedPermissionsModal';
 import { CORE_USER } from '../../googlesitekit/datastore/user/constants';
-import { CORE_LOCATION } from '../../googlesitekit/datastore/location/constants';
-import { snapshotAllStores } from '../../googlesitekit/data/create-snapshot-store';
-import Dialog from '../Dialog';
-import Portal from '../Portal';
-const { useSelect, useDispatch, useRegistry } = Data;
-
-const AuthenticatedPermissionsModal = () => {
-	const registry = useRegistry();
-	const permissionsError = useSelect( ( select ) =>
-		select( CORE_USER ).getPermissionScopeError()
-	);
-	const connectURL = useSelect( ( select ) =>
-		select( CORE_USER ).getConnectURL( {
-			additionalScopes: permissionsError?.data?.scopes,
-			redirectURL: global.location.href,
-		} )
-	);
-
-	const { clearPermissionScopeError } = useDispatch( CORE_USER );
-	const { navigateTo } = useDispatch( CORE_LOCATION );
-
-	const onCancel = useCallback( () => {
-		clearPermissionScopeError();
-	}, [ clearPermissionScopeError ] );
-
-	const onConfirm = useCallback( async () => {
-		// If we have a datastores to snapshot before navigating away to the
-		// authorization page, do that first.
-		await snapshotAllStores( registry );
-		navigateTo( connectURL );
-	}, [ registry, connectURL, navigateTo ] );
-
-	useEffect( () => {
-		// If error has flag to skip the modal, redirect to the authorization
-		// page immediately without prompting the user, essentially short-
-		// circuiting to the confirm step.
-		const confirmIfSkipModal = async () => {
-			if (
-				permissionsError?.data?.skipModal &&
-				permissionsError?.data?.scopes?.length
-			) {
-				await onConfirm();
-			}
-		};
-		confirmIfSkipModal();
-	}, [ onConfirm, permissionsError ] );
-
-	if ( ! permissionsError ) {
-		return null;
-	}
-
-	// If there aren't any scopes for us to request, there's no reason to show
-	// the modal. Log a console warning if this happens and return `null`.
-	if ( ! permissionsError?.data?.scopes?.length ) {
-		global.console.warn(
-			'permissionsError lacks scopes array to use for redirect, so not showing the PermissionsModal. permissionsError was:',
-			permissionsError
-		);
-		return null;
-	}
-
-	if ( permissionsError?.data?.skipModal ) {
-		return null;
-	}
-
-	return (
-		<Portal>
-			<Dialog
-				title={ __(
-					'Additional Permissions Required',
-					'google-site-kit'
-				) }
-				subtitle={ permissionsError.message }
-				confirmButton={ __( 'Proceed', 'google-site-kit' ) }
-				dialogActive={ true }
-				handleConfirm={ onConfirm }
-				handleDialog={ onCancel }
-			/>
-		</Portal>
-	);
-};
+const { useSelect } = Data;
 
 const PermissionsModal = () => {
 	const isAuthenticated = useSelect( ( select ) =>

--- a/assets/js/components/PermissionsModal/index.js
+++ b/assets/js/components/PermissionsModal/index.js
@@ -33,7 +33,7 @@ import Dialog from '../Dialog';
 import Portal from '../Portal';
 const { useSelect, useDispatch, useRegistry } = Data;
 
-const PermissionsModal = () => {
+const AuthenticatedPermissionsModal = () => {
 	const registry = useRegistry();
 	const permissionsError = useSelect( ( select ) =>
 		select( CORE_USER ).getPermissionScopeError()
@@ -107,6 +107,18 @@ const PermissionsModal = () => {
 			/>
 		</Portal>
 	);
+};
+
+const PermissionsModal = () => {
+	const isAuthenticated = useSelect( ( select ) =>
+		select( CORE_USER ).isAuthenticated()
+	);
+
+	if ( isAuthenticated ) {
+		return <AuthenticatedPermissionsModal />;
+	}
+
+	return null;
 };
 
 export default PermissionsModal;

--- a/assets/js/components/PermissionsModal/index.test.js
+++ b/assets/js/components/PermissionsModal/index.test.js
@@ -1,0 +1,58 @@
+/**
+ * PermissionsModal component tests.
+ *
+ * Site Kit by Google, Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import PermissionsModal from './';
+import {
+	render,
+	createTestRegistry,
+	provideUserAuthentication,
+} from '../../../../tests/js/test-utils';
+import { CORE_USER } from '../../googlesitekit/datastore/user/constants';
+
+describe( 'PermissionsModal', () => {
+	let registry;
+
+	beforeEach( () => {
+		registry = createTestRegistry();
+		registry.dispatch( CORE_USER ).receiveConnectURL( 'test-url' );
+		registry.dispatch( CORE_USER ).setPermissionScopeError( {
+			status: 500,
+			message: 'Bad',
+			data: {
+				scopes: [
+					'https://www.googleapis.com/auth/analytics.readonly',
+				],
+			},
+		} );
+	} );
+
+	it( 'Does not render AuthenticatedPermissionsModal when user is not authenticated', () => {
+		provideUserAuthentication( registry, { authenticated: false } );
+		const { baseElement } = render( <PermissionsModal />, { registry } );
+		expect( baseElement.childElementCount ).toBe( 1 );
+	} );
+
+	it( 'Renders AuthenticatedPermissionsModal when user is authenticated', () => {
+		provideUserAuthentication( registry );
+		const { baseElement } = render( <PermissionsModal />, { registry } );
+		expect( baseElement.childElementCount ).toBe( 2 );
+	} );
+} );

--- a/assets/js/components/PermissionsModal/index.test.js
+++ b/assets/js/components/PermissionsModal/index.test.js
@@ -44,15 +44,21 @@ describe( 'PermissionsModal', () => {
 		} );
 	} );
 
-	it( 'Does not render AuthenticatedPermissionsModal when user is not authenticated', () => {
+	it( 'does not render AuthenticatedPermissionsModal when user is not authenticated', () => {
 		provideUserAuthentication( registry, { authenticated: false } );
 		const { baseElement } = render( <PermissionsModal />, { registry } );
-		expect( baseElement.childElementCount ).toBe( 1 );
+
+		expect( baseElement ).not.toHaveTextContent(
+			'Additional Permissions Required'
+		);
 	} );
 
-	it( 'Renders AuthenticatedPermissionsModal when user is authenticated', () => {
+	it( 'renders AuthenticatedPermissionsModal when user is authenticated', () => {
 		provideUserAuthentication( registry );
 		const { baseElement } = render( <PermissionsModal />, { registry } );
-		expect( baseElement.childElementCount ).toBe( 2 );
+
+		expect( baseElement ).toHaveTextContent(
+			'Additional Permissions Required'
+		);
 	} );
 } );

--- a/assets/js/components/notifications/ErrorNotifications.js
+++ b/assets/js/components/notifications/ErrorNotifications.js
@@ -24,16 +24,22 @@ import { Fragment } from '@wordpress/element';
 /**
  * Internal dependencies
  */
+import Data from 'googlesitekit-data';
 import AuthError from './AuthError';
 import UnsatisfiedScopesAlert from './UnsatisfiedScopesAlert';
 import InternalServerError from './InternalServerError';
+import { CORE_USER } from '../../googlesitekit/datastore/user/constants';
+const { useSelect } = Data;
 
 export default function ErrorNotifications() {
+	const isAuthenticated = useSelect( ( select ) =>
+		select( CORE_USER ).isAuthenticated()
+	);
 	return (
 		<Fragment>
 			<InternalServerError />
 			<AuthError />
-			<UnsatisfiedScopesAlert />
+			{ isAuthenticated && <UnsatisfiedScopesAlert /> }
 		</Fragment>
 	);
 }

--- a/assets/js/components/notifications/ErrorNotifications.test.js
+++ b/assets/js/components/notifications/ErrorNotifications.test.js
@@ -37,7 +37,7 @@ describe( 'ErrorNotifications', () => {
 		registry.dispatch( CORE_USER ).receiveConnectURL( 'test-url' );
 	} );
 
-	it( 'Does not render UnsatisfiedScopesAlert when user is not authenticated', () => {
+	it( 'does not render UnsatisfiedScopesAlert when user is not authenticated', () => {
 		provideUserAuthentication( registry, {
 			authenticated: false,
 			unsatisfiedScopes: [
@@ -50,7 +50,7 @@ describe( 'ErrorNotifications', () => {
 		expect( container.childElementCount ).toBe( 0 );
 	} );
 
-	it( 'Renders UnsatisfiedScopesAlert when user is authenticated', () => {
+	it( 'renders UnsatisfiedScopesAlert when user is authenticated', () => {
 		provideUserAuthentication( registry, {
 			unsatisfiedScopes: [
 				'https://www.googleapis.com/auth/analytics.readonly',
@@ -59,6 +59,9 @@ describe( 'ErrorNotifications', () => {
 		const { container } = render( <ErrorNotifications />, {
 			registry,
 		} );
-		expect( container.childElementCount ).toBe( 1 );
+
+		expect( container ).toHaveTextContent(
+			'Site Kit can’t access necessary data'
+		);
 	} );
 } );

--- a/assets/js/components/notifications/ErrorNotifications.test.js
+++ b/assets/js/components/notifications/ErrorNotifications.test.js
@@ -1,0 +1,64 @@
+/**
+ * ErrorNotifications component tests.
+ *
+ * Site Kit by Google, Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import ErrorNotifications from './ErrorNotifications';
+import {
+	render,
+	createTestRegistry,
+	provideUserAuthentication,
+	provideModules,
+} from '../../../../tests/js/test-utils';
+import { CORE_USER } from '../../googlesitekit/datastore/user/constants';
+
+describe( 'ErrorNotifications', () => {
+	let registry;
+
+	beforeEach( () => {
+		registry = createTestRegistry();
+		provideModules( registry );
+		registry.dispatch( CORE_USER ).receiveConnectURL( 'test-url' );
+	} );
+
+	it( 'Does not render UnsatisfiedScopesAlert when user is not authenticated', () => {
+		provideUserAuthentication( registry, {
+			authenticated: false,
+			unsatisfiedScopes: [
+				'https://www.googleapis.com/auth/analytics.readonly',
+			],
+		} );
+		const { container } = render( <ErrorNotifications />, {
+			registry,
+		} );
+		expect( container.childElementCount ).toBe( 0 );
+	} );
+
+	it( 'Renders UnsatisfiedScopesAlert when user is authenticated', () => {
+		provideUserAuthentication( registry, {
+			unsatisfiedScopes: [
+				'https://www.googleapis.com/auth/analytics.readonly',
+			],
+		} );
+		const { container } = render( <ErrorNotifications />, {
+			registry,
+		} );
+		expect( container.childElementCount ).toBe( 1 );
+	} );
+} );

--- a/assets/js/googlesitekit/datastore/user/permissions.js
+++ b/assets/js/googlesitekit/datastore/user/permissions.js
@@ -151,7 +151,7 @@ export const selectors = {
 	 * @private
 	 *
 	 * @param {Object} state Data store's state.
-	 * @return {(Object|undefined)} Permission scope errors. Returns `null` if no error exists.
+	 * @return {(Object|null)} Permission scope errors. Returns `null` if no error exists.
 	 */
 	getPermissionScopeError( state ) {
 		const { permissionError } = state;


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #4819

## Relevant technical choices

I had to divert a bit away from the IB to make sure `PermissionModal` doesn't render for non authenticated users. As we can't really use selectors in the `Root` component, I created a Inner Component and extracted everything from the `PermissionModal` to the new one. That way we can check the user authentication status inside the now mostly empty and wrapper `PermissionMolal` and return inner component or null accordingly. See the comments on the original issue for discussion and thanks @aaemnnosttv for the suggestion!

<!-- Please describe your changes. -->

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
