### PR TITLE
Move `*UseSnippetSwitch` variants to respective component directories

### DIFF
--- a/assets/js/modules/analytics-4/components/common/index.js
+++ b/assets/js/modules/analytics-4/components/common/index.js
@@ -18,5 +18,4 @@
 
 export { default as PropertySelect } from './PropertySelect';
 export { default as SettingsUseSnippetSwitch } from './SettingsUseSnippetSwitch';
-export { default as SetupUseSnippetSwitch } from './SetupUseSnippetSwitch';
 export { default as UseSnippetSwitch } from './UseSnippetSwitch';

--- a/assets/js/modules/analytics-4/components/common/index.js
+++ b/assets/js/modules/analytics-4/components/common/index.js
@@ -17,5 +17,4 @@
  */
 
 export { default as PropertySelect } from './PropertySelect';
-export { default as SettingsUseSnippetSwitch } from './SettingsUseSnippetSwitch';
 export { default as UseSnippetSwitch } from './UseSnippetSwitch';

--- a/assets/js/modules/analytics-4/components/settings/SettingsUseSnippetSwitch.js
+++ b/assets/js/modules/analytics-4/components/settings/SettingsUseSnippetSwitch.js
@@ -27,7 +27,7 @@ import { __, sprintf } from '@wordpress/i18n';
  */
 import Data from 'googlesitekit-data';
 import { MODULES_ANALYTICS_4 } from '../../datastore/constants';
