### PR TITLE
Don't render Analytics setup component when Analytics isn't available.

### DIFF
--- a/assets/js/components/setup/SetupUsingProxyWithSignIn.js
+++ b/assets/js/components/setup/SetupUsingProxyWithSignIn.js
@@ -244,20 +244,23 @@ export default function SetupUsingProxyWithSignIn() {
 												smSize={ 4 }
 												mdSize={ 8 }
 												lgSize={
-													! analyticsModuleActive
-														? 4
-														: 6
+													analyticsModuleActive
+														? 6
+														: 4
 												}
 												className="googlesitekit-setup__icon"
 											>
-												{ analyticsModuleActive && (
-													<WelcomeSVG
-														width="570"
-														height="336"
-													/>
-												) }
+												{ analyticsModuleActive ||
+													( analyticsModuleActive ===
+														null && (
+														<WelcomeSVG
+															width="570"
+															height="336"
+														/>
+													) ) }
 
-												{ ! analyticsModuleActive && (
+												{ analyticsModuleActive ===
+													false && (
 													<WelcomeAnalyticsSVG
 														height="167"
 														width="175"
@@ -298,7 +301,8 @@ export default function SetupUsingProxyWithSignIn() {
 														</p>
 													) }
 
-												{ ! analyticsModuleActive && (
+												{ analyticsModuleActive ===
+													false && (
 													<ActivateAnalyticsNotice />
 												) }
 


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #5071.

## Relevant technical choices

<!-- Please describe your changes. -->

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [ ] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
