### PR TITLE
Consolidate gettext strings.

### DIFF
--- a/assets/js/components/notifications/UserInputSuccessBannerNotification.js
+++ b/assets/js/components/notifications/UserInputSuccessBannerNotification.js
@@ -55,7 +55,7 @@ export default function UserInputSuccessBannerNotification() {
 				'google-site-kit'
 			) }
 			SmallImageSVG={ MilestoneBlueSVG }
-			dismiss={ __( 'OK, got it!', 'google-site-kit' ) }
+			dismiss={ __( 'OK, Got it!', 'google-site-kit' ) }
 			format="small"
 			onDismiss={ handleOnDismiss }
 		/>

--- a/assets/js/modules/analytics-4/components/dashboard/ActivationBanner/SuccessBanner.js
+++ b/assets/js/modules/analytics-4/components/dashboard/ActivationBanner/SuccessBanner.js
@@ -46,7 +46,7 @@ export default function SuccessBanner() {
 				'GA4 is collecting data for your site. You’ll only see Universal Analytics data on your dashboard for now.',
 				'google-site-kit'
 			) }
-			dismiss={ __( 'OK, got it!', 'google-site-kit' ) }
+			dismiss={ __( 'OK, Got it!', 'google-site-kit' ) }
 			WinImageSVG={ SuccessGreenSVG }
 			format="smaller"
 			type="win-success"

--- a/assets/js/modules/idea-hub/components/dashboard/DashboardCTA.js
+++ b/assets/js/modules/idea-hub/components/dashboard/DashboardCTA.js
@@ -177,7 +177,7 @@ export default function DashboardCTA( { Widget, WidgetNull } ) {
 				<div className="googlesitekit-idea-hub__dashboard-cta-footer">
 					<Button onClick={ onSetupButtonClick }>
 						{ active && ! connected
-							? __( 'Complete set up', 'google-site-kit' )
+							? __( 'Complete setup', 'google-site-kit' )
 							: __( 'Set up', 'google-site-kit' ) }
 					</Button>
 

--- a/assets/js/modules/optimize/components/common/AMPExperimentJSONField.js
+++ b/assets/js/modules/optimize/components/common/AMPExperimentJSONField.js
@@ -69,7 +69,7 @@ export default function AMPExperimentJSONField() {
 					href="https://developers.google.com/optimize/devguides/amp-experiments"
 					external
 				>
-					{ __( 'Learn More', 'google-site-kit' ) }
+					{ __( 'Learn more', 'google-site-kit' ) }
 				</Link>
 			</p>
 			<TextField

--- a/stories/notifications.stories.js
+++ b/stories/notifications.stories.js
@@ -132,7 +132,7 @@ storiesOf( 'Global/Notifications', module )
 				) }
 				dismiss={ __( 'OK, Got it!', 'google-site-kit' ) }
 				learnMoreURL="http://google.com"
-				learnMoreLabel={ __( 'Learn More', 'google-site-kit' ) }
+				learnMoreLabel={ __( 'Learn more', 'google-site-kit' ) }
 				learnMoreDescription={ __(
 					'about the particular win',
 					'google-site-kit'
@@ -181,7 +181,7 @@ storiesOf( 'Global/Notifications', module )
 				id="notification-id"
 				title={ __( 'Index Warning', 'google-site-kit' ) }
 				description={ __(
-					'Indexed, though blocked by robots.text.',
+					'Indexed, though blocked by robots.txt.',
 					'google-site-kit'
 				) }
 				learnMoreURL="http://google.com"


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #5659.

## Relevant technical choices

After auditing the `.pot` file and the codebase it seems like there were very few issues with gettext consistencies. These are the few small fixes I found 🙂 

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [x] Run the code.
- [x] Ensure the acceptance criteria are satisfied.
- [x] Reassess the implementation with the IB.
- [x] Ensure no unrelated changes are included.
- [x] Ensure CI checks pass.
- [x] Check Storybook where applicable.
- [x] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [x] Ensure the PR has the correct target branch.
- [x] Double-check that the PR is okay to be merged.
- [x] Ensure the corresponding issue has a ZenHub release assigned.
- [x] Add a changelog message to the issue.
