### PR TITLE
Show "Reset sharing permissions" conditionally

### DIFF
--- a/assets/js/components/dashboard-sharing/DashboardSharingDialog/Footer/index.js
+++ b/assets/js/components/dashboard-sharing/DashboardSharingDialog/Footer/index.js
@@ -66,6 +66,9 @@ export default function Footer( { closeDialog, openResetDialog } ) {
 	const haveSharingSettingsChangedRoles = useSelect( ( select ) =>
 		select( CORE_MODULES ).haveSharingSettingsExpanded( 'sharedRoles' )
 	);
+	const haveSharingSettingsUpdated = useSelect( ( select ) =>
+		select( CORE_MODULES ).haveSharingSettingsUpdated()
+	);
 	const settingsDialogOpen = useSelect(
 		( select ) => !! select( CORE_UI ).getValue( SETTINGS_DIALOG )
 	);
@@ -129,16 +132,18 @@ export default function Footer( { closeDialog, openResetDialog } ) {
 			) }
 
 			<div className="googlesitekit-dashboard-sharing-settings__footer-actions">
-				{ settingsDialogOpen && ! showNotice && (
-					<div className="googlesitekit-dashboard-sharing-settings__footer-actions-left">
-						<Link onClick={ openResetDialog } danger>
-							{ __(
-								'Reset sharing permissions',
-								'google-site-kit'
-							) }
-						</Link>
-					</div>
-				) }
+				{ haveSharingSettingsUpdated &&
+					settingsDialogOpen &&
+					! showNotice && (
+						<div className="googlesitekit-dashboard-sharing-settings__footer-actions-left">
+							<Link onClick={ openResetDialog } danger>
+								{ __(
+									'Reset sharing permissions',
+									'google-site-kit'
+								) }
+							</Link>
+						</div>
+					) }
 
 				<div className="googlesitekit-dashboard-sharing-settings__footer-actions-right">
 					<Link onClick={ onCancel }>

