### PR TITLE
Add `MediaErrorHandler`

### DIFF
--- a/assets/js/components/MediaErrorHandler.js
+++ b/assets/js/components/MediaErrorHandler.js
@@ -1,0 +1,66 @@
+/**
+ * MediaErrorHandler component.
+ *
+ * Site Kit by Google, Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+
+/**
+ * WordPress dependencies
+ */
+import { Component } from '@wordpress/element';
+
+class MediaErrorHandler extends Component {
+	constructor( props ) {
+		super( props );
+
+		this.state = {
+			error: null,
+		};
+	}
+
+	componentDidCatch( error, info ) {
+		global.console.error( 'Caught an error:', error, info );
+
+		this.setState( { error } );
+	}
+
+	render() {
+		const { children, errorMessage } = this.props;
+		const { error } = this.state;
+
+		if ( error && errorMessage && '' !== errorMessage ) {
+			return <p>{ errorMessage }</p>;
+		}
+
+		// If there is no caught error, render the children components normally.
+		return children;
+	}
+}
+
+MediaErrorHandler.defaultProps = {
+	errorMessage: '',
+};
+
+MediaErrorHandler.propTypes = {
+	children: PropTypes.node.isRequired,
+	errorMessage: PropTypes.string.isRequired,
+};
+
+export default MediaErrorHandler;

