### PR TITLE
Fix datapoint request execution

### DIFF
--- a/includes/Core/Modules/Module.php
+++ b/includes/Core/Modules/Module.php
@@ -343,7 +343,7 @@ abstract class Module {
 			// even if a different client will be the one to execute the request because
 			// the default instance is what services are setup with.
 			$restore_defers[] = $this->get_client()->withDefer( true );
-			if ( $this->get_client() !== $oauth_client ) {
+			if ( $this->authentication->get_oauth_client() !== $oauth_client ) {
 				$restore_defers[] = $oauth_client->get_client()->withDefer( true );
 			}
 


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #5356

## Relevant technical choices

This PR fixes the reported issue by fixing a flaw in the datapoint request execution which resulted in the client having a "stacked" defer that resulted in the request for Analytics account summaries in the `accounts-properties-profiles` parse response method being deferred and thus not executed.
https://github.com/google/site-kit-wp/blob/abeb47e26e5d4ffea8849fa1ec44796780a28337/includes/Modules/Analytics.php#L781

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
