### PR TITLE
Expose `@wordpress/element`

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -82,7 +82,8 @@
       "googlesitekit-api",
       "googlesitekit-widgets",
       "@wordpress/i18n__non-shim",
-      "@wordpress/api-fetch__non-shim"
+      "@wordpress/api-fetch__non-shim",
+      "@wordpress/element__non-shim"
     ],
     "import/resolver": {
       "alias": {

--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -10,10 +10,15 @@ module.exports = async ( { config } ) => {
 	const siteKitPackageAliases = mapValues(
 		mainConfig.siteKitExternals,
 		( [ global, api ] ) => {
-			// Revert "@wordpress/i18n: [ googlesitekit, i18n ]" external back to the original @wordpress/i18n.
 			if ( global === 'googlesitekit' ) {
+				// Revert "@wordpress/i18n: [ googlesitekit, i18n ]" external back to the original @wordpress/i18n.
 				if ( api === 'i18n' ) {
 					return require.resolve( '@wordpress/i18n' );
+				}
+
+				// Revert "@wordpress/element: [ googlesitekit, element ]" external back to the original @wordpress/element.
+				if ( api === 'element' ) {
+					return require.resolve( '@wordpress/element' );
 				}
 			}
 

--- a/assets/js/googlesitekit-element.js
+++ b/assets/js/googlesitekit-element.js
@@ -1,0 +1,22 @@
+/**
+ * Site Kit Element.
+ *
+ * Site Kit by Google, Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as Element from '@wordpress/element__non-shim';
+
+global.googlesitekit = global.googlesitekit || {};
+global.googlesitekit.element = global.googlesitekit.element || Element;

--- a/includes/Core/Assets/Assets.php
+++ b/includes/Core/Assets/Assets.php
@@ -459,12 +459,19 @@ final class Assets {
 				)
 			),
 			new Script(
+				'googlesitekit-element',
+				array(
+					'src' => $base_url . 'js/googlesitekit-element.js',
+				)
+			),
+			new Script(
 				'googlesitekit-base',
 				array(
 					'src'          => $base_url . 'js/googlesitekit-base.js',
 					'dependencies' => array(
 						'googlesitekit-base-data',
 						'googlesitekit-i18n',
+						'googlesitekit-element',
 					),
 					'execution'    => 'defer',
 				)

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -265,6 +265,7 @@ function* webpackConfig( env, argv ) {
 				'./assets/js/googlesitekit-datastore-ui.js',
 			'googlesitekit-modules': './assets/js/googlesitekit-modules.js',
 			'googlesitekit-widgets': './assets/js/googlesitekit-widgets.js',
+			'googlesitekit-element': './assets/js/googlesitekit-element.js',
 			'googlesitekit-modules-adsense':
 				'./assets/js/googlesitekit-modules-adsense.js',
 			'googlesitekit-modules-analytics':

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -135,6 +135,7 @@ const siteKitExternals = {
 	'googlesitekit-modules': [ 'googlesitekit', 'modules' ],
 	'googlesitekit-widgets': [ 'googlesitekit', 'widgets' ],
 	'@wordpress/i18n': [ 'googlesitekit', 'i18n' ],
+	'@wordpress/element': [ 'googlesitekit', 'element' ],
 };
 
 const externals = { ...siteKitExternals };
@@ -199,6 +200,7 @@ const resolve = {
 		),
 		'@wordpress/api-fetch$': path.resolve( 'assets/js/api-fetch-shim.js' ),
 		'@wordpress/i18n__non-shim': require.resolve( '@wordpress/i18n' ),
+		'@wordpress/element__non-shim': require.resolve( '@wordpress/element' ),
 	},
 	modules: [ projectPath( '.' ), 'node_modules' ],
 };
@@ -320,7 +322,7 @@ function* webpackConfig( env, argv ) {
 		},
 		plugins: [
 			new ProvidePlugin( {
-				React: '@wordpress/element',
+				React: '@wordpress/element__non-shim',
 			} ),
 			new WebpackBar( {
 				name: 'Module Entry Points',


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #4863 

## Relevant technical choices

This PR exposes `@wordpress/element` as an external module by the Site Kit plugin.

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
