### PR TITLE
Default the MDC Menu quickOpen attribute to true.

### DIFF
--- a/assets/js/components/Menu.js
+++ b/assets/js/components/Menu.js
@@ -75,6 +75,7 @@ const Menu = forwardRef(
 
 			const menuComponent = new MDCMenu( menuRef.current );
 			menuComponent.listen( 'MDCMenu:selected', handleMenuSelected );
+			menuComponent.quickOpen = true;
 
 			setMenu( menuComponent );
 


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue: 

- #4735 

## Relevant technical choices

<!-- Please describe your changes. -->
As outlined in  #4735, the dropdown animations cause the underlying menu items to still be able to be clicked. This PR adresses the issue by changing the quickOpen attribute on the MDC Menu component to be true by default, disabling the animation and fixing the issue.

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [x] Run the code.
- [x] Ensure the acceptance criteria are satisfied.
- [x] Reassess the implementation with the IB.
- [x] Ensure no unrelated changes are included.
- [x] Ensure CI checks pass.
- [x] Check Storybook where applicable.
- [x] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [x] Ensure the PR has the correct target branch.
- [x] Double-check that the PR is okay to be merged.
- [x] Ensure the corresponding issue has a ZenHub release assigned.
- [x] Add a changelog message to the issue.
