### PR TITLE
Bug/#5110 fix php81 warnings

### DIFF
--- a/includes/Core/Admin/Screens.php
+++ b/includes/Core/Admin/Screens.php
@@ -367,7 +367,10 @@ final class Screens {
 					'render_callback'  => function( Context $context ) {
 						$is_view_only = ! $this->authentication->is_authenticated();
 
-						$setup_slug = htmlspecialchars( $context->input()->filter( INPUT_GET, 'slug' ) );
+						$setup_slug = $context->input()->filter( INPUT_GET, 'slug' );
+						if ( $setup_slug ) {
+							$setup_slug = htmlspecialchars( $setup_slug );
+						}
 						$reauth = $context->input()->filter( INPUT_GET, 'reAuth', FILTER_VALIDATE_BOOLEAN );
 						if ( $context->input()->filter( INPUT_GET, 'permaLink' ) ) {
 							?>

--- a/includes/Core/Admin/Screens.php
+++ b/includes/Core/Admin/Screens.php
@@ -367,10 +367,7 @@ final class Screens {
 					'render_callback'  => function( Context $context ) {
 						$is_view_only = ! $this->authentication->is_authenticated();
 
-						$setup_slug = $context->input()->filter( INPUT_GET, 'slug' );
-						if ( $setup_slug ) {
-							$setup_slug = htmlspecialchars( $setup_slug );
-						}
+						$setup_slug = htmlspecialchars( $context->input()->filter( INPUT_GET, 'slug' ) ?: '' );
 						$reauth = $context->input()->filter( INPUT_GET, 'reAuth', FILTER_VALIDATE_BOOLEAN );
 						if ( $context->input()->filter( INPUT_GET, 'permaLink' ) ) {
 							?>

--- a/includes/Core/Admin/Screens.php
+++ b/includes/Core/Admin/Screens.php
@@ -367,7 +367,7 @@ final class Screens {
 					'render_callback'  => function( Context $context ) {
 						$is_view_only = ! $this->authentication->is_authenticated();
 
-						$setup_slug = $context->input()->filter( INPUT_GET, 'slug', FILTER_SANITIZE_STRING );
+						$setup_slug = htmlspecialchars( $context->input()->filter( INPUT_GET, 'slug' ) );
 						$reauth = $context->input()->filter( INPUT_GET, 'reAuth', FILTER_VALIDATE_BOOLEAN );
 						if ( $context->input()->filter( INPUT_GET, 'permaLink' ) ) {
 							?>

--- a/includes/Core/Admin/Standalone.php
+++ b/includes/Core/Admin/Standalone.php
@@ -92,7 +92,7 @@ final class Standalone {
 	public function is_standalone() {
 		global $pagenow;
 
-		$page       = $this->context->input()->filter( INPUT_GET, 'page', FILTER_SANITIZE_STRING );
+		$page       = htmlspecialchars( $this->context->input()->filter( INPUT_GET, 'page' ) );
 		$standalone = $this->context->input()->filter( INPUT_GET, 'googlesitekit-standalone', FILTER_VALIDATE_BOOLEAN );
 
 		return ( 'admin.php' === $pagenow && false !== strpos( $page, 'googlesitekit' ) && $standalone );

--- a/includes/Core/Admin/Standalone.php
+++ b/includes/Core/Admin/Standalone.php
@@ -92,7 +92,7 @@ final class Standalone {
 	public function is_standalone() {
 		global $pagenow;
 
-		$page       = htmlspecialchars( $this->context->input()->filter( INPUT_GET, 'page' ) );
+		$page       = htmlspecialchars( $this->context->input()->filter( INPUT_GET, 'page' ) ?: '' );
 		$standalone = $this->context->input()->filter( INPUT_GET, 'googlesitekit-standalone', FILTER_VALIDATE_BOOLEAN );
 
 		return ( 'admin.php' === $pagenow && false !== strpos( $page, 'googlesitekit' ) && $standalone );

--- a/includes/Core/Assets/Assets.php
+++ b/includes/Core/Assets/Assets.php
@@ -911,17 +911,13 @@ final class Assets {
 	 * @return array The inline data to be output.
 	 */
 	private function get_inline_data() {
-		$current_user = wp_get_current_user();
-		$site_url     = $this->context->get_reference_site_url();
-		$input        = $this->context->input();
-		$page         = $input->filter( INPUT_GET, 'page', FILTER_SANITIZE_STRING );
+		$site_url = $this->context->get_reference_site_url();
+		$input    = $this->context->input();
 
 		$admin_data = array(
 			'siteURL'      => esc_url_raw( $site_url ),
 			'resetSession' => $input->filter( INPUT_GET, 'googlesitekit_reset_session', FILTER_VALIDATE_BOOLEAN ),
 		);
-
-		$current_entity = $this->context->get_reference_entity();
 
 		return array(
 

--- a/includes/Core/Authentication/Authentication.php
+++ b/includes/Core/Authentication/Authentication.php
@@ -305,7 +305,7 @@ final class Authentication {
 			'admin_init',
 			function() {
 				if (
-					'googlesitekit-dashboard' === $this->context->input()->filter( INPUT_GET, 'page', FILTER_SANITIZE_STRING )
+					'googlesitekit-dashboard' === htmlspecialchars( $this->context->input()->filter( INPUT_GET, 'page' ) )
 					&& User_Input_State::VALUE_REQUIRED === $this->user_input_state->get()
 				) {
 					wp_safe_redirect( $this->context->admin_url( 'user-input' ) );

--- a/includes/Core/Authentication/Authentication.php
+++ b/includes/Core/Authentication/Authentication.php
@@ -305,7 +305,7 @@ final class Authentication {
 			'admin_init',
 			function() {
 				if (
-					'googlesitekit-dashboard' === htmlspecialchars( $this->context->input()->filter( INPUT_GET, 'page' ) )
+					'googlesitekit-dashboard' === htmlspecialchars( $this->context->input()->filter( INPUT_GET, 'page' ) ?: '' )
 					&& User_Input_State::VALUE_REQUIRED === $this->user_input_state->get()
 				) {
 					wp_safe_redirect( $this->context->admin_url( 'user-input' ) );

--- a/includes/Core/Authentication/Clients/OAuth_Client.php
+++ b/includes/Core/Authentication/Clients/OAuth_Client.php
@@ -399,8 +399,8 @@ final class OAuth_Client extends OAuth_Client_Base {
 	 * @since 1.49.0 Uses the new `Google_Proxy::setup_url_v2` method when the `serviceSetupV2` feature flag is enabled.
 	 */
 	public function authorize_user() {
-		$code       = $this->context->input()->filter( INPUT_GET, 'code', FILTER_SANITIZE_STRING );
-		$error_code = $this->context->input()->filter( INPUT_GET, 'error', FILTER_SANITIZE_STRING );
+		$code       = htmlspecialchars( $this->context->input()->filter( INPUT_GET, 'code' ) );
+		$error_code = htmlspecialchars( $this->context->input()->filter( INPUT_GET, 'error' ) );
 		// If the OAuth redirects with an error code, handle it.
 		if ( ! empty( $error_code ) ) {
 			$this->user_options->set( self::OPTION_ERROR_CODE, $error_code );
@@ -450,7 +450,7 @@ final class OAuth_Client extends OAuth_Client_Base {
 		if ( isset( $token_response['scope'] ) ) {
 			$scopes = explode( ' ', sanitize_text_field( $token_response['scope'] ) );
 		} elseif ( $this->context->input()->filter( INPUT_GET, 'scope' ) ) {
-			$scope  = $this->context->input()->filter( INPUT_GET, 'scope', FILTER_SANITIZE_STRING );
+			$scope  = htmlspecialchars( $this->context->input()->filter( INPUT_GET, 'scope' ) );
 			$scopes = explode( ' ', $scope );
 		} else {
 			$scopes = $this->get_required_scopes();

--- a/includes/Core/Authentication/Setup.php
+++ b/includes/Core/Authentication/Setup.php
@@ -127,7 +127,7 @@ class Setup {
 	 * @since 1.48.0
 	 */
 	public function handle_action_setup_start() {
-		$nonce        = $this->context->input()->filter( INPUT_GET, 'nonce', FILTER_SANITIZE_STRING );
+		$nonce        = htmlspecialchars( $this->context->input()->filter( INPUT_GET, 'nonce' ) );
 		$redirect_url = $this->context->input()->filter( INPUT_GET, 'redirect', FILTER_SANITIZE_URL );
 
 		$this->verify_nonce( $nonce, Google_Proxy::ACTION_SETUP_START );
@@ -207,12 +207,12 @@ class Setup {
 	 */
 	public function handle_action_verify() {
 		$input               = $this->context->input();
-		$step                = $input->filter( INPUT_GET, 'step', FILTER_SANITIZE_STRING );
-		$nonce               = $input->filter( INPUT_GET, 'nonce', FILTER_SANITIZE_STRING );
-		$code                = $input->filter( INPUT_GET, 'googlesitekit_code', FILTER_SANITIZE_STRING );
-		$site_code           = $input->filter( INPUT_GET, 'googlesitekit_site_code', FILTER_SANITIZE_STRING );
-		$verification_token  = $input->filter( INPUT_GET, 'googlesitekit_verification_token', FILTER_SANITIZE_STRING );
-		$verification_method = $input->filter( INPUT_GET, 'googlesitekit_verification_token_type', FILTER_SANITIZE_STRING );
+		$step                = htmlspecialchars( $input->filter( INPUT_GET, 'step' ) );
+		$nonce               = htmlspecialchars( $input->filter( INPUT_GET, 'nonce' ) );
+		$code                = htmlspecialchars( $input->filter( INPUT_GET, 'googlesitekit_code' ) );
+		$site_code           = htmlspecialchars( $input->filter( INPUT_GET, 'googlesitekit_site_code' ) );
+		$verification_token  = htmlspecialchars( $input->filter( INPUT_GET, 'googlesitekit_verification_token' ) );
+		$verification_method = htmlspecialchars( $input->filter( INPUT_GET, 'googlesitekit_verification_token_type' ) );
 
 		$this->verify_nonce( $nonce );
 
@@ -266,10 +266,10 @@ class Setup {
 	 */
 	public function handle_action_exchange_site_code() {
 		$input     = $this->context->input();
-		$step      = $input->filter( INPUT_GET, 'step', FILTER_SANITIZE_STRING );
-		$nonce     = $input->filter( INPUT_GET, 'nonce', FILTER_SANITIZE_STRING );
-		$code      = $input->filter( INPUT_GET, 'googlesitekit_code', FILTER_SANITIZE_STRING );
-		$site_code = $input->filter( INPUT_GET, 'googlesitekit_site_code', FILTER_SANITIZE_STRING );
+		$step      = htmlspecialchars( $input->filter( INPUT_GET, 'step' ) );
+		$nonce     = htmlspecialchars( $input->filter( INPUT_GET, 'nonce' ) );
+		$code      = htmlspecialchars( $input->filter( INPUT_GET, 'googlesitekit_code' ) );
+		$site_code = htmlspecialchars( $input->filter( INPUT_GET, 'googlesitekit_site_code' ) );
 
 		$this->verify_nonce( $nonce );
 

--- a/includes/Core/REST_API/Data_Request.php
+++ b/includes/Core/REST_API/Data_Request.php
@@ -123,7 +123,7 @@ class Data_Request implements \ArrayAccess {
 	 */
 	// phpcs:ignore Squiz.Commenting.InlineComment.WrongStyle,Squiz.PHP.CommentedOutCode.Found
 	#[\ReturnTypeWillChange]
-	public function offsetExists( $key ) { // phpcs:ignore Squiz.Commenting.FunctionComment.WrongStyle
+	public function offsetExists( $key ) { // phpcs:ignore Squiz.Commenting.FunctionComment
 		return array_key_exists( $key, $this->data );
 	}
 
@@ -136,7 +136,7 @@ class Data_Request implements \ArrayAccess {
 	 */
 	// phpcs:ignore Squiz.Commenting.InlineComment.WrongStyle,Squiz.PHP.CommentedOutCode.Found
 	#[\ReturnTypeWillChange]
-	public function offsetGet( $key ) { // phpcs:ignore Squiz.Commenting.FunctionComment.WrongStyle
+	public function offsetGet( $key ) { // phpcs:ignore Squiz.Commenting.FunctionComment
 		if ( $this->offsetExists( $key ) ) {
 			return $this->data[ $key ];
 		}
@@ -152,7 +152,7 @@ class Data_Request implements \ArrayAccess {
 	 */
 	// phpcs:ignore Squiz.Commenting.InlineComment.WrongStyle,Squiz.PHP.CommentedOutCode.Found
 	#[\ReturnTypeWillChange]
-	public function offsetSet( $key, $value ) { // phpcs:ignore Squiz.Commenting.FunctionComment.WrongStyle
+	public function offsetSet( $key, $value ) { // phpcs:ignore Squiz.Commenting.FunctionComment
 		// Data is immutable.
 	}
 
@@ -163,7 +163,7 @@ class Data_Request implements \ArrayAccess {
 	 */
 	// phpcs:ignore Squiz.Commenting.InlineComment.WrongStyle,Squiz.PHP.CommentedOutCode.Found
 	#[\ReturnTypeWillChange]
-	public function offsetUnset( $key ) { // phpcs:ignore Squiz.Commenting.FunctionComment.WrongStyle
+	public function offsetUnset( $key ) { // phpcs:ignore Squiz.Commenting.FunctionComment
 		// Data is immutable.
 	}
 }

--- a/includes/Core/REST_API/Data_Request.php
+++ b/includes/Core/REST_API/Data_Request.php
@@ -121,9 +121,9 @@ class Data_Request implements \ArrayAccess {
 	 *
 	 * @return bool
 	 */
-	// phpcs:disable Squiz.Commenting.InlineComment.WrongStyle,Squiz.Commenting.FunctionComment.WrongStyle, Squiz.PHP.CommentedOutCode.Found
+	// phpcs:ignore Squiz.Commenting.InlineComment.WrongStyle,Squiz.PHP.CommentedOutCode.Found
 	#[\ReturnTypeWillChange]
-	public function offsetExists( $key ) {
+	public function offsetExists( $key ) { // phpcs:ignore Squiz.Commenting.FunctionComment.WrongStyle
 		return array_key_exists( $key, $this->data );
 	}
 
@@ -134,9 +134,9 @@ class Data_Request implements \ArrayAccess {
 	 *
 	 * @return mixed
 	 */
-	// phpcs:disable Squiz.Commenting.InlineComment.WrongStyle, Squiz.Commenting.FunctionComment.WrongStyle, Squiz.PHP.CommentedOutCode.Found
+	// phpcs:ignore Squiz.Commenting.InlineComment.WrongStyle,Squiz.PHP.CommentedOutCode.Found
 	#[\ReturnTypeWillChange]
-	public function offsetGet( $key ) {
+	public function offsetGet( $key ) { // phpcs:ignore Squiz.Commenting.FunctionComment.WrongStyle
 		if ( $this->offsetExists( $key ) ) {
 			return $this->data[ $key ];
 		}
@@ -150,9 +150,9 @@ class Data_Request implements \ArrayAccess {
 	 * @param string|int $key Key to set the value for.
 	 * @param mixed      $value New value for the given key.
 	 */
-	// phpcs:disable Squiz.Commenting.InlineComment.WrongStyle, Squiz.Commenting.FunctionComment.WrongStyle, Squiz.PHP.CommentedOutCode.Found
+	// phpcs:ignore Squiz.Commenting.InlineComment.WrongStyle,Squiz.PHP.CommentedOutCode.Found
 	#[\ReturnTypeWillChange]
-	public function offsetSet( $key, $value ) {
+	public function offsetSet( $key, $value ) { // phpcs:ignore Squiz.Commenting.FunctionComment.WrongStyle
 		// Data is immutable.
 	}
 
@@ -161,9 +161,9 @@ class Data_Request implements \ArrayAccess {
 	 *
 	 * @param string|int $key Key to unset.
 	 */
-	// phpcs:disable Squiz.Commenting.InlineComment.WrongStyle, Squiz.Commenting.FunctionComment.WrongStyle, Squiz.PHP.CommentedOutCode.Found
+	// phpcs:ignore Squiz.Commenting.InlineComment.WrongStyle,Squiz.PHP.CommentedOutCode.Found
 	#[\ReturnTypeWillChange]
-	public function offsetUnset( $key ) {
+	public function offsetUnset( $key ) { // phpcs:ignore Squiz.Commenting.FunctionComment.WrongStyle
 		// Data is immutable.
 	}
 }

--- a/includes/Core/REST_API/Data_Request.php
+++ b/includes/Core/REST_API/Data_Request.php
@@ -121,6 +121,8 @@ class Data_Request implements \ArrayAccess {
 	 *
 	 * @return bool
 	 */
+	// phpcs:disable Squiz.Commenting.InlineComment.WrongStyle,Squiz.Commenting.FunctionComment.WrongStyle, Squiz.PHP.CommentedOutCode.Found
+	#[\ReturnTypeWillChange]
 	public function offsetExists( $key ) {
 		return array_key_exists( $key, $this->data );
 	}
@@ -132,6 +134,8 @@ class Data_Request implements \ArrayAccess {
 	 *
 	 * @return mixed
 	 */
+	// phpcs:disable Squiz.Commenting.InlineComment.WrongStyle,Squiz.Commenting.FunctionComment.WrongStyle, Squiz.PHP.CommentedOutCode.Found
+	#[\ReturnTypeWillChange]
 	public function offsetGet( $key ) {
 		if ( $this->offsetExists( $key ) ) {
 			return $this->data[ $key ];
@@ -146,6 +150,8 @@ class Data_Request implements \ArrayAccess {
 	 * @param string|int $key Key to set the value for.
 	 * @param mixed      $value New value for the given key.
 	 */
+	// phpcs:disable Squiz.Commenting.InlineComment.WrongStyle,Squiz.Commenting.FunctionComment.WrongStyle, Squiz.PHP.CommentedOutCode.Found
+	#[\ReturnTypeWillChange]
 	public function offsetSet( $key, $value ) {
 		// Data is immutable.
 	}
@@ -155,6 +161,8 @@ class Data_Request implements \ArrayAccess {
 	 *
 	 * @param string|int $key Key to unset.
 	 */
+	// phpcs:disable Squiz.Commenting.InlineComment.WrongStyle,Squiz.Commenting.FunctionComment.WrongStyle, Squiz.PHP.CommentedOutCode.Found
+	#[\ReturnTypeWillChange]
 	public function offsetUnset( $key ) {
 		// Data is immutable.
 	}

--- a/includes/Core/REST_API/Data_Request.php
+++ b/includes/Core/REST_API/Data_Request.php
@@ -134,7 +134,7 @@ class Data_Request implements \ArrayAccess {
 	 *
 	 * @return mixed
 	 */
-	// phpcs:disable Squiz.Commenting.InlineComment.WrongStyle,Squiz.Commenting.FunctionComment.WrongStyle, Squiz.PHP.CommentedOutCode.Found
+	// phpcs:disable Squiz.Commenting.InlineComment.WrongStyle, Squiz.Commenting.FunctionComment.WrongStyle, Squiz.PHP.CommentedOutCode.Found
 	#[\ReturnTypeWillChange]
 	public function offsetGet( $key ) {
 		if ( $this->offsetExists( $key ) ) {
@@ -150,7 +150,7 @@ class Data_Request implements \ArrayAccess {
 	 * @param string|int $key Key to set the value for.
 	 * @param mixed      $value New value for the given key.
 	 */
-	// phpcs:disable Squiz.Commenting.InlineComment.WrongStyle,Squiz.Commenting.FunctionComment.WrongStyle, Squiz.PHP.CommentedOutCode.Found
+	// phpcs:disable Squiz.Commenting.InlineComment.WrongStyle, Squiz.Commenting.FunctionComment.WrongStyle, Squiz.PHP.CommentedOutCode.Found
 	#[\ReturnTypeWillChange]
 	public function offsetSet( $key, $value ) {
 		// Data is immutable.
@@ -161,7 +161,7 @@ class Data_Request implements \ArrayAccess {
 	 *
 	 * @param string|int $key Key to unset.
 	 */
-	// phpcs:disable Squiz.Commenting.InlineComment.WrongStyle,Squiz.Commenting.FunctionComment.WrongStyle, Squiz.PHP.CommentedOutCode.Found
+	// phpcs:disable Squiz.Commenting.InlineComment.WrongStyle, Squiz.Commenting.FunctionComment.WrongStyle, Squiz.PHP.CommentedOutCode.Found
 	#[\ReturnTypeWillChange]
 	public function offsetUnset( $key ) {
 		// Data is immutable.

--- a/includes/Core/Util/Input.php
+++ b/includes/Core/Util/Input.php
@@ -45,6 +45,7 @@ class Input {
 	 * Gets a specific external variable by name and optionally filters it.
 	 *
 	 * @since 1.1.2
+	 * @since n.e.x.t Changed default value of $options parameter to 0.
 	 *
 	 * @link https://php.net/manual/en/function.filter-input.php
 	 *
@@ -60,7 +61,7 @@ class Input {
 	 *                                      If the flag FILTER_NULL_ON_FAILURE is used, it returns FALSE if the variable is not set
 	 *                                      and NULL if the filter fails.
 	 */
-	public function filter( $type, $variable_name, $filter = FILTER_DEFAULT, $options = null ) {
+	public function filter( $type, $variable_name, $filter = FILTER_DEFAULT, $options = 0 ) {
 		$value = filter_input( $type, $variable_name, $filter, $options );
 
 		// Fallback for environments where filter_input may not work with specific types.

--- a/includes/Modules/Analytics.php
+++ b/includes/Modules/Analytics.php
@@ -277,10 +277,10 @@ final class Analytics extends Module
 		}
 
 		// Check for a returned error.
-		$error = htmlspecialchars( $input->filter( INPUT_GET, 'error' ) );
+		$error = $input->filter( INPUT_GET, 'error' );
 		if ( ! empty( $error ) ) {
 			wp_safe_redirect(
-				$this->context->admin_url( 'module-analytics', array( 'error_code' => $error ) )
+				$this->context->admin_url( 'module-analytics', array( 'error_code' => htmlspecialchars( $error ) ) )
 			);
 			exit;
 		}

--- a/includes/Modules/Analytics.php
+++ b/includes/Modules/Analytics.php
@@ -265,7 +265,7 @@ final class Analytics extends Module
 		}
 
 		// The handler should check the received Account Ticket id parameter against the id stored in the provisioning step.
-		$account_ticket_id        = $input->filter( INPUT_GET, 'accountTicketId', FILTER_SANITIZE_STRING );
+		$account_ticket_id        = htmlspecialchars( $input->filter( INPUT_GET, 'accountTicketId' ) );
 		$stored_account_ticket_id = get_transient( self::PROVISION_ACCOUNT_TICKET_ID . '::' . get_current_user_id() );
 		delete_transient( self::PROVISION_ACCOUNT_TICKET_ID . '::' . get_current_user_id() );
 
@@ -277,7 +277,7 @@ final class Analytics extends Module
 		}
 
 		// Check for a returned error.
-		$error = $input->filter( INPUT_GET, 'error', FILTER_SANITIZE_STRING );
+		$error = htmlspecialchars( $input->filter( INPUT_GET, 'error' ) );
 		if ( ! empty( $error ) ) {
 			wp_safe_redirect(
 				$this->context->admin_url( 'module-analytics', array( 'error_code' => $error ) )
@@ -285,9 +285,9 @@ final class Analytics extends Module
 			exit;
 		}
 
-		$account_id      = $input->filter( INPUT_GET, 'accountId', FILTER_SANITIZE_STRING );
-		$web_property_id = $input->filter( INPUT_GET, 'webPropertyId', FILTER_SANITIZE_STRING );
-		$profile_id      = $input->filter( INPUT_GET, 'profileId', FILTER_SANITIZE_STRING );
+		$account_id      = htmlspecialchars( $input->filter( INPUT_GET, 'accountId' ) );
+		$web_property_id = htmlspecialchars( $input->filter( INPUT_GET, 'webPropertyId' ) );
+		$profile_id      = htmlspecialchars( $input->filter( INPUT_GET, 'profileId' ) );
 
 		if ( empty( $account_id ) || empty( $web_property_id ) || empty( $profile_id ) ) {
 			wp_safe_redirect(

--- a/tests/phpunit/integration/ContextTest.php
+++ b/tests/phpunit/integration/ContextTest.php
@@ -71,7 +71,7 @@ class ContextTest extends TestCase {
 		$this->assertTrue( $context->input()->filter( INPUT_GET, 'foo', FILTER_VALIDATE_BOOLEAN ) );
 
 		$_GET['dirty'] = '<script>dirt</script>';
-		$this->assertEquals( 'dirt', htmlspecialchars( $context->input()->filter( INPUT_GET, 'dirty' ) ) );
+		$this->assertEquals( '&lt;script&gt;dirt&lt;/script&gt;', htmlspecialchars( $context->input()->filter( INPUT_GET, 'dirty' ) ) );
 	}
 
 	public function test_admin_url() {

--- a/tests/phpunit/integration/ContextTest.php
+++ b/tests/phpunit/integration/ContextTest.php
@@ -71,7 +71,7 @@ class ContextTest extends TestCase {
 		$this->assertTrue( $context->input()->filter( INPUT_GET, 'foo', FILTER_VALIDATE_BOOLEAN ) );
 
 		$_GET['dirty'] = '<script>dirt</script>';
-		$this->assertEquals( 'dirt', $context->input()->filter( INPUT_GET, 'dirty', FILTER_SANITIZE_STRING ) );
+		$this->assertEquals( 'dirt', htmlspecialchars( $context->input()->filter( INPUT_GET, 'dirty' ) ) );
 	}
 
 	public function test_admin_url() {

--- a/tests/phpunit/integration/ContextTest.php
+++ b/tests/phpunit/integration/ContextTest.php
@@ -69,9 +69,6 @@ class ContextTest extends TestCase {
 		$_GET['foo'] = true;
 
 		$this->assertTrue( $context->input()->filter( INPUT_GET, 'foo', FILTER_VALIDATE_BOOLEAN ) );
-
-		$_GET['dirty'] = '<script>dirt</script>';
-		$this->assertEquals( '&lt;script&gt;dirt&lt;/script&gt;', htmlspecialchars( $context->input()->filter( INPUT_GET, 'dirty' ) ) );
 	}
 
 	public function test_admin_url() {


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #5110 

## Relevant technical choices

The remaining `strpos` and `str_replace` errors are related to how we use `add_submenu_page` and will be addressed in #5998.

The remaining `rtrim` errors are caused by `load_script_textdomain` function and we are consuming the function correctly in our code. It's something that will probably be fixed in Core. 

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [x] Run the code.
- [x] Ensure the acceptance criteria are satisfied.
- [x] Reassess the implementation with the IB.
- [x] Ensure no unrelated changes are included.
- [x] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [x] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [x] Ensure the PR has the correct target branch.
- [x] Double-check that the PR is okay to be merged.
- [x] Ensure the corresponding issue has a ZenHub release assigned.
- [x] Add a changelog message to the issue.
