### PR TITLE
Enhancement/5882 Check Measurement ID for edit scope

### DIFF
--- a/assets/js/modules/analytics-4/components/dashboard/ActivationBanner/SetupBanner.js
+++ b/assets/js/modules/analytics-4/components/dashboard/ActivationBanner/SetupBanner.js
@@ -92,6 +92,10 @@ export default function SetupBanner( { onSubmitSuccess } ) {
 		select( MODULES_ANALYTICS_4 ).getPropertyID()
 	);
 
+	const getMeasurementID = useSelect(
+		( select ) => select( MODULES_ANALYTICS_4 ).getMeasurementID
+	);
+
 	const determineVariant = useCallback( async () => {
 		// Ensure variant is only set once, to avoid flickering between variants. For example
 		// when properties.length is zero we are in the "no existing property" variant, and we
@@ -157,7 +161,10 @@ export default function SetupBanner( { onSubmitSuccess } ) {
 	const handleSubmitChanges = useCallback( async () => {
 		const scopes = [];
 
-		if ( hasEditScope === false && getPropertyID() === PROPERTY_CREATE ) {
+		if (
+			hasEditScope === false &&
+			( getPropertyID() === PROPERTY_CREATE || ! getMeasurementID() )
+		) {
 			scopes.push( EDIT_SCOPE );
 		}
 
@@ -210,9 +217,10 @@ export default function SetupBanner( { onSubmitSuccess } ) {
 		setPermissionScopeError,
 		setValues,
 		submitChanges,
-		// Here we pass the selector through to avoid creating a new
+		// Here we pass the selectors through to avoid creating a new
 		// callback when the property ID changes on creation.
 		getPropertyID,
+		getMeasurementID,
 	] );
 
 	// If the user lands back on this component with autoSubmit and the edit scope,
@@ -314,7 +322,10 @@ export default function SetupBanner( { onSubmitSuccess } ) {
 			</div>
 		);
 
-		if ( hasEditScope === false && ga4PropertyID === PROPERTY_CREATE ) {
+		if (
+			hasEditScope === false &&
+			( ga4PropertyID === PROPERTY_CREATE || ! getMeasurementID() )
+		) {
 			footerMessages.push(
 				__(
 					'You will need to give Site Kit permission to create an Analytics property on your behalf',

--- a/assets/js/modules/analytics-4/components/dashboard/ActivationBanner/SetupBanner.js
+++ b/assets/js/modules/analytics-4/components/dashboard/ActivationBanner/SetupBanner.js
@@ -95,6 +95,9 @@ export default function SetupBanner( { onSubmitSuccess } ) {
 	const getMeasurementID = useSelect(
 		( select ) => select( MODULES_ANALYTICS_4 ).getMeasurementID
 	);
+	const measurementID = useSelect( ( select ) =>
+		select( MODULES_ANALYTICS_4 ).getMeasurementID()
+	);
 
 	const determineVariant = useCallback( async () => {
 		// Ensure variant is only set once, to avoid flickering between variants. For example
@@ -324,7 +327,7 @@ export default function SetupBanner( { onSubmitSuccess } ) {
 
 		if (
 			hasEditScope === false &&
-			( ga4PropertyID === PROPERTY_CREATE || ! getMeasurementID() )
+			( ga4PropertyID === PROPERTY_CREATE || ! measurementID )
 		) {
 			footerMessages.push(
 				__(


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #5882 

## Relevant technical choices

The implementation matches the changes in #6040 to pass the selector method instead of the measurementID to avoid the `useEffect` being called when the measurementID is set internally when submitting changes.

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