--- a/assets/js/components/MediaErrorHandler.js
+++ b/assets/js/components/MediaErrorHandler.js
@@ -25,6 +25,12 @@ import PropTypes from 'prop-types';
  * WordPress dependencies
  */
 import { Component } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import ErrorText from './ErrorText';
 
 class MediaErrorHandler extends Component {
 	constructor( props ) {
@@ -45,17 +51,17 @@ class MediaErrorHandler extends Component {
 		const { children, errorMessage } = this.props;
 		const { error } = this.state;
 
-		if ( error && errorMessage && '' !== errorMessage ) {
-			return <p>{ errorMessage }</p>;
+		// If there is no caught error, render the children components normally.
+		if ( ! error ) {
+			return children;
 		}
 
-		// If there is no caught error, render the children components normally.
-		return children;
+		return <ErrorText message={ errorMessage } />;
 	}
 }
 
 MediaErrorHandler.defaultProps = {
-	errorMessage: '',
+	errorMessage: __( 'Failed to load media.', 'google-site-kit' ),
 };
 
 MediaErrorHandler.propTypes = {

--- a/assets/js/components/MediaErrorHandler/index.js
+++ b/assets/js/components/MediaErrorHandler/index.js
@@ -30,7 +30,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import ErrorText from './ErrorText';
+import ErrorText from '../ErrorText';
 
 class MediaErrorHandler extends Component {
 	constructor( props ) {

--- a/assets/js/components/MediaErrorHandler/index.stories.js
+++ b/assets/js/components/MediaErrorHandler/index.stories.js
@@ -25,8 +25,8 @@ const ErrorComponent = () => {
 	throw new Error();
 };
 
-const Template = () => (
-	<MediaErrorHandler>
+const Template = ( args ) => (
+	<MediaErrorHandler { ...args }>
 		<ErrorComponent />
 	</MediaErrorHandler>
 );
@@ -41,6 +41,12 @@ export const Default = Template.bind( {} );
 Default.storyName = 'Default';
 Default.scenario = {
 	label: 'Global/MediaErrorHandler',
+};
+
+export const WithCustomErrorMessage = Template.bind( {} );
+WithCustomErrorMessage.storyName = 'With Custom Error Message';
+WithCustomErrorMessage.args = {
+	errorMessage: 'This is a custom error message 🐞',
 };
 
 export const NoErrors = NoErrorsTemplate.bind( {} );

--- a/assets/js/components/MediaErrorHandler/index.stories.js
+++ b/assets/js/components/MediaErrorHandler/index.stories.js
@@ -31,11 +31,20 @@ const Template = () => (
 	</MediaErrorHandler>
 );
 
+const NoErrorsTemplate = () => (
+	<MediaErrorHandler>
+		<div>There are no errors here.</div>
+	</MediaErrorHandler>
+);
+
 export const Default = Template.bind( {} );
 Default.storyName = 'Default';
 Default.scenario = {
 	label: 'Global/MediaErrorHandler',
 };
+
+export const NoErrors = NoErrorsTemplate.bind( {} );
+NoErrors.storyName = 'No Errors';
 
 export default {
 	title: 'Components/MediaErrorHandler',

--- a/assets/js/components/MediaErrorHandler/index.stories.js
+++ b/assets/js/components/MediaErrorHandler/index.stories.js
@@ -1,0 +1,45 @@
+/**
+ * MediaErrorHandler Component Stories.
+ *
+ * Site Kit by Google, Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import MediaErrorHandler from './';
+
+const ErrorComponent = () => {
+	throw new Error(
+		'Something bad happened. 💣 (On purpose; ErrorComponent was used to simulate an error.)'
+	);
+};
+
+const Template = () => (
+	<MediaErrorHandler>
+		<ErrorComponent />
+	</MediaErrorHandler>
+);
+
+export const Default = Template.bind( {} );
+Default.storyName = 'Default';
+Default.scenario = {
+	label: 'Global/MediaErrorHandler',
+};
+
+export default {
+	title: 'Components/MediaErrorHandler',
+	component: MediaErrorHandler,
+};

--- a/assets/js/components/MediaErrorHandler/index.stories.js
+++ b/assets/js/components/MediaErrorHandler/index.stories.js
@@ -22,9 +22,7 @@
 import MediaErrorHandler from './';
 
 const ErrorComponent = () => {
-	throw new Error(
-		'Something bad happened. 💣 (On purpose; ErrorComponent was used to simulate an error.)'
-	);
+	throw new Error();
 };
 
 const Template = () => (

--- a/assets/js/components/MediaErrorHandler/index.test.js
+++ b/assets/js/components/MediaErrorHandler/index.test.js
@@ -1,0 +1,74 @@
+/**
+ * MediaErrorHandler component tests.
+ *
+ * Site Kit by Google, Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import { getByText } from '@testing-library/dom';
+
+/**
+ * Internal dependencies
+ */
+import MediaErrorHandler from './';
+import { render } from '../../../../tests/js/test-utils';
+
+const ErrorComponent = () => {
+	throw new Error();
+};
+
+describe( 'Media Error Handler', () => {
+	it( 'should render error message when there is an error', () => {
+		const { container } = render(
+			<MediaErrorHandler>
+				<ErrorComponent />
+			</MediaErrorHandler>
+		);
+
+		expect( console ).toHaveErrored();
+
+		expect(
+			getByText( container, /Error: Failed to load media/ )
+		).toBeInTheDocument();
+	} );
+
+	it( 'should render defined error message when there is an error', () => {
+		const { container } = render(
+			<MediaErrorHandler errorMessage="Failed to load graphic.">
+				<ErrorComponent />
+			</MediaErrorHandler>
+		);
+
+		expect( console ).toHaveErrored();
+
+		expect(
+			getByText( container, /Error: Failed to load graphic/ )
+		).toBeInTheDocument();
+	} );
+
+	it( 'should render children if there is no error', () => {
+		const { container } = render(
+			<MediaErrorHandler>No errors encountered</MediaErrorHandler>
+		);
+
+		expect( console ).not.toHaveErrored();
+
+		expect(
+			getByText( container, /No errors encountered/ )
+		).toBeInTheDocument();
+	} );
+} );

--- a/assets/js/modules/adsense/components/common/AdSenseConnectCTA/ContentSVG.js
+++ b/assets/js/modules/adsense/components/common/AdSenseConnectCTA/ContentSVG.js
@@ -24,12 +24,14 @@ import { PropTypes } from 'prop-types';
 /**
  * WordPress dependencies
  */
+import { __ } from '@wordpress/i18n';
 import { lazy, Suspense } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import PreviewBlock from '../../../../../components/PreviewBlock';
+import MediaErrorHandler from '../../../../../components/MediaErrorHandler';
 const LazyContentSVG0 = lazy( () =>
 	import( '../../../../../../svg/graphics/adsense-connect-0.svg' )
 );
@@ -40,14 +42,39 @@ const LazyContentSVG2 = lazy( () =>
 	import( '../../../../../../svg/graphics/adsense-connect-2.svg' )
 );
 
+function ErrorHandler( { children } ) {
+	return (
+		<MediaErrorHandler
+			errorMessage={ __(
+				'Error: Failed to load graphic.',
+				'google-site-kit'
+			) }
+		>
+			{ children }
+		</MediaErrorHandler>
+	);
+}
+
 function LazyContentSVG( { stage } ) {
 	switch ( stage ) {
 		case 0:
-			return <LazyContentSVG0 />;
+			return (
+				<ErrorHandler>
+					<LazyContentSVG0 />
+				</ErrorHandler>
+			);
 		case 1:
-			return <LazyContentSVG1 />;
+			return (
+				<ErrorHandler>
+					<LazyContentSVG1 />
+				</ErrorHandler>
+			);
 		case 2:
-			return <LazyContentSVG2 />;
+			return (
+				<ErrorHandler>
+					<LazyContentSVG2 />
+				</ErrorHandler>
+			);
 	}
 }
 

--- a/assets/js/modules/adsense/components/common/AdSenseConnectCTA/ContentSVG.js
+++ b/assets/js/modules/adsense/components/common/AdSenseConnectCTA/ContentSVG.js
@@ -42,37 +42,24 @@ const LazyContentSVG2 = lazy( () =>
 	import( '../../../../../../svg/graphics/adsense-connect-2.svg' )
 );
 
-function ErrorHandler( { children } ) {
+function LazyContentSVG( { stage } ) {
+	const graphics = {
+		0: <LazyContentSVG0 />,
+		1: <LazyContentSVG1 />,
+		2: <LazyContentSVG2 />,
+	};
+
+	if ( ! graphics[ stage ] ) {
+		return null;
+	}
+
 	return (
 		<MediaErrorHandler
 			errorMessage={ __( 'Failed to load graphic.', 'google-site-kit' ) }
 		>
-			{ children }
+			{ graphics[ stage ] }
 		</MediaErrorHandler>
 	);
-}
-
-function LazyContentSVG( { stage } ) {
-	switch ( stage ) {
-		case 0:
-			return (
-				<ErrorHandler>
-					<LazyContentSVG0 />
-				</ErrorHandler>
-			);
-		case 1:
-			return (
-				<ErrorHandler>
-					<LazyContentSVG1 />
-				</ErrorHandler>
-			);
-		case 2:
-			return (
-				<ErrorHandler>
-					<LazyContentSVG2 />
-				</ErrorHandler>
-			);
-	}
 }
 
 export default function ContentSVG( { stage } ) {

--- a/assets/js/modules/adsense/components/common/AdSenseConnectCTA/ContentSVG.js
+++ b/assets/js/modules/adsense/components/common/AdSenseConnectCTA/ContentSVG.js
@@ -24,8 +24,8 @@ import { PropTypes } from 'prop-types';
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
 import { lazy, Suspense } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -45,10 +45,7 @@ const LazyContentSVG2 = lazy( () =>
 function ErrorHandler( { children } ) {
 	return (
 		<MediaErrorHandler
-			errorMessage={ __(
-				'Error: Failed to load graphic.',
-				'google-site-kit'
-			) }
+			errorMessage={ __( 'Failed to load graphic.', 'google-site-kit' ) }
 		>
 			{ children }
 		</MediaErrorHandler>


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #5605 

## Relevant technical choices

This PR adds `MediaErrorHandler`, an error boundary to be used around media imports.

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [x] Ensure the PR has the correct target branch.
- [x] Double-check that the PR is okay to be merged.
- [x] Ensure the corresponding issue has a ZenHub release assigned.
- [x] Add a changelog message to the issue.
