### PR TITLE
Clarify 'All Admins' wording

### DIFF
--- a/assets/js/components/dashboard-sharing/DashboardSharingSettings/Module.js
+++ b/assets/js/components/dashboard-sharing/DashboardSharingSettings/Module.js
@@ -65,7 +65,7 @@ const viewAccessOptions = [
 	},
 	{
 		value: 'all_admins',
-		label: __( 'All Admins', 'google-site-kit' ),
+		label: __( 'Any admin signed in with Google', 'google-site-kit' ),
 	},
 ];
 

--- a/assets/js/components/dashboard-sharing/DashboardSharingSettings/Module.js
+++ b/assets/js/components/dashboard-sharing/DashboardSharingSettings/Module.js
@@ -61,7 +61,7 @@ const { useSelect, useDispatch } = Data;
 const viewAccessOptions = [
 	{
 		value: 'owner',
-		label: __( 'Only Me', 'google-site-kit' ),
+		label: __( 'Only me', 'google-site-kit' ),
 	},
 	{
 		value: 'all_admins',

--- a/assets/js/components/dashboard-sharing/DashboardSharingSettings/Notice.js
+++ b/assets/js/components/dashboard-sharing/DashboardSharingSettings/Notice.js
@@ -51,7 +51,7 @@ export default function Notice() {
 				isEditingManagement &&
 				createInterpolateElement(
 					__(
-						'By clicking <strong>Apply</strong>, you are giving other admins permission to manage view-only access on your behalf to data from the Google services you selected “Any admin signed in with Google” for.',
+						'By clicking <strong>Apply</strong>, you are giving other admins permission to manage view-only access on your behalf to data from the Google services you selected “All Admins” for.',
 						'google-site-kit'
 					),
 					{

--- a/assets/js/components/dashboard-sharing/DashboardSharingSettings/Notice.js
+++ b/assets/js/components/dashboard-sharing/DashboardSharingSettings/Notice.js
@@ -51,7 +51,7 @@ export default function Notice() {
 				isEditingManagement &&
 				createInterpolateElement(
 					__(
-						'By clicking <strong>Apply</strong>, you are giving other admins permission to manage view-only access on your behalf to data from the Google services you selected “All Admins” for.',
+						'By clicking <strong>Apply</strong>, you are giving other admins permission to manage view-only access on your behalf to data from the Google services you selected “Any admin signed in with Google” for.',
 						'google-site-kit'
 					),
 					{

--- a/assets/js/components/dashboard-sharing/DashboardSharingSettings/index.test.js
+++ b/assets/js/components/dashboard-sharing/DashboardSharingSettings/index.test.js
@@ -184,7 +184,7 @@ describe( 'DashboardSharingSettings', () => {
 			).toBeInTheDocument();
 		} );
 
-		it( 'should set sharing management to `All Admins` and disabled if a module has shared ownership', () => {
+		it( 'should set sharing management to `Any admin signed in with Google` and disabled if a module has shared ownership', () => {
 			provideModules( registry, modules );
 			provideModuleRegistrations( registry );
 			provideSiteConnection( registry, {


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #5374 

## Relevant technical choices

This PR replaces the wording "All Admins" with "All admin signed in with Google", which conveys a more clearer message.

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [x] Run the code.
- [x] Ensure the acceptance criteria are satisfied.
- [x] Reassess the implementation with the IB.
- [x] Ensure no unrelated changes are included.
- [x] Ensure CI checks pass.
- [x] Check Storybook where applicable.
- [x] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [x] Ensure the PR has the correct target branch.
- [x] Double-check that the PR is okay to be merged.
- [x] Ensure the corresponding issue has a ZenHub release assigned.
- [x] Add a changelog message to the issue.
