### PR TITLE
Fix escape action in Dashboard Sharing `UserRoleSelect` 

### DIFF
--- a/assets/js/components/dashboard-sharing/DashboardSharingSettings/Module.js
+++ b/assets/js/components/dashboard-sharing/DashboardSharingSettings/Module.js
@@ -159,7 +159,7 @@ export default function Module( { moduleSlug, moduleName, ownerUsername } ) {
 					<UserRoleSelect
 						moduleSlug={ moduleSlug }
 						isLocked={ isLocked }
-						moduleRef={ moduleRef }
+						ref={ moduleRef }
 					/>
 				) }
 

--- a/assets/js/components/dashboard-sharing/DashboardSharingSettings/Module.js
+++ b/assets/js/components/dashboard-sharing/DashboardSharingSettings/Module.js
@@ -33,6 +33,7 @@ import {
 	useCallback,
 	useEffect,
 	useState,
+	useRef,
 } from '@wordpress/element';
 
 /**
@@ -68,6 +69,7 @@ const viewAccessOptions = [
 
 export default function Module( { moduleSlug, moduleName, ownerUsername } ) {
 	const viewContext = useViewContext();
+	const moduleRef = useRef();
 
 	const [ manageViewAccess, setManageViewAccess ] = useState( undefined );
 	const hasMultipleAdmins = useSelect( ( select ) =>
@@ -142,6 +144,7 @@ export default function Module( { moduleSlug, moduleName, ownerUsername } ) {
 					'googlesitekit-dashboard-sharing-settings__row--disabled': isLocked,
 				}
 			) }
+			ref={ moduleRef }
 		>
 			<div className="googlesitekit-dashboard-sharing-settings__column--product">
 				<ModuleIcon slug={ moduleSlug } size={ 48 } />
@@ -156,6 +159,7 @@ export default function Module( { moduleSlug, moduleName, ownerUsername } ) {
 					<UserRoleSelect
 						moduleSlug={ moduleSlug }
 						isLocked={ isLocked }
+						moduleRef={ moduleRef }
 					/>
 				) }
 

--- a/assets/js/components/dashboard-sharing/UserRoleSelect.js
+++ b/assets/js/components/dashboard-sharing/UserRoleSelect.js
@@ -53,7 +53,7 @@ const ALL_CHIP_DISPLAY_NAME = __( 'All', 'google-site-kit' );
 const UserRoleSelect = forwardRef(
 	( { moduleSlug, isLocked = false }, ref ) => {
 		const viewContext = useViewContext();
-		const roleSelectBtnRef = useRef();
+		const roleSelectButtonRef = useRef();
 
 		const [ initialSharedRoles, setInitialSharedRoles ] = useState( [] );
 
@@ -183,7 +183,7 @@ const UserRoleSelect = forwardRef(
 						)
 					}
 					tabIndex={ isLocked ? -1 : undefined }
-					ref={ roleSelectBtnRef }
+					ref={ roleSelectButtonRef }
 				/>
 
 				{ ! editMode && sharedRoles?.length > 0 && (
@@ -199,7 +199,7 @@ const UserRoleSelect = forwardRef(
 								onClick={ () => {
 									// As this link exits the DOM on click, we change
 									// the focus to the role select button.
-									roleSelectBtnRef.current.focus();
+									roleSelectButtonRef.current.focus();
 
 									toggleEditMode();
 								} }

--- a/assets/js/components/dashboard-sharing/UserRoleSelect.js
+++ b/assets/js/components/dashboard-sharing/UserRoleSelect.js
@@ -74,6 +74,9 @@ const UserRoleSelect = forwardRef(
 		useKeyCodesInside( [ ESCAPE ], ref, () => {
 			if ( editMode ) {
 				setValue( EDITING_USER_ROLE_SELECT_SLUG_KEY, undefined );
+
+				// Reset focus to edit roles button.
+				roleSelectButtonRef.current.focus();
 			}
 		} );
 

--- a/assets/js/components/dashboard-sharing/UserRoleSelect.js
+++ b/assets/js/components/dashboard-sharing/UserRoleSelect.js
@@ -53,6 +53,7 @@ const ALL_CHIP_DISPLAY_NAME = __( 'All', 'google-site-kit' );
 export default function UserRoleSelect( { moduleSlug, isLocked = false } ) {
 	const viewContext = useViewContext();
 	const wrapperRef = useRef();
+	const roleSelectBtnRef = useRef();
 
 	const [ initialSharedRoles, setInitialSharedRoles ] = useState( [] );
 
@@ -181,6 +182,7 @@ export default function UserRoleSelect( { moduleSlug, isLocked = false } ) {
 					)
 				}
 				tabIndex={ isLocked ? -1 : undefined }
+				ref={ roleSelectBtnRef }
 			/>
 
 			{ ! editMode && sharedRoles?.length > 0 && (
@@ -192,7 +194,13 @@ export default function UserRoleSelect( { moduleSlug, isLocked = false } ) {
 			{ ! editMode && ( ! sharedRoles || sharedRoles?.length === 0 ) && (
 				<span className="googlesitekit-user-role-select__add-roles">
 					<Link
-						onClick={ toggleEditMode }
+						onClick={ () => {
+							// As this link exits the DOM on click, we change
+							// the focus to the role select button.
+							roleSelectBtnRef.current.focus();
+
+							toggleEditMode();
+						} }
 						tabIndex={ isLocked ? -1 : undefined }
 					>
 						{ __( 'Add roles', 'google-site-kit' ) }

--- a/assets/js/components/dashboard-sharing/UserRoleSelect.js
+++ b/assets/js/components/dashboard-sharing/UserRoleSelect.js
@@ -29,7 +29,7 @@ import isEqual from 'lodash/isEqual';
  */
 import { __ } from '@wordpress/i18n';
 import { ESCAPE, ENTER } from '@wordpress/keycodes';
