### PR TITLE
Bug/6023 - Trigger the custom GA view_notification event only when the banner notifications are visible

### DIFF
--- a/assets/js/components/activation/activation-app.js
+++ b/assets/js/components/activation/activation-app.js
@@ -17,14 +17,9 @@
  */
 
 /**
- * External dependencies
- */
-import { useMount } from 'react-use';
-
-/**
  * WordPress dependencies
  */
-import { useCallback } from '@wordpress/element';
+import { useCallback, useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -58,14 +53,22 @@ export function ActivationApp() {
 		select( CORE_USER ).hasCapability( PERMISSION_VIEW_DASHBOARD )
 	);
 
-	useMount( () => {
-		trackEvent( viewContext, 'view_notification' );
-	} );
+	const [ viewNotificationSent, setViewNotificationSent ] = useState( false );
 
 	const buttonURL = canViewDashboard ? dashboardURL : splashURL;
 	const buttonLabel = canViewDashboard
 		? __( 'Go to Dashboard', 'google-site-kit' )
 		: __( 'Start setup', 'google-site-kit' );
+
+	useEffect( () => {
+		// Only trigger the view event if the notification is visible and we haven't
+		// already sent this notification.
+		if ( ! viewNotificationSent && buttonURL ) {
+			trackEvent( viewContext, 'view_notification' );
+			// Don't send the view event again.
+			setViewNotificationSent( true );
+		}
+	}, [ viewContext, buttonURL, viewNotificationSent ] );
 
 	const onButtonClick = useCallback(
 		async ( event ) => {

--- a/assets/js/components/notifications/SetupSuccessBannerNotification.js
+++ b/assets/js/components/notifications/SetupSuccessBannerNotification.js
@@ -118,27 +118,26 @@ function SetupSuccessBannerNotification() {
 
 			// Only trigger these events if this is a site/plugin setup event,
 			// and not setup of an individual module (eg. AdSense, Analytics, etc.)
-			if ( slug === null ) {
-				if ( ! completeUserSetupSent ) {
-					trackEvent(
-						`${ viewContext }_authentication-success-notification`,
-						'complete_user_setup',
-						isUsingProxy ? 'proxy' : 'custom-oauth'
-					);
-					setCompleteUserSetupSent( true );
-				}
-
-				// If the site doesn't yet have multiple admins, this is the initial
-				// site setup so we can log the "site setup complete" event.
-				if ( ! completeSiteSetup && hasMultipleAdmins === false ) {
-					trackEvent(
-						`${ viewContext }_authentication-success-notification`,
-						'complete_site_setup',
-						isUsingProxy ? 'proxy' : 'custom-oauth'
-					);
-					setCompleteSiteSetup( true );
-				}
+			if ( slug === null && ! completeUserSetupSent ) {
+				trackEvent(
+					`${ viewContext }_authentication-success-notification`,
+					'complete_user_setup',
+					isUsingProxy ? 'proxy' : 'custom-oauth'
+				);
+				
+				setCompleteUserSetupSent( true );
 			}
+
+			// If the site doesn't yet have multiple admins, this is the initial
+			// site setup so we can log the "site setup complete" event.
+			if ( slug === null && ! completeSiteSetup && hasMultipleAdmins === false ) {
+				trackEvent(
+					`${ viewContext }_authentication-success-notification`,
+					'complete_site_setup',
+					isUsingProxy ? 'proxy' : 'custom-oauth'
+				);
+
+				setCompleteSiteSetup( true );
 		}
 	}, [
 		canManageOptions,
@@ -175,14 +174,12 @@ function SetupSuccessBannerNotification() {
 		return null;
 	}
 
-	if ( notification === 'authentication_success' ) {
-		if ( ! canManageOptions ) {
-			return null;
-		}
+	if ( notification === 'authentication_success' && ! canManageOptions ) {
+		return null;
+	}
 
-		if ( slug && ! modules[ slug ]?.active ) {
-			return null;
-		}
+	if ( notification === 'authentication_success' && slug && ! modules[ slug ]?.active ) {
+		return null;
 	}
 
 	const winData = {

--- a/assets/js/components/notifications/SetupSuccessBannerNotification.js
+++ b/assets/js/components/notifications/SetupSuccessBannerNotification.js
@@ -124,13 +124,17 @@ function SetupSuccessBannerNotification() {
 					'complete_user_setup',
 					isUsingProxy ? 'proxy' : 'custom-oauth'
 				);
-				
+
 				setCompleteUserSetupSent( true );
 			}
 
 			// If the site doesn't yet have multiple admins, this is the initial
 			// site setup so we can log the "site setup complete" event.
-			if ( slug === null && ! completeSiteSetup && hasMultipleAdmins === false ) {
+			if (
+				slug === null &&
+				! completeSiteSetup &&
+				hasMultipleAdmins === false
+			) {
 				trackEvent(
 					`${ viewContext }_authentication-success-notification`,
 					'complete_site_setup',
@@ -138,6 +142,7 @@ function SetupSuccessBannerNotification() {
 				);
 
 				setCompleteSiteSetup( true );
+			}
 		}
 	}, [
 		canManageOptions,
@@ -178,7 +183,11 @@ function SetupSuccessBannerNotification() {
 		return null;
 	}
 
-	if ( notification === 'authentication_success' && slug && ! modules[ slug ]?.active ) {
+	if (
+		notification === 'authentication_success' &&
+		slug &&
+		! modules[ slug ]?.active
+	) {
 		return null;
 	}
 

--- a/assets/js/components/notifications/SetupSuccessBannerNotification.js
+++ b/assets/js/components/notifications/SetupSuccessBannerNotification.js
@@ -17,14 +17,9 @@
  */
 
 /**
- * External dependencies
- */
-import { useMount } from 'react-use';
-
-/**
  * WordPress dependencies
  */
-import { Fragment, useCallback } from '@wordpress/element';
+import { Fragment, useCallback, useEffect, useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { removeQueryArgs } from '@wordpress/url';
 
@@ -50,6 +45,7 @@ const { useSelect } = Data;
 
 function SetupSuccessBannerNotification() {
 	const slug = getQueryParameter( 'slug' );
+	const notification = getQueryParameter( 'notification' );
 	const viewContext = useViewContext();
 	const twgEnabled = useFeature( 'twgModule' );
 
@@ -95,32 +91,67 @@ function SetupSuccessBannerNotification() {
 			)
 	);
 
-	useMount( () => {
-		trackEvent(
-			`${ viewContext }_authentication-success-notification`,
-			'view_notification'
-		);
+	const [ viewNotificationSent, setViewNotificationSent ] = useState( false );
+	const [ completeUserSetupSent, setCompleteUserSetupSent ] =
+		useState( false );
+	const [ completeSiteSetup, setCompleteSiteSetup ] = useState( false );
 
-		// Only trigger these events if this is a site/plugin setup event,
-		// and not setup of an individual module (eg. AdSense, Analytics, etc.)
-		if ( slug === null ) {
-			trackEvent(
-				`${ viewContext }_authentication-success-notification`,
-				'complete_user_setup',
-				isUsingProxy ? 'proxy' : 'custom-oauth'
-			);
-
-			// If the site doesn't yet have multiple admins, this is the initial
-			// site setup so we can log the "site setup complete" event.
-			if ( ! hasMultipleAdmins ) {
+	useEffect( () => {
+		// Only trigger the GA events if the notification is visible and we haven't
+		// already sent these notifications.
+		if (
+			modules !== undefined &&
+			notification === 'authentication_success'
+		) {
+			if (
+				! viewNotificationSent &&
+				canManageOptions &&
+				slug &&
+				modules[ slug ]?.active
+			) {
 				trackEvent(
 					`${ viewContext }_authentication-success-notification`,
-					'complete_site_setup',
-					isUsingProxy ? 'proxy' : 'custom-oauth'
+					'view_notification'
 				);
+				setViewNotificationSent( true );
+			}
+
+			// Only trigger these events if this is a site/plugin setup event,
+			// and not setup of an individual module (eg. AdSense, Analytics, etc.)
+			if ( slug === null ) {
+				if ( ! completeUserSetupSent ) {
+					trackEvent(
+						`${ viewContext }_authentication-success-notification`,
+						'complete_user_setup',
+						isUsingProxy ? 'proxy' : 'custom-oauth'
+					);
+					setCompleteUserSetupSent( true );
+				}
+
+				// If the site doesn't yet have multiple admins, this is the initial
+				// site setup so we can log the "site setup complete" event.
+				if ( ! completeSiteSetup && hasMultipleAdmins === false ) {
+					trackEvent(
+						`${ viewContext }_authentication-success-notification`,
+						'complete_site_setup',
+						isUsingProxy ? 'proxy' : 'custom-oauth'
+					);
+					setCompleteSiteSetup( true );
+				}
 			}
 		}
-	} );
+	}, [
+		canManageOptions,
+		completeSiteSetup,
+		completeUserSetupSent,
+		hasMultipleAdmins,
+		isUsingProxy,
+		modules,
+		notification,
+		slug,
+		viewContext,
+		viewNotificationSent,
+	] );
 
 	const onDismiss = useCallback( async () => {
 		await trackEvent(
@@ -140,9 +171,18 @@ function SetupSuccessBannerNotification() {
 	}
 
 	// Only show the connected win when the user completes setup flow.
-	const notification = getQueryParameter( 'notification' );
 	if ( ! notification || '' === notification ) {
 		return null;
+	}
+
+	if ( notification === 'authentication_success' ) {
+		if ( ! canManageOptions ) {
+			return null;
+		}
+
+		if ( slug && ! modules[ slug ]?.active ) {
+			return null;
+		}
 	}
 
 	const winData = {
@@ -158,14 +198,6 @@ function SetupSuccessBannerNotification() {
 
 	switch ( notification ) {
 		case 'authentication_success':
-			if ( ! canManageOptions ) {
-				return null;
-			}
-
-			if ( slug && ! modules[ slug ]?.active ) {
-				return null;
-			}
-
 			if ( modules[ slug ] ) {
 				winData.id = `${ winData.id }-${ slug }`;
 				winData.setupTitle = modules[ slug ].name;

--- a/assets/js/components/notifications/WPVersionBumpNotification.js
+++ b/assets/js/components/notifications/WPVersionBumpNotification.js
@@ -17,15 +17,10 @@
  */
 
 /**
- * External dependencies
- */
-import { useMount } from 'react-use';
-
-/**
  * WordPress dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
-import { useCallback } from '@wordpress/element';
+import { useCallback, useEffect, useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -49,10 +44,6 @@ export default function WPVersionBumpNotification() {
 		trackEvent( eventCategory, 'confirm_notification' );
 	}, [ eventCategory ] );
 
-	useMount( () => {
-		trackEvent( eventCategory, 'view_notification' );
-	} );
-
 	const hasMinimumWPVersion = useSelect( ( select ) =>
 		select( CORE_SITE ).hasMinimumWordPressVersion( '5.2' )
 	);
@@ -66,6 +57,28 @@ export default function WPVersionBumpNotification() {
 	const updateCoreURL = useSelect( ( select ) =>
 		select( CORE_SITE ).getUpdateCoreURL()
 	);
+
+	const [ viewNotificationSent, setViewNotificationSent ] = useState( false );
+
+	useEffect( () => {
+		// Only trigger the view event if the notification is visible and we haven't
+		// already sent this notification.
+		if (
+			! viewNotificationSent &&
+			hasMinimumWPVersion === false &&
+			version !== undefined
+		) {
+			trackEvent( eventCategory, 'view_notification' );
+			// Don't send the view event again.
+			setViewNotificationSent( true );
+		}
+	}, [
+		eventCategory,
+		hasMinimumWPVersion,
+		version,
+		viewContext,
+		viewNotificationSent,
+	] );
 
 	if ( hasMinimumWPVersion || version === undefined ) {
 		return null;


### PR DESCRIPTION
## Summary

Addresses issue:

- #6023 

## Relevant technical choices

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
