### PR TITLE
Don't show the linking CTA for view only users.

### DIFF
--- a/assets/js/modules/adsense/components/dashboard/DashboardTopEarningPagesWidget.js
+++ b/assets/js/modules/adsense/components/dashboard/DashboardTopEarningPagesWidget.js
@@ -48,10 +48,13 @@ import {
 import { numFmt } from '../../../../util';
 import { getCurrencyFormat } from '../../util/currency';
 import { useFeature } from '../../../../hooks/useFeature';
+import useViewOnly from '../../../../hooks/useViewOnly';
 const { useSelect, useInViewSelect } = Data;
 
 function DashboardTopEarningPagesWidget( props ) {
-	const { Widget, WidgetReportZero, WidgetReportError } = props;
+	const { Widget, WidgetReportZero, WidgetReportError, WidgetNull } = props;
+
+	const isViewOnly = useViewOnly();
 
 	const zeroDataStates = useFeature( 'zeroDataStates' );
 
@@ -147,9 +150,13 @@ function DashboardTopEarningPagesWidget( props ) {
 		);
 	}
 
+	if ( ! isAdSenseLinked && isViewOnly ) {
+		return <WidgetNull />;
+	}
+
 	// A restricted metrics error will cause this value to change in the resolver
 	// so this check should happen before an error, which is only relevant if they are linked.
-	if ( ! isAdSenseLinked ) {
+	if ( ! isAdSenseLinked && ! isViewOnly ) {
 		return (
 			<Widget Footer={ Footer }>
 				<AdSenseLinkCTA />


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #5346 

## Relevant technical choices

Adresses the issue of view only users being served CTA's by returning the WidgetNull component. A story for the component already exists.

https://github.com/google/site-kit-wp/blob/fbc29c96e865228db390175cd195425b18e13ffc/stories/module-adsense-components.stories.js#L393

<!-- Please describe your changes. -->

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [x] Run the code.
- [x] Ensure the acceptance criteria are satisfied.
- [x] Reassess the implementation with the IB.
- [x] Ensure no unrelated changes are included.
- [x] Ensure CI checks pass.
- [x] Check Storybook where applicable.
- [x] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [x] Ensure the PR has the correct target branch.
- [x] Double-check that the PR is okay to be merged.
- [x] Ensure the corresponding issue has a ZenHub release assigned.
- [x] Add a changelog message to the issue.
