### PR TITLE
Remove tracking of legacy `search_console_error` event

### DIFF
--- a/assets/js/components/wp-dashboard/WPDashboardClicks.js
+++ b/assets/js/components/wp-dashboard/WPDashboardClicks.js
@@ -20,7 +20,6 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useEffect } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -32,7 +31,7 @@ import {
 } from '../../modules/search-console/datastore/constants';
 import { CORE_USER } from '../../googlesitekit/datastore/user/constants';
 import { isZeroReport } from '../../modules/search-console/util';
-import { calculateChange, trackEvent } from '../../util';
+import { calculateChange } from '../../util';
 import sumObjectListValue from '../../util/sum-object-list-value';
 import { partitionReport } from '../../util/partition-report';
 import DataBlock from '../DataBlock';
@@ -77,12 +76,6 @@ const WPDashboardClicks = ( { WidgetReportZero, WidgetReportError } ) => {
 				MODULES_SEARCH_CONSOLE
 			).hasFinishedResolution( 'getReport', [ reportArgs ] )
 	);
-
-	useEffect( () => {
-		if ( error ) {
-			trackEvent( 'plugin_setup', 'search_console_error', error.message );
-		}
-	}, [ error ] );
 
 	if ( loading || isGatheringData === undefined ) {
 		return <PreviewBlock width="48%" height="92px" />;

--- a/assets/js/components/wp-dashboard/WPDashboardImpressions.js
+++ b/assets/js/components/wp-dashboard/WPDashboardImpressions.js
@@ -19,7 +19,6 @@
 /**
  * WordPress dependencies
  */
-import { useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -35,7 +34,7 @@ import { isZeroReport } from '../../modules/search-console/util';
 import DataBlock from '../DataBlock';
 import PreviewBlock from '../PreviewBlock';
 import { NOTICE_STYLE } from '../GatheringDataNotice';
-import { calculateChange, trackEvent } from '../../util';
+import { calculateChange } from '../../util';
 import sumObjectListValue from '../../util/sum-object-list-value';
 import { partitionReport } from '../../util/partition-report';
 import { useFeature } from '../../hooks/useFeature';
@@ -77,12 +76,6 @@ const WPDashboardImpressions = ( { WidgetReportZero, WidgetReportError } ) => {
 				MODULES_SEARCH_CONSOLE
 			).hasFinishedResolution( 'getReport', [ reportArgs ] )
 	);
-
-	useEffect( () => {
-		if ( error ) {
-			trackEvent( 'plugin_setup', 'search_console_error', error.message );
-		}
-	}, [ error ] );
 
 	if ( loading || isGatheringData === undefined ) {
 		return <PreviewBlock width="48%" height="92px" />;

--- a/assets/js/modules/search-console/components/dashboard/DashboardClicksWidget.js
+++ b/assets/js/modules/search-console/components/dashboard/DashboardClicksWidget.js
@@ -33,7 +33,6 @@ import { CORE_SITE } from '../../../../googlesitekit/datastore/site/constants';
 import { CORE_USER } from '../../../../googlesitekit/datastore/user/constants';
 import extractForSparkline from '../../../../util/extract-for-sparkline';
 import { untrailingslashit, calculateChange } from '../../../../util';
-import { trackEvent } from '../../../../util/tracking';
 import { isZeroReport } from '../../util';
 import whenActive from '../../../../util/when-active';
 import DataBlock from '../../../../components/DataBlock';
@@ -113,7 +112,6 @@ function DashboardClicksWidget( { WidgetReportZero, WidgetReportError } ) {
 	);
 
 	if ( error ) {
-		trackEvent( 'plugin_setup', 'search_console_error', error.message );
 		return (
 			<WidgetReportError moduleSlug="search-console" error={ error } />
 		);

--- a/assets/js/modules/search-console/components/dashboard/DashboardImpressionsWidget.js
+++ b/assets/js/modules/search-console/components/dashboard/DashboardImpressionsWidget.js
@@ -34,7 +34,6 @@ import { CORE_USER } from '../../../../googlesitekit/datastore/user/constants';
 import { isZeroReport } from '../../util';
 import { calculateChange, untrailingslashit } from '../../../../util';
 import extractForSparkline from '../../../../util/extract-for-sparkline';
-import { trackEvent } from '../../../../util/tracking';
 import whenActive from '../../../../util/when-active';
 import DataBlock from '../../../../components/DataBlock';
 import Sparkline from '../../../../components/Sparkline';
@@ -113,7 +112,6 @@ function DashboardImpressionsWidget( { WidgetReportZero, WidgetReportError } ) {
 	);
 
 	if ( error ) {
-		trackEvent( 'plugin_setup', 'search_console_error', error.message );
 		return (
 			<WidgetReportError moduleSlug="search-console" error={ error } />
 		);


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #5116 

## Relevant technical choices

This PR simply removes `trackEvent` calls with `search_console_error` as the second argument, from the following locations:

- `assets/js/components/wp-dashboard/WPDashboardClicks.js`
- `assets/js/components/wp-dashboard/WPDashboardImpressions.js`
- `assets/js/modules/search-console/components/dashboard/DashboardClicksWidget.js`
- `assets/js/modules/search-console/components/dashboard/DashboardImpressionsWidget.js`

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [x] Run the code.
- [x] Ensure the acceptance criteria are satisfied.
- [x] Reassess the implementation with the IB.
- [x] Ensure no unrelated changes are included.
- [x] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [x] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
