### PR TITLE
Fix regression on Idea Hub notification.

### DIFF
--- a/assets/js/components/notifications/BannerNotification/index.js
+++ b/assets/js/components/notifications/BannerNotification/index.js
@@ -104,6 +104,10 @@ function BannerNotification( {
 	title,
 	type,
 	WinImageSVG,
+	smWinImageSVGWidth = 75,
+	smWinImageSVGHeight = 75,
+	mdWinImageSVGWidth = 105,
+	mdWinImageSVGHeight = 105,
 	rounded = false,
 	footer,
 	secondaryPane,
@@ -324,7 +328,10 @@ function BannerNotification( {
 						<div
 							className={ `googlesitekit-publisher-win__image-${ format } googlesitekit-non-mobile-display-none` }
 						>
-							<WinImageSVG width={ 75 } height={ 75 } />
+							<WinImageSVG
+								width={ smWinImageSVGWidth }
+								height={ smWinImageSVGHeight }
+							/>
 						</div>
 					) }
 				</div>
@@ -515,7 +522,10 @@ function BannerNotification( {
 							<div
 								className={ `googlesitekit-publisher-win__image-${ format }` }
 							>
-								<WinImageSVG width={ 105 } height={ 105 } />
+								<WinImageSVG
+									width={ mdWinImageSVGWidth }
+									height={ mdWinImageSVGHeight }
+								/>
 							</div>
 						</Cell>
 					) }
@@ -583,6 +593,10 @@ BannerNotification.propTypes = {
 	rounded: PropTypes.bool,
 	footer: PropTypes.node,
 	secondaryPane: PropTypes.node,
+	smWinImageSVGWidth: PropTypes.number,
+	smWinImageSVGHeight: PropTypes.number,
+	mdWinImageSVGWidth: PropTypes.number,
+	mdWinImageSVGHeight: PropTypes.number,
 };
 
 BannerNotification.defaultProps = {

--- a/assets/js/components/notifications/BannerNotification/index.js
+++ b/assets/js/components/notifications/BannerNotification/index.js
@@ -104,10 +104,10 @@ function BannerNotification( {
 	title,
 	type,
 	WinImageSVG,
-	smWinImageSVGWidth = 75,
-	smWinImageSVGHeight = 75,
-	mdWinImageSVGWidth = 105,
-	mdWinImageSVGHeight = 105,
+	smallWinImageSVGWidth = 75,
+	smallWinImageSVGHeight = 75,
+	mediumWinImageSVGWidth = 105,
+	mediumWinImageSVGHeight = 105,
 	rounded = false,
 	footer,
 	secondaryPane,
@@ -329,8 +329,8 @@ function BannerNotification( {
 							className={ `googlesitekit-publisher-win__image-${ format } googlesitekit-non-mobile-display-none` }
 						>
 							<WinImageSVG
-								width={ smWinImageSVGWidth }
-								height={ smWinImageSVGHeight }
+								width={ smallWinImageSVGWidth }
+								height={ smallWinImageSVGHeight }
 							/>
 						</div>
 					) }
@@ -523,8 +523,8 @@ function BannerNotification( {
 								className={ `googlesitekit-publisher-win__image-${ format }` }
 							>
 								<WinImageSVG
-									width={ mdWinImageSVGWidth }
-									height={ mdWinImageSVGHeight }
+									width={ mediumWinImageSVGWidth }
+									height={ mediumWinImageSVGHeight }
 								/>
 							</div>
 						</Cell>
@@ -593,10 +593,10 @@ BannerNotification.propTypes = {
 	rounded: PropTypes.bool,
 	footer: PropTypes.node,
 	secondaryPane: PropTypes.node,
-	smWinImageSVGWidth: PropTypes.number,
-	smWinImageSVGHeight: PropTypes.number,
-	mdWinImageSVGWidth: PropTypes.number,
-	mdWinImageSVGHeight: PropTypes.number,
+	smallWinImageSVGWidth: PropTypes.number,
+	smallWinImageSVGHeight: PropTypes.number,
+	mediumWinImageSVGWidth: PropTypes.number,
+	mediumWinImageSVGHeight: PropTypes.number,
 };
 
 BannerNotification.defaultProps = {

--- a/assets/js/components/notifications/IdeaHubPromptBannerNotification.js
+++ b/assets/js/components/notifications/IdeaHubPromptBannerNotification.js
@@ -144,6 +144,8 @@ export default function IdeaHubPromptBannerNotification() {
 			learnMoreLabel={ __( 'Learn more', 'google-site-kit' ) }
 			learnMoreURL={ ideaHubSupportURL }
 			WinImageSVG={ IdeaHubPromptSVG }
+			mdWinImageSVGWidth={ 765 }
+			mdWinImageSVGHeight={ 304 }
 			noBottomPadding
 		/>
 	);

--- a/assets/js/components/notifications/IdeaHubPromptBannerNotification.js
+++ b/assets/js/components/notifications/IdeaHubPromptBannerNotification.js
@@ -144,8 +144,8 @@ export default function IdeaHubPromptBannerNotification() {
 			learnMoreLabel={ __( 'Learn more', 'google-site-kit' ) }
 			learnMoreURL={ ideaHubSupportURL }
 			WinImageSVG={ IdeaHubPromptSVG }
-			mdWinImageSVGWidth={ 765 }
-			mdWinImageSVGHeight={ 304 }
+			mediumWinImageSVGWidth={ 765 }
+			mediumWinImageSVGHeight={ 304 }
 			noBottomPadding
 		/>
 	);

--- a/assets/sass/components/global/_googlesitekit-publisher-wins.scss
+++ b/assets/sass/components/global/_googlesitekit-publisher-wins.scss
@@ -85,15 +85,6 @@
 			margin-left: $grid-gap-phone / 2;
 		}
 
-		& + .googlesitekit-cta-link,
-		& + .googlesitekit-publisher-win__actions {
-			margin-top: $grid-gap-phone;
-
-			@media (min-width: $bp-desktop) {
-				margin-top: $grid-gap-desktop;
-			}
-		}
-
 		.googlesitekit-publisher-win__image-smaller {
 			flex-basis: 75px;
 		}
@@ -215,6 +206,15 @@
 		display: flex;
 		flex-wrap: nowrap;
 		gap: $grid-gap-phone;
+
+		+ .googlesitekit-cta-link,
+		+ .googlesitekit-publisher-win__actions {
+			margin-top: $grid-gap-phone;
+
+			@media (min-width: $bp-desktop) {
+				margin-top: $grid-gap-desktop;
+			}
+		}
 	}
 
 	&.googlesitekit-publisher-win--no-bottom-padding {


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #5934 

## Relevant technical choices

- Added width and height options for the SVG to cater for the Idea Hub widget notification where the layout is different. Changing the layout will involve using a new SVG which I think we can prevent right now by adding the props to control the dimension of the SVG

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
