### PR TITLE
Add `recoverModules` action to fix `ModuleRecoveryAlert` glitches. 

### DIFF
--- a/assets/js/components/dashboard-sharing/ModuleRecoveryAlert.js
+++ b/assets/js/components/dashboard-sharing/ModuleRecoveryAlert.js
@@ -68,7 +68,7 @@ export default function ModuleRecoveryAlert() {
 			.map( ( { slug } ) => slug );
 	} );
 
-	const { recoverModule } = useDispatch( CORE_MODULES );
+	const { recoverModules } = useDispatch( CORE_MODULES );
 
 	const updateCheckboxes = useCallback(
 		( slug ) =>
@@ -84,10 +84,10 @@ export default function ModuleRecoveryAlert() {
 		const modulesToRecover = Object.keys( checkboxes ).filter(
 			( module ) => checkboxes[ module ]
 		);
-		Promise.all(
-			modulesToRecover.map( ( module ) => recoverModule( module ) )
-		).finally( () => setRecoveringModules( false ) );
-	}, [ checkboxes, recoverModule ] );
+		recoverModules( modulesToRecover ).finally( () =>
+			setRecoveringModules( false )
+		);
+	}, [ checkboxes, recoverModules ] );
 
 	useEffect( () => {
 		if ( userAccessibleModules !== undefined && checkboxes === null ) {

--- a/assets/js/components/dashboard-sharing/ModuleRecoveryAlert.js
+++ b/assets/js/components/dashboard-sharing/ModuleRecoveryAlert.js
@@ -84,9 +84,10 @@ export default function ModuleRecoveryAlert() {
 		const modulesToRecover = Object.keys( checkboxes ).filter(
 			( module ) => checkboxes[ module ]
 		);
-		recoverModules( modulesToRecover ).finally( () =>
-			setRecoveringModules( false )
-		);
+		recoverModules( modulesToRecover ).finally( () => {
+			setRecoveringModules( false );
+			setCheckboxes( null );
+		} );
 	}, [ checkboxes, recoverModules ] );
 
 	useEffect( () => {

--- a/assets/js/googlesitekit/modules/datastore/modules.js
+++ b/assets/js/googlesitekit/modules/datastore/modules.js
@@ -505,7 +505,7 @@ const baseActions = {
 	 *
 	 * @since n.e.x.t
 	 *
-	 * @param {Array.<string>} slugs Slugs of the modules to recover.
+	 * @param {Array.<string>} slugs Array of slugs of the modules to recover.
 	 * @return {Object} Object with `{response, error}`.
 	 */
 	recoverModules: createValidatedAction(

--- a/assets/js/googlesitekit/modules/datastore/modules.js
+++ b/assets/js/googlesitekit/modules/datastore/modules.js
@@ -536,7 +536,7 @@ const baseActions = {
 
 					recoveredModules.push( slug );
 				} else {
-					errors.push( error );
+					errors.push( [ slug, error ] );
 				}
 			}
 
@@ -558,19 +558,26 @@ const baseActions = {
 				}
 			}
 
+			const response = {
+				success: {
+					...Object.fromEntries(
+						recoveredModules.map( ( slug ) => [ slug, true ] )
+					),
+					...Object.fromEntries(
+						errors.map( ( [ slug ] ) => [ slug, false ] )
+					),
+				},
+			};
+
 			if ( errors.length ) {
 				return {
-					response: {
-						success: false,
-					},
-					error: errors,
+					response,
+					error: Object.fromEntries( errors ),
 				};
 			}
 
 			return {
-				response: {
-					success: true,
-				},
+				response,
 			};
 		}
 	),

--- a/assets/js/googlesitekit/modules/datastore/modules.test.js
+++ b/assets/js/googlesitekit/modules/datastore/modules.test.js
@@ -400,6 +400,279 @@ describe( 'core/modules modules', () => {
 			} );
 		} );
 
