### PR TITLE
Restrict data requests for recoverable modules for view-only users

### DIFF
--- a/assets/js/components/notifications/ZeroDataStateNotifications/index.js
+++ b/assets/js/components/notifications/ZeroDataStateNotifications/index.js
@@ -46,22 +46,58 @@ export default function ZeroDataStateNotifications() {
 
 		return select( CORE_USER ).canViewSharedModule( 'analytics' );
 	} );
+	const showRecoverableAnalytics = useSelect( ( select ) => {
+		if ( ! viewOnly ) {
+			return false;
+		}
+
+		const recoverableModules =
+			select( CORE_MODULES ).getRecoverableModules();
+
+		if ( recoverableModules === undefined ) {
+			return undefined;
+		}
+
+		return Object.keys( recoverableModules ).includes( 'analytics' );
+	} );
+	const showRecoverableSearchConsole = useSelect( ( select ) => {
+		if ( ! viewOnly ) {
+			return false;
+		}
+
+		const recoverableModules =
+			select( CORE_MODULES ).getRecoverableModules();
+
+		if ( recoverableModules === undefined ) {
+			return undefined;
+		}
+
+		return Object.keys( recoverableModules ).includes( 'search-console' );
+	} );
 
 	const analyticsGatheringData = useInViewSelect( ( select ) =>
-		isAnalyticsConnected && canViewSharedAnalytics
+		isAnalyticsConnected &&
+		canViewSharedAnalytics &&
+		false === showRecoverableAnalytics
 			? select( MODULES_ANALYTICS ).isGatheringData()
 			: false
 	);
-	const searchConsoleGatheringData = useInViewSelect( ( select ) =>
-		select( MODULES_SEARCH_CONSOLE ).isGatheringData()
+	const searchConsoleGatheringData = useInViewSelect(
+		( select ) =>
+			false === showRecoverableSearchConsole &&
+			select( MODULES_SEARCH_CONSOLE ).isGatheringData()
 	);
 	const analyticsHasZeroData = useInViewSelect( ( select ) =>
-		isAnalyticsConnected && canViewSharedAnalytics
+		isAnalyticsConnected &&
+		canViewSharedAnalytics &&
+		false === showRecoverableAnalytics
 			? select( MODULES_ANALYTICS ).hasZeroData()
 			: false
 	);
-	const searchConsoleHasZeroData = useInViewSelect( ( select ) =>
-		select( MODULES_SEARCH_CONSOLE ).hasZeroData()
+	const searchConsoleHasZeroData = useInViewSelect(
+		( select ) =>
+			false === showRecoverableSearchConsole &&
+			select( MODULES_SEARCH_CONSOLE ).hasZeroData()
 	);
 
 	// If any of the checks for gathering data or zero data states have


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #5505 

## Relevant technical choices

This PR prevents the `ZeroDataStateNotifications` component to make data requests for recoverable modules from a view-only user.

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [x] Run the code.
- [x] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [x] Ensure no unrelated changes are included.
- [x] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [x] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
