### PR TITLE
Only "No ad impressions yet" CTA if adsenseSetupV2 is disabled.

### DIFF
--- a/assets/js/modules/adsense/components/module/ModuleOverviewWidget/index.js
+++ b/assets/js/modules/adsense/components/module/ModuleOverviewWidget/index.js
@@ -51,7 +51,7 @@ const ModuleOverviewWidget = ( {
 	WidgetReportError,
 } ) => {
 	const [ selectedStats, setSelectedStats ] = useState( 0 );
-	const isAdsenceSetupV2 = useFeature( 'adsenseSetupV2' );
+	const adsenseSetupV2Enabled = useFeature( 'adsenseSetupV2' );
 
 	const {
 		startDate,
@@ -143,7 +143,7 @@ const ModuleOverviewWidget = ( {
 		);
 	}
 
-	if ( ! isAdsenceSetupV2 ) {
+	if ( ! adsenseSetupV2Enabled ) {
 		if (
 			isZeroReport( currentRangeData ) ||
 			isZeroReport( currentRangeChartData )

--- a/assets/js/modules/adsense/components/module/ModuleOverviewWidget/index.js
+++ b/assets/js/modules/adsense/components/module/ModuleOverviewWidget/index.js
@@ -30,6 +30,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
+import { useFeature } from '../../../../../hooks/useFeature';
 import { MODULES_ADSENSE } from '../../../datastore/constants';
 import { CORE_USER } from '../../../../../googlesitekit/datastore/user/constants';
 import { isZeroReport } from '../../../util';
@@ -50,6 +51,7 @@ const ModuleOverviewWidget = ( {
 	WidgetReportError,
 } ) => {
 	const [ selectedStats, setSelectedStats ] = useState( 0 );
+	const isAdsenceSetupV2 = useFeature( 'adsenseSetupV2' );
 
 	const {
 		startDate,
@@ -141,18 +143,20 @@ const ModuleOverviewWidget = ( {
 		);
 	}
 
-	if (
-		isZeroReport( currentRangeData ) ||
-		isZeroReport( currentRangeChartData )
-	) {
-		return (
-			<Widget noPadding>
-				<DashboardZeroData />
-				<div className={ HIDDEN_CLASS }>
-					<WidgetReportZero moduleSlug="adsense" />
-				</div>
-			</Widget>
-		);
+	if ( ! isAdsenceSetupV2 ) {
+		if (
+			isZeroReport( currentRangeData ) ||
+			isZeroReport( currentRangeChartData )
+		) {
+			return (
+				<Widget noPadding>
+					<DashboardZeroData />
+					<div className={ HIDDEN_CLASS }>
+						<WidgetReportZero moduleSlug="adsense" />
+					</div>
+				</Widget>
+			);
+		}
 	}
 
 	return (

--- a/stories/module-adsense-components.stories.js
+++ b/stories/module-adsense-components.stories.js
@@ -38,6 +38,33 @@ const generateAnalyticsData = makeReportDataGenerator(
 );
 const generateAdSenseData = makeReportDataGenerator( getAdSenseMockResponse );
 
+const zeroing = ( report ) => {
+	const zeroValue = ( cell ) => ( { ...cell, value: 0 } );
+
+	let clonedReport = { ...report };
+
+	const { totals, rows } = clonedReport;
+	const { cells } = totals;
+
+	clonedReport = {
+		...clonedReport,
+		totals: {
+			cells: cells.map( zeroValue ),
+		},
+		rows: rows.map( ( row ) => ( {
+			...row,
+			cells: row.cells.map( ( cell, index ) => {
+				if ( index !== 0 ) {
+					return zeroValue( cell );
+				}
+				return cell;
+			} ),
+		} ) ),
+	};
+
+	return clonedReport;
+};
+
 const topEarningPagesArgs = {
 	startDate: '2020-08-15',
 	endDate: '2020-09-11',
@@ -100,6 +127,7 @@ generateReportBasedWidgetStories( {
 	datastore: MODULES_ADSENSE,
 	group: 'AdSense Module/Components/Module/Overview Widget',
 	referenceDate: '2020-11-25',
+	zeroing,
 	...generateAdSenseData( [
 		{
 			metrics: [

--- a/stories/module-adsense-components.stories.js
+++ b/stories/module-adsense-components.stories.js
@@ -101,6 +101,11 @@ generateReportBasedWidgetStories( {
 	datastore: MODULES_ADSENSE,
 	group: 'AdSense Module/Components/Module/Overview Widget',
 	referenceDate: '2020-11-25',
+	defaultVariantOptions: {
+		ZeroData: {
+			features: [ 'adsenseSetupV2' ],
+		},
+	},
 	zeroing,
 	...generateAdSenseData( [
 		{

--- a/stories/module-adsense-components.stories.js
+++ b/stories/module-adsense-components.stories.js
@@ -23,6 +23,7 @@ import {
 	generateReportBasedWidgetStories,
 	makeReportDataGenerator,
 } from './utils/generate-widget-stories';
+import { zeroing } from './utils/adsense-data-zeroing';
 import DashboardTopEarningPagesWidget from '../assets/js/modules/adsense/components/dashboard/DashboardTopEarningPagesWidget';
 import ModuleOverviewWidget from '../assets/js/modules/adsense/components/module/ModuleOverviewWidget';
 import { MODULES_ADSENSE } from '../assets/js/modules/adsense/datastore/constants';
@@ -37,33 +38,6 @@ const generateAnalyticsData = makeReportDataGenerator(
 	getAnalyticsMockResponse
 );
 const generateAdSenseData = makeReportDataGenerator( getAdSenseMockResponse );
-
-const zeroing = ( report ) => {
-	const zeroValue = ( cell ) => ( { ...cell, value: 0 } );
-
-	let clonedReport = { ...report };
-
-	const { totals, rows } = clonedReport;
-	const { cells } = totals;
-
-	clonedReport = {
-		...clonedReport,
-		totals: {
-			cells: cells.map( zeroValue ),
-		},
-		rows: rows.map( ( row ) => ( {
-			...row,
-			cells: row.cells.map( ( cell, index ) => {
-				if ( index !== 0 ) {
-					return zeroValue( cell );
-				}
-				return cell;
-			} ),
-		} ) ),
-	};
-
-	return clonedReport;
-};
 
 const topEarningPagesArgs = {
 	startDate: '2020-08-15',

--- a/stories/utils/adsense-data-zeroing.js
+++ b/stories/utils/adsense-data-zeroing.js
@@ -1,3 +1,29 @@
+/**
+ * AdSense Settings components.
+ *
+ * Site Kit by Google, Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Returns an AdSense report with zeroed data.
+ *
+ * @since 1.77.0
+ *
+ * @param {Object} report AdSense report data.
+ * @return {Object} AdSense report data with zeroed data.
+ */
 export const zeroing = ( report ) => {
 	const zeroValue = ( cell ) => ( { ...cell, value: 0 } );
 

--- a/stories/utils/adsense-data-zeroing.js
+++ b/stories/utils/adsense-data-zeroing.js
@@ -1,0 +1,26 @@
+export const zeroing = ( report ) => {
+	const zeroValue = ( cell ) => ( { ...cell, value: 0 } );
+
+	let clonedReport = { ...report };
+
+	const { totals, rows } = clonedReport;
+	const { cells } = totals;
+
+	clonedReport = {
+		...clonedReport,
+		totals: {
+			cells: cells.map( zeroValue ),
+		},
+		rows: rows.map( ( row ) => ( {
+			...row,
+			cells: row.cells.map( ( cell, index ) => {
+				if ( index !== 0 ) {
+					return zeroValue( cell );
+				}
+				return cell;
+			} ),
+		} ) ),
+	};
+
+	return clonedReport;
+};

--- a/stories/utils/adsense-data-zeroing.js
+++ b/stories/utils/adsense-data-zeroing.js
@@ -1,7 +1,7 @@
 /**
  * AdSense Settings components.
  *
- * Site Kit by Google, Copyright 2021 Google LLC
+ * Site Kit by Google, Copyright 2022 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@
 /**
  * Returns an AdSense report with zeroed data.
  *
- * @since 1.77.0
+ * @since n.e.x.t
  *
  * @param {Object} report AdSense report data.
  * @return {Object} AdSense report data with zeroed data.

--- a/stories/utils/generate-widget-stories.js
+++ b/stories/utils/generate-widget-stories.js
@@ -203,6 +203,7 @@ export function generateReportBasedWidgetStories( args ) {
 		ZeroData:
 			typeof zeroing === 'function'
 				? {
+						features: [ 'adsenseSetupV2' ],
 						callback: ( { dispatch } ) => {
 							if ( Array.isArray( options ) ) {
 								options.forEach( ( option, index ) => {

--- a/stories/utils/generate-widget-stories.js
+++ b/stories/utils/generate-widget-stories.js
@@ -65,6 +65,7 @@ export function generateReportBasedWidgetStories( args ) {
 		Component,
 		referenceDate,
 		wrapWidget = true,
+		defaultVariantOptions = {},
 		additionalVariants = {},
 		additionalVariantCallbacks = {},
 		setup = () => {},
@@ -134,6 +135,7 @@ export function generateReportBasedWidgetStories( args ) {
 	// Existing default variants.
 	const defaultVariants = {
 		Loaded: {
+			...defaultVariantOptions.Loaded,
 			callback( { dispatch } ) {
 				if ( Array.isArray( options ) ) {
 					options.forEach( ( option, index ) => {
@@ -152,6 +154,7 @@ export function generateReportBasedWidgetStories( args ) {
 			},
 		},
 		Loading: {
+			...defaultVariantOptions.Loading,
 			callback( { dispatch } ) {
 				if ( Array.isArray( options ) ) {
 					options.forEach( ( option, index ) => {
@@ -176,6 +179,7 @@ export function generateReportBasedWidgetStories( args ) {
 			},
 		},
 		DataUnavailable: {
+			...defaultVariantOptions.DataUnavailable,
 			callback( { dispatch } ) {
 				if ( Array.isArray( options ) ) {
 					options.forEach( ( option, index ) => {
@@ -203,7 +207,7 @@ export function generateReportBasedWidgetStories( args ) {
 		ZeroData:
 			typeof zeroing === 'function'
 				? {
-						features: [ 'adsenseSetupV2' ],
+						...defaultVariantOptions.ZeroData,
 						callback: ( { dispatch } ) => {
 							if ( Array.isArray( options ) ) {
 								options.forEach( ( option, index ) => {
@@ -235,6 +239,7 @@ export function generateReportBasedWidgetStories( args ) {
 				  }
 				: undefined,
 		Error: {
+			...defaultVariantOptions.Error,
 			callback( { dispatch } ) {
 				const error = {
 					code: 'missing_required_param',


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #5385 

## Relevant technical choices

<!-- Please describe your changes. -->
This pull request adds an extra check to see whether or not the `adsenseSetupV2` feature flag is enabled, and only shows the zero data CTA-component if its disabled. 

This PR also adds a new Zero Data story in storybook

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [ ] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [x] Run the code.
- [x] Ensure the acceptance criteria are satisfied.
- [x] Reassess the implementation with the IB.
- [x] Ensure no unrelated changes are included.
- [x] Ensure CI checks pass.
- [x] Check Storybook where applicable.
- [x] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [x] Ensure the PR has the correct target branch.
- [x] Double-check that the PR is okay to be merged.
- [x] Ensure the corresponding issue has a ZenHub release assigned.
- [x] Add a changelog message to the issue.
