### PR TITLE
Enhance/5568 - Update active consumers metadata when accessing shared dashboard

### DIFF
--- a/includes/Core/Authentication/Clients/OAuth_Client.php
+++ b/includes/Core/Authentication/Clients/OAuth_Client.php
@@ -18,12 +18,14 @@ use Google\Site_Kit\Core\Authentication\Google_Proxy;
 use Google\Site_Kit\Core\Authentication\Owner_ID;
 use Google\Site_Kit\Core\Authentication\Profile;
 use Google\Site_Kit\Core\Authentication\Token;
+use Google\Site_Kit\Core\Dashboard_Sharing\Activity_Metrics\Active_Consumers;
 use Google\Site_Kit\Core\Permissions\Permissions;
 use Google\Site_Kit\Core\Storage\Options;
 use Google\Site_Kit\Core\Storage\User_Options;
 use Google\Site_Kit\Core\Util\Scopes;
 use Google\Site_Kit\Core\Util\URL;
 use Google\Site_Kit_Dependencies\Google\Service\PeopleService as Google_Service_PeopleService;
+use WP_User;
 
 /**
  * Class for connecting to Google APIs via OAuth.
@@ -46,6 +48,14 @@ final class OAuth_Client extends OAuth_Client_Base {
 	 * @var Owner_ID
 	 */
 	private $owner_id;
+
+	/**
+	 * Active_Consumers instance.
+	 *
+	 * @since n.e.x.t
+	 * @var Active_Consumers
+	 */
+	private $active_consumers;
 
 	/**
 	 * Constructor.
@@ -79,7 +89,8 @@ final class OAuth_Client extends OAuth_Client_Base {
 			$token
 		);
 
-		$this->owner_id = new Owner_ID( $this->options );
+		$this->owner_id         = new Owner_ID( $this->options );
+		$this->active_consumers = new Active_Consumers( $this->user_options );
 	}
 
 	/**
@@ -622,5 +633,16 @@ final class OAuth_Client extends OAuth_Client_Base {
 		return current_user_can( Permissions::VIEW_DASHBOARD )
 			? $this->context->admin_url( 'dashboard' )
 			: $this->context->admin_url( 'splash' );
+	}
+
+	/**
+	 * Adds a user to the active consumers list.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param WP_User $user User object.
+	 */
+	public function add_active_consumer( WP_User $user ) {
+		$this->active_consumers->add( $user->ID, $user->roles );
 	}
 }

--- a/includes/Core/Dashboard_Sharing/Activity_Metrics/Active_Consumers.php
+++ b/includes/Core/Dashboard_Sharing/Activity_Metrics/Active_Consumers.php
@@ -93,4 +93,20 @@ class Active_Consumers extends User_Setting {
 			return $results;
 		};
 	}
+
+	/**
+	 * Adds a consumer to the active consumers list.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param int      $user_id User ID.
+	 * @param string[] $roles User roles.
+	 */
+	public function add( $user_id, $roles ) {
+		$active_consumers = $this->get();
+		if ( ! array_key_exists( $user_id, $active_consumers ) ) {
+			$active_consumers[ $user_id ] = $roles;
+			$this->set( $active_consumers );
+		}
+	}
 }

--- a/includes/Core/Modules/Module.php
+++ b/includes/Core/Modules/Module.php
@@ -360,6 +360,10 @@ abstract class Module {
 
 				// Set request as using shared credentials if oAuth clients do not match.
 				$this->is_using_shared_credentials = true;
+
+				$current_user = wp_get_current_user();
+				// Adds the current user to the active consumers list.
+				$oauth_client->add_active_consumer( $current_user );
 			}
 
 			$request = $this->create_data_request( $data );

--- a/tests/phpunit/integration/Core/Dashboard_Sharing/Active_ConsumersTest.php
+++ b/tests/phpunit/integration/Core/Dashboard_Sharing/Active_ConsumersTest.php
@@ -85,8 +85,10 @@ class Active_ConsumersTest extends TestCase {
 		$active_consumers = new Active_Consumers( $this->user_options );
 		$active_consumers->register();
 
+		// Verify the active consumers list is empty.
 		$this->assertEmpty( $active_consumers->get() );
 
+		// Verify the new user is added to the active consumers list.
 		$active_consumers->add( 1, array( 'editor' ) );
 		$this->assertEquals(
 			array(
@@ -95,7 +97,18 @@ class Active_ConsumersTest extends TestCase {
 			$active_consumers->get()
 		);
 
+		// Verify the new user is added to the active consumers list along with the existing user.
 		$active_consumers->add( 2, array( 'contributor', 'editor' ) );
+		$this->assertEquals(
+			array(
+				1 => array( 'editor' ),
+				2 => array( 'contributor', 'editor' ),
+			),
+			$active_consumers->get()
+		);
+
+		// Verify that adding the same user again does not result in duplicates or updating the value.
+		$active_consumers->add( 1, array( 'author' ) );
 		$this->assertEquals(
 			array(
 				1 => array( 'editor' ),

--- a/tests/phpunit/integration/Core/Dashboard_Sharing/Active_ConsumersTest.php
+++ b/tests/phpunit/integration/Core/Dashboard_Sharing/Active_ConsumersTest.php
@@ -81,6 +81,30 @@ class Active_ConsumersTest extends TestCase {
 		$this->assertEquals( array( 1 => array( 'a', 'c' ) ), $this->get_value() );
 	}
 
+	public function test_add_active_consumers() {
+		$active_consumers = new Active_Consumers( $this->user_options );
+		$active_consumers->register();
+
+		$this->assertEmpty( $active_consumers->get() );
+
+		$active_consumers->add( 1, array( 'editor' ) );
+		$this->assertEquals(
+			array(
+				1 => array( 'editor' ),
+			),
+			$active_consumers->get()
+		);
+
+		$active_consumers->add( 2, array( 'contributor', 'editor' ) );
+		$this->assertEquals(
+			array(
+				1 => array( 'editor' ),
+				2 => array( 'contributor', 'editor' ),
+			),
+			$active_consumers->get()
+		);
+	}
+
 	/**
 	 * Gets the value directly to isolate tested method.
 	 *


### PR DESCRIPTION
## Summary

Addresses issue:

- #5568 

## Relevant technical choices

- The IB mentions:
>Update the `test_get_data()` and `test_set_data()` methods which call the protected `Module::execute_data_request()` in `ModuleTest.php`.

- However, it's not necessary to test the integration (test) since this PR adds a unit test for the `Active_Consumers::add()` method, which covers all possible scenarios.

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
