### PR TITLE
Fix the shape of sharing settings response to always be an object.

### DIFF
--- a/includes/Core/Modules/REST_Dashboard_Sharing_Controller.php
+++ b/includes/Core/Modules/REST_Dashboard_Sharing_Controller.php
@@ -95,7 +95,9 @@ class REST_Dashboard_Sharing_Controller {
 						return new WP_REST_Response(
 							array(
 								'settings'    => $new_sharing_settings,
-								'newOwnerIDs' => $changed_module_owners,
+								// Cast array to an object so JSON encoded response is always an object,
+								// even when the array is empty.
+								'newOwnerIDs' => (object) $changed_module_owners,
 							)
 						);
 					},

--- a/tests/phpunit/integration/Core/Modules/REST_Dashboard_Sharing_ControllerTest.php
+++ b/tests/phpunit/integration/Core/Modules/REST_Dashboard_Sharing_ControllerTest.php
@@ -149,7 +149,7 @@ class REST_Dashboard_Sharing_ControllerTest extends TestCase {
 		);
 		$expected_response = array(
 			'settings'    => $expected_sharing_settings,
-			'newOwnerIDs' => array(
+			'newOwnerIDs' => (object) array(
 				// ownerID should be updated as settings have changed.
 				'pagespeed-insights' => $admin_2->ID,
 			),


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #4481

## Relevant technical choices

<!-- Please describe your changes. -->

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [x] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [x] Ensure no unrelated changes are included.
- [x] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [x] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
