### PR TITLE
Add common test case for service URLs.

### DIFF
--- a/assets/js/modules/adsense/datastore/service.js
+++ b/assets/js/modules/adsense/datastore/service.js
@@ -48,15 +48,15 @@ export const selectors = {
 	getServiceURL: createRegistrySelector(
 		( select ) =>
 			( state, { path, query } = {} ) => {
-				let serviceURL = 'https://www.google.com/adsense/new';
-
-				if ( query ) {
-					serviceURL = addQueryArgs( serviceURL, query );
-				}
+				let serviceURL = 'https://www.google.com/adsense/new/u/0';
 
 				if ( path ) {
 					const sanitizedPath = `/${ path.replace( /^\//, '' ) }`;
-					serviceURL = `${ serviceURL }#${ sanitizedPath }`;
+					serviceURL = `${ serviceURL }${ sanitizedPath }`;
+				}
+
+				if ( query ) {
+					serviceURL = addQueryArgs( serviceURL, query );
 				}
 
 				const accountChooserBaseURI =

--- a/assets/js/modules/adsense/datastore/service.js
+++ b/assets/js/modules/adsense/datastore/service.js
@@ -48,6 +48,8 @@ export const selectors = {
 	getServiceURL: createRegistrySelector(
 		( select ) =>
 			( state, { path, query } = {} ) => {
+				// Note: /u/0 is necessary to keep here in order for paths to be resolved properly;
+				// AccountChooser will update this part of the URL accordingly.
 				let serviceURL = 'https://www.google.com/adsense/new/u/0';
 
 				if ( path ) {

--- a/assets/js/modules/adsense/datastore/service.test.js
+++ b/assets/js/modules/adsense/datastore/service.test.js
@@ -72,7 +72,9 @@ describe( 'module/adsense service store', () => {
 					.getServiceURL();
 
 				expect( serviceURL ).toMatchInlineSnapshot(
-					'"https://accounts.google.com/accountchooser?continue=https%3A%2F%2Fwww.google.com%2Fadsense%2Fnew&Email=admin%40example.com"'
+					`"https://accounts.google.com/accountchooser?continue=${ encodeURIComponent(
+						'https://www.google.com/adsense/new/u/0'
+					) }&Email=admin%40example.com"`
 				);
 			} );
 
@@ -82,7 +84,9 @@ describe( 'module/adsense service store', () => {
 					.getServiceURL( { path: 'test/path/to/deeplink' } );
 
 				expect( serviceURLNoSlashes ).toMatchInlineSnapshot(
-					'"https://accounts.google.com/accountchooser?continue=https%3A%2F%2Fwww.google.com%2Fadsense%2Fnew%23%2Ftest%2Fpath%2Fto%2Fdeeplink&Email=admin%40example.com"'
+					`"https://accounts.google.com/accountchooser?continue=${ encodeURIComponent(
+						'https://www.google.com/adsense/new/u/0/test/path/to/deeplink'
+					) }&Email=admin%40example.com"`
 				);
 
 				const serviceURLWithLeadingSlash = registry
@@ -90,7 +94,9 @@ describe( 'module/adsense service store', () => {
 					.getServiceURL( { path: '/test/path/to/deeplink' } );
 
 				expect( serviceURLWithLeadingSlash ).toMatchInlineSnapshot(
-					'"https://accounts.google.com/accountchooser?continue=https%3A%2F%2Fwww.google.com%2Fadsense%2Fnew%23%2Ftest%2Fpath%2Fto%2Fdeeplink&Email=admin%40example.com"'
+					`"https://accounts.google.com/accountchooser?continue=${ encodeURIComponent(
+						'https://www.google.com/adsense/new/u/0/test/path/to/deeplink'
+					) }&Email=admin%40example.com"`
 				);
 			} );
 
@@ -188,8 +194,8 @@ describe( 'module/adsense service store', () => {
 					.getServiceReportURL();
 
 				expect(
-					decodeServiceURL( resultingURL ).endsWith( correctPath )
-				).toBe( true );
+					new URL( decodeServiceURL( resultingURL ) ).pathname
+				).toMatch( new RegExp( `${ correctPath }$` ) );
 			} );
 
 			it( 'should append `reportArgs` arguments to the `query` if received', () => {

--- a/assets/js/modules/search-console/datastore/service.js
+++ b/assets/js/modules/search-console/datastore/service.js
@@ -49,13 +49,13 @@ export const selectors = {
 			( state, { path, query } = {} ) => {
 				let serviceURL = 'https://search.google.com/search-console';
 
-				if ( query ) {
-					serviceURL = addQueryArgs( serviceURL, query );
-				}
-
 				if ( path ) {
 					const sanitizedPath = `/${ path.replace( /^\//, '' ) }`;
-					serviceURL = `${ serviceURL }#${ sanitizedPath }`;
+					serviceURL = `${ serviceURL }${ sanitizedPath }`;
+				}
+
+				if ( query ) {
+					serviceURL = addQueryArgs( serviceURL, query );
 				}
 
 				const accountChooserBaseURI =

--- a/assets/js/modules/search-console/datastore/service.test.js
+++ b/assets/js/modules/search-console/datastore/service.test.js
@@ -84,9 +84,9 @@ describe( 'module/search-console service store', () => {
 					.select( MODULES_SEARCH_CONSOLE )
 					.getServiceURL( { path: '/test/path/to/deeplink' } );
 
-				expect( serviceURL ).toMatchInlineSnapshot(
-					'"https://accounts.google.com/accountchooser?continue=https%3A%2F%2Fsearch.google.com%2Fsearch-console%23%2Ftest%2Fpath%2Fto%2Fdeeplink&Email=admin%40example.com"'
-				);
+				expect(
+					new URL( decodeServiceURL( serviceURL ) ).pathname
+				).toMatch( new RegExp( '/test/path/to/deeplink$' ) );
 			} );
 
 			it( 'merges given query args to the base service URL args', async () => {

--- a/assets/js/modules/search-console/datastore/service.test.js
+++ b/assets/js/modules/search-console/datastore/service.test.js
@@ -120,11 +120,9 @@ describe( 'module/search-console service store', () => {
 
 				const decodedServiceURL = decodeServiceURL( serviceURL );
 
-				expect(
-					decodedServiceURL.endsWith(
-						'#/performance/search-analytics'
-					)
-				).toBe( true );
+				expect( new URL( decodedServiceURL ).pathname ).toMatch(
+					new RegExp( '/performance/search-analytics$' )
+				);
 			} );
 
 			it( 'adds the `resource_id` query arg for the current property ID', () => {

--- a/assets/js/modules/search-console/datastore/service.test.js
+++ b/assets/js/modules/search-console/datastore/service.test.js
@@ -62,9 +62,14 @@ describe( 'module/search-console service store', () => {
 					.select( MODULES_SEARCH_CONSOLE )
 					.getServiceURL();
 
-				expect( serviceURL ).toMatchInlineSnapshot(
-					'"https://accounts.google.com/accountchooser?continue=https%3A%2F%2Fsearch.google.com%2Fsearch-console&Email=admin%40example.com"'
-				);
+				expect( new URL( serviceURL ) ).toMatchObject( {
+					origin: 'https://accounts.google.com',
+					pathname: '/accountchooser',
+				} );
+				expect( serviceURL ).toMatchQueryParameters( {
+					continue: 'https://search.google.com/search-console',
+					Email: 'admin@example.com',
+				} );
 			} );
 
 			it( 'appends the given path (without leading slash) to the path of the base URL', () => {
@@ -73,10 +78,8 @@ describe( 'module/search-console service store', () => {
 					.getServiceURL( { path: 'test/path/to/deeplink' } );
 
 				expect(
-					serviceURL.endsWith(
-						'%2Ftest%2Fpath%2Fto%2Fdeeplink&Email=admin%40example.com'
-					)
-				).toBe( true );
+					new URL( decodeServiceURL( serviceURL ) ).pathname
+				).toMatch( new RegExp( '/test/path/to/deeplink$' ) );
 			} );
 
 			it( 'appends the given path (with leading slash) to the path of the base URL', () => {

--- a/assets/js/modules/service-urls.test.js
+++ b/assets/js/modules/service-urls.test.js
@@ -1,0 +1,95 @@
+/**
+ * Common Service URL tests.
+ *
+ * Site Kit by Google, Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import { createTestRegistry, provideUserInfo } from '../../../tests/js/utils';
+
+function mapURLs( cases, getServiceURL ) {
+	return cases
+		.map( ( ...args ) => getServiceURL( ...args ) )
+		.map( ( url ) => {
+			let u = new URL( url );
+			// Check if it's a new service URL first.
+			if ( u.pathname === '/accountchooser' ) {
+				// If so, return the service URL from its `continue` param.
+				u = new URL( u.searchParams.get( 'continue' ) );
+			} else if ( u.searchParams.has( 'authuser' ) ) {
+				u.searchParams.delete( 'authuser' );
+			}
+			return u.toString();
+		} );
+}
+
+it( 'ensures all serviceURLs are properly constructed', () => {
+	const registry = createTestRegistry();
+	provideUserInfo( registry );
+
+	// Each item in the array is the object of arguments to pass to getServiceURL.
+	const cases = [
+		{},
+		{ path: 'foo-path' },
+		{ path: 'foo-path', query: { bar: 'baz' } },
+	];
+
+	const serviceURLsByStore = {};
+	for ( const storeName in registry.stores ) {
+		if ( registry.stores[ storeName ]?.selectors?.getServiceURL ) {
+			serviceURLsByStore[ storeName ] = mapURLs(
+				cases,
+				registry.stores[ storeName ].selectors.getServiceURL
+			);
+		}
+	}
+
+	// These URLs were generated using the 1.82.0 source, and stripped of the `authuser` param.
+	// This assertion ensures these are constructed in the same way going forward.
+	expect( serviceURLsByStore ).toEqual( {
+		'modules/adsense': [
+			'https://www.google.com/adsense/new/u/0',
+			'https://www.google.com/adsense/new/u/0/foo-path',
+			'https://www.google.com/adsense/new/u/0/foo-path?bar=baz',
+		],
+		'modules/analytics': [
+			'https://analytics.google.com/analytics/web/',
+			'https://analytics.google.com/analytics/web/#/foo-path',
+			'https://analytics.google.com/analytics/web/?bar=baz#/foo-path',
+		],
+		'modules/optimize': [
+			'https://optimize.google.com/optimize/home/',
+			'https://optimize.google.com/optimize/home/#/foo-path',
+			'https://optimize.google.com/optimize/home/?bar=baz#/foo-path',
+		],
+		'modules/pagespeed-insights': [
+			'https://pagespeed.web.dev/',
+			'https://pagespeed.web.dev/foo-path',
+			'https://pagespeed.web.dev/foo-path?bar=baz',
+		],
+		'modules/search-console': [
+			'https://search.google.com/search-console',
+			'https://search.google.com/search-console/foo-path',
+			'https://search.google.com/search-console/foo-path?bar=baz',
+		],
+		'modules/tagmanager': [
+			'https://tagmanager.google.com/',
+			'https://tagmanager.google.com/#/foo-path',
+			'https://tagmanager.google.com/?bar=baz#/foo-path',
+		],
+	} );
+} );


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #5548 

This PR primarily fixes the issue noted in https://github.com/google/site-kit-wp/issues/5548#issuecomment-1241173813 where some service URLs were changed to apply the `path` as a URL fragment rather than part of the service URL's `pathname`. It also adds some infrastructure that informed the changes to ensure the previous (now encoded) URL format is preserved. 

## Relevant technical choices

- Added a new common test case for all modules that have a `getServiceURL` selector that was used as a basis for this refactoring
- In order to ensure no regression was introduced, the above test was created using URLs generated using the current 1.82.0 source
- This test was then used to update the underlying selectors, and finally their existing tests

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
