### PR TITLE
Reset Sharing Settings modal updates

### DIFF
--- a/assets/js/components/dashboard-sharing/DashboardSharingDialog/Footer/index.js
+++ b/assets/js/components/dashboard-sharing/DashboardSharingDialog/Footer/index.js
@@ -129,7 +129,7 @@ export default function Footer( { closeDialog, openResetDialog } ) {
 			) }
 
 			<div className="googlesitekit-dashboard-sharing-settings__footer-actions">
-				{ settingsDialogOpen && (
+				{ settingsDialogOpen && ! showNotice && (
 					<div className="googlesitekit-dashboard-sharing-settings__footer-actions-left">
 						<Link onClick={ openResetDialog } danger>
 							{ __(

--- a/assets/js/components/dashboard-sharing/DashboardSharingDialog/index.js
+++ b/assets/js/components/dashboard-sharing/DashboardSharingDialog/index.js
@@ -20,6 +20,7 @@
  * External dependencies
  */
 import { useWindowScroll } from 'react-use';
+import classnames from 'classnames';
 
 /**
  * WordPress dependencies
@@ -193,7 +194,15 @@ export default function DashboardSharingDialog() {
 									) }
 							</h2>
 
-							<p className="googlesitekit-dialog__subtitle">
+							<p
+								className={ classnames(
+									'googlesitekit-dialog__subtitle',
+									{
+										'googlesitekit-dialog__subtitle--emphasis':
+											resetDialogOpen,
+									}
+								) }
+							>
 								{ settingsDialogOpen &&
 									createInterpolateElement(
 										__(

--- a/assets/sass/components/global/_googlesitekit-dialog.scss
+++ b/assets/sass/components/global/_googlesitekit-dialog.scss
@@ -137,6 +137,10 @@
 			margin: 0;
 		}
 
+		.googlesitekit-dialog__subtitle--emphasis {
+			font-size: $fs-body-md;
+		}
+
 		.googlesitekit-dialog__footer {
 			border-top: 1px solid $c-utility-divider;
 			justify-content: flex-end;


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #5445 

## Relevant technical choices

This PR updates the Reset Sharing Settings modal depending on feedback from the QA team. Currently, it does the following:

1. Increases the font-size for the Reset Sharing Settings modal content.
2. Removes the reset action from the footer if a notice/error is present.

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
