### PR TITLE
Improve experience with recoverable modules for view-only users.

### DIFF
--- a/assets/js/components/RecoverableModules.js
+++ b/assets/js/components/RecoverableModules.js
@@ -36,12 +36,19 @@ import CTA from './notifications/CTA';
 const { useSelect } = Data;
 
 export default function RecoverableModules( { moduleSlugs } ) {
-	const moduleNames = useSelect( ( select ) =>
-		moduleSlugs.map(
-			( moduleSlug ) =>
-				select( CORE_MODULES ).getModule( moduleSlug ).name
-		)
-	);
+	const moduleNames = useSelect( ( select ) => {
+		const modules = select( CORE_MODULES ).getModules();
+
+		if ( modules === undefined ) {
+			return undefined;
+		}
+
+		return moduleSlugs.map( ( moduleSlug ) => modules[ moduleSlug ].name );
+	} );
+
+	if ( moduleNames === undefined ) {
+		return null;
+	}
 
 	const description =
 		moduleNames.length === 1

--- a/assets/js/components/RecoverableModules.js
+++ b/assets/js/components/RecoverableModules.js
@@ -1,0 +1,77 @@
+/**
+ * RecoverableModules component.
+ *
+ * Site Kit by Google, Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+
+/**
+ * WordPress dependencies
+ */
+import { __, _x, sprintf } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import Data from 'googlesitekit-data';
+import { CORE_MODULES } from '../googlesitekit/modules/datastore/constants';
+import CTA from './notifications/CTA';
+
+const { useSelect } = Data;
+
+export default function RecoverableModules( { moduleSlugs } ) {
+	const moduleNames = useSelect( ( select ) =>
+		moduleSlugs.map(
+			( moduleSlug ) =>
+				select( CORE_MODULES ).getModule( moduleSlug ).name
+		)
+	);
+
+	const description =
+		moduleNames.length === 1
+			? sprintf(
+					/* translators: %s: Module name */
+					__(
+						'%s data was previously shared by an admin who no longer has access. Please contact another admin to restore it.',
+						'google-site-kit'
+					),
+					moduleNames[ 0 ]
+			  )
+			: sprintf(
+					/* translators: %s: List of module names */
+					__(
+						'The data for the following modules was previously shared by an admin who no longer has access: %s. Please contact another admin to restore it.',
+						'google-site-kit'
+					),
+					moduleNames.join(
+						_x( ', ', 'Recoverable modules', 'google-site-kit' )
+					)
+			  );
+
+	return (
+		<CTA
+			title={ __( 'Data Unavailable', 'google-site-kit' ) }
+			description={ description }
+		/>
+	);
+}
+
+RecoverableModules.propTypes = {
+	moduleSlugs: PropTypes.arrayOf( PropTypes.string ).isRequired,
+};

--- a/assets/js/googlesitekit/modules/datastore/modules.js
+++ b/assets/js/googlesitekit/modules/datastore/modules.js
@@ -100,6 +100,29 @@ const normalizeModules = memize( ( serverDefinitions, clientDefinitions ) => {
 		}, {} );
 } );
 