-import { useState, useCallback, useRef } from '@wordpress/element';
+import { useState, useCallback, useRef, forwardRef } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -50,201 +50,206 @@ const { useSelect, useDispatch } = Data;
 const ALL_CHIP_ID = 'all';
 const ALL_CHIP_DISPLAY_NAME = __( 'All', 'google-site-kit' );
 
-export default function UserRoleSelect( {
-	moduleSlug,
-	isLocked = false,
-	moduleRef,
-} ) {
-	const viewContext = useViewContext();
-	const roleSelectBtnRef = useRef();
+const UserRoleSelect = forwardRef(
+	( { moduleSlug, isLocked = false }, ref ) => {
+		const viewContext = useViewContext();
+		const roleSelectBtnRef = useRef();
 
-	const [ initialSharedRoles, setInitialSharedRoles ] = useState( [] );
+		const [ initialSharedRoles, setInitialSharedRoles ] = useState( [] );
 
-	const { setSharedRoles } = useDispatch( CORE_MODULES );
-	const { setValue } = useDispatch( CORE_UI );
+		const { setSharedRoles } = useDispatch( CORE_MODULES );
+		const { setValue } = useDispatch( CORE_UI );
 
-	const shareableRoles = useSelect( ( select ) =>
-		select( CORE_MODULES ).getShareableRoles()
-	);
-	const sharedRoles = useSelect( ( select ) =>
-		select( CORE_MODULES ).getSharedRoles( moduleSlug )
-	);
-	const editingUserRoleSelect = useSelect( ( select ) =>
-		select( CORE_UI ).getValue( EDITING_USER_ROLE_SELECT_SLUG_KEY )
-	);
-	const editMode = editingUserRoleSelect === moduleSlug;
+		const shareableRoles = useSelect( ( select ) =>
+			select( CORE_MODULES ).getShareableRoles()
+		);
+		const sharedRoles = useSelect( ( select ) =>
+			select( CORE_MODULES ).getSharedRoles( moduleSlug )
+		);
+		const editingUserRoleSelect = useSelect( ( select ) =>
+			select( CORE_UI ).getValue( EDITING_USER_ROLE_SELECT_SLUG_KEY )
+		);
+		const editMode = editingUserRoleSelect === moduleSlug;
 
-	useKeyCodesInside( [ ESCAPE ], moduleRef, () => {
-		if ( editMode ) {
-			setValue( EDITING_USER_ROLE_SELECT_SLUG_KEY, undefined );
-		}
-	} );
-
-	const toggleEditMode = useCallback( () => {
-		if ( ! editMode ) {
-			if (
-				! isEqual(
-					[ ...( sharedRoles || [] ) ].sort(),
-					initialSharedRoles
-				)
-			) {
-				trackEvent(
-					`${ viewContext }_sharing`,
-					'change_shared_roles',
-					moduleSlug
-				);
+		useKeyCodesInside( [ ESCAPE ], ref, () => {
+			if ( editMode ) {
+				setValue( EDITING_USER_ROLE_SELECT_SLUG_KEY, undefined );
 			}
+		} );
 
-			// Set these state to disable modules in when editing user roles
-			setValue( EDITING_USER_ROLE_SELECT_SLUG_KEY, moduleSlug );
-		} else {
-			setInitialSharedRoles( [ ...( sharedRoles || [] ) ].sort() );
-
-			// Reset the state to enable modules in when not editing.
-			setValue( EDITING_USER_ROLE_SELECT_SLUG_KEY, undefined );
-		}
-	}, [
-		editMode,
-		sharedRoles,
-		initialSharedRoles,
-		viewContext,
-		moduleSlug,
-		setValue,
-	] );
-
-	const toggleChip = useCallback(
-		( { type, target, keyCode } ) => {
-			if ( type === 'keyup' && keyCode !== ENTER ) {
-				return;
-			}
-
-			const chip = target.closest( '.mdc-chip' );
-			const chipID = chip?.dataset?.chipId; // eslint-disable-line sitekit/acronym-case
-
-			if ( ! chipID ) {
-				return;
-			}
-
-			let updatedSharedRoles;
-			if ( chipID === ALL_CHIP_ID ) {
-				if ( sharedRoles?.length === shareableRoles?.length ) {
-					updatedSharedRoles = [];
-				} else {
-					updatedSharedRoles = shareableRoles.map( ( { id } ) => id );
-				}
-			} else if ( sharedRoles === null ) {
-				updatedSharedRoles = [ chipID ];
-			} else if ( sharedRoles.includes( chipID ) ) {
-				updatedSharedRoles = sharedRoles.filter(
-					( role ) => role !== chipID
-				);
-			} else {
-				updatedSharedRoles = [ ...sharedRoles, chipID ];
-			}
-
-			setSharedRoles( moduleSlug, updatedSharedRoles );
-		},
-		[ moduleSlug, setSharedRoles, sharedRoles, shareableRoles ]
-	);
-
-	const getSharedRolesDisplayNames = () => {
-		const roleDisplayNames = shareableRoles?.reduce( ( acc, role ) => {
-			if ( sharedRoles.includes( role.id ) ) {
-				acc.push( role.displayName );
-			}
-			return acc;
-		}, [] );
-
-		return roleDisplayNames.join( ', ' );
-	};
-
-	if ( ! shareableRoles ) {
-		return null;
-	}
-
-	return (
-		<div
-			className={ classnames( 'googlesitekit-user-role-select', {
-				'googlesitekit-user-role-select--open': editMode,
-			} ) }
-		>
-			<Button
-				aria-label={
-					editMode
-						? __( 'Close', 'google-site-kit' )
-						: __( 'Edit roles', 'google-site-kit' )
-				}
-				className="googlesitekit-user-role-select__button"
-				onClick={ toggleEditMode }
-				icon={
-					editMode ? (
-						<CloseIcon width={ 18 } height={ 18 } />
-					) : (
-						<ShareIcon width={ 23 } height={ 23 } />
+		const toggleEditMode = useCallback( () => {
+			if ( ! editMode ) {
+				if (
+					! isEqual(
+						[ ...( sharedRoles || [] ) ].sort(),
+						initialSharedRoles
 					)
+				) {
+					trackEvent(
+						`${ viewContext }_sharing`,
+						'change_shared_roles',
+						moduleSlug
+					);
 				}
-				tabIndex={ isLocked ? -1 : undefined }
-				ref={ roleSelectBtnRef }
-			/>
 
-			{ ! editMode && sharedRoles?.length > 0 && (
-				<span className="googlesitekit-user-role-select__current-roles">
-					{ getSharedRolesDisplayNames() }
-				</span>
-			) }
+				// Set these state to disable modules in when editing user roles
+				setValue( EDITING_USER_ROLE_SELECT_SLUG_KEY, moduleSlug );
+			} else {
+				setInitialSharedRoles( [ ...( sharedRoles || [] ) ].sort() );
 
-			{ ! editMode && ( ! sharedRoles || sharedRoles?.length === 0 ) && (
-				<span className="googlesitekit-user-role-select__add-roles">
-					<Link
-						onClick={ () => {
-							// As this link exits the DOM on click, we change
-							// the focus to the role select button.
-							roleSelectBtnRef.current.focus();
+				// Reset the state to enable modules in when not editing.
+				setValue( EDITING_USER_ROLE_SELECT_SLUG_KEY, undefined );
+			}
+		}, [
+			editMode,
+			sharedRoles,
+			initialSharedRoles,
+			viewContext,
+			moduleSlug,
+			setValue,
+		] );
 
-							toggleEditMode();
-						} }
-						tabIndex={ isLocked ? -1 : undefined }
-					>
-						{ __( 'Add roles', 'google-site-kit' ) }
-					</Link>
-				</span>
-			) }
+		const toggleChip = useCallback(
+			( { type, target, keyCode } ) => {
+				if ( type === 'keyup' && keyCode !== ENTER ) {
+					return;
+				}
 
-			{ editMode && (
-				<div className="googlesitekit-user-role-select__chipset">
-					<Chip
-						chipCheckmark={ <ChipCheckmark /> }
-						data-chip-id={ ALL_CHIP_ID }
-						id={ ALL_CHIP_ID }
-						label={ ALL_CHIP_DISPLAY_NAME }
-						onClick={ toggleChip }
-						onKeyUp={ toggleChip }
-						selected={
-							sharedRoles?.length === shareableRoles?.length
-						}
-						className="googlesitekit-user-role-select__chip googlesitekit-user-role-select__chip--all"
-					/>
+				const chip = target.closest( '.mdc-chip' );
+				const chipID = chip?.dataset?.chipId; // eslint-disable-line sitekit/acronym-case
 
-					{ shareableRoles.map( ( { id, displayName }, index ) => (
+				if ( ! chipID ) {
+					return;
+				}
+
+				let updatedSharedRoles;
+				if ( chipID === ALL_CHIP_ID ) {
+					if ( sharedRoles?.length === shareableRoles?.length ) {
+						updatedSharedRoles = [];
+					} else {
+						updatedSharedRoles = shareableRoles.map(
+							( { id } ) => id
+						);
+					}
+				} else if ( sharedRoles === null ) {
+					updatedSharedRoles = [ chipID ];
+				} else if ( sharedRoles.includes( chipID ) ) {
+					updatedSharedRoles = sharedRoles.filter(
+						( role ) => role !== chipID
+					);
+				} else {
+					updatedSharedRoles = [ ...sharedRoles, chipID ];
+				}
+
+				setSharedRoles( moduleSlug, updatedSharedRoles );
+			},
+			[ moduleSlug, setSharedRoles, sharedRoles, shareableRoles ]
+		);
+
+		const getSharedRolesDisplayNames = () => {
+			const roleDisplayNames = shareableRoles?.reduce( ( acc, role ) => {
+				if ( sharedRoles.includes( role.id ) ) {
+					acc.push( role.displayName );
+				}
+				return acc;
+			}, [] );
+
+			return roleDisplayNames.join( ', ' );
+		};
+
+		if ( ! shareableRoles ) {
+			return null;
+		}
+
+		return (
+			<div
+				className={ classnames( 'googlesitekit-user-role-select', {
+					'googlesitekit-user-role-select--open': editMode,
+				} ) }
+			>
+				<Button
+					aria-label={
+						editMode
+							? __( 'Close', 'google-site-kit' )
+							: __( 'Edit roles', 'google-site-kit' )
+					}
+					className="googlesitekit-user-role-select__button"
+					onClick={ toggleEditMode }
+					icon={
+						editMode ? (
+							<CloseIcon width={ 18 } height={ 18 } />
+						) : (
+							<ShareIcon width={ 23 } height={ 23 } />
+						)
+					}
+					tabIndex={ isLocked ? -1 : undefined }
+					ref={ roleSelectBtnRef }
+				/>
+
+				{ ! editMode && sharedRoles?.length > 0 && (
+					<span className="googlesitekit-user-role-select__current-roles">
+						{ getSharedRolesDisplayNames() }
+					</span>
+				) }
+
+				{ ! editMode &&
+					( ! sharedRoles || sharedRoles?.length === 0 ) && (
+						<span className="googlesitekit-user-role-select__add-roles">
+							<Link
+								onClick={ () => {
+									// As this link exits the DOM on click, we change
+									// the focus to the role select button.
+									roleSelectBtnRef.current.focus();
+
+									toggleEditMode();
+								} }
+								tabIndex={ isLocked ? -1 : undefined }
+							>
+								{ __( 'Add roles', 'google-site-kit' ) }
+							</Link>
+						</span>
+					) }
+
+				{ editMode && (
+					<div className="googlesitekit-user-role-select__chipset">
 						<Chip
 							chipCheckmark={ <ChipCheckmark /> }
-							data-chip-id={ id }
-							id={ id }
-							key={ index }
-							label={ displayName }
+							data-chip-id={ ALL_CHIP_ID }
+							id={ ALL_CHIP_ID }
+							label={ ALL_CHIP_DISPLAY_NAME }
 							onClick={ toggleChip }
 							onKeyUp={ toggleChip }
-							selected={ sharedRoles?.includes( id ) }
-							className="googlesitekit-user-role-select__chip"
+							selected={
+								sharedRoles?.length === shareableRoles?.length
+							}
+							className="googlesitekit-user-role-select__chip googlesitekit-user-role-select__chip--all"
 						/>
-					) ) }
-				</div>
-			) }
-		</div>
-	);
-}
+
+						{ shareableRoles.map(
+							( { id, displayName }, index ) => (
+								<Chip
+									chipCheckmark={ <ChipCheckmark /> }
+									data-chip-id={ id }
+									id={ id }
+									key={ index }
+									label={ displayName }
+									onClick={ toggleChip }
+									onKeyUp={ toggleChip }
+									selected={ sharedRoles?.includes( id ) }
+									className="googlesitekit-user-role-select__chip"
+								/>
+							)
+						) }
+					</div>
+				) }
+			</div>
+		);
+	}
+);
 
 UserRoleSelect.propTypes = {
 	moduleSlug: PropTypes.string.isRequired,
 	isLocked: PropTypes.bool,
 };
+
+export default UserRoleSelect;

--- a/assets/js/components/dashboard-sharing/UserRoleSelect.js
+++ b/assets/js/components/dashboard-sharing/UserRoleSelect.js
@@ -50,9 +50,12 @@ const { useSelect, useDispatch } = Data;
 const ALL_CHIP_ID = 'all';
 const ALL_CHIP_DISPLAY_NAME = __( 'All', 'google-site-kit' );
 
-export default function UserRoleSelect( { moduleSlug, isLocked = false } ) {
+export default function UserRoleSelect( {
+	moduleSlug,
+	isLocked = false,
+	moduleRef,
+} ) {
 	const viewContext = useViewContext();
-	const wrapperRef = useRef();
 	const roleSelectBtnRef = useRef();
 
 	const [ initialSharedRoles, setInitialSharedRoles ] = useState( [] );
@@ -71,7 +74,7 @@ export default function UserRoleSelect( { moduleSlug, isLocked = false } ) {
 	);
 	const editMode = editingUserRoleSelect === moduleSlug;
 
-	useKeyCodesInside( [ ESCAPE ], wrapperRef, () => {
+	useKeyCodesInside( [ ESCAPE ], moduleRef, () => {
 		if ( editMode ) {
 			setValue( EDITING_USER_ROLE_SELECT_SLUG_KEY, undefined );
 		}
@@ -164,7 +167,6 @@ export default function UserRoleSelect( { moduleSlug, isLocked = false } ) {
 			className={ classnames( 'googlesitekit-user-role-select', {
 				'googlesitekit-user-role-select--open': editMode,
 			} ) }
-			ref={ wrapperRef }
 		>
 			<Button
 				aria-label={


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- https://github.com/google/site-kit-wp/issues/5442#issuecomment-1174990912

## Relevant technical choices
This PR:
1. Resets focus to the user role select button on clicking the 'Add Roles' link as it exits the DOM on click.
2. Make the `esc` event work across the module.

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [x] Run the code.
- [x] Ensure the acceptance criteria are satisfied.
- [x] Reassess the implementation with the IB.
- [x] Ensure no unrelated changes are included.
- [x] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [x] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
