### PR TITLE
Translate plugin name separately

### DIFF
--- a/includes/Core/Authentication/Authentication.php
+++ b/includes/Core/Authentication/Authentication.php
@@ -1057,7 +1057,7 @@ final class Authentication {
 					$content       = '<p>' . sprintf(
 						/* translators: %1$s: Plugin name. %2$s: Notice content. %3$s: Proxy setup URL. %4$s: Reconnect string. */
 						__( '%1$s: %2$s <a href="%3$s">%4$s</a>', 'google-site-kit' ),
-						get_plugin_data( GOOGLESITEKIT_PLUGIN_MAIN_FILE )['Name'],
+						esc_html__( 'Site Kit by Google', 'google-site-kit' ),
 						esc_html__( 'Looks like the URL of your site has changed. In order to continue using Site Kit, you’ll need to reconnect, so that your plugin settings are updated with the new URL.', 'google-site-kit' ),
 						esc_url( $this->get_proxy_setup_url() ),
 						esc_html__( 'Reconnect', 'google-site-kit' )
@@ -1112,7 +1112,7 @@ final class Authentication {
 								sprintf(
 									/* translators: %1$s: Plugin name. %2$s: Notice content. */
 									__( '%1$s: %2$s', 'google-site-kit' ),
-									get_plugin_data( GOOGLESITEKIT_PLUGIN_MAIN_FILE )['Name'],
+									__( 'Site Kit by Google', 'google-site-kit' ),
 									esc_html__( 'You need to reauthenticate your Google account.', 'google-site-kit' )
 								)
 							);
@@ -1184,7 +1184,7 @@ final class Authentication {
 					$message = sprintf(
 						/* translators: %1$s: Plugin name. %2$s: Error message. */
 						__( '%1$s: %2$s', 'google-site-kit' ),
-						get_plugin_data( GOOGLESITEKIT_PLUGIN_MAIN_FILE )['Name'],
+						esc_html__( 'Site Kit by Google', 'google-site-kit' ),
 						$auth_client->get_error_message( $error_code )
 					);
 

--- a/includes/Core/Authentication/Authentication.php
+++ b/includes/Core/Authentication/Authentication.php
@@ -1184,7 +1184,7 @@ final class Authentication {
 					$message = sprintf(
 						/* translators: %1$s: Plugin name. %2$s: Message. */
 						__( '%1$s: %2$s', 'google-site-kit' ),
-						esc_html__( 'Site Kit by Google', 'google-site-kit' ),
+						__( 'Site Kit by Google', 'google-site-kit' ),
 						$auth_client->get_error_message( $error_code )
 					);
 

--- a/includes/Core/Authentication/Authentication.php
+++ b/includes/Core/Authentication/Authentication.php
@@ -1055,7 +1055,7 @@ final class Authentication {
 					$connected_url = $this->connected_proxy_url->get();
 					$current_url   = $this->context->get_canonical_home_url();
 					$content       = '<p>' . sprintf(
-						/* translators: %1$s: Plugin name. %2$s: Notice content. %3$s: Proxy setup URL. %4$s: Reconnect string. */
+						/* translators: %1$s: Plugin name. %2$s: Message. %3$s: Proxy setup URL. %4$s: Reconnect string. */
 						__( '%1$s: %2$s <a href="%3$s">%4$s</a>', 'google-site-kit' ),
 						esc_html__( 'Site Kit by Google', 'google-site-kit' ),
 						esc_html__( 'Looks like the URL of your site has changed. In order to continue using Site Kit, you’ll need to reconnect, so that your plugin settings are updated with the new URL.', 'google-site-kit' ),
@@ -1110,7 +1110,7 @@ final class Authentication {
 						<?php
 							echo esc_html(
 								sprintf(
-									/* translators: %1$s: Plugin name. %2$s: Notice content. */
+									/* translators: %1$s: Plugin name. %2$s: Message. */
 									__( '%1$s: %2$s', 'google-site-kit' ),
 									__( 'Site Kit by Google', 'google-site-kit' ),
 									__( 'You need to reauthenticate your Google account.', 'google-site-kit' )
@@ -1182,7 +1182,7 @@ final class Authentication {
 					}
 
 					$message = sprintf(
-						/* translators: %1$s: Plugin name. %2$s: Error message. */
+						/* translators: %1$s: Plugin name. %2$s: Message. */
 						__( '%1$s: %2$s', 'google-site-kit' ),
 						esc_html__( 'Site Kit by Google', 'google-site-kit' ),
 						$auth_client->get_error_message( $error_code )

--- a/includes/Core/Authentication/Authentication.php
+++ b/includes/Core/Authentication/Authentication.php
@@ -1054,12 +1054,14 @@ final class Authentication {
 				'content'         => function() {
 					$connected_url = $this->connected_proxy_url->get();
 					$current_url   = $this->context->get_canonical_home_url();
-					$content       = sprintf(
-						'<p>%s <a href="%s">%s</a></p>',
-						esc_html__( 'Site Kit by Google: Looks like the URL of your site has changed. In order to continue using Site Kit, you’ll need to reconnect, so that your plugin settings are updated with the new URL.', 'google-site-kit' ),
+					$content       = '<p>' . sprintf(
+						/* translators: %1$s: Plugin name. %2$s: Notice content. %3$s: Proxy setup URL. %4$s: Reconnect string. */
+						__( '%1$s: %2$s <a href="%3$s">%4$s</a>', 'google-site-kit' ),
+						get_plugin_data( GOOGLESITEKIT_PLUGIN_MAIN_FILE )['Name'],
+						esc_html__( 'Looks like the URL of your site has changed. In order to continue using Site Kit, you’ll need to reconnect, so that your plugin settings are updated with the new URL.', 'google-site-kit' ),
 						esc_url( $this->get_proxy_setup_url() ),
 						esc_html__( 'Reconnect', 'google-site-kit' )
-					);
+					) . '</p>';
 
 					// Only show the comparison if URLs don't match as it is possible
 					// they could already match again at this point, although they most likely won't.
@@ -1105,7 +1107,16 @@ final class Authentication {
 					ob_start();
 					?>
 					<p>
-						<?php esc_html_e( 'Site Kit by Google: You need to reauthenticate your Google account.', 'google-site-kit' ); ?>
+						<?php
+							echo esc_html(
+								sprintf(
+									/* translators: %1$s: Plugin name. %2$s: Notice content. */
+									__( '%1$s: %2$s', 'google-site-kit' ),
+									get_plugin_data( GOOGLESITEKIT_PLUGIN_MAIN_FILE )['Name'],
+									esc_html__( 'You need to reauthenticate your Google account.', 'google-site-kit' )
+								)
+							);
+						?>
 						<a
 							href="#"
 							onclick="clearSiteKitAppStorage()"
@@ -1171,8 +1182,9 @@ final class Authentication {
 					}
 
 					$message = sprintf(
-						/* translators: %s: Error message */
-						esc_html__( 'Site Kit by Google: %s', 'google-site-kit' ),
+						/* translators: %1$s: Plugin name. %2$s: Error message. */
+						__( '%1$s: %2$s', 'google-site-kit' ),
+						get_plugin_data( GOOGLESITEKIT_PLUGIN_MAIN_FILE )['Name'],
 						$auth_client->get_error_message( $error_code )
 					);
 

--- a/includes/Core/Authentication/Authentication.php
+++ b/includes/Core/Authentication/Authentication.php
@@ -1055,7 +1055,7 @@ final class Authentication {
 					$connected_url = $this->connected_proxy_url->get();
 					$current_url   = $this->context->get_canonical_home_url();
 					$content       = '<p>' . sprintf(
-						/* translators: %1$s: Plugin name. %2$s: Message. %3$s: Proxy setup URL. %4$s: Reconnect string. */
+						/* translators: 1: Plugin name. 2: Message. 3: Proxy setup URL. 4: Reconnect string. */
 						__( '%1$s: %2$s <a href="%3$s">%4$s</a>', 'google-site-kit' ),
 						esc_html__( 'Site Kit by Google', 'google-site-kit' ),
 						esc_html__( 'Looks like the URL of your site has changed. In order to continue using Site Kit, you’ll need to reconnect, so that your plugin settings are updated with the new URL.', 'google-site-kit' ),
@@ -1110,7 +1110,7 @@ final class Authentication {
 						<?php
 							echo esc_html(
 								sprintf(
-									/* translators: %1$s: Plugin name. %2$s: Message. */
+									/* translators: 1: Plugin name. 2: Message. */
 									__( '%1$s: %2$s', 'google-site-kit' ),
 									__( 'Site Kit by Google', 'google-site-kit' ),
 									__( 'You need to reauthenticate your Google account.', 'google-site-kit' )
@@ -1182,7 +1182,7 @@ final class Authentication {
 					}
 
 					$message = sprintf(
-						/* translators: %1$s: Plugin name. %2$s: Message. */
+						/* translators: 1: Plugin name. 2: Message. */
 						__( '%1$s: %2$s', 'google-site-kit' ),
 						__( 'Site Kit by Google', 'google-site-kit' ),
 						$auth_client->get_error_message( $error_code )

--- a/includes/Core/Authentication/Authentication.php
+++ b/includes/Core/Authentication/Authentication.php
@@ -1113,7 +1113,7 @@ final class Authentication {
 									/* translators: %1$s: Plugin name. %2$s: Notice content. */
 									__( '%1$s: %2$s', 'google-site-kit' ),
 									__( 'Site Kit by Google', 'google-site-kit' ),
-									esc_html__( 'You need to reauthenticate your Google account.', 'google-site-kit' )
+									__( 'You need to reauthenticate your Google account.', 'google-site-kit' )
 								)
 							);
 						?>

--- a/includes/Modules/Idea_Hub.php
+++ b/includes/Modules/Idea_Hub.php
@@ -311,15 +311,17 @@ final class Idea_Hub extends Module
 			self::SLUG_SAVED_IDEAS,
 			array(
 				'content'         => function() use ( $escape_and_wrap_notice_content ) {
+					$message_body = sprintf(
+						/* translators: %s: URL to saved ideas */
+						__( 'Want some inspiration for a new post? <a href="%s">Revisit your saved ideas</a> in Site Kit.', 'google-site-kit' ),
+						esc_url( $this->context->admin_url( 'dashboard', array( 'idea-hub-tab' => 'saved-ideas' ) ) )
+					);
+
 					$message = sprintf(
 						/* translators: %1$s: Plugin name. %2$s: Notice content. */
 						__( '%1$s: %2$s', 'google-site-kit' ),
-						get_plugin_data( GOOGLESITEKIT_PLUGIN_MAIN_FILE )['Name'],
-						sprintf(
-							/* translators: %s: URL to saved ideas */
-							__( 'Want some inspiration for a new post? <a href="%s">Revisit your saved ideas</a> in Site Kit.', 'google-site-kit' ),
-							esc_url( $this->context->admin_url( 'dashboard', array( 'idea-hub-tab' => 'saved-ideas' ) ) )
-						)
+						__( 'Site Kit by Google', 'google-site-kit' ),
+						$message_body
 					);
 
 					return $escape_and_wrap_notice_content( $message );
@@ -352,15 +354,17 @@ final class Idea_Hub extends Module
 			self::SLUG_NEW_IDEAS,
 			array(
 				'content'         => function() use ( $escape_and_wrap_notice_content ) {
+					$message_body = sprintf(
+						/* translators: %s: URL to saved ideas */
+						__( 'Want some inspiration for a new post? <a href="%s">Review your new ideas</a> in Site Kit.', 'google-site-kit' ),
+						esc_url( $this->context->admin_url( 'dashboard', array( 'idea-hub-tab' => 'new-ideas' ) ) )
+					);
+
 					$message = sprintf(
 						/* translators: %1$s: Plugin name. %2$s: Notice content. */
 						__( '%1$s: %2$s', 'google-site-kit' ),
-						get_plugin_data( GOOGLESITEKIT_PLUGIN_MAIN_FILE )['Name'],
-						sprintf(
-							/* translators: %s: URL to saved ideas */
-							__( 'Want some inspiration for a new post? <a href="%s">Review your new ideas</a> in Site Kit.', 'google-site-kit' ),
-							esc_url( $this->context->admin_url( 'dashboard', array( 'idea-hub-tab' => 'new-ideas' ) ) )
-						)
+						__( 'Site Kit by Google', 'google-site-kit' ),
+						$message_body
 					);
 
 					return $escape_and_wrap_notice_content( $message );

--- a/includes/Modules/Idea_Hub.php
+++ b/includes/Modules/Idea_Hub.php
@@ -312,9 +312,14 @@ final class Idea_Hub extends Module
 			array(
 				'content'         => function() use ( $escape_and_wrap_notice_content ) {
 					$message = sprintf(
-						/* translators: %s: URL to saved ideas */
-						__( 'Site Kit by Google: Want some inspiration for a new post? <a href="%s">Revisit your saved ideas</a> in Site Kit.', 'google-site-kit' ),
-						esc_url( $this->context->admin_url( 'dashboard', array( 'idea-hub-tab' => 'saved-ideas' ) ) )
+						/* translators: %1$s: Plugin name. %2$s: Notice content. */
+						__( '%1$s: %2$s', 'google-site-kit' ),
+						get_plugin_data( GOOGLESITEKIT_PLUGIN_MAIN_FILE )['Name'],
+						sprintf(
+							/* translators: %s: URL to saved ideas */
+							__( 'Want some inspiration for a new post? <a href="%s">Revisit your saved ideas</a> in Site Kit.', 'google-site-kit' ),
+							esc_url( $this->context->admin_url( 'dashboard', array( 'idea-hub-tab' => 'saved-ideas' ) ) )
+						)
 					);
 
 					return $escape_and_wrap_notice_content( $message );
@@ -348,9 +353,14 @@ final class Idea_Hub extends Module
 			array(
 				'content'         => function() use ( $escape_and_wrap_notice_content ) {
 					$message = sprintf(
-						/* translators: %s: URL to new ideas */
-						__( 'Site Kit by Google: Want some inspiration for a new post? <a href="%s">Review your new ideas</a> in Site Kit.', 'google-site-kit' ),
-						esc_url( $this->context->admin_url( 'dashboard', array( 'idea-hub-tab' => 'new-ideas' ) ) )
+						/* translators: %1$s: Plugin name. %2$s: Notice content. */
+						__( '%1$s: %2$s', 'google-site-kit' ),
+						get_plugin_data( GOOGLESITEKIT_PLUGIN_MAIN_FILE )['Name'],
+						sprintf(
+							/* translators: %s: URL to saved ideas */
+							__( 'Want some inspiration for a new post? <a href="%s">Review your new ideas</a> in Site Kit.', 'google-site-kit' ),
+							esc_url( $this->context->admin_url( 'dashboard', array( 'idea-hub-tab' => 'new-ideas' ) ) )
+						)
 					);
 
 					return $escape_and_wrap_notice_content( $message );

--- a/includes/Modules/Idea_Hub.php
+++ b/includes/Modules/Idea_Hub.php
@@ -318,7 +318,7 @@ final class Idea_Hub extends Module
 					);
 
 					$message = sprintf(
-						/* translators: %1$s: Plugin name. %2$s: Notice content. */
+						/* translators: 1: Plugin name. 2: Notice content. */
 						__( '%1$s: %2$s', 'google-site-kit' ),
 						__( 'Site Kit by Google', 'google-site-kit' ),
 						$message_body
@@ -361,7 +361,7 @@ final class Idea_Hub extends Module
 					);
 
 					$message = sprintf(
-						/* translators: %1$s: Plugin name. %2$s: Notice content. */
+						/* translators: 1: Plugin name. 2: Notice content. */
 						__( '%1$s: %2$s', 'google-site-kit' ),
 						__( 'Site Kit by Google', 'google-site-kit' ),
 						$message_body

--- a/includes/Modules/Idea_Hub.php
+++ b/includes/Modules/Idea_Hub.php
@@ -318,7 +318,7 @@ final class Idea_Hub extends Module
 					);
 
 					$message = sprintf(
-						/* translators: 1: Plugin name. 2: Notice content. */
+						/* translators: 1: Plugin name. 2: Message. */
 						__( '%1$s: %2$s', 'google-site-kit' ),
 						__( 'Site Kit by Google', 'google-site-kit' ),
 						$message_body
@@ -361,7 +361,7 @@ final class Idea_Hub extends Module
 					);
 
 					$message = sprintf(
-						/* translators: 1: Plugin name. 2: Notice content. */
+						/* translators: 1: Plugin name. 2: Message. */
 						__( '%1$s: %2$s', 'google-site-kit' ),
 						__( 'Site Kit by Google', 'google-site-kit' ),
 						$message_body


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #4721 

## Relevant technical choices

This PR intends to address [this review](https://github.com/google/site-kit-wp/pull/5223/files#r877684691), i.e. translates the notice prefix and notice message separately. The idea is to keep the existing translated strings as they were before and just concatenate the already translated plugin name as the prefix, with translating the concatenation as well.

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
