### PR TITLE
Only try to load custom fonts in Google Charts when Google WebFont is not loaded

### DIFF
--- a/assets/js/components/GoogleChart.js
+++ b/assets/js/components/GoogleChart.js
@@ -225,24 +225,44 @@ export default function GoogleChart( props ) {
 		}
 	}
 
+	// Note the `typeof WebFont === 'undefined'` check for every `fontName`
+	// property. If the Google `WebFont` global exists and we try to use
+	// the `fontName` property in a Google Chart, we'll encounter an
+	// exception and the entire dashboard will crash.
+	//
+	// Our "workaround" is not to load custom fonts when the `WebFont`
+	// global exists, as these are usually very small UI elements
+	// and there's no clear way to get them to load without errors
+	// when the `WebFont` global/script is loaded.
+	//
+	// See: https://github.com/google/site-kit-wp/issues/5572
 	merge( chartOptions, {
 		hAxis: {
 			textStyle: {
-				fontName: 'Google Sans Text',
+				fontName:
+					typeof WebFont === 'undefined'
+						? '"Google Sans Text", "Helvetica Neue", Helvetica, Arial, sans-serif'
+						: undefined,
 				fontSize: 10,
 				color: '#5f6561',
 			},
 		},
 		vAxis: {
 			textStyle: {
-				fontName: 'Google Sans Text',
+				fontName:
+					typeof WebFont === 'undefined'
+						? '"Google Sans Text", "Helvetica Neue", Helvetica, Arial, sans-serif'
+						: undefined,
 				color: '#5f6561',
 				fontSize: 10,
 			},
 		},
 		legend: {
 			textStyle: {
-				fontName: 'Google Sans Text',
+				fontName:
+					typeof WebFont === 'undefined'
+						? '"Google Sans Text", "Helvetica Neue", Helvetica, Arial, sans-serif'
+						: undefined,
 				color: '#131418',
 				fontSize: 12,
 			},

--- a/assets/js/modules/analytics/components/dashboard/DashboardAllTrafficWidget/UserDimensionsPieChart.js
+++ b/assets/js/modules/analytics/components/dashboard/DashboardAllTrafficWidget/UserDimensionsPieChart.js
@@ -725,7 +725,20 @@ UserDimensionsPieChart.chartOptions = {
 	pieSliceTextStyle: {
 		color: '#131418',
 		fontSize: 12,
-		fontName: 'Google Sans Text',
+		fontName:
+			// If the Google `WebFont` global exists and we try to use
+			// the `fontName` property in a Google Chart, we'll encounter an
+			// exception and the entire dashboard will crash.
+			//
+			// Our "workaround" is not to load custom fonts when the `WebFont`
+			// global exists, as these are usually very small UI elements
+			// and there's no clear way to get them to load without errors
+			// when the `WebFont` global/script is loaded.
+			//
+			// See: https://github.com/google/site-kit-wp/issues/5572
+			typeof WebFont === 'undefined'
+				? '"Google Sans Text", "Helvetica Neue", Helvetica, Arial, sans-serif'
+				: undefined,
 	},
 	slices: {
 		0: { color: '#fece72' },


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #5572

## Relevant technical choices

This is essentially a "don't run the code that causes the bug" rather than "fix the root cause" fix/workaround, because the underlying error is quite unclear and the bug here is somewhat niche.

This fixes an error that only happens when another file creates/overwrites the `window.WebFont` global. There’s no straightforward fix as the errors happening are very opaque, and the visual difference in this bugfix approach is quite subtle AND only affects users who even have the Google WebFont loader script in their theme (not a default).

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