-import UseSnippetSwitch from './UseSnippetSwitch';
+import UseSnippetSwitch from '../common/UseSnippetSwitch';
 const { useSelect } = Data;
 
 export default function SettingsUseSnippetSwitch() {

--- a/assets/js/modules/analytics-4/components/settings/index.js
+++ b/assets/js/modules/analytics-4/components/settings/index.js
@@ -1,7 +1,7 @@
 /**
- * Analytics Settings components.
+ * GA4 settings components.
  *
- * Site Kit by Google, Copyright 2021 Google LLC
+ * Site Kit by Google, Copyright 2022 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,9 +16,4 @@
  * limitations under the License.
  */
 
-export { default as SettingsEdit } from './SettingsEdit';
-export { default as SettingsForm } from './SettingsForm';
-export { default as SettingsView } from './SettingsView';
-export { default as SettingsControls } from './SettingsControls';
 export { default as SettingsUseSnippetSwitch } from './SettingsUseSnippetSwitch';
-export { default as GA4SettingsControls } from './GA4SettingsControls';

--- a/assets/js/modules/analytics-4/components/setup/SetupUseSnippetSwitch.js
+++ b/assets/js/modules/analytics-4/components/setup/SetupUseSnippetSwitch.js
@@ -1,5 +1,5 @@
 /**
- * Tag Manager Setup Use Snippet Switch component.
+ * GA4 Setup Use Snippet Switch component.
  *
  * Site Kit by Google, Copyright 2022 Google LLC
  *
@@ -26,27 +26,26 @@ import { __, sprintf } from '@wordpress/i18n';
  * Internal dependencies
  */
 import Data from 'googlesitekit-data';
-import { MODULES_TAGMANAGER } from '../../datastore/constants';
-import UseSnippetSwitch from './UseSnippetSwitch';
+import { MODULES_ANALYTICS_4 } from '../../datastore/constants';
+import UseSnippetSwitch from '../common/UseSnippetSwitch';
 const { useSelect } = Data;
 
 export default function SetupUseSnippetSwitch() {
-	const primaryContainerID = useSelect( ( select ) =>
-		select( MODULES_TAGMANAGER ).getPrimaryContainerID()
-	);
-
 	const existingTag = useSelect( ( select ) =>
-		select( MODULES_TAGMANAGER ).getExistingTag()
+		select( MODULES_ANALYTICS_4 ).getExistingTag()
+	);
+	const measurementID = useSelect( ( select ) =>
+		select( MODULES_ANALYTICS_4 ).getMeasurementID()
 	);
 
 	const description =
-		primaryContainerID === existingTag ? (
+		existingTag === measurementID ? (
 			<Fragment>
 				<p>
 					{ sprintf(
 						/* translators: %s: existing tag ID */
 						__(
-							'A tag %s for the selected container already exists on the site.',
+							'A tag %s for the selected property already exists on the site.',
 							'google-site-kit'
 						),
 						existingTag
@@ -54,7 +53,7 @@ export default function SetupUseSnippetSwitch() {
 				</p>
 				<p>
 					{ __(
-						'Make sure you remove it if you want to place the same tag via Site Kit, otherwise they will be duplicated.',
+						'Make sure you remove it if you decide to place the same GA4 tag via Site Kit, otherwise they will be duplicated.',
 						'google-site-kit'
 					) }
 				</p>
@@ -73,7 +72,7 @@ export default function SetupUseSnippetSwitch() {
 				</p>
 				<p>
 					{ __(
-						'If you prefer to collect data using that existing tag, please select the corresponding account and property above.',
+						'If you prefer to collect data using that existing GA4 tag, please select the corresponding account and property above.',
 						'google-site-kit'
 					) }
 				</p>

--- a/assets/js/modules/analytics-4/components/setup/index.js
+++ b/assets/js/modules/analytics-4/components/setup/index.js
@@ -1,7 +1,7 @@
 /**
- * Analytics Setup components.
+ * GA4 setup components.
  *
- * Site Kit by Google, Copyright 2021 Google LLC
+ * Site Kit by Google, Copyright 2022 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,10 +16,4 @@
  * limitations under the License.
  */
 
-export { default as SetupForm } from './SetupForm';
-export { default as SetupMain } from './SetupMain';
-export { default as SetupFormLegacy } from './SetupFormLegacy';
-export { default as SetupFormUA } from './SetupFormUA';
-export { default as SetupFormGA4 } from './SetupFormGA4';
-export { default as SetupFormGA4Transitional } from './SetupFormGA4Transitional';
 export { default as SetupUseSnippetSwitch } from './SetupUseSnippetSwitch';

--- a/assets/js/modules/analytics/components/common/index.js
+++ b/assets/js/modules/analytics/components/common/index.js
@@ -30,7 +30,6 @@ export { default as PropertySelect } from './PropertySelect';
 export { default as PropertySelectIncludingGA4 } from './PropertySelectIncludingGA4';
 export { default as TrackingExclusionSwitches } from './TrackingExclusionSwitches';
 export { default as SettingsUseSnippetSwitch } from './SettingsUseSnippetSwitch';
-export { default as SetupUseSnippetSwitch } from './SetupUseSnippetSwitch';
 export { default as UseSnippetSwitch } from './UseSnippetSwitch';
 export { default as GA4ActivateSwitch } from './GA4ActivateSwitch';
 export { default as GA4PropertyNotice } from './GA4PropertyNotice';

--- a/assets/js/modules/analytics/components/common/index.js
+++ b/assets/js/modules/analytics/components/common/index.js
@@ -29,7 +29,6 @@ export { default as ProfileSelect } from './ProfileSelect';
 export { default as PropertySelect } from './PropertySelect';
 export { default as PropertySelectIncludingGA4 } from './PropertySelectIncludingGA4';
 export { default as TrackingExclusionSwitches } from './TrackingExclusionSwitches';
-export { default as SettingsUseSnippetSwitch } from './SettingsUseSnippetSwitch';
 export { default as UseSnippetSwitch } from './UseSnippetSwitch';
 export { default as GA4ActivateSwitch } from './GA4ActivateSwitch';
 export { default as GA4PropertyNotice } from './GA4PropertyNotice';

--- a/assets/js/modules/analytics/components/settings/GA4SettingsControls.js
+++ b/assets/js/modules/analytics/components/settings/GA4SettingsControls.js
@@ -40,11 +40,9 @@ import {
 import { FORM_SETUP, MODULES_ANALYTICS } from '../../datastore/constants';
 import { Select, Option } from '../../../../material-components';
 import { GA4ActivateSwitch } from '../common';
-import {
-	PropertySelect,
-	SettingsUseSnippetSwitch,
-} from '../../../analytics-4/components/common';
+import { PropertySelect } from '../../../analytics-4/components/common';
 import ProgressBar from '../../../../components/ProgressBar';
+import SettingsUseSnippetSwitch from './SettingsUseSnippetSwitch';
 const { useSelect, useDispatch } = Data;
 
 export default function GA4SettingsControls() {

--- a/assets/js/modules/analytics/components/settings/SettingsControls.js
+++ b/assets/js/modules/analytics/components/settings/SettingsControls.js
@@ -26,8 +26,8 @@ import {
 	ProfileNameTextField,
 	ProfileSelect,
 	PropertySelect,
-	SettingsUseSnippetSwitch,
 } from '../common';
+import SettingsUseSnippetSwitch from './SettingsUseSnippetSwitch';
 const { useSelect } = Data;
 
 export default function SettingsControls() {

--- a/assets/js/modules/analytics/components/settings/SettingsUseSnippetSwitch.js
+++ b/assets/js/modules/analytics/components/settings/SettingsUseSnippetSwitch.js
@@ -1,5 +1,5 @@
 /**
- * Tag Manager Settings Use Snippet Switch component.
+ * Analytics Settings Use Snippet Switch component.
  *
  * Site Kit by Google, Copyright 2022 Google LLC
  *
@@ -26,34 +26,55 @@ import { __, sprintf } from '@wordpress/i18n';
  * Internal dependencies
  */
 import Data from 'googlesitekit-data';
-import UseSnippetSwitch from './UseSnippetSwitch';
-import { MODULES_TAGMANAGER } from '../../datastore/constants';
+import { MODULES_ANALYTICS } from '../../datastore/constants';
+import UseSnippetSwitch from '../common/UseSnippetSwitch';
 const { useSelect } = Data;
 
 export default function SettingsUseSnippetSwitch() {
 	const useSnippet = useSelect( ( select ) =>
-		select( MODULES_TAGMANAGER ).getUseSnippet()
+		select( MODULES_ANALYTICS ).getUseSnippet()
 	);
-
-	const primaryContainerID = useSelect( ( select ) =>
-		select( MODULES_TAGMANAGER ).getPrimaryContainerID()
+	const canUseSnippet = useSelect( ( select ) =>
+		select( MODULES_ANALYTICS ).getCanUseSnippet()
 	);
 
 	const existingTag = useSelect( ( select ) =>
-		select( MODULES_TAGMANAGER ).getExistingTag()
+		select( MODULES_ANALYTICS ).getExistingTag()
 	);
+	const propertyID = useSelect( ( select ) =>
+		select( MODULES_ANALYTICS ).getPropertyID()
+	);
+
+	if ( canUseSnippet === undefined ) {
+		return null;
+	}
+
+	if ( canUseSnippet === false ) {
+		return (
+			<UseSnippetSwitch
+				description={
+					<p>
+						{ __(
+							'The code is controlled by the Tag Manager module.',
+							'google-site-kit'
+						) }
+					</p>
+				}
+			/>
+		);
+	}
 
 	let description;
 
 	if ( existingTag ) {
 		description =
-			primaryContainerID === existingTag ? (
+			existingTag === propertyID ? (
 				<Fragment>
 					<p>
 						{ sprintf(
 							/* translators: %s: existing tag ID */
 							__(
-								'A tag %s for the selected container already exists on the site.',
+								'A tag %s for the selected property already exists on the site.',
 								'google-site-kit'
 							),
 							existingTag
@@ -61,7 +82,7 @@ export default function SettingsUseSnippetSwitch() {
 					</p>
 					<p>
 						{ __(
-							'Make sure you remove it if you want to place the same tag via Site Kit, otherwise they will be duplicated.',
+							'Make sure you remove it if you want to place the same UA tag via Site Kit, otherwise they will be duplicated.',
 							'google-site-kit'
 						) }
 					</p>
@@ -80,7 +101,7 @@ export default function SettingsUseSnippetSwitch() {
 					</p>
 					<p>
 						{ __(
-							'If you prefer to collect data using that existing tag, please select the corresponding account and property above.',
+							'If you prefer to collect data using that existing UA tag, please select the corresponding account and property above.',
 							'google-site-kit'
 						) }
 					</p>
@@ -90,14 +111,14 @@ export default function SettingsUseSnippetSwitch() {
 		description = useSnippet ? (
 			<p>
 				{ __(
-					'Site Kit will add the code automatically.',
+					'Site Kit will add the UA code automatically.',
 					'google-site-kit'
 				) }
 			</p>
 		) : (
 			<p>
 				{ __(
-					'Site Kit will not add the code to your site.',
+					'Site Kit will not add the UA code to your site.',
 					'google-site-kit'
 				) }
 			</p>

--- a/assets/js/modules/analytics/components/setup/SetupFormGA4.js
+++ b/assets/js/modules/analytics/components/setup/SetupFormGA4.js
@@ -46,7 +46,7 @@ import {
 	GA4PropertyNotice,
 	ExistingGTMPropertyNotice,
 } from '../common';
-import { SetupUseSnippetSwitch as SetupUseSnippetSwitchUA } from '../setup';
+import SetupUseSnippetSwitchUA from './SetupUseSnippetSwitch';
 import { SetupUseSnippetSwitch as SetupUseSnippetSwitchGA4 } from '../../../analytics-4/components/setup';
 const { useSelect, useDispatch } = Data;
 

--- a/assets/js/modules/analytics/components/setup/SetupFormGA4.js
+++ b/assets/js/modules/analytics/components/setup/SetupFormGA4.js
@@ -45,9 +45,9 @@ import {
 	AccountSelect,
 	GA4PropertyNotice,
 	ExistingGTMPropertyNotice,
-	SetupUseSnippetSwitch as SetupUseSnippetSwitchUA,
 } from '../common';
-import { SetupUseSnippetSwitch as SetupUseSnippetSwitchGA4 } from '../../../analytics-4/components/common';
+import { SetupUseSnippetSwitch as SetupUseSnippetSwitchUA } from '../setup';
+import { SetupUseSnippetSwitch as SetupUseSnippetSwitchGA4 } from '../../../analytics-4/components/setup';
 const { useSelect, useDispatch } = Data;
 
 export default function SetupFormGA4() {

--- a/assets/js/modules/analytics/components/setup/SetupFormGA4Transitional.js
+++ b/assets/js/modules/analytics/components/setup/SetupFormGA4Transitional.js
@@ -44,9 +44,9 @@ import {
 	ProfileNameTextField,
 	GA4PropertyNotice,
 	ExistingGTMPropertyNotice,
-	SetupUseSnippetSwitch as SetupUseSnippetSwitchUA,
 } from '../common';
-import { SetupUseSnippetSwitch as SetupUseSnippetSwitchGA4 } from '../../../analytics-4/components/common';
+import { SetupUseSnippetSwitch as SetupUseSnippetSwitchUA } from '../setup';
+import { SetupUseSnippetSwitch as SetupUseSnippetSwitchGA4 } from '../../../analytics-4/components/setup';
 const { useSelect } = Data;
 
 export default function SetupFormGA4Transitional() {

--- a/assets/js/modules/analytics/components/setup/SetupFormGA4Transitional.js
+++ b/assets/js/modules/analytics/components/setup/SetupFormGA4Transitional.js
@@ -45,7 +45,7 @@ import {
 	GA4PropertyNotice,
 	ExistingGTMPropertyNotice,
 } from '../common';
-import { SetupUseSnippetSwitch as SetupUseSnippetSwitchUA } from '../setup';
+import SetupUseSnippetSwitchUA from './SetupUseSnippetSwitch';
 import { SetupUseSnippetSwitch as SetupUseSnippetSwitchGA4 } from '../../../analytics-4/components/setup';
 const { useSelect } = Data;
 

--- a/assets/js/modules/analytics/components/setup/SetupFormLegacy.js
+++ b/assets/js/modules/analytics/components/setup/SetupFormLegacy.js
@@ -35,8 +35,8 @@ import {
 	PropertySelect,
 	ProfileNameTextField,
 	GA4Notice,
-	SetupUseSnippetSwitch,
 } from '../common';
+import { SetupUseSnippetSwitch } from '../setup';
 const { useSelect } = Data;
 
 export default function SetupFormLegacy() {

--- a/assets/js/modules/analytics/components/setup/SetupFormLegacy.js
+++ b/assets/js/modules/analytics/components/setup/SetupFormLegacy.js
@@ -36,7 +36,7 @@ import {
 	ProfileNameTextField,
 	GA4Notice,
 } from '../common';
-import { SetupUseSnippetSwitch } from '../setup';
+import SetupUseSnippetSwitch from './SetupUseSnippetSwitch';
 const { useSelect } = Data;
 
 export default function SetupFormLegacy() {

--- a/assets/js/modules/analytics/components/setup/SetupFormUA.js
+++ b/assets/js/modules/analytics/components/setup/SetupFormUA.js
@@ -37,7 +37,6 @@ import {
 	ProfileSelect,
 	PropertySelect,
 	ProfileNameTextField,
-	SetupUseSnippetSwitch as SetupUseSnippetSwitchUA,
 } from '../common';
 import {
 	MODULES_ANALYTICS,
@@ -50,7 +49,8 @@ import {
 } from '../../../analytics-4/datastore/constants';
 import GA4PropertyNotice from '../common/GA4PropertyNotice';
 import StoreErrorNotices from '../../../../components/StoreErrorNotices';
-import { SetupUseSnippetSwitch as SetupUseSnippetSwitchGA4 } from '../../../analytics-4/components/common';
+import { SetupUseSnippetSwitch as SetupUseSnippetSwitchUA } from '../setup';
+import { SetupUseSnippetSwitch as SetupUseSnippetSwitchGA4 } from '../../../analytics-4/components/setup';
 
 const { useSelect, useDispatch } = Data;
 

--- a/assets/js/modules/analytics/components/setup/SetupFormUA.js
+++ b/assets/js/modules/analytics/components/setup/SetupFormUA.js
@@ -49,7 +49,7 @@ import {
 } from '../../../analytics-4/datastore/constants';
 import GA4PropertyNotice from '../common/GA4PropertyNotice';
 import StoreErrorNotices from '../../../../components/StoreErrorNotices';
-import { SetupUseSnippetSwitch as SetupUseSnippetSwitchUA } from '../setup';
+import SetupUseSnippetSwitchUA from './SetupUseSnippetSwitch';
 import { SetupUseSnippetSwitch as SetupUseSnippetSwitchGA4 } from '../../../analytics-4/components/setup';
 
 const { useSelect, useDispatch } = Data;

--- a/assets/js/modules/analytics/components/setup/SetupUseSnippetSwitch.js
+++ b/assets/js/modules/analytics/components/setup/SetupUseSnippetSwitch.js
@@ -27,7 +27,7 @@ import { __, sprintf } from '@wordpress/i18n';
  */
 import Data from 'googlesitekit-data';
 import { MODULES_ANALYTICS } from '../../datastore/constants';
-import UseSnippetSwitch from './UseSnippetSwitch';
+import UseSnippetSwitch from '../common/UseSnippetSwitch';
 const { useSelect } = Data;
 
 export default function SetupUseSnippetSwitch() {

--- a/assets/js/modules/tagmanager/components/common/index.js
+++ b/assets/js/modules/tagmanager/components/common/index.js
@@ -25,7 +25,6 @@ export { default as ContainerNameTextField } from './ContainerNameTextField';
 export { default as ContainerSelect } from './ContainerSelect';
 export { default as FormInstructions } from './FormInstructions';
 export { default as SettingsUseSnippetSwitch } from './SettingsUseSnippetSwitch';
-export { default as SetupUseSnippetSwitch } from './SetupUseSnippetSwitch';
 export { default as TagCheckProgress } from './TagCheckProgress';
 export { default as UseSnippetSwitch } from './UseSnippetSwitch';
 export { default as WebContainerNameTextField } from './WebContainerNameTextField';

--- a/assets/js/modules/tagmanager/components/common/index.js
+++ b/assets/js/modules/tagmanager/components/common/index.js
@@ -24,7 +24,6 @@ export { default as ContainerNames } from './ContainerNames';
 export { default as ContainerNameTextField } from './ContainerNameTextField';
 export { default as ContainerSelect } from './ContainerSelect';
 export { default as FormInstructions } from './FormInstructions';
-export { default as SettingsUseSnippetSwitch } from './SettingsUseSnippetSwitch';
 export { default as TagCheckProgress } from './TagCheckProgress';
 export { default as UseSnippetSwitch } from './UseSnippetSwitch';
 export { default as WebContainerNameTextField } from './WebContainerNameTextField';

--- a/assets/js/modules/tagmanager/components/settings/SettingsForm.js
+++ b/assets/js/modules/tagmanager/components/settings/SettingsForm.js
@@ -25,11 +25,11 @@ import {
 	ContainerNames,
 	FormInstructions,
 	TagCheckProgress,
-	SettingsUseSnippetSwitch,
 	WebContainerSelect,
 } from '../common';
 import StoreErrorNotices from '../../../../components/StoreErrorNotices';
 import { MODULES_TAGMANAGER } from '../../datastore/constants';
+import SettingsUseSnippetSwitch from './SettingsUseSnippetSwitch';
 
 export default function SettingsForm() {
 	return (

--- a/assets/js/modules/tagmanager/components/settings/SettingsUseSnippetSwitch.js
+++ b/assets/js/modules/tagmanager/components/settings/SettingsUseSnippetSwitch.js
@@ -1,5 +1,5 @@
 /**
- * Analytics Settings Use Snippet Switch component.
+ * Tag Manager Settings Use Snippet Switch component.
  *
  * Site Kit by Google, Copyright 2022 Google LLC
  *
@@ -26,55 +26,34 @@ import { __, sprintf } from '@wordpress/i18n';
  * Internal dependencies
  */
 import Data from 'googlesitekit-data';
-import { MODULES_ANALYTICS } from '../../datastore/constants';
-import UseSnippetSwitch from './UseSnippetSwitch';
+import UseSnippetSwitch from '../common/UseSnippetSwitch';
+import { MODULES_TAGMANAGER } from '../../datastore/constants';
 const { useSelect } = Data;
 
 export default function SettingsUseSnippetSwitch() {
 	const useSnippet = useSelect( ( select ) =>
-		select( MODULES_ANALYTICS ).getUseSnippet()
+		select( MODULES_TAGMANAGER ).getUseSnippet()
 	);
-	const canUseSnippet = useSelect( ( select ) =>
-		select( MODULES_ANALYTICS ).getCanUseSnippet()
+
+	const primaryContainerID = useSelect( ( select ) =>
+		select( MODULES_TAGMANAGER ).getPrimaryContainerID()
 	);
 
 	const existingTag = useSelect( ( select ) =>
-		select( MODULES_ANALYTICS ).getExistingTag()
+		select( MODULES_TAGMANAGER ).getExistingTag()
 	);
-	const propertyID = useSelect( ( select ) =>
-		select( MODULES_ANALYTICS ).getPropertyID()
-	);
-
-	if ( canUseSnippet === undefined ) {
-		return null;
-	}
-
-	if ( canUseSnippet === false ) {
-		return (
-			<UseSnippetSwitch
-				description={
-					<p>
-						{ __(
-							'The code is controlled by the Tag Manager module.',
-							'google-site-kit'
-						) }
-					</p>
-				}
-			/>
-		);
-	}
 
 	let description;
 
 	if ( existingTag ) {
 		description =
-			existingTag === propertyID ? (
+			primaryContainerID === existingTag ? (
 				<Fragment>
 					<p>
 						{ sprintf(
 							/* translators: %s: existing tag ID */
 							__(
-								'A tag %s for the selected property already exists on the site.',
+								'A tag %s for the selected container already exists on the site.',
 								'google-site-kit'
 							),
 							existingTag
@@ -82,7 +61,7 @@ export default function SettingsUseSnippetSwitch() {
 					</p>
 					<p>
 						{ __(
-							'Make sure you remove it if you want to place the same UA tag via Site Kit, otherwise they will be duplicated.',
+							'Make sure you remove it if you want to place the same tag via Site Kit, otherwise they will be duplicated.',
 							'google-site-kit'
 						) }
 					</p>
@@ -101,7 +80,7 @@ export default function SettingsUseSnippetSwitch() {
 					</p>
 					<p>
 						{ __(
-							'If you prefer to collect data using that existing UA tag, please select the corresponding account and property above.',
+							'If you prefer to collect data using that existing tag, please select the corresponding account and property above.',
 							'google-site-kit'
 						) }
 					</p>
@@ -111,14 +90,14 @@ export default function SettingsUseSnippetSwitch() {
 		description = useSnippet ? (
 			<p>
 				{ __(
-					'Site Kit will add the UA code automatically.',
+					'Site Kit will add the code automatically.',
 					'google-site-kit'
 				) }
 			</p>
 		) : (
 			<p>
 				{ __(
-					'Site Kit will not add the UA code to your site.',
+					'Site Kit will not add the code to your site.',
 					'google-site-kit'
 				) }
 			</p>

--- a/assets/js/modules/tagmanager/components/settings/index.js
+++ b/assets/js/modules/tagmanager/components/settings/index.js
@@ -18,4 +18,5 @@
 
 export { default as SettingsEdit } from './SettingsEdit';
 export { default as SettingsForm } from './SettingsForm';
+export { default as SettingsUseSnippetSwitch } from './SettingsUseSnippetSwitch';
 export { default as SettingsView } from './SettingsView';

--- a/assets/js/modules/tagmanager/components/setup/SetupForm.js
+++ b/assets/js/modules/tagmanager/components/setup/SetupForm.js
@@ -45,14 +45,14 @@ import {
 	AccountSelect,
 	AMPContainerSelect,
 	ContainerNames,
+	FormInstructions,
 	WebContainerSelect,
 	TagCheckProgress,
-	SetupUseSnippetSwitch,
 } from '../common';
 import Button from '../../../../components/Button';
 import Link from '../../../../components/Link';
 import SetupErrorNotice from './SetupErrorNotice';
-import FormInstructions from '../common/FormInstructions';
+import SetupUseSnippetSwitch from './SetupUseSnippetSwitch';
 const { useSelect, useDispatch } = Data;
 
 export default function SetupForm( { finishSetup } ) {

--- a/assets/js/modules/tagmanager/components/setup/SetupUseSnippetSwitch.js
+++ b/assets/js/modules/tagmanager/components/setup/SetupUseSnippetSwitch.js
@@ -1,5 +1,5 @@
 /**
- * GA4 Setup Use Snippet Switch component.
+ * Tag Manager Setup Use Snippet Switch component.
  *
  * Site Kit by Google, Copyright 2022 Google LLC
  *
@@ -26,26 +26,27 @@ import { __, sprintf } from '@wordpress/i18n';
  * Internal dependencies
  */
 import Data from 'googlesitekit-data';
-import { MODULES_ANALYTICS_4 } from '../../datastore/constants';
-import UseSnippetSwitch from './UseSnippetSwitch';
+import { MODULES_TAGMANAGER } from '../../datastore/constants';
+import UseSnippetSwitch from '../common/UseSnippetSwitch';
 const { useSelect } = Data;
 
 export default function SetupUseSnippetSwitch() {
-	const existingTag = useSelect( ( select ) =>
-		select( MODULES_ANALYTICS_4 ).getExistingTag()
+	const primaryContainerID = useSelect( ( select ) =>
+		select( MODULES_TAGMANAGER ).getPrimaryContainerID()
 	);
-	const measurementID = useSelect( ( select ) =>
-		select( MODULES_ANALYTICS_4 ).getMeasurementID()
+
+	const existingTag = useSelect( ( select ) =>
+		select( MODULES_TAGMANAGER ).getExistingTag()
 	);
 
 	const description =
-		existingTag === measurementID ? (
+		primaryContainerID === existingTag ? (
 			<Fragment>
 				<p>
 					{ sprintf(
 						/* translators: %s: existing tag ID */
 						__(
-							'A tag %s for the selected property already exists on the site.',
+							'A tag %s for the selected container already exists on the site.',
 							'google-site-kit'
 						),
 						existingTag
@@ -53,7 +54,7 @@ export default function SetupUseSnippetSwitch() {
 				</p>
 				<p>
 					{ __(
-						'Make sure you remove it if you decide to place the same GA4 tag via Site Kit, otherwise they will be duplicated.',
+						'Make sure you remove it if you want to place the same tag via Site Kit, otherwise they will be duplicated.',
 						'google-site-kit'
 					) }
 				</p>
@@ -72,7 +73,7 @@ export default function SetupUseSnippetSwitch() {
 				</p>
 				<p>
 					{ __(
-						'If you prefer to collect data using that existing GA4 tag, please select the corresponding account and property above.',
+						'If you prefer to collect data using that existing tag, please select the corresponding account and property above.',
 						'google-site-kit'
 					) }
 				</p>

--- a/assets/js/modules/tagmanager/components/setup/index.js
+++ b/assets/js/modules/tagmanager/components/setup/index.js
@@ -19,3 +19,4 @@
 export { default as SetupErrorNotice } from './SetupErrorNotice';
 export { default as SetupForm } from './SetupForm';
 export { default as SetupMain } from './SetupMain';
+export { default as SetupUseSnippetSwitch } from './SetupUseSnippetSwitch';


### PR DESCRIPTION
## Summary

Addresses issue:

- #5204 

## Relevant technical choices

* This PR just moves `SetupUseSnippetSwitch` and `SettingsUseSnippetSwitch` components into their respective `setup` or `settings` directories rather than living on `common` components which are not specific to either.

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [ ] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