+/**
+ * Memoized function to build an object mapping recoverable module slugs to their corresponding
+ * module objects.
+ *
+ * @since n.e.x.t
+ *
+ * @param {Object} modules            Module definitions.
+ * @param {Array}  recoverableModules Array of recoverable module slugs.
+ * @return {Object} Map of recoverable module slugs to their corresponding module objects.
+ */
+const calculateRecoverableModules = memize( ( modules, recoverableModules ) =>
+	Object.values( modules ).reduce( ( recoverable, module ) => {
+		if ( recoverableModules.includes( module.slug ) ) {
+			return {
+				...recoverable,
+				[ module.slug ]: module,
+			};
+		}
+
+		return recoverable;
+	}, {} )
+);
+
 const fetchGetModulesStore = createFetchStore( {
 	baseName: 'getModules',
 	controlCallback: () => {
@@ -1244,19 +1267,7 @@ const baseSelectors = {
 			return undefined;
 		}
 
-		return Object.values( modules ).reduce(
-			( recoverableModules, module ) => {
-				if ( state.recoverableModules.includes( module.slug ) ) {
-					return {
-						...recoverableModules,
-						[ module.slug ]: module,
-					};
-				}
-
-				return recoverableModules;
-			},
-			{}
-		);
+		return calculateRecoverableModules( modules, state.recoverableModules );
 	} ),
 
 	/**

--- a/assets/js/googlesitekit/modules/datastore/modules.js
+++ b/assets/js/googlesitekit/modules/datastore/modules.js
@@ -101,7 +101,7 @@ const normalizeModules = memize( ( serverDefinitions, clientDefinitions ) => {
 } );
 
 /**
- * Memoized function to build an object mapping recoverable module slugs to their corresponding
+ * Gets a memoized object mapping recoverable module slugs to their corresponding
  * module objects.
  *
  * @since n.e.x.t

--- a/assets/js/googlesitekit/widgets/components/WidgetAreaRenderer.test.js
+++ b/assets/js/googlesitekit/widgets/components/WidgetAreaRenderer.test.js
@@ -27,6 +27,7 @@ import {
 	WIDGET_AREA_STYLES,
 } from '../datastore/constants';
 import { CORE_SITE } from '../../../googlesitekit/datastore/site/constants';
+import { CORE_MODULES } from '../../modules/datastore/constants';
 import {
 	createTestRegistry,
 	render,
@@ -88,10 +89,14 @@ describe( 'WidgetAreaRenderer', () => {
 	const areaName = 'gridcell-test';
 	let registry;
 
-	beforeEach( async () => {
+	beforeEach( () => {
 		registry = createTestRegistryWithArea( areaName );
+
+		provideModules( registry );
+		registry.dispatch( CORE_MODULES ).receiveRecoverableModules( [] );
+
 		const connection = { connected: true };
-		await registry.dispatch( CORE_SITE ).receiveGetConnection( connection );
+		registry.dispatch( CORE_SITE ).receiveGetConnection( connection );
 	} );
 
 	afterEach( () => {
@@ -623,6 +628,8 @@ describe( 'WidgetAreaRenderer', () => {
 			areaName,
 			WIDGET_AREA_STYLES.COMPOSITE
 		);
+		provideModules( registry );
+		registry.dispatch( CORE_MODULES ).receiveRecoverableModules( [] );
 		registry
 			.dispatch( CORE_SITE )
 			.receiveGetConnection( { connected: true } );

--- a/assets/js/googlesitekit/widgets/components/WidgetAreaRenderer.test.js
+++ b/assets/js/googlesitekit/widgets/components/WidgetAreaRenderer.test.js
@@ -17,6 +17,11 @@
  */
 
 /**
+ * External dependencies
+ */
+import { getByText } from '@testing-library/dom';
+
+/**
  * Internal dependencies
  */
 import Data from 'googlesitekit-data';
@@ -708,5 +713,63 @@ describe( 'WidgetAreaRenderer', () => {
 				'.googlesitekit-widget-area-header'
 			)
 		).toHaveLength( 1 );
+	} );
+
+	it( 'should combine multiple widgets in RecoverableModules state with the same metadata into a single widget', async () => {
+		registry
+			.dispatch( CORE_MODULES )
+			.receiveRecoverableModules( [ 'search-console' ] );
+
+		provideUserCapabilities( registry, {
+			[ PERMISSION_VIEW_DASHBOARD ]: true,
+			[ `${ PERMISSION_READ_SHARED_MODULE_DATA }::["search-console"]` ]: true,
+		} );
+
+		createWidgets( registry, areaName, [
+			{
+				Component: WidgetComponent,
+				slug: 'one',
+				modules: [ 'search-console' ],
+			},
+			{
+				Component: WidgetComponent,
+				slug: 'two',
+				modules: [ 'search-console' ],
+			},
+		] );
+
+		const { container } = render(
+			<WidgetAreaRenderer slug={ areaName } />,
+			{ registry, viewContext: VIEW_CONTEXT_DASHBOARD_VIEW_ONLY }
+		);
+
+		const visibleWidgetSelector =
+			'.googlesitekit-widget-area-widgets > .mdc-layout-grid__inner > .mdc-layout-grid__cell > .googlesitekit-widget';
+
+		// There should be a single visible widget.
+		expect(
+			container.firstChild.querySelectorAll( visibleWidgetSelector )
+		).toHaveLength( 1 );
+
+		// The visible widget should be rendered as the RecoverableModules component.
+		expect(
+			getByText(
+				container.firstChild.querySelector( visibleWidgetSelector ),
+				'Search Console data was previously shared by an admin who no longer has access. Please contact another admin to restore it.'
+			)
+		).toBeInTheDocument();
+
+		// There should also be a hidden widget.
+		expect(
+			container.firstChild.querySelectorAll(
+				'.googlesitekit-widget-area-widgets .googlesitekit-hidden .googlesitekit-widget'
+			)
+		).toHaveLength( 1 );
+
+		expect(
+			container.firstChild.querySelector(
+				'.googlesitekit-widget-area-widgets'
+			)
+		).toMatchSnapshot();
 	} );
 } );

