### PR TITLE
Add get help link to AdBlockerWarning

### DIFF
--- a/assets/js/modules/adsense/components/common/AdBlockerWarning.js
+++ b/assets/js/modules/adsense/components/common/AdBlockerWarning.js
@@ -23,17 +23,28 @@ import PropTypes from 'prop-types';
 import classnames from 'classnames';
 
 /**
+ * WordPress dependencies
+ */
+import { sprintf, __ } from '@wordpress/i18n';
+import { createInterpolateElement } from '@wordpress/element';
+
+/**
  * Internal dependencies
  */
 import Data from 'googlesitekit-data';
 import ErrorIcon from '../../../../../svg/icons/error.svg';
+import Link from '../../../../components/Link';
 
 import { MODULES_ADSENSE } from '../../datastore/constants';
+import { CORE_SITE } from '../../../../googlesitekit/datastore/site/constants';
 const { useSelect } = Data;
 
 export default function AdBlockerWarning( { context } ) {
 	const adBlockerWarningMessage = useSelect( ( select ) =>
 		select( MODULES_ADSENSE ).getAdBlockerWarningMessage()
+	);
+	const getHelpLink = useSelect( ( select ) =>
+		select( CORE_SITE ).getDocumentationLinkURL( 'ad-blocker-detected' )
 	);
 
 	// Return nothing if loading or if everything is fine.
@@ -47,7 +58,21 @@ export default function AdBlockerWarning( { context } ) {
 				[ `googlesitekit-settings-module-warning--${ context }` ]: context,
 			} ) }
 		>
-			<ErrorIcon height="20" width="23" /> { adBlockerWarningMessage }
+			{ createInterpolateElement(
+				sprintf(
+					/* translators: 1: The warning message. 2: The Get Help text. */
+					__(
+						'<ErrorIcon /> %1$s. <Link>%2$s</Link>',
+						'google-site-kit'
+					),
+					adBlockerWarningMessage,
+					__( 'Get Help', 'google-site-kit' )
+				),
+				{
+					ErrorIcon: <ErrorIcon height="20" width="23" />,
+					Link: <Link href={ getHelpLink } external />,
+				}
+			) }
 		</div>
 	);
 }

--- a/assets/js/modules/adsense/components/common/AdBlockerWarning.js
+++ b/assets/js/modules/adsense/components/common/AdBlockerWarning.js
@@ -60,13 +60,13 @@ export default function AdBlockerWarning( { context } ) {
 		>
 			{ createInterpolateElement(
 				sprintf(
-					/* translators: 1: The warning message. 2: The Get Help text. */
+					/* translators: 1: The warning message. 2: "Get help" text. */
 					__(
 						'<ErrorIcon /> %1$s. <Link>%2$s</Link>',
 						'google-site-kit'
 					),
 					adBlockerWarningMessage,
-					__( 'Get Help', 'google-site-kit' )
+					__( 'Get help', 'google-site-kit' )
 				),
 				{
 					ErrorIcon: <ErrorIcon height="20" width="23" />,


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #5558 

## Relevant technical choices

This PR adds a get help link to `<AdBlockerWarning />` component.

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [x] Run the code.
- [x] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [x] Ensure no unrelated changes are included.
- [x] Ensure CI checks pass.
- [x] Check Storybook where applicable.
- [x] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
