### PR TITLE
Prevent the success notification appearing when returning from OAuth in the GA4 Activation Banner flow.

### DIFF
--- a/assets/js/components/PermissionsModal/AuthenticatedPermissionsModal.js
+++ b/assets/js/components/PermissionsModal/AuthenticatedPermissionsModal.js
@@ -41,7 +41,8 @@ const AuthenticatedPermissionsModal = () => {
 	const connectURL = useSelect( ( select ) =>
 		select( CORE_USER ).getConnectURL( {
 			additionalScopes: permissionsError?.data?.scopes,
-			redirectURL: global.location.href,
+			redirectURL:
+				permissionsError?.data?.redirectURL || global.location.href,
 		} )
 	);
 

--- a/assets/js/components/notifications/BannerNotifications.js
+++ b/assets/js/components/notifications/BannerNotifications.js
@@ -67,9 +67,9 @@ export default function BannerNotifications() {
 					) }
 					{ isAuthenticated && <CoreSiteBannerNotifications /> }
 					{ dashboardSharingEnabled && <ModuleRecoveryAlert /> }
+					{ ga4ActivationBannerEnabled && <ActivationBanner /> }
 				</Fragment>
 			) }
-			{ ga4ActivationBannerEnabled && <ActivationBanner /> }
 			<ZeroDataStateNotifications />
 			{ ! viewOnly && (
 				<Fragment>

--- a/assets/js/modules/analytics-4/components/dashboard/ActivationBanner/SetupBanner.js
+++ b/assets/js/modules/analytics-4/components/dashboard/ActivationBanner/SetupBanner.js
@@ -20,6 +20,7 @@
  * WordPress dependencies
  */
 import { Fragment, useCallback, useEffect, useState } from '@wordpress/element';
+import { addQueryArgs } from '@wordpress/url';
 import { __, sprintf } from '@wordpress/i18n';
 
 /**
@@ -163,6 +164,11 @@ export default function SetupBanner( { onSubmitSuccess } ) {
 			setValues( GA4_ACTIVATION_BANNER_STATE_KEY, {
 				returnToSetupStep: true,
 			} );
+
+			const redirectURL = addQueryArgs( global.location.href, {
+				notification: 'ga4_setup',
+			} );
+
 			setPermissionScopeError( {
 				code: ERROR_CODE_MISSING_REQUIRED_SCOPE,
 				message: __(
@@ -173,6 +179,7 @@ export default function SetupBanner( { onSubmitSuccess } ) {
 					status: 403,
 					scopes,
 					skipModal: true,
+					redirectURL,
 				},
 			} );
 			return;

--- a/includes/Core/Authentication/Clients/OAuth_Client.php
+++ b/includes/Core/Authentication/Clients/OAuth_Client.php
@@ -344,10 +344,10 @@ final class OAuth_Client extends OAuth_Client_Base {
 			$additional_scopes = array();
 		}
 
-		$parts = URL::parse( $redirect_url );
+		$url_query = URL::parse( $redirect_url, PHP_URL_QUERY );
 
-		if ( isset( $parts['query'] ) ) {
-			parse_str( $parts['query'], $query_args );
+		if ( $url_query ) {
+			parse_str( $url_query, $query_args );
 		}
 
 		if ( empty( $query_args['notification'] ) ) {
@@ -475,10 +475,10 @@ final class OAuth_Client extends OAuth_Client_Base {
 		$redirect_url = $this->user_options->get( self::OPTION_REDIRECT_URL );
 
 		if ( $redirect_url ) {
-			$parts = URL::parse( $redirect_url );
+			$url_query = URL::parse( $redirect_url, PHP_URL_QUERY );
 
-			if ( isset( $parts['query'] ) ) {
-				parse_str( $parts['query'], $query_args );
+			if ( $url_query ) {
+				parse_str( $url_query, $query_args );
 			}
 
 			$reauth = isset( $query_args['reAuth'] ) && 'true' === $query_args['reAuth'];

--- a/includes/Core/Authentication/Clients/OAuth_Client.php
+++ b/includes/Core/Authentication/Clients/OAuth_Client.php
@@ -344,7 +344,15 @@ final class OAuth_Client extends OAuth_Client_Base {
 			$additional_scopes = array();
 		}
 
-		$redirect_url = add_query_arg( array( 'notification' => 'authentication_success' ), $redirect_url );
+		$parts = URL::parse( $redirect_url );
+
+		if ( isset( $parts['query'] ) ) {
+			parse_str( $parts['query'], $query_args );
+		}
+
+		if ( empty( $query_args['notification'] ) ) {
+			$redirect_url = add_query_arg( array( 'notification' => 'authentication_success' ), $redirect_url );
+		}
 		// Ensure we remove error query string.
 		$redirect_url = remove_query_arg( 'error', $redirect_url );
 
@@ -467,9 +475,15 @@ final class OAuth_Client extends OAuth_Client_Base {
 		$redirect_url = $this->user_options->get( self::OPTION_REDIRECT_URL );
 
 		if ( $redirect_url ) {
-			$parts  = URL::parse( $redirect_url );
-			$reauth = strpos( $parts['query'], 'reAuth=true' );
-			if ( false === $reauth ) {
+			$parts = URL::parse( $redirect_url );
+
+			if ( isset( $parts['query'] ) ) {
+				parse_str( $parts['query'], $query_args );
+			}
+
+			$reauth = isset( $query_args['reAuth'] ) && 'true' === $query_args['reAuth'];
+
+			if ( false === $reauth && empty( $query_args['notification'] ) ) {
 				$redirect_url = add_query_arg( array( 'notification' => 'authentication_success' ), $redirect_url );
 			}
 			$this->user_options->delete( self::OPTION_REDIRECT_URL );


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #5837

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
