### PR TITLE
Make sure only the visible portion of the sub-action clickable

### DIFF
--- a/assets/sass/components/setup/_googlesitekit-setup-module.scss
+++ b/assets/sass/components/setup/_googlesitekit-setup-module.scss
@@ -182,7 +182,6 @@
 
 	.googlesitekit-setup-module__sub-action {
 		display: flex;
-		flex: 1 1 auto;
 		margin-top: $grid-gap-phone;
 
 		@media (min-width: $bp-tablet) {


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #5068 

## Relevant technical choices

This PR removes the `flex: 1 1 auto` property from `.googlesitekit-setup-module__sub-action` in `_googlesitekit-setup-module.scss`.

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
