### PR TITLE
Extract reusable AdminMenuTooltip component from AdSenseConnectCTAWidget.

### DIFF
--- a/assets/js/components/AdminMenuTooltip/AdminMenuTooltip.js
+++ b/assets/js/components/AdminMenuTooltip/AdminMenuTooltip.js
@@ -1,0 +1,60 @@
+import { useCallback } from '@wordpress/element';
+
+import PropTypes from 'prop-types';
+
+import Data from 'googlesitekit-data';
+import Tooltip from '../Tooltip';
+import { CORE_UI } from '../../googlesitekit/datastore/ui/constants';
+
+import { useTooltipState } from './useTooltipState';
+
+const { useDispatch } = Data;
+
+export function AdminMenuTooltip( { onDismiss, tooltipStateKey, ...props } ) {
+	const { setValue } = useDispatch( CORE_UI );
+
+	const { rehideAdminMenu, rehideAdminSubMenu } = useTooltipState(
+		tooltipStateKey
+	);
+
+	const handleDismissTooltip = useCallback( async () => {
+		// If the WordPress admin menu was closed, re-close it.
+		if ( rehideAdminMenu ) {
+			const isAdminMenuOpen =
+				document.querySelector( '#adminmenu' ).offsetHeight > 0;
+
+			if ( isAdminMenuOpen ) {
+				document.getElementById( 'wp-admin-bar-menu-toggle' )?.click();
+			}
+		}
+
+		// If the Site Kit admin submenu was hidden, re-hide it.
+		if ( rehideAdminSubMenu ) {
+			// Click on the body to close the submenu.
+			document.querySelector( 'body' ).click();
+		}
+
+		await onDismiss?.();
+
+		setValue( tooltipStateKey, undefined );
+	}, [
+		onDismiss,
+		rehideAdminMenu,
+		rehideAdminSubMenu,
+		setValue,
+		tooltipStateKey,
+	] );
+
+	return <Tooltip onDismiss={ handleDismissTooltip } { ...props } />;
+}
+
+AdminMenuTooltip.propTypes = {
+	...Tooltip.propTypes,
+	target: PropTypes.string,
+	tooltipStateKey: PropTypes.string.isRequired,
+};
+
+AdminMenuTooltip.defaultProps = {
+	// Point to the Site Kit Settings menu item by default.
+	target: '#adminmenu [href*="page=googlesitekit-settings"]',
+};

--- a/assets/js/components/AdminMenuTooltip/index.js
+++ b/assets/js/components/AdminMenuTooltip/index.js
@@ -1,0 +1,3 @@
+export * from './useShowTooltip';
+export * from './useTooltipState';
+export * from './AdminMenuTooltip';

--- a/assets/js/components/AdminMenuTooltip/useShowTooltip.js
+++ b/assets/js/components/AdminMenuTooltip/useShowTooltip.js
@@ -1,0 +1,50 @@
+import { useCallback } from '@wordpress/element';
+
+import Data from 'googlesitekit-data';
+import { CORE_UI } from '../../googlesitekit/datastore/ui/constants';
+
+const { useDispatch } = Data;
+
+export function useShowTooltip( tooltipStateKey ) {
+	const { setValue } = useDispatch( CORE_UI );
+
+	return useCallback( async () => {
+		// Check if the WordPress admin menu is open, and if not, open it.
+		// The admin menu is hidden via responsive CSS. This is a simple and effective way to check if it's visible.
+		const isAdminMenuOpen =
+			document.querySelector( '#adminmenu' ).offsetHeight > 0;
+
+		if ( ! isAdminMenuOpen ) {
+			const adminMenuToggle = document.getElementById(
+				'wp-admin-bar-menu-toggle'
+			);
+
+			if ( adminMenuToggle ) {
+				adminMenuToggle.click();
+
+				// On iOS, at least, this is necessary, without it the settings menu item
+				// is not scrolled into view when the Tooltip is shown.
+				await new Promise( ( resolve ) => {
+					setTimeout( resolve, 0 );
+				} );
+			}
+		}
+
+		// Check if the Site Kit admin submenu is hidden, and if so, show it.
+		const adminSubMenuSelector =
+			"#adminmenu [href*='page=googlesitekit-dashboard']";
+		const isAdminSubMenuHidden = !! document.querySelector(
+			`${ adminSubMenuSelector }[aria-haspopup=true]`
+		);
+
+		if ( isAdminSubMenuHidden ) {
+			document.querySelector( adminSubMenuSelector ).click();
+		}
+
+		setValue( tooltipStateKey, {
+			isTooltipVisible: true,
+			rehideAdminMenu: ! isAdminMenuOpen,
+			rehideAdminSubMenu: isAdminSubMenuHidden,
+		} );
+	}, [ setValue, tooltipStateKey ] );
+}

