### PR TITLE
Enhance/5145 - Show measurement id instead of property id when the property select is disabled

### DIFF
--- a/assets/js/modules/analytics-4/components/common/PropertySelect.js
+++ b/assets/js/modules/analytics-4/components/common/PropertySelect.js
@@ -90,7 +90,7 @@ export default function PropertySelect( {
 	const { selectProperty } = useDispatch( MODULES_ANALYTICS_4 );
 
 	const measurementIDs = useSelect( ( select ) =>
-		select( MODULES_ANALYTICS_4 ).getMatchedMeasurementIDByPropertyID(
+		select( MODULES_ANALYTICS_4 ).getMatchedMeasurementIDsByPropertyIDs(
 			properties
 		)
 	);

--- a/assets/js/modules/analytics-4/components/common/PropertySelect.js
+++ b/assets/js/modules/analytics-4/components/common/PropertySelect.js
@@ -89,36 +89,11 @@ export default function PropertySelect( {
 
 	const { selectProperty } = useDispatch( MODULES_ANALYTICS_4 );
 
-	const measurementIDs = useSelect( ( select ) => {
-		// We should conditionally check the properties length here
-		// because the properties will be null if the user does not have access to the module.
-		if ( ! properties?.length ) {
-			return null;
-		}
-
-		return properties.reduce( ( acc, property ) => {
-			const currentPropertyID = property._id;
-			const dataStream =
-				select( MODULES_ANALYTICS_4 ).getWebDataStreamsBatch(
-					currentPropertyID
-				);
-
-			if (
-				! Object.keys( dataStream ).length ||
-				! Object.values( dataStream[ currentPropertyID ] ).length
-			) {
-				return acc;
-			}
-
-			const measurementID =
-				dataStream[ currentPropertyID ][ 0 ].webStreamData
-					.measurementId; // eslint-disable-line sitekit/acronym-case
-			return {
-				...acc,
-				[ currentPropertyID ]: measurementID,
-			};
-		}, {} );
-	} );
+	const measurementIDs = useSelect( ( select ) =>
+		select( MODULES_ANALYTICS_4 ).getMatchedMeasurementIDByPropertyID(
+			properties
+		)
+	);
 
 	const viewContext = useViewContext();
 

--- a/assets/js/modules/analytics-4/datastore/webdatastreams.js
+++ b/assets/js/modules/analytics-4/datastore/webdatastreams.js
@@ -326,11 +326,11 @@ const baseSelectors = {
 	/**
 	 * Gets the matched measurement IDs for the given properties.
 	 *
-	 * @since 1.88.0
+	 * @since n.e.x.t
 	 *
 	 * @param {Object}         state      Data store's state.
 	 * @param {Array.<Object>} properties GA4 properties array of objects.
-	 * @return {(Object|null)} Matched property ID as the key and measurement ID as the value; otherwise, an empty object. Null if no properties are provided.
+	 * @return {(Object|null)} Object with matched property ID as the key and measurement ID as the value, or an empty object if no matches are found. Null if no properties are provided.
 	 */
 	getMatchedMeasurementIDByPropertyID: createRegistrySelector(
 		( select ) => ( state, properties ) => {

--- a/assets/js/modules/analytics-4/datastore/webdatastreams.js
+++ b/assets/js/modules/analytics-4/datastore/webdatastreams.js
@@ -332,7 +332,7 @@ const baseSelectors = {
 	 * @param {Array.<Object>} properties GA4 properties array of objects.
 	 * @return {(Object|null)} Object with matched property ID as the key and measurement ID as the value, or an empty object if no matches are found. Null if no properties are provided.
 	 */
-	getMatchedMeasurementIDByPropertyID: createRegistrySelector(
+	getMatchedMeasurementIDsByPropertyIDs: createRegistrySelector(
 		( select ) => ( state, properties ) => {
 			if ( ! properties?.length ) {
 				return null;

--- a/assets/js/modules/analytics-4/datastore/webdatastreams.test.js
+++ b/assets/js/modules/analytics-4/datastore/webdatastreams.test.js
@@ -487,18 +487,18 @@ describe( 'modules/analytics-4 webdatastreams', () => {
 			} );
 		} );
 
-		describe( 'getMatchedMeasurementIDByPropertyID', () => {
+		describe( 'getMatchedMeasurementIDsByPropertyIDs', () => {
 			it( 'should return null if the properties are empty', () => {
 				expect(
 					registry
 						.select( MODULES_ANALYTICS_4 )
-						.getMatchedMeasurementIDByPropertyID( [] )
+						.getMatchedMeasurementIDsByPropertyIDs( [] )
 				).toBeNull();
 
 				expect(
 					registry
 						.select( MODULES_ANALYTICS_4 )
-						.getMatchedMeasurementIDByPropertyID( null )
+						.getMatchedMeasurementIDsByPropertyIDs( null )
 				).toBeNull();
 			} );
 
@@ -516,7 +516,7 @@ describe( 'modules/analytics-4 webdatastreams', () => {
 
 				const matchedProperties = registry
 					.select( MODULES_ANALYTICS_4 )
-					.getMatchedMeasurementIDByPropertyID( [
+					.getMatchedMeasurementIDsByPropertyIDs( [
 						{
 							_id: '1100',
 							_accountID: '100',
@@ -540,7 +540,9 @@ describe( 'modules/analytics-4 webdatastreams', () => {
 
 				const matchedProperties = registry
 					.select( MODULES_ANALYTICS_4 )
-					.getMatchedMeasurementIDByPropertyID( fixtures.properties );
+					.getMatchedMeasurementIDsByPropertyIDs(
+						fixtures.properties
+					);
 				expect( matchedProperties ).toEqual( {
 					1000: '1A2BCD345E',
 					1001: '155BC2366E',
@@ -561,7 +563,7 @@ describe( 'modules/analytics-4 webdatastreams', () => {
 
 				const matchedProperties = registry
 					.select( MODULES_ANALYTICS_4 )
-					.getMatchedMeasurementIDByPropertyID( [
+					.getMatchedMeasurementIDsByPropertyIDs( [
 						...fixtures.properties,
 						// Add an object that does not have the _id property.
 						// Hence, it should be skipped from the matching.

--- a/assets/js/modules/analytics/components/settings/GA4SettingsControls.js
+++ b/assets/js/modules/analytics/components/settings/GA4SettingsControls.js
@@ -178,7 +178,7 @@ export default function GA4SettingsControls( { hasModuleAccess } ) {
 	] );
 
 	const measurementIDs = useSelect( ( select ) =>
-		select( MODULES_ANALYTICS_4 ).getMatchedMeasurementIDByPropertyID(
+		select( MODULES_ANALYTICS_4 ).getMatchedMeasurementIDsByPropertyIDs(
 			properties
 		)
 	);

--- a/assets/js/modules/analytics/components/settings/GA4SettingsControls.js
+++ b/assets/js/modules/analytics/components/settings/GA4SettingsControls.js
@@ -177,6 +177,12 @@ export default function GA4SettingsControls( { hasModuleAccess } ) {
 		propertyID,
 	] );
 
+	const measurementIDs = useSelect( ( select ) =>
+		select( MODULES_ANALYTICS_4 ).getMatchedMeasurementIDByPropertyID(
+			properties
+		)
+	);
+
 	if ( isAdminAPIWorking === undefined ) {
 		return <ProgressBar height={ isDisabled ? 180 : 212 } small />;
 	}
@@ -259,7 +265,9 @@ export default function GA4SettingsControls( { hasModuleAccess } ) {
 											'google-site-kit'
 										),
 										matchedProperty.displayName,
-										matchedProperty._id
+										measurementIDs?.[
+											matchedProperty._id
+										] || ''
 								  ) }
 						</Option>
 					</Select>

--- a/stories/module-analytics-settings.stories.js
+++ b/stories/module-analytics-settings.stories.js
@@ -438,6 +438,12 @@ storiesOf( 'Analytics Module/Settings', module )
 				],
 				{ propertyID: '1001' }
 			);
+			dispatch( MODULES_ANALYTICS_4 ).receiveGetWebDataStreamsBatch(
+				webDataStreamsBatch,
+				{
+					propertyIDs: ga4Properties.map( ( { _id } ) => _id ),
+				}
+			);
 
 			return (
 				<Settings


### PR DESCRIPTION
## Summary

Addresses issue:

- #5145 

## Relevant technical choices

- This PR fixes the of showing the property id instead of the measurement id when reading the edit page, as per the third QA [observation](https://github.com/google/site-kit-wp/issues/5145#issuecomment-1318200320):
>Placeholder showing property name with property id instead of measurement id when we reload the settings page.


## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [x] Run the code.
- [x] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [x] Ensure no unrelated changes are included.
- [x] Ensure CI checks pass.
- [x] Check Storybook where applicable.
- [x] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [x] Ensure the PR has the correct target branch.
- [x] Double-check that the PR is okay to be merged.
- [x] Ensure the corresponding issue has a ZenHub release assigned.
- [x] Add a changelog message to the issue.
