### PR TITLE
Fix the search traffic tab line colour for gathering data state.

### DIFF
--- a/assets/sass/components/global/_googlesitekit-data-block.scss
+++ b/assets/sass/components/global/_googlesitekit-data-block.scss
@@ -289,5 +289,15 @@
 
 	.googlesitekit-data-block--is-gathering-data {
 		cursor: auto;
+
+		&.googlesitekit-data-block--selected {
+
+			// FIXME: The bar still goes blue when navigating away, during the
+			// transition/fade.
+			&::before {
+				background-color: $c-jumbo;
+				opacity: 0.6;
+			}
+		}
 	}
 }

--- a/assets/sass/components/global/_googlesitekit-data-block.scss
+++ b/assets/sass/components/global/_googlesitekit-data-block.scss
@@ -91,6 +91,17 @@
 			}
 		}
 
+		&--button-#{$button}.googlesitekit-data-block--is-gathering-data {
+
+			&::before {
+				background-color: $c-jumbo;
+			}
+
+			&.googlesitekit-data-block--selected::before {
+				opacity: 0.6;
+			}
+		}
+
 		&--button-#{$button}::before {
 			background-color: $color;
 		}
@@ -289,15 +300,5 @@
 
 	.googlesitekit-data-block--is-gathering-data {
 		cursor: auto;
-
-		&.googlesitekit-data-block--selected {
-
-			// FIXME: The bar still goes blue when navigating away, during the
-			// transition/fade.
-			&::before {
-				background-color: $c-jumbo;
-				opacity: 0.6;
-			}
-		}
 	}
 }


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #5056 

## Relevant technical choices

I had to diverge slightly from the IB, as I noticed that having implemented according to the IB, the line colour would still flash back to blue during the transition when clicking on another tab - see video:

https://user-images.githubusercontent.com/18395600/166480763-f6edabcb-dcb9-40f5-a7e0-9ea5254c0a7d.mp4

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
