### PR TITLE
Fix Top Earning Pages widget for view-only mode.

### DIFF
--- a/assets/js/modules/adsense/components/dashboard/DashboardTopEarningPagesWidget.js
+++ b/assets/js/modules/adsense/components/dashboard/DashboardTopEarningPagesWidget.js
@@ -108,9 +108,12 @@ function DashboardTopEarningPagesWidget( props ) {
 			] )
 	);
 
-	const isAdSenseLinked = useSelect( ( select ) =>
-		select( MODULES_ANALYTICS ).getAdsenseLinked()
-	);
+	const isAdSenseLinked = useSelect( ( select ) => {
+		if ( viewOnlyDashboard && loading ) {
+			return undefined;
+		}
+		return select( MODULES_ANALYTICS ).getAdsenseLinked();
+	} );
 
 	const isAdblockerActive = useSelect( ( select ) =>
 		select( MODULES_ADSENSE ).isAdBlockerActive()

--- a/assets/js/modules/adsense/components/dashboard/DashboardTopEarningPagesWidget.js
+++ b/assets/js/modules/adsense/components/dashboard/DashboardTopEarningPagesWidget.js
@@ -52,8 +52,6 @@ const { useSelect, useInViewSelect } = Data;
 function DashboardTopEarningPagesWidget( props ) {
 	const { Widget, WidgetReportError, WidgetNull } = props;
 
-	const isViewOnly = useViewOnly();
-
 	const viewOnlyDashboard = useViewOnly();
 
 	const isGatheringData = useInViewSelect( ( select ) =>
@@ -156,13 +154,13 @@ function DashboardTopEarningPagesWidget( props ) {
 		);
 	}
 
-	if ( ! isAdSenseLinked && isViewOnly ) {
+	if ( ! isAdSenseLinked && viewOnlyDashboard ) {
 		return <WidgetNull />;
 	}
 
 	// A restricted metrics error will cause this value to change in the resolver
 	// so this check should happen before an error, which is only relevant if they are linked.
-	if ( ! isAdSenseLinked && ! isViewOnly ) {
+	if ( ! isAdSenseLinked && ! viewOnlyDashboard ) {
 		return (
 			<Widget Footer={ Footer }>
 				<AdSenseLinkCTA />


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #5493 

## Relevant technical choices

<!-- Please describe your changes. -->

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [x] Run the code.
- [x] Ensure the acceptance criteria are satisfied.
- [x] Reassess the implementation with the IB.
- [x] Ensure no unrelated changes are included.
- [x] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [x] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [x] Ensure the PR has the correct target branch.
- [x] Double-check that the PR is okay to be merged.
- [x] Ensure the corresponding issue has a ZenHub release assigned.
- [x] Add a changelog message to the issue.
