### PR TITLE
Bug/5107 - Show errors instead of infinite loading state in AdSense V2 setup flow (follow-up)

### DIFF
--- a/assets/js/modules/adsense/components/setup/v2/SetupMain.js
+++ b/assets/js/modules/adsense/components/setup/v2/SetupMain.js
@@ -109,6 +109,9 @@ export default function SetupMain( { finishSetup } ) {
 	const hasErrors = useSelect( ( select ) =>
 		select( MODULES_ADSENSE ).hasErrors()
 	);
+	const hasResolvedAccounts = useSelect( ( select ) =>
+		select( MODULES_ADSENSE ).hasFinishedResolution( 'getAccounts' )
+	);
 
 	const account = accounts?.find( ( { _id } ) => _id === accountID );
 
@@ -252,7 +255,7 @@ export default function SetupMain( { finishSetup } ) {
 		}
 	}, [ eventCategory, siteStatus ] );
 
-	if ( accounts === undefined ) {
+	if ( ! hasResolvedAccounts ) {
 		return <ProgressBar />;
 	}
 
@@ -260,7 +263,7 @@ export default function SetupMain( { finishSetup } ) {
 
 	if ( hasErrors ) {
 		viewComponent = <ErrorNotices />;
-	} else if ( ! accounts.length ) {
+	} else if ( ! accounts?.length ) {
 		viewComponent = <SetupCreateAccount />;
 	} else if ( ! accountID ) {
 		viewComponent = <SetupSelectAccount />;


### PR DESCRIPTION
## Summary

Addresses issue:

- #5107 

## Relevant technical choices

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