--- a/assets/js/components/AdminMenuTooltip/useTooltipState.js
+++ b/assets/js/components/AdminMenuTooltip/useTooltipState.js
@@ -1,0 +1,15 @@
+import Data from 'googlesitekit-data';
+import { CORE_UI } from '../../googlesitekit/datastore/ui/constants';
+
+const { useSelect } = Data;
+
+export function useTooltipState( tooltipStateKey ) {
+	return useSelect(
+		( select ) =>
+			select( CORE_UI ).getValue( tooltipStateKey ) || {
+				isTooltipVisible: false,
+				rehideAdminMenu: false,
+				rehideAdminSubMenu: false,
+			}
+	);
+}

--- a/assets/js/modules/adsense/components/dashboard/AdSenseConnectCTAWidget.js
+++ b/assets/js/modules/adsense/components/dashboard/AdSenseConnectCTAWidget.js
@@ -36,27 +36,24 @@ import {
 	ADSENSE_CTA_WIDGET_DISMISSED_ITEM_KEY,
 	ADSENSE_CTA_WIDGET_TOOLTIP_STATE_KEY,
 } from '../../constants';
-import { CORE_UI } from '../../../../googlesitekit/datastore/ui/constants';
 import { CORE_USER } from '../../../../googlesitekit/datastore/user/constants';
 import { CORE_MODULES } from '../../../../googlesitekit/modules/datastore/constants';
-import Tooltip from '../../../../components/Tooltip';
 import useViewContext from '../../../../hooks/useViewContext';
 import { trackEvent } from '../../../../util';
