### PR TITLE
Enhance/5806 - Enhance TwG HTTPS restriction to be based on home URL rather than current request

### DIFF
--- a/includes/Core/Modules/Modules.php
+++ b/includes/Core/Modules/Modules.php
@@ -39,6 +39,7 @@ use WP_REST_Response;
 use WP_Error;
 use Exception;
 use Google\Site_Kit\Core\Util\Build_Mode;
+use Google\Site_Kit\Core\Util\URL;
 
 /**
  * Class managing the different modules.
@@ -215,11 +216,7 @@ final class Modules {
 			return true;
 		}
 
-		if ( is_ssl() ) {
-			return true;
-		}
-
-		if ( isset( $_SERVER['HTTP_X_FORWARDED_PROTO'] ) && 'https' === $_SERVER['HTTP_X_FORWARDED_PROTO'] ) {
+		if ( 'https' === URL::parse( home_url(), PHP_URL_SCHEME ) ) {
 			return true;
 		}
 

--- a/tests/phpunit/integration/Core/Modules/ModulesTest.php
+++ b/tests/phpunit/integration/Core/Modules/ModulesTest.php
@@ -121,12 +121,24 @@ class ModulesTest extends TestCase {
 		$this->assertEquals( false, Modules::should_enable_twg() );
 	}
 
-	public function test_should_enable_twg_behind_proxy() {
+	public function test_should_enable_twg_ssl_home_url() {
 		$this->enable_feature( 'twgModule' );
-		$_SERVER['HTTP_X_FORWARDED_PROTO'] = 'https';
+
+		$home_url_hook = function() {
+			return 'http://non-https.site';
+		};
+
+		add_filter( 'home_url', $home_url_hook );
+		$this->assertEquals( false, Modules::should_enable_twg() );
+		remove_filter( 'home_url', $home_url_hook );
+
+		$home_url_hook = function() {
+			return 'https://with-https.site';
+		};
+
+		add_filter( 'home_url', $home_url_hook );
 		$this->assertEquals( true, Modules::should_enable_twg() );
-		// Reset HTTP_X_FORWARDED_PROTO.
-		unset( $_SERVER['HTTP_X_FORWARDED_PROTO'] );
+		remove_filter( 'home_url', $home_url_hook );
 	}
 
 	public function test_should_enable_twg_ssl() {
@@ -135,6 +147,7 @@ class ModulesTest extends TestCase {
 		$this->assertEquals( true, Modules::should_enable_twg() );
 		// Reset HTTPS.
 		unset( $_SERVER['HTTPS'] );
+		$this->assertEquals( false, Modules::should_enable_twg() );
 	}
 
 	public function test_register() {


### PR DESCRIPTION
## Summary

Addresses issue:

- #5806 

## Relevant technical choices

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [x] Run the code.
- [x] Ensure the acceptance criteria are satisfied.
- [x] Reassess the implementation with the IB.
- [x] Ensure no unrelated changes are included.
- [x] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [x] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [x] Ensure the PR has the correct target branch.
- [x] Double-check that the PR is okay to be merged.
- [x] Ensure the corresponding issue has a ZenHub release assigned.
- [x] Add a changelog message to the issue.
