### PR TITLE
Feat/4811 splash screen view only button fix

### DIFF
--- a/assets/js/components/setup/SetupUsingProxyWithSignIn.js
+++ b/assets/js/components/setup/SetupUsingProxyWithSignIn.js
@@ -361,6 +361,7 @@ export default function SetupUsingProxyWithSignIn() {
 																			onClick={
 																				goToSharedDashboard
 																			}
+																			inherit
 																		>
 																			{ __(
 																				'Go to dashboard',


### PR DESCRIPTION
## Summary

As per @felixarntz's [comment](https://github.com/google/site-kit-wp/issues/4811#issuecomment-1118753221) - update the "Go to dashboard" button so it matches the "Reset Site Kit" button styling.

Addresses issue:

- #4811 

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
