### PR TITLE
Add minimal MU support for Site Kit

### DIFF
--- a/includes/Context.php
+++ b/includes/Context.php
@@ -147,11 +147,6 @@ class Context {
 	/**
 	 * Determines whether the plugin is running in network mode.
 	 *
-	 * Network mode is active under the following conditions:
-	 * * Multisite is enabled.
-	 * * The plugin is network-active.
-	 * * The site's domain matches the network's domain (which means it is a subdirectory site).
-	 *
 	 * @since 1.0.0
 	 *
 	 * @return bool True if the plugin is in network mode, false otherwise.
@@ -162,11 +157,16 @@ class Context {
 			return false;
 		}
 
-		$site    = get_site( get_current_blog_id() );
-		$network = get_network( $site->network_id );
-
-		// Use network mode when the site's domain is the same as the network's domain.
-		return $network && $site->domain === $network->domain;
+		/**
+		 * Filters whether network mode is active in Site Kit.
+		 *
+		 * This is always false by default since Site Kit does not support a network mode yet.
+		 *
+		 * @since n.e.x.t
+		 *
+		 * @param bool $active Whether network mode is active.
+		 */
+		return (bool) apply_filters( 'googlesitekit_is_network_mode', false );
 	}
 
 	/**

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -64,7 +64,7 @@ final class Plugin {
 	 * @since 1.0.0
 	 */
 	public function register() {
-		if ( $this->context->is_network_active() ) {
+		if ( $this->context->is_network_mode() ) {
 			add_action(
 				'network_admin_notices',
 				function() {
@@ -73,15 +73,12 @@ final class Plugin {
 						<p>
 							<?php
 							echo wp_kses(
-								__( 'The Site Kit by Google plugin is <strong>not yet compatible</strong> for use in a WordPress multisite network, but we&#8217;re actively working on that.', 'google-site-kit' ),
+								__( 'The Site Kit by Google plugin does <strong>not yet offer</strong> a network mode, but we&#8217;re actively working on that.', 'google-site-kit' ),
 								array(
 									'strong' => array(),
 								)
 							);
 							?>
-						</p>
-						<p>
-							<?php esc_html_e( 'Meanwhile, we recommend deactivating it in the network and re-activating it for an individual site.', 'google-site-kit' ); ?>
 						</p>
 					</div>
 					<?php

--- a/tests/phpunit/integration/Core/Storage/OptionsTest.php
+++ b/tests/phpunit/integration/Core/Storage/OptionsTest.php
@@ -52,6 +52,10 @@ class OptionsTest extends TestCase {
 		$options = new Options( $context );
 		delete_network_option( null, 'test_option' );
 		$this->network_activate_site_kit();
+
+		// Force enable network mode.
+		add_filter( 'googlesitekit_is_network_mode', '__return_true' );
+
 		$this->assertTrue( $context->is_network_mode() );
 
 		$this->assertFalse( $options->get( 'test_option' ) );
@@ -76,6 +80,10 @@ class OptionsTest extends TestCase {
 		$context = new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE );
 		$options = new Options( $context );
 		$this->network_activate_site_kit();
+
+		// Force enable network mode.
+		add_filter( 'googlesitekit_is_network_mode', '__return_true' );
+
 		$this->assertTrue( $context->is_network_mode() );
 
 		$this->assertFalse( get_network_option( null, 'test_option' ) );
@@ -101,6 +109,10 @@ class OptionsTest extends TestCase {
 		$context = new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE );
 		$options = new Options( $context );
 		$this->network_activate_site_kit();
+
+		// Force enable network mode.
+		add_filter( 'googlesitekit_is_network_mode', '__return_true' );
+
 		$this->assertTrue( $context->is_network_mode() );
 
 		update_network_option( null, 'test_option', 'test-value' );

--- a/tests/phpunit/integration/Core/Storage/SettingTest.php
+++ b/tests/phpunit/integration/Core/Storage/SettingTest.php
@@ -82,6 +82,10 @@ class SettingTest extends TestCase {
 		$setting = new FakeSetting( new Options( $this->context ) );
 		delete_network_option( null, FakeSetting::OPTION );
 		$this->network_activate_site_kit();
+
+		// Force enable network mode.
+		add_filter( 'googlesitekit_is_network_mode', '__return_true' );
+
 		$this->assertTrue( $this->context->is_network_mode() );
 
 		$this->assertFalse( $setting->get() );
@@ -105,6 +109,10 @@ class SettingTest extends TestCase {
 	public function test_network_mode_set() {
 		$setting = new FakeSetting( new Options( $this->context ) );
 		$this->network_activate_site_kit();
+
+		// Force enable network mode.
+		add_filter( 'googlesitekit_is_network_mode', '__return_true' );
+
 		$this->assertTrue( $this->context->is_network_mode() );
 
 		$this->assertFalse( get_network_option( null, FakeSetting::OPTION ) );
@@ -129,6 +137,10 @@ class SettingTest extends TestCase {
 	public function test_network_mode_delete() {
 		$setting = new FakeSetting( new Options( $this->context ) );
 		$this->network_activate_site_kit();
+
+		// Force enable network mode.
+		add_filter( 'googlesitekit_is_network_mode', '__return_true' );
+
 		$this->assertTrue( $this->context->is_network_mode() );
 
 		update_network_option( null, FakeSetting::OPTION, 'test-value' );

--- a/tests/phpunit/integration/Core/Storage/TransientsTest.php
+++ b/tests/phpunit/integration/Core/Storage/TransientsTest.php
@@ -33,6 +33,10 @@ class TransientsTest extends TestCase {
 	 */
 	public function test_network_mode_get() {
 		$this->network_activate_site_kit();
+
+		// Force enable network mode.
+		add_filter( 'googlesitekit_is_network_mode', '__return_true' );
+
 		$context    = new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE );
 		$transients = new Transients( $context );
 		$this->assertTrue( $context->is_network_mode() );
@@ -57,6 +61,10 @@ class TransientsTest extends TestCase {
 	 */
 	public function test_network_mode_set() {
 		$this->network_activate_site_kit();
+
+		// Force enable network mode.
+		add_filter( 'googlesitekit_is_network_mode', '__return_true' );
+
 		$context    = new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE );
 		$transients = new Transients( $context );
 		$this->assertTrue( $context->is_network_mode() );
@@ -84,6 +92,10 @@ class TransientsTest extends TestCase {
 	 */
 	public function test_network_mode_delete() {
 		$this->network_activate_site_kit();
+
+		// Force enable network mode.
+		add_filter( 'googlesitekit_is_network_mode', '__return_true' );
+
 		$context    = new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE );
 		$transients = new Transients( $context );
 		$this->assertTrue( $context->is_network_mode() );

--- a/tests/phpunit/integration/Core/Storage/User_OptionsTest.php
+++ b/tests/phpunit/integration/Core/Storage/User_OptionsTest.php
@@ -39,6 +39,10 @@ class User_OptionsTest extends TestCase {
 	 */
 	public function test_network_mode_get() {
 		$this->network_activate_site_kit();
+
+		// Force enable network mode.
+		add_filter( 'googlesitekit_is_network_mode', '__return_true' );
+
 		$user_id = $this->factory()->user->create();
 		$context = new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE );
 		$options = new User_Options( $context, $user_id );
@@ -67,6 +71,10 @@ class User_OptionsTest extends TestCase {
 	 */
 	public function test_network_mode_set() {
 		$this->network_activate_site_kit();
+
+		// Force enable network mode.
+		add_filter( 'googlesitekit_is_network_mode', '__return_true' );
+
 		$user_id = $this->factory()->user->create();
 		$context = new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE );
 		$options = new User_Options( $context, $user_id );
@@ -96,6 +104,10 @@ class User_OptionsTest extends TestCase {
 	 */
 	public function test_network_mode_delete() {
 		$this->network_activate_site_kit();
+
+		// Force enable network mode.
+		add_filter( 'googlesitekit_is_network_mode', '__return_true' );
+
 		$user_id = $this->factory()->user->create();
 		$context = new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE );
 		$options = new User_Options( $context, $user_id );

--- a/tests/phpunit/integration/Core/Storage/User_TransientsTest.php
+++ b/tests/phpunit/integration/Core/Storage/User_TransientsTest.php
@@ -83,6 +83,9 @@ class User_TransientsTest extends TestCase {
 	public function test_network_mode_get_using_external_cache() {
 		$this->network_activate_site_kit();
 
+		// Force enable network mode.
+		add_filter( 'googlesitekit_is_network_mode', '__return_true' );
+
 		list( $user_transients, $user_id ) = $this->using_external_cache();
 		wp_cache_set( "user_{$user_id}_testkey2", 'qwerty2', 'site-transient', 1000 );
 		$this->assertEquals( 'qwerty2', $user_transients->get( 'testkey2' ) );
@@ -99,6 +102,9 @@ class User_TransientsTest extends TestCase {
 	 */
 	public function test_network_mode_set_using_external_cache() {
 		$this->network_activate_site_kit();
+
+		// Force enable network mode.
+		add_filter( 'googlesitekit_is_network_mode', '__return_true' );
 
 		list( $user_transients, $user_id ) = $this->using_external_cache();
 		$user_transients->set( 'testkey4', 'qwerty4', 1000 );
@@ -119,6 +125,9 @@ class User_TransientsTest extends TestCase {
 	 */
 	public function test_network_mode_delete_using_external_cache() {
 		$this->network_activate_site_kit();
+
+		// Force enable network mode.
+		add_filter( 'googlesitekit_is_network_mode', '__return_true' );
 
 		list( $user_transients, $user_id ) = $this->using_external_cache();
 		wp_cache_set( "user_{$user_id}_testkey6", 'qwerty6', 'site-transient', 1000 );

--- a/tests/phpunit/integration/Core/Util/Activation_FlagTest.php
+++ b/tests/phpunit/integration/Core/Util/Activation_FlagTest.php
@@ -43,6 +43,10 @@ class Activation_FlagTest extends TestCase {
 	 */
 	public function test_network_mode_register() {
 		$this->network_activate_site_kit();
+
+		// Force enable network mode.
+		add_filter( 'googlesitekit_is_network_mode', '__return_true' );
+
 		// Fake network admin context for assets enqueue
 		set_current_screen( 'test-network' );
 		$context         = new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE );

--- a/tests/phpunit/integration/Core/Util/ResetPersistentTest.php
+++ b/tests/phpunit/integration/Core/Util/ResetPersistentTest.php
@@ -37,6 +37,10 @@ class ResetPersistentTest extends TestCase {
 	 */
 	public function test_network_mode_all() {
 		$this->network_activate_site_kit();
+
+		// Force enable network mode.
+		add_filter( 'googlesitekit_is_network_mode', '__return_true' );
+
 		$context = new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE );
 		$this->assertTrue( $context->is_network_mode() );
 

--- a/tests/phpunit/integration/Core/Util/ResetTest.php
+++ b/tests/phpunit/integration/Core/Util/ResetTest.php
@@ -72,6 +72,10 @@ class ResetTest extends TestCase {
 	 */
 	public function test_network_mode_all() {
 		$this->network_activate_site_kit();
+
+		// Force enable network mode.
+		add_filter( 'googlesitekit_is_network_mode', '__return_true' );
+
 		$context = new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE );
 		$this->assertTrue( $context->is_network_mode() );
 

--- a/tests/phpunit/integration/PluginTest.php
+++ b/tests/phpunit/integration/PluginTest.php
@@ -102,6 +102,10 @@ class PluginTest extends TestCase {
 	 */
 	public function test_network_mode_register() {
 		$this->network_activate_site_kit();
+
+		// Force enable network mode.
+		add_filter( 'googlesitekit_is_network_mode', '__return_true' );
+
 		$plugin = new Plugin( GOOGLESITEKIT_PLUGIN_MAIN_FILE );
 		$this->assertTrue( $plugin->context()->is_network_mode() );
 		remove_all_actions( 'network_admin_notices' );

--- a/tests/phpunit/integration/PluginTest.php
+++ b/tests/phpunit/integration/PluginTest.php
@@ -117,7 +117,7 @@ class PluginTest extends TestCase {
 		$network_admin_notices = ob_get_clean();
 
 		// Regex is case-insensitive and dotall (s) to match over multiple lines.
-		$this->assertMatchesRegularExpression( '#<div class="notice notice-warning.*?not yet compatible.*?</div>#is', $network_admin_notices );
+		$this->assertMatchesRegularExpression( '#<div class="notice notice-warning.*?not yet offer.*?</div>#is', $network_admin_notices );
 	}
 
 	public function test_load_and_instance() {


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #5871 

## Relevant technical choices

This PR adds minimal support for multisite so that when Site Kit is network active, it still works as expected in single sites.

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
