### PR TITLE
Ensure site has multiple admins for skip sign-in

### DIFF
--- a/assets/js/components/setup/SetupUsingProxyWithSignIn.js
+++ b/assets/js/components/setup/SetupUsingProxyWithSignIn.js
@@ -86,6 +86,7 @@ export default function SetupUsingProxyWithSignIn() {
 		isConnected,
 		connectedProxyURL,
 		homeURL,
+		hasMultipleAdmins,
 	} = useSelect( ( select ) => {
 		const site = select( CORE_SITE );
 		const user = select( CORE_USER );
@@ -99,6 +100,7 @@ export default function SetupUsingProxyWithSignIn() {
 			connectedProxyURL: untrailingslashit( user.getConnectedProxyURL() ),
 			homeURL: untrailingslashit( site.getHomeURL() ),
 			isConnected: site.isConnected(),
+			hasMultipleAdmins: site.hasMultipleAdmins(),
 		};
 	} );
 
@@ -362,7 +364,9 @@ export default function SetupUsingProxyWithSignIn() {
 																{
 																	inProgressFeedback
 																}
-																{ dashboardSharingEnabled &&
+																{ hasMultipleAdmins &&
+																	isSecondAdmin &&
+																	dashboardSharingEnabled &&
 																	hasViewableModules &&
 																	complete && (
 																		<Link

--- a/assets/js/components/setup/SetupUsingProxyWithSignIn.stories.js
+++ b/assets/js/components/setup/SetupUsingProxyWithSignIn.stories.js
@@ -170,6 +170,37 @@ SharedDashboardAdminCanView.parameters = {
 	features: [ 'dashboardSharing' ],
 };
 
+export const SharedDashboardSingleAdminCanView = Template.bind( {} );
+SharedDashboardSingleAdminCanView.storyName =
+	'Start - with Dashboard Sharing enabled and available but there is only one admin';
+SharedDashboardSingleAdminCanView.args = {
+	setupRegistry: ( registry ) => {
+		provideSiteConnection( registry, {
+			hasConnectedAdmins: true,
+			hasMultipleAdmins: false,
+		} );
+
+		provideModules( registry, [
+			{
+				slug: 'analytics',
+				active: true,
+				connected: true,
+			},
+		] );
+
+		provideUserCapabilities( registry, {
+			[ PERMISSION_VIEW_SHARED_DASHBOARD ]: true,
+			[ getMetaCapabilityPropertyName(
+				PERMISSION_READ_SHARED_MODULE_DATA,
+				'analytics'
+			) ]: true,
+		} );
+	},
+};
+SharedDashboardSingleAdminCanView.parameters = {
+	features: [ 'dashboardSharing' ],
+};
+
 export default {
 	title: 'Setup / Using Proxy With Sign-in',
 	decorators: [

--- a/assets/js/components/setup/SetupUsingProxyWithSignIn.stories.js
+++ b/assets/js/components/setup/SetupUsingProxyWithSignIn.stories.js
@@ -24,6 +24,7 @@ import {
 	CORE_USER,
 	DISCONNECTED_REASON_CONNECTED_URL_MISMATCH,
 	PERMISSION_VIEW_SHARED_DASHBOARD,
+	PERMISSION_READ_SHARED_MODULE_DATA,
 } from '../../googlesitekit/datastore/user/constants';
 import {
 	provideSiteConnection,
@@ -32,6 +33,7 @@ import {
 	provideUserCapabilities,
 } from '../../../../tests/js/utils';
 import WithRegistrySetup from '../../../../tests/js/WithRegistrySetup';
+import { getMetaCapabilityPropertyName } from '../../googlesitekit/datastore/util/permissions';
 
 const Template = () => <SetupUsingProxyWithSignIn />;
 
@@ -157,6 +159,10 @@ SharedDashboardAdminCanView.args = {
 
 		provideUserCapabilities( registry, {
 			[ PERMISSION_VIEW_SHARED_DASHBOARD ]: true,
+			[ getMetaCapabilityPropertyName(
+				PERMISSION_READ_SHARED_MODULE_DATA,
+				'analytics'
+			) ]: true,
 		} );
 	},
 };

--- a/assets/js/components/setup/SetupUsingProxyWithSignIn.stories.js
+++ b/assets/js/components/setup/SetupUsingProxyWithSignIn.stories.js
@@ -144,6 +144,7 @@ SharedDashboardAdminCanView.args = {
 	setupRegistry: ( registry ) => {
 		provideSiteConnection( registry, {
 			hasConnectedAdmins: true,
+			hasMultipleAdmins: true,
 		} );
 
 		provideModules( registry, [


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #5380 

## Relevant technical choices

This PR fixes an issue where the skip sign-in link is displayed to the only admin of the site, which is unexpected. Before showing this link, it simply checks if there are multiple admins and at least one (Site Kit) authenticated admin in the site.

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
