### PR TITLE
Use `add_query_arg()` for get help URL

### DIFF
--- a/includes/Core/Authentication/Setup.php
+++ b/includes/Core/Authentication/Setup.php
@@ -116,7 +116,7 @@ class Setup {
 		return sprintf(
 			/* translators: 1: Support link URL. 2: Get help string. */
 			__( '<a href="%1$s" target="_blank">%2$s</a>', 'google-site-kit' ),
-			esc_url( $this->proxy_support_link_url . '/?error_id=request_to_auth_proxy_failed' ),
+			esc_url( add_query_arg( 'error_id', 'request_to_auth_proxy_failed', $this->proxy_support_link_url ) ),
 			esc_html__( 'Get help', 'google-site-kit' )
 		);
 	}

--- a/tests/phpunit/integration/Core/Authentication/Setup_Test.php
+++ b/tests/phpunit/integration/Core/Authentication/Setup_Test.php
@@ -207,7 +207,7 @@ class Setup_Test extends TestCase {
 			$error = $has_credentials ? 'Test error message.' : 'test_error_code';
 			$this->assertStringContainsString(
 				sprintf(
-					'The request to the authentication proxy has failed with an error: %s <a href="https://sitekit.withgoogle.com/support/?error_id=request_to_auth_proxy_failed" target="_blank">Get help</a>.',
+					'The request to the authentication proxy has failed with an error: %s <a href="https://sitekit.withgoogle.com/support?error_id=request_to_auth_proxy_failed" target="_blank">Get help</a>.',
 					$error
 				),
 				$exception->getMessage()
@@ -267,7 +267,7 @@ class Setup_Test extends TestCase {
 			$this->fail( 'Expected WPDieException!' );
 		} catch ( WPDieException $exception ) {
 			$this->assertStringContainsString(
-				'The request to the authentication proxy has failed. Please, try again later. <a href="https://sitekit.withgoogle.com/support/?error_id=request_to_auth_proxy_failed" target="_blank">Get help</a>.',
+				'The request to the authentication proxy has failed. Please, try again later. <a href="https://sitekit.withgoogle.com/support?error_id=request_to_auth_proxy_failed" target="_blank">Get help</a>.',
 				$exception->getMessage()
 			);
 		}


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- https://github.com/google/site-kit-wp/issues/5484#issuecomment-1212373554

## Relevant technical choices

This PR updates the current implementation for #5484 which uses `add_query_arg()` instead of manually concatenating parts of the URL.

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
