### PR TITLE
Only access the full_name attribute if it exists.

### DIFF
--- a/assets/js/googlesitekit/datastore/user/user-info.js
+++ b/assets/js/googlesitekit/datastore/user/user-info.js
@@ -406,7 +406,7 @@ export const selectors = {
 	 * @since n.e.x.t
 	 *
 	 * @param {Object} state Data store's state.
-	 * @return {(string|undefined)} The user's full name.
+	 * @return {(string|null|undefined)} The user's full name; will be set to `null` if not available in the user's profile data and `undefined` while loading.
 	 */
 	getFullName: createRegistrySelector( ( select ) => () => {
 		const user = select( CORE_USER ).getUser();

--- a/includes/Core/Authentication/Authentication.php
+++ b/includes/Core/Authentication/Authentication.php
@@ -365,22 +365,14 @@ final class Authentication {
 					$profile_data            = $this->profile->get();
 					$user['user']['email']   = $profile_data['email'];
 					$user['user']['picture'] = $profile_data['photo'];
-
-					// Older versions of Site Kit (before 1.86.0) did not
+					// Older versions of Site Kit (before n.e.x.t) did not
 					// fetch the user's full name, so we need to check for
 					// that attribute before using it.
 					//
-					// If it isn't detected, we schedule the profile to be
-					// updated in the background so it's available ASAP.
-					if ( isset( $profile_data['full_name'] ) ) {
-						$user['user']['full_name'] = $profile_data['full_name'];
-					} else {
-						$this->cron_refresh_profile_data(
-							$this->user_options->get_user_id()
-						);
-
-						$user['user']['full_name'] = null;
-					}
+					// WP Cron will eventually update the profile data with
+					// this `full_name` attribute, but this prevents errors
+					// when a user upgrades to n.e.x.t but cron hasn't run yet.
+					$user['user']['full_name'] = isset( $profile_data['full_name'] ) ? $profile_data['full_name'] : null;
 				}
 
 				$user['connectURL']        = esc_url_raw( $this->get_connect_url() );

--- a/includes/Core/Authentication/Authentication.php
+++ b/includes/Core/Authentication/Authentication.php
@@ -368,10 +368,6 @@ final class Authentication {
 					// Older versions of Site Kit (before n.e.x.t) did not
 					// fetch the user's full name, so we need to check for
 					// that attribute before using it.
-					//
-					// WP Cron will eventually update the profile data with
-					// this `full_name` attribute, but this prevents errors
-					// when a user upgrades to n.e.x.t but cron hasn't run yet.
 					$user['user']['full_name'] = isset( $profile_data['full_name'] ) ? $profile_data['full_name'] : null;
 				}
 

--- a/includes/Core/Authentication/Authentication.php
+++ b/includes/Core/Authentication/Authentication.php
@@ -372,7 +372,7 @@ final class Authentication {
 					//
 					// If it isn't detected, we schedule the profile to be
 					// updated in the background so it's available ASAP.
-					if ( ! empty( $profile_data['full_name'] ) ) {
+					if ( isset( $profile_data['full_name'] ) ) {
 						$user['user']['full_name'] = $profile_data['full_name'];
 					} else {
 						$this->cron_refresh_profile_data(

--- a/includes/Core/Authentication/Authentication.php
+++ b/includes/Core/Authentication/Authentication.php
@@ -362,10 +362,25 @@ final class Authentication {
 			'googlesitekit_user_data',
 			function( $user ) {
 				if ( $this->profile->has() ) {
-					$profile_data              = $this->profile->get();
-					$user['user']['email']     = $profile_data['email'];
-					$user['user']['picture']   = $profile_data['photo'];
-					$user['user']['full_name'] = $profile_data['full_name'];
+					$profile_data            = $this->profile->get();
+					$user['user']['email']   = $profile_data['email'];
+					$user['user']['picture'] = $profile_data['photo'];
+
+					// Older versions of Site Kit (before 1.86.0) did not
+					// fetch the user's full name, so we need to check for
+					// that attribute before using it.
+					//
+					// If it isn't detected, we schedule the profile to be
+					// updated in the background so it's available ASAP.
+					if ( ! empty( $profile_data['full_name'] ) ) {
+						$user['user']['full_name'] = $profile_data['full_name'];
+					} else {
+						$this->cron_refresh_profile_data(
+							$this->user_options->get_user_id()
+						);
+
+						$user['user']['full_name'] = null;
+					}
 				}
 
 				$user['connectURL']        = esc_url_raw( $this->get_connect_url() );


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #5724.

## Relevant technical choices

Ensure that the `full_name` attribute on the user profile is only accessed if available. Filed #6003 to trigger refreshes of user data.

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
