### PR TITLE
Receive empty array instead of object.

### DIFF
--- a/assets/js/modules/analytics/components/dashboard/DashboardOverallPageMetricsWidget.stories.js
+++ b/assets/js/modules/analytics/components/dashboard/DashboardOverallPageMetricsWidget.stories.js
@@ -170,15 +170,12 @@ export const GatheringDataZeroDataStates = Template.bind( {} );
 GatheringDataZeroDataStates.storyName = 'Gathering Data w/ zeroDataStates';
 GatheringDataZeroDataStates.args = {
 	setupRegistry: ( { dispatch } ) => {
-		dispatch( MODULES_ANALYTICS ).receiveGetReport(
-			{},
-			{
-				options: gatheringReportOptions,
-			}
-		);
+		dispatch( MODULES_ANALYTICS ).receiveGetReport( [], {
+			options: gatheringReportOptions,
+		} );
 
 		for ( const options of reportOptions ) {
-			dispatch( MODULES_ANALYTICS ).receiveGetReport( {}, { options } );
+			dispatch( MODULES_ANALYTICS ).receiveGetReport( [], { options } );
 		}
 	},
 };
@@ -191,15 +188,12 @@ GatheringDataZeroDataStatesDisabled.storyName =
 	'Gathering Data w/o zeroDataStates';
 GatheringDataZeroDataStatesDisabled.args = {
 	setupRegistry: ( { dispatch } ) => {
-		dispatch( MODULES_ANALYTICS ).receiveGetReport(
-			{},
-			{
-				options: gatheringReportOptions,
-			}
-		);
+		dispatch( MODULES_ANALYTICS ).receiveGetReport( [], {
+			options: gatheringReportOptions,
+		} );
 
 		for ( const options of reportOptions ) {
-			dispatch( MODULES_ANALYTICS ).receiveGetReport( {}, { options } );
+			dispatch( MODULES_ANALYTICS ).receiveGetReport( [], { options } );
 		}
 	},
 };
@@ -311,15 +305,12 @@ GatheringDataEntityURLZeroDataStates.storyName =
 	'Gathering w/ entity URL and zeroDataStates';
 GatheringDataEntityURLZeroDataStates.args = {
 	setupRegistry: ( { dispatch } ) => {
-		dispatch( MODULES_ANALYTICS ).receiveGetReport(
-			{},
-			{
-				options: gatheringReportOptions,
-			}
-		);
+		dispatch( MODULES_ANALYTICS ).receiveGetReport( [], {
+			options: gatheringReportOptions,
+		} );
 
 		for ( const options of reportOptions ) {
-			dispatch( MODULES_ANALYTICS ).receiveGetReport( {}, { options } );
+			dispatch( MODULES_ANALYTICS ).receiveGetReport( [], { options } );
 		}
 	},
 };
@@ -332,15 +323,12 @@ GatheringDataEntityURLZeroDataStatesDisabled.storyName =
 	'Gathering w/ entity URL and w/o zeroDataStates';
 GatheringDataEntityURLZeroDataStatesDisabled.args = {
 	setupRegistry: ( { dispatch } ) => {
-		dispatch( MODULES_ANALYTICS ).receiveGetReport(
-			{},
-			{
-				options: gatheringReportOptions,
-			}
-		);
+		dispatch( MODULES_ANALYTICS ).receiveGetReport( [], {
+			options: gatheringReportOptions,
+		} );
 
 		for ( const options of reportOptions ) {
-			dispatch( MODULES_ANALYTICS ).receiveGetReport( {}, { options } );
+			dispatch( MODULES_ANALYTICS ).receiveGetReport( [], { options } );
 		}
 	},
 };


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #5404

Changes will be visible here until merged:
https://google.github.io/site-kit-wp/storybook/pull/5405/?path=/story/modules-analytics-widgets-dashboardoverallpagemetricswidget--gathering-data-entity-url-zero-data-states-disabled

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
