### PR TITLE
Don't show success notification on return from OAuth to GA4 Activation Banner.

### DIFF
--- a/assets/js/components/PermissionsModal/AuthenticatedPermissionsModal.js
+++ b/assets/js/components/PermissionsModal/AuthenticatedPermissionsModal.js
@@ -21,6 +21,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useEffect, useCallback } from '@wordpress/element';
+import { addQueryArgs } from '@wordpress/url';
 
 /**
  * Internal dependencies
@@ -41,7 +42,11 @@ const AuthenticatedPermissionsModal = () => {
 	const connectURL = useSelect( ( select ) =>
 		select( CORE_USER ).getConnectURL( {
 			additionalScopes: permissionsError?.data?.scopes,
-			redirectURL: global.location.href,
+			redirectURL: permissionsError?.data?.skipNotification
+				? addQueryArgs( global.location.href, {
+						skipNotification: true,
+				  } )
+				: global.location.href,
 		} )
 	);
 

--- a/assets/js/modules/analytics-4/components/dashboard/ActivationBanner/SetupBanner.js
+++ b/assets/js/modules/analytics-4/components/dashboard/ActivationBanner/SetupBanner.js
@@ -173,6 +173,7 @@ export default function SetupBanner( { onSubmitSuccess } ) {
 					status: 403,
 					scopes,
 					skipModal: true,
+					skipNotification: true,
 				},
 			} );
 			return;

--- a/includes/Core/Authentication/Clients/OAuth_Client.php
+++ b/includes/Core/Authentication/Clients/OAuth_Client.php
@@ -344,7 +344,12 @@ final class OAuth_Client extends OAuth_Client_Base {
 			$additional_scopes = array();
 		}
 
-		$redirect_url = add_query_arg( array( 'notification' => 'authentication_success' ), $redirect_url );
+		$parts             = URL::parse( $redirect_url );
+		$skip_notification = strpos( $parts['query'], 'skipNotification=true' );
+
+		if ( false === $skip_notification ) {
+			$redirect_url = add_query_arg( array( 'notification' => 'authentication_success' ), $redirect_url );
+		}
 		// Ensure we remove error query string.
 		$redirect_url = remove_query_arg( 'error', $redirect_url );
 
@@ -467,9 +472,10 @@ final class OAuth_Client extends OAuth_Client_Base {
 		$redirect_url = $this->user_options->get( self::OPTION_REDIRECT_URL );
 
 		if ( $redirect_url ) {
-			$parts  = URL::parse( $redirect_url );
-			$reauth = strpos( $parts['query'], 'reAuth=true' );
-			if ( false === $reauth ) {
+			$parts             = URL::parse( $redirect_url );
+			$reauth            = strpos( $parts['query'], 'reAuth=true' );
+			$skip_notification = strpos( $parts['query'], 'skipNotification=true' );
+			if ( false === $reauth && false === $skip_notification ) {
 				$redirect_url = add_query_arg( array( 'notification' => 'authentication_success' ), $redirect_url );
 			}
 			$this->user_options->delete( self::OPTION_REDIRECT_URL );


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #5837 

## Relevant technical choices

<!-- Please describe your changes. -->

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [ ] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
