### PR TITLE
Rename AdSense `GET:earnings` endpoint to `GET:report`

### DIFF
--- a/assets/js/modules/adsense/datastore/report.js
+++ b/assets/js/modules/adsense/datastore/report.js
@@ -40,7 +40,7 @@ import { validateDimensions, validateMetrics } from '../util/report-validation';
 const fetchGetReportStore = createFetchStore( {
 	baseName: 'getReport',
 	controlCallback: ( { options } ) => {
-		return API.get( 'modules', 'adsense', 'reports', options );
+		return API.get( 'modules', 'adsense', 'report', options );
 	},
 	reducerCallback: ( state, report, { options } ) => {
 		return {

--- a/assets/js/modules/adsense/datastore/report.js
+++ b/assets/js/modules/adsense/datastore/report.js
@@ -40,7 +40,7 @@ import { validateDimensions, validateMetrics } from '../util/report-validation';
 const fetchGetReportStore = createFetchStore( {
 	baseName: 'getReport',
 	controlCallback: ( { options } ) => {
-		return API.get( 'modules', 'adsense', 'earnings', options );
+		return API.get( 'modules', 'adsense', 'reports', options );
 	},
 	reducerCallback: ( state, report, { options } ) => {
 		return {

--- a/assets/js/modules/adsense/datastore/report.test.js
+++ b/assets/js/modules/adsense/datastore/report.test.js
@@ -62,7 +62,7 @@ describe( 'modules/adsense report', () => {
 				const report = getAdSenseMockResponse( options );
 
 				fetchMock.getOnce(
-					/^\/google-site-kit\/v1\/modules\/adsense\/data\/reports/,
+					/^\/google-site-kit\/v1\/modules\/adsense\/data\/report/,
 					{ body: report }
 				);
 

--- a/assets/js/modules/adsense/datastore/report.test.js
+++ b/assets/js/modules/adsense/datastore/report.test.js
@@ -112,7 +112,7 @@ describe( 'modules/adsense report', () => {
 					data: { status: 500 },
 				};
 				fetchMock.getOnce(
-					/^\/google-site-kit\/v1\/modules\/adsense\/data\/earnings/,
+					/^\/google-site-kit\/v1\/modules\/adsense\/data\/report/,
 					{ body: response, status: 500 }
 				);
 

--- a/assets/js/modules/adsense/datastore/report.test.js
+++ b/assets/js/modules/adsense/datastore/report.test.js
@@ -62,7 +62,7 @@ describe( 'modules/adsense report', () => {
 				const report = getAdSenseMockResponse( options );
 
 				fetchMock.getOnce(
-					/^\/google-site-kit\/v1\/modules\/adsense\/data\/earnings/,
+					/^\/google-site-kit\/v1\/modules\/adsense\/data\/reports/,
 					{ body: report }
 				);
 

--- a/includes/Modules/AdSense.php
+++ b/includes/Modules/AdSense.php
@@ -201,7 +201,7 @@ final class AdSense extends Module
 			'GET:accounts'      => array( 'service' => 'adsense' ),
 			'GET:alerts'        => array( 'service' => 'adsense' ),
 			'GET:clients'       => array( 'service' => 'adsense' ),
-			'GET:reports'       => array(
+			'GET:report'        => array(
 				'service'   => 'adsense',
 				'shareable' => Feature_Flags::enabled( 'dashboardSharing' ),
 			),
@@ -264,7 +264,7 @@ final class AdSense extends Module
 				}
 				$service = $this->get_service( 'adsense' );
 				return $service->accounts_adclients->listAccountsAdclients( self::normalize_account_id( $data['accountID'] ) );
-			case 'GET:reports':
+			case 'GET:report':
 				$start_date = $data['startDate'];
 				$end_date   = $data['endDate'];
 				if ( ! strtotime( $start_date ) || ! strtotime( $end_date ) ) {
@@ -396,7 +396,7 @@ final class AdSense extends Module
 				return array_map( array( self::class, 'filter_client_with_ids' ), $response->getAdClients() );
 			case 'GET:urlchannels':
 				return $response->getUrlChannels();
-			case 'GET:reports':
+			case 'GET:report':
 				return $response;
 			case 'GET:sites':
 				return $response->getSites();

--- a/includes/Modules/AdSense.php
+++ b/includes/Modules/AdSense.php
@@ -201,7 +201,7 @@ final class AdSense extends Module
 			'GET:accounts'      => array( 'service' => 'adsense' ),
 			'GET:alerts'        => array( 'service' => 'adsense' ),
 			'GET:clients'       => array( 'service' => 'adsense' ),
-			'GET:earnings'      => array(
+			'GET:reports'       => array(
 				'service'   => 'adsense',
 				'shareable' => Feature_Flags::enabled( 'dashboardSharing' ),
 			),
@@ -264,7 +264,7 @@ final class AdSense extends Module
 				}
 				$service = $this->get_service( 'adsense' );
 				return $service->accounts_adclients->listAccountsAdclients( self::normalize_account_id( $data['accountID'] ) );
-			case 'GET:earnings':
+			case 'GET:reports':
 				$start_date = $data['startDate'];
 				$end_date   = $data['endDate'];
 				if ( ! strtotime( $start_date ) || ! strtotime( $end_date ) ) {
@@ -396,7 +396,7 @@ final class AdSense extends Module
 				return array_map( array( self::class, 'filter_client_with_ids' ), $response->getAdClients() );
 			case 'GET:urlchannels':
 				return $response->getUrlChannels();
-			case 'GET:earnings':
+			case 'GET:reports':
 				return $response;
 			case 'GET:sites':
 				return $response->getSites();

--- a/tests/phpunit/integration/Modules/AdSenseTest.php
+++ b/tests/phpunit/integration/Modules/AdSenseTest.php
@@ -393,7 +393,7 @@ class AdSenseTest extends TestCase {
 				'alerts',
 				'clients',
 				'urlchannels',
-				'reports',
+				'report',
 				'adunits',
 				'sites',
 			),

--- a/tests/phpunit/integration/Modules/AdSenseTest.php
+++ b/tests/phpunit/integration/Modules/AdSenseTest.php
@@ -393,7 +393,7 @@ class AdSenseTest extends TestCase {
 				'alerts',
 				'clients',
 				'urlchannels',
-				'earnings',
+				'reports',
 				'adunits',
 				'sites',
 			),


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #4914 

## Relevant technical choices

- Renames `GET:earnings` to `GET:report` in `includes/Modules/AdSense.php`.
- Replaces `earnings` by `report` in `controlCallback` within `assets/js/modules/adsense/datastore/report.js`.
- Updates tests (`tests/phpunit/integration/Modules/AdSenseTest.php` and `assets/js/modules/adsense/datastore/report.test.js`) to reflect above changes.

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [x] Run the code.
- [x] Ensure the acceptance criteria are satisfied.
- [x] Reassess the implementation with the IB.
- [x] Ensure no unrelated changes are included.
- [x] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [x] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [x] Ensure the PR has the correct target branch.
- [x] Double-check that the PR is okay to be merged.
- [x] Ensure the corresponding issue has a ZenHub release assigned.
- [x] Add a changelog message to the issue.
