### PR TITLE
Bug/5074 - Fix errors if Tag Manager is disabled via `googlesitekit_available_modules`

### DIFF
--- a/assets/js/modules/analytics/components/common/ExistingGTMPropertyNotice.js
+++ b/assets/js/modules/analytics/components/common/ExistingGTMPropertyNotice.js
@@ -27,6 +27,7 @@ import { sprintf, __ } from '@wordpress/i18n';
 import Data from 'googlesitekit-data';
 import { MODULES_ANALYTICS } from '../../datastore/constants';
 import { MODULES_TAGMANAGER } from '../../../tagmanager/datastore/constants';
+import { CORE_MODULES } from '../../../../googlesitekit/modules/datastore/constants';
 const { useSelect } = Data;
 
 export default function ExistingGTMPropertyNotice() {
@@ -34,8 +35,14 @@ export default function ExistingGTMPropertyNotice() {
 		select( MODULES_ANALYTICS ).getPropertyID()
 	);
 
-	const gtmAnalyticsPropertyID = useSelect( ( select ) =>
-		select( MODULES_TAGMANAGER ).getSingleAnalyticsPropertyID()
+	const isTagManagerAvaliable = useSelect( ( select ) =>
+		select( CORE_MODULES ).isModuleAvailable( 'tagmanager' )
+	);
+
+	const gtmAnalyticsPropertyID = useSelect(
+		( select ) =>
+			isTagManagerAvaliable &&
+			select( MODULES_TAGMANAGER ).getSingleAnalyticsPropertyID()
 	);
 
 	if ( ! gtmAnalyticsPropertyID ) {

--- a/assets/js/modules/analytics/components/common/ExistingGTMPropertyNotice.js
+++ b/assets/js/modules/analytics/components/common/ExistingGTMPropertyNotice.js
@@ -35,13 +35,13 @@ export default function ExistingGTMPropertyNotice() {
 		select( MODULES_ANALYTICS ).getPropertyID()
 	);
 
-	const isTagManagerAvaliable = useSelect( ( select ) =>
+	const isTagManagerAvailable = useSelect( ( select ) =>
 		select( CORE_MODULES ).isModuleAvailable( 'tagmanager' )
 	);
 
 	const gtmAnalyticsPropertyID = useSelect(
 		( select ) =>
-			isTagManagerAvaliable &&
+			isTagManagerAvailable &&
 			select( MODULES_TAGMANAGER ).getSingleAnalyticsPropertyID()
 	);
 

--- a/assets/js/modules/analytics/components/settings/SettingsForm.js
+++ b/assets/js/modules/analytics/components/settings/SettingsForm.js
@@ -38,6 +38,7 @@ import SettingsControls from './SettingsControls';
 import GA4SettingsControls from './GA4SettingsControls';
 import EntityOwnershipChangeNotice from '../../../../components/settings/EntityOwnershipChangeNotice';
 import { isValidAccountID } from '../../util';
+import { CORE_MODULES } from '../../../../googlesitekit/modules/datastore/constants';
 const { useSelect } = Data;
 
 export default function SettingsForm( {
@@ -50,11 +51,18 @@ export default function SettingsForm( {
 	const useAnalyticsSnippet = useSelect( ( select ) =>
 		select( MODULES_ANALYTICS ).getUseSnippet()
 	);
-	const useTagManagerSnippet = useSelect( ( select ) =>
-		select( MODULES_TAGMANAGER ).getUseSnippet()
+	const isTagManagerAvaliable = useSelect( ( select ) =>
+		select( CORE_MODULES ).isModuleAvailable( 'tagmanager' )
 	);
-	const analyticsSinglePropertyID = useSelect( ( select ) =>
-		select( MODULES_TAGMANAGER ).getSingleAnalyticsPropertyID()
+	const useTagManagerSnippet = useSelect(
+		( select ) =>
+			isTagManagerAvaliable &&
+			select( MODULES_TAGMANAGER ).getUseSnippet()
+	);
+	const analyticsSinglePropertyID = useSelect(
+		( select ) =>
+			isTagManagerAvaliable &&
+			select( MODULES_TAGMANAGER ).getSingleAnalyticsPropertyID()
 	);
 	const showTrackingExclusion =
 		useAnalyticsSnippet ||

--- a/assets/js/modules/analytics/components/settings/SettingsForm.js
+++ b/assets/js/modules/analytics/components/settings/SettingsForm.js
@@ -51,17 +51,17 @@ export default function SettingsForm( {
 	const useAnalyticsSnippet = useSelect( ( select ) =>
 		select( MODULES_ANALYTICS ).getUseSnippet()
 	);
-	const isTagManagerAvaliable = useSelect( ( select ) =>
+	const isTagManagerAvailable = useSelect( ( select ) =>
 		select( CORE_MODULES ).isModuleAvailable( 'tagmanager' )
 	);
 	const useTagManagerSnippet = useSelect(
 		( select ) =>
-			isTagManagerAvaliable &&
+			isTagManagerAvailable &&
 			select( MODULES_TAGMANAGER ).getUseSnippet()
 	);
 	const analyticsSinglePropertyID = useSelect(
 		( select ) =>
-			isTagManagerAvaliable &&
+			isTagManagerAvailable &&
 			select( MODULES_TAGMANAGER ).getSingleAnalyticsPropertyID()
 	);
 	const showTrackingExclusion =

--- a/assets/js/modules/analytics/datastore/settings.js
+++ b/assets/js/modules/analytics/datastore/settings.js
@@ -246,10 +246,10 @@ export const getCanUseSnippet = createRegistrySelector( ( select ) => () => {
 		return undefined;
 	}
 
-	const isTagManagerAvaliable =
+	const isTagManagerAvailable =
 		select( CORE_MODULES ).isModuleAvailable( 'tagmanager' );
 	const isTagManagerConnected =
-		isTagManagerAvaliable &&
+		isTagManagerAvailable &&
 		select( CORE_MODULES ).isModuleConnected( 'tagmanager' );
 
 	if ( ! isTagManagerConnected || ! select( MODULES_TAGMANAGER ) ) {

--- a/assets/js/modules/analytics/datastore/settings.js
+++ b/assets/js/modules/analytics/datastore/settings.js
@@ -246,7 +246,10 @@ export const getCanUseSnippet = createRegistrySelector( ( select ) => () => {
 		return undefined;
 	}
 
+	const isTagManagerAvaliable =
+		select( CORE_MODULES ).isModuleAvailable( 'tagmanager' );
 	const isTagManagerConnected =
+		isTagManagerAvaliable &&
 		select( CORE_MODULES ).isModuleConnected( 'tagmanager' );
 
 	if ( ! isTagManagerConnected || ! select( MODULES_TAGMANAGER ) ) {

--- a/assets/js/modules/optimize/components/common/UseSnippetInstructions.js
+++ b/assets/js/modules/optimize/components/common/UseSnippetInstructions.js
@@ -45,11 +45,18 @@ export default function UseSnippetInstructions() {
 	const analyticsUseSnippet = useSelect( ( select ) =>
 		select( MODULES_ANALYTICS ).getUseSnippet()
 	);
-	const gtmActive = useSelect( ( select ) =>
-		select( CORE_MODULES ).isModuleActive( 'tagmanager' )
+	const isTagManagerAvaliable = useSelect( ( select ) =>
+		select( CORE_MODULES ).isModuleAvailable( 'tagmanager' )
 	);
-	const gtmUseSnippet = useSelect( ( select ) =>
-		select( MODULES_TAGMANAGER ).getUseSnippet()
+	const gtmActive = useSelect(
+		( select ) =>
+			isTagManagerAvaliable &&
+			select( CORE_MODULES ).isModuleActive( 'tagmanager' )
+	);
+	const gtmUseSnippet = useSelect(
+		( select ) =>
+			isTagManagerAvaliable &&
+			select( MODULES_TAGMANAGER ).getUseSnippet()
 	);
 	const settingsURL = useSelect( ( select ) =>
 		select( CORE_SITE ).getAdminURL( 'googlesitekit-settings' )

--- a/assets/js/modules/optimize/components/common/UseSnippetInstructions.js
+++ b/assets/js/modules/optimize/components/common/UseSnippetInstructions.js
@@ -45,17 +45,17 @@ export default function UseSnippetInstructions() {
 	const analyticsUseSnippet = useSelect( ( select ) =>
 		select( MODULES_ANALYTICS ).getUseSnippet()
 	);
-	const isTagManagerAvaliable = useSelect( ( select ) =>
+	const isTagManagerAvailable = useSelect( ( select ) =>
 		select( CORE_MODULES ).isModuleAvailable( 'tagmanager' )
 	);
 	const gtmActive = useSelect(
 		( select ) =>
-			isTagManagerAvaliable &&
+			isTagManagerAvailable &&
 			select( CORE_MODULES ).isModuleActive( 'tagmanager' )
 	);
 	const gtmUseSnippet = useSelect(
 		( select ) =>
-			isTagManagerAvaliable &&
+			isTagManagerAvailable &&
 			select( MODULES_TAGMANAGER ).getUseSnippet()
 	);
 	const settingsURL = useSelect( ( select ) =>


### PR DESCRIPTION
## Summary

Addresses issue:

- #5074 

## Relevant technical choices

<!-- Please describe your changes. -->

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [x] Run the code.
- [x] Ensure the acceptance criteria are satisfied.
- [x] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [x] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [x] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
