### PR TITLE
Infrastructure/5104 - Add StrictMode to React code

### DIFF
--- a/assets/js/components/Root/index.js
+++ b/assets/js/components/Root/index.js
@@ -24,7 +24,7 @@ import PropTypes from 'prop-types';
 /**
  * WordPress dependencies
  */
-import { useState } from '@wordpress/element';
+import { StrictMode, useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -47,27 +47,29 @@ export default function Root( { children, registry, viewContext = null } ) {
 	} );
 
 	return (
-		<InViewProvider value={ inViewState }>
-			<Data.RegistryProvider value={ registry }>
-				<FeaturesProvider value={ enabledFeatures }>
-					<ViewContextProvider value={ viewContext }>
-						<ErrorHandler>
-							<RestoreSnapshots>
-								{ children }
-								{ /*
+		<StrictMode>
+			<InViewProvider value={ inViewState }>
+				<Data.RegistryProvider value={ registry }>
+					<FeaturesProvider value={ enabledFeatures }>
+						<ViewContextProvider value={ viewContext }>
+							<ErrorHandler>
+								<RestoreSnapshots>
+									{ children }
+									{ /*
 									TODO: Replace `FeatureToursDesktop` with `FeatureTours`
 									once tour conflicts in smaller viewports are resolved.
 									@see https://github.com/google/site-kit-wp/issues/3003
 								*/ }
-								{ viewContext && <FeatureToursDesktop /> }
-								<CurrentSurveyPortal />
-							</RestoreSnapshots>
-							<PermissionsModal />
-						</ErrorHandler>
-					</ViewContextProvider>
-				</FeaturesProvider>
-			</Data.RegistryProvider>
-		</InViewProvider>
+									{ viewContext && <FeatureToursDesktop /> }
+									<CurrentSurveyPortal />
+								</RestoreSnapshots>
+								<PermissionsModal />
+							</ErrorHandler>
+						</ViewContextProvider>
+					</FeaturesProvider>
+				</Data.RegistryProvider>
+			</InViewProvider>
+		</StrictMode>
 	);
 }
 


### PR DESCRIPTION
## Summary

Addresses issue:

- #5104 

## Relevant technical choices

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
