### PR TITLE
Limit Widgets in view-only dashboard context to ones the user has access to

### DIFF
--- a/assets/js/googlesitekit/widgets/components/WidgetAreaRenderer.js
+++ b/assets/js/googlesitekit/widgets/components/WidgetAreaRenderer.js
@@ -48,6 +48,8 @@ import {
 import InViewProvider from '../../../components/InViewProvider';
 import WidgetRenderer from './WidgetRenderer';
 import WidgetCellWrapper from './WidgetCellWrapper';
+import useViewOnly from '../../../hooks/useViewOnly';
+import { CORE_USER } from '../../datastore/user/constants';
 const { useSelect } = Data;
 
 /**
@@ -75,6 +77,16 @@ function getRootMargin( breakpoint ) {
 export default function WidgetAreaRenderer( { slug, totalAreas, contextID } ) {
 	const unifiedDashboardEnabled = useFeature( 'unifiedDashboard' );
 
+	const viewOnly = useViewOnly();
+
+	const viewableModules = useSelect( ( select ) => {
+		if ( ! viewOnly ) {
+			return null;
+		}
+
+		return select( CORE_USER ).getViewableModules();
+	} );
+
 	const breakpoint = useBreakpoint();
 
 	const widgetAreaRef = useRef();
@@ -87,7 +99,9 @@ export default function WidgetAreaRenderer( { slug, totalAreas, contextID } ) {
 		select( CORE_WIDGETS ).getWidgetArea( slug )
 	);
 	const widgets = useSelect( ( select ) =>
-		select( CORE_WIDGETS ).getWidgets( slug )
+		select( CORE_WIDGETS ).getWidgets( slug, {
+			modules: viewableModules ? viewableModules : undefined,
+		} )
 	);
 	const widgetStates = useSelect( ( select ) =>
 		select( CORE_WIDGETS ).getWidgetStates()

--- a/tests/js/test-utils.js
+++ b/tests/js/test-utils.js
@@ -46,6 +46,7 @@ const customRender = ( ui, options = {} ) => {
 		history = createMemoryHistory(),
 		route = undefined,
 		inView = true,
+		viewContext = null,
 		...renderOptions
 	} = options;
 
@@ -81,7 +82,9 @@ const customRender = ( ui, options = {} ) => {
 			<InViewProvider value={ inViewState }>
 				<RegistryProvider value={ registry }>
 					<FeaturesProvider value={ enabledFeatures }>
-						<Router history={ history }>{ children }</Router>
+						<ViewContextProvider value={ viewContext }>
+							<Router history={ history }>{ children }</Router>
+						</ViewContextProvider>
 					</FeaturesProvider>
 				</RegistryProvider>
 			</InViewProvider>


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #4813

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
