### PR TITLE
Avoid including `ModuleRecoveryAlert` on splash screen

### DIFF
--- a/assets/js/components/Header.js
+++ b/assets/js/components/Header.js
@@ -43,12 +43,14 @@ import EntityHeader from './EntityHeader';
 import ViewOnlyMenu from './ViewOnlyMenu';
 import { useFeature } from '../hooks/useFeature';
 import useViewOnly from '../hooks/useViewOnly';
+import useDashboardType from '../hooks/useDashboardType';
 const { useSelect } = Data;
 
 const Header = ( { children, subHeader, showNavigation } ) => {
 	const unifiedDashboardEnabled = useFeature( 'unifiedDashboard' );
 	const dashboardSharingEnabled = useFeature( 'dashboardSharing' );
-	const viewOnlyDashboard = useViewOnly();
+	const isDashboard = !! useDashboardType();
+	const isViewOnly = useViewOnly();
 
 	const isAuthenticated = useSelect( ( select ) =>
 		select( CORE_USER ).isAuthenticated()
@@ -88,10 +90,11 @@ const Header = ( { children, subHeader, showNavigation } ) => {
 
 							{ ! isAuthenticated &&
 								dashboardSharingEnabled &&
-								viewOnlyDashboard && <ViewOnlyMenu /> }
+								isDashboard &&
+								isViewOnly && <ViewOnlyMenu /> }
 							{ isAuthenticated &&
 								( ! dashboardSharingEnabled ||
-									! viewOnlyDashboard ) && <UserMenu /> }
+									! isViewOnly ) && <UserMenu /> }
 						</Cell>
 					</Row>
 				</Grid>
@@ -107,7 +110,7 @@ const Header = ( { children, subHeader, showNavigation } ) => {
 
 			<ErrorNotifications />
 
-			{ ! viewOnlyDashboard && dashboardSharingEnabled && (
+			{ dashboardSharingEnabled && isDashboard && ! isViewOnly && (
 				<ModuleRecoveryAlert />
 			) }
 		</Fragment>


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #5256 

## Relevant technical choices

This fixes https://github.com/google/site-kit-wp/issues/5256#issuecomment-1139732375 as follows:
* Check for whether we're actually on the dashboard (main or entity dashboard), in addition to checking for whether we are in a view-only area.
* The main fix here is around the `ModuleRecoveryAlert` condition. However, technically it's a good idea to add the same check around the `ViewOnlyMenu`. While that effectively didn't show up on splash anyway, we should really ensure it never possibly could, similarly to the `ModuleRecoveryAlert`. (This is different e.g. for the `UserMenu` for authenticated users, which _should_ display anywhere.)

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
