### PR TITLE
Prevent fatal error from sharing data being available for a non-existent module.

### DIFF
--- a/includes/Core/Modules/Modules.php
+++ b/includes/Core/Modules/Modules.php
@@ -367,6 +367,10 @@ final class Modules {
 				array_walk(
 					$values,
 					function( $value, $module_slug ) {
+						if ( ! $this->module_exists( $module_slug ) ) {
+							return;
+						}
+
 						$module = $this->get_module( $module_slug );
 
 						if ( ! $module instanceof Module_With_Service_Entity ) {
@@ -392,6 +396,10 @@ final class Modules {
 					array_walk(
 						$values,
 						function( $value, $module_slug ) use ( $old_values ) {
+							if ( ! $this->module_exists( $module_slug ) ) {
+								return;
+							}
+
 							$module = $this->get_module( $module_slug );
 
 							if ( ! $module instanceof Module_With_Service_Entity ) {
@@ -558,6 +566,23 @@ final class Modules {
 		}
 
 		return $modules[ $slug ];
+	}
+
+	/**
+	 * Checks if the module exists.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param string $slug Module slug.
+	 * @return bool True if the module exists, false otherwise.
+	 */
+	public function module_exists( $slug ) {
+		try {
+			$this->get_module( $slug );
+			return true;
+		} catch ( Exception $e ) {
+			return false;
+		}
 	}
 
 	/**

--- a/tests/phpunit/integration/Core/Modules/ModulesTest.php
+++ b/tests/phpunit/integration/Core/Modules/ModulesTest.php
@@ -177,6 +177,17 @@ class ModulesTest extends TestCase {
 		$this->fail( 'Failed to catch exception thrown for non-existent module in get_module_dependencies.' );
 	}
 
+	public function test_module_exists() {
+		$fake_module = new FakeModule( new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE ) );
+		$modules     = new Modules( new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE ) );
+
+		$this->force_set_property( $modules, 'modules', array( 'fake-module' => $fake_module ) );
+		$this->assertTrue( $modules->module_exists( 'fake-module' ) );
+
+		$module_slug = 'non-existent-module';
+		$this->assertFalse( $modules->module_exists( $module_slug ) );
+	}
+
 	public function test_get_module_dependants() {
 		$modules = new Modules( new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE ) );
 


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #5488 

## Relevant technical choices

Return early in case a module doesn't exist, instead of letting the function throw an exception.

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [x] Run the code.
- [x] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [x] Ensure no unrelated changes are included.
- [x] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [x] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
