### PR TITLE
Enhance/5145 - Fix measurementID not loaded when clicking the edit link - Follow-up

### DIFF
--- a/assets/js/components/settings/SettingsActiveModule/Footer.js
+++ b/assets/js/components/settings/SettingsActiveModule/Footer.js
@@ -160,15 +160,20 @@ export default function Footer( props ) {
 		setValue( dialogActiveKey, ! dialogActive );
 	}, [ dialogActive, dialogActiveKey, setValue ] );
 
-	const handleEdit = useCallback(
-		() =>
-			trackEvent(
-				`${ viewContext }_module-list`,
-				'edit_module_settings',
-				slug
-			),
-		[ slug, viewContext ]
-	);
+	const handleEdit = useCallback( () => {
+		trackEvent(
+			`${ viewContext }_module-list`,
+			'edit_module_settings',
+			slug
+		);
+
+		setValues( FORM_SETUP, {
+			// Pre-enable GA4 controls.
+			enableGA4: true,
+			// Enable tooltip highlighting GA4 property select.
+			enableGA4PropertyTooltip: true,
+		} );
+	}, [ setValues, slug, viewContext ] );
 
 	if ( ! module ) {
 		return null;


### PR DESCRIPTION
## Summary

Addresses issue:

- #5145 

## Relevant technical choices

- This PR fixes the issue observed in the [QA](https://github.com/google/site-kit-wp/issues/5145#issuecomment-1308700620) process.
- The issue occurs only when we click the `/edit` link; however, it works with the `Connect Google Analytics 4` CTA. That’s because the `enableGA4` global state is set to `true` in the CTA handler but not in the edit link handler.

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [x] Run the code.
- [x] Ensure the acceptance criteria are satisfied.
- [x] Reassess the implementation with the IB.
- [x] Ensure no unrelated changes are included.
- [x] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [x] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [x] Ensure the PR has the correct target branch.
- [x] Double-check that the PR is okay to be merged.
- [x] Ensure the corresponding issue has a ZenHub release assigned.
- [x] Add a changelog message to the issue.
