### PR TITLE
Fix DS view-only information alignment

### DIFF
--- a/assets/js/components/ViewOnlyMenu/Service.js
+++ b/assets/js/components/ViewOnlyMenu/Service.js
@@ -53,7 +53,9 @@ export default function Service( { module } ) {
 
 	return (
 		<li className="googlesitekit-view-only-menu__service">
-			<Icon />
+			<span className="googlesitekit-view-only-menu__service--icon">
+				<Icon />
+			</span>
 			<span className="googlesitekit-view-only-menu__service--name">
 				{ name }
 			</span>

--- a/assets/sass/components/global/_googlesitekit-view-only-menu.scss
+++ b/assets/sass/components/global/_googlesitekit-view-only-menu.scss
@@ -93,23 +93,28 @@
 
 		.googlesitekit-view-only-menu__service {
 			display: flex;
+			gap: 8px;
 			margin-bottom: 10px;
 
 			svg {
-				margin-right: 8px;
 				padding: 2px;
 				width: 24px;
 			}
 		}
 
+		.googlesitekit-view-only-menu__service--icon {
+			flex: 0 0 24px;
+		}
+
 		.googlesitekit-view-only-menu__service--name {
-			flex: 1;
+			flex: 0 0 100px;
 			font-size: 14px;
 			margin-right: 8px;
 		}
 
 		.googlesitekit-view-only-menu__service--owner {
 			color: $c-primary;
+			flex: 1;
 			font-size: 12px;
 			margin-left: auto;
 		}


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #5381 

## Relevant technical choices

This PR fixes the alignment of information in the Dashboard Sharing view-only menu for `admin` users. 

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [x] Run the code.
- [x] Ensure the acceptance criteria are satisfied.
- [x] Reassess the implementation with the IB.
- [x] Ensure no unrelated changes are included.
- [x] Ensure CI checks pass.
- [x] Check Storybook where applicable.
- [x] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [x] Ensure the PR has the correct target branch.
- [x] Double-check that the PR is okay to be merged.
- [x] Ensure the corresponding issue has a ZenHub release assigned.
- [x] Add a changelog message to the issue.
