### PR TITLE
Bug/5358 Fix Dashboard Sharing Settings Modal position on mobile

### DIFF
--- a/assets/js/components/dashboard-sharing/DashboardSharingSettingsButton.js
+++ b/assets/js/components/dashboard-sharing/DashboardSharingSettingsButton.js
@@ -17,6 +17,10 @@
  */
 
 /**
+ * External dependencies
+ */
+import { useWindowScroll } from 'react-use';
+/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
@@ -50,6 +54,7 @@ const { useSelect, useDispatch } = Data;
 export default function DashboardSharingSettingsButton() {
 	const viewContext = useViewContext();
 	const breakpoint = useBreakpoint();
+	const { y } = useWindowScroll();
 	const { setValue } = useDispatch( CORE_UI );
 	const [ dialogOpen, setDialogOpen ] = useState( false );
 
@@ -87,6 +92,13 @@ export default function DashboardSharingSettingsButton() {
 					open={ dialogOpen }
 					onClose={ closeDialog }
 					className="googlesitekit-dialog googlesitekit-sharing-settings-dialog"
+					// On mobile, the dialog box's flexbox is set to stretch items within to cover
+					// the whole screen. But we have to move the box and adjust its height below the
+					// WP Admin bar of 46px which gradually scrolls off the screen.
+					style={ {
+						top: `${ y < 46 ? 46 - y : 0 }px`,
+						height: `calc(100vh - 46px + ${ y < 46 ? y : 46 }px)`,
+					} }
 				>
 					<div
 						className="googlesitekit-dialog__back-wrapper"

--- a/assets/js/components/dashboard-sharing/DashboardSharingSettingsButton.js
+++ b/assets/js/components/dashboard-sharing/DashboardSharingSettingsButton.js
@@ -97,7 +97,7 @@ export default function DashboardSharingSettingsButton() {
 					// WP Admin bar of 46px which gradually scrolls off the screen.
 					style={ {
 						top: `${ y < 46 ? 46 - y : 0 }px`,
-						height: `calc(100vh - 46px + ${ y < 46 ? y : 46 }px)`,
+						height: `calc(100% - 46px + ${ y < 46 ? y : 46 }px)`,
 					} }
 				>
 					<div

--- a/assets/js/components/dashboard-sharing/DashboardSharingSettingsButton.js
+++ b/assets/js/components/dashboard-sharing/DashboardSharingSettingsButton.js
@@ -20,6 +20,7 @@
  * External dependencies
  */
 import { useWindowScroll } from 'react-use';
+
 /**
  * WordPress dependencies
  */
@@ -78,6 +79,15 @@ export default function DashboardSharingSettingsButton() {
 		setValue( EDITING_USER_ROLE_SELECT_SLUG_KEY, undefined );
 	}, [ setValue ] );
 
+	const dialogStyles = {};
+	// On mobile, the dialog box's flexbox is set to stretch items within to cover
+	// the whole screen. But we have to move the box and adjust its height below the
+	// WP Admin bar of 46px which gradually scrolls off the screen.
+	if ( breakpoint === BREAKPOINT_SMALL ) {
+		dialogStyles.top = `${ y < 46 ? 46 - y : 0 }px`;
+		dialogStyles.height = `calc(100% - 46px + ${ y < 46 ? y : 46 }px)`;
+	}
+
 	return (
 		<Fragment>
 			<Button
@@ -92,13 +102,7 @@ export default function DashboardSharingSettingsButton() {
 					open={ dialogOpen }
 					onClose={ closeDialog }
 					className="googlesitekit-dialog googlesitekit-sharing-settings-dialog"
-					// On mobile, the dialog box's flexbox is set to stretch items within to cover
-					// the whole screen. But we have to move the box and adjust its height below the
-					// WP Admin bar of 46px which gradually scrolls off the screen.
-					style={ {
-						top: `${ y < 46 ? 46 - y : 0 }px`,
-						height: `calc(100% - 46px + ${ y < 46 ? y : 46 }px)`,
-					} }
+					style={ dialogStyles }
 				>
 					<div
 						className="googlesitekit-dialog__back-wrapper"

--- a/assets/sass/components/global/_googlesitekit-dialog.scss
+++ b/assets/sass/components/global/_googlesitekit-dialog.scss
@@ -43,7 +43,7 @@
 
 		.mdc-dialog__surface {
 			border-radius: 0;
-			max-height: 100%; // Height is programmatically set upto 100% on mobile.
+			max-height: 100%; // Height is programmatically set up to 100% on mobile.
 			max-width: 100%;
 			padding: 0;
 			width: 100%;

--- a/assets/sass/components/global/_googlesitekit-dialog.scss
+++ b/assets/sass/components/global/_googlesitekit-dialog.scss
@@ -41,7 +41,7 @@
 
 		.mdc-dialog__surface {
 			border-radius: 0;
-			max-height: 100vh; // Height is programmatically set upto 100vh on mobile.
+			max-height: 100%; // Height is programmatically set upto 100vh on mobile.
 			max-width: 100%;
 			padding: 0;
 			width: 100%;

--- a/assets/sass/components/global/_googlesitekit-dialog.scss
+++ b/assets/sass/components/global/_googlesitekit-dialog.scss
@@ -21,7 +21,12 @@
 	.googlesitekit-dialog {
 
 		.admin-bar & {
-			top: 23px;
+			// Stretch to cover full screen on mobile.
+			align-items: stretch;
+
+			@media (min-width: $bp-tablet) {
+				align-items: center;
+			}
 		}
 
 		.mdc-dialog__container {
@@ -36,8 +41,7 @@
 
 		.mdc-dialog__surface {
 			border-radius: 0;
-			height: 100vh;
-			max-height: 100%;
+			max-height: 100vh; // Height is programmatically set upto 100vh on mobile.
 			max-width: 100%;
 			padding: 0;
 			width: 100%;
@@ -45,14 +49,6 @@
 			@media (min-width: $bp-tablet) {
 				border-radius: 8px;
 				height: auto;
-			}
-
-			.admin-bar & {
-				height: calc(100vh - 46px);
-
-				@media (min-width: $bp-tablet) {
-					height: auto;
-				}
 			}
 		}
 


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #5358 

## Relevant technical choices

The solution within the IB did not fully fix the issue when we scrolled a tiny bit, so that only a part of the WP Admin Bar is scrolled. In this little edge case, the `top` and `height` values of the dialog box need to be set dynamically, based on the number of pixels actually scrolled. Also used flex to stretch instead of hardcoding heights. Could potentially clean up more of the height values on the `.mdc-dialog__container` that were recently added to develop - but not sure what they were fixing so have kept them for now.

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [x] Run the code.
- [x] Ensure the acceptance criteria are satisfied.
- [x] Reassess the implementation with the IB.
- [x] Ensure no unrelated changes are included.
- [x] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [x] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [x] Ensure the PR has the correct target branch.
- [x] Double-check that the PR is okay to be merged.
- [x] Ensure the corresponding issue has a ZenHub release assigned.
- [x] Add a changelog message to the issue.
