### PR TITLE
Make GA4 activation banner appear only at a time.

### DIFF
--- a/assets/js/modules/analytics-4/components/dashboard/ActivationBanner/SetupBanner.js
+++ b/assets/js/modules/analytics-4/components/dashboard/ActivationBanner/SetupBanner.js
@@ -217,13 +217,15 @@ export default function SetupBanner( { onSubmitSuccess } ) {
 
 	if ( variant === null ) {
 		return (
-			<Grid>
-				<Row>
-					<Cell size={ 12 }>
-						<ProgressBar />
-					</Cell>
-				</Row>
-			</Grid>
+			<div className="googlesitekit-publisher-win">
+				<Grid>
+					<Row>
+						<Cell size={ 12 }>
+							<ProgressBar />
+						</Cell>
+					</Row>
+				</Grid>
+			</div>
 		);
 	}
 

--- a/assets/js/modules/analytics-4/components/dashboard/ActivationBanner/SetupBanner.js
+++ b/assets/js/modules/analytics-4/components/dashboard/ActivationBanner/SetupBanner.js
@@ -216,6 +216,8 @@ export default function SetupBanner( { onSubmitSuccess } ) {
 	);
 
 	if ( variant === null ) {
+		// Wrap in the googlesitekit-publisher-win class to ensure the output is treated in the same way as BannerNotification,
+		// with only one instance visible on the screen at a time.
 		return (
 			<div className="googlesitekit-publisher-win">
 				<Grid>


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #5823 

## Relevant technical choices

<!-- Please describe your changes. -->

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [x] Run the code.
- [x] Ensure the acceptance criteria are satisfied.
- [x] Reassess the implementation with the IB.
- [x] Ensure no unrelated changes are included.
- [x] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [x] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [x] Ensure the PR has the correct target branch.
- [x] Double-check that the PR is okay to be merged.
- [x] Ensure the corresponding issue has a ZenHub release assigned.
- [x] Add a changelog message to the issue.
