### PR TITLE
Prevent navigation timeout in E2E tests

### DIFF
--- a/tests/e2e/specs/modules/tagmanager/setup.test.js
+++ b/tests/e2e/specs/modules/tagmanager/setup.test.js
@@ -206,7 +206,10 @@ describe( 'Tag Manager module setup', () => {
 			// Ensure expected tag is placed.
 			await Promise.all( [
 				page.goto( createURL( '/' ) ),
-				page.waitForNavigation(),
+				page.waitForNavigation( {
+					waitUntil: 'networkidle2',
+					timeout: 0,
+				} ),
 			] );
 			await expect( page ).toMatchElement(
 				'script[src^="https://www.googletagmanager.com/gtm.js?id=GTM-ABCXYZ"]'
@@ -299,7 +302,10 @@ describe( 'Tag Manager module setup', () => {
 			// Ensure expected tag is placed.
 			await Promise.all( [
 				page.goto( createURL( '/' ) ),
-				page.waitForNavigation(),
+				page.waitForNavigation( {
+					waitUntil: 'networkidle2',
+					timeout: 0,
+				} ),
 			] );
 			await expect( page ).toMatchElement(
 				'script[src^="https://www.googletagmanager.com/gtm.js?id=GTM-BCDWXY"]'

--- a/tests/e2e/specs/modules/tagmanager/setup.test.js
+++ b/tests/e2e/specs/modules/tagmanager/setup.test.js
@@ -423,9 +423,13 @@ describe( 'Tag Manager module setup', () => {
 							text: /Congrats on completing the setup for Tag Manager!/i,
 						}
 					);
-					await page.goto( createURL( '/', 'amp' ), {
-						waitUntil: 'load',
-					} );
+					await Promise.all( [
+						page.goto( createURL( '/', 'amp' ) ),
+						page.waitForNavigation( {
+							waitUntil: 'networkidle2',
+							timeout: 0,
+						} ),
+					] );
 				} );
 
 				it( 'validates homepage AMP for logged-in users', async () => {


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #5154 

## Relevant technical choices

This PR works on preventing the navigation timeout errors that we frequently get in our CI E2E tests.

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
