### PR TITLE
Update tooltip copy if admin can't manage view access

### DIFF
--- a/assets/js/components/dashboard-sharing/DashboardSharingSettings/Module.js
+++ b/assets/js/components/dashboard-sharing/DashboardSharingSettings/Module.js
@@ -214,14 +214,25 @@ export default function Module( { moduleSlug, moduleName, ownerUsername } ) {
 								) }
 
 								<Tooltip
-									title={ sprintf(
-										/* translators: %s: name of the user who manages the module. */
-										__(
-											'%s has connected this and given managing permissions to all admins. You can change who can view this on the dashboard.',
-											'google-site-kit'
-										),
-										ownerUsername
-									) }
+									title={
+										hasSharingCapability
+											? sprintf(
+													/* translators: %s: name of the user who manages the module. */
+													__(
+														'%s has connected this and given managing permissions to all admins. You can change who can view this on the dashboard.',
+														'google-site-kit'
+													),
+													ownerUsername
+											  )
+											: sprintf(
+													/* translators: %s: name of the user who manages the module. */
+													__(
+														'Contact %s to change who can manage view access for this module.',
+														'google-site-kit'
+													),
+													ownerUsername
+											  )
+									}
 									classes={ {
 										popper: 'googlesitekit-tooltip-popper',
 										tooltip: 'googlesitekit-tooltip',


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #5370 

## Relevant technical choices

This PR updates the tooltip copy in the "Who can manage view access" column for secondary connected admins if they don't have permissions to manage view access.

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [x] Run the code.
- [x] Ensure the acceptance criteria are satisfied.
- [x] Reassess the implementation with the IB.
- [x] Ensure no unrelated changes are included.
- [x] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [x] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [x] Ensure the PR has the correct target branch.
- [x] Double-check that the PR is okay to be merged.
- [x] Ensure the corresponding issue has a ZenHub release assigned.
- [x] Add a changelog message to the issue.
