### PR TITLE
Open up access to `permissions` endpoint

### DIFF
--- a/includes/Core/Permissions/Permissions.php
+++ b/includes/Core/Permissions/Permissions.php
@@ -716,7 +716,7 @@ final class Permissions {
 							return new WP_REST_Response( $this->check_all_for_current_user() );
 						},
 						'permission_callback' => function() {
-							return current_user_can( Permissions::VIEW_SPLASH );
+							return current_user_can( Permissions::VIEW_SPLASH ) || current_user_can( Permissions::VIEW_DASHBOARD );
 						},
 					),
 				)


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #5772 

## Relevant technical choices

This PR makes the `/permissions` endpoint available to users with the `VIEW_DASHBOARD` cap, thus addressing the issue mentioned [here](https://github.com/google/site-kit-wp/issues/5772#issuecomment-1266890649).

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
