### PR TITLE
Fix/5605 - Wrap LazyIdeaHubPromptSVG with MediaErrorHandler

### DIFF
--- a/assets/js/modules/idea-hub/components/common/IdeaHubPromptSVG.js
+++ b/assets/js/modules/idea-hub/components/common/IdeaHubPromptSVG.js
@@ -20,11 +20,13 @@
  * WordPress dependencies
  */
 import { lazy, Suspense } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
 import PreviewBlock from '../../../../components/PreviewBlock';
+import MediaErrorHandler from '../../../../components/MediaErrorHandler';
 const LazyIdeaHubPromptSVG = lazy( () =>
 	import( '../../../../../svg/graphics/idea-hub-prompt.svg' )
 );
@@ -32,7 +34,14 @@ const LazyIdeaHubPromptSVG = lazy( () =>
 export default function IdeaHubPromptSVG( props ) {
 	return (
 		<Suspense fallback={ <PreviewBlock width="100%" height="39.77%" /> }>
-			<LazyIdeaHubPromptSVG { ...props } />
+			<MediaErrorHandler
+				errorMessage={ __(
+					'Failed to load graphic.',
+					'google-site-kit'
+				) }
+			>
+				<LazyIdeaHubPromptSVG { ...props } />
+			</MediaErrorHandler>
 		</Suspense>
 	);
 }


### PR DESCRIPTION
## Summary

Addresses issue:

- #5605 

## Relevant technical choices

- This follow-up PR wraps the `LazyIdeaHubPromptSVG` with the `MediaErrorHandler` component, as [observed](https://github.com/google/site-kit-wp/issues/5605#issuecomment-1312339743) in this comment.

![Screenshot 2022-11-15 at 11 49 16 AM](https://user-images.githubusercontent.com/24408261/201843276-a0d9da43-19f8-4e81-b020-b20f555fe312.png)


## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
