### PR TITLE
Add module slug to get help link.

### DIFF
--- a/assets/js/components/ReportError.js
+++ b/assets/js/components/ReportError.js
@@ -70,11 +70,17 @@ export default function ReportError( { moduleSlug, error } ) {
 
 	const showRetry = !! retryableErrors.length;
 
-	const errorTroubleshootingLinkURL = useSelect( ( select ) =>
-		select( CORE_SITE ).getErrorTroubleshootingLinkURL(
-			showRetry ? retryableErrors[ 0 ] : errors[ 0 ]
-		)
-	);
+	const errorTroubleshootingLinkURL = useSelect( ( select ) => {
+		const err = {
+			...( showRetry ? retryableErrors[ 0 ] : errors[ 0 ] ),
+		};
+
+		if ( isInsufficientPermissionsError( err ) ) {
+			err.code = `${ moduleSlug }_insufficient_permissions`;
+		}
+
+		return select( CORE_SITE ).getErrorTroubleshootingLinkURL( err );
+	} );
 
 	const dispatch = useDispatch();
 

--- a/assets/js/components/ReportError.test.js
+++ b/assets/js/components/ReportError.test.js
@@ -211,6 +211,31 @@ describe( 'ReportError', () => {
 		expect( queryByText( /request access/i ) ).toBeInTheDocument();
 	} );
 
+	it( 'renders the help link with the moduleSlug_insufficient_permissions string when ERROR_REASON_INSUFFICIENT_PERMISSIONS is provided as reason', () => {
+		const { container } = render(
+			<ReportError
+				moduleSlug={ moduleName }
+				error={ {
+					code: 'test-error-code',
+					message: 'Test error message',
+					data: {
+						reason: ERROR_REASON_INSUFFICIENT_PERMISSIONS,
+					},
+				} }
+			/>,
+			{
+				registry,
+			}
+		);
+
+		expect( container.querySelector( 'a' ) ).toHaveAttribute(
+			'href',
+			expect.stringContaining(
+				`error_id=${ moduleName }_insufficient_permissions`
+			)
+		);
+	} );
+
 	it( "should not render the `Retry` button if the error's `selectorData.name` is not `getReport`", () => {
 		const { queryByText } = render(
 			<ReportError


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #5987 

## Relevant technical choices
The IB suggested looping through all the errors and then setting the code to `moduleSlug_insufficient_permissions` if the error is an insufficient permission one. However since we only need to set the code when generating the help link, I moved the check within `errorTroubleshootingLinkURL`, i.e only when we need to generate the help link.

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
