### PR TITLE
Fix deprecation notices in MUI Tooltips.

### DIFF
--- a/assets/js/components/Root/index.js
+++ b/assets/js/components/Root/index.js
@@ -23,6 +23,9 @@ import PropTypes from 'prop-types';
 import {
 	ThemeProvider,
 	createMuiTheme,
+	// We're using the to avoid `StrictMode` warnings. It's a temporary
+	// workaround until we can upgrade `material-ui/core` to v5+.
+	// See: https://github.com/google/site-kit-wp/issues/5378
 	unstable_createMuiStrictModeTheme, // eslint-disable-line camelcase
 } from '@material-ui/core';
 

--- a/assets/js/components/Root/index.js
+++ b/assets/js/components/Root/index.js
@@ -20,6 +20,11 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
+import {
+	ThemeProvider,
+	createTheme,
+	unstable_createMuiStrictModeTheme, // eslint-disable-line camelcase
+} from '@material-ui/core';
 
 /**
  * WordPress dependencies
@@ -42,6 +47,11 @@ import InViewProvider from '../InViewProvider';
 import { isSiteKitScreen } from '../../util/is-site-kit-screen';
 
 export default function Root( { children, registry, viewContext = null } ) {
+	const theme =
+		process.env.NODE_ENV === 'production'
+			? createTheme
+			: unstable_createMuiStrictModeTheme; // eslint-disable-line camelcase
+
 	const [ inViewState ] = useState( {
 		key: 'Root',
 		value: true,
@@ -53,21 +63,25 @@ export default function Root( { children, registry, viewContext = null } ) {
 				<Data.RegistryProvider value={ registry }>
 					<FeaturesProvider value={ enabledFeatures }>
 						<ViewContextProvider value={ viewContext }>
-							<ErrorHandler>
-								<RestoreSnapshots>
-									{ children }
-									{ /*
-									TODO: Replace `FeatureToursDesktop` with `FeatureTours`
-									once tour conflicts in smaller viewports are resolved.
-									@see https://github.com/google/site-kit-wp/issues/3003
-								*/ }
-									{ viewContext && <FeatureToursDesktop /> }
-									<CurrentSurveyPortal />
-								</RestoreSnapshots>
-								{ isSiteKitScreen( viewContext ) && (
-									<PermissionsModal />
-								) }
-							</ErrorHandler>
+							<ThemeProvider theme={ theme() }>
+								<ErrorHandler>
+									<RestoreSnapshots>
+										{ children }
+										{ /*
+											TODO: Replace `FeatureToursDesktop` with `FeatureTours`
+											once tour conflicts in smaller viewports are resolved.
+											@see https://github.com/google/site-kit-wp/issues/3003
+										*/ }
+										{ viewContext && (
+											<FeatureToursDesktop />
+										) }
+										<CurrentSurveyPortal />
+									</RestoreSnapshots>
+									{ isSiteKitScreen( viewContext ) && (
+										<PermissionsModal />
+									) }
+								</ErrorHandler>
+							</ThemeProvider>
 						</ViewContextProvider>
 					</FeaturesProvider>
 				</Data.RegistryProvider>

--- a/assets/js/components/Root/index.js
+++ b/assets/js/components/Root/index.js
@@ -22,7 +22,7 @@
 import PropTypes from 'prop-types';
 import {
 	ThemeProvider,
-	createTheme,
+	createMuiTheme,
 	unstable_createMuiStrictModeTheme, // eslint-disable-line camelcase
 } from '@material-ui/core';
 
@@ -49,7 +49,7 @@ import { isSiteKitScreen } from '../../util/is-site-kit-screen';
 export default function Root( { children, registry, viewContext = null } ) {
 	const theme =
 		process.env.NODE_ENV === 'production'
-			? createTheme
+			? createMuiTheme
 			: unstable_createMuiStrictModeTheme; // eslint-disable-line camelcase
 
 	const [ inViewState ] = useState( {


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #5378 

## Relevant technical choices

<!-- Please describe your changes. -->

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