+
+import {
+	useShowTooltip,
+	useTooltipState,
+	AdminMenuTooltip,
+} from '../../../../components/AdminMenuTooltip';
+
 const { useDispatch, useSelect } = Data;
 
 function AdSenseConnectCTAWidget( { Widget, WidgetNull } ) {
 	const { dismissItem } = useDispatch( CORE_USER );
-	const { setValue } = useDispatch( CORE_UI );
 
-	const { isTooltipVisible, rehideAdminMenu, rehideAdminSubMenu } = useSelect(
-		( select ) =>
-			select( CORE_UI ).getValue(
-				ADSENSE_CTA_WIDGET_TOOLTIP_STATE_KEY
-			) || {
-				isTooltipVisible: false,
-				rehideAdminMenu: false,
-				rehideAdminSubMenu: false,
-			}
+	const { isTooltipVisible } = useTooltipState(
+		ADSENSE_CTA_WIDGET_TOOLTIP_STATE_KEY
 	);
 
 	const viewContext = useViewContext();
@@ -70,83 +67,21 @@ function AdSenseConnectCTAWidget( { Widget, WidgetNull } ) {
 		)
 	);
 
-	const onDismissModule = useCallback( async () => {
-		// Check if the WordPress admin menu is open, and if not, open it.
-		// The admin menu is hidden via responsive CSS. This is a simple and effective way to check if it's visible.
-		const isAdminMenuOpen =
-			document.querySelector( '#adminmenu' ).offsetHeight > 0;
-
-		if ( ! isAdminMenuOpen ) {
-			const adminMenuToggle = document.getElementById(
-				'wp-admin-bar-menu-toggle'
-			);
-
-			if ( adminMenuToggle ) {
-				adminMenuToggle.click();
-
-				// On iOS, at least, this is necessary, without it the settings menu item
-				// is not scrolled into view when the Tooltip is shown.
-				await new Promise( ( resolve ) => {
-					setTimeout( resolve, 0 );
-				} );
-			}
-		}
-
-		// Check if the Site Kit admin submenu is hidden, and if so, show it.
-		const adminSubMenuSelector =
-			"#adminmenu [href*='page=googlesitekit-dashboard']";
-		const isAdminSubMenuHidden = !! document.querySelector(
-			`${ adminSubMenuSelector }[aria-haspopup=true]`
-		);
-
-		if ( isAdminSubMenuHidden ) {
-			document.querySelector( adminSubMenuSelector ).click();
-		}
-
-		setValue( ADSENSE_CTA_WIDGET_TOOLTIP_STATE_KEY, {
-			isTooltipVisible: true,
-			rehideAdminMenu: ! isAdminMenuOpen,
-			rehideAdminSubMenu: isAdminSubMenuHidden,
-		} );
-	}, [ setValue ] );
+	const showTooltip = useShowTooltip( ADSENSE_CTA_WIDGET_TOOLTIP_STATE_KEY );
 
 	const handleDismissTooltip = useCallback( async () => {
-		// If the WordPress admin menu was closed, re-close it.
-		if ( rehideAdminMenu ) {
-			const isAdminMenuOpen =
-				document.querySelector( '#adminmenu' ).offsetHeight > 0;
-
-			if ( isAdminMenuOpen ) {
-				document.getElementById( 'wp-admin-bar-menu-toggle' )?.click();
-			}
-		}
-
-		// If the Site Kit admin submenu was hidden, re-hide it.
-		if ( rehideAdminSubMenu ) {
-			// Click on the body to close the submenu.
-			document.querySelector( 'body' ).click();
-		}
-
 		await trackEvent(
 			`${ viewContext }_adsense-cta-widget`,
 			'dismiss_tooltip'
 		);
 		await dismissItem( ADSENSE_CTA_WIDGET_DISMISSED_ITEM_KEY );
-
-		setValue( ADSENSE_CTA_WIDGET_TOOLTIP_STATE_KEY, undefined );
-	}, [
-		dismissItem,
-		rehideAdminMenu,
-		rehideAdminSubMenu,
-		setValue,
-		viewContext,
-	] );
+	}, [ dismissItem, viewContext ] );
 
 	if ( isTooltipVisible ) {
 		return (
 			<Fragment>
 				<WidgetNull />
-				<Tooltip
+				<AdminMenuTooltip
 					title={ __(
 						'You can always connect AdSense from here later',
 						'google-site-kit'
@@ -156,8 +91,8 @@ function AdSenseConnectCTAWidget( { Widget, WidgetNull } ) {
 						'google-site-kit'
 					) }
 					dismissLabel={ __( 'Got it', 'google-site-kit' ) }
-					target="#adminmenu [href*='page=googlesitekit-settings']"
 					onDismiss={ handleDismissTooltip }
+					tooltipStateKey={ ADSENSE_CTA_WIDGET_TOOLTIP_STATE_KEY }
 				/>
 			</Fragment>
 		);
@@ -169,7 +104,7 @@ function AdSenseConnectCTAWidget( { Widget, WidgetNull } ) {
 
 	return (
 		<Widget noPadding>
-			<AdSenseConnectCTA onDismissModule={ onDismissModule } />
+			<AdSenseConnectCTA onDismissModule={ showTooltip } />
 		</Widget>
 	);
 }


### PR DESCRIPTION
## Summary

This is a PoC for extracting a reusable `AdminMenuTooltip` component for use in #5279.

## Relevant technical choices

<!-- Please describe your changes. -->

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [ ] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
