### PR TITLE
Refresh user permission on module recovery

### DIFF
--- a/assets/js/googlesitekit/datastore/user/permissions.js
+++ b/assets/js/googlesitekit/datastore/user/permissions.js
@@ -29,6 +29,7 @@ import Data from 'googlesitekit-data';
 import { CORE_USER, PERMISSION_READ_SHARED_MODULE_DATA } from './constants';
 import { CORE_MODULES } from '../../modules/datastore/constants';
 import { getMetaCapabilityPropertyName } from '../util/permissions';
+import { createFetchStore } from '../../data/create-fetch-store';
 const { createRegistrySelector } = Data;
 
 // Actions
@@ -36,12 +37,21 @@ const CLEAR_PERMISSION_SCOPE_ERROR = 'CLEAR_PERMISSION_SCOPE_ERROR';
 const SET_PERMISSION_SCOPE_ERROR = 'SET_PERMISSION_SCOPE_ERROR';
 const RECEIVE_CAPABILITIES = 'RECEIVE_CAPABILITIES';
 
-export const initialState = {
+const fetchRefreshCapabilitiesStore = createFetchStore( {
+	baseName: 'refreshCapabilities',
+	controlCallback: () => {
+		return API.get( 'core', 'user', 'permissions', undefined, {
+			useCache: false,
+		} );
+	},
+} );
+
+const baseInitialState = {
 	permissionError: null,
 	capabilities: undefined,
 };
 
-export const actions = {
+const baseActions = {
 	/**
 	 * Clears the permission scope error, if one was previously set.
 	 *
@@ -101,23 +111,21 @@ export const actions = {
 	*refreshCapabilities() {
 		const { dispatch } = yield Data.commonActions.getRegistry();
 
-		const newCapabilities = yield API.get(
-			'core',
-			'user',
-			'permissions',
-			undefined,
-			{ useCache: false }
-		);
+		const {
+			response,
+		} = yield fetchRefreshCapabilitiesStore.actions.fetchRefreshCapabilities();
 
-		global._googlesitekitUserData.permissions = newCapabilities;
+		global._googlesitekitUserData = {
+			permissions: response,
+		};
 
-		return dispatch( CORE_USER ).receiveCapabilities( newCapabilities );
+		return dispatch( CORE_USER ).receiveCapabilities( response );
 	},
 };
 
-export const controls = {};
+const baseControls = {};
 
-export const reducer = ( state, { type, payload } ) => {
+const baseReducer = ( state, { type, payload } ) => {
 	switch ( type ) {
 		case CLEAR_PERMISSION_SCOPE_ERROR: {
 			return {
@@ -150,7 +158,7 @@ export const reducer = ( state, { type, payload } ) => {
 	}
 };
 
-export const resolvers = {
+const baseResolvers = {
 	*getCapabilities() {
 		const registry = yield Data.commonActions.getRegistry();
 
@@ -168,7 +176,7 @@ export const resolvers = {
 	},
 };
 
-export const selectors = {
+const baseSelectors = {
 	/**
 	 * Gets the most recent permission error encountered by this user.
 	 *
@@ -285,11 +293,20 @@ export const selectors = {
 	),
 };
 
-export default {
-	initialState,
-	actions,
-	controls,
-	reducer,
-	resolvers,
-	selectors,
-};
+const store = Data.combineStores( fetchRefreshCapabilitiesStore, {
+	initialState: baseInitialState,
+	actions: baseActions,
+	controls: baseControls,
+	reducer: baseReducer,
+	resolvers: baseResolvers,
+	selectors: baseSelectors,
+} );
+
+export const initialState = store.initialState;
+export const actions = store.actions;
+export const controls = store.controls;
+export const reducer = store.reducer;
+export const resolvers = store.resolvers;
+export const selectors = store.selectors;
+
+export default store;

--- a/assets/js/googlesitekit/datastore/user/permissions.js
+++ b/assets/js/googlesitekit/datastore/user/permissions.js
@@ -113,7 +113,12 @@ const baseActions = {
 
 		const {
 			response,
+			error,
 		} = yield fetchRefreshCapabilitiesStore.actions.fetchRefreshCapabilities();
+
+		if ( error ) {
+			return dispatch( CORE_USER ).setPermissionScopeError( error );
+		}
 
 		global._googlesitekitUserData = {
 			permissions: response,

--- a/assets/js/googlesitekit/datastore/user/permissions.js
+++ b/assets/js/googlesitekit/datastore/user/permissions.js
@@ -24,6 +24,7 @@ import invariant from 'invariant';
 /**
  * Internal dependencies
  */
+import API from 'googlesitekit-api';
 import Data from 'googlesitekit-data';
 import { CORE_USER, PERMISSION_READ_SHARED_MODULE_DATA } from './constants';
 import { CORE_MODULES } from '../../modules/datastore/constants';
@@ -88,6 +89,29 @@ export const actions = {
 			type: RECEIVE_CAPABILITIES,
 			payload: { capabilities },
 		};
+	},
+
+	/**
+	 * Refreshs user capabilities.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @return {Object} Redux-style action.
+	 */
+	*refreshCapabilities() {
+		const { dispatch } = yield Data.commonActions.getRegistry();
+
+		const newCapabilities = yield API.get(
+			'core',
+			'user',
+			'permissions',
+			undefined,
+			{ useCache: false }
+		);
+
+		global._googlesitekitUserData.permissions = newCapabilities;
+
+		return dispatch( CORE_USER ).receiveCapabilities( newCapabilities );
 	},
 };
 

--- a/assets/js/googlesitekit/datastore/user/permissions.js
+++ b/assets/js/googlesitekit/datastore/user/permissions.js
@@ -102,7 +102,7 @@ const baseActions = {
 	},
 
 	/**
-	 * Refreshs user capabilities.
+	 * Refreshes user capabilities.
 	 *
 	 * @since n.e.x.t
 	 *

--- a/assets/js/googlesitekit/datastore/user/permissions.test.js
+++ b/assets/js/googlesitekit/datastore/user/permissions.test.js
@@ -130,7 +130,7 @@ describe( 'core/user authentication', () => {
 				).toEqual( updatedCapabilities );
 			} );
 
-			it( 'Sets permissionScopeError when api throws an error', async () => {
+			it( 'sets permissionScopeError when API throws an error', async () => {
 				const error = {
 					code: 'rest_forbidden',
 					message: 'Sorry, you are not allowed to do that.',

--- a/assets/js/googlesitekit/datastore/user/permissions.test.js
+++ b/assets/js/googlesitekit/datastore/user/permissions.test.js
@@ -26,6 +26,7 @@ import {
 import { CORE_USER, PERMISSION_MANAGE_OPTIONS } from './constants';
 import FIXTURES from '../../modules/datastore/__fixtures__';
 import { CORE_MODULES } from '../../modules/datastore/constants';
+import fetchMock from 'fetch-mock';
 
 describe( 'core/user authentication', () => {
 	const capabilitiesBaseVar = '_googlesitekitUserData';
@@ -90,6 +91,43 @@ describe( 'core/user authentication', () => {
 				expect(
 					registry.select( CORE_USER ).getPermissionScopeError()
 				).toEqual( someError );
+			} );
+		} );
+
+		describe( 'refreshCapabilities', () => {
+			it( 'updates capabilities from server', async () => {
+				const updatedCapabilities = {
+					googlesitekit_view_dashboard: true,
+					googlesitekit_manage_options: true,
+					'googlesitekit_read_shared_module_data::["site-verification"]': true,
+					'googlesitekit_read_shared_module_data::["tagmanager"]': true,
+					'googlesitekit_read_shared_module_data::["optimize"]': false,
+					'googlesitekit_read_shared_module_data::["adsense"]': false,
+					'googlesitekit_manage_module_sharing_options::["search-console"]': true,
+					'googlesitekit_read_shared_module_data::["search-console"]': false,
+					'googlesitekit_read_shared_module_data::["analytics"]': false,
+					'googlesitekit_read_shared_module_data::["pagespeed-insights"]': false,
+					'googlesitekit_read_shared_module_data::["idea-hub"]': false,
+				};
+				global[ capabilitiesBaseVar ] = capabilities;
+				expect(
+					registry.select( CORE_USER ).getCapabilities()
+				).toEqual( capabilities.permissions );
+
+				fetchMock.getOnce(
+					/^\/google-site-kit\/v1\/core\/user\/data\/permissions/,
+					{
+						body: updatedCapabilities,
+						status: 200,
+					}
+				);
+
+				await registry.dispatch( CORE_USER ).refreshCapabilities();
+
+				expect( fetchMock ).toHaveFetchedTimes( 1 );
+				expect(
+					registry.select( CORE_USER ).getCapabilities()
+				).toEqual( updatedCapabilities );
 			} );
 		} );
 	} );

--- a/assets/js/googlesitekit/modules/datastore/modules.js
+++ b/assets/js/googlesitekit/modules/datastore/modules.js
@@ -568,6 +568,9 @@ const baseActions = {
 					CORE_MODULES
 				).getRecoverableModules();
 
+				// Refresh user capabilities from the server.
+				yield dispatch( CORE_USER ).refreshCapabilities();
+
 				if ( recoverableModules ) {
 					// Remove the recovered modules from the list of recoverable modules in state.
 					yield baseActions.receiveRecoverableModules(

--- a/assets/js/googlesitekit/modules/datastore/modules.test.js
+++ b/assets/js/googlesitekit/modules/datastore/modules.test.js
@@ -530,7 +530,7 @@ describe( 'core/modules modules', () => {
 					/^\/google-site-kit\/v1\/core\/modules\/data\/list/
 				);
 
-				// Ensure refreshCapabilities have been called.
+				// Ensure `refreshCapabilities` has been called.
 				expect( fetchMock ).toHaveFetched(
 					/^\/google-site-kit\/v1\/core\/user\/data\/permissions/
 				);

--- a/assets/js/googlesitekit/modules/datastore/modules.test.js
+++ b/assets/js/googlesitekit/modules/datastore/modules.test.js
@@ -452,6 +452,14 @@ describe( 'core/modules modules', () => {
 					}
 				);
 
+				fetchMock.getOnce(
+					/^\/google-site-kit\/v1\/core\/user\/data\/permissions/,
+					{
+						body: {},
+						status: 200,
+					}
+				);
+
 				const initialModules = registry
 					.select( CORE_MODULES )
 					.getModules();
@@ -469,7 +477,7 @@ describe( 'core/modules modules', () => {
 					tagmanager: true,
 				} );
 
-				expect( fetchMock ).toHaveFetchedTimes( 6 );
+				expect( fetchMock ).toHaveFetchedTimes( 7 );
 
 				// Ensure the proper body parameters were sent.
 				expect( fetchMock ).toHaveFetched(
@@ -520,6 +528,11 @@ describe( 'core/modules modules', () => {
 				// Ensure fetchGetModules have been called.
 				expect( fetchMock ).toHaveFetched(
 					/^\/google-site-kit\/v1\/core\/modules\/data\/list/
+				);
+
+				// Ensure refreshCapabilities have been called.
+				expect( fetchMock ).toHaveFetched(
+					/^\/google-site-kit\/v1\/core\/user\/data\/permissions/
 				);
 
 				// Ensure the module has been removed from the recoverable modules list.
@@ -586,6 +599,14 @@ describe( 'core/modules modules', () => {
 					}
 				);
 
+				fetchMock.getOnce(
+					/^\/google-site-kit\/v1\/core\/user\/data\/permissions/,
+					{
+						body: {},
+						status: 200,
+					}
+				);
+
 				const initialModules = registry
 					.select( CORE_MODULES )
 					.getModules();
@@ -607,7 +628,7 @@ describe( 'core/modules modules', () => {
 					errorResponse.message
 				);
 
-				expect( fetchMock ).toHaveFetchedTimes( 5 );
+				expect( fetchMock ).toHaveFetchedTimes( 6 );
 
 				// Ensure the proper body parameters were sent.
 				expect( fetchMock ).toHaveFetched(

--- a/includes/Core/Permissions/Permissions.php
+++ b/includes/Core/Permissions/Permissions.php
@@ -16,8 +16,11 @@ use Google\Site_Kit\Core\Authentication\Authentication;
 use Google\Site_Kit\Core\Dismissals\Dismissed_Items;
 use Google\Site_Kit\Core\Modules\Module_With_Owner;
 use Google\Site_Kit\Core\Modules\Modules;
+use Google\Site_Kit\Core\REST_API\REST_Route;
 use Google\Site_Kit\Core\Storage\User_Options;
 use Google\Site_Kit\Core\Util\Feature_Flags;
+use WP_REST_Response;
+use WP_REST_Server;
 use WP_User;
 
 /**
@@ -222,6 +225,13 @@ final class Permissions {
 			},
 			10,
 			4
+		);
+
+		add_filter(
+			'googlesitekit_rest_routes',
+			function( $routes ) {
+				return array_merge( $routes, $this->get_rest_routes() );
+			}
 		);
 
 		add_filter(
@@ -681,6 +691,32 @@ final class Permissions {
 		}
 
 		return $allcaps;
+	}
+
+	/**
+	 * Gets related REST routes.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @return array List of REST_Route objects.
+	 */
+	private function get_rest_routes() {
+		return array(
+			new REST_Route(
+				'core/user/data/permissions',
+				array(
+					array(
+						'methods'             => WP_REST_Server::READABLE,
+						'callback'            => function() {
+							return new WP_REST_Response( $this->check_all_for_current_user() );
+						},
+						'permission_callback' => function() {
+							return current_user_can( Permissions::VIEW_SPLASH );
+						},
+					),
+				)
+			),
+		);
 	}
 
 	/**

--- a/tests/phpunit/integration/Core/Permissions/PermissionsTest.php
+++ b/tests/phpunit/integration/Core/Permissions/PermissionsTest.php
@@ -72,6 +72,12 @@ class PermissionsTest extends TestCase {
 		$this->dismissed_items = new Dismissed_Items( $this->user_options );
 	}
 
+	public function tear_down() {
+		parent::tear_down();
+		// This ensures the REST server is initialized fresh for each test using it.
+		unset( $GLOBALS['wp_rest_server'] );
+	}
+
 	public function test_register() {
 		$permissions = new Permissions( $this->context, $this->authentication, $this->modules, $this->user_options, $this->dismissed_items );
 		$permissions->register();

--- a/tests/phpunit/integration/Core/Permissions/PermissionsTest.php
+++ b/tests/phpunit/integration/Core/Permissions/PermissionsTest.php
@@ -600,7 +600,7 @@ class PermissionsTest extends TestCase {
 		$this->assertTrue( user_can( $user, Permissions::VIEW_SPLASH ) );
 	}
 
-	public function test_permissions_route_unauthorized_request() {
+	public function test_permissions_route__unauthorized_request() {
 		$permissions = new Permissions( $this->context, $this->authentication, $this->modules, $this->user_options, $this->dismissed_items );
 		$permissions->register();
 
@@ -613,7 +613,7 @@ class PermissionsTest extends TestCase {
 		$this->assertEquals( 'rest_forbidden', $data['code'] );
 	}
 
-	public function test_permissions_route_non_admin() {
+	public function test_permissions_route__non_admin() {
 		$permissions = new Permissions( $this->context, $this->authentication, $this->modules, $this->user_options, $this->dismissed_items );
 		$permissions->register();
 
@@ -629,7 +629,7 @@ class PermissionsTest extends TestCase {
 		$this->assertEquals( 'rest_forbidden', $data['code'] );
 	}
 
-	public function test_permissions_route() {
+	public function test_permissions_route__success() {
 		$permissions = new Permissions( $this->context, $this->authentication, $this->modules, $this->user_options, $this->dismissed_items );
 		$permissions->register();
 
@@ -644,7 +644,7 @@ class PermissionsTest extends TestCase {
 		$this->assertEqualSetsWithIndex( $data, $permissions->check_all_for_current_user() );
 	}
 
-	public function test_permissions_route_dashboard_sharing() {
+	public function test_permissions_route__dashboard_sharing() {
 		$this->enable_feature( 'dashboardSharing' );
 		$user_id = $this->factory()->user->create( array( 'role' => 'editor' ) );
 		wp_set_current_user( $user_id );


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #5416 

## Relevant technical choices

<!-- Please describe your changes. -->

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [x] Run the code.
- [x] Ensure the acceptance criteria are satisfied.
- [x] Reassess the implementation with the IB.
- [x] Ensure no unrelated changes are included.
- [x] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [x] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [x] Ensure the PR has the correct target branch.
- [x] Double-check that the PR is okay to be merged.
- [x] Ensure the corresponding issue has a ZenHub release assigned.
- [x] Add a changelog message to the issue.
