### PR TITLE
Fix content overlap inside PageSpeed widget on mobile

### DIFF
--- a/assets/sass/components/dashboard/_googlesitekit-DashboardPageSpeed.scss
+++ b/assets/sass/components/dashboard/_googlesitekit-DashboardPageSpeed.scss
@@ -118,6 +118,20 @@
 		}
 	}
 
+	.googlesitekit-pagespeed-report__footer {
+		gap: 16px;
+		justify-content: flex-end;
+		padding-top: 0;
+
+		p {
+			text-align: right;
+		}
+
+		&--with-action {
+			justify-content: space-between;
+		}
+	}
+
 	.googlesitekit-pagespeed-report__row,
 	.googlesitekit-pagespeed-report__footer {
 		align-items: center;
@@ -204,15 +218,6 @@
 			.googlesitekit-accordion:last-child {
 				margin-bottom: $grid-gap-desktop;
 			}
-		}
-	}
-
-	.googlesitekit-pagespeed-report__footer {
-		justify-content: flex-end;
-		padding-top: 0;
-
-		&--with-action {
-			justify-content: space-between;
 		}
 	}
 }


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #4497 

## Relevant technical choices

This PR sets `gap` to `16px` for `.googlesitekit-pagespeed-report__footer` and `text-align` to `right` for `.googlesitekit-pagespeed-report__footer p` in `assets/sass/components/dashboard/_googlesitekit-DashboardPageSpeed.scss`.

**Note:** Re-ordered the selector to fix the `no-descending-specificity` error from StyleLint.

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [x] Run the code.
- [x] Ensure the acceptance criteria are satisfied.
- [x] Reassess the implementation with the IB.
- [x] Ensure no unrelated changes are included.
- [x] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [x] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
