### PR TITLE
Replace waitFor render with waitForRegistry in tests.

### DIFF
--- a/assets/js/modules/analytics/components/settings/SettingsEdit.test.js
+++ b/assets/js/modules/analytics/components/settings/SettingsEdit.test.js
@@ -21,7 +21,6 @@
  */
 import {
 	render,
-	waitFor,
 	createTestRegistry,
 } from '../../../../../../tests/js/test-utils';
 import { CORE_MODULES } from '../../../../googlesitekit/modules/datastore/constants';
@@ -104,9 +103,10 @@ describe( 'SettingsEdit', () => {
 			.dispatch( MODULES_ANALYTICS )
 			.receiveGetExistingTag( existingTag.propertyID );
 
-		await waitFor( () => {
-			render( <SettingsEdit />, { registry } );
+		const { waitForRegistry } = render( <SettingsEdit />, {
+			registry,
 		} );
+		await waitForRegistry();
 
 		expect(
 			registry.select( MODULES_ANALYTICS ).getAccountID()

--- a/assets/js/modules/tagmanager/components/settings/SettingsEdit.test.js
+++ b/assets/js/modules/tagmanager/components/settings/SettingsEdit.test.js
@@ -25,7 +25,6 @@ import {
 } from '../../../../../../tests/js/utils';
 import {
 	render,
-	waitFor,
 	createTestRegistry,
 } from '../../../../../../tests/js/test-utils';
 import {
@@ -99,9 +98,13 @@ describe( 'SettingsEdit', () => {
 			} );
 
 			it( 'should display a default container name when nothing is entered yet', async () => {
-				const { container } = await waitFor( () =>
-					render( <SettingsEdit />, { registry } )
+				const { container, waitForRegistry } = render(
+					<SettingsEdit />,
+					{
+						registry,
+					}
 				);
+				await waitForRegistry();
 				expect(
 					container.querySelector( '#containerName' )
 				).toHaveValue( siteName );
@@ -116,10 +119,13 @@ describe( 'SettingsEdit', () => {
 						{ slug: 'tagmanager' }
 					);
 
-				const { container } = await waitFor( () =>
-					render( <SettingsEdit />, { registry } )
+				const { container, waitForRegistry } = render(
+					<SettingsEdit />,
+					{
+						registry,
+					}
 				);
-
+				await waitForRegistry();
 				expect(
 					container.querySelector( '#containerName' )
 				).toHaveValue( siteName );
@@ -144,9 +150,13 @@ describe( 'SettingsEdit', () => {
 
 			it( 'should use a domain name as a default value when siteName is empty', async () => {
 				provideSiteInfo( registry, { siteName: '' } );
-				const { container } = await waitFor( () =>
-					render( <SettingsEdit />, { registry } )
+				const { container, waitForRegistry } = render(
+					<SettingsEdit />,
+					{
+						registry,
+					}
 				);
+				await waitForRegistry();
 				expect(
 					container.querySelector( '#containerName' )
 				).toHaveValue( 'example.com' );
@@ -157,10 +167,13 @@ describe( 'SettingsEdit', () => {
 					containerName: allContainers[ 0 ].name,
 				} );
 
-				const { container } = await waitFor( () =>
-					render( <SettingsEdit />, { registry } )
+				const { container, waitForRegistry } = render(
+					<SettingsEdit />,
+					{
+						registry,
+					}
 				);
-
+				await waitForRegistry();
 				expect(
 					container.querySelector( '#containerName' )
 				).toHaveValue( allContainers[ 0 ].name );
@@ -188,9 +201,13 @@ describe( 'SettingsEdit', () => {
 			} );
 
 			it( 'should display a default container name when nothing is entered yet', async () => {
-				const { container } = await waitFor( () =>
-					render( <SettingsEdit />, { registry } )
+				const { container, waitForRegistry } = render(
+					<SettingsEdit />,
+					{
+						registry,
+					}
 				);
+				await waitForRegistry();
 				expect(
 					container.querySelector( '#ampContainerName' )
 				).toHaveValue( `${ siteName } AMP` );
@@ -205,9 +222,13 @@ describe( 'SettingsEdit', () => {
 						{ slug: 'tagmanager' }
 					);
 
-				const { container } = await waitFor( () =>
-					render( <SettingsEdit />, { registry } )
+				const { container, waitForRegistry } = render(
+					<SettingsEdit />,
+					{
+						registry,
+					}
 				);
+				await waitForRegistry();
 
 				expect(
 					container.querySelector( '#ampContainerName' )
@@ -233,9 +254,13 @@ describe( 'SettingsEdit', () => {
 
 			it( 'should use a domain name as a default value when siteName is empty', async () => {
 				provideSiteInfo( registry, { siteName: '' } );
-				const { container } = await waitFor( () =>
-					render( <SettingsEdit />, { registry } )
+				const { container, waitForRegistry } = render(
+					<SettingsEdit />,
+					{
+						registry,
+					}
 				);
+				await waitForRegistry();
 				expect(
 					container.querySelector( '#ampContainerName' )
 				).toHaveValue( 'example.com AMP' );
@@ -246,10 +271,13 @@ describe( 'SettingsEdit', () => {
 					ampContainerName: allContainers[ 0 ].name,
 				} );
 
-				const { container } = await waitFor( () =>
-					render( <SettingsEdit />, { registry } )
+				const { container, waitForRegistry } = render(
+					<SettingsEdit />,
+					{
+						registry,
+					}
 				);
-
+				await waitForRegistry();
 				expect(
 					container.querySelector( '#ampContainerName' )
 				).toHaveValue( allContainers[ 0 ].name );
@@ -284,9 +312,14 @@ describe( 'SettingsEdit', () => {
 			} );
 
 			it( 'should display default container names when nothing is entered yet', async () => {
-				const { container } = await waitFor( () =>
-					render( <SettingsEdit />, { registry } )
+				const { container, waitForRegistry } = render(
+					<SettingsEdit />,
+					{
+						registry,
+					}
 				);
+				await waitForRegistry();
+
 				expect(
 					container.querySelector( '#containerName' )
 				).toHaveValue( siteName );
@@ -304,10 +337,13 @@ describe( 'SettingsEdit', () => {
 						{ slug: 'tagmanager' }
 					);
 
-				const { container } = await waitFor( () =>
-					render( <SettingsEdit />, { registry } )
+				const { container, waitForRegistry } = render(
+					<SettingsEdit />,
+					{
+						registry,
+					}
 				);
-
+				await waitForRegistry();
 				expect(
 					container.querySelector( '#containerName' )
 				).toHaveValue( siteName );
@@ -335,9 +371,13 @@ describe( 'SettingsEdit', () => {
 
 			it( 'should use domain name as default values when siteName is empty', async () => {
 				provideSiteInfo( registry, { siteName: '' } );
-				const { container } = await waitFor( () =>
-					render( <SettingsEdit />, { registry } )
+				const { container, waitForRegistry } = render(
+					<SettingsEdit />,
+					{
+						registry,
+					}
 				);
+				await waitForRegistry();
 				expect(
 					container.querySelector( '#containerName' )
 				).toHaveValue( 'example.com' );
@@ -352,10 +392,13 @@ describe( 'SettingsEdit', () => {
 					ampContainerName: allContainers[ 1 ].name,
 				} );
 
-				const { container } = await waitFor( () =>
-					render( <SettingsEdit />, { registry } )
+				const { container, waitForRegistry } = render(
+					<SettingsEdit />,
+					{
+						registry,
+					}
 				);
-
+				await waitForRegistry();
 				expect(
 					container.querySelector( '#containerName' )
 				).toHaveValue( allContainers[ 0 ].name );

--- a/assets/js/modules/tagmanager/components/setup/SetupMain.test.js
+++ b/assets/js/modules/tagmanager/components/setup/SetupMain.test.js
@@ -25,7 +25,6 @@ import {
 } from '../../../../../../tests/js/utils';
 import {
 	render,
-	waitFor,
 	createTestRegistry,
 } from '../../../../../../tests/js/test-utils';
 import {
@@ -100,9 +99,10 @@ describe( 'SetupMain', () => {
 			} );
 
 			it( 'should display a default container name when nothing is entered yet', async () => {
-				const { container } = await waitFor( () =>
-					render( <SetupMain />, { registry } )
-				);
+				const { container, waitForRegistry } = render( <SetupMain />, {
+					registry,
+				} );
+				await waitForRegistry();
 				expect(
 					container.querySelector( '#containerName' )
 				).toHaveValue( siteName );
@@ -110,9 +110,10 @@ describe( 'SetupMain', () => {
 
 			it( 'should use a domain name as a default value when siteName is empty', async () => {
 				provideSiteInfo( registry, { siteName: '' } );
-				const { container } = await waitFor( () =>
-					render( <SetupMain />, { registry } )
-				);
+				const { container, waitForRegistry } = render( <SetupMain />, {
+					registry,
+				} );
+				await waitForRegistry();
 				expect(
 					container.querySelector( '#containerName' )
 				).toHaveValue( 'example.com' );
@@ -122,11 +123,10 @@ describe( 'SetupMain', () => {
 				registry.dispatch( CORE_FORMS ).setValues( FORM_SETUP, {
 					containerName: allContainers[ 0 ].name,
 				} );
-
-				const { container } = await waitFor( () =>
-					render( <SetupMain />, { registry } )
-				);
-
+				const { container, waitForRegistry } = render( <SetupMain />, {
+					registry,
+				} );
+				await waitForRegistry();
 				expect(
 					container.querySelector( '#containerName' )
 				).toHaveValue( allContainers[ 0 ].name );
@@ -154,9 +154,10 @@ describe( 'SetupMain', () => {
 			} );
 
 			it( 'should display a default container name when nothing is entered yet', async () => {
-				const { container } = await waitFor( () =>
-					render( <SetupMain />, { registry } )
-				);
+				const { container, waitForRegistry } = render( <SetupMain />, {
+					registry,
+				} );
+				await waitForRegistry();
 				expect(
 					container.querySelector( '#ampContainerName' )
 				).toHaveValue( `${ siteName } AMP` );
@@ -164,9 +165,10 @@ describe( 'SetupMain', () => {
 
 			it( 'should use a domain name as a default value when siteName is empty', async () => {
 				provideSiteInfo( registry, { siteName: '' } );
-				const { container } = await waitFor( () =>
-					render( <SetupMain />, { registry } )
-				);
+				const { container, waitForRegistry } = render( <SetupMain />, {
+					registry,
+				} );
+				await waitForRegistry();
 				expect(
 					container.querySelector( '#ampContainerName' )
 				).toHaveValue( 'example.com AMP' );
@@ -176,11 +178,10 @@ describe( 'SetupMain', () => {
 				registry.dispatch( CORE_FORMS ).setValues( FORM_SETUP, {
 					ampContainerName: allContainers[ 0 ].name,
 				} );
-
-				const { container } = await waitFor( () =>
-					render( <SetupMain />, { registry } )
-				);
-
+				const { container, waitForRegistry } = render( <SetupMain />, {
+					registry,
+				} );
+				await waitForRegistry();
 				expect(
 					container.querySelector( '#ampContainerName' )
 				).toHaveValue( allContainers[ 0 ].name );
@@ -215,9 +216,10 @@ describe( 'SetupMain', () => {
 			} );
 
 			it( 'should display default container names when nothing is entered yet', async () => {
-				const { container } = await waitFor( () =>
-					render( <SetupMain />, { registry } )
-				);
+				const { container, waitForRegistry } = render( <SetupMain />, {
+					registry,
+				} );
+				await waitForRegistry();
 				expect(
 					container.querySelector( '#containerName' )
 				).toHaveValue( siteName );
@@ -228,9 +230,10 @@ describe( 'SetupMain', () => {
 
 			it( 'should use domain name as default values when siteName is empty', async () => {
 				provideSiteInfo( registry, { siteName: '' } );
-				const { container } = await waitFor( () =>
-					render( <SetupMain />, { registry } )
-				);
+				const { container, waitForRegistry } = render( <SetupMain />, {
+					registry,
+				} );
+				await waitForRegistry();
 				expect(
 					container.querySelector( '#containerName' )
 				).toHaveValue( 'example.com' );
@@ -244,11 +247,10 @@ describe( 'SetupMain', () => {
 					containerName: allContainers[ 0 ].name,
 					ampContainerName: allContainers[ 1 ].name,
 				} );
-
-				const { container } = await waitFor( () =>
-					render( <SetupMain />, { registry } )
-				);
-
+				const { container, waitForRegistry } = render( <SetupMain />, {
+					registry,
+				} );
+				await waitForRegistry();
 				expect(
 					container.querySelector( '#containerName' )
 				).toHaveValue( allContainers[ 0 ].name );


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #5734 

## Relevant technical choices

<!-- Please describe your changes. -->

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
