### PR TITLE
Add position to `Pointer`.

### DIFF
--- a/includes/Core/Admin/Pointer.php
+++ b/includes/Core/Admin/Pointer.php
@@ -44,12 +44,14 @@ final class Pointer {
 	 * @param array  $args {
 	 *     Associative array of pointer arguments.
 	 *
-	 *     @type string   $title           Required pointer title.
-	 *     @type string   $content         Required pointer content. May contain inline HTML tags.
-	 *     @type string   $target_id       ID of the element the pointer should be attached to.
-	 *     @type callable $active_callback Callback function to determine whether the pointer is active in the
-	 *                                     current context. The current admin screen's hook suffix is passed to
-	 *                                     the callback. Default is that the pointer is active unconditionally.
+	 *     @type string         $title           Required. Pointer title.
+	 *     @type string         $content         Required. Pointer content. May contain inline HTML tags.
+	 *     @type string         $target_id       Required. ID of the element the pointer should be attached to.
+	 *     @type string|array   $position        Optional. Position of the pointer. Can be 'top', 'bottom', 'left', 'right',
+	 *                                           or an array of `edge` and `align`. Default 'top'.
+	 *     @type callable       $active_callback Optional. Callback function to determine whether the pointer is active in
+	 *                                           the current context. The current admin screen's hook suffix is passed to
+	 *                                           the callback. Default is that the pointer is active unconditionally.
 	 * }
 	 */
 	public function __construct( $slug, array $args ) {
@@ -60,6 +62,7 @@ final class Pointer {
 				'title'           => '',
 				'content'         => '',
 				'target_id'       => '',
+				'position'        => 'top',
 				'active_callback' => null,
 			)
 		);
@@ -111,6 +114,17 @@ final class Pointer {
 	 */
 	public function get_target_id() {
 		return $this->args['target_id'];
+	}
+
+	/**
+	 * Gets the pointer position.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @return string|array Pointer position.
+	 */
+	public function get_position() {
+		return $this->args['position'];
 	}
 
 	/**

--- a/includes/Core/Admin/Pointer.php
+++ b/includes/Core/Admin/Pointer.php
@@ -44,14 +44,14 @@ final class Pointer {
 	 * @param array  $args {
 	 *     Associative array of pointer arguments.
 	 *
-	 *     @type string         $title           Required. Pointer title.
-	 *     @type string         $content         Required. Pointer content. May contain inline HTML tags.
-	 *     @type string         $target_id       Required. ID of the element the pointer should be attached to.
-	 *     @type string|array   $position        Optional. Position of the pointer. Can be 'top', 'bottom', 'left', 'right',
-	 *                                           or an array of `edge` and `align`. Default 'top'.
-	 *     @type callable       $active_callback Optional. Callback function to determine whether the pointer is active in
-	 *                                           the current context. The current admin screen's hook suffix is passed to
-	 *                                           the callback. Default is that the pointer is active unconditionally.
+	 *     @type string       $title           Required. Pointer title.
+	 *     @type string       $content         Required. Pointer content. May contain inline HTML tags.
+	 *     @type string       $target_id       Required. ID of the element the pointer should be attached to.
+	 *     @type string|array $position        Optional. Position of the pointer. Can be 'top', 'bottom', 'left', 'right',
+	 *                                         or an array of `edge` and `align`. Default 'top'.
+	 *     @type callable     $active_callback Optional. Callback function to determine whether the pointer is active in
+	 *                                         the current context. The current admin screen's hook suffix is passed to
+	 *                                         the callback. Default is that the pointer is active unconditionally.
 	 * }
 	 */
 	public function __construct( $slug, array $args ) {

--- a/includes/Core/Admin/Pointers.php
+++ b/includes/Core/Admin/Pointers.php
@@ -120,11 +120,7 @@ class Pointers {
 				jQuery( function() {
 					var options = {
 						content: "<h3>%s</h3>%s",
-						position: {
-							edge:  "left",
-							align: "right",
-						},
-						pointerClass: "wp-pointer arrow-top",
+						position: %s,
 						pointerWidth: 420,
 						close: function() {
 							jQuery.post(
@@ -142,6 +138,7 @@ class Pointers {
 				',
 				esc_js( $pointer->get_title() ),
 				$content,
+				wp_json_encode( $pointer->get_position() ),
 				esc_js( $slug ),
 				esc_js( $pointer->get_target_id() )
 			),

--- a/tests/phpunit/integration/Core/Admin/PointerTest.php
+++ b/tests/phpunit/integration/Core/Admin/PointerTest.php
@@ -73,6 +73,49 @@ class PointerTest extends TestCase {
 		$this->assertEquals( 'test-target-id', $pointer->get_target_id() );
 	}
 
+	public function test_get_position_string() {
+		$pointer = new Pointer(
+			'test-slug',
+			array(
+				'position' => 'bottom',
+			)
+		);
+
+		$this->assertEquals(
+			'bottom',
+			$pointer->get_position()
+		);
+	}
+
+	public function test_get_position_array() {
+		$pointer = new Pointer(
+			'test-slug',
+			array(
+				'position' => array(
+					'edge'  => 'top',
+					'align' => 'left',
+				),
+			)
+		);
+
+		$this->assertEquals(
+			array(
+				'edge'  => 'top',
+				'align' => 'left',
+			),
+			$pointer->get_position()
+		);
+	}
+
+	public function test_get_position_default() {
+		$pointer = new Pointer( 'test-slug', array() );
+
+		$this->assertEquals(
+			'top',
+			$pointer->get_position()
+		);
+	}
+
 	/**
 	 * @dataProvider data_is_active
 	 *

--- a/tests/phpunit/integration/Core/Dashboard_Sharing/View_Only_PointerTest.php
+++ b/tests/phpunit/integration/Core/Dashboard_Sharing/View_Only_PointerTest.php
@@ -2,7 +2,7 @@
 /**
  * View_Only_PointerTest
  *
- * @package   Google\Site_Kit\Tests\Core\Util
+ * @package   Google\Site_Kit\Tests\Core\Dashboard_Sharing
  * @copyright 2022 Google LLC
  * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
  * @link      https://sitekit.withgoogle.com


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #5486 

## Relevant technical choices

With the default `top`, the View only pointer will also show up properly without it's title getting cut off under the Admin Bar. 

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
