### PR TITLE
User menu does not show which account is connected.

### DIFF
--- a/assets/js/components/Button.js
+++ b/assets/js/components/Button.js
@@ -49,6 +49,7 @@ const Button = forwardRef(
 			trailingIcon,
 			'aria-label': ariaLabel,
 			title,
+			customizedTooltip,
 			tooltip,
 			inverse,
 			...extraProps
@@ -112,14 +113,14 @@ const Button = forwardRef(
 			</SemanticButton>
 		);
 
+		const tooltipTitle = title || customizedTooltip || ariaLabel;
+
 		if (
-			( tooltip && ( title || ariaLabel ) ) ||
-			( icon && ( title || ariaLabel ) && children === undefined )
+			( tooltip && tooltipTitle ) ||
+			( icon && tooltipTitle && children === undefined )
 		) {
 			return (
-				<Tooltip title={ title || ariaLabel }>
-					{ ButtonComponent }
-				</Tooltip>
+				<Tooltip title={ tooltipTitle }>{ ButtonComponent }</Tooltip>
 			);
 		}
 
@@ -140,6 +141,7 @@ Button.propTypes = {
 	icon: PropTypes.element,
 	trailingIcon: PropTypes.element,
 	title: PropTypes.string,
+	customizedTooltip: PropTypes.element,
 	tooltip: PropTypes.bool,
 	inverse: PropTypes.bool,
 };
@@ -154,6 +156,7 @@ Button.defaultProps = {
 	icon: null,
 	trailingIcon: null,
 	title: null,
+	customizedTooltip: null,
 	tooltip: false,
 	inverse: false,
 };

--- a/assets/js/components/UserMenu.js
+++ b/assets/js/components/UserMenu.js
@@ -58,6 +58,9 @@ export default function UserMenu() {
 	const userPicture = useSelect( ( select ) =>
 		select( CORE_USER ).getPicture()
 	);
+	const userFullName = useSelect( ( select ) =>
+		select( CORE_USER ).getFullName()
+	);
 	const postDisconnectURL = useSelect( ( select ) =>
 		select( CORE_SITE ).getAdminURL( 'googlesitekit-splash', {
 			googlesitekit_context: 'revoked',
@@ -185,6 +188,13 @@ export default function UserMenu() {
 					aria-controls="user-menu"
 					aria-label={ __( 'Account', 'google-site-kit' ) }
 					tooltip
+					customizedTooltip={
+						<Fragment>
+							<strong>Google Account</strong>
+							<p>{ userFullName }</p>
+							<p>{ userEmail }</p>
+						</Fragment>
+					}
 				/>
 
 				<Menu

--- a/assets/js/components/UserMenu.js
+++ b/assets/js/components/UserMenu.js
@@ -190,9 +190,11 @@ export default function UserMenu() {
 					tooltip
 					customizedTooltip={
 						<Fragment>
-							<strong>Google Account</strong>
-							<p>{ userFullName }</p>
-							<p>{ userEmail }</p>
+							<strong>{ __( 'Google Account' ) }</strong>
+							<br />
+							{ userFullName }
+							<br />
+							{ userEmail }
 						</Fragment>
 					}
 				/>

--- a/assets/js/components/UserMenu.js
+++ b/assets/js/components/UserMenu.js
@@ -190,7 +190,10 @@ export default function UserMenu() {
 					tooltip
 					customizedTooltip={
 						<Fragment>
-							<strong>{ __( 'Google Account' ) }</strong>
+							<strong>
+								{ __( 'Google Account', 'google-site-kit' ) }
+							</strong>
+							<br />
 							<br />
 							{ userFullName }
 							<br />

--- a/assets/js/components/UserMenu.stories.js
+++ b/assets/js/components/UserMenu.stories.js
@@ -1,7 +1,7 @@
 /**
  * UserMenu stories.
  *
- * Site Kit by Google, Copyright 2022 Google LLC
+ * Site Kit by Google, Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/assets/js/components/UserMenu.stories.js
+++ b/assets/js/components/UserMenu.stories.js
@@ -1,7 +1,7 @@
 /**
  * UserMenu stories.
  *
- * Site Kit by Google, Copyright 2021 Google LLC
+ * Site Kit by Google, Copyright 2022 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,29 +17,34 @@
  */
 
 /**
- * External dependencies
- */
-import { storiesOf } from '@storybook/react';
-
-/**
  * Internal dependencies
  */
 import {
 	provideSiteInfo,
 	provideUserInfo,
 	WithTestRegistry,
-} from '../tests/js/utils';
-import UserMenu from '../assets/js/components/UserMenu';
+} from '../../../tests/js/utils';
+import UserMenu from './UserMenu';
 
-storiesOf( 'Global', module ).add( 'UserMenu', () => {
-	const setupRegistry = ( registry ) => {
-		provideSiteInfo( registry );
-		provideUserInfo( registry );
-	};
+const Template = ( args ) => <UserMenu { ...args } />;
 
-	return (
-		<WithTestRegistry callback={ setupRegistry }>
-			<UserMenu />
-		</WithTestRegistry>
-	);
-} );
+export const DefaultUserMenu = Template.bind( {} );
+
+export default {
+	title: 'Components/UserMenu',
+	component: UserMenu,
+	decorators: [
+		( Story ) => {
+			const setupRegistry = ( registry ) => {
+				provideSiteInfo( registry );
+				provideUserInfo( registry );
+			};
+
+			return (
+				<WithTestRegistry callback={ setupRegistry }>
+					<Story />
+				</WithTestRegistry>
+			);
+		},
+	],
+};

--- a/assets/js/components/setup/__snapshots__/SetupUsingProxyWithSignIn.test.js.snap
+++ b/assets/js/components/setup/__snapshots__/SetupUsingProxyWithSignIn.test.js.snap
@@ -119,7 +119,6 @@ exports[`SetupUsingProxyWithSignIn should not render the Activate Analytics noti
               aria-label="Account"
               class="mdc-button googlesitekit-header__dropdown mdc-button--dropdown googlesitekit-border-radius-round--tablet googlesitekit-border-radius-round--phone googlesitekit-border-radius-round googlesitekit-button-icon"
               target="_self"
-              title="Account"
             >
               <i
                 aria-hidden="true"
@@ -387,7 +386,6 @@ exports[`SetupUsingProxyWithSignIn should render the setup page, including the A
               aria-label="Account"
               class="mdc-button googlesitekit-header__dropdown mdc-button--dropdown googlesitekit-border-radius-round--tablet googlesitekit-border-radius-round--phone googlesitekit-border-radius-round googlesitekit-button-icon"
               target="_self"
-              title="Account"
             >
               <i
                 aria-hidden="true"

--- a/assets/js/googlesitekit/datastore/user/user-info.js
+++ b/assets/js/googlesitekit/datastore/user/user-info.js
@@ -399,6 +399,21 @@ export const selectors = {
 	} ),
 
 	/**
+	 * Gets the full name name for this user.
+	 *
+	 * Returns full name of the user or `undefined` if the user info is not available/loaded.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param {Object} state Data store's state.
+	 * @return {(string|undefined)} The user's full name.
+	 */
+	getFullName: createRegistrySelector( ( select ) => () => {
+		const user = select( CORE_USER ).getUser();
+		return user !== undefined ? user.full_name : user;
+	} ),
+
+	/**
 	 * Gets an account chooser url with the current user's email.
 	 *
 	 * @since 1.80.0

--- a/assets/js/googlesitekit/datastore/user/user-info.js
+++ b/assets/js/googlesitekit/datastore/user/user-info.js
@@ -410,11 +410,11 @@ export const selectors = {
 	 */
 	getFullName: createRegistrySelector( ( select ) => () => {
 		const user = select( CORE_USER ).getUser();
-		
+
 		if ( user === undefined ) {
 			return undefined;
 		}
-		
+
 		return user.full_name;
 	} ),
 

--- a/assets/js/googlesitekit/datastore/user/user-info.js
+++ b/assets/js/googlesitekit/datastore/user/user-info.js
@@ -410,7 +410,12 @@ export const selectors = {
 	 */
 	getFullName: createRegistrySelector( ( select ) => () => {
 		const user = select( CORE_USER ).getUser();
-		return user !== undefined ? user.full_name : user;
+		
+		if ( user === undefined ) {
+			return undefined;
+		}
+		
+		return user.full_name;
 	} ),
 
 	/**

--- a/assets/js/googlesitekit/datastore/user/user-info.test.js
+++ b/assets/js/googlesitekit/datastore/user/user-info.test.js
@@ -344,7 +344,7 @@ describe( 'core/user userInfo', () => {
 				expect( console ).toHaveErrored();
 			} );
 			it( 'will return the correct value when data is available', async () => {
-				// Set up the global
+				// Set up the global.
 				global[ userDataGlobal ] = userData;
 
 				registry.select( CORE_USER )[ selector ]();

--- a/includes/Core/Authentication/Authentication.php
+++ b/includes/Core/Authentication/Authentication.php
@@ -362,9 +362,10 @@ final class Authentication {
 			'googlesitekit_user_data',
 			function( $user ) {
 				if ( $this->profile->has() ) {
-					$profile_data            = $this->profile->get();
-					$user['user']['email']   = $profile_data['email'];
-					$user['user']['picture'] = $profile_data['photo'];
+					$profile_data              = $this->profile->get();
+					$user['user']['email']     = $profile_data['email'];
+					$user['user']['picture']   = $profile_data['photo'];
+					$user['user']['full_name'] = $profile_data['full_name'];
 				}
 
 				$user['connectURL']        = esc_url_raw( $this->get_connect_url() );

--- a/includes/Core/Authentication/Clients/OAuth_Client.php
+++ b/includes/Core/Authentication/Clients/OAuth_Client.php
@@ -21,7 +21,6 @@ use Google\Site_Kit\Core\Authentication\Token;
 use Google\Site_Kit\Core\Permissions\Permissions;
 use Google\Site_Kit\Core\Storage\Options;
 use Google\Site_Kit\Core\Storage\User_Options;
-use Google\Site_Kit\Core\Util\Feature_Flags;
 use Google\Site_Kit\Core\Util\Scopes;
 use Google\Site_Kit\Core\Util\URL;
 use Google\Site_Kit_Dependencies\Google\Service\PeopleService as Google_Service_PeopleService;
@@ -507,13 +506,14 @@ final class OAuth_Client extends OAuth_Client_Base {
 	public function refresh_profile_data( $retry_after = 0 ) {
 		try {
 			$people_service = new Google_Service_PeopleService( $this->get_client() );
-			$response       = $people_service->people->get( 'people/me', array( 'personFields' => 'emailAddresses,photos' ) );
+			$response       = $people_service->people->get( 'people/me', array( 'personFields' => 'emailAddresses,photos,names' ) );
 
-			if ( isset( $response['emailAddresses'][0]['value'], $response['photos'][0]['url'] ) ) {
+			if ( isset( $response['emailAddresses'][0]['value'], $response['photos'][0]['url'], $response['names'][0]['displayName'] ) ) {
 				$this->profile->set(
 					array(
-						'email' => $response['emailAddresses'][0]['value'],
-						'photo' => $response['photos'][0]['url'],
+						'email'     => $response['emailAddresses'][0]['value'],
+						'photo'     => $response['photos'][0]['url'],
+						'full_name' => $response['names'][0]['displayName'],
 					)
 				);
 			}

--- a/tests/js/utils.js
+++ b/tests/js/utils.js
@@ -258,6 +258,7 @@ export const provideUserInfo = ( registry, extraData = {} ) => {
 	const defaults = {
 		id: 1,
 		name: 'Wapuu WordPress',
+		full_name: 'Wapuu WordPress PhD',
 		email: 'wapuu.wordpress@gmail.com',
 		picture:
 			'https://wapu.us/wp-content/uploads/2017/11/WapuuFinal-100x138.png',

--- a/tests/phpunit/integration/Core/Authentication/AuthenticationTest.php
+++ b/tests/phpunit/integration/Core/Authentication/AuthenticationTest.php
@@ -132,9 +132,10 @@ class AuthenticationTest extends TestCase {
 		);
 
 		// When a profile is set, additional data is added.
-		$email = 'wapuu.wordpress@gmail.com';
-		$photo = 'https://wapu.us/wp-content/uploads/2017/11/WapuuFinal-100x138.png';
-		$auth->profile()->set( compact( 'email', 'photo' ) );
+		$email     = 'wapuu.wordpress@gmail.com';
+		$photo     = 'https://wapu.us/wp-content/uploads/2017/11/WapuuFinal-100x138.png';
+		$full_name = 'Wapuu WordPress';
+		$auth->profile()->set( compact( 'email', 'photo', 'full_name' ) );
 		$user_data = apply_filters( 'googlesitekit_user_data', array() );
 		$this->assertEqualSets(
 			array(
@@ -149,6 +150,7 @@ class AuthenticationTest extends TestCase {
 		);
 		$this->assertEquals( $email, $user_data['user']['email'] );
 		$this->assertEquals( $photo, $user_data['user']['picture'] );
+		$this->assertEquals( $full_name, $user_data['user']['full_name'] );
 	}
 
 	/**

--- a/tests/phpunit/integration/Core/Authentication/Clients/OAuth_ClientTest.php
+++ b/tests/phpunit/integration/Core/Authentication/Clients/OAuth_ClientTest.php
@@ -425,6 +425,9 @@ class OAuth_ClientTest extends TestCase {
 								'photos'         => array(
 									array( 'url' => 'https://example.com/fresh.jpg' ),
 								),
+								'names'          => array(
+									array( 'displayName' => 'Dr Funkenstein' ),
+								),
 							)
 						)
 					)
@@ -448,6 +451,7 @@ class OAuth_ClientTest extends TestCase {
 		$profile = $user_options->get( Profile::OPTION );
 		$this->assertEquals( 'fresh@foo.com', $profile['email'] );
 		$this->assertEquals( 'https://example.com/fresh.jpg', $profile['photo'] );
+		$this->assertEquals( 'Dr Funkenstein', $profile['full_name'] );
 	}
 
 	public function test_authorize_user__with_redirect_url_notification() {
@@ -484,6 +488,9 @@ class OAuth_ClientTest extends TestCase {
 								),
 								'photos'         => array(
 									array( 'url' => 'https://example.com/fresh.jpg' ),
+								),
+								'names'          => array(
+									array( 'displayName' => 'Dr Funkenstein' ),
 								),
 							)
 						)
@@ -615,6 +622,9 @@ class OAuth_ClientTest extends TestCase {
 								),
 								'photos'         => array(
 									array( 'url' => 'https://example.com/fresh.jpg' ),
+								),
+								'names'          => array(
+									array( 'displayName' => 'Dr Funkenstein' ),
 								),
 							)
 						)


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #5724 

## Relevant technical choices

<!-- Please describe your changes. -->

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
