### PR TITLE
Fix "Review AdSense account" button text.

### DIFF
--- a/assets/js/modules/adsense/components/setup/v2/SetupAccountPendingTasks.js
+++ b/assets/js/modules/adsense/components/setup/v2/SetupAccountPendingTasks.js
@@ -75,7 +75,7 @@ export default function SetupAccountPendingTasks( { accountID } ) {
 
 			<div className="googlesitekit-setup-module__action">
 				<Button onClick={ onButtonClick } href={ serviceAccountURL }>
-					{ __( 'Add site to AdSense', 'google-site-kit' ) }
+					{ __( 'Review AdSense account', 'google-site-kit' ) }
 				</Button>
 			</div>
 		</Fragment>


### PR DESCRIPTION
## Summary

Followup PR to fix the **Review AdSense account** button text in the `SetupAccountPendingTasks` component.

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #4763 

## Relevant technical choices

<!-- Please describe your changes. -->

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
