### PR TITLE
Register required scopes for TwG

### DIFF
--- a/includes/Modules/Thank_With_Google.php
+++ b/includes/Modules/Thank_With_Google.php
@@ -19,6 +19,7 @@ use Google\Site_Kit\Core\Modules\Module_With_Assets;
 use Google\Site_Kit\Core\Modules\Module_With_Assets_Trait;
 use Google\Site_Kit\Core\Modules\Module_With_Deactivation;
 use Google\Site_Kit\Core\Modules\Module_With_Scopes;
+use Google\Site_Kit\Core\Modules\Module_With_Scopes_Trait;
 use Google\Site_Kit\Core\Modules\Module_With_Settings;
 use Google\Site_Kit\Core\Modules\Module_With_Settings_Trait;
 use Google\Site_Kit\Core\Modules\Module_With_Owner;
@@ -48,6 +49,7 @@ final class Thank_With_Google extends Module
 	use Method_Proxy_Trait;
 	use Module_With_Assets_Trait;
 	use Module_With_Owner_Trait;
+	use Module_With_Scopes_Trait;
 	use Module_With_Settings_Trait;
 
 	/**
@@ -61,6 +63,8 @@ final class Thank_With_Google extends Module
 	 * @since 1.78.0
 	 */
 	public function register() {
+		$this->register_scopes_hook();
+
 		if ( ! $this->is_connected() ) {
 			return;
 		}

--- a/tests/phpunit/integration/Modules/Thank_With_GoogleTest.php
+++ b/tests/phpunit/integration/Modules/Thank_With_GoogleTest.php
@@ -60,6 +60,14 @@ class Thank_With_GoogleTest extends TestCase {
 		);
 	}
 
+	public function test_register() {
+		remove_all_actions( 'googlesitekit_auth_scopes' );
+
+		$this->thank_with_google->register();
+
+		$this->assertTrue( has_filter( 'googlesitekit_auth_scopes' ) );
+	}
+
 	public function test_web_tag_hooks_are_added_when_tag_is_registered() {
 		remove_all_actions( 'template_redirect' );
 


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #5534 

## Relevant technical choices

- Forgot that `Module_With_Scopes` has an accompanying trait for registering the required scopes when implementing originally

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