+		describe( 'recoverModules', () => {
+			it( 'dispatches requests to recover modules', async () => {
+				const slugs = [ 'analytics', 'tagmanager' ];
+				global[ dashboardSharingDataBaseVar ] = recoverableModuleList;
+
+				fetchMock.get(
+					/^\/google-site-kit\/v1\/core\/modules\/data\/list/,
+					{
+						body: [
+							...FIXTURES,
+							{
+								slug: 'analytics',
+								name: 'Analytics',
+								active: true,
+								connected: true,
+								shareable: true,
+								storeName: 'modules/analytics',
+							},
+							{
+								slug: 'tagmanager',
+								name: 'Tag Manager',
+								active: true,
+								connected: true,
+								shareable: true,
+								storeName: 'modules/tagmanager',
+							},
+						],
+						status: 200,
+					}
+				);
+				fetchMock.post(
+					/^\/google-site-kit\/v1\/core\/modules\/data\/recover-module/,
+					{ body: { ownerID: 1 } },
+					{ repeat: 2 }
+				);
+
+				fetchMock.getOnce(
+					/^\/google-site-kit\/v1\/modules\/analytics\/data\/settings/,
+					{
+						body: getModulesBySlugList( [ slugs ], FIXTURES ),
+						status: 200,
+					}
+				);
+
+				fetchMock.getOnce(
+					/^\/google-site-kit\/v1\/modules\/tagmanager\/data\/settings/,
+					{
+						body: getModulesBySlugList( [ slugs ], FIXTURES ),
+						status: 200,
+					}
+				);
+
+				const initialModules = registry
+					.select( CORE_MODULES )
+					.getModules();
+				// The modules info will be its initial value while the modules
+				// info is fetched.
+				expect( initialModules ).toBeUndefined();
+				await untilResolved( registry, CORE_MODULES ).getModules();
+
+				const { response } = await registry
+					.dispatch( CORE_MODULES )
+					.recoverModules( slugs );
+
+				expect( response.success ).toStrictEqual( {
+					analytics: true,
+					tagmanager: true,
+				} );
+
+				expect( fetchMock ).toHaveFetchedTimes( 6 );
+
+				// Ensure the proper body parameters were sent.
+				expect( fetchMock ).toHaveFetched(
+					/^\/google-site-kit\/v1\/core\/modules\/data\/recover-module/,
+					{
+						body: {
+							data: {
+								slug: 'analytics',
+							},
+						},
+					}
+				);
+
+				expect( fetchMock ).toHaveFetched(
+					/^\/google-site-kit\/v1\/core\/modules\/data\/recover-module/,
+					{
+						body: {
+							data: {
+								slug: 'tagmanager',
+							},
+						},
+					}
+				);
+
+				// Ensure fetchGetSettings have been called.
+				expect( fetchMock ).toHaveFetched(
+					/^\/google-site-kit\/v1\/modules\/analytics\/data\/settings/,
+					{
+						body: {
+							data: {
+								slug: 'analytics',
+							},
+						},
+					}
+				);
+
+				expect( fetchMock ).toHaveFetched(
+					/^\/google-site-kit\/v1\/modules\/analytics\/data\/settings/,
+					{
+						body: {
+							data: {
+								slug: 'tagmanager',
+							},
+						},
+					}
+				);
+
+				// Ensure fetchGetModules have been called.
+				expect( fetchMock ).toHaveFetched(
+					/^\/google-site-kit\/v1\/core\/modules\/data\/list/
+				);
+
+				// Ensure the module has been removed from the recoverable modules list.
+				const recoverableModules = registry
+					.select( CORE_MODULES )
+					.getRecoverableModules();
+
+				expect( Object.keys( recoverableModules ) ).toEqual( [
+					'search-console',
+				] );
+			} );
+
+			it( 'encounters an error if the any module is not recoverable', async () => {
+				const slugs = [ 'analytics', 'tagmanager' ];
+				global[ dashboardSharingDataBaseVar ] = recoverableModuleList;
+
+				fetchMock.get(
+					/^\/google-site-kit\/v1\/core\/modules\/data\/list/,
+					{
+						body: [
+							...FIXTURES,
+							{
+								slug: 'analytics',
+								name: 'Analytics',
+								active: true,
+								connected: true,
+								shareable: true,
+								storeName: 'modules/analytics',
+							},
+							{
+								slug: 'tagmanager',
+								name: 'Tag Manager',
+								active: true,
+								connected: true,
+								shareable: true,
+								storeName: 'modules/tagmanager',
+							},
+						],
+						status: 200,
+					}
+				);
+
+				const errorResponse = {
+					code: 'module_not_recoverable',
+					message: 'Module is not recoverable.',
+					data: { status: 403 },
+				};
+
+				fetchMock.postOnce(
+					/^\/google-site-kit\/v1\/core\/modules\/data\/recover-module/,
+					{ body: { ownerID: 1 } }
+				);
+
+				fetchMock.postOnce(
+					/^\/google-site-kit\/v1\/core\/modules\/data\/recover-module/,
+					{ body: errorResponse, status: 403 }
+				);
+
+				fetchMock.getOnce(
+					/^\/google-site-kit\/v1\/modules\/analytics\/data\/settings/,
+					{
+						body: getModulesBySlugList( [ slugs ], FIXTURES ),
+						status: 200,
+					}
+				);
+
+				const initialModules = registry
+					.select( CORE_MODULES )
+					.getModules();
+				// The modules info will be its initial value while the modules
+				// info is fetched.
+				expect( initialModules ).toBeUndefined();
+				await untilResolved( registry, CORE_MODULES ).getModules();
+
+				const { response, error } = await registry
+					.dispatch( CORE_MODULES )
+					.recoverModules( slugs );
+
+				expect( console ).toHaveErrored();
+				expect( response.success ).toStrictEqual( {
+					analytics: true,
+					tagmanager: false,
+				} );
+				expect( error.tagmanager.message ).toBe(
+					errorResponse.message
+				);
+
+				expect( fetchMock ).toHaveFetchedTimes( 5 );
+
+				// Ensure the proper body parameters were sent.
+				expect( fetchMock ).toHaveFetched(
+					/^\/google-site-kit\/v1\/core\/modules\/data\/recover-module/,
+					{
+						body: {
+							data: {
+								slug: 'analytics',
+							},
+						},
+					}
+				);
+
+				expect( fetchMock ).toHaveFetched(
+					/^\/google-site-kit\/v1\/core\/modules\/data\/recover-module/,
+					{
+						body: {
+							data: {
+								slug: 'tagmanager',
+							},
+						},
+					}
+				);
+
+				// Ensure fetchGetSettings has been called for Analytics.
+				expect( fetchMock ).toHaveFetched(
+					/^\/google-site-kit\/v1\/modules\/analytics\/data\/settings/,
+					{
+						body: {
+							data: {
+								slug: 'analytics',
+							},
+						},
+					}
+				);
+
+				// Ensure fetchGetSettings haven't been called for Tag Manager.
+				expect( fetchMock ).not.toHaveFetched(
+					/^\/google-site-kit\/v1\/modules\/tagmanager\/data\/settings/,
+					{
+						body: {
+							data: {
+								slug: 'tagmanager',
+							},
+						},
+					}
+				);
+
+				// Ensure fetchGetModules have been called.
+				expect( fetchMock ).toHaveFetched(
+					/^\/google-site-kit\/v1\/core\/modules\/data\/list/
+				);
+
+				// Ensure the module has been removed from the recoverable modules list.
+				const recoverableModules = registry
+					.select( CORE_MODULES )
+					.getRecoverableModules();
+
+				expect( Object.keys( recoverableModules ) ).toEqual( [
+					'search-console',
+					'tagmanager',
+				] );
+			} );
+		} );
+
 		describe( 'deactivateModule', () => {
 			it( 'dispatches a request to deactivate this module', async () => {
 				// In our fixtures, analytics is off by default.


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #4823 

## Relevant technical choices

This PR:
1. introduces `recoverModules` which uses the existing API attempt to recover modules and only updates the recoverable module list after  recovery attempts for all modules have been settled. This way there's no flicker that's observed by @wpdarren. 
2. This newly introduced action is then used in the `ModuleRecoveryAlert` component. 
3. This also sets the `checkboxes` to `null` once the `handleRecoverModule` wraps up to refresh the checkboxes with the `checked: true` state. This is needed because, If there is more than one recoverable module and the user only recovers one, There is no way to manually check Single module in the Single module UI. The downside of this approach is, if there's more than 1 recoverable modules after recovery attempt, those will be checked again. 
4. The current tests for `recoverModules` is pretty repetitive and odd. Hopefully we can improve that once the API supports multiple module recovery in one request. See #5298 

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
