### PR TITLE
Add Supporter Wall section to TwG edit screen

### DIFF
--- a/assets/js/modules/thank-with-google/components/common/SupporterWall.js
+++ b/assets/js/modules/thank-with-google/components/common/SupporterWall.js
@@ -66,7 +66,10 @@ export default function SupporterWall() {
 							</h5>
 							<p className="googlesitekit-twg-supporter-wall__value">
 								<DisplaySetting
-									value={ supporterWallSidebars.join( ', ' ) }
+									value={ supporterWallSidebars.join(
+										/* translators: used between list items, there is a space after the comma. */
+										__( ', ', 'google-site-kit' )
+									) }
 								/>
 							</p>
 						</Fragment>

--- a/assets/js/modules/thank-with-google/components/common/SupporterWall.js
+++ b/assets/js/modules/thank-with-google/components/common/SupporterWall.js
@@ -1,4 +1,6 @@
 /**
+ * Supporter Wall component for Thank with Google.
+ *
  * Site Kit by Google, Copyright 2022 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/assets/js/modules/thank-with-google/components/common/SupporterWall.js
+++ b/assets/js/modules/thank-with-google/components/common/SupporterWall.js
@@ -1,0 +1,90 @@
+/**
+ * Site Kit by Google, Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { Fragment } from '@wordpress/element';
+import { sprintf, __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import Data from 'googlesitekit-data';
+import DisplaySetting from '../../../../components/DisplaySetting';
+import Link from '../../../../components/Link';
+import ProgressBar from '../../../../components/ProgressBar';
+import { CORE_SITE } from '../../../../googlesitekit/datastore/site/constants';
+import { MODULES_THANK_WITH_GOOGLE } from '../../datastore/constants';
+const { useSelect } = Data;
+
+export default function SupporterWall() {
+	const supporterWallSidebars = useSelect( ( select ) =>
+		select( MODULES_THANK_WITH_GOOGLE ).getSupporterWallSidebars()
+	);
+	const supporterWallURL = useSelect( ( select ) =>
+		select( CORE_SITE ).getWidgetsAdminURL()
+	);
+
+	const hasSupporterWallSidebar =
+		supporterWallSidebars && supporterWallSidebars.length > 0;
+
+	return (
+		<div className="googlesitekit-twg-setting-field googlesitekit-twg-supporter-wall">
+			<h4>{ __( 'Supporter wall widget', 'google-site-kit' ) }</h4>
+
+			{ supporterWallSidebars === undefined ? (
+				<ProgressBar small />
+			) : (
+				<Fragment>
+					{ ! hasSupporterWallSidebar ? (
+						<p>
+							{ __(
+								'A supporter wall page shows the list of everyone who has supported your site using Thank with Google. Look for the "Thank with Google Supporter Wall" widget and add it to your site.',
+								'google-site-kit'
+							) }
+						</p>
+					) : (
+						<Fragment>
+							<h5 className="googlesitekit-twg-supporter-wall__headline">
+								{ __( 'Widget Position', 'google-site-kit' ) }
+							</h5>
+							<p className="googlesitekit-twg-supporter-wall__value">
+								<DisplaySetting
+									value={ supporterWallSidebars.join( ', ' ) }
+								/>
+							</p>
+						</Fragment>
+					) }
+					<Link
+						className="googlesitekit-twg-supporter-wall__link"
+						href={ supporterWallURL }
+						external={ hasSupporterWallSidebar }
+						hideExternalIndicator
+					>
+						{ sprintf(
+							/* translators: %s is replaced with the appropriate action term */
+							__( '%s supporter wall widget', 'google-site-kit' ),
+							hasSupporterWallSidebar
+								? __( 'Edit', 'google-site-kit' )
+								: __( 'Activate', 'google-site-kit' )
+						) }
+					</Link>
+				</Fragment>
+			) }
+		</div>
+	);
+}

--- a/assets/js/modules/thank-with-google/components/common/SupporterWall.js
+++ b/assets/js/modules/thank-with-google/components/common/SupporterWall.js
@@ -20,7 +20,7 @@
  * WordPress dependencies
  */
 import { Fragment } from '@wordpress/element';
-import { sprintf, __ } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -80,13 +80,15 @@ export default function SupporterWall() {
 						external={ hasSupporterWallSidebar }
 						hideExternalIndicator
 					>
-						{ sprintf(
-							/* translators: %s is replaced with the appropriate action term */
-							__( '%s supporter wall widget', 'google-site-kit' ),
-							hasSupporterWallSidebar
-								? __( 'Edit', 'google-site-kit' )
-								: __( 'Activate', 'google-site-kit' )
-						) }
+						{ hasSupporterWallSidebar
+							? __(
+									'Edit supporter wall widget',
+									'google-site-kit'
+							  )
+							: __(
+									'Activate supporter wall widget',
+									'google-site-kit'
+							  ) }
 					</Link>
 				</Fragment>
 			) }

--- a/assets/js/modules/thank-with-google/components/common/SupporterWall.js
+++ b/assets/js/modules/thank-with-google/components/common/SupporterWall.js
@@ -42,7 +42,7 @@ export default function SupporterWall() {
 	);
 
 	const hasSupporterWallSidebar =
