### PR TITLE
Fix Idea Hub icon in View Only menu

### DIFF
--- a/assets/js/components/ViewOnlyMenu/Service.js
+++ b/assets/js/components/ViewOnlyMenu/Service.js
@@ -54,7 +54,7 @@ export default function Service( { module } ) {
 	return (
 		<li className="googlesitekit-view-only-menu__service">
 			<span className="googlesitekit-view-only-menu__service--icon">
-				<Icon />
+				<Icon height={ 26 } />
 			</span>
 			<span className="googlesitekit-view-only-menu__service--name">
 				{ name }


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #5446 

## Relevant technical choices

This PR applies a height which essentially acts a maximum height to the module icons in the Dashboard Sharing View Only menu, thus fixing the oddly displayed Idea Hub icon.

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
