### PR TITLE
Bug/5282 - Call selectProperty selectProperty from a correct place

### DIFF
--- a/assets/js/modules/analytics-4/components/dashboard/ActivationBanner/SetupBanner.js
+++ b/assets/js/modules/analytics-4/components/dashboard/ActivationBanner/SetupBanner.js
@@ -104,6 +104,7 @@ export default function SetupBanner( { onSubmitSuccess } ) {
 
 		if ( properties.length === 0 ) {
 			setVariant( VARIANT.NO_EXISTING_PROPERTY );
+			selectProperty( PROPERTY_CREATE );
 			return;
 		}
 
@@ -123,6 +124,7 @@ export default function SetupBanner( { onSubmitSuccess } ) {
 		ga4PropertyID,
 		matchAndSelectProperty,
 		properties,
+		selectProperty,
 		variant,
 	] );
 
@@ -321,8 +323,6 @@ export default function SetupBanner( { onSubmitSuccess } ) {
 			)
 		);
 	} else {
-		selectProperty( PROPERTY_CREATE );
-
 		title = __(
 			'No existing Google Analytics 4 property found, Site Kit will help you create a new one and insert it on your site',
 			'google-site-kit'


### PR DESCRIPTION
## Summary

Addresses issue:

- #5282 

## Relevant technical choices
- Previously, we were dispatching the `selectProperty( PROPERTY_CREATE )` action in the wrong place. That causes the  observation `#2` from this [comment](https://github.com/google/site-kit-wp/issues/5282#issuecomment-1249998835).
- This PR dispatches the above action in an appropriate place.

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
