### PR TITLE
Fix spread error in Dashboard Sharing settings modal.

### DIFF
--- a/assets/js/components/dashboard-sharing/UserRoleSelect.js
+++ b/assets/js/components/dashboard-sharing/UserRoleSelect.js
@@ -81,7 +81,12 @@ export default function UserRoleSelect( { moduleSlug, isLocked = false } ) {
 
 	const toggleEditMode = useCallback( () => {
 		if ( editMode ) {
-			if ( ! isEqual( [ ...sharedRoles ].sort(), initialSharedRoles ) ) {
+			if (
+				! isEqual(
+					[ ...( sharedRoles || [] ) ].sort(),
+					initialSharedRoles
+				)
+			) {
 				trackEvent(
 					`${ viewContext }_sharing`,
 					'change_shared_roles',
@@ -89,7 +94,7 @@ export default function UserRoleSelect( { moduleSlug, isLocked = false } ) {
 				);
 			}
 		} else {
-			setInitialSharedRoles( [ ...sharedRoles ].sort() );
+			setInitialSharedRoles( [ ...( sharedRoles || [] ) ].sort() );
 		}
 
 		setEditMode( ! editMode );


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #4822

## Relevant technical choices

If no sharing roles are set then `sharedRoles` will be `null`, causing an error @wpdarren reported here: https://github.com/google/site-kit-wp/issues/4822#issuecomment-1143677482

This change fixes that issue.

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [x] Run the code.
- [x] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [x] Check Storybook where applicable.
- [x] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
