### PR TITLE
Include plugin name in non Site Kit page notices

### DIFF
--- a/includes/Core/Authentication/Authentication.php
+++ b/includes/Core/Authentication/Authentication.php
@@ -1056,7 +1056,7 @@ final class Authentication {
 					$current_url   = $this->context->get_canonical_home_url();
 					$content       = sprintf(
 						'<p>%s <a href="%s">%s</a></p>',
-						esc_html__( 'Looks like the URL of your site has changed. In order to continue using Site Kit, you’ll need to reconnect, so that your plugin settings are updated with the new URL.', 'google-site-kit' ),
+						esc_html__( 'Site Kit by Google: Looks like the URL of your site has changed. In order to continue using Site Kit, you’ll need to reconnect, so that your plugin settings are updated with the new URL.', 'google-site-kit' ),
 						esc_url( $this->get_proxy_setup_url() ),
 						esc_html__( 'Reconnect', 'google-site-kit' )
 					);
@@ -1105,7 +1105,7 @@ final class Authentication {
 					ob_start();
 					?>
 					<p>
-						<?php esc_html_e( 'You need to reauthenticate your Google account.', 'google-site-kit' ); ?>
+						<?php esc_html_e( 'Site Kit by Google: You need to reauthenticate your Google account.', 'google-site-kit' ); ?>
 						<a
 							href="#"
 							onclick="clearSiteKitAppStorage()"
@@ -1170,7 +1170,11 @@ final class Authentication {
 						return '';
 					}
 
-					$message = $auth_client->get_error_message( $error_code );
+					$message = sprintf(
+						/* translators: %s: Error message */
+						esc_html__( 'Site Kit by Google: %s', 'google-site-kit' ),
+						$auth_client->get_error_message( $error_code )
+					);
 
 					$access_code = $this->user_options->get( OAuth_Client::OPTION_PROXY_ACCESS_CODE );
 

--- a/includes/Modules/Idea_Hub.php
+++ b/includes/Modules/Idea_Hub.php
@@ -313,7 +313,7 @@ final class Idea_Hub extends Module
 				'content'         => function() use ( $escape_and_wrap_notice_content ) {
 					$message = sprintf(
 						/* translators: %s: URL to saved ideas */
-						__( 'Want some inspiration for a new post? <a href="%s">Revisit your saved ideas</a> in Site Kit.', 'google-site-kit' ),
+						__( 'Site Kit by Google: Want some inspiration for a new post? <a href="%s">Revisit your saved ideas</a> in Site Kit.', 'google-site-kit' ),
 						esc_url( $this->context->admin_url( 'dashboard', array( 'idea-hub-tab' => 'saved-ideas' ) ) )
 					);
 
@@ -349,7 +349,7 @@ final class Idea_Hub extends Module
 				'content'         => function() use ( $escape_and_wrap_notice_content ) {
 					$message = sprintf(
 						/* translators: %s: URL to new ideas */
-						__( 'Want some inspiration for a new post? <a href="%s">Review your new ideas</a> in Site Kit.', 'google-site-kit' ),
+						__( 'Site Kit by Google: Want some inspiration for a new post? <a href="%s">Review your new ideas</a> in Site Kit.', 'google-site-kit' ),
 						esc_url( $this->context->admin_url( 'dashboard', array( 'idea-hub-tab' => 'new-ideas' ) ) )
 					);
 


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #4721 

## Relevant technical choices

This PR updates all notices in the `Authentication` and `Idea_Hub` classes to have the "Site Kit by Google:" prefix before the content of the notice. These prefixes, like the rest of the notices, are localised as well.

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
