### PR TITLE
Fix entity header background color with alternate color schemes

### DIFF
--- a/assets/sass/components/global/_googlesitekit-dashboard-navigation.scss
+++ b/assets/sass/components/global/_googlesitekit-dashboard-navigation.scss
@@ -97,8 +97,9 @@
 	.googlesitekit-navigation--is-sticky {
 
 		+ .googlesitekit-entity-header {
+			background-color: $c-seashell;
 			box-shadow: 0 3px 3px rgb(0 0 0 / 10%);
-			transition: box-shadow $t-speed-2;
+			transition: background-color $t-speed-2, box-shadow $t-speed-2;
 		}
 	}
 

--- a/assets/sass/components/global/_googlesitekit-entity-header.scss
+++ b/assets/sass/components/global/_googlesitekit-entity-header.scss
@@ -20,7 +20,7 @@
 
 	.googlesitekit-entity-header {
 		align-items: center;
-		background-color: map-get($wp-colors, "gray-2");
+		background-color: transparent;
 		color: $c-cape-cod;
 		display: flex;
 		justify-content: space-between;

--- a/assets/sass/config/_variables.scss
+++ b/assets/sass/config/_variables.scss
@@ -73,6 +73,7 @@ $c-tundora: #484848;
 $c-aqua-haze: #f5f9f9;
 $c-salomie-40: rgba(255, 220, 130, 0.4);
 $c-link-water: #ebf2fb;
+$c-seashell: #f1f1f1;
 
 // WordPress core pallete (see https://make.wordpress.org/core/2021/02/23/standardization-of-wp-admin-colors-in-wordpress-5-7/)
 // For use primarily outside of Site Kit screens.


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #4769 

## Relevant technical choices

This PR addresses the issue where the background color of entity header is off with alternate WP color schemes. It only applies the background color to the entity header when it is sticky, i.e. on scroll.

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
