### PR TITLE
Exclude users who can authenticate from redirection

### DIFF
--- a/includes/Core/Admin/Screens.php
+++ b/includes/Core/Admin/Screens.php
@@ -414,7 +414,8 @@ final class Screens {
 						(
 							Feature_Flags::enabled( 'dashboardSharing' ) &&
 							$dismissed_items->is_dismissed( 'shared_dashboard_splash' ) &&
-							current_user_can( Permissions::VIEW_SHARED_DASHBOARD )
+							current_user_can( Permissions::VIEW_SHARED_DASHBOARD ) &&
+							! current_user_can( Permissions::AUTHENTICATE )
 						)
 					) {
 						wp_safe_redirect(

--- a/includes/Core/Admin/Screens.php
+++ b/includes/Core/Admin/Screens.php
@@ -413,9 +413,9 @@ final class Screens {
 						$this->authentication->is_authenticated() ||
 						(
 							Feature_Flags::enabled( 'dashboardSharing' ) &&
+							! current_user_can( Permissions::AUTHENTICATE ) &&
 							$dismissed_items->is_dismissed( 'shared_dashboard_splash' ) &&
-							current_user_can( Permissions::VIEW_SHARED_DASHBOARD ) &&
-							! current_user_can( Permissions::AUTHENTICATE )
+							current_user_can( Permissions::VIEW_SHARED_DASHBOARD )
 						)
 					) {
 						wp_safe_redirect(

--- a/includes/Core/Admin/Screens.php
+++ b/includes/Core/Admin/Screens.php
@@ -126,6 +126,8 @@ final class Screens {
 			function() {
 				// Redirect dashboard to splash if no dashboard access (yet).
 				$this->no_access_redirect_dashboard_to_splash();
+				// Redirect splash to (shared) dashboard if splash is dismissed.
+				$this->no_access_redirect_splash_to_dashboard();
 
 				// Redirect module pages to dashboard.
 				$this->no_access_redirect_module_to_dashboard();
@@ -277,6 +279,30 @@ final class Screens {
 		if ( current_user_can( Permissions::VIEW_SPLASH ) ) {
 			wp_safe_redirect(
 				$this->context->admin_url( 'splash' )
+			);
+			exit;
+		}
+	}
+
+	/**
+	 * Redirects from the splash to the dashboard screen if permissions to access the splash are currently not met.
+	 *
+	 * Admins always have the ability to view the splash page, so this redirects non-admins who have access
+	 * to view the shared dashboard if the splash has been dismissed.
+	 * Currently the dismissal check is built into the capability for VIEW_SPLASH so this is implied.
+	 *
+	 * @since 1.77.0
+	 */
+	private function no_access_redirect_splash_to_dashboard() {
+		global $plugin_page;
+
+		if ( ! isset( $plugin_page ) || self::PREFIX . 'splash' !== $plugin_page ) {
+			return;
+		}
+
+		if ( current_user_can( Permissions::VIEW_DASHBOARD ) ) {
+			wp_safe_redirect(
+				$this->context->admin_url()
 			);
 			exit;
 		}


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #4525 

## Relevant technical choices

This PR addresses the issue raised in [this comment](https://github.com/google/site-kit-wp/issues/4525#issuecomment-1159047373) where a user who can authenticate is also included in the redirection.

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
