### PR TITLE
Add "US Only" badge to TwG

### DIFF
--- a/assets/js/components/settings/SettingsActiveModule/Header.js
+++ b/assets/js/components/settings/SettingsActiveModule/Header.js
@@ -108,6 +108,13 @@ export default function Header( { slug } ) {
 									hasLeftSpacing={ true }
 								/>
 							) }
+
+							{ 'thank-with-google' === slug && (
+								<Badge
+									label={ __( 'US Only', 'google-site-kit' ) }
+									hasLeftSpacing={ true }
+								/>
+							) }
 						</h3>
 					</Cell>
 

--- a/assets/js/components/settings/SetupModule.js
+++ b/assets/js/components/settings/SetupModule.js
@@ -115,6 +115,10 @@ export default function SetupModule( { slug, name, description } ) {
 				{ EXPERIMENTAL_MODULES.includes( slug ) && (
 					<Badge label={ __( 'Experimental', 'google-site-kit' ) } />
 				) }
+
+				{ 'thank-with-google' === slug && (
+					<Badge label={ __( 'US Only', 'google-site-kit' ) } />
+				) }
 			</div>
 			<p className="googlesitekit-settings-connect-module__text">
 				{ description }

--- a/assets/js/modules/thank-with-google/components/setup/SetupMain.js
+++ b/assets/js/modules/thank-with-google/components/setup/SetupMain.js
@@ -71,6 +71,7 @@ export default function SetupMain( { finishSetup } ) {
 				</div>
 
 				<Badge label={ __( 'Experimental', 'google-site-kit' ) } />
+				<Badge label={ __( 'US Only', 'google-site-kit' ) } />
 			</div>
 
 			{ viewComponent }

--- a/assets/sass/components/settings/_googlesitekit-settings-module.scss
+++ b/assets/sass/components/settings/_googlesitekit-settings-module.scss
@@ -272,7 +272,7 @@
 			.googlesitekit-settings-module__title {
 				width: min-content;
 
-				@media (min-width: $bp-wpAdminBarTablet) {
+				@media (min-width: $width-desktop) {
 					min-width: 400px;
 				}
 			}


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #5457 

## Relevant technical choices

This PR adds the "US Only" badge to Thank with Google module.

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
