### PR TITLE
Update view-only Search Funnel widget with recoverable Analytics

### DIFF
--- a/assets/js/modules/search-console/components/dashboard/SearchFunnelWidget/Overview.js
+++ b/assets/js/modules/search-console/components/dashboard/SearchFunnelWidget/Overview.js
@@ -80,6 +80,7 @@ const Overview = ( {
 	dateRangeLength,
 	error,
 	WidgetReportError,
+	showRecoverableAnalytics,
 } ) => {
 	const dashboardType = useDashboardType();
 	const zeroDataStatesEnabled = useFeature( 'zeroDataStates' );
@@ -111,7 +112,9 @@ const Overview = ( {
 		select( CORE_LOCATION ).isNavigatingTo( adminReauthURL )
 	);
 	const isAnalyticsGatheringData = useInViewSelect( ( select ) =>
-		analyticsModuleActiveAndConnected && canViewSharedAnalytics
+		analyticsModuleActiveAndConnected &&
+		canViewSharedAnalytics &&
+		! showRecoverableAnalytics
 			? select( MODULES_ANALYTICS ).isGatheringData()
 			: false
 	);

--- a/assets/js/modules/search-console/components/dashboard/SearchFunnelWidget/Overview.js
+++ b/assets/js/modules/search-console/components/dashboard/SearchFunnelWidget/Overview.js
@@ -51,6 +51,7 @@ import CTA from '../../../../../components/notifications/CTA';
 import DataBlock from '../../../../../components/DataBlock';
 import ProgressBar from '../../../../../components/ProgressBar';
 import ReportZero from '../../../../../components/ReportZero';
+import RecoverableModules from '../../../../../components/RecoverableModules';
 import {
 	BREAKPOINT_SMALL,
 	useBreakpoint,
@@ -167,15 +168,16 @@ const Overview = ( {
 	}
 
 	const showAnalytics =
-		( canViewSharedAnalytics &&
+		( ( canViewSharedAnalytics &&
 			analyticsModuleConnected &&
 			! isAnalyticsGatheringData &&
 			! zeroDataStatesEnabled &&
 			! error ) ||
-		( canViewSharedAnalytics &&
-			analyticsModuleConnected &&
-			zeroDataStatesEnabled &&
-			! error );
+			( canViewSharedAnalytics &&
+				analyticsModuleConnected &&
+				zeroDataStatesEnabled &&
+				! error ) ) &&
+		! showRecoverableAnalytics;
 
 	const showGoalsCTA =
 		isAuthenticated &&
@@ -352,7 +354,8 @@ const Overview = ( {
 						</Cell>
 					) }
 
-				{ canViewSharedAnalytics &&
+				{ ! showRecoverableAnalytics &&
+					canViewSharedAnalytics &&
 					analyticsModuleActiveAndConnected &&
 					error && (
 						<Cell { ...halfCellProps }>
@@ -398,6 +401,16 @@ const Overview = ( {
 						) }
 					</Cell>
 				) }
+
+				{ canViewSharedAnalytics &&
+					analyticsModuleActiveAndConnected &&
+					showRecoverableAnalytics && (
+						<Cell { ...halfCellProps }>
+							<RecoverableModules
+								moduleSlugs={ [ 'analytics' ] }
+							/>
+						</Cell>
+					) }
 			</Row>
 		</Grid>
 	);

--- a/assets/js/modules/search-console/components/dashboard/SearchFunnelWidget/index.js
+++ b/assets/js/modules/search-console/components/dashboard/SearchFunnelWidget/index.js
@@ -111,6 +111,10 @@ const SearchFunnelWidget = ( {
 	);
 
 	const showRecoverableAnalytics = useSelect( ( select ) => {
+		if ( ! viewOnly ) {
+			return false;
+		}
+
 		const recoverableModules = select(
 			CORE_MODULES
 		).getRecoverableModules();
@@ -119,10 +123,7 @@ const SearchFunnelWidget = ( {
 			return undefined;
 		}
 
-		return (
-			Object.keys( recoverableModules ).includes( 'analytics' ) &&
-			viewOnly
-		);
+		return Object.keys( recoverableModules ).includes( 'analytics' );
 	} );
 
 	const analyticsGoalsData = useInViewSelect( ( select ) => {

--- a/assets/js/modules/search-console/components/dashboard/SearchFunnelWidget/index.js
+++ b/assets/js/modules/search-console/components/dashboard/SearchFunnelWidget/index.js
@@ -110,14 +110,33 @@ const SearchFunnelWidget = ( {
 		} )
 	);
 
+	const showRecoverableAnalytics = useSelect( ( select ) => {
+		const recoverableModules = select(
+			CORE_MODULES
+		).getRecoverableModules();
+
+		if ( recoverableModules === undefined ) {
+			return undefined;
+		}
+
+		return (
+			Object.keys( recoverableModules ).includes( 'analytics' ) &&
+			viewOnly
+		);
+	} );
+
 	const analyticsGoalsData = useInViewSelect( ( select ) => {
-		return isAnalyticsConnected && canViewSharedAnalytics
+		return isAnalyticsConnected &&
+			canViewSharedAnalytics &&
+			! showRecoverableAnalytics
 			? select( MODULES_ANALYTICS ).getGoals()
 			: {};
 	} );
 
 	const analyticsGoalsLoading = useSelect( ( select ) =>
-		isAnalyticsConnected && canViewSharedAnalytics
+		isAnalyticsConnected &&
+		canViewSharedAnalytics &&
+		! showRecoverableAnalytics
 			? ! select( MODULES_ANALYTICS ).hasFinishedResolution(
 					'getGoals',
 					[]
@@ -126,7 +145,7 @@ const SearchFunnelWidget = ( {
 	);
 
 	const analyticsGoalsError = useSelect( ( select ) =>
-		isAnalyticsConnected
+		isAnalyticsConnected && ! showRecoverableAnalytics
 			? select( MODULES_ANALYTICS ).getErrorForSelector( 'getGoals', [] )
 			: null
 	);
@@ -189,7 +208,11 @@ const SearchFunnelWidget = ( {
 	);
 
 	const analyticsOverviewLoading = useSelect( ( select ) => {
-		if ( ! isAnalyticsConnected || ! canViewSharedAnalytics ) {
+		if (
+			! isAnalyticsConnected ||
+			! canViewSharedAnalytics ||
+			showRecoverableAnalytics
+		) {
 			return false;
 		}
 
@@ -199,14 +222,18 @@ const SearchFunnelWidget = ( {
 		);
 	} );
 	const analyticsOverviewData = useInViewSelect( ( select ) => {
-		if ( ! isAnalyticsConnected || ! canViewSharedAnalytics ) {
+		if (
+			! isAnalyticsConnected ||
+			! canViewSharedAnalytics ||
+			showRecoverableAnalytics
+		) {
 			return null;
 		}
 
 		return select( MODULES_ANALYTICS ).getReport( analyticsOverviewArgs );
 	} );
 	const analyticsOverviewError = useSelect( ( select ) => {
-		if ( ! isAnalyticsConnected ) {
+		if ( ! isAnalyticsConnected || showRecoverableAnalytics ) {
 			return false;
 		}
 
@@ -216,7 +243,11 @@ const SearchFunnelWidget = ( {
 	} );
 
 	const analyticsStatsLoading = useSelect( ( select ) => {
-		if ( ! isAnalyticsConnected || ! canViewSharedAnalytics ) {
+		if (
+			! isAnalyticsConnected ||
+			! canViewSharedAnalytics ||
+			showRecoverableAnalytics
+		) {
 			return false;
 		}
 
@@ -226,14 +257,18 @@ const SearchFunnelWidget = ( {
 		);
 	} );
 	const analyticsStatsData = useInViewSelect( ( select ) => {
-		if ( ! isAnalyticsConnected || ! canViewSharedAnalytics ) {
+		if (
+			! isAnalyticsConnected ||
+			! canViewSharedAnalytics ||
+			showRecoverableAnalytics
+		) {
 			return null;
 		}
 
 		return select( MODULES_ANALYTICS ).getReport( analyticsStatsArgs );
 	} );
 	const analyticsStatsError = useSelect( ( select ) => {
-		if ( ! isAnalyticsConnected ) {
+		if ( ! isAnalyticsConnected || showRecoverableAnalytics ) {
 			return false;
 		}
 
@@ -243,7 +278,11 @@ const SearchFunnelWidget = ( {
 	} );
 
 	const analyticsVisitorsOverviewAndStatsLoading = useSelect( ( select ) => {
-		if ( ! isAnalyticsConnected || ! canViewSharedAnalytics ) {
+		if (
+			! isAnalyticsConnected ||
+			! canViewSharedAnalytics ||
+			showRecoverableAnalytics
+		) {
 			return false;
 		}
 
@@ -254,7 +293,11 @@ const SearchFunnelWidget = ( {
 	} );
 	const analyticsVisitorsOverviewAndStatsData = useInViewSelect(
 		( select ) => {
-			if ( ! isAnalyticsConnected || ! canViewSharedAnalytics ) {
+			if (
+				! isAnalyticsConnected ||
+				! canViewSharedAnalytics ||
+				showRecoverableAnalytics
+			) {
 				return null;
 			}
 
@@ -264,7 +307,7 @@ const SearchFunnelWidget = ( {
 		}
 	);
 	const analyticsVisitorsOverviewAndStatsError = useSelect( ( select ) => {
-		if ( ! isAnalyticsConnected ) {
+		if ( ! isAnalyticsConnected || showRecoverableAnalytics ) {
 			return false;
 		}
 
@@ -274,7 +317,9 @@ const SearchFunnelWidget = ( {
 	} );
 
 	const isAnalyticsGatheringData = useInViewSelect( ( select ) =>
-		isAnalyticsConnected && canViewSharedAnalytics
+		isAnalyticsConnected &&
+		canViewSharedAnalytics &&
+		! showRecoverableAnalytics
 			? select( MODULES_ANALYTICS ).isGatheringData()
 			: false
 	);
@@ -370,6 +415,7 @@ const SearchFunnelWidget = ( {
 					analyticsGoalsError
 				}
 				WidgetReportError={ WidgetReportError }
+				showRecoverableAnalytics={ showRecoverableAnalytics }
 			/>
 
 			{ ( selectedStats === 0 || selectedStats === 1 ) && (


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #5470 

## Relevant technical choices

This PR updates the Search Funnel widget for view-only users when the Analytics module is recoverable so that instead of displaying a data fetching error, it displays a recoverable module CTA.

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [x] Run the code.
- [x] Ensure the acceptance criteria are satisfied.
- [x] Reassess the implementation with the IB.
- [x] Ensure no unrelated changes are included.
- [x] Ensure CI checks pass.
- [x] Check Storybook where applicable.
- [x] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [x] Ensure the PR has the correct target branch.
- [x] Double-check that the PR is okay to be merged.
- [x] Ensure the corresponding issue has a ZenHub release assigned.
- [x] Add a changelog message to the issue.
