### PR TITLE
Pass finishSetup() prop to AdSense UI components.

### DIFF
--- a/assets/js/modules/adsense/components/setup/v2/SetupAccount.js
+++ b/assets/js/modules/adsense/components/setup/v2/SetupAccount.js
@@ -51,7 +51,7 @@ import SetupAccountCreateSite from './SetupAccountCreateSite';
 import SetupAccountPendingTasks from './SetupAccountPendingTasks';
 const { useSelect, useDispatch } = Data;
 
-export default function SetupAccount( { account } ) {
+export default function SetupAccount( { account, finishSetup } ) {
 	const { _id: accountID, state: accountState } = account;
 
 	const clientID = useSelect( ( select ) =>
@@ -126,7 +126,7 @@ export default function SetupAccount( { account } ) {
 		return <SetupAccountPendingTasks accountID={ accountID } />;
 	}
 
-	return <SetupAccountSite site={ site } />;
+	return <SetupAccountSite site={ site } finishSetup={ finishSetup } />;
 }
 
 SetupAccount.propTypes = {
@@ -134,4 +134,5 @@ SetupAccount.propTypes = {
 		_id: PropTypes.string,
 		state: PropTypes.string,
 	} ),
+	finishSetup: PropTypes.func,
 };

--- a/assets/js/modules/adsense/components/setup/v2/SetupMain.js
+++ b/assets/js/modules/adsense/components/setup/v2/SetupMain.js
@@ -20,6 +20,7 @@
  * External dependencies
  */
 import { useUpdateEffect } from 'react-use';
+import PropTypes from 'prop-types';
 
 /**
  * WordPress dependencies
@@ -47,7 +48,7 @@ import {
 import useViewContext from '../../../../../hooks/useViewContext';
 const { useSelect, useDispatch } = Data;
 
-export default function SetupMain() {
+export default function SetupMain( { finishSetup } ) {
 	const viewContext = useViewContext();
 	const eventCategory = `${ viewContext }_adsense`;
 
@@ -264,7 +265,9 @@ export default function SetupMain() {
 	} else if ( ! accountID ) {
 		viewComponent = <SetupSelectAccount />;
 	} else {
-		viewComponent = <SetupAccount account={ account } />;
+		viewComponent = (
+			<SetupAccount account={ account } finishSetup={ finishSetup } />
+		);
 	}
 
 	return (
@@ -287,3 +290,7 @@ export default function SetupMain() {
 		</div>
 	);
 }
+
+SetupMain.propTypes = {
+	finishSetup: PropTypes.func,
+};


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #4764 

## Relevant technical choices

<!-- Please describe your changes. -->

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
