### PR TITLE
Don't close DS dialog on escape key while editing roles

### DIFF
--- a/assets/js/components/dashboard-sharing/DashboardSharingSettingsButton.js
+++ b/assets/js/components/dashboard-sharing/DashboardSharingSettingsButton.js
@@ -67,6 +67,9 @@ export default function DashboardSharingSettingsButton() {
 	const haveSettingsChanged = useSelect( ( select ) =>
 		select( CORE_MODULES ).haveSharingSettingsChanged()
 	);
+	const editingUserRoleSelect = useSelect( ( select ) =>
+		select( CORE_UI ).getValue( EDITING_USER_ROLE_SELECT_SLUG_KEY )
+	);
 
 	const openDialog = useCallback( () => {
 		trackEvent(
@@ -116,6 +119,9 @@ export default function DashboardSharingSettingsButton() {
 					onClose={ closeDialog }
 					className="googlesitekit-dialog googlesitekit-sharing-settings-dialog"
 					style={ dialogStyles }
+					escapeKeyAction={
+						editingUserRoleSelect === undefined ? 'close' : ''
+					}
 				>
 					<div
 						className="googlesitekit-dialog__back-wrapper"


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #5442 

## Relevant technical choices

This PR simply checks if the roles are being edited, and if so, prevents closing the dialog.

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [x] Run the code.
- [x] Ensure the acceptance criteria are satisfied.
- [x] Reassess the implementation with the IB.
- [x] Ensure no unrelated changes are included.
- [x] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [x] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [x] Ensure the PR has the correct target branch.
- [x] Double-check that the PR is okay to be merged.
- [x] Ensure the corresponding issue has a ZenHub release assigned.
- [x] Add a changelog message to the issue.
