### PR TITLE
Increase E2E workflow timeouts to 30 minutes.

### DIFF
--- a/.github/workflows/e2e-tests-wp-4-7.yml
+++ b/.github/workflows/e2e-tests-wp-4-7.yml
@@ -82,7 +82,7 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    timeout-minutes: 20
+    timeout-minutes: 30
 
     if: github.event_name == 'push' || github.event.pull_request.draft == false
 

--- a/.github/workflows/e2e-tests-wp-4-9-gutenberg.yml
+++ b/.github/workflows/e2e-tests-wp-4-9-gutenberg.yml
@@ -82,6 +82,8 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    timeout-minutes: 30
+
     if: github.event_name == 'push' || github.event.pull_request.draft == false
 
     steps:

--- a/.github/workflows/e2e-tests-wp-latest.yml
+++ b/.github/workflows/e2e-tests-wp-latest.yml
@@ -81,7 +81,7 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    timeout-minutes: 20
+    timeout-minutes: 30
 
     if: github.event_name == 'push' || github.event.pull_request.draft == false
 

--- a/.github/workflows/e2e-tests-wp-nightly.yml
+++ b/.github/workflows/e2e-tests-wp-nightly.yml
@@ -81,7 +81,7 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    timeout-minutes: 20
+    timeout-minutes: 30
 
     if: github.event_name == 'push' || github.event.pull_request.draft == false
 


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #5152 

## Relevant technical choices

<!-- Please describe your changes. -->

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [ ] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
