### PR TITLE
Add store names to all instances of createErrorStore()

### DIFF
--- a/assets/js/googlesitekit/data/create-error-store.js
+++ b/assets/js/googlesitekit/data/create-error-store.js
@@ -87,7 +87,9 @@ export const actions = {
 	},
 };
 
-export function createErrorStore() {
+export function createErrorStore( storeName ) {
+	invariant( storeName, 'storeName must be defined.' );
+
 	const initialState = {
 		errors: {},
 		error: undefined,

--- a/assets/js/googlesitekit/data/create-error-store.test.js
+++ b/assets/js/googlesitekit/data/create-error-store.test.js
@@ -66,6 +66,20 @@ describe( 'createErrorStore store', () => {
 	const baseName = 'getFoo';
 	const args = [ 'bar', 'baz' ];
 
+	describe( 'createErrorStore', () => {
+		it( 'requires a storeName argument', () => {
+			expect( () => {
+				createErrorStore();
+			} ).toThrow( 'storeName must be defined.' );
+		} );
+
+		it( 'does not error when storeName is provided', () => {
+			expect( () => {
+				createErrorStore( TEST_STORE );
+			} ).not.toThrow();
+		} );
+	} );
+
 	describe( 'actions', () => {
 		describe( 'receiveError', () => {
 			it( 'requires the error param', () => {

--- a/assets/js/googlesitekit/data/create-error-store.test.js
+++ b/assets/js/googlesitekit/data/create-error-store.test.js
@@ -55,7 +55,7 @@ describe( 'createErrorStore store', () => {
 	beforeEach( () => {
 		registry = createRegistry();
 
-		storeDefinition = createErrorStore();
+		storeDefinition = createErrorStore( TEST_STORE );
 		registry.registerStore( TEST_STORE, storeDefinition );
 		dispatch = registry.dispatch( TEST_STORE );
 		store = registry.stores[ TEST_STORE ].store;

--- a/assets/js/googlesitekit/datastore/forms/index.js
+++ b/assets/js/googlesitekit/datastore/forms/index.js
@@ -29,7 +29,7 @@ const store = Data.combineStores(
 	Data.commonStore,
 	forms,
 	createSnapshotStore( CORE_FORMS ),
-	createErrorStore()
+	createErrorStore( CORE_FORMS )
 );
 
 export const initialState = store.initialState;

--- a/assets/js/googlesitekit/datastore/site/index.js
+++ b/assets/js/googlesitekit/datastore/site/index.js
@@ -45,7 +45,7 @@ const store = Data.combineStores(
 	urls,
 	notifications,
 	registryKey,
-	createErrorStore()
+	createErrorStore( CORE_SITE )
 );
 
 export const initialState = store.initialState;

--- a/assets/js/googlesitekit/datastore/ui/index.js
+++ b/assets/js/googlesitekit/datastore/ui/index.js
@@ -29,7 +29,7 @@ const store = Data.combineStores(
 	Data.commonStore,
 	ui,
 	createSnapshotStore( CORE_UI ),
-	createErrorStore()
+	createErrorStore( CORE_UI )
 );
 
 export const initialState = store.initialState;

--- a/assets/js/googlesitekit/datastore/user/index.js
+++ b/assets/js/googlesitekit/datastore/user/index.js
@@ -36,7 +36,7 @@ import { CORE_USER } from './constants';
 
 const store = Data.combineStores(
 	Data.commonStore,
-	createErrorStore(),
+	createErrorStore( CORE_USER ),
 	authentication,
 	dateRange,
 	disconnect,

--- a/assets/js/googlesitekit/modules/create-module-store.js
+++ b/assets/js/googlesitekit/modules/create-module-store.js
@@ -136,7 +136,7 @@ export function createModuleStore( slug, args = {} ) {
 			settingsStore,
 			submitChangesStore,
 			infoStore,
-			createErrorStore(),
+			createErrorStore( storeName ),
 			setupBlockedStore
 		);
 	} else {
@@ -145,7 +145,7 @@ export function createModuleStore( slug, args = {} ) {
 			notificationsStore,
 			infoStore,
 			setupBlockedStore,
-			createErrorStore(),
+			createErrorStore( storeName ),
 			createSubmitChangesStore( {
 				submitChanges,
 				validateCanSubmitChanges,

--- a/assets/js/googlesitekit/modules/create-submit-changes-store.test.js
+++ b/assets/js/googlesitekit/modules/create-submit-changes-store.test.js
@@ -56,7 +56,7 @@ describe( 'createSubmitChangesStore', () => {
 					Data.combineStores(
 						Data.commonStore,
 						createSubmitChangesStore( { submitChanges } ),
-						createErrorStore()
+						createErrorStore( storeName )
 					)
 				);
 
@@ -77,7 +77,7 @@ describe( 'createSubmitChangesStore', () => {
 						createSubmitChangesStore( {
 							submitChanges: async () => ( { error } ),
 						} ),
-						createErrorStore()
+						createErrorStore( storeName )
 					)
 				);
 
@@ -107,7 +107,7 @@ describe( 'createSubmitChangesStore', () => {
 						createSubmitChangesStore( {
 							submitChanges: async () => ( { error } ),
 						} ),
-						createErrorStore()
+						createErrorStore( storeName )
 					)
 				);
 
@@ -180,7 +180,7 @@ describe( 'createSubmitChangesStore', () => {
 					storeName,
 					Data.combineStores(
 						Data.commonStore,
-						createErrorStore(),
+						createErrorStore( storeName ),
 						createSubmitChangesStore( {
 							submitChanges: async () => {
 								expect(
@@ -207,7 +207,7 @@ describe( 'createSubmitChangesStore', () => {
 						createSubmitChangesStore( {
 							submitChanges: async () => ( {} ),
 						} ),
-						createErrorStore()
+						createErrorStore( storeName )
 					)
 				);
 

--- a/assets/js/googlesitekit/modules/datastore/index.js
+++ b/assets/js/googlesitekit/modules/datastore/index.js
@@ -30,7 +30,7 @@ import { CORE_MODULES } from './constants';
 const store = Data.combineStores(
 	Data.commonStore,
 	modules,
-	createErrorStore(),
+	createErrorStore( CORE_MODULES ),
 	settingsPanel,
 	settings,
 	sharingSettings

--- a/assets/js/googlesitekit/widgets/datastore/index.js
+++ b/assets/js/googlesitekit/widgets/datastore/index.js
@@ -31,7 +31,7 @@ const store = Data.combineStores(
 	areas,
 	widgets,
 	contexts,
-	createErrorStore()
+	createErrorStore( CORE_WIDGETS )
 );
 
 export const registerStore = ( registry ) => {


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #5235.

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
