### PR TITLE
Enhance/5921 - GA4 settings tooltip when it wasn't closed manually

### DIFF
--- a/assets/js/modules/analytics/components/settings/GA4SettingsControls.js
+++ b/assets/js/modules/analytics/components/settings/GA4SettingsControls.js
@@ -176,6 +176,15 @@ export default function GA4SettingsControls( { hasModuleAccess } ) {
 		propertyID,
 	] );
 
+	useEffect( () => {
+		if ( enableGA4PropertyTooltip && propertyID ) {
+			// Hide the tooltip once the property is selected.
+			setValues( FORM_SETUP, {
+				enableGA4PropertyTooltip: false,
+			} );
+		}
+	}, [ enableGA4PropertyTooltip, propertyID, setValues ] );
+
 	if ( isAdminAPIWorking === undefined ) {
 		return <ProgressBar height={ isDisabled ? 180 : 212 } small />;
 	}


### PR DESCRIPTION
## Summary

Addresses issue:

- #5921 

## Relevant technical choices

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
