### PR TITLE
Cleanup wp_options table after plugin uninstall

### DIFF
--- a/uninstall.php
+++ b/uninstall.php
@@ -8,6 +8,8 @@
  * @link      https://sitekit.withgoogle.com
  */
 
+global $wpdb;
+
 // Prevent execution from directly accessing the file.
 if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
 	exit;
@@ -18,3 +20,18 @@ require_once dirname( __FILE__ ) . '/google-site-kit.php';
 
 // Fire action to trigger uninstallation logic.
 do_action( 'googlesitekit_uninstallation' );
+
+// Remove options introduced by the plugin.
+delete_option( 'googlesitekit_analytics_settings' );
+delete_option( 'googlesitekit_analytics-4_settings' );
+delete_option( 'googlesitekit_owner_id' );
+delete_option( 'googlesitekit_search-console_settings' );
+delete_option( 'googlesitekit_connected_proxy_url' );
+delete_option( 'googlesitekitpersistent_remote_features' );
+delete_option( 'googlesitekit_credentials' );
+delete_option( 'googlesitekit_active_modules' );
+delete_option( 'googlesitekit_has_connected_admins' );
+delete_option( 'googlesitekit_db_version' );
+
+// Remove any transients which the plugin may have left behind.
+$wpdb->query( "DELETE FROM {$wpdb->options} WHERE `option_name` LIKE '_transient_%googlesitekit%'" );


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

Cleanup wp_options table after plugin uninstall.

Currently, if we uninstall site-kit-wp plugin - it leaves wp_options entries with AUTOLOAD = yes values which increases website loading time when the plugin is uninstalled.

<img width="1133" alt="Screenshot at Jun 04 12-58-35" src="https://user-images.githubusercontent.com/16621855/171999643-3c7f68b0-cc84-48d3-b645-818f36d881b5.png">


## Relevant technical choices
Use Uninstall method referenced at https://developer.wordpress.org/plugins/plugin-basics/uninstall-methods/


<!-- Please describe your changes. -->

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
