### PR TITLE
Do not open accordion on action click

### DIFF
--- a/assets/js/components/settings/SettingsActiveModule/Header.js
+++ b/assets/js/components/settings/SettingsActiveModule/Header.js
@@ -78,6 +78,11 @@ export default function Header( { slug } ) {
 		);
 	}, [ history, isOpen, slug, viewContext ] );
 
+	const onActionClick = useCallback(
+		( event ) => event.stopPropagation(),
+		[]
+	);
+
 	if ( ! module ) {
 		return null;
 	}
@@ -155,7 +160,10 @@ export default function Header( { slug } ) {
 
 						{ ! connected && (
 							<Fragment>
-								<Button href={ adminReauthURL }>
+								<Button
+									href={ adminReauthURL }
+									onClick={ onActionClick }
+								>
 									{ sprintf(
 										/* translators: %s: module name. */
 										__(


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #5620 

## Relevant technical choices

This PR prevents opening the panel when the action is clicked.

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
