### PR TITLE
Display text instead of dropdown for shared modules

### DIFF
--- a/assets/js/components/dashboard-sharing/DashboardSharingSettings/Module.js
+++ b/assets/js/components/dashboard-sharing/DashboardSharingSettings/Module.js
@@ -182,14 +182,38 @@ export default function Module( { moduleSlug, moduleName, ownerUsername } ) {
 
 			{ hasMultipleAdmins && (
 				<div className="googlesitekit-dashboard-sharing-settings__column--manage">
-					{ ( sharedOwnershipModule || hasOwnedModule ) && (
+					{ sharedOwnershipModule && (
+						<p className="googlesitekit-dashboard-sharing-settings__note">
+							<span>
+								{ __(
+									'Any admin signed in with Google',
+									'google-site-kit'
+								) }
+							</span>
+
+							<Tooltip
+								title={ __(
+									'This service requires general access to Google APIs rather than access to a specific user-owned property/entity, so view access is manageable by any admin signed in with Google.',
+									'google-site-kit'
+								) }
+								classes={ {
+									popper: 'googlesitekit-tooltip-popper',
+									tooltip: 'googlesitekit-tooltip',
+								} }
+							>
+								<span className="googlesitekit-dashboard-sharing-settings__tooltip-icon">
+									<Icon icon={ info } size={ 18 } />
+								</span>
+							</Tooltip>
+						</p>
+					) }
+					{ ! sharedOwnershipModule && hasOwnedModule && (
 						<Select
 							className="googlesitekit-dashboard-sharing-settings__select"
 							value={ manageViewAccess }
 							options={ viewAccessOptions }
 							onChange={ handleOnChange }
 							onClick={ handleOnChange }
-							disabled={ sharedOwnershipModule }
 							outlined
 						/>
 					) }

--- a/assets/js/components/dashboard-sharing/DashboardSharingSettings/index.test.js
+++ b/assets/js/components/dashboard-sharing/DashboardSharingSettings/index.test.js
@@ -184,40 +184,6 @@ describe( 'DashboardSharingSettings', () => {
 			).toBeInTheDocument();
 		} );
 
-		it( 'should set sharing management to `Any admin signed in with Google` and disabled if a module has shared ownership', () => {
-			provideModules( registry, modules );
-			provideModuleRegistrations( registry );
-			provideSiteConnection( registry, {
-				hasMultipleAdmins: true,
-			} );
-			provideUserInfo( registry );
-
-			registry
-				.dispatch( CORE_MODULES )
-				.receiveGetSharingSettings( sharingSettings );
-			registry.dispatch( CORE_MODULES ).receiveShareableRoles( roles );
-			registry
-				.dispatch( CORE_MODULES )
-				.receiveSharedOwnershipModules( [ 'search-console' ] );
-
-			registry.dispatch( CORE_USER ).receiveCapabilities( {
-				'googlesitekit_delegate_module_sharing_management::["search-console"]': true,
-				'googlesitekit_manage_module_sharing_options::["search-console"]': true,
-			} );
-			registry
-				.dispatch( MODULES_SEARCH_CONSOLE )
-				.receiveGetSettings( { ownerID: 1 } );
-
-			const { container } = render( <DashboardSharingSettings />, {
-				registry,
-			} );
-
-			expect( console ).not.toHaveErrored();
-			expect(
-				container.querySelector( '.mdc-select__native-control' )
-			).toBeDisabled();
-		} );
-
 		it( 'should disable other modules while editing user roles', () => {
 			provideModules( registry, modules );
 			provideModuleRegistrations( registry );


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #5352 

## Relevant technical choices

This PR removes the disabled dropdown for view manage access column with plain text which aims to clarify why the view access for shared ownership modules can't be managed.

Difference from IB:
- This PR removes the `should set sharing management to 'Any admin signed in with Google' and disabled if a module has shared ownership` test case in `assets/js/components/dashboard-sharing/DashboardSharingSettings/index.test.js` as it just checks if the shared ownership modules have their dropdown disabled. This is no longer relevant because we've removed those drop-downs as a whole in this PR.

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [x] Run the code.
- [x] Ensure the acceptance criteria are satisfied.
- [x] Reassess the implementation with the IB.
- [x] Ensure no unrelated changes are included.
- [x] Ensure CI checks pass.
- [x] Check Storybook where applicable.
- [x] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [x] Ensure the PR has the correct target branch.
- [x] Double-check that the PR is okay to be merged.
- [x] Ensure the corresponding issue has a ZenHub release assigned.
- [x] Add a changelog message to the issue.
