### PR TITLE
Remove unnecessary full-stop for multiple text lines in GA4 activation banner.

### DIFF
--- a/assets/js/modules/analytics-4/components/dashboard/ActivationBanner/SetupBanner.js
+++ b/assets/js/modules/analytics-4/components/dashboard/ActivationBanner/SetupBanner.js
@@ -307,15 +307,6 @@ export default function SetupBanner( { onSubmitSuccess } ) {
 			</div>
 		);
 
-		if ( hasEditScope === false ) {
-			footerMessages.push(
-				__(
-					'You will need to give Site Kit permission to create an Analytics property on your behalf.',
-					'google-site-kit'
-				)
-			);
-		}
-
 		footerMessages.push(
 			__(
 				'You can always add/edit this in the Site Kit Settings.',
@@ -350,13 +341,6 @@ export default function SetupBanner( { onSubmitSuccess } ) {
 				)
 			);
 		}
-
-		footerMessages.push(
-			__(
-				'You can always add/edit this in the Site Kit Settings.',
-				'google-site-kit'
-			)
-		);
 	}
 
 	return (


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #5927 

## Relevant technical choices

<!-- Please describe your changes. -->

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
