### PR TITLE
Enhancement/6132-update_adsense_tag

### DIFF
--- a/includes/Modules/AdSense/Web_Tag.php
+++ b/includes/Modules/AdSense/Web_Tag.php
@@ -54,8 +54,9 @@ class Web_Tag extends Module_Web_Tag {
 		// because it is required for account verification.
 
 		$adsense_script_src = sprintf(
-			'https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=%s&host=ca-host-pub-2644536267352236',
-			esc_attr( $this->tag_id )
+			'https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=%s&host=%s',
+			esc_attr( $this->tag_id ), // Site owner's web property code
+			'ca-host-pub-2644536267352236' // SiteKit's web property code
 		);
 
 		$adsense_script_attributes = array(

--- a/includes/Modules/AdSense/Web_Tag.php
+++ b/includes/Modules/AdSense/Web_Tag.php
@@ -54,7 +54,7 @@ class Web_Tag extends Module_Web_Tag {
 		// because it is required for account verification.
 
 		$adsense_script_src = sprintf(
-			'https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=%s',
+			'https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=%s&host=ca-host-pub-2644536267352236',
 			esc_attr( $this->tag_id )
 		);
 

--- a/includes/Modules/AdSense/Web_Tag.php
+++ b/includes/Modules/AdSense/Web_Tag.php
@@ -55,8 +55,8 @@ class Web_Tag extends Module_Web_Tag {
 
 		$adsense_script_src = sprintf(
 			'https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=%s&host=%s',
-			esc_attr( $this->tag_id ), // Site owner's web property code
-			'ca-host-pub-2644536267352236' // SiteKit's web property code
+			esc_attr( $this->tag_id ), // Site owner's web property code.
+			'ca-host-pub-2644536267352236' // SiteKit's web property code.
 		);
 
 		$adsense_script_attributes = array(

--- a/tests/phpunit/integration/Modules/AdSenseTest.php
+++ b/tests/phpunit/integration/Modules/AdSenseTest.php
@@ -165,9 +165,7 @@ class AdSenseTest extends TestCase {
 
 		$this->assertStringContainsString( 'Google AdSense snippet added by Site Kit', $output );
 
-		$this->assertStringContainsString( 'pagead2.googlesyndication.com/pagead/js/adsbygoogle.js', $output );
-
-		$this->assertStringContainsString( '&ca-host-pub-2644536267352236', $output );
+		$this->assertStringContainsString( 'pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-12345678&host=ca-host-pub-2644536267352236', $output );
 
 		if ( $enabled ) {
 			$this->assertMatchesRegularExpression( '/\sdata-block-on-consent\b/', $output );

--- a/tests/phpunit/integration/Modules/AdSenseTest.php
+++ b/tests/phpunit/integration/Modules/AdSenseTest.php
@@ -167,6 +167,8 @@ class AdSenseTest extends TestCase {
 
 		$this->assertStringContainsString( 'pagead2.googlesyndication.com/pagead/js/adsbygoogle.js', $output );
 
+		$this->assertStringContainsString( '&ca-host-pub-2644536267352236', $output );
+
 		if ( $enabled ) {
 			$this->assertMatchesRegularExpression( '/\sdata-block-on-consent\b/', $output );
 		} else {

--- a/tests/phpunit/integration/Modules/AdSenseTest.php
+++ b/tests/phpunit/integration/Modules/AdSenseTest.php
@@ -165,7 +165,7 @@ class AdSenseTest extends TestCase {
 
 		$this->assertStringContainsString( 'Google AdSense snippet added by Site Kit', $output );
 
-		$this->assertStringContainsString( 'pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-12345678&host=ca-host-pub-2644536267352236', $output );
+		$this->assertStringContainsString( 'pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-12345678&amp;host=ca-host-pub-2644536267352236', $output );
 
 		if ( $enabled ) {
 			$this->assertMatchesRegularExpression( '/\sdata-block-on-consent\b/', $output );


### PR DESCRIPTION
## Summary

Addresses issue:

- #6132

## Relevant technical choices

Add SiteKit host property code in the source parameter of the AdSense tag as per the official documentation: https://developers.google.com/adsense/platforms/direct/ad-tags#auto_ads

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [ ] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
