### PR TITLE
BannerNotification: Restore the explicit check for navigation to the CTA link.

### DIFF
--- a/assets/js/components/notifications/BannerNotification/index.js
+++ b/assets/js/components/notifications/BannerNotification/index.js
@@ -166,8 +166,8 @@ function BannerNotification( {
 		}, 350 );
 	}
 
-	const isNavigating = useSelect( ( select ) =>
-		select( CORE_LOCATION ).isNavigating()
+	const isNavigatingToCTALink = useSelect( ( select ) =>
+		select( CORE_LOCATION ).isNavigatingTo( ctaLink || '' )
 	);
 
 	const { navigateTo } = useDispatch( CORE_LOCATION );
@@ -237,14 +237,15 @@ function BannerNotification( {
 	// isDismissed will be undefined until resolved from browser storage.
 	// isNavigating will be true until the navigation is complete.
 	if (
-		! isNavigating &&
+		! isNavigatingToCTALink &&
 		isDismissible &&
 		( undefined === isDismissed || isDismissed )
 	) {
 		return null;
 	}
 
-	const closedClass = ! isNavigating && isClosed ? 'is-closed' : 'is-open';
+	const closedClass =
+		! isNavigatingToCTALink && isClosed ? 'is-closed' : 'is-open';
 	const inlineLayout = 'large' === format && 'win-stats-increase' === type;
 
 	const imageCellSizeProperties = getImageCellSizeProperties( format );
@@ -458,7 +459,7 @@ function BannerNotification( {
 										onClick={ handleCTAClick }
 										disabled={
 											isAwaitingCTAResponse ||
-											isNavigating
+											isNavigatingToCTALink
 										}
 									>
 										{ ctaLabel }
@@ -467,14 +468,15 @@ function BannerNotification( {
 
 								<Spinner
 									isSaving={
-										isAwaitingCTAResponse || isNavigating
+										isAwaitingCTAResponse ||
+										isNavigatingToCTALink
 									}
 								/>
 
 								{ isDismissible &&
 									dismiss &&
 									! isAwaitingCTAResponse &&
-									! isNavigating && (
+									! isNavigatingToCTALink && (
 										<DismissComponent
 											onClick={ handleDismiss }
 										>


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #5974 

## Relevant technical choices

- Restore the explicit check for navigation to the CTA link. This avoids clashes with calls to `navigateTo` made outside of the banner, addressing issues like the one seen [here](https://github.com/google/site-kit-wp/issues/5974#issuecomment-1293527475).

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [ ] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [x] Run the code.
- [x] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [x] Ensure no unrelated changes are included.
- [x] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [x] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
