### PR TITLE
Move module sharing settings capability filtering to REST controller

### DIFF
--- a/includes/Core/Modules/Module_Sharing_Settings.php
+++ b/includes/Core/Modules/Module_Sharing_Settings.php
@@ -127,28 +127,24 @@ class Module_Sharing_Settings extends Setting {
 	/**
 	 * Merges a partial Module_Sharing_Settings option array into existing sharing settings.
 	 *
-	 * Only updates sharing settings for a module if the current user has the capability to
-	 * do so.
-	 *
 	 * @since 1.75.0
+	 * @since n.e.x.t Removed capability checks.
 	 *
-	 * @param array $new_partial_settings Partial settings array to update existing settings with.
+	 * @param array $partial Partial settings array to update existing settings with.
 	 *
 	 * @return bool True if sharing settings option was updated, false otherwise.
 	 */
-	public function merge( array $new_partial_settings ) {
+	public function merge( array $partial ) {
 		$settings = $this->get();
-
-		foreach ( $new_partial_settings as $module_slug => $new_settings ) {
-			if ( null === $new_settings ) {
-				continue;
+		$partial  = array_filter(
+			$partial,
+			function ( $value ) {
+				return null !== $value;
 			}
-			if ( current_user_can( Permissions::MANAGE_MODULE_SHARING_OPTIONS, $module_slug ) ) {
-				$settings[ $module_slug ] = $new_settings;
-			}
-		}
+		);
+		$updated  = array_intersect_key( $partial, $settings );
 
-		return $this->set( $settings );
+		return $this->set( array_merge( $settings, $updated ) );
 	}
 
 	/**

--- a/includes/Core/Modules/Module_Sharing_Settings.php
+++ b/includes/Core/Modules/Module_Sharing_Settings.php
@@ -11,7 +11,6 @@
 namespace Google\Site_Kit\Core\Modules;
 
 use Google\Site_Kit\Core\Storage\Setting;
-use SimplePie_Misc;
 
 /**
  * Class for module sharing settings.

--- a/includes/Core/Modules/Module_Sharing_Settings.php
+++ b/includes/Core/Modules/Module_Sharing_Settings.php
@@ -10,7 +10,6 @@
 
 namespace Google\Site_Kit\Core\Modules;
 
-use Google\Site_Kit\Core\Permissions\Permissions;
 use Google\Site_Kit\Core\Storage\Setting;
 
 /**

--- a/includes/Core/Modules/Module_Sharing_Settings.php
+++ b/includes/Core/Modules/Module_Sharing_Settings.php
@@ -11,6 +11,7 @@
 namespace Google\Site_Kit\Core\Modules;
 
 use Google\Site_Kit\Core\Storage\Setting;
+use SimplePie_Misc;
 
 /**
  * Class for module sharing settings.
@@ -143,7 +144,7 @@ class Module_Sharing_Settings extends Setting {
 		);
 		$updated  = array_intersect_key( $partial, $settings );
 
-		return $this->set( array_merge( $settings, $updated ) );
+		return $this->set( $this->array_merge_deep( $settings, $updated ) );
 	}
 
 	/**
@@ -198,6 +199,29 @@ class Module_Sharing_Settings extends Setting {
 		}
 
 		return array();
+	}
+
+	/**
+	 * Merges two arrays recursively to a specific depth.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param array $array1 First array.
+	 * @param array $array2 Second array.
+	 * @param int   $depth Optional. Depth to merge to. Default is 1.
+	 *
+	 * @return array Merged array.
+	 */
+	private function array_merge_deep( $array1, $array2, $depth = 1 ) {
+		foreach ( $array2 as $key => $value ) {
+			if ( $depth > 0 && is_array( $value ) ) {
+				$array1[ $key ] = $this->array_merge_deep( $array1[ $key ], $value, $depth - 1 );
+			} else {
+				$array1[ $key ] = $value;
+			}
+		}
+
+		return $array1;
 	}
 
 }

--- a/includes/Core/Modules/REST_Dashboard_Sharing_Controller.php
+++ b/includes/Core/Modules/REST_Dashboard_Sharing_Controller.php
@@ -12,6 +12,7 @@ namespace Google\Site_Kit\Core\Modules;
 
 use Google\Site_Kit\Core\Permissions\Permissions;
 use Google\Site_Kit\Core\REST_API\REST_Route;
+use Google\Site_Kit\Core\Util\Collection_Key_Cap_Filter;
 use WP_REST_Request;
 use WP_REST_Response;
 use WP_REST_Server;
@@ -78,10 +79,19 @@ class REST_Dashboard_Sharing_Controller {
 					'callback'            => function ( WP_REST_Request $request ) {
 						$original_module_owners = $this->modules->get_shareable_modules_owners();
 
-						$sharing_settings = $this->modules->get_module_sharing_settings();
-						$sharing_settings->merge( (array) $request['data'] );
+						$sharing_settings     = $this->modules->get_module_sharing_settings();
+						$new_sharing_settings = array_reduce(
+							array(
+								new Collection_Key_Cap_Filter( 'sharedRoles', Permissions::MANAGE_MODULE_SHARING_OPTIONS ),
+								new Collection_Key_Cap_Filter( 'management', Permissions::DELEGATE_MODULE_SHARING_MANAGEMENT ),
+							),
+							function ( $settings, Collection_Key_Cap_Filter $filter ) {
+								return $filter->filter_key_by_cap( $settings );
+							},
+							(array) $request['data']
+						);
 
-						$new_sharing_settings = $sharing_settings->get();
+						$sharing_settings->merge( $new_sharing_settings );
 
 						$new_module_owners = $this->modules->get_shareable_modules_owners();
 						$changed_module_owners = array_filter(
@@ -94,7 +104,7 @@ class REST_Dashboard_Sharing_Controller {
 
 						return new WP_REST_Response(
 							array(
-								'settings'    => $new_sharing_settings,
+								'settings'    => $sharing_settings->get(),
 								'newOwnerIDs' => $changed_module_owners,
 							)
 						);

--- a/includes/Core/Util/Collection_Key_Cap_Filter.php
+++ b/includes/Core/Util/Collection_Key_Cap_Filter.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * Class Google\Site_Kit\Core\Util\Collection_Key_Cap_Filter
+ *
+ * @package   Google\Site_Kit\Core\Util
+ * @copyright 2022 Google LLC
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
+ * @link      https://sitekit.withgoogle.com
+ */
+
+namespace Google\Site_Kit\Core\Util;
+
+/**
+ * Class for filtering a specific key of a collection based on a capability.
+ *
+ * @since n.e.x.t
+ * @access private
+ * @ignore
+ */
+class Collection_Key_Cap_Filter {
+
+	/**
+	 * Collection key.
+	 *
+	 * @since n.e.x.t
+	 * @var string
+	 */
+	private $key;
+
+	/**
+	 * Capability.
+	 *
+	 * @since n.e.x.t
+	 * @var string
+	 */
+	private $cap;
+
+	/**
+	 * Constructor.
+	 *
+	 * @since n.e.x.t.
+	 *
+	 * @param string $key        Target collection key to filter.
+	 * @param string $capability Required capability to filter by.
+	 */
+	public function __construct( $key, $capability ) {
+		$this->key = $key;
+		$this->cap = $capability;
+	}
+
+	/**
+	 * Filters the given value of a specific key in each item of the given collection
+	 * based on the key and capability.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param array[] $collection Array of arrays.
+	 * @return array[] Filtered collection.
+	 */
+	public function filter_key_by_cap( array $collection ) {
+		foreach ( $collection as $meta_arg => &$value ) {
+			if ( ! current_user_can( $this->cap, $meta_arg ) ) {
+				unset( $value[ $this->key ] );
+			}
+		}
+		return $collection;
+	}
+}

--- a/tests/phpunit/integration/Core/Modules/Module_Sharing_SettingsTest.php
+++ b/tests/phpunit/integration/Core/Modules/Module_Sharing_SettingsTest.php
@@ -11,13 +11,8 @@
 namespace Google\Site_Kit\Tests\Core\Modules;
 
 use Google\Site_Kit\Context;
-use Google\Site_Kit\Core\Authentication\Authentication;
-use Google\Site_Kit\Core\Dismissals\Dismissed_Items;
 use Google\Site_Kit\Core\Modules\Module_Sharing_Settings;
-use Google\Site_Kit\Core\Modules\Modules;
-use Google\Site_Kit\Core\Permissions\Permissions;
 use Google\Site_Kit\Core\Storage\Options;
-use Google\Site_Kit\Core\Storage\User_Options;
 use Google\Site_Kit\Tests\Modules\SettingsTestCase;
 
 class Module_Sharing_SettingsTest extends SettingsTestCase {
@@ -338,128 +333,6 @@ class Module_Sharing_SettingsTest extends SettingsTestCase {
 
 		$this->assertTrue( $this->settings->merge( $test_sharing_settings ) );
 		$this->assertEquals( $expected, $this->settings->get() );
-	}
-
-	public function test_merge__authenticated_user() {
-		$this->markTestSkipped( 'This test is skipped because will be removed.' );
-		$this->enable_feature( 'dashboardSharing' );
-
-		update_option(
-			'googlesitekit_active_modules',
-			array(
-				'search-console',
-				'analytics',
-				'pagespeed-insights',
-			)
-		);
-
-		$test_sharing_settings = array(
-			'search-console'     => array(
-				'sharedRoles' => array( 'editor', 'subscriber' ),
-				'management'  => 'all_admins',
-			),
-			'analytics'          => array(
-				'sharedRoles' => array( 'editor' ),
-				'management'  => 'all_admins',
-			),
-			'pagespeed-insights' => array(
-				'sharedRoles' => array( 'editor' ),
-				'management'  => 'all_admins',
-			),
-		);
-
-		$admin_1 = self::factory()->user->create_and_get( array( 'role' => 'administrator' ) );
-		$admin_2 = self::factory()->user->create_and_get( array( 'role' => 'administrator' ) );
-
-		wp_set_current_user( $admin_1->ID );
-
-		$modules = new Modules( $this->context );
-		// Adds filters which insert default dashboard_sharing settings for shared_ownership_modules.
-		$modules->register();
-
-		// Authenticate current user to partially grant capability to manage module sharing options.
-		$authentication = new Authentication( $this->context );
-		$authentication->get_oauth_client()->set_token(
-			array(
-				'access_token' => 'valid-auth-token',
-			)
-		);
-
-		// Re-register Permissions after enabling the dashboardSharing feature to include dashboard sharing capabilities.
-		$user_options = new User_Options( $this->context );
-		$permissions  = new Permissions( $this->context, $authentication, $modules, $user_options, new Dismissed_Items( $user_options ) );
-		$permissions->register();
-
-		// Add owners for search-console and analytics to test capability required to update sharing settings.
-		// Pagespeed-insights (shared ownership module) does not require an owner as its sharing settings
-		// can always be managed by any authenticated admin.
-		update_option( 'googlesitekit_search-console_settings', array( 'ownerID' => $admin_1->ID ) );
-		update_option( 'googlesitekit_analytics_settings', array( 'ownerID' => $admin_2->ID ) );
-
-		// In the absence of dashboard sharing settings in the DB to begin with, admin_1 can only update
-		// search-console (as an owner) and pagespeed-insights (set to "all_admins" by default).
-		$this->assertTrue( $this->settings->merge( $test_sharing_settings ) );
-		$expected_sharing_settings = array(
-			'search-console'     => array(
-				'sharedRoles' => array( 'editor', 'subscriber' ),
-				'management'  => 'all_admins',
-			),
-			'pagespeed-insights' => array(
-				'sharedRoles' => array( 'editor' ),
-				'management'  => 'all_admins',
-			),
-		);
-		$this->assertEquals( $expected_sharing_settings, $this->settings->get() );
-
-		wp_set_current_user( $admin_2->ID );
-
-		$updated_sharing_settings = array(
-			'search-console'     => array(
-				'sharedRoles' => array( 'subscriber' ),
-				'management'  => 'all_admins',
-			),
-			'analytics'          => array(
-				'sharedRoles' => array( 'contributor', 'subscriber' ),
-				'management'  => 'all_admins',
-			),
-			'pagespeed-insights' => array(
-				'sharedRoles' => array(),
-				'management'  => 'all_admins',
-			),
-		);
-		// admin_2 should be able to change search-console (set to "all_admins"), analytics (not
-		// already in DB but as an owner) and pagespeed-insights (as an authenticated admin).
-		$this->assertTrue( $this->settings->merge( $updated_sharing_settings ) );
-		$this->assertEquals( $updated_sharing_settings, $this->settings->get() );
-
-		// Test updating partial settings changing search-console to owner only.
-		$updated_sharing_settings = array(
-			'search-console' => array(
-				'sharedRoles' => array( 'contributor' ),
-				'management'  => 'owner',
-			),
-		);
-		$this->assertTrue( $this->settings->merge( $updated_sharing_settings ) );
-		$this->assertEquals(
-			array(
-				'search-console'     => array(
-					'sharedRoles' => array( 'contributor' ),
-					'management'  => 'owner',
-				),
-				'analytics'          => array(
-					'sharedRoles' => array( 'contributor', 'subscriber' ),
-					'management'  => 'all_admins',
-				),
-				'pagespeed-insights' => array(
-					'sharedRoles' => array(),
-					'management'  => 'all_admins',
-				),
-			),
-			$this->settings->get()
-		);
-
-		// admin_2 now cannot update search-console settings as management setting is set to "owner".
-		$this->assertFalse( $this->settings->merge( $updated_sharing_settings ) );
 	}
 
 }

--- a/tests/phpunit/integration/Core/Util/Collection_Key_Cap_FilterTest.php
+++ b/tests/phpunit/integration/Core/Util/Collection_Key_Cap_FilterTest.php
@@ -21,50 +21,35 @@ class Collection_Key_Cap_FilterTest extends TestCase {
 	}
 
 	public function data_filter_key_by_cap() {
+		$collection_with_foo    = array(
+			array(
+				'foo' => 'bar',
+				'baz' => 'buzz',
+			),
+			array(
+				'foo' => '123',
+				'baz' => 'any',
+			),
+		);
+		$collection_without_foo = array(
+			array( 'baz' => 'buzz' ),
+			array( 'baz' => 'any' ),
+		);
+
 		yield 'editor with delete_users' => array(
 			'editor',
 			'delete_users',
 			'foo',
-			array(
-				array(
-					'foo' => 'bar',
-					'baz' => 'buzz',
-				),
-				array(
-					'foo' => '123',
-					'baz' => 'any',
-				),
-			),
-			array(
-				array( 'baz' => 'buzz' ),
-				array( 'baz' => 'any' ),
-			),
+			$collection_with_foo,
+			$collection_without_foo,
 		);
 
 		yield 'admin with delete_users' => array(
 			'administrator',
 			'delete_users',
 			'foo',
-			array(
-				array(
-					'foo' => 'bar',
-					'baz' => 'buzz',
-				),
-				array(
-					'foo' => '123',
-					'baz' => 'any',
-				),
-			),
-			array(
-				array(
-					'foo' => 'bar',
-					'baz' => 'buzz',
-				),
-				array(
-					'foo' => '123',
-					'baz' => 'any',
-				),
-			),
+			$collection_with_foo,
+			$collection_with_foo,
 		);
 	}
 }

--- a/tests/phpunit/integration/Core/Util/Collection_Key_Cap_FilterTest.php
+++ b/tests/phpunit/integration/Core/Util/Collection_Key_Cap_FilterTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace phpunit\integration\Core\Util;
+
+use Google\Site_Kit\Core\Util\Collection_Key_Cap_Filter;
+use Google\Site_Kit\Tests\TestCase;
+
+class Collection_Key_Cap_FilterTest extends TestCase {
+
+	/**
+	 * @dataProvider data_filter_key_by_cap
+	 */
+	public function test_filter_key_by_cap( $role, $cap, $key, $input, $expected ) {
+		$user_id = $this->factory()->user->create( array( 'role' => $role ) );
+		wp_set_current_user( $user_id );
+
+		$filter = new Collection_Key_Cap_Filter( $key, $cap );
+		$output = $filter->filter_key_by_cap( $input );
+
+		$this->assertEquals( $expected, $output );
+	}
+
+	public function data_filter_key_by_cap() {
+		yield 'editor with delete_users' => array(
+			'editor',
+			'delete_users',
+			'foo',
+			array(
+				array(
+					'foo' => 'bar',
+					'baz' => 'buzz',
+				),
+				array(
+					'foo' => '123',
+					'baz' => 'any',
+				),
+			),
+			array(
+				array( 'baz' => 'buzz' ),
+				array( 'baz' => 'any' ),
+			),
+		);
+
+		yield 'admin with delete_users' => array(
+			'administrator',
+			'delete_users',
+			'foo',
+			array(
+				array(
+					'foo' => 'bar',
+					'baz' => 'buzz',
+				),
+				array(
+					'foo' => '123',
+					'baz' => 'any',
+				),
+			),
+			array(
+				array(
+					'foo' => 'bar',
+					'baz' => 'buzz',
+				),
+				array(
+					'foo' => '123',
+					'baz' => 'any',
+				),
+			),
+		);
+	}
+}

--- a/tests/phpunit/integration/Core/Util/Collection_Key_Cap_FilterTest.php
+++ b/tests/phpunit/integration/Core/Util/Collection_Key_Cap_FilterTest.php
@@ -36,17 +36,17 @@ class Collection_Key_Cap_FilterTest extends TestCase {
 			array( 'baz' => 'any' ),
 		);
 
-		yield 'editor with delete_users' => array(
+		yield 'editor with manage_options' => array(
 			'editor',
-			'delete_users',
+			'manage_options',
 			'foo',
 			$collection_with_foo,
 			$collection_without_foo,
 		);
 
-		yield 'admin with delete_users' => array(
+		yield 'admin with manage_options' => array(
 			'administrator',
-			'delete_users',
+			'manage_options',
 			'foo',
 			$collection_with_foo,
 			$collection_with_foo,


### PR DESCRIPTION
## Summary

Addresses issue:

- #5229

## Relevant technical choices

<!-- Please describe your changes. -->

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [ ] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [x] Run the code.
- [x] Ensure the acceptance criteria are satisfied.
- [x] Reassess the implementation with the IB.
- [x] Ensure no unrelated changes are included.
- [x] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [x] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [x] Ensure the PR has the correct target branch.
- [x] Double-check that the PR is okay to be merged.
- [x] Ensure the corresponding issue has a ZenHub release assigned.
- [x] Add a changelog message to the issue.
