### PR TITLE
Use useInViewSelect to lazy load PSI reports.

### DIFF
--- a/assets/js/modules/pagespeed-insights/components/dashboard/DashboardPageSpeed.js
+++ b/assets/js/modules/pagespeed-insights/components/dashboard/DashboardPageSpeed.js
@@ -222,7 +222,7 @@ export default function DashboardPageSpeed() {
 			[ referenceURL, strategy ]
 		)
 	);
-	const recommendations = useSelect(
+	const recommendations = useInViewSelect(
 		( select ) => {
 			if ( reportError ) {
 				return [];


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #4878 

## Relevant technical choices

Use `useInViewSelect` to avoid loading the PSI mobile report before the widget is in view, as flagged [here](https://github.com/google/site-kit-wp/issues/4878#issuecomment-1299464077).

<!-- Please describe your changes. -->

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 4.7 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [ ] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
