### PR TITLE
Enhance/5234 - Add new selectorData object in getErrorForSelector

### DIFF
--- a/assets/js/googlesitekit/data/create-error-store.js
+++ b/assets/js/googlesitekit/data/create-error-store.js
@@ -183,7 +183,20 @@ export function createErrorStore( storeName ) {
 		 */
 		getErrorForSelector( state, selectorName, args = [] ) {
 			invariant( selectorName, 'selectorName is required.' );
-			return selectors.getError( state, selectorName, args );
+
+			const error = selectors.getError( state, selectorName, args );
+			if ( ! error ) {
+				return undefined;
+			}
+
+			return {
+				...error,
+				selectorData: {
+					storeName,
+					name: selectorName,
+					args,
+				},
+			};
 		},
 
 		/**

--- a/assets/js/googlesitekit/data/create-error-store.test.js
+++ b/assets/js/googlesitekit/data/create-error-store.test.js
@@ -171,21 +171,19 @@ describe( 'createErrorStore store', () => {
 
 	describe( 'selectors', () => {
 		describe( 'getErrorForSelector', () => {
-			const baseNameParam = 'selectorName';
-
-			it( `requires a \`${ baseNameParam }\` param`, () => {
+			it( 'requires a `selectorName` param', () => {
 				expect( () => {
 					select.getErrorForSelector();
-				} ).toThrow( `${ baseNameParam } is required.` );
+				} ).toThrow( 'selectorName is required.' );
 			} );
 
-			it( `returns \`undefined\` when no has been received error for the given \`${ baseNameParam }\``, () => {
+			it( 'returns `undefined` when no has been received error for the given `selectorName`', () => {
 				expect(
 					select.getErrorForSelector( 'nonExistentBaseName' )
 				).toBeUndefined();
 			} );
 
-			it( `returns the error for the given \`${ baseNameParam }\` with empty \`args\` or none`, () => {
+			it( 'returns the error for the given `selectorName` with empty `args` or none', () => {
 				dispatch.receiveError( errorForbidden, baseName, [] );
 
 				expect( select.getErrorForSelector( baseName ) ).toEqual( {
@@ -208,10 +206,10 @@ describe( 'createErrorStore store', () => {
 
 			it.each( [
 				[
-					`returns the error received for the given \`${ baseNameParam }\` and \`args\``,
+					'returns the error received for the given `selectorName` and `args`',
 				],
 				[
-					`\`selectorData\` matches the selector name for the given \`${ baseNameParam }\` and \`args\``,
+					'`selectorData` matches the selector name for the given `selectorName` and `args`',
 				],
 			] )( '%s', () => {
 				dispatch.receiveError( errorNotFound, baseName, [] );
@@ -231,21 +229,19 @@ describe( 'createErrorStore store', () => {
 		} );
 
 		describe( 'getErrorForAction', () => {
-			const baseNameParam = 'actionName';
-
-			it( `requires a \`${ baseNameParam }\` param`, () => {
+			it( 'requires a `actionName` param', () => {
 				expect( () => {
 					select.getErrorForAction();
-				} ).toThrow( `${ baseNameParam } is required.` );
+				} ).toThrow( 'actionName is required.' );
 			} );
 
-			it( `returns \`undefined\` when no has been received error for the given \`${ baseNameParam }\``, () => {
+			it( 'returns `undefined` when no has been received error for the given `actionName`', () => {
 				expect(
 					select.getErrorForAction( 'nonExistentBaseName' )
 				).toBeUndefined();
 			} );
 
-			it( `returns the error for the given \`${ baseNameParam }\` with empty \`args\` or none`, () => {
+			it( 'returns the error for the given `actionName` with empty `args` or none', () => {
 				dispatch.receiveError( errorForbidden, baseName, [] );
 
 				expect( select.getErrorForAction( baseName ) ).toEqual(
@@ -256,7 +252,7 @@ describe( 'createErrorStore store', () => {
 				);
 			} );
 
-			it( `returns the error received for the given \`${ baseNameParam }\` and \`args\``, () => {
+			it( 'returns the error received for the given `actionName` and `args`', () => {
 				dispatch.receiveError( errorNotFound, baseName, [] );
 				dispatch.receiveError( errorForbidden, baseName, args );
 

--- a/assets/js/googlesitekit/data/create-error-store.test.js
+++ b/assets/js/googlesitekit/data/create-error-store.test.js
@@ -170,47 +170,101 @@ describe( 'createErrorStore store', () => {
 	} );
 
 	describe( 'selectors', () => {
-		describe.each( [ 'getErrorForSelector', 'getErrorForAction' ] )(
-			'%s',
-			( selectorName ) => {
-				const baseNameParam =
-					selectorName === 'getErrorForSelector'
-						? 'selectorName'
-						: 'actionName';
+		describe( 'getErrorForSelector', () => {
+			const baseNameParam = 'selectorName';
 
-				it( `requires a \`${ baseNameParam }\` param`, () => {
-					expect( () => {
-						select[ selectorName ]();
-					} ).toThrow( `${ baseNameParam } is required.` );
+			it( `requires a \`${ baseNameParam }\` param`, () => {
+				expect( () => {
+					select.getErrorForSelector();
+				} ).toThrow( `${ baseNameParam } is required.` );
+			} );
+
+			it( `returns \`undefined\` when no has been received error for the given \`${ baseNameParam }\``, () => {
+				expect(
+					select.getErrorForSelector( 'nonExistentBaseName' )
+				).toBeUndefined();
+			} );
+
+			it( `returns the error for the given \`${ baseNameParam }\` with empty \`args\` or none`, () => {
+				dispatch.receiveError( errorForbidden, baseName, [] );
+
+				expect( select.getErrorForSelector( baseName ) ).toEqual( {
+					...errorForbidden,
+					selectorData: {
+						args: [],
+						name: baseName,
+						storeName: TEST_STORE,
+					},
 				} );
-
-				it( `returns \`undefined\` when no has been received error for the given \`${ baseNameParam }\``, () => {
-					expect(
-						select[ selectorName ]( 'nonExistentBaseName' )
-					).toBeUndefined();
+				expect( select.getErrorForSelector( baseName, [] ) ).toEqual( {
+					...errorForbidden,
+					selectorData: {
+						args: [],
+						name: baseName,
+						storeName: TEST_STORE,
+					},
 				} );
+			} );
 
-				it( `returns the error for the given \`${ baseNameParam }\` with empty \`args\` or none`, () => {
-					dispatch.receiveError( errorForbidden, baseName, [] );
+			it.each( [
+				[
+					`returns the error received for the given \`${ baseNameParam }\` and \`args\``,
+				],
+				[
+					`\`selectorData\` matches the selector name for the given \`${ baseNameParam }\` and \`args\``,
+				],
+			] )( '%s', () => {
+				dispatch.receiveError( errorNotFound, baseName, [] );
+				dispatch.receiveError( errorForbidden, baseName, args );
 
-					expect( select[ selectorName ]( baseName ) ).toEqual(
-						errorForbidden
-					);
-					expect( select[ selectorName ]( baseName, [] ) ).toEqual(
-						errorForbidden
-					);
-				} );
+				expect( select.getErrorForSelector( baseName, args ) ).toEqual(
+					{
+						...errorForbidden,
+						selectorData: {
+							args,
+							name: baseName,
+							storeName: TEST_STORE,
+						},
+					}
+				);
+			} );
+		} );
 
-				it( `returns the error received for the given \`${ baseNameParam }\` and \`args\``, () => {
-					dispatch.receiveError( errorNotFound, baseName, [] );
-					dispatch.receiveError( errorForbidden, baseName, args );
+		describe( 'getErrorForAction', () => {
+			const baseNameParam = 'actionName';
 
-					expect( select[ selectorName ]( baseName, args ) ).toEqual(
-						errorForbidden
-					);
-				} );
-			}
-		);
+			it( `requires a \`${ baseNameParam }\` param`, () => {
+				expect( () => {
+					select.getErrorForAction();
+				} ).toThrow( `${ baseNameParam } is required.` );
+			} );
+
+			it( `returns \`undefined\` when no has been received error for the given \`${ baseNameParam }\``, () => {
+				expect(
+					select.getErrorForAction( 'nonExistentBaseName' )
+				).toBeUndefined();
+			} );
+
+			it( `returns the error for the given \`${ baseNameParam }\` with empty \`args\` or none`, () => {
+				dispatch.receiveError( errorForbidden, baseName, [] );
+
+				expect( select.getErrorForAction( baseName ) ).toEqual(
+					errorForbidden
+				);
+				expect( select.getErrorForAction( baseName, [] ) ).toEqual(
+					errorForbidden
+				);
+			} );
+
+			it( `returns the error received for the given \`${ baseNameParam }\` and \`args\``, () => {
+				dispatch.receiveError( errorNotFound, baseName, [] );
+				dispatch.receiveError( errorForbidden, baseName, args );
+
+				expect( select.getErrorForAction( baseName, args ) ).toEqual(
+					errorForbidden
+				);
+			} );
+		} );
 
 		describe( 'getError', () => {
 			describe( 'legacy argumentless behavior', () => {

--- a/assets/js/googlesitekit/datastore/user/authentication.test.js
+++ b/assets/js/googlesitekit/datastore/user/authentication.test.js
@@ -272,11 +272,6 @@ describe( 'core/user authentication', () => {
 					code: 'internal_server_error',
 					message: 'Internal server error',
 					data: { status: 500 },
-					selectorData: {
-						args: [],
-						name: 'getAuthentication',
-						storeName: CORE_USER,
-					},
 				};
 				fetchMock.getOnce( coreUserDataEndpointRegExp, {
 					body: response,
@@ -293,7 +288,14 @@ describe( 'core/user authentication', () => {
 
 				expect( fetchMock ).toHaveFetchedTimes( 1 );
 				expect( value ).toBeUndefined();
-				expect( error ).toEqual( response );
+				expect( error ).toEqual( {
+					...response,
+					selectorData: {
+						args: [],
+						name: 'getAuthentication',
+						storeName: CORE_USER,
+					},
+				} );
 				expect( console ).toHaveErrored();
 			} );
 

--- a/assets/js/googlesitekit/datastore/user/authentication.test.js
+++ b/assets/js/googlesitekit/datastore/user/authentication.test.js
@@ -272,6 +272,11 @@ describe( 'core/user authentication', () => {
 					code: 'internal_server_error',
 					message: 'Internal server error',
 					data: { status: 500 },
+					selectorData: {
+						args: [],
+						name: 'getAuthentication',
+						storeName: CORE_USER,
+					},
 				};
 				fetchMock.getOnce( coreUserDataEndpointRegExp, {
 					body: response,

--- a/assets/js/modules/adsense/datastore/urlchannels.test.js
+++ b/assets/js/modules/adsense/datastore/urlchannels.test.js
@@ -105,18 +105,23 @@ describe( 'modules/adsense URL channels', () => {
 			} );
 
 			it( 'dispatches an error if the request fails', async () => {
+				const fakeAccountID = 'pub-777888999';
+				const fakeClientID = 'ca-pub-777888999';
+
 				const response = {
 					code: 'internal_server_error',
 					message: 'Internal server error',
 					data: { status: 500 },
+					selectorData: {
+						args: [ fakeAccountID, fakeClientID ],
+						name: 'getURLChannels',
+						storeName: MODULES_ADSENSE,
+					},
 				};
 				fetchMock.getOnce(
 					/^\/google-site-kit\/v1\/modules\/adsense\/data\/urlchannels/,
 					{ body: response, status: 500 }
 				);
-
-				const fakeAccountID = 'pub-777888999';
-				const fakeClientID = 'ca-pub-777888999';
 
 				registry
 					.select( MODULES_ADSENSE )

--- a/assets/js/modules/adsense/datastore/urlchannels.test.js
+++ b/assets/js/modules/adsense/datastore/urlchannels.test.js
@@ -112,11 +112,6 @@ describe( 'modules/adsense URL channels', () => {
 					code: 'internal_server_error',
 					message: 'Internal server error',
 					data: { status: 500 },
-					selectorData: {
-						args: [ fakeAccountID, fakeClientID ],
-						name: 'getURLChannels',
-						storeName: MODULES_ADSENSE,
-					},
 				};
 				fetchMock.getOnce(
 					/^\/google-site-kit\/v1\/modules\/adsense\/data\/urlchannels/,
@@ -144,7 +139,14 @@ describe( 'modules/adsense URL channels', () => {
 						fakeAccountID,
 						fakeClientID,
 					] );
-				expect( urlChannelsError ).toEqual( response );
+				expect( urlChannelsError ).toEqual( {
+					...response,
+					selectorData: {
+						args: [ fakeAccountID, fakeClientID ],
+						name: 'getURLChannels',
+						storeName: MODULES_ADSENSE,
+					},
+				} );
 			} );
 		} );
 	} );

--- a/assets/js/modules/tagmanager/datastore/containers.test.js
+++ b/assets/js/modules/tagmanager/datastore/containers.test.js
@@ -425,11 +425,6 @@ describe( 'modules/tagmanager containers', () => {
 					code: 'internal_server_error',
 					message: 'Internal server error',
 					data: { status: 500 },
-					selectorData: {
-						args: [ accountID ],
-						name: 'getContainers',
-						storeName: MODULES_TAGMANAGER,
-					},
 				};
 				fetchMock.getOnce(
 					/^\/google-site-kit\/v1\/modules\/tagmanager\/data\/containers/,
@@ -453,7 +448,14 @@ describe( 'modules/tagmanager containers', () => {
 				const error = registry
 					.select( MODULES_TAGMANAGER )
 					.getErrorForSelector( 'getContainers', [ accountID ] );
-				expect( error ).toEqual( errorResponse );
+				expect( error ).toEqual( {
+					...errorResponse,
+					selectorData: {
+						args: [ accountID ],
+						name: 'getContainers',
+						storeName: MODULES_TAGMANAGER,
+					},
+				} );
 				expect( console ).toHaveErrored();
 			} );
 		} );

--- a/assets/js/modules/tagmanager/datastore/containers.test.js
+++ b/assets/js/modules/tagmanager/datastore/containers.test.js
@@ -425,6 +425,11 @@ describe( 'modules/tagmanager containers', () => {
 					code: 'internal_server_error',
 					message: 'Internal server error',
 					data: { status: 500 },
+					selectorData: {
+						args: [ accountID ],
+						name: 'getContainers',
+						storeName: MODULES_TAGMANAGER,
+					},
 				};
 				fetchMock.getOnce(
 					/^\/google-site-kit\/v1\/modules\/tagmanager\/data\/containers/,

--- a/assets/js/modules/tagmanager/datastore/versions.test.js
+++ b/assets/js/modules/tagmanager/datastore/versions.test.js
@@ -789,11 +789,6 @@ describe( 'modules/tagmanager versions', () => {
 					code: 'internal_server_error',
 					message: 'Internal server error',
 					data: { status: 500 },
-					selectorData: {
-						args: [ accountID, internalContainerID ],
-						name: 'getLiveContainerVersion',
-						storeName: MODULES_TAGMANAGER,
-					},
 				};
 				fetchMock.getOnce(
 					/^\/google-site-kit\/v1\/modules\/tagmanager\/data\/live-container-version/,
@@ -816,7 +811,14 @@ describe( 'modules/tagmanager versions', () => {
 							accountID,
 							internalContainerID,
 						] )
-				).toEqual( errorResponse );
+				).toEqual( {
+					...errorResponse,
+					selectorData: {
+						args: [ accountID, internalContainerID ],
+						name: 'getLiveContainerVersion',
+						storeName: MODULES_TAGMANAGER,
+					},
+				} );
 				expect(
 					registry
 						.select( MODULES_TAGMANAGER )

--- a/assets/js/modules/tagmanager/datastore/versions.test.js
+++ b/assets/js/modules/tagmanager/datastore/versions.test.js
@@ -789,6 +789,11 @@ describe( 'modules/tagmanager versions', () => {
 					code: 'internal_server_error',
 					message: 'Internal server error',
 					data: { status: 500 },
+					selectorData: {
+						args: [ accountID, internalContainerID ],
+						name: 'getLiveContainerVersion',
+						storeName: MODULES_TAGMANAGER,
+					},
 				};
 				fetchMock.getOnce(
 					/^\/google-site-kit\/v1\/modules\/tagmanager\/data\/live-container-version/,


### PR DESCRIPTION
## Summary

Addresses issue:

- #5234 

## Relevant technical choices

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
