### PR TITLE
Add learn more link for second admin

### DIFF
--- a/assets/js/components/setup/SetupUsingProxyWithSignIn.js
+++ b/assets/js/components/setup/SetupUsingProxyWithSignIn.js
@@ -24,7 +24,11 @@ import punycode from 'punycode';
 /**
  * WordPress dependencies
  */
-import { Fragment, useCallback } from '@wordpress/element';
+import {
+	createInterpolateElement,
+	Fragment,
+	useCallback,
+} from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { getQueryArg, addQueryArgs } from '@wordpress/url';
 
@@ -184,7 +188,7 @@ export default function SetupUsingProxyWithSignIn() {
 
 	let title;
 	let description;
-	let learnMore;
+	let showLearnMoreLink = false;
 	let cellDetailsProp = {
 		smSize: 4,
 		mdSize: 8,
@@ -226,7 +230,7 @@ export default function SetupUsingProxyWithSignIn() {
 			'Site Kit has already been configured by another admin of this site. To use Site Kit as well, sign in with your Google account which has access to Google services for this site (e.g. Google Analytics). Once you complete the 3 setup steps, you’ll see stats from all activated Google products.',
 			'google-site-kit'
 		);
-		learnMore = secondAdminLearnMoreLink;
+		showLearnMoreLink = true;
 	} else {
 		title = __( 'Set up Site Kit', 'google-site-kit' );
 		description = __(
@@ -307,23 +311,34 @@ export default function SetupUsingProxyWithSignIn() {
 												</h1>
 
 												<p className="googlesitekit-setup__description">
-													{ description }
-													{ learnMore && (
-														<Fragment>
-															{ ' ' }
-															<Link
-																href={
-																	learnMore
-																}
-																external
-															>
-																{ __(
+													{ ! showLearnMoreLink &&
+														description }
+
+													{ showLearnMoreLink &&
+														createInterpolateElement(
+															sprintf(
+																/* translators: 1: The description. 2: The learn more link. */
+																__(
+																	'%1$s <Link>%2$s</Link>',
+																	'google-site-kit'
+																),
+																description,
+																__(
 																	'Learn more',
 																	'google-site-kit'
-																) }
-															</Link>
-														</Fragment>
-													) }
+																)
+															),
+															{
+																Link: (
+																	<Link
+																		href={
+																			secondAdminLearnMoreLink
+																		}
+																		external
+																	/>
+																),
+															}
+														) }
 												</p>
 												{ DISCONNECTED_REASON_CONNECTED_URL_MISMATCH ===
 													disconnectedReason &&

--- a/assets/js/components/setup/SetupUsingProxyWithSignIn.js
+++ b/assets/js/components/setup/SetupUsingProxyWithSignIn.js
@@ -318,7 +318,7 @@ export default function SetupUsingProxyWithSignIn() {
 																external
 															>
 																{ __(
-																	'Learn More',
+																	'Learn more',
 																	'google-site-kit'
 																) }
 															</Link>

--- a/assets/js/components/setup/SetupUsingProxyWithSignIn.js
+++ b/assets/js/components/setup/SetupUsingProxyWithSignIn.js
@@ -87,6 +87,7 @@ export default function SetupUsingProxyWithSignIn() {
 		connectedProxyURL,
 		homeURL,
 		hasMultipleAdmins,
+		secondAdminLearnMoreLink,
 	} = useSelect( ( select ) => {
 		const site = select( CORE_SITE );
 		const user = select( CORE_USER );
@@ -101,6 +102,9 @@ export default function SetupUsingProxyWithSignIn() {
 			homeURL: untrailingslashit( site.getHomeURL() ),
 			isConnected: site.isConnected(),
 			hasMultipleAdmins: site.hasMultipleAdmins(),
+			secondAdminLearnMoreLink: site.getDocumentationLinkURL(
+				'already-configured'
+			),
 		};
 	} );
 
@@ -180,6 +184,7 @@ export default function SetupUsingProxyWithSignIn() {
 
 	let title;
 	let description;
+	let learnMore;
 	let cellDetailsProp = {
 		smSize: 4,
 		mdSize: 8,
@@ -221,6 +226,7 @@ export default function SetupUsingProxyWithSignIn() {
 			'Site Kit has already been configured by another admin of this site. To use Site Kit as well, sign in with your Google account which has access to Google services for this site (e.g. Google Analytics). Once you complete the 3 setup steps, you’ll see stats from all activated Google products.',
 			'google-site-kit'
 		);
+		learnMore = secondAdminLearnMoreLink;
 	} else {
 		title = __( 'Set up Site Kit', 'google-site-kit' );
 		description = __(
@@ -302,6 +308,22 @@ export default function SetupUsingProxyWithSignIn() {
 
 												<p className="googlesitekit-setup__description">
 													{ description }
+													{ learnMore && (
+														<Fragment>
+															{ ' ' }
+															<Link
+																href={
+																	learnMore
+																}
+																external
+															>
+																{ __(
+																	'Learn More',
+																	'google-site-kit'
+																) }
+															</Link>
+														</Fragment>
+													) }
 												</p>
 												{ DISCONNECTED_REASON_CONNECTED_URL_MISMATCH ===
 													disconnectedReason &&


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #5559 

## Relevant technical choices

This PR adds a learn more link to the setup description if it is a second admin (i.e. Site Kit was configured by another admin).

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
