### PR TITLE
Fix issues with Idea Hub banner notification.

### DIFF
--- a/assets/js/components/notifications/BannerNotification/index.js
+++ b/assets/js/components/notifications/BannerNotification/index.js
@@ -23,6 +23,7 @@ import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import map from 'lodash/map';
 import { useMount, useMountedState } from 'react-use';
+import { useWindowWidth } from '@react-hook/window-size/throttled';
 
 /*
  * WordPress dependencies
@@ -125,8 +126,13 @@ function BannerNotification( {
 	const persistDismissal = () =>
 		setItem( cacheKeyDismissed, new Date(), { ttl: null } );
 
+	const windowWidth = useWindowWidth();
 	const breakpoint = useBreakpoint();
 	const isMounted = useMountedState();
+
+	// There is a 1px difference between the tablet breakpoint determination in `useBreakpoint` and the `min-width: $bp-tablet` breakpoint the `@mixin googlesitekit-inner-padding` uses,
+	// which in turn is used by the notification. This why we are using `useWindowWidth` here, instead of the breakpoint returned by `useBreakpoint`.
+	const isMinWidthTablet = windowWidth >= 600;
 
 	useMount( async () => {
 		if ( dismissExpires > 0 ) {
@@ -324,9 +330,9 @@ function BannerNotification( {
 						{ badgeLabel && <Badge label={ badgeLabel } /> }
 					</h3>
 
-					{ WinImageSVG && (
+					{ WinImageSVG && ! isMinWidthTablet && (
 						<div
-							className={ `googlesitekit-publisher-win__image-${ format } googlesitekit-non-mobile-display-none` }
+							className={ `googlesitekit-publisher-win__image-${ format }` }
 						>
 							<WinImageSVG
 								width={ smallWinImageSVGWidth }
@@ -510,14 +516,13 @@ function BannerNotification( {
 						) }
 					</Cell>
 
-					{ WinImageSVG && (
+					{ WinImageSVG && isMinWidthTablet && (
 						<Cell
 							{ ...imageCellSizeProperties }
 							{ ...imageCellOrderProperties }
 							alignBottom={
 								format === 'larger' && noBottomPadding
 							}
-							className="googlesitekit-display-none googlesitekit-non-mobile-display-block"
 						>
 							<div
 								className={ `googlesitekit-publisher-win__image-${ format }` }

--- a/assets/js/components/notifications/BannerNotification/index.js
+++ b/assets/js/components/notifications/BannerNotification/index.js
@@ -530,8 +530,10 @@ function BannerNotification( {
 									className={ `googlesitekit-publisher-win__image-${ format }` }
 								>
 									<WinImageSVG
-										width={ mediumWinImageSVGWidth }
-										height={ mediumWinImageSVGHeight }
+										style={ {
+											maxWidth: mediumWinImageSVGWidth,
+											maxHeight: mediumWinImageSVGHeight,
+										} }
 									/>
 								</div>
 							</Cell>

--- a/assets/js/components/notifications/BannerNotification/index.js
+++ b/assets/js/components/notifications/BannerNotification/index.js
@@ -105,6 +105,7 @@ function BannerNotification( {
 	title,
 	type,
 	WinImageSVG,
+	showSmallWinImage = true,
 	smallWinImageSVGWidth = 75,
 	smallWinImageSVGHeight = 75,
 	mediumWinImageSVGWidth = 105,
@@ -330,7 +331,7 @@ function BannerNotification( {
 						{ badgeLabel && <Badge label={ badgeLabel } /> }
 					</h3>
 
-					{ WinImageSVG && ! isMinWidthTablet && (
+					{ WinImageSVG && ! isMinWidthTablet && showSmallWinImage && (
 						<div
 							className={ `googlesitekit-publisher-win__image-${ format }` }
 						>
@@ -516,24 +517,25 @@ function BannerNotification( {
 						) }
 					</Cell>
 
-					{ WinImageSVG && isMinWidthTablet && (
-						<Cell
-							{ ...imageCellSizeProperties }
-							{ ...imageCellOrderProperties }
-							alignBottom={
-								format === 'larger' && noBottomPadding
-							}
-						>
-							<div
-								className={ `googlesitekit-publisher-win__image-${ format }` }
+					{ WinImageSVG &&
+						( isMinWidthTablet || ! showSmallWinImage ) && (
+							<Cell
+								{ ...imageCellSizeProperties }
+								{ ...imageCellOrderProperties }
+								alignBottom={
+									format === 'larger' && noBottomPadding
+								}
 							>
-								<WinImageSVG
-									width={ mediumWinImageSVGWidth }
-									height={ mediumWinImageSVGHeight }
-								/>
-							</div>
-						</Cell>
-					) }
+								<div
+									className={ `googlesitekit-publisher-win__image-${ format }` }
+								>
+									<WinImageSVG
+										width={ mediumWinImageSVGWidth }
+										height={ mediumWinImageSVGHeight }
+									/>
+								</div>
+							</Cell>
+						) }
 
 					{ ( 'win-error' === type || 'win-warning' === type ) && (
 						<Cell size={ 1 }>
@@ -598,6 +600,7 @@ BannerNotification.propTypes = {
 	rounded: PropTypes.bool,
 	footer: PropTypes.node,
 	secondaryPane: PropTypes.node,
+	showSmallWinImage: PropTypes.bool,
 	smallWinImageSVGWidth: PropTypes.number,
 	smallWinImageSVGHeight: PropTypes.number,
 	mediumWinImageSVGWidth: PropTypes.number,

--- a/assets/js/components/notifications/IdeaHubPromptBannerNotification.js
+++ b/assets/js/components/notifications/IdeaHubPromptBannerNotification.js
@@ -144,6 +144,7 @@ export default function IdeaHubPromptBannerNotification() {
 			learnMoreLabel={ __( 'Learn more', 'google-site-kit' ) }
 			learnMoreURL={ ideaHubSupportURL }
 			WinImageSVG={ IdeaHubPromptSVG }
+			showSmallWinImage={ false }
 			mediumWinImageSVGWidth={ 765 }
 			mediumWinImageSVGHeight={ 304 }
 			noBottomPadding

--- a/assets/sass/utilities/_display.scss
+++ b/assets/sass/utilities/_display.scss
@@ -21,32 +21,4 @@
 	.googlesitekit-display-block {
 		display: block;
 	}
-
-	.googlesitekit-display-none {
-		display: none;
-	}
-
-	.googlesitekit-mobile-display-block {
-		@media (max-width: $bp-mobileOnly) {
-			display: block;
-		}
-	}
-
-	.googlesitekit-mobile-display-none {
-		@media (max-width: $bp-mobileOnly) {
-			display: none;
-		}
-	}
-
-	.googlesitekit-non-mobile-display-none {
-		@media (min-width: $bp-tablet) {
-			display: none;
-		}
-	}
-
-	.googlesitekit-non-mobile-display-block {
-		@media (min-width: $bp-tablet) {
-			display: block;
-		}
-	}
 }


### PR DESCRIPTION
## Summary

Fix the issues issues raised here: https://github.com/google/site-kit-wp/issues/5934#issuecomment-1313214538

Addresses issue:

- #5934 

## Relevant technical choices

- Fix the missing orange part of the image by avoiding rendering the SVG twice in the page. See https://github.com/google/site-kit-wp/commit/22d62c79a003ce7a6ef7be447c11e9497dfb87b5
- Address the small Idea Hub graphic by reverting to the old layout for Idea Hub.
- Fix an issue where the image can overflow and clip between 600 - 840px, by using inline `minWidth`/`minHeight` styles instead of `width`/`height` attributes on the SVG.

<!-- Please describe your changes. -->

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [ ] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
