### PR TITLE
Limit name to 100px only when user can authenticate

### DIFF
--- a/assets/js/components/ViewOnlyMenu/index.js
+++ b/assets/js/components/ViewOnlyMenu/index.js
@@ -20,6 +20,7 @@
  * External dependencies
  */
 import { useClickAway } from 'react-use';
+import classnames from 'classnames';
 
 /**
  * WordPress dependencies
@@ -40,6 +41,12 @@ import Menu from '../Menu';
 import Description from './Description';
 import SharedServices from './SharedServices';
 import Tracking from './Tracking';
+import Data from 'googlesitekit-data';
+import {
+	CORE_USER,
+	PERMISSION_AUTHENTICATE,
+} from '../../googlesitekit/datastore/user/constants';
+const { useSelect } = Data;
 
 export default function ViewOnlyMenu() {
 	const [ menuOpen, setMenuOpen ] = useState( false );
@@ -59,10 +66,22 @@ export default function ViewOnlyMenu() {
 		setMenuOpen( ! menuOpen );
 	}, [ menuOpen, viewContext ] );
 
+	const canAuthenticate = useSelect( ( select ) =>
+		select( CORE_USER ).hasCapability( PERMISSION_AUTHENTICATE )
+	);
+
 	return (
 		<div
 			ref={ menuWrapperRef }
-			className="googlesitekit-view-only-menu googlesitekit-dropdown-menu googlesitekit-dropdown-menu__icon-menu mdc-menu-surface--anchor"
+			className={ classnames(
+				'googlesitekit-view-only-menu',
+				'googlesitekit-dropdown-menu',
+				'googlesitekit-dropdown-menu__icon-menu',
+				'mdc-menu-surface--anchor',
+				{
+					'googlesitekit-view-only-menu--user-can-authenticate': canAuthenticate,
+				}
+			) }
 		>
 			<Button
 				className="googlesitekit-header__dropdown mdc-button--dropdown googlesitekit-border-radius-round--phone googlesitekit-button-icon"

--- a/assets/sass/components/global/_googlesitekit-view-only-menu.scss
+++ b/assets/sass/components/global/_googlesitekit-view-only-menu.scss
@@ -99,9 +99,7 @@
 		}
 
 		.googlesitekit-view-only-menu__service--name {
-			flex: 0 0 100px;
 			font-size: 14px;
-			margin-right: 8px;
 		}
 
 		.googlesitekit-view-only-menu__service--owner {
@@ -115,6 +113,14 @@
 			// Compensate for the padding & absolute positioning of the checkbox
 			// provided by the OptIn component.
 			margin-left: -11px;
+		}
+
+		&--user-can-authenticate {
+
+			.googlesitekit-view-only-menu__service--name {
+				flex: 0 0 100px;
+				margin-right: 8px;
+			}
 		}
 	}
 }


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- https://github.com/google/site-kit-wp/issues/5381#issuecomment-1170228681

## Relevant technical choices

- This PR limits the service name in the view-only menu to 100px only when the current user is a user who can authenticate.
- Adds a modifier class `--user-can-authenticate` to the view-only menu container.
- Using the above modifier class, applies the width of 100px.

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
