### PR TITLE
Avoid using `_n()` in strings that do not contain a number

### DIFF
--- a/assets/js/components/notifications/SetupSuccessBannerNotification.js
+++ b/assets/js/components/notifications/SetupSuccessBannerNotification.js
@@ -19,7 +19,13 @@
 /**
  * WordPress dependencies
  */
-import { Fragment, useCallback, useEffect, useState } from '@wordpress/element';
+import {
+	createInterpolateElement,
+	Fragment,
+	useCallback,
+	useEffect,
+	useState,
+} from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { removeQueryArgs } from '@wordpress/url';
 
@@ -31,6 +37,7 @@ import { getQueryParameter } from '../../util';
 import BannerNotification, { LEARN_MORE_TARGET } from './BannerNotification';
 import SuccessGreenSVG from '../../../svg/graphics/success-green.svg';
 import UserInputSuccessBannerNotification from './UserInputSuccessBannerNotification';
+import Link from '../Link';
 import { CORE_MODULES } from '../../googlesitekit/modules/datastore/constants';
 import { CORE_SITE } from '../../googlesitekit/datastore/site/constants';
 import {
@@ -254,18 +261,21 @@ function SetupSuccessBannerNotification() {
 			}
 
 			if ( 'thank-with-google' === slug ) {
-				winData.description = __(
-					'Thank with Google is visible to your visitors. To see metrics,',
-					'google-site-kit'
+				winData.description = (
+					<p>
+						{ createInterpolateElement(
+							__(
+								'Thank with Google is visible to your visitors. To see metrics, <link>open the administrator panel.</link>',
+								'google-site-kit'
+							),
+							{
+								link: <Link href={ publicationURL } external />,
+							}
+						) }
+					</p>
 				);
-				winData.learnMore = {
-					label: __(
-						'open the administrator panel.',
-						'google-site-kit'
-					),
-					url: publicationURL,
-					target: LEARN_MORE_TARGET.EXTERNAL,
-				};
+
+				winData.learnMore.label = '';
 			}
 
 			return (

--- a/assets/js/googlesitekit/components-gm2/Dialog.js
+++ b/assets/js/googlesitekit/components-gm2/Dialog.js
@@ -27,8 +27,8 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { useInstanceId } from '@wordpress/compose';
-import { useCallback } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { createInterpolateElement, useCallback } from '@wordpress/element';
+import { sprintf, __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -119,10 +119,19 @@ const Dialog = ( {
 							) }
 							{ dependentModules && (
 								<p className="mdc-dialog__dependecies">
-									<strong>
-										{ __( 'Note: ', 'google-site-kit' ) }
-									</strong>
-									{ dependentModules }
+									{ createInterpolateElement(
+										sprintf(
+											/* translators: %s is replaced with the dependent modules. */
+											__(
+												'<strong>Note:</strong> %s',
+												'google-site-kit'
+											),
+											dependentModules
+										),
+										{
+											strong: <strong />,
+										}
+									) }
 								</p>
 							) }
 							<footer className="mdc-dialog__actions">

--- a/includes/Modules/AdSense.php
+++ b/includes/Modules/AdSense.php
@@ -886,12 +886,10 @@ final class AdSense extends Module
 		$invalid_metrics = array_diff( $metrics, $valid_metrics );
 
 		if ( count( $invalid_metrics ) > 0 ) {
-			$message = sprintf(
+			$message = count( $invalid_metrics ) > 1 ? sprintf(
 				/* translators: %s: is replaced with a comma separated list of the invalid metrics. */
-				_n(
-					'Unsupported metric requested: %s',
+				__(
 					'Unsupported metrics requested: %s',
-					count( $invalid_metrics ),
 					'google-site-kit'
 				),
 				join(
@@ -899,6 +897,13 @@ final class AdSense extends Module
 					__( ', ', 'google-site-kit' ),
 					$invalid_metrics
 				)
+			) : sprintf(
+				/* translators: %s: is replaced with the invalid metric. */
+				__(
+					'Unsupported metric requested: %s',
+					'google-site-kit'
+				),
+				$invalid_metrics
 			);
 
 			throw new Invalid_Report_Metrics_Exception( $message );
@@ -928,12 +933,10 @@ final class AdSense extends Module
 		$invalid_dimensions = array_diff( $dimensions, $valid_dimensions );
 
 		if ( count( $invalid_dimensions ) > 0 ) {
-			$message = sprintf(
+			$message = count( $invalid_dimensions ) > 1 ? sprintf(
 				/* translators: %s: is replaced with a comma separated list of the invalid dimensions. */
-				_n(
-					'Unsupported dimension requested: %s',
+				__(
 					'Unsupported dimensions requested: %s',
-					count( $invalid_dimensions ),
 					'google-site-kit'
 				),
 				join(
@@ -941,6 +944,13 @@ final class AdSense extends Module
 					__( ', ', 'google-site-kit' ),
 					$invalid_dimensions
 				)
+			) : sprintf(
+				/* translators: %s: is replaced with the invalid dimension. */
+				__(
+					'Unsupported dimension requested: %s',
+					'google-site-kit'
+				),
+				$invalid_dimensions
 			);
 
 			throw new Invalid_Report_Dimensions_Exception( $message );

--- a/includes/Modules/Analytics.php
+++ b/includes/Modules/Analytics.php
@@ -1393,12 +1393,10 @@ final class Analytics extends Module
 		);
 
 		if ( count( $invalid_metrics ) > 0 ) {
-			$message = sprintf(
+			$message = count( $invalid_metrics ) > 1 ? sprintf(
 				/* translators: %s: is replaced with a comma separated list of the invalid metrics. */
-				_n(
-					'Unsupported metric requested: %s',
+				__(
 					'Unsupported metrics requested: %s',
-					count( $invalid_metrics ),
 					'google-site-kit'
 				),
 				join(
@@ -1406,6 +1404,13 @@ final class Analytics extends Module
 					__( ', ', 'google-site-kit' ),
 					$invalid_metrics
 				)
+			) : sprintf(
+				/* translators: %s: is replaced with the invalid metric. */
+				__(
+					'Unsupported metric requested: %s',
+					'google-site-kit'
+				),
+				$invalid_metrics
 			);
 
 			throw new Invalid_Report_Metrics_Exception( $message );
@@ -1449,12 +1454,10 @@ final class Analytics extends Module
 		);
 
 		if ( count( $invalid_dimensions ) > 0 ) {
-			$message = sprintf(
+			$message = count( $invalid_dimensions ) > 1 ? sprintf(
 				/* translators: %s: is replaced with a comma separated list of the invalid dimensions. */
-				_n(
-					'Unsupported dimension requested: %s',
+				__(
 					'Unsupported dimensions requested: %s',
-					count( $invalid_dimensions ),
 					'google-site-kit'
 				),
 				join(
@@ -1462,6 +1465,13 @@ final class Analytics extends Module
 					__( ', ', 'google-site-kit' ),
 					$invalid_dimensions
 				)
+			) : sprintf(
+				/* translators: %s: is replaced with the invalid dimension. */
+				__(
+					'Unsupported dimension requested: %s',
+					'google-site-kit'
+				),
+				$invalid_dimensions
 			);
 
 			throw new Invalid_Report_Dimensions_Exception( $message );


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #6069 

## Relevant technical choices

This PR updates all strings that use `_n()` to differentiate between singular and plural, but do not have a number in them.

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [x] Run the code.
- [x] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [x] Ensure no unrelated changes are included.
- [x] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [x] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [x] Ensure the PR has the correct target branch.
- [x] Double-check that the PR is okay to be merged.
- [x] Ensure the corresponding issue has a ZenHub release assigned.
- [x] Add a changelog message to the issue.