--- a/assets/js/googlesitekit/modules/datastore/sharing-settings.js
+++ b/assets/js/googlesitekit/modules/datastore/sharing-settings.js
@@ -713,11 +713,7 @@ const baseSelectors = {
 		( select ) => ( state ) => {
 			const { savedSharingSettings } = state;
 
-			if ( ! savedSharingSettings ) {
-				return false;
-			}
-
-			if ( isEmpty( savedSharingSettings ) ) {
+			if ( ! savedSharingSettings || isEmpty( savedSharingSettings ) ) {
 				return false;
 			}
 

--- a/assets/js/googlesitekit/modules/datastore/sharing-settings.js
+++ b/assets/js/googlesitekit/modules/datastore/sharing-settings.js
@@ -713,7 +713,7 @@ const baseSelectors = {
 		( select ) => ( state ) => {
 			const { savedSharingSettings } = state;
 
-			if ( ! savedSharingSettings || isEmpty( savedSharingSettings ) ) {
+			if ( isEmpty( savedSharingSettings ) ) {
 				return false;
 			}
 

--- a/assets/js/googlesitekit/modules/datastore/sharing-settings.js
+++ b/assets/js/googlesitekit/modules/datastore/sharing-settings.js
@@ -42,6 +42,8 @@ const RECEIVE_SHAREABLE_ROLES = 'RECEIVE_SHAREABLE_ROLES';
 const START_SUBMIT_SHARING_CHANGES = 'START_SUBMIT_SHARING_CHANGES';
 const FINISH_SUBMIT_SHARING_CHANGES = 'FINISH_SUBMIT_SHARING_CHANGES';
 const ROLLBACK_SHARING_SETTINGS = 'ROLLBACK_SHARING_SETTINGS';
+const RECEIVE_DEFAULT_SHARED_OWNERSHIP_MODULE_SETTINGS =
+	'RECEIVE_DEFAULT_SHARED_OWNERSHIP_MODULE_SETTINGS';
 
 // Invariant error messages.
 export const INVARIANT_DOING_SUBMIT_SHARING_CHANGES =
@@ -56,6 +58,7 @@ const baseInitialState = {
 	savedSharingSettings: undefined,
 	shareableRoles: undefined,
 	isDoingSubmitSharingChanges: undefined,
+	defaultSharedOwnershipModuleSettings: undefined,
 };
 
 const fetchSaveSharingSettingsStore = createFetchStore( {
@@ -283,6 +286,32 @@ const baseActions = {
 			type: ROLLBACK_SHARING_SETTINGS,
 		};
 	},
+
+	/**
+	 * Receives defaultSharedOwnershipModuleSettings for dashboard sharing.
+	 * Stores defaultSharedOwnershipModuleSettings in the datastore.
+	 *
+	 * Because this is frequently-accessed data, this is usually sourced
+	 * from a global variable (`_googlesitekitDashboardSharingData`), set by PHP
+	 * in the `before_print` callback for `googlesitekit-datastore-site`.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param {Object} defaultSharedOwnershipModuleSettings Default sharing settings for the shared ownership modules.
+	 * @return {Object} Action for RECEIVE_DEFAULT_SHARED_OWNERSHIP_MODULE_SETTINGS.
+	 */
+	receiveDefaultSharedOwnershipModuleSettings(
+		defaultSharedOwnershipModuleSettings
+	) {
+		invariant(
+			defaultSharedOwnershipModuleSettings,
+			'defaultSharedOwnershipModuleSettings is required.'
+		);
+		return {
+			payload: { defaultSharedOwnershipModuleSettings },
+			type: RECEIVE_DEFAULT_SHARED_OWNERSHIP_MODULE_SETTINGS,
+		};
+	},
 };
 
 const baseReducer = ( state, { type, payload } ) => {
@@ -357,6 +386,14 @@ const baseReducer = ( state, { type, payload } ) => {
 			};
 		}
 
+		case RECEIVE_DEFAULT_SHARED_OWNERSHIP_MODULE_SETTINGS:
+			const { defaultSharedOwnershipModuleSettings } = payload;
+
+			return {
+				...state,
+				defaultSharedOwnershipModuleSettings,
+			};
+
 		default: {
 			return state;
 		}
@@ -398,6 +435,31 @@ const baseResolvers = {
 
 		const { roles } = global._googlesitekitDashboardSharingData;
 		yield actions.receiveShareableRoles( roles );
+	},
+
+	*getDefaultSharedOwnershipModuleSettings() {
+		const registry = yield Data.commonActions.getRegistry();
+
+		if (
+			registry
+				.select( CORE_MODULES )
+				.getDefaultSharedOwnershipModuleSettings()
+		) {
+			return;
+		}
+
+		if ( ! global._googlesitekitDashboardSharingData ) {
+			global.console.error(
+				'Could not load core/modules dashboard sharing.'
+			);
+			return;
+		}
+
+		const { defaultSharedOwnershipModuleSettings } =
+			global._googlesitekitDashboardSharingData;
+		yield baseActions.receiveDefaultSharedOwnershipModuleSettings(
+			defaultSharedOwnershipModuleSettings
+		);
 	},
 };
 
@@ -623,6 +685,19 @@ const baseSelectors = {
 	 */
 	isDoingSubmitSharingChanges( state ) {
 		return !! state.isDoingSubmitSharingChanges;
+	},
+
+	/**
+	 * Gets the default sharing settings for shared ownership modules.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param {Object} state Data store's state.
+	 * @return {(Object|undefined)} Sharing Settings object. Returns undefined if it is not loaded yet.
+	 */
+	getDefaultSharedOwnershipModuleSettings( state ) {
+		const { defaultSharedOwnershipModuleSettings } = state;
+		return defaultSharedOwnershipModuleSettings;
 	},
 };
 

--- a/assets/js/googlesitekit/modules/datastore/sharing-settings.js
+++ b/assets/js/googlesitekit/modules/datastore/sharing-settings.js
@@ -21,6 +21,7 @@
  */
 import invariant from 'invariant';
 import isEqual from 'lodash/isEqual';
+import isEmpty from 'lodash/isEmpty';
 import pick from 'lodash/pick';
 
 /**
@@ -699,6 +700,35 @@ const baseSelectors = {
 		const { defaultSharedOwnershipModuleSettings } = state;
 		return defaultSharedOwnershipModuleSettings;
 	},
+
+	/**
+	 * Indicates whether the sharing settings have updated from default.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param {Object} state Data store's state.
+	 * @return {boolean} True if the sharing settings have updated, false otherwise.
+	 */
+	haveSharingSettingsUpdated: createRegistrySelector(
+		( select ) => ( state ) => {
+			const { savedSharingSettings } = state;
+
+			if ( ! savedSharingSettings ) {
+				return false;
+			}
+
+			if ( isEmpty( savedSharingSettings ) ) {
+				return false;
+			}
+
+			const defaultSharingSettings =
+				select(
+					CORE_MODULES
+				).getDefaultSharedOwnershipModuleSettings();
+
+			return ! isEqual( savedSharingSettings, defaultSharingSettings );
+		}
+	),
 };
 
 const store = Data.combineStores(

--- a/assets/js/googlesitekit/modules/datastore/sharing-settings.test.js
+++ b/assets/js/googlesitekit/modules/datastore/sharing-settings.test.js
@@ -1068,6 +1068,10 @@ describe( 'core/modules sharing-settings', () => {
 
 		describe( 'haveSharingSettingsUpdated', () => {
 			it( 'informs whether saved sharing settings differ from the initial default ones', () => {
+				global[ dashboardSharingDataBaseVar ] = {
+					defaultSharedOwnershipModuleSettings,
+				};
+
 				// Initially false.
 				expect(
 					registry.select( CORE_MODULES ).haveSharingSettingsUpdated()

--- a/assets/js/googlesitekit/modules/datastore/sharing-settings.test.js
+++ b/assets/js/googlesitekit/modules/datastore/sharing-settings.test.js
@@ -1037,7 +1037,7 @@ describe( 'core/modules sharing-settings', () => {
 				).toBeUndefined();
 			} );
 
-			it( 'should return an empty object if there is no `defaultSharedOwnershipModuleSettings`', async () => {
+			it( 'should return an empty object if there is no `defaultSharedOwnershipModuleSettings`', () => {
 				global[ dashboardSharingDataBaseVar ] = {
 					defaultSharedOwnershipModuleSettings: {},
 				};
@@ -1051,7 +1051,7 @@ describe( 'core/modules sharing-settings', () => {
 				);
 			} );
 
-			it( 'should return the `defaultSharedOwnershipModuleSettings` object', async () => {
+			it( 'should return the `defaultSharedOwnershipModuleSettings` object', () => {
 				global[ dashboardSharingDataBaseVar ] = {
 					defaultSharedOwnershipModuleSettings,
 				};

--- a/includes/Core/Modules/Modules.php
+++ b/includes/Core/Modules/Modules.php
@@ -388,8 +388,8 @@ final class Modules {
 			2
 		);
 
-		add_filter( 'option_' . Module_Sharing_Settings::OPTION, $this->get_method_proxy( 'filter_shared_ownership_module_settings' ) );
-		add_filter( 'default_option_' . Module_Sharing_Settings::OPTION, $this->get_method_proxy( 'filter_shared_ownership_module_settings' ), 20 );
+		add_filter( 'option_' . Module_Sharing_Settings::OPTION, $this->get_method_proxy( 'populate_default_shared_ownership_module_settings' ) );
+		add_filter( 'default_option_' . Module_Sharing_Settings::OPTION, $this->get_method_proxy( 'populate_default_shared_ownership_module_settings' ), 20 );
 
 		add_action(
 			'add_option_' . Module_Sharing_Settings::OPTION,
@@ -1550,7 +1550,7 @@ final class Modules {
 	 * @param array $sharing_settings The dashboard_sharing settings option fetched from the database.
 	 * @return array Dashboard sharing settings option with default settings inserted for shared ownership modules.
 	 */
-	protected function filter_shared_ownership_module_settings( $sharing_settings ) {
+	protected function populate_default_shared_ownership_module_settings( $sharing_settings ) {
 		$shared_ownership_modules = array_keys( $this->get_shared_ownership_modules() );
 		foreach ( $shared_ownership_modules as $shared_ownership_module ) {
 			if ( ! isset( $sharing_settings[ $shared_ownership_module ] ) ) {

--- a/includes/Core/Modules/Modules.php
+++ b/includes/Core/Modules/Modules.php
@@ -1537,16 +1537,15 @@ final class Modules {
 	}
 
 	/**
-	 * Inserts default settings for shared ownership modules.
+	 * Inserts default settings for shared ownership modules in passed dashboard sharing settings.
 	 *
 	 * Sharing settings for shared ownership modules such as pagespeed-insights
 	 * and idea-hub should always be manageable by "all admins". This filter inserts
 	 * this 'default' setting for their respective module slugs even when the
 	 * dashboard_sharing settings option is not defined in the database or when settings
-	 * are not set for these modules. This filter is applied after every attempt to fetch
-	 * the googlesitekit-dashboard_sharing settings option from the database.
+	 * are not set for these modules.
 	 *
-	 * @since 1.75.0
+	 * @since n.e.x.t
 	 *
 	 * @param array $sharing_settings The dashboard_sharing settings option fetched from the database.
 	 * @return array Dashboard sharing settings option with default settings inserted for shared ownership modules.

--- a/includes/Core/Modules/Modules.php
+++ b/includes/Core/Modules/Modules.php
@@ -1540,12 +1540,13 @@ final class Modules {
 	 * Inserts default settings for shared ownership modules in passed dashboard sharing settings.
 	 *
 	 * Sharing settings for shared ownership modules such as pagespeed-insights
-	 * and idea-hub should always be manageable by "all admins". This filter inserts
+	 * and idea-hub should always be manageable by "all admins". This function inserts
 	 * this 'default' setting for their respective module slugs even when the
 	 * dashboard_sharing settings option is not defined in the database or when settings
 	 * are not set for these modules.
 	 *
-	 * @since n.e.x.t
+	 * @since 1.75.0
+	 * @since n.e.x.t Renamed from filter_shared_ownership_module_settings to populate_default_shared_ownership_module_settings.
 	 *
 	 * @param array $sharing_settings The dashboard_sharing settings option fetched from the database.
 	 * @return array Dashboard sharing settings option with default settings inserted for shared ownership modules.

--- a/includes/Core/Modules/Modules.php
+++ b/includes/Core/Modules/Modules.php
@@ -373,7 +373,8 @@ final class Modules {
 		add_filter(
 			'googlesitekit_dashboard_sharing_data',
 			function ( $data ) {
-				$data['sharedOwnershipModules'] = array_keys( $this->get_shared_ownership_modules() );
+				$data['sharedOwnershipModules']               = array_keys( $this->get_shared_ownership_modules() );
+				$data['defaultSharedOwnershipModuleSettings'] = $this->populate_default_shared_ownership_module_settings( array() );
 
 				return $data;
 			}


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #5840 

## Relevant technical choices

This PR updates the Dashboard Sharing Settings Dialog so that the "Reset sharing permissions" link is only displayed if the settings have been updated from the default settings.

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [x] Run the code.
- [x] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [x] Ensure no unrelated changes are included.
- [x] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [x] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [x] Ensure the PR has the correct target branch.
- [x] Double-check that the PR is okay to be merged.
- [x] Ensure the corresponding issue has a ZenHub release assigned.
- [x] Add a changelog message to the issue.
