### PR TITLE
Don't show "How to improve" CTA on "In the Field" tab when field data is unavailable.

### DIFF
--- a/assets/js/modules/pagespeed-insights/components/dashboard/DashboardPageSpeed.js
+++ b/assets/js/modules/pagespeed-insights/components/dashboard/DashboardPageSpeed.js
@@ -270,6 +270,14 @@ export default function DashboardPageSpeed() {
 	const isLoading =
 		! referenceURL || ( isFetching && ! reportData ) || ! dataSrc;
 
+	const isFieldTabWithData =
+		dataSrc === DATA_SRC_FIELD &&
+		[
+			'LARGEST_CONTENTFUL_PAINT_MS',
+			'CUMULATIVE_LAYOUT_SHIFT_SCORE',
+			'FIRST_INPUT_DELAY_MS',
+		].every( ( key ) => reportData?.loadingExperience?.metrics?.[ key ] );
+
 	return (
 		<div
 			id="googlesitekit-pagespeed-header" // Used by jump link.
@@ -392,8 +400,7 @@ export default function DashboardPageSpeed() {
 					) }
 				</section>
 
-				{ ( dataSrc === DATA_SRC_LAB ||
-					dataSrc === DATA_SRC_FIELD ) && (
+				{ ( dataSrc === DATA_SRC_LAB || isFieldTabWithData ) && (
 					<div className="googlesitekit-pagespeed-report__row">
 						<Button
 							className={ classnames( {


### PR DESCRIPTION
## Summary

Following up on the point raised in QA [here](https://github.com/google/site-kit-wp/issues/4878#issuecomment-1297157100), this PR ensures the "How to improve" CTA on the PSI widget's "In the Field" tab is not shown when field data is unavailable.

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #4848

<!-- Please describe your changes. -->

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [ ] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
