### PR TITLE
Refactor container heights to percentages.

### DIFF
--- a/assets/sass/components/global/_googlesitekit-dialog.scss
+++ b/assets/sass/components/global/_googlesitekit-dialog.scss
@@ -21,14 +21,16 @@
 	.googlesitekit-dialog {
 
 		.admin-bar & {
-			top: 23px;
+			top: 46px;
 		}
 
 		.mdc-dialog__container {
+			height: 100%;
 			max-width: 908px;
 			width: 100%;
 
 			@media (min-width: $bp-tablet) {
+				height: auto;
 				max-height: calc(100vh - 120px);
 				width: 80%;
 			}
@@ -36,7 +38,7 @@
 
 		.mdc-dialog__surface {
 			border-radius: 0;
-			height: 100vh;
+			height: 100%;
 			max-height: 100%;
 			max-width: 100%;
 			padding: 0;
@@ -48,7 +50,7 @@
 			}
 
 			.admin-bar & {
-				height: calc(100vh - 46px);
+				height: calc(100% - 46px);
 
 				@media (min-width: $bp-tablet) {
 					height: auto;


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #5360 

## Relevant technical choices

<!-- Please describe your changes. -->
This PR adresses the issue where content in the add user modal gets hidden behind the floating safari address bar.

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [x] Run the code.
- [x] Ensure the acceptance criteria are satisfied.
- [x] Reassess the implementation with the IB.
- [x] Ensure no unrelated changes are included.
- [x] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [x] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [x] Ensure the PR has the correct target branch.
- [x] Double-check that the PR is okay to be merged.
- [x] Ensure the corresponding issue has a ZenHub release assigned.
- [x] Add a changelog message to the issue.
