### PR TITLE
Pre-fetch permissions endpoint

### DIFF
--- a/.storybook/utils/resetGlobals.js
+++ b/.storybook/utils/resetGlobals.js
@@ -67,15 +67,6 @@ export const resetGlobals = () => {
 		initialVersion: '',
 		verified: true,
 		userInputState: 'completed',
-		permissions: {
-			googlesitekit_authenticate: true,
-			googlesitekit_setup: true,
-			googlesitekit_view_posts_insights: true,
-			googlesitekit_view_dashboard: true,
-			googlesitekit_view_module_details: true,
-			googlesitekit_manage_options: true,
-			googlesitekit_publish_posts: true,
-		},
 	};
 	global._googlesitekitTrackingData = {
 		referenceSiteURL: 'http://example.com/',

--- a/assets/js/components/DashboardNavigation/index.test.js
+++ b/assets/js/components/DashboardNavigation/index.test.js
@@ -24,6 +24,7 @@ import {
 	VIEW_CONTEXT_DASHBOARD,
 	VIEW_CONTEXT_DASHBOARD_VIEW_ONLY,
 } from '../../googlesitekit/constants';
+import { CORE_USER } from '../../googlesitekit/datastore/user/constants';
 import { CORE_MODULES } from '../../googlesitekit/modules/datastore/constants';
 import { CORE_WIDGETS } from '../../googlesitekit/widgets/datastore/constants';
 import { CONTEXT_MAIN_DASHBOARD_SPEED } from '../../googlesitekit/widgets/default-contexts';
@@ -54,18 +55,16 @@ describe( 'Dashboard Navigation', () => {
 	} );
 
 	it( 'always uses `ANCHOR_ID_TRAFFIC` as the default chip when not viewing a shared dashboard', async () => {
-		global._googlesitekitUserData = {
-			permissions: {
-				googlesitekit_view_dashboard: true,
-				googlesitekit_manage_options: true,
-				'googlesitekit_manage_module_sharing_options::["search-console"]': true,
-				'googlesitekit_read_shared_module_data::["search-console"]': true,
-				'googlesitekit_read_shared_module_data::["analytics"]': false,
-			},
-		};
-
 		const { container } = render( <DashboardNavigation />, {
 			setupRegistry: ( registry ) => {
+				registry.dispatch( CORE_USER ).receiveGetCapabilities( {
+					googlesitekit_view_dashboard: true,
+					googlesitekit_manage_options: true,
+					'googlesitekit_manage_module_sharing_options::["search-console"]': true,
+					'googlesitekit_read_shared_module_data::["search-console"]': true,
+					'googlesitekit_read_shared_module_data::["analytics"]': false,
+				} );
+
 				registry.dispatch( CORE_MODULES ).receiveGetModules( [
 					{
 						slug: 'search-console',
@@ -90,18 +89,16 @@ describe( 'Dashboard Navigation', () => {
 	} );
 
 	it( 'uses `ANCHOR_ID_TRAFFIC` as the chip viewing a shared dashboard with the traffic section enabled', () => {
-		global._googlesitekitUserData = {
-			permissions: {
-				googlesitekit_view_dashboard: true,
-				googlesitekit_manage_options: true,
-				'googlesitekit_manage_module_sharing_options::["search-console"]': true,
-				'googlesitekit_read_shared_module_data::["search-console"]': true,
-				'googlesitekit_read_shared_module_data::["analytics"]': false,
-			},
-		};
-
 		const { container } = render( <DashboardNavigation />, {
 			setupRegistry: ( registry ) => {
+				registry.dispatch( CORE_USER ).receiveGetCapabilities( {
+					googlesitekit_view_dashboard: true,
+					googlesitekit_manage_options: true,
+					'googlesitekit_manage_module_sharing_options::["search-console"]': true,
+					'googlesitekit_read_shared_module_data::["search-console"]': true,
+					'googlesitekit_read_shared_module_data::["analytics"]': false,
+				} );
+
 				registry.dispatch( CORE_MODULES ).receiveGetModules( [
 					{
 						slug: 'search-console',
@@ -126,19 +123,17 @@ describe( 'Dashboard Navigation', () => {
 	} );
 
 	it( 'uses `ANCHOR_ID_CONTENT` as the chip viewing a shared dashboard with the traffic sections unavailable', async () => {
-		global._googlesitekitUserData = {
-			permissions: {
-				googlesitekit_view_dashboard: true,
-				googlesitekit_manage_options: true,
-				'googlesitekit_manage_module_sharing_options::["search-console"]': false,
-				'googlesitekit_read_shared_module_data::["search-console"]': false,
-				'googlesitekit_read_shared_module_data::["analytics"]': false,
-				'googlesitekit_read_shared_module_data::["pagespeed-insights"]': true,
-			},
-		};
-
 		const { container } = render( <DashboardNavigation />, {
 			setupRegistry: ( registry ) => {
+				registry.dispatch( CORE_USER ).receiveGetCapabilities( {
+					googlesitekit_view_dashboard: true,
+					googlesitekit_manage_options: true,
+					'googlesitekit_manage_module_sharing_options::["search-console"]': false,
+					'googlesitekit_read_shared_module_data::["search-console"]': false,
+					'googlesitekit_read_shared_module_data::["analytics"]': false,
+					'googlesitekit_read_shared_module_data::["pagespeed-insights"]': true,
+				} );
+
 				registry.dispatch( CORE_MODULES ).receiveGetModules( [
 					{
 						slug: 'pagespeed-insights',

--- a/assets/js/components/legacy-setup/SetupUsingGCP.js
+++ b/assets/js/components/legacy-setup/SetupUsingGCP.js
@@ -63,10 +63,7 @@ class SetupUsingGCP extends Component {
 			needReauthenticate,
 		} = global._googlesitekitLegacyData.setup;
 
-		const { canSetup } = props;
-
 		this.state = {
-			canSetup,
 			isAuthenticated,
 			isVerified,
 			needReauthenticate,
@@ -214,7 +211,6 @@ class SetupUsingGCP extends Component {
 
 	render() {
 		const {
-			canSetup,
 			isAuthenticated,
 			isVerified,
 			needReauthenticate,
@@ -223,7 +219,7 @@ class SetupUsingGCP extends Component {
 			isSiteKitConnected,
 		} = this.state;
 
-		const { redirectURL } = this.props;
+		const { canSetup, redirectURL } = this.props;
 
 		if ( this.isSetupFinished() ) {
 			delay(

--- a/assets/js/googlesitekit/datastore/user/permissions.js
+++ b/assets/js/googlesitekit/datastore/user/permissions.js
@@ -108,7 +108,7 @@ const baseActions = {
 	/**
 	 * Refreshes user capabilities.
 	 *
-	 * @since 1.82.0*
+	 * @since 1.82.0
 	 *
 	 * @return {Object} Redux-style action.
 	 */

--- a/assets/js/googlesitekit/datastore/user/permissions.js
+++ b/assets/js/googlesitekit/datastore/user/permissions.js
@@ -108,10 +108,21 @@ const baseActions = {
 	/**
 	 * Refreshes user capabilities.
 	 *
-	 * @since 1.82.0
+	 * @since 1.82.0*
+	 *
+	 * @return {Object} Redux-style action.
 	 */
 	*refreshCapabilities() {
-		yield fetchGetCapabilitiesStore.actions.fetchGetCapabilities();
+		const { dispatch } = yield Data.commonActions.getRegistry();
+
+		const { response, error } =
+			yield fetchGetCapabilitiesStore.actions.fetchGetCapabilities();
+
+		if ( error ) {
+			yield dispatch( CORE_USER ).setPermissionScopeError( error );
+		}
+
+		return { response, error };
 	},
 };
 

--- a/includes/Core/Permissions/Permissions.php
+++ b/includes/Core/Permissions/Permissions.php
@@ -17,6 +17,7 @@ use Google\Site_Kit\Core\Dismissals\Dismissed_Items;
 use Google\Site_Kit\Core\Modules\Module_With_Owner;
 use Google\Site_Kit\Core\Modules\Modules;
 use Google\Site_Kit\Core\REST_API\REST_Route;
+use Google\Site_Kit\Core\REST_API\REST_Routes;
 use Google\Site_Kit\Core\Storage\User_Options;
 use Google\Site_Kit\Core\Util\Feature_Flags;
 use WP_REST_Response;
@@ -235,10 +236,14 @@ final class Permissions {
 		);
 
 		add_filter(
-			'googlesitekit_user_data',
-			function( $data ) {
-				$data['permissions'] = $this->check_all_for_current_user();
-				return $data;
+			'googlesitekit_apifetch_preload_paths',
+			function ( $paths ) {
+				return array_merge(
+					$paths,
+					array(
+						'/' . REST_Routes::REST_ROOT . '/core/user/data/permissions',
+					)
+				);
 			}
 		);
 

--- a/stories/setup.stories.js
+++ b/stories/setup.stories.js
@@ -29,6 +29,7 @@ import { CORE_USER } from '../assets/js/googlesitekit/datastore/user/constants';
 import {
 	createTestRegistry,
 	provideUserAuthentication,
+	provideUserCapabilities,
 	WithTestRegistry,
 } from '../tests/js/utils';
 
@@ -50,6 +51,8 @@ storiesOf( 'Setup / Using GCP', module ).add(
 		provideUserAuthentication( registry, {
 			authenticated: false,
 		} );
+
+		provideUserCapabilities( registry );
 
 		return (
 			<WithTestRegistry registry={ registry }>

--- a/tests/phpunit/integration/Core/Permissions/PermissionsTest.php
+++ b/tests/phpunit/integration/Core/Permissions/PermissionsTest.php
@@ -84,7 +84,7 @@ class PermissionsTest extends TestCase {
 
 		$this->assertTrue( has_filter( 'map_meta_cap' ) );
 		$this->assertTrue( has_filter( 'googlesitekit_rest_routes' ) );
-		$this->assertTrue( has_filter( 'googlesitekit_user_data' ) );
+		$this->assertTrue( has_filter( 'googlesitekit_apifetch_preload_paths' ) );
 		$this->assertTrue( has_filter( 'user_has_cap' ) );
 	}
 
@@ -99,7 +99,7 @@ class PermissionsTest extends TestCase {
 
 		$this->assertTrue( has_filter( 'map_meta_cap' ) );
 		$this->assertTrue( has_filter( 'googlesitekit_rest_routes' ) );
-		$this->assertTrue( has_filter( 'googlesitekit_user_data' ) );
+		$this->assertTrue( has_filter( 'googlesitekit_apifetch_preload_paths' ) );
 		$this->assertFalse( has_filter( 'user_has_cap' ) );
 	}
 


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #5772 

## Relevant technical choices

This PR prevents the permissions endpoint from being globally exposed and pre-fetches its data.

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
