### PR TITLE
Fix inconsistencies in Analytics exclusion settings

### DIFF
--- a/assets/js/modules/analytics/components/settings/SettingsView.js
+++ b/assets/js/modules/analytics/components/settings/SettingsView.js
@@ -165,7 +165,7 @@ export default function SettingsView() {
 						{ canUseSnippet === false && (
 							<span>
 								{ __(
-									'The code is controlled by the Tag Manager module.',
+									'The code is controlled by the Tag Manager module',
 									'google-site-kit'
 								) }
 							</span>
@@ -331,7 +331,7 @@ export default function SettingsView() {
 								) }
 						{ ! trackingDisabled.length &&
 							__(
-								'Analytics is currently enabled for all visitors.',
+								'Analytics is currently enabled for all visitors',
 								'google-site-kit'
 							) }
 					</p>

--- a/includes/Modules/Analytics/Settings.php
+++ b/includes/Modules/Analytics/Settings.php
@@ -214,7 +214,12 @@ class Settings extends Module_Settings implements Setting_With_Owned_Keys_Interf
 					$option['anonymizeIP'] = (bool) $option['anonymizeIP'];
 				}
 				if ( isset( $option['trackingDisabled'] ) ) {
-					$option['trackingDisabled'] = (array) $option['trackingDisabled'];
+					// Prevent other options from being saved if 'loggedinUsers' is selected.
+					if ( in_array( 'loggedinUsers', $option['trackingDisabled'], true ) ) {
+						$option['trackingDisabled'] = array( 'loggedinUsers' );
+					} else {
+						$option['trackingDisabled'] = (array) $option['trackingDisabled'];
+					}
 				}
 				if ( isset( $option['adsenseLinked'] ) ) {
 					$option['adsenseLinked'] = (bool) $option['adsenseLinked'];

--- a/tests/phpunit/integration/Modules/Analytics/SettingsTest.php
+++ b/tests/phpunit/integration/Modules/Analytics/SettingsTest.php
@@ -304,7 +304,6 @@ class SettingsTest extends SettingsTestCase {
 		$context  = new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE );
 		$settings = new Settings( new Options( $context ) );
 		$settings->register();
-		$analytics = new Analytics( $context );
 
 		// Defaults to `[ 'loggedinUsers' ]`
 		$this->assertEqualSets( array( 'loggedinUsers' ), $settings->get()['trackingDisabled'] );

--- a/tests/phpunit/integration/Modules/Analytics/SettingsTest.php
+++ b/tests/phpunit/integration/Modules/Analytics/SettingsTest.php
@@ -300,6 +300,32 @@ class SettingsTest extends SettingsTestCase {
 		$this->assertTrue( $settings->get()['canUseSnippet'] );
 	}
 
+	public function test_tracking_disabled() {
+		$context  = new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE );
+		$settings = new Settings( new Options( $context ) );
+		$settings->register();
+		$analytics = new Analytics( $context );
+
+		// Defaults to `[ 'loggedinUsers' ]`
+		$this->assertEqualSets( array( 'loggedinUsers' ), $settings->get()['trackingDisabled'] );
+
+		// Save with defaults.
+		$settings->merge( array() );
+		$this->assertEqualSets( array( 'loggedinUsers' ), $settings->get()['trackingDisabled'] );
+
+		// Save with loggedinUsers.
+		$settings->merge( array( 'trackingDisabled' => array( 'loggedinUsers' ) ) );
+		$this->assertEqualSets( array( 'loggedinUsers' ), $settings->get()['trackingDisabled'] );
+
+		// Save with contentCreators.
+		$settings->merge( array( 'trackingDisabled' => array( 'contentCreators' ) ) );
+		$this->assertEqualSets( array( 'contentCreators' ), $settings->get()['trackingDisabled'] );
+
+		// Save with multiple options including loggedinUsers.
+		$settings->merge( array( 'trackingDisabled' => array( 'loggedinUsers', 'contentCreators' ) ) );
+		$this->assertEqualSets( array( 'loggedinUsers' ), $settings->get()['trackingDisabled'] );
+	}
+
 	protected function get_testcase() {
 		return $this;
 	}


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #5243 

## Relevant technical choices

- When saving exclusion settings for Analytics, if the chosen options contain logged-in users, the setting is saved with this option only, disregarding the other selected options.
- Removes trailing full stops from two instances in the Analytics settings.

(This PR contains a force-push because I mistakenly pushed [a test commit](https://github.com/google/site-kit-wp/commit/0795ae753e8388bde02a5a4a4cc924fe656162e2) from my fork to the upstream repository)

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