-		supporterWallSidebars && supporterWallSidebars.length > 0;
+		supporterWallSidebars && supporterWallSidebars?.length > 0;
 
 	return (
 		<div className="googlesitekit-twg-setting-field googlesitekit-twg-supporter-wall">

--- a/assets/js/modules/thank-with-google/components/common/SupporterWall.stories.js
+++ b/assets/js/modules/thank-with-google/components/common/SupporterWall.stories.js
@@ -1,0 +1,73 @@
+/**
+ * Site Kit by Google, Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import SupporterWall from './SupporterWall';
+import { MODULES_THANK_WITH_GOOGLE } from '../../datastore/constants';
+import { provideModules } from '../../../../../../tests/js/utils';
+import WithRegistrySetup from '../../../../../../tests/js/WithRegistrySetup';
+
+const Template = ( args ) => <SupporterWall { ...args } />;
+
+export const WidgetNotPlaced = Template.bind( {} );
+WidgetNotPlaced.storyName = 'No Widget Placed';
+WidgetNotPlaced.args = {
+	setupRegistry: ( registry ) => {
+		registry
+			.dispatch( MODULES_THANK_WITH_GOOGLE )
+			.receiveGetSupporterWallSidebars( [] );
+	},
+};
+
+export const WidgetPlaced = Template.bind( {} );
+WidgetPlaced.storyName = 'With Widget Placed';
+WidgetPlaced.args = {
+	setupRegistry: ( registry ) => {
+		registry
+			.dispatch( MODULES_THANK_WITH_GOOGLE )
+			.receiveGetSupporterWallSidebars( [ 'All sidebars' ] );
+	},
+};
+
+export default {
+	title: 'Modules/Thank with Google/Common/SupporterWall',
+	decorators: [
+		( Story, { args } ) => {
+			const setupRegistry = ( registry ) => {
+				provideModules( registry, [
+					{
+						slug: 'thank-with-google',
+						active: true,
+						connected: true,
+					},
+				] );
+
+				// Call story-specific setup.
+				if ( typeof args?.setupRegistry === 'function' ) {
+					args.setupRegistry( registry );
+				}
+			};
+
+			return (
+				<WithRegistrySetup func={ setupRegistry }>
+					<Story />
+				</WithRegistrySetup>
+			);
+		},
+	],
+};

--- a/assets/js/modules/thank-with-google/components/common/index.js
+++ b/assets/js/modules/thank-with-google/components/common/index.js
@@ -22,3 +22,4 @@ export { default as PositionRadio } from './PositionRadio';
 export { default as ColorRadio } from './ColorRadio';
 export { default as PostTypesSelect } from './PostTypesSelect';
 export { default as CTAPlacement } from './CTAPlacement';
+export { default as SupporterWall } from './SupporterWall';

--- a/assets/js/modules/thank-with-google/components/settings/SettingsForm.js
+++ b/assets/js/modules/thank-with-google/components/settings/SettingsForm.js
@@ -26,7 +26,12 @@ import { Fragment } from '@wordpress/element';
  */
 import StoreErrorNotices from '../../../../components/StoreErrorNotices';
 import { MODULES_THANK_WITH_GOOGLE } from '../../datastore/constants';
-import { CTAPlacement, ColorRadio, PostTypesSelect } from '../common';
+import {
+	CTAPlacement,
+	ColorRadio,
+	PostTypesSelect,
+	SupporterWall,
+} from '../common';
 
 export default function SettingsForm() {
 	return (
@@ -38,6 +43,7 @@ export default function SettingsForm() {
 
 			<div className="googlesitekit-setup-module__inputs">
 				<CTAPlacement />
+				<SupporterWall />
 				<ColorRadio />
 				<PostTypesSelect />
 			</div>

--- a/assets/sass/components/thank-with-google/_googlesitekit-twg-supporter-wall.scss
+++ b/assets/sass/components/thank-with-google/_googlesitekit-twg-supporter-wall.scss
@@ -14,11 +14,31 @@
  * limitations under the License.
  */
 
-@import "googlesitekit-twg-settings";
-@import "googlesitekit-twg-setup";
-@import "googlesitekit-twg-color-radio";
-@import "googlesitekit-twg-post-types-select";
-@import "googlesitekit-twg-position-radio";
-@import "googlesitekit-twg-prominence-radio";
-@import "googlesitekit-twg-type-radio";
-@import "googlesitekit-twg-supporter-wall";
+.googlesitekit-plugin {
+
+	.googlesitekit-twg-supporter-wall {
+
+		> p {
+			max-width: 34.25rem;
+		}
+
+		.googlesitekit-twg-supporter-wall__headline {
+			color: $c-surfaces-on-surface-variant;
+			font-size: $fs-body-sm;
+			font-weight: $fw-normal;
+			line-height: $lh-headline-sm;
+			margin: 0;
+		}
+
+		.googlesitekit-twg-supporter-wall__value {
+			color: $c-surfaces-on-surface;
+			font-size: $fs-body-md;
+			margin: 5px 0 0;
+		}
+
+		.googlesitekit-twg-supporter-wall__link {
+			display: block;
+			margin-top: 30px;
+		}
+	}
+}


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #5736 

## Relevant technical choices

This PR adds the supporter wall widget section to the Thank with Google module edit screen.

Besides following the IB, this PR also checks if the `getSupporterWallSidebars` selector is undefined (resolving) and displays a `small` `<ProgressBar />` in that case.

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
