### PR TITLE
Only show "All sidebar" when more than one sidebar exists.

### DIFF
--- a/includes/Modules/Thank_With_Google.php
+++ b/includes/Modules/Thank_With_Google.php
@@ -316,8 +316,8 @@ final class Thank_With_Google extends Module
 
 					if (
 						// Only show the "All sidebars" text if there is more
-						// than two sidebars.
-						$actual_sidebars_count >= 2 &&
+						// than one sidebar.
+						$actual_sidebars_count > 1 &&
 						count( $sidebars ) === $actual_sidebars_count
 					) {
 						return array( __( 'All sidebars', 'google-site-kit' ) );


### PR DESCRIPTION
## Summary

Only shows the "All sidebars" text when at least two sidebars are present, see: https://github.com/google/site-kit-wp/issues/5736#issuecomment-1241048414

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #5736

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
