### PR TITLE
Simplify SpinnerButton and rename prop for consistency with Spinner.

### DIFF
--- a/assets/js/components/SpinnerButton.js
+++ b/assets/js/components/SpinnerButton.js
@@ -21,11 +21,6 @@ import PropTypes from 'prop-types';
 import classnames from 'classnames';
 
 /**
- * WordPress dependencies
- */
-import { useState, useCallback, useEffect } from '@wordpress/element';
-
-/**
  * Internal dependencies
  */
 import { CircularProgress } from '../material-components';
@@ -35,24 +30,9 @@ export default function SpinnerButton( props ) {
 	const {
 		className,
 		onClick = () => {},
-		forceProcessing = false,
+		isSaving = false,
 		...restProps
 	} = props;
-
-	const [ processing, setProcessing ] = useState( false );
-
-	const handleClick = useCallback(
-		async ( ...params ) => {
-			setProcessing( true );
-			await onClick( ...params );
-			setProcessing( false );
-		},
-		[ onClick ]
-	);
-
-	useEffect( () => {
-		setProcessing( forceProcessing );
-	}, [ forceProcessing ] );
 
 	return (
 		<Button
@@ -60,13 +40,13 @@ export default function SpinnerButton( props ) {
 				className,
 				'googlesitekit-button-icon--spinner',
 				{
-					'googlesitekit-button-icon--spinner__running': processing,
+					'googlesitekit-button-icon--spinner__running': isSaving,
 				}
 			) }
 			trailingIcon={
-				processing ? <CircularProgress size={ 14 } /> : undefined
+				isSaving ? <CircularProgress size={ 14 } /> : undefined
 			}
-			onClick={ handleClick }
+			onClick={ onClick }
 			{ ...restProps }
 		/>
 	);
@@ -75,5 +55,5 @@ export default function SpinnerButton( props ) {
 SpinnerButton.propTypes = {
 	className: PropTypes.string,
 	onClick: PropTypes.func,
-	forceProcessing: PropTypes.bool,
+	isSaving: PropTypes.bool,
 };

--- a/assets/js/modules/analytics-4/components/dashboard/ActivationBanner/SetupBanner.js
+++ b/assets/js/modules/analytics-4/components/dashboard/ActivationBanner/SetupBanner.js
@@ -66,7 +66,7 @@ const VARIANT = {
 export default function SetupBanner( { onSubmitSuccess } ) {
 	const [ errorNotice, setErrorNotice ] = useState( null );
 	const [ variant, setVariant ] = useState( null );
-	const [ forceProcessing, setForceProcessing ] = useState( false );
+	const [ isSaving, setIsSaving ] = useState( false );
 
 	const { submitChanges, selectProperty, matchAndSelectProperty } =
 		useDispatch( MODULES_ANALYTICS_4 );
@@ -178,6 +178,8 @@ export default function SetupBanner( { onSubmitSuccess } ) {
 			return;
 		}
 
+		setIsSaving( true );
+
 		const { error } = await submitChanges();
 
 		if ( error ) {
@@ -187,7 +189,8 @@ export default function SetupBanner( { onSubmitSuccess } ) {
 			// Ask the parent component to show the success banner.
 			onSubmitSuccess();
 		}
-		setForceProcessing( false );
+
+		setIsSaving( false );
 	}, [
 		hasEditScope,
 		onSubmitSuccess,
@@ -200,8 +203,6 @@ export default function SetupBanner( { onSubmitSuccess } ) {
 	// resubmit the form.
 	useEffect( () => {
 		if ( autoSubmit && hasEditScope ) {
-			// Force the SpinnerButton to show the processing state.
-			setForceProcessing( true );
 			handleSubmitChanges();
 		}
 	}, [ autoSubmit, handleSubmitChanges, hasEditScope ] );
@@ -358,7 +359,7 @@ export default function SetupBanner( { onSubmitSuccess } ) {
 			ctaComponent={
 				<SpinnerButton
 					onClick={ handleSubmitChanges }
-					forceProcessing={ forceProcessing }
+					isSaving={ isSaving }
 				>
 					{ ctaLabel }
 				</SpinnerButton>


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #5282 

## Relevant technical choices

Suggested amendment to #5813, simplifying the `SpinnerButton` and renaming a prop for consistency with `Spinner`.

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [ ] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
