### PR TITLE
Add dropdown & toggle to GA4 Activation Banner

### DIFF
--- a/assets/js/modules/analytics-4/components/common/PropertySelect.js
+++ b/assets/js/modules/analytics-4/components/common/PropertySelect.js
@@ -46,6 +46,13 @@ import useViewContext from '../../../../hooks/useViewContext';
 const { useSelect, useDispatch } = Data;
 
 export default function PropertySelect( { label, hasModuleAccess } ) {
+	// Analytics accounts need to be loaded in order to load the properties,
+	// otherwise this component will stay in a loading state forever.
+	// eslint-disable-next-line no-unused-vars
+	const accounts = useSelect( ( select ) =>
+		select( MODULES_ANALYTICS ).getAccounts()
+	);
+
 	// TODO: Update this select hook to pull accountID from the modules/analytics-4 datastore when GA4 module becomes separated from the Analytics one
 	const accountID = useSelect( ( select ) =>
 		select( MODULES_ANALYTICS ).getAccountID()

--- a/assets/js/modules/analytics-4/components/dashboard/ActivationBanner/SetupBanner.js
+++ b/assets/js/modules/analytics-4/components/dashboard/ActivationBanner/SetupBanner.js
@@ -45,7 +45,7 @@ export default function SetupBanner( { onCTAClick } ) {
 		select( MODULES_ANALYTICS_4 ).getExistingTag()
 	);
 
-  useExistingTagEffect();
+	useExistingTagEffect();
 
 	const referenceDateString = useSelect( ( select ) =>
 		select( CORE_USER ).getReferenceDate()
@@ -136,7 +136,7 @@ export default function SetupBanner( { onCTAClick } ) {
 			onCTAClick={ onCTAClick }
 			footer={ <p>{ footer }</p> }
 			dismiss={ __( 'Cancel', 'google-site-kit' ) }
-      dismissExpires={ getBannerDismissalExpiryTime(
+			dismissExpires={ getBannerDismissalExpiryTime(
 				referenceDateString
 			) }
 		>

--- a/assets/js/modules/analytics-4/components/dashboard/ActivationBanner/SetupBanner.js
+++ b/assets/js/modules/analytics-4/components/dashboard/ActivationBanner/SetupBanner.js
@@ -32,15 +32,10 @@ import {
 	UseSnippetSwitch,
 } from '../../../../analytics-4/components/common';
 import useExistingTagEffect from '../../../../analytics-4/hooks/useExistingTagEffect';
-import { MODULES_ANALYTICS } from '../../../../analytics/datastore/constants';
 import { MODULES_ANALYTICS_4 } from '../../../datastore/constants';
 const { useSelect } = Data;
 
 export default function SetupBanner( { onCTAClick } ) {
-	// We need this useSelect hook to trigger starting getAccounts resolution which is needed to properly
-	// display the Property Select.
-	useSelect( ( select ) => select( MODULES_ANALYTICS ).getAccounts() );
-
 	const ga4MeasurementID = useSelect( ( select ) =>
 		select( MODULES_ANALYTICS_4 ).getMeasurementID()
 	);

--- a/assets/js/modules/analytics-4/components/dashboard/ActivationBanner/SetupBanner.js
+++ b/assets/js/modules/analytics-4/components/dashboard/ActivationBanner/SetupBanner.js
@@ -19,6 +19,7 @@
 /**
  * WordPress dependencies
  */
+import { Fragment } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 
 /**
@@ -26,7 +27,10 @@ import { __, sprintf } from '@wordpress/i18n';
  */
 import Data from 'googlesitekit-data';
 import BannerNotification from '../../../../../components/notifications/BannerNotification';
-import { Grid, Row, Cell } from '../../../../../material-components';
+import {
+	PropertySelect,
+	UseSnippetSwitch,
+} from '../../../../analytics-4/components/common';
 import { MODULES_ANALYTICS_4 } from '../../../datastore/constants';
 const { useSelect } = Data;
 
@@ -41,6 +45,7 @@ export default function SetupBanner( { onCTAClick } ) {
 	let title;
 	let ctaLabel;
 	let footer;
+	let children;
 
 	if ( ga4MeasurementID ) {
 		title = __(
@@ -51,6 +56,40 @@ export default function SetupBanner( { onCTAClick } ) {
 		footer = __(
 			'You can always add/edit this in the Site Kit Settings.',
 			'google-site-kit'
+		);
+		children = (
+			<div className="googlesitekit-ga4-setup-banner__field-group">
+				<PropertySelect
+					label={ __(
+						'Google Analytics 4 Property',
+						'google-site-kit'
+					) }
+				/>
+				{ existingTag && (
+					<UseSnippetSwitch
+						description={
+							<Fragment>
+								<p>
+									{ sprintf(
+										/* translators: %s: existing tag ID */
+										__(
+											'A tag %s for the selected property already exists on the site.',
+											'google-site-kit'
+										),
+										existingTag
+									) }
+								</p>
+								<p>
+									{ __(
+										'Make sure you remove it if you decide to place the same GA4 tag via Site Kit, otherwise they will be duplicated.',
+										'google-site-kit'
+									) }
+								</p>
+							</Fragment>
+						}
+					/>
+				) }
+			</div>
 		);
 	} else if ( existingTag ) {
 		title = __(
@@ -79,21 +118,17 @@ export default function SetupBanner( { onCTAClick } ) {
 	}
 
 	return (
-		<Grid>
-			<Row>
-				<Cell lgSize={ 8 } mdSize={ 8 }>
-					<BannerNotification
-						id="ga4-activation-banner"
-						className="googlesitekit-ga4-setup-banner"
-						title={ title }
-						ctaLabel={ ctaLabel }
-						ctaLink={ onCTAClick ? '#' : null }
-						onCTAClick={ onCTAClick }
-						footer={ <p>{ footer }</p> }
-						dismiss={ __( 'Cancel', 'google-site-kit' ) }
-					/>
-				</Cell>
-			</Row>
-		</Grid>
+		<BannerNotification
+			id="ga4-activation-banner"
+			className="googlesitekit-ga4-setup-banner"
+			title={ title }
+			ctaLabel={ ctaLabel }
+			ctaLink={ onCTAClick ? '#' : null }
+			onCTAClick={ onCTAClick }
+			footer={ <p>{ footer }</p> }
+			dismiss={ __( 'Cancel', 'google-site-kit' ) }
+		>
+			{ children }
+		</BannerNotification>
 	);
 }

--- a/assets/js/modules/analytics-4/components/dashboard/ActivationBanner/SetupBanner.js
+++ b/assets/js/modules/analytics-4/components/dashboard/ActivationBanner/SetupBanner.js
@@ -31,16 +31,24 @@ import {
 	PropertySelect,
 	UseSnippetSwitch,
 } from '../../../../analytics-4/components/common';
+import useExistingTagEffect from '../../../../analytics-4/hooks/useExistingTagEffect';
+import { MODULES_ANALYTICS } from '../../../../analytics/datastore/constants';
 import { MODULES_ANALYTICS_4 } from '../../../datastore/constants';
 const { useSelect } = Data;
 
 export default function SetupBanner( { onCTAClick } ) {
+	// We need this useSelect hook to trigger starting getAccounts resolution which is needed to properly
+	// display the Property Select.
+	useSelect( ( select ) => select( MODULES_ANALYTICS ).getAccounts() );
+
 	const ga4MeasurementID = useSelect( ( select ) =>
 		select( MODULES_ANALYTICS_4 ).getMeasurementID()
 	);
 	const existingTag = useSelect( ( select ) =>
 		select( MODULES_ANALYTICS_4 ).getExistingTag()
 	);
+
+	useExistingTagEffect();
 
 	let title;
 	let ctaLabel;

--- a/assets/js/modules/analytics-4/components/dashboard/ActivationBanner/SetupBanner.stories.js
+++ b/assets/js/modules/analytics-4/components/dashboard/ActivationBanner/SetupBanner.stories.js
@@ -29,7 +29,7 @@ import WithRegistrySetup from '../../../../../../../tests/js/WithRegistrySetup';
 import { MODULES_ANALYTICS_4 } from '../../../datastore/constants';
 import * as ga4Fixtures from '../../../../analytics-4/datastore/__fixtures__';
 
-const Template = () => <SetupBanner />;
+const Template = ( args ) => <SetupBanner { ...args } />;
 
 export const NoPropertyNoTag = Template.bind( {} );
 NoPropertyNoTag.storyName = 'No GA4 Property - No Existing Tag';
@@ -97,6 +97,9 @@ NoPropertyWithTag.decorators = [
 
 export default {
 	title: 'Modules/Analytics4/SetupBanner',
+	args: {
+		onCTAClick: () => {},
+	},
 	decorators: [
 		( Story ) => {
 			const setupRegistry = ( registry ) => {

--- a/assets/js/modules/analytics-4/components/dashboard/ActivationBanner/SetupBanner.stories.js
+++ b/assets/js/modules/analytics-4/components/dashboard/ActivationBanner/SetupBanner.stories.js
@@ -74,7 +74,7 @@ WithPropertyAndTag.decorators = [
 				// eslint-disable-next-line sitekit/acronym-case
 				ga4Fixtures.webDataStreams[ 0 ].webStreamData.measurementId
 			);
-			registry.dispatch( MODULES_ANALYTICS_4 ).setUseSnippet( true );
+			registry.dispatch( MODULES_ANALYTICS_4 ).setUseSnippet( false );
 		};
 
 		return (

--- a/assets/js/modules/analytics-4/components/dashboard/ActivationBanner/SetupBanner.stories.js
+++ b/assets/js/modules/analytics-4/components/dashboard/ActivationBanner/SetupBanner.stories.js
@@ -26,7 +26,9 @@ import {
 	provideSiteInfo,
 } from '../../../../../../../tests/js/utils';
 import WithRegistrySetup from '../../../../../../../tests/js/WithRegistrySetup';
+import { MODULES_ANALYTICS } from '../../../../analytics/datastore/constants';
 import { MODULES_ANALYTICS_4 } from '../../../datastore/constants';
+import * as fixtures from '../../../../analytics/datastore/__fixtures__';
 import * as ga4Fixtures from '../../../../analytics-4/datastore/__fixtures__';
 
 const Template = ( args ) => <SetupBanner { ...args } />;
@@ -102,6 +104,12 @@ export default {
 	},
 	decorators: [
 		( Story ) => {
+			const accounts = fixtures.accountsPropertiesProfiles.accounts.slice(
+				0,
+				1
+			);
+			const accountID = accounts[ 0 ].id;
+
 			const setupRegistry = ( registry ) => {
 				provideModules( registry, [
 					{
@@ -117,6 +125,10 @@ export default {
 				registry
 					.dispatch( MODULES_ANALYTICS_4 )
 					.receiveGetExistingTag( null );
+
+				registry
+					.dispatch( MODULES_ANALYTICS )
+					.selectAccount( accountID );
 			};
 
 			return (

--- a/assets/sass/components/analytics-4/_googlesitekit-analytics-4-setup-banner.scss
+++ b/assets/sass/components/analytics-4/_googlesitekit-analytics-4-setup-banner.scss
@@ -21,7 +21,7 @@
 	.googlesitekit-ga4-setup-banner {
 
 		.googlesitekit-publisher-win__title {
-
+			font-size: $fs-title-lg;
 
 			@media (min-width: $bp-desktop) {
 				max-width: 66.67%;

--- a/assets/sass/components/analytics-4/_googlesitekit-analytics-4-setup-banner.scss
+++ b/assets/sass/components/analytics-4/_googlesitekit-analytics-4-setup-banner.scss
@@ -20,8 +20,33 @@
 
 	.googlesitekit-ga4-setup-banner {
 
+		.googlesitekit-publisher-win__title {
+
+
+			@media (min-width: $bp-desktop) {
+				max-width: 66.67%;
+			}
+		}
+
 		.googlesitekit-publisher-win__footer p {
 			color: $c-boulder;
+
+			@media (min-width: $bp-desktop) {
+				max-width: 66.67%;
+			}
+		}
+
+		.googlesitekit-ga4-setup-banner__field-group {
+			align-items: center;
+			column-gap: 30px;
+			display: flex;
+			flex-wrap: wrap;
+			margin: 25px 0 10px 0;
+			row-gap: 24px;
+
+			.googlesitekit-analytics-usesnippet p {
+				margin-left: 0;
+			}
 		}
 	}
 }

--- a/assets/sass/components/analytics-4/_googlesitekit-analytics-4-setup-banner.scss
+++ b/assets/sass/components/analytics-4/_googlesitekit-analytics-4-setup-banner.scss
@@ -43,10 +43,6 @@
 			flex-wrap: wrap;
 			margin: 25px 0 10px 0;
 			row-gap: 24px;
-
-			.googlesitekit-analytics-usesnippet p {
-				margin-left: 0;
-			}
 		}
 	}
 }


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #5276 

## Relevant technical choices

This PR adds the Property Select dropdown and tag placement toggle to the GA4 Activation Banner.

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
