### PR TITLE
Fix/ga4 setup banner progress bar

### DIFF
--- a/assets/js/modules/analytics-4/components/dashboard/ActivationBanner/SetupBanner.js
+++ b/assets/js/modules/analytics-4/components/dashboard/ActivationBanner/SetupBanner.js
@@ -154,8 +154,8 @@ export default function SetupBanner( { onSubmitSuccess } ) {
 		return (
 			<Grid>
 				<Row>
-					<Cell>
-						<ProgressBar size={ 12 } />
+					<Cell size={ 12 }>
+						<ProgressBar />
 					</Cell>
 				</Row>
 			</Grid>

--- a/assets/js/modules/analytics-4/components/dashboard/ActivationBanner/SetupBanner.js
+++ b/assets/js/modules/analytics-4/components/dashboard/ActivationBanner/SetupBanner.js
@@ -45,6 +45,8 @@ import { useTooltipState } from '../../../../../components/AdminMenuTooltip/useT
 import { useShowTooltip } from '../../../../../components/AdminMenuTooltip/useShowTooltip';
 import { AdminMenuTooltip } from '../../../../../components/AdminMenuTooltip/AdminMenuTooltip';
 import { getBannerDismissalExpiryTime } from '../../../utils/banner-dismissal-expiry';
+import { Cell, Grid, Row } from '../../../../../material-components';
+import ProgressBar from '../../../../../components/ProgressBar';
 const { useDispatch, useSelect } = Data;
 
 export default function SetupBanner( { onSubmitSuccess } ) {
@@ -52,9 +54,27 @@ export default function SetupBanner( { onSubmitSuccess } ) {
 
 	const hasExistingProperty = useSelect( ( select ) => {
 		const accountID = select( MODULES_ANALYTICS ).getAccountID();
+
 		const properties =
-			select( MODULES_ANALYTICS_4 ).getProperties( accountID ) || [];
-		return properties.length > 0;
+			select( MODULES_ANALYTICS_4 ).getProperties( accountID );
+
+		if ( properties === undefined ) {
+			return undefined;
+		}
+
+		if ( properties.length === 0 ) {
+			return false;
+		}
+
+		// Make a call here to ensure getAccounts is resolved before rendering the PropertySelect
+		// component, to avoid showing a ProgressBar in the PropertySelect.
+		const accounts = select( MODULES_ANALYTICS ).getAccounts();
+
+		if ( accounts === undefined ) {
+			return undefined;
+		}
+
+		return true;
 	} );
 	const existingTag = useSelect( ( select ) =>
 		select( MODULES_ANALYTICS_4 ).getExistingTag()
@@ -89,6 +109,18 @@ export default function SetupBanner( { onSubmitSuccess } ) {
 	const showTooltip = useShowTooltip(
 		ACTIVATION_ACKNOWLEDGEMENT_TOOLTIP_STATE_KEY
 	);
+
+	if ( hasExistingProperty === undefined ) {
+		return (
+			<Grid>
+				<Row>
+					<Cell>
+						<ProgressBar />
+					</Cell>
+				</Row>
+			</Grid>
+		);
+	}
 
 	if ( isTooltipVisible ) {
 		return (

--- a/assets/js/modules/analytics-4/components/dashboard/ActivationBanner/SetupBanner.js
+++ b/assets/js/modules/analytics-4/components/dashboard/ActivationBanner/SetupBanner.js
@@ -79,6 +79,10 @@ export default function SetupBanner( { onSubmitSuccess } ) {
 	);
 
 	const determineVariant = useCallback( async () => {
+		// Ensure variant is only set once, to avoid flickering between variants. For example
+		// when properties.length is zero we are in the "no existing property" variant, and we
+		// want to avoid changing to the "existing property" variant mid-way through the form
+		// submission as a result of adding a property.
 		if ( variant !== null ) {
 			return;
 		}

--- a/assets/js/modules/analytics-4/components/dashboard/ActivationBanner/SetupBanner.stories.js
+++ b/assets/js/modules/analytics-4/components/dashboard/ActivationBanner/SetupBanner.stories.js
@@ -41,6 +41,24 @@ const Template = ( args ) => <SetupBanner { ...args } />;
 
 export const NoPropertyNoTag = Template.bind( {} );
 NoPropertyNoTag.storyName = 'No GA4 Property - No Existing Tag';
+NoPropertyNoTag.decorators = [
+	( Story ) => {
+		const setupRegistry = ( registry ) => {
+			registry.dispatch( MODULES_ANALYTICS_4 ).receiveGetProperties( [], {
+				accountID,
+			} );
+			registry
+				.dispatch( MODULES_ANALYTICS_4 )
+				.finishResolution( 'getProperties', [ accountID ] );
+		};
+
+		return (
+			<WithRegistrySetup func={ setupRegistry }>
+				<Story />
+			</WithRegistrySetup>
+		);
+	},
+];
 
 export const WithPropertyNoTag = Template.bind( {} );
 WithPropertyNoTag.storyName = 'Existing GA4 Property - No Existing Tag';
@@ -121,6 +139,13 @@ NoPropertyWithTag.storyName = 'No GA4 Property - Existing Tag';
 NoPropertyWithTag.decorators = [
 	( Story ) => {
 		const setupRegistry = ( registry ) => {
+			registry.dispatch( MODULES_ANALYTICS_4 ).receiveGetProperties( [], {
+				accountID,
+			} );
+			registry
+				.dispatch( MODULES_ANALYTICS_4 )
+				.finishResolution( 'getProperties', [ accountID ] );
+
 			registry.dispatch( MODULES_ANALYTICS_4 ).receiveGetExistingTag(
 				// eslint-disable-next-line sitekit/acronym-case
 				ga4Fixtures.webDataStreams[ 0 ].webStreamData.measurementId


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #5276 

## Relevant technical choices

Followup fix to show a progress bar while determining which `SetupBanner` variant to display.

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
