### PR TITLE
Ensure publications are returned as an array

### DIFF
--- a/includes/Modules/Thank_With_Google.php
+++ b/includes/Modules/Thank_With_Google.php
@@ -305,7 +305,7 @@ final class Thank_With_Google extends Module
 		switch ( "{$data->method}:{$data->datapoint}" ) {
 			case 'GET:publications':
 				/* @var $response Google_Service_SubscribewithGoogle_ListPublicationsResponse phpcs:ignore Squiz.PHP.CommentedOutCode.Found */
-				return $response->getPublications();
+				return (array) $response->getPublications();
 		}
 
 		return parent::parse_data_response( $data, $response );


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #5534

This PR fixes an error caused by a non-JSON response `null` returned when a user has no publications.

## Relevant technical choices

- May be something about built client service library – I feel like other resources properly cast this to an array already

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
