### PR TITLE
Improve reset action display behaviour

### DIFF
--- a/assets/js/googlesitekit/modules/datastore/sharing-settings.js
+++ b/assets/js/googlesitekit/modules/datastore/sharing-settings.js
@@ -709,22 +709,30 @@ const baseSelectors = {
 	 * @param {Object} state Data store's state.
 	 * @return {boolean} True if the sharing settings have updated, false otherwise.
 	 */
-	haveSharingSettingsUpdated: createRegistrySelector(
-		( select ) => ( state ) => {
-			const { savedSharingSettings } = state;
+	haveSharingSettingsUpdated( state ) {
+		const { savedSharingSettings, sharedOwnershipModules } = state;
 
-			if ( isEmpty( savedSharingSettings ) ) {
-				return false;
-			}
-
-			const defaultSharingSettings =
-				select(
-					CORE_MODULES
-				).getDefaultSharedOwnershipModuleSettings();
-
-			return ! isEqual( savedSharingSettings, defaultSharingSettings );
+		if (
+			isEmpty( savedSharingSettings ) ||
+			isEmpty( sharedOwnershipModules )
+		) {
+			return false;
 		}
-	),
+
+		return Object.keys( savedSharingSettings ).some( ( moduleSlug ) => {
+			const { sharedRoles, management } =
+				savedSharingSettings[ moduleSlug ];
+
+			const isSharedOwnershipModule =
+				sharedOwnershipModules.includes( moduleSlug );
+
+			const defaultManagement = isSharedOwnershipModule
+				? 'all_admins'
+				: 'owner';
+
+			return sharedRoles.length > 0 || management !== defaultManagement;
+		} );
+	},
 };
 
 const store = Data.combineStores(

--- a/assets/js/googlesitekit/modules/datastore/sharing-settings.test.js
+++ b/assets/js/googlesitekit/modules/datastore/sharing-settings.test.js
@@ -82,6 +82,11 @@ describe( 'core/modules sharing-settings', () => {
 			management: 'all_admins',
 		},
 	};
+	const sharedOwnershipModules = [
+		'analytics',
+		'search-console',
+		'tagmanager',
+	];
 
 	let registry;
 	let store;
@@ -1068,10 +1073,6 @@ describe( 'core/modules sharing-settings', () => {
 
 		describe( 'haveSharingSettingsUpdated', () => {
 			it( 'informs whether saved sharing settings differ from the initial default ones', () => {
-				global[ dashboardSharingDataBaseVar ] = {
-					defaultSharedOwnershipModuleSettings,
-				};
-
 				// Initially false.
 				expect(
 					registry.select( CORE_MODULES ).haveSharingSettingsUpdated()
@@ -1088,11 +1089,29 @@ describe( 'core/modules sharing-settings', () => {
 
 				registry
 					.dispatch( CORE_MODULES )
-					.receiveGetSharingSettings(
-						defaultSharedOwnershipModuleSettings
-					);
+					.receiveSharedOwnershipModules( {} );
 
-				// False after getting the default sharing settings.
+				// False if sharedOwnershipModules is an empty object
+				expect(
+					registry.select( CORE_MODULES ).haveSharingSettingsUpdated()
+				).toBe( false );
+
+				registry
+					.dispatch( CORE_MODULES )
+					.receiveSharedOwnershipModules( sharedOwnershipModules );
+
+				registry.dispatch( CORE_MODULES ).receiveGetSharingSettings( {
+					analytics: {
+						sharedRoles: [],
+						management: 'all_admins',
+					},
+					adsense: {
+						sharedRoles: [],
+						management: 'owner',
+					},
+				} );
+
+				// False after using the default sharing settings.
 				expect(
 					registry.select( CORE_MODULES ).haveSharingSettingsUpdated()
 				).toBe( false );


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #5840 

## Relevant technical choices

This PR improves the `Reset sharing permissions` action display behaviour so that even if the settings are reset manually (not using the action), the action doesn't show up anymore.

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
