### PR TITLE
Hide SourceLinks for view-only dashboard contexts

### DIFF
--- a/assets/js/components/SourceLink.js
+++ b/assets/js/components/SourceLink.js
@@ -32,8 +32,15 @@ import { __, sprintf } from '@wordpress/i18n';
  * Internal dependencies
  */
 import Link from './Link';
+import useViewOnly from '../hooks/useViewOnly';
 
 function SourceLink( { name, href, className, external } ) {
+	const viewOnlyDashboard = useViewOnly();
+
+	if ( viewOnlyDashboard ) {
+		return null;
+	}
+
 	return (
 		<div className={ classnames( 'googlesitekit-source-link', className ) }>
 			{ createInterpolateElement(

--- a/assets/js/components/SourceLink.test.js
+++ b/assets/js/components/SourceLink.test.js
@@ -1,0 +1,60 @@
+/**
+ * SourceLink tests.
+ *
+ * Site Kit by Google, Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import { render } from '../../../tests/js/test-utils';
+import {
+	VIEW_CONTEXT_DASHBOARD,
+	VIEW_CONTEXT_DASHBOARD_VIEW_ONLY,
+} from '../googlesitekit/constants';
+import { Provider as ViewContextProvider } from './Root/ViewContextContext';
+import SourceLink from './SourceLink';
+
+describe( 'SourceLink', () => {
+	it( 'should not render the SourceLink when the view context is "view only"', async () => {
+		const { container } = render(
+			<ViewContextProvider value={ VIEW_CONTEXT_DASHBOARD_VIEW_ONLY }>
+				<SourceLink
+					name="Analytics"
+					href={ 'https://analytics.google.com/test' }
+					external
+				/>
+			</ViewContextProvider>
+		);
+
+		expect( container ).not.toHaveTextContent( 'Analytics' );
+		expect( container.firstChild ).toBeNull();
+	} );
+
+	it( 'should render the SourceLink normally when the view context is NOT "view only"', async () => {
+		const { container } = render(
+			<ViewContextProvider value={ VIEW_CONTEXT_DASHBOARD }>
+				<SourceLink
+					name="Analytics"
+					href={ 'https://analytics.google.com/test' }
+					external
+				/>
+			</ViewContextProvider>
+		);
+
+		expect( container ).toHaveTextContent( 'Analytics' );
+		expect( container.firstChild ).not.toBeNull();
+	} );
+} );


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #4815.

## Relevant technical choices

Because there's no way to QA the "view-only" mode right now I've added a few unit tests to ensure the behaviour is correct.

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [x] Run the code.
- [x] Ensure the acceptance criteria are satisfied.
- [x] Reassess the implementation with the IB.
- [x] Ensure no unrelated changes are included.
- [x] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [x] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
