### PR TITLE
Allow merging sharing settings when module not present in DB option.

### DIFF
--- a/includes/Core/Modules/Module_Sharing_Settings.php
+++ b/includes/Core/Modules/Module_Sharing_Settings.php
@@ -141,9 +141,8 @@ class Module_Sharing_Settings extends Setting {
 				return null !== $value;
 			}
 		);
-		$updated  = array_intersect_key( $partial, $settings );
 
-		return $this->set( $this->array_merge_deep( $settings, $updated ) );
+		return $this->set( $this->array_merge_deep( $settings, $partial ) );
 	}
 
 	/**
@@ -203,6 +202,10 @@ class Module_Sharing_Settings extends Setting {
 	/**
 	 * Merges two arrays recursively to a specific depth.
 	 *
+	 * When array1 and array2 have the same string keys, it overwrites
+	 * the elements of array1 with elements of array2. Otherwise, it adds/appends
+	 * elements of array2.
+	 *
 	 * @since n.e.x.t
 	 *
 	 * @param array $array1 First array.
@@ -214,7 +217,8 @@ class Module_Sharing_Settings extends Setting {
 	private function array_merge_deep( $array1, $array2, $depth = 1 ) {
 		foreach ( $array2 as $key => $value ) {
 			if ( $depth > 0 && is_array( $value ) ) {
-				$array1[ $key ] = $this->array_merge_deep( $array1[ $key ], $value, $depth - 1 );
+				$array1_key     = isset( $array1[ $key ] ) ? $array1[ $key ] : null;
+				$array1[ $key ] = $this->array_merge_deep( $array1_key, $value, $depth - 1 );
 			} else {
 				$array1[ $key ] = $value;
 			}

--- a/tests/phpunit/integration/Core/Modules/Module_Sharing_SettingsTest.php
+++ b/tests/phpunit/integration/Core/Modules/Module_Sharing_SettingsTest.php
@@ -220,40 +220,19 @@ class Module_Sharing_SettingsTest extends SettingsTestCase {
 	public function test_merge() {
 		$this->enable_feature( 'dashboardSharing' );
 
-		update_option(
-			'googlesitekit_active_modules',
-			array(
-				'search-console',
-				'analytics',
-				'pagespeed-insights',
-			)
-		);
+		// Check there are no settings to begin with.
+		$this->assertEmpty( $this->settings->get() );
 
-		$initial_sharing_settings = array(
-			'search-console'     => array(
-				'sharedRoles' => array( 'contributor' ),
-				'management'  => 'owner',
-			),
-			'analytics'          => array(
-				'sharedRoles' => array( 'contributor', 'subscriber' ),
-				'management'  => 'all_admins',
-			),
-			'pagespeed-insights' => array(
-				'sharedRoles' => array(),
-				'management'  => 'all_admins',
-			),
-		);
-
-		// Set some valid sharing settings to test merging.
-		$this->settings->set( $initial_sharing_settings );
-
-		// Can not merge with inactive modules (module already not present in settings).
-		$this->assertFalse(
+		$this->assertTrue(
 			$this->settings->merge(
 				array(
-					'adsense' => array(
-						'sharedRoles' => array( 'editor' ),
+					'search-console' => array(
+						'sharedRoles' => array( 'contributor' ),
 						'management'  => 'owner',
+					),
+					'analytics'      => array(
+						'sharedRoles' => array( 'contributor', 'subscriber' ),
+						'management'  => 'all_admins',
 					),
 				)
 			)
@@ -300,12 +279,8 @@ class Module_Sharing_SettingsTest extends SettingsTestCase {
 		$this->assertTrue( $this->settings->merge( $test_sharing_settings ) );
 		$this->assertEquals( $expected, $this->settings->get() );
 
-		// Keeps the valid parts of partial and descards the invalid parts.
+		// Keeps the valid parts of partial and discards the invalid parts.
 		$test_sharing_settings = array(
-			'adsense'            => array(
-				'sharedRoles' => array( 'editor' ),
-				'management'  => 'owner',
-			),
 			'search-console'     => null,
 			'analytics'          => array(
 				'sharedRoles' => array( 'contributor' ),


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #5229 

## Relevant technical choices

Remove code that requires sharing settings for modules to be already present in the DB Option for settings of that module to be saved/merged.

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