--- a/assets/js/googlesitekit/widgets/components/WidgetAreaRenderer.test.js
+++ b/assets/js/googlesitekit/widgets/components/WidgetAreaRenderer.test.js
@@ -94,14 +94,11 @@ describe( 'WidgetAreaRenderer', () => {
 	const areaName = 'gridcell-test';
 	let registry;
 
-	beforeEach( () => {
+	beforeEach( async () => {
 		registry = createTestRegistryWithArea( areaName );
 
-		provideModules( registry );
-		registry.dispatch( CORE_MODULES ).receiveRecoverableModules( [] );
-
 		const connection = { connected: true };
-		registry.dispatch( CORE_SITE ).receiveGetConnection( connection );
+		await registry.dispatch( CORE_SITE ).receiveGetConnection( connection );
 	} );
 
 	afterEach( () => {
@@ -633,8 +630,6 @@ describe( 'WidgetAreaRenderer', () => {
 			areaName,
 			WIDGET_AREA_STYLES.COMPOSITE
 		);
-		provideModules( registry );
-		registry.dispatch( CORE_MODULES ).receiveRecoverableModules( [] );
 		registry
 			.dispatch( CORE_SITE )
 			.receiveGetConnection( { connected: true } );
@@ -715,7 +710,8 @@ describe( 'WidgetAreaRenderer', () => {
 		).toHaveLength( 1 );
 	} );
 
-	it( 'should combine multiple widgets in RecoverableModules state with the same metadata into a single widget', async () => {
+	it( 'should combine multiple widgets in RecoverableModules state with the same metadata into a single widget', () => {
+		provideModules( registry );
 		registry
 			.dispatch( CORE_MODULES )
 			.receiveRecoverableModules( [ 'search-console' ] );
@@ -740,7 +736,11 @@ describe( 'WidgetAreaRenderer', () => {
 
 		const { container } = render(
 			<WidgetAreaRenderer slug={ areaName } />,
-			{ registry, viewContext: VIEW_CONTEXT_DASHBOARD_VIEW_ONLY }
+			{
+				registry,
+				viewContext: VIEW_CONTEXT_DASHBOARD_VIEW_ONLY,
+				features: [ 'dashboardSharing' ],
+			}
 		);
 
 		const visibleWidgetSelector =

--- a/assets/js/googlesitekit/widgets/components/WidgetContextRenderer.test.js
+++ b/assets/js/googlesitekit/widgets/components/WidgetContextRenderer.test.js
@@ -21,9 +21,7 @@
  */
 import WidgetContextRenderer from './WidgetContextRenderer';
 import { CORE_WIDGETS } from '../datastore/constants';
-import { CORE_MODULES } from '../../modules/datastore/constants';
 import {
-	provideModules,
 	createTestRegistry,
 	render,
 	waitFor,
@@ -42,9 +40,6 @@ describe( 'WidgetContextRenderer', () => {
 
 	beforeEach( () => {
 		registry = createTestRegistry();
-
-		provideModules( registry );
-		registry.dispatch( CORE_MODULES ).receiveRecoverableModules( [] );
 
 		// Register a widget area.
 		registry.dispatch( CORE_WIDGETS ).registerWidgetArea( 'TestArea1', {

--- a/assets/js/googlesitekit/widgets/components/WidgetContextRenderer.test.js
+++ b/assets/js/googlesitekit/widgets/components/WidgetContextRenderer.test.js
@@ -21,7 +21,9 @@
  */
 import WidgetContextRenderer from './WidgetContextRenderer';
 import { CORE_WIDGETS } from '../datastore/constants';
+import { CORE_MODULES } from '../../modules/datastore/constants';
 import {
+	provideModules,
 	createTestRegistry,
 	render,
 	waitFor,
@@ -40,6 +42,9 @@ describe( 'WidgetContextRenderer', () => {
 
 	beforeEach( () => {
 		registry = createTestRegistry();
+
+		provideModules( registry );
+		registry.dispatch( CORE_MODULES ).receiveRecoverableModules( [] );
 
 		// Register a widget area.
 		registry.dispatch( CORE_WIDGETS ).registerWidgetArea( 'TestArea1', {

--- a/assets/js/googlesitekit/widgets/components/WidgetRecoverableModules.js
+++ b/assets/js/googlesitekit/widgets/components/WidgetRecoverableModules.js
@@ -1,0 +1,50 @@
+/**
+ * WidgetRecoverableModules component.
+ *
+ * Site Kit by Google, Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+
+/**
+ * WordPress dependencies
+ */
+import { useMemo } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import useWidgetStateEffect from '../hooks/useWidgetStateEffect';
+import RecoverableModules from '../../../components/RecoverableModules';
+
+// The supported props must match `RecoverableModules` (except `widgetSlug`).
+export default function WidgetRecoverableModules( {
+	widgetSlug,
+	moduleSlugs,
+	...props
+} ) {
+	const metadata = useMemo( () => ( { moduleSlugs } ), [ moduleSlugs ] );
+	useWidgetStateEffect( widgetSlug, RecoverableModules, metadata );
+
+	return <RecoverableModules moduleSlugs={ moduleSlugs } { ...props } />;
+}
+
+WidgetRecoverableModules.propTypes = {
+	widgetSlug: PropTypes.string.isRequired,
+	...RecoverableModules.propTypes,
+};

--- a/assets/js/googlesitekit/widgets/components/WidgetRecoverableModules.js
+++ b/assets/js/googlesitekit/widgets/components/WidgetRecoverableModules.js
@@ -43,7 +43,7 @@ export default function WidgetRecoverableModules( {
 			// Here we serialize to `moduleSlug` for compatibility with the logic in
 			// `combineWidgets()`. In future we may wish to take a less "hacky" approach.
 			// See https://github.com/google/site-kit-wp/issues/5376#issuecomment-1165771399.
-			moduleSlug: JSON.stringify( moduleSlugs.sort() ),
+			moduleSlug: [ ...moduleSlugs ].sort().join( ',' ),
 			// We also store `moduleSlugs` in the metadata in order for it to be passed back
 			// into RecoverableModules as a prop.
 			// See https://github.com/google/site-kit-wp/blob/c272c20eddcca61aae24c9812b6b11dbc15ec673/assets/js/googlesitekit/widgets/components/WidgetAreaRenderer.js#L171.

--- a/assets/js/googlesitekit/widgets/components/WidgetRecoverableModules.js
+++ b/assets/js/googlesitekit/widgets/components/WidgetRecoverableModules.js
@@ -38,7 +38,19 @@ export default function WidgetRecoverableModules( {
 	moduleSlugs,
 	...props
 } ) {
-	const metadata = useMemo( () => ( { moduleSlugs } ), [ moduleSlugs ] );
+	const metadata = useMemo(
+		() => ( {
+			// Here we serialize to `moduleSlug` for compatibility with the logic in
+			// `combineWidgets()`. In future we may wish to take a less "hacky" approach.
+			// See https://github.com/google/site-kit-wp/issues/5376#issuecomment-1165771399.
+			moduleSlug: JSON.stringify( moduleSlugs.sort() ),
+			// We also store `moduleSlugs` in the metadata in order for it to be passed back
+			// into RecoverableModules as a prop.
+			// See https://github.com/google/site-kit-wp/blob/c272c20eddcca61aae24c9812b6b11dbc15ec673/assets/js/googlesitekit/widgets/components/WidgetAreaRenderer.js#L171.
+			moduleSlugs,
+		} ),
+		[ moduleSlugs ]
+	);
 	useWidgetStateEffect( widgetSlug, RecoverableModules, metadata );
 
 	return <RecoverableModules moduleSlugs={ moduleSlugs } { ...props } />;

--- a/assets/js/googlesitekit/widgets/components/WidgetRenderer.js
+++ b/assets/js/googlesitekit/widgets/components/WidgetRenderer.js
@@ -37,6 +37,7 @@ import BaseWidget from './Widget';
 import WidgetRecoverableModules from './WidgetRecoverableModules';
 import { getWidgetComponentProps } from '../util';
 import { HIDDEN_CLASS } from '../util/constants';
+import useViewOnly from '../../../hooks/useViewOnly';
 
 const { useSelect } = Data;
 
@@ -51,6 +52,7 @@ const WidgetRenderer = ( { slug, OverrideComponent } ) => {
 		select( CORE_MODULES ).getRecoverableModules()
 	);
 
+	const viewOnly = useViewOnly();
 	const widgetRecoverableModules = useMemo(
 		() =>
 			widget &&
@@ -67,7 +69,7 @@ const WidgetRenderer = ( { slug, OverrideComponent } ) => {
 
 	let widgetElement = <Component { ...widgetComponentProps } />;
 
-	if ( widgetRecoverableModules?.length ) {
+	if ( viewOnly && widgetRecoverableModules?.length ) {
 		widgetElement = (
 			<WidgetRecoverableModules
 				widgetSlug={ slug }

--- a/assets/js/googlesitekit/widgets/components/WidgetRenderer.js
+++ b/assets/js/googlesitekit/widgets/components/WidgetRenderer.js
@@ -38,18 +38,23 @@ import WidgetRecoverableModules from './WidgetRecoverableModules';
 import { getWidgetComponentProps } from '../util';
 import { HIDDEN_CLASS } from '../util/constants';
 import useViewOnly from '../../../hooks/useViewOnly';
+import { useFeature } from '../../../hooks/useFeature';
 
 const { useSelect } = Data;
 
 const WidgetRenderer = ( { slug, OverrideComponent } ) => {
+	const dashboardSharingEnabled = useFeature( 'dashboardSharing' );
+
 	const widget = useSelect( ( select ) =>
 		select( CORE_WIDGETS ).getWidget( slug )
 	);
 	const widgetComponentProps = getWidgetComponentProps( slug );
 	const { Widget, WidgetNull } = widgetComponentProps;
 
-	const recoverableModules = useSelect( ( select ) =>
-		select( CORE_MODULES ).getRecoverableModules()
+	const recoverableModules = useSelect(
+		( select ) =>
+			dashboardSharingEnabled &&
+			select( CORE_MODULES ).getRecoverableModules()
 	);
 
 	const viewOnly = useViewOnly();

--- a/assets/js/googlesitekit/widgets/components/WidgetRenderer.js
+++ b/assets/js/googlesitekit/widgets/components/WidgetRenderer.js
@@ -53,9 +53,10 @@ const WidgetRenderer = ( { slug, OverrideComponent } ) => {
 
 	const widgetRecoverableModules = useMemo(
 		() =>
+			widget &&
 			recoverableModules &&
 			intersection( widget.modules, Object.keys( recoverableModules ) ),
-		[ recoverableModules, widget.modules ]
+		[ recoverableModules, widget ]
 	);
 
 	if ( ! widget ) {

--- a/assets/js/googlesitekit/widgets/components/WidgetRenderer.test.js
+++ b/assets/js/googlesitekit/widgets/components/WidgetRenderer.test.js
@@ -20,7 +20,6 @@
  * Internal dependencies
  */
 import WidgetRenderer from './WidgetRenderer';
-import { Provider as ViewContextProvider } from '../../../components/Root/ViewContextContext';
 import { VIEW_CONTEXT_DASHBOARD_VIEW_ONLY } from '../../../googlesitekit/constants';
 import { CORE_MODULES } from '../../modules/datastore/constants';
 import { CORE_WIDGETS } from '../datastore/constants';
@@ -92,16 +91,12 @@ describe( 'WidgetRenderer', () => {
 	} );
 
 	it( 'should output the recoverable modules component when the widget depends on a recoverable module', async () => {
-		const { getByText } = render(
-			<ViewContextProvider value={ VIEW_CONTEXT_DASHBOARD_VIEW_ONLY }>
-				<WidgetRenderer slug="TestWidget" />
-			</ViewContextProvider>,
-			{
-				setupRegistry: setupRegistry( {
-					recoverableModules: [ 'search-console' ],
-				} ),
-			}
-		);
+		const { getByText } = render( <WidgetRenderer slug="TestWidget" />, {
+			setupRegistry: setupRegistry( {
+				recoverableModules: [ 'search-console' ],
+			} ),
+			viewContext: VIEW_CONTEXT_DASHBOARD_VIEW_ONLY,
+		} );
 
 		expect(
 			getByText(
@@ -111,23 +106,16 @@ describe( 'WidgetRenderer', () => {
 	} );
 
 	it( 'should output the recoverable modules component when the widget depends on multiple recoverable modules', async () => {
-		const { getByText } = render(
-			<ViewContextProvider value={ VIEW_CONTEXT_DASHBOARD_VIEW_ONLY }>
-				<WidgetRenderer slug="TestWidget" />
-			</ViewContextProvider>,
-			{
-				setupRegistry: setupRegistry( {
-					recoverableModules: [
-						'search-console',
-						'pagespeed-insights',
-					],
-				} ),
-			}
-		);
+		const { getByText } = render( <WidgetRenderer slug="TestWidget" />, {
+			setupRegistry: setupRegistry( {
+				recoverableModules: [ 'search-console', 'pagespeed-insights' ],
+			} ),
+			viewContext: VIEW_CONTEXT_DASHBOARD_VIEW_ONLY,
+		} );
 
 		expect(
 			getByText(
-				/The data for the following modules was previously shared by an admin who no longer has access: Search Console, PageSpeed Insights/
+				/The data for the following modules was previously shared by an admin who no longer has access: PageSpeed Insights, Search Console/
 			)
 		).toBeInTheDocument();
 	} );

--- a/assets/js/googlesitekit/widgets/components/WidgetRenderer.test.js
+++ b/assets/js/googlesitekit/widgets/components/WidgetRenderer.test.js
@@ -20,14 +20,20 @@
  * Internal dependencies
  */
 import WidgetRenderer from './WidgetRenderer';
+import { CORE_MODULES } from '../../modules/datastore/constants';
 import { CORE_WIDGETS } from '../datastore/constants';
-import { render } from '../../../../../tests/js/test-utils';
+import { provideModules, render } from '../../../../../tests/js/test-utils';
 
 const setupRegistry = ( {
 	Component = () => <div>Test</div>,
 	wrapWidget = false,
 } = {} ) => {
-	return ( { dispatch } ) => {
+	return ( registry ) => {
+		const { dispatch } = registry;
+
+		provideModules( registry );
+		dispatch( CORE_MODULES ).receiveRecoverableModules( [] );
+
 		dispatch( CORE_WIDGETS ).registerWidgetArea( 'dashboard-header', {
 			title: 'Dashboard Header',
 			subtitle: 'Cool stuff for yoursite.com',

--- a/assets/js/googlesitekit/widgets/components/WidgetRenderer.test.js
+++ b/assets/js/googlesitekit/widgets/components/WidgetRenderer.test.js
@@ -96,6 +96,7 @@ describe( 'WidgetRenderer', () => {
 				recoverableModules: [ 'search-console' ],
 			} ),
 			viewContext: VIEW_CONTEXT_DASHBOARD_VIEW_ONLY,
+			features: [ 'dashboardSharing' ],
 		} );
 
 		expect(
@@ -111,6 +112,7 @@ describe( 'WidgetRenderer', () => {
 				recoverableModules: [ 'search-console', 'pagespeed-insights' ],
 			} ),
 			viewContext: VIEW_CONTEXT_DASHBOARD_VIEW_ONLY,
+			features: [ 'dashboardSharing' ],
 		} );
 
 		expect(

--- a/assets/js/googlesitekit/widgets/components/WidgetRenderer.test.js
+++ b/assets/js/googlesitekit/widgets/components/WidgetRenderer.test.js
@@ -120,7 +120,7 @@ describe( 'WidgetRenderer', () => {
 
 		expect(
 			getByText(
-				/The data for the following modules was previously shared by an admin who no longer has access: PageSpeed Insights, Search Console/
+				/The data for the following modules was previously shared by an admin who no longer has access: Search Console, PageSpeed Insights/
 			)
 		).toBeInTheDocument();
 	} );

--- a/assets/js/googlesitekit/widgets/components/WidgetRenderer.test.js
+++ b/assets/js/googlesitekit/widgets/components/WidgetRenderer.test.js
@@ -20,7 +20,10 @@
  * Internal dependencies
  */
 import WidgetRenderer from './WidgetRenderer';
-import { VIEW_CONTEXT_DASHBOARD_VIEW_ONLY } from '../../../googlesitekit/constants';
+import {
+	VIEW_CONTEXT_DASHBOARD,
+	VIEW_CONTEXT_DASHBOARD_VIEW_ONLY,
+} from '../../../googlesitekit/constants';
 import { CORE_MODULES } from '../../modules/datastore/constants';
 import { CORE_WIDGETS } from '../datastore/constants';
 import { provideModules, render } from '../../../../../tests/js/test-utils';
@@ -90,7 +93,7 @@ describe( 'WidgetRenderer', () => {
 		expect( container.firstChild ).toEqual( null );
 	} );
 
-	it( 'should output the recoverable modules component when the widget depends on a recoverable module', async () => {
+	it( 'should output the recoverable modules component when the widget depends on a recoverable module in view-only mode', async () => {
 		const { getByText } = render( <WidgetRenderer slug="TestWidget" />, {
 			setupRegistry: setupRegistry( {
 				recoverableModules: [ 'search-console' ],
@@ -106,7 +109,7 @@ describe( 'WidgetRenderer', () => {
 		).toBeInTheDocument();
 	} );
 
-	it( 'should output the recoverable modules component when the widget depends on multiple recoverable modules', async () => {
+	it( 'should output the recoverable modules component when the widget depends on multiple recoverable modules in view-only mode', async () => {
 		const { getByText } = render( <WidgetRenderer slug="TestWidget" />, {
 			setupRegistry: setupRegistry( {
 				recoverableModules: [ 'search-console', 'pagespeed-insights' ],
@@ -120,5 +123,26 @@ describe( 'WidgetRenderer', () => {
 				/The data for the following modules was previously shared by an admin who no longer has access: PageSpeed Insights, Search Console/
 			)
 		).toBeInTheDocument();
+	} );
+
+	it( 'should not output the recoverable modules component when the widget depends on a recoverable module and is not in view-only mode ', async () => {
+		const { getByText, queryByText } = render(
+			<WidgetRenderer slug="TestWidget" />,
+			{
+				setupRegistry: setupRegistry( {
+					recoverableModules: [ 'search-console' ],
+				} ),
+				viewContext: VIEW_CONTEXT_DASHBOARD,
+				features: [ 'dashboardSharing' ],
+			}
+		);
+
+		expect(
+			queryByText(
+				/Search Console data was previously shared by an admin who no longer has access/
+			)
+		).toBeNull();
+
+		expect( getByText( 'Test' ) ).toBeInTheDocument();
 	} );
 } );

--- a/assets/js/googlesitekit/widgets/components/__snapshots__/WidgetAreaRenderer.test.js.snap
+++ b/assets/js/googlesitekit/widgets/components/__snapshots__/WidgetAreaRenderer.test.js.snap
@@ -1,5 +1,92 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`WidgetAreaRenderer should combine multiple widgets in RecoverableModules state with the same metadata into a single widget 1`] = `
+<div
+  class="googlesitekit-widget-area-widgets"
+>
+  <div
+    class="mdc-layout-grid__inner"
+  >
+    <div
+      class="mdc-layout-grid__cell mdc-layout-grid__cell--span-12"
+    >
+      <div
+        class="googlesitekit-widget googlesitekit-widget--overridden"
+      >
+        <div
+          class="googlesitekit-widget__body"
+        >
+          <div
+            class="googlesitekit-cta"
+          >
+            <h3
+              class="googlesitekit-cta__title"
+            >
+              Data Unavailable
+            </h3>
+            <p
+              class="googlesitekit-cta__description"
+            >
+              Search Console data was previously shared by an admin who no longer has access. Please contact another admin to restore it.
+            </p>
+            
+            
+          </div>
+        </div>
+      </div>
+      <div
+        class="googlesitekit-hidden"
+      >
+        <div
+          class="googlesitekit-cta"
+        >
+          <h3
+            class="googlesitekit-cta__title"
+          >
+            Data Unavailable
+          </h3>
+          <p
+            class="googlesitekit-cta__description"
+          >
+            Search Console data was previously shared by an admin who no longer has access. Please contact another admin to restore it.
+          </p>
+          
+          
+        </div>
+      </div>
+    </div>
+    <div
+      class="googlesitekit-hidden"
+    >
+      <div
+        class="googlesitekit-widget googlesitekit-widget--two"
+      >
+        <div
+          class="googlesitekit-widget__body"
+        >
+          <div
+            class="googlesitekit-cta"
+          >
+            <h3
+              class="googlesitekit-cta__title"
+            >
+              Data Unavailable
+            </h3>
+            <p
+              class="googlesitekit-cta__description"
+            >
+              Search Console data was previously shared by an admin who no longer has access. Please contact another admin to restore it.
+            </p>
+            
+            
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`WidgetAreaRenderer should not resize widgets in a row that is smaller than 9 columns (3, 12, 3-3) 1`] = `
 <div
   class="googlesitekit-widget-area-widgets"

--- a/assets/js/googlesitekit/widgets/util/constants.js
+++ b/assets/js/googlesitekit/widgets/util/constants.js
@@ -21,6 +21,7 @@
  */
 import { WIDGET_WIDTHS } from '../datastore/constants';
 import ReportZero from '../../../components/ReportZero';
+import RecoverableModules from '../../../components/RecoverableModules';
 import CompleteModuleActivationCTA from '../../../components/CompleteModuleActivationCTA';
 import ActivateModuleCTA from '../../../components/ActivateModuleCTA';
 
@@ -35,4 +36,5 @@ export const SPECIAL_WIDGET_STATES = [
 	ActivateModuleCTA,
 	CompleteModuleActivationCTA,
 	ReportZero,
+	RecoverableModules,
 ];


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #5376 

## Relevant technical choices

- Added a check for the `recoverableModules` feature flag being enabled to avoid calling `getRecoverableModules()` when the feature is not enabled and logging an error as a result.
- Memoized the result of `getRecoverableModules` in order to help prevent an issue with unwanted rerendering.
- As discussed here https://github.com/google/site-kit-wp/issues/5376#issuecomment-1165771399, serialized `moduleSlugs` as `metadata.moduleSlug` in order to play nicely with the existing logic in `combineWidgets() -> shouldCombineAllWidgets()`.

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [x] Run the code.
- [x] Ensure the acceptance criteria are satisfied.
- [x] Reassess the implementation with the IB.
- [x] Ensure no unrelated changes are included.
- [x] Ensure CI checks pass.
- [x] Check Storybook where applicable.
- [x] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [x] Ensure the PR has the correct target branch.
- [x] Double-check that the PR is okay to be merged.
- [x] Ensure the corresponding issue has a ZenHub release assigned.
- [x] Add a changelog message to the issue.
