### PR TITLE
Add get help link to authentication request failed message

### DIFF
--- a/includes/Core/Authentication/Authentication.php
+++ b/includes/Core/Authentication/Authentication.php
@@ -1340,7 +1340,7 @@ final class Authentication {
 	 *
 	 * @return string|null Support URL.
 	 */
-	private function get_proxy_support_link_url() {
+	public function get_proxy_support_link_url() {
 		return $this->google_proxy->url( Google_Proxy::SUPPORT_LINK_URI );
 	}
 

--- a/includes/Core/Authentication/Setup.php
+++ b/includes/Core/Authentication/Setup.php
@@ -106,6 +106,22 @@ class Setup {
 	}
 
 	/**
+	 * Composes the oAuth proxy get help link.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @return string The get help link.
+	 */
+	public function get_oauth_proxy_failed_help_link() {
+		return sprintf(
+			/* translators: 1: Support link URL. 2: Get Help string. */
+			__( '<a href="%1$s" target="_blank">%2$s</a>', 'google-site-kit' ),
+			esc_url( $this->proxy_support_link_url . '/?error_id=request_to_auth_proxy_failed' ),
+			esc_html__( 'Get Help', 'google-site-kit' )
+		);
+	}
+
+	/**
 	 * Handles the setup start action, taking the user to the proxy setup screen.
 	 *
 	 * @since 1.48.0
@@ -131,12 +147,7 @@ class Setup {
 			? $this->google_proxy->sync_site_fields( $this->credentials, 'sync' )
 			: $this->google_proxy->register_site( 'sync' );
 
-		$oauth_proxy_failed_help_link = sprintf(
-			/* translators: 1: Support link URL. 2: Get Help string. */
-			__( '<a href="%1$s" target="_blank">%2$s</a>', 'google-site-kit' ),
-			esc_url( $this->proxy_support_link_url . '/?error_id=request_to_auth_proxy_failed' ),
-			esc_html__( 'Get Help', 'google-site-kit' )
-		);
+		$oauth_proxy_failed_help_link = $this->get_oauth_proxy_failed_help_link();
 
 		if ( is_wp_error( $oauth_setup_redirect ) ) {
 			$error_message = $oauth_setup_redirect->get_error_message();

--- a/includes/Core/Authentication/Setup.php
+++ b/includes/Core/Authentication/Setup.php
@@ -114,10 +114,10 @@ class Setup {
 	 */
 	private function get_oauth_proxy_failed_help_link() {
 		return sprintf(
-			/* translators: 1: Support link URL. 2: Get Help string. */
+			/* translators: 1: Support link URL. 2: Get help string. */
 			__( '<a href="%1$s" target="_blank">%2$s</a>', 'google-site-kit' ),
 			esc_url( $this->proxy_support_link_url . '/?error_id=request_to_auth_proxy_failed' ),
-			esc_html__( 'Get Help', 'google-site-kit' )
+			esc_html__( 'Get help', 'google-site-kit' )
 		);
 	}
 
@@ -157,7 +157,7 @@ class Setup {
 
 			wp_die(
 				sprintf(
-					/* translators: 1: Error message or error code. 2: Get Help link. */
+					/* translators: 1: Error message or error code. 2: Get help link. */
 					esc_html__( 'The request to the authentication proxy has failed with an error: %1$s %2$s.', 'google-site-kit' ),
 					esc_html( $error_message ),
 					wp_kses(
@@ -176,7 +176,7 @@ class Setup {
 		if ( ! filter_var( $oauth_setup_redirect, FILTER_VALIDATE_URL ) ) {
 			wp_die(
 				sprintf(
-					/* translators: %s: Get Help link. */
+					/* translators: %s: Get help link. */
 					esc_html__( 'The request to the authentication proxy has failed. Please, try again later. %s.', 'google-site-kit' ),
 					wp_kses(
 						$oauth_proxy_failed_help_link,

--- a/includes/Core/Authentication/Setup.php
+++ b/includes/Core/Authentication/Setup.php
@@ -112,7 +112,7 @@ class Setup {
 	 *
 	 * @return string The get help link.
 	 */
-	public function get_oauth_proxy_failed_help_link() {
+	private function get_oauth_proxy_failed_help_link() {
 		return sprintf(
 			/* translators: 1: Support link URL. 2: Get Help string. */
 			__( '<a href="%1$s" target="_blank">%2$s</a>', 'google-site-kit' ),

--- a/includes/Core/Authentication/Setup.php
+++ b/includes/Core/Authentication/Setup.php
@@ -158,7 +158,7 @@ class Setup {
 			wp_die(
 				sprintf(
 					/* translators: 1: Error message or error code. 2: Get Help link. */
-					esc_html__( 'The request to the authentication proxy has failed with an error: %1$s. %2$s.', 'google-site-kit' ),
+					esc_html__( 'The request to the authentication proxy has failed with an error: %1$s %2$s.', 'google-site-kit' ),
 					esc_html( $error_message ),
 					wp_kses(
 						$oauth_proxy_failed_help_link,

--- a/includes/Core/Authentication/Setup.php
+++ b/includes/Core/Authentication/Setup.php
@@ -145,12 +145,18 @@ class Setup {
 			}
 
 			wp_die(
-				esc_html(
-					sprintf(
-						/* translators: 1: Error message or error code. 2: Get Help link. */
-						__( 'The request to the authentication proxy has failed with an error: %1$s. %2$s.', 'google-site-kit' ),
-						$error_message,
-						$oauth_proxy_failed_help_link
+				sprintf(
+					/* translators: 1: Error message or error code. 2: Get Help link. */
+					esc_html__( 'The request to the authentication proxy has failed with an error: %1$s. %2$s.', 'google-site-kit' ),
+					esc_html( $error_message ),
+					wp_kses(
+						$oauth_proxy_failed_help_link,
+						array(
+							'a' => array(
+								'href'   => array(),
+								'target' => array(),
+							),
+						)
 					)
 				)
 			);
@@ -158,11 +164,17 @@ class Setup {
 
 		if ( ! filter_var( $oauth_setup_redirect, FILTER_VALIDATE_URL ) ) {
 			wp_die(
-				esc_html(
-					sprintf(
-						/* translators: %s: Get Help link. */
-						__( 'The request to the authentication proxy has failed. Please, try again later. %s.', 'google-site-kit' ),
-						$oauth_proxy_failed_help_link
+				sprintf(
+					/* translators: %s: Get Help link. */
+					esc_html__( 'The request to the authentication proxy has failed. Please, try again later. %s.', 'google-site-kit' ),
+					wp_kses(
+						$oauth_proxy_failed_help_link,
+						array(
+							'a' => array(
+								'href'   => array(),
+								'target' => array(),
+							),
+						)
 					)
 				)
 			);

--- a/tests/phpunit/integration/Core/Authentication/Setup_Test.php
+++ b/tests/phpunit/integration/Core/Authentication/Setup_Test.php
@@ -167,8 +167,9 @@ class Setup_Test extends TestCase {
 		$user_id = $this->factory()->user->create( array( 'role' => 'administrator' ) );
 		wp_set_current_user( $user_id );
 
-		$context = new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE, new MutableInput() );
-		$setup   = new Setup( $context, new User_Options( $context ), new Authentication( $context ) );
+		$context                      = new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE, new MutableInput() );
+		$setup                        = new Setup( $context, new User_Options( $context ), new Authentication( $context ) );
+		$oauth_proxy_failed_help_link = $setup->get_oauth_proxy_failed_help_link();
 		$setup->register();
 
 		if ( $has_credentials ) {
@@ -206,7 +207,11 @@ class Setup_Test extends TestCase {
 		} catch ( WPDieException $exception ) {
 			$error = $has_credentials ? 'Test error message.' : 'test_error_code';
 			$this->assertStringContainsString(
-				sprintf( 'The request to the authentication proxy has failed with an error: %s', $error ),
+				sprintf(
+					'The request to the authentication proxy has failed with an error: %1$s. %2$s.',
+					$error,
+					$oauth_proxy_failed_help_link
+				),
 				$exception->getMessage()
 			);
 		}

--- a/tests/phpunit/integration/Core/Authentication/Setup_Test.php
+++ b/tests/phpunit/integration/Core/Authentication/Setup_Test.php
@@ -208,7 +208,7 @@ class Setup_Test extends TestCase {
 			$error = $has_credentials ? 'Test error message.' : 'test_error_code';
 			$this->assertStringContainsString(
 				sprintf(
-					'The request to the authentication proxy has failed with an error: %1$s. %2$s.',
+					'The request to the authentication proxy has failed with an error: %1$s %2$s.',
 					$error,
 					$oauth_proxy_failed_help_link
 				),


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #5484 

## Relevant technical choices

This PR simply adds "Get Help" links to the authentication request failed message. It also updates test cases to address this change.

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [x] Run the code.
- [x] Ensure the acceptance criteria are satisfied.
- [x] Reassess the implementation with the IB.
- [x] Ensure no unrelated changes are included.
- [x] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [x] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [x] Ensure the PR has the correct target branch.
- [x] Double-check that the PR is okay to be merged.
- [x] Ensure the corresponding issue has a ZenHub release assigned.
- [x] Add a changelog message to the issue.
