### PR TITLE
Refine copy of skip to view-only dashboard button

### DIFF
--- a/assets/js/components/setup/SetupUsingProxyWithSignIn.js
+++ b/assets/js/components/setup/SetupUsingProxyWithSignIn.js
@@ -360,7 +360,7 @@ export default function SetupUsingProxyWithSignIn() {
 																			inherit
 																		>
 																			{ __(
-																				'Go to dashboard',
+																				'Skip sign-in and view limited dashboard',
 																				'google-site-kit'
 																			) }
 																		</Link>


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #5176 

## Relevant technical choices

In the `<SetupUsingProxyWithSignIn />` component (`assets/js/components/setup/SetupUsingProxyWithSignIn.js`), this PR changes the copy of the secondary CTA responsible for skipping to the view-only dashboard from "Go to Dashboard" to "Skip sign-in and view limited dashboard".

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [x] Run the code.
- [x] Ensure the acceptance criteria are satisfied.
- [x] Reassess the implementation with the IB.
- [x] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [x] Check Storybook where applicable.
- [x] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [x] Ensure the PR has the correct target branch.
- [x] Double-check that the PR is okay to be merged.
- [x] Ensure the corresponding issue has a ZenHub release assigned.
- [x] Add a changelog message to the issue.
