### PR TITLE
Update CTA link color in error notice.

### DIFF
--- a/assets/sass/components/global/_googlesitekit-cta-link.scss
+++ b/assets/sass/components/global/_googlesitekit-cta-link.scss
@@ -45,17 +45,26 @@
 		letter-spacing: $ls-xs;
 	}
 
-	&.googlesitekit-cta-link--arrow,
-	&.googlesitekit-cta-link--external {
-		background-image: url("data:image/svg+xml;charset=UTF-8,%3Csvg%20width%3D%2213%22%20height%3D%2213%22%20viewBox%3D%220%200%2013%2013%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cg%20fill%3D%22none%22%20fill-rule%3D%22evenodd%22%3E%3Cpath%20d%3D%22M11%2011H2V2h3V0H2a2%202%200%200%200-2%202v9a2%202%200%200%200%202%202h9c1.1%200%202-.9%202-2V8h-2v3z%22%20fill%3D%22%23108080%22%20fill-rule%3D%22nonzero%22%2F%3E%3Cpath%20fill%3D%22%23108080%22%20d%3D%22M7%200h6v2H7zM11%202h2v4h-2z%22%2F%3E%3Cpath%20d%3D%22M11%202L5%208%22%20stroke%3D%22%23108080%22%20stroke-width%3D%222%22%20stroke-linecap%3D%22square%22%2F%3E%3C%2Fg%3E%3C%2Fsvg%3E");
+	&.googlesitekit-cta-link--arrow {
+		background-image: url("data:image/svg+xml;charset=UTF-8,%3Csvg%20width%3D%2213%22%20height%3D%2213%22%20viewBox%3D%220%200%2013%2013%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cg%20fill%3D%22none%22%20fill-rule%3D%22evenodd%22%3E%3Ccircle%20fill%3D%22%23108080%22%20cx%3D%226.5%22%20cy%3D%226.5%22%20r%3D%226.5%22%2F%3E%3Cpath%20d%3D%22M3.461%206.96h5.15L6.36%209.21a.464.464%200%200%200%20.325.79.459.459%200%200%200%20.325-.135l3.037-3.038a.459.459%200%200%200%200-.65L7.015%203.135a.46.46%200%200%200-.65.65L8.61%206.039H3.461a.462.462%200%200%200-.461.46c0%20.254.207.462.461.462z%22%20fill%3D%22%23FFF%22%2F%3E%3C%2Fg%3E%3C%2Fsvg%3E");
 		background-position: calc(100% - 1px) center;
 		background-repeat: no-repeat;
 		background-size: 13px 13px;
 		padding-right: 20px;
 	}
 
-	&.googlesitekit-cta-link--arrow {
-		background-image: url("data:image/svg+xml;charset=UTF-8,%3Csvg%20width%3D%2213%22%20height%3D%2213%22%20viewBox%3D%220%200%2013%2013%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cg%20fill%3D%22none%22%20fill-rule%3D%22evenodd%22%3E%3Ccircle%20fill%3D%22%23108080%22%20cx%3D%226.5%22%20cy%3D%226.5%22%20r%3D%226.5%22%2F%3E%3Cpath%20d%3D%22M3.461%206.96h5.15L6.36%209.21a.464.464%200%200%200%20.325.79.459.459%200%200%200%20.325-.135l3.037-3.038a.459.459%200%200%200%200-.65L7.015%203.135a.46.46%200%200%200-.65.65L8.61%206.039H3.461a.462.462%200%200%200-.461.46c0%20.254.207.462.461.462z%22%20fill%3D%22%23FFF%22%2F%3E%3C%2Fg%3E%3C%2Fsvg%3E");
+	&.googlesitekit-cta-link--external::after {
+		background-color: currentColor;
+		content: " ";
+		display: inline-block;
+		height: 14px;
+		margin-bottom: -2px;
+		margin-left: 6px;
+		mask-image: url("data:image/svg+xml;charset=UTF-8,%3Csvg%20width%3D%2213%22%20height%3D%2213%22%20viewBox%3D%220%200%2013%2013%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cg%20fill%3D%22none%22%20fill-rule%3D%22evenodd%22%3E%3Cpath%20d%3D%22M11%2011H2V2h3V0H2a2%202%200%200%200-2%202v9a2%202%200%200%200%202%202h9c1.1%200%202-.9%202-2V8h-2v3z%22%20fill%3D%22%23108080%22%20fill-rule%3D%22nonzero%22%2F%3E%3Cpath%20fill%3D%22%23108080%22%20d%3D%22M7%200h6v2H7zM11%202h2v4h-2z%22%2F%3E%3Cpath%20d%3D%22M11%202L5%208%22%20stroke%3D%22%23108080%22%20stroke-width%3D%222%22%20stroke-linecap%3D%22square%22%2F%3E%3C%2Fg%3E%3C%2Fsvg%3E");
+		mask-position: center left;
+		mask-repeat: no-repeat;
+		mask-size: 13px 13px;
+		width: 14px;
 	}
 
 	&.googlesitekit-cta-link--arrow.googlesitekit-cta-link--inverse {

--- a/assets/sass/components/global/_googlesitekit-cta-link.scss
+++ b/assets/sass/components/global/_googlesitekit-cta-link.scss
@@ -45,26 +45,17 @@
 		letter-spacing: $ls-xs;
 	}
 
-	&.googlesitekit-cta-link--arrow {
-		background-image: url("data:image/svg+xml;charset=UTF-8,%3Csvg%20width%3D%2213%22%20height%3D%2213%22%20viewBox%3D%220%200%2013%2013%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cg%20fill%3D%22none%22%20fill-rule%3D%22evenodd%22%3E%3Ccircle%20fill%3D%22%23108080%22%20cx%3D%226.5%22%20cy%3D%226.5%22%20r%3D%226.5%22%2F%3E%3Cpath%20d%3D%22M3.461%206.96h5.15L6.36%209.21a.464.464%200%200%200%20.325.79.459.459%200%200%200%20.325-.135l3.037-3.038a.459.459%200%200%200%200-.65L7.015%203.135a.46.46%200%200%200-.65.65L8.61%206.039H3.461a.462.462%200%200%200-.461.46c0%20.254.207.462.461.462z%22%20fill%3D%22%23FFF%22%2F%3E%3C%2Fg%3E%3C%2Fsvg%3E");
+	&.googlesitekit-cta-link--arrow,
+	&.googlesitekit-cta-link--external {
+		background-image: url("data:image/svg+xml;charset=UTF-8,%3Csvg%20width%3D%2213%22%20height%3D%2213%22%20viewBox%3D%220%200%2013%2013%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cg%20fill%3D%22none%22%20fill-rule%3D%22evenodd%22%3E%3Cpath%20d%3D%22M11%2011H2V2h3V0H2a2%202%200%200%200-2%202v9a2%202%200%200%200%202%202h9c1.1%200%202-.9%202-2V8h-2v3z%22%20fill%3D%22%23108080%22%20fill-rule%3D%22nonzero%22%2F%3E%3Cpath%20fill%3D%22%23108080%22%20d%3D%22M7%200h6v2H7zM11%202h2v4h-2z%22%2F%3E%3Cpath%20d%3D%22M11%202L5%208%22%20stroke%3D%22%23108080%22%20stroke-width%3D%222%22%20stroke-linecap%3D%22square%22%2F%3E%3C%2Fg%3E%3C%2Fsvg%3E");
 		background-position: calc(100% - 1px) center;
 		background-repeat: no-repeat;
 		background-size: 13px 13px;
 		padding-right: 20px;
 	}
 
-	&.googlesitekit-cta-link--external::after {
-		background-color: currentColor;
-		content: " ";
-		display: inline-block;
-		height: 14px;
-		margin-bottom: -2px;
-		margin-left: 6px;
-		mask-image: url("data:image/svg+xml;charset=UTF-8,%3Csvg%20width%3D%2213%22%20height%3D%2213%22%20viewBox%3D%220%200%2013%2013%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cg%20fill%3D%22none%22%20fill-rule%3D%22evenodd%22%3E%3Cpath%20d%3D%22M11%2011H2V2h3V0H2a2%202%200%200%200-2%202v9a2%202%200%200%200%202%202h9c1.1%200%202-.9%202-2V8h-2v3z%22%20fill%3D%22%23108080%22%20fill-rule%3D%22nonzero%22%2F%3E%3Cpath%20fill%3D%22%23108080%22%20d%3D%22M7%200h6v2H7zM11%202h2v4h-2z%22%2F%3E%3Cpath%20d%3D%22M11%202L5%208%22%20stroke%3D%22%23108080%22%20stroke-width%3D%222%22%20stroke-linecap%3D%22square%22%2F%3E%3C%2Fg%3E%3C%2Fsvg%3E");
-		mask-position: center left;
-		mask-repeat: no-repeat;
-		mask-size: 13px 13px;
-		width: 14px;
+	&.googlesitekit-cta-link--arrow {
+		background-image: url("data:image/svg+xml;charset=UTF-8,%3Csvg%20width%3D%2213%22%20height%3D%2213%22%20viewBox%3D%220%200%2013%2013%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cg%20fill%3D%22none%22%20fill-rule%3D%22evenodd%22%3E%3Ccircle%20fill%3D%22%23108080%22%20cx%3D%226.5%22%20cy%3D%226.5%22%20r%3D%226.5%22%2F%3E%3Cpath%20d%3D%22M3.461%206.96h5.15L6.36%209.21a.464.464%200%200%200%20.325.79.459.459%200%200%200%20.325-.135l3.037-3.038a.459.459%200%200%200%200-.65L7.015%203.135a.46.46%200%200%200-.65.65L8.61%206.039H3.461a.462.462%200%200%200-.461.46c0%20.254.207.462.461.462z%22%20fill%3D%22%23FFF%22%2F%3E%3C%2Fg%3E%3C%2Fsvg%3E");
 	}
 
 	&.googlesitekit-cta-link--arrow.googlesitekit-cta-link--inverse {

--- a/assets/sass/components/global/_googlesitekit-cta-link.scss
+++ b/assets/sass/components/global/_googlesitekit-cta-link.scss
@@ -47,6 +47,7 @@
 
 	&.googlesitekit-cta-link--arrow,
 	&.googlesitekit-cta-link--external {
+		// This is the external link icon in the color #108080 ($c-content-link).
 		background-image: url("data:image/svg+xml;charset=UTF-8,%3Csvg%20width%3D%2213%22%20height%3D%2213%22%20viewBox%3D%220%200%2013%2013%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cg%20fill%3D%22none%22%20fill-rule%3D%22evenodd%22%3E%3Cpath%20d%3D%22M11%2011H2V2h3V0H2a2%202%200%200%200-2%202v9a2%202%200%200%200%202%202h9c1.1%200%202-.9%202-2V8h-2v3z%22%20fill%3D%22%23108080%22%20fill-rule%3D%22nonzero%22%2F%3E%3Cpath%20fill%3D%22%23108080%22%20d%3D%22M7%200h6v2H7zM11%202h2v4h-2z%22%2F%3E%3Cpath%20d%3D%22M11%202L5%208%22%20stroke%3D%22%23108080%22%20stroke-width%3D%222%22%20stroke-linecap%3D%22square%22%2F%3E%3C%2Fg%3E%3C%2Fsvg%3E");
 		background-position: calc(100% - 1px) center;
 		background-repeat: no-repeat;

--- a/assets/sass/components/global/_googlesitekit-cta.scss
+++ b/assets/sass/components/global/_googlesitekit-cta.scss
@@ -75,6 +75,7 @@
 	&.googlesitekit-cta--error {
 		background-color: $c-utility-error-container;
 
+		a,
 		.googlesitekit-cta__title {
 			color: $c-utility-on-error-container;
 		}

--- a/assets/sass/components/global/_googlesitekit-cta.scss
+++ b/assets/sass/components/global/_googlesitekit-cta.scss
@@ -91,6 +91,7 @@
 		}
 
 		.googlesitekit-cta-link--external {
+			// This is the external link icon in the color #7a1e00 ($c-utility-on-error-container).
 			background-image: url("data:image/svg+xml;charset=UTF-8,%3Csvg%20width%3D%2213%22%20height%3D%2213%22%20viewBox%3D%220%200%2013%2013%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cg%20fill%3D%22none%22%20fill-rule%3D%22evenodd%22%3E%3Cpath%20d%3D%22M11%2011H2V2h3V0H2a2%202%200%200%200-2%202v9a2%202%200%200%200%202%202h9c1.1%200%202-.9%202-2V8h-2v3z%22%20fill%3D%22%237a1e00%22%20fill-rule%3D%22nonzero%22%2F%3E%3Cpath%20fill%3D%22%237a1e00%22%20d%3D%22M7%200h6v2H7zM11%202h2v4h-2z%22%2F%3E%3Cpath%20d%3D%22M11%202L5%208%22%20stroke%3D%22%237a1e00%22%20stroke-width%3D%222%22%20stroke-linecap%3D%22square%22%2F%3E%3C%2Fg%3E%3C%2Fsvg%3E");
 		}
 	}

--- a/assets/sass/components/global/_googlesitekit-cta.scss
+++ b/assets/sass/components/global/_googlesitekit-cta.scss
@@ -89,6 +89,10 @@
 			background-color: $c-utility-error;
 			color: $c-utility-on-error;
 		}
+
+		.googlesitekit-cta-link--external {
+			background-image: url("data:image/svg+xml;charset=UTF-8,%3Csvg%20width%3D%2213%22%20height%3D%2213%22%20viewBox%3D%220%200%2013%2013%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cg%20fill%3D%22none%22%20fill-rule%3D%22evenodd%22%3E%3Cpath%20d%3D%22M11%2011H2V2h3V0H2a2%202%200%200%200-2%202v9a2%202%200%200%200%202%202h9c1.1%200%202-.9%202-2V8h-2v3z%22%20fill%3D%22%237a1e00%22%20fill-rule%3D%22nonzero%22%2F%3E%3Cpath%20fill%3D%22%237a1e00%22%20d%3D%22M7%200h6v2H7zM11%202h2v4h-2z%22%2F%3E%3Cpath%20d%3D%22M11%202L5%208%22%20stroke%3D%22%237a1e00%22%20stroke-width%3D%222%22%20stroke-linecap%3D%22square%22%2F%3E%3C%2Fg%3E%3C%2Fsvg%3E");
+		}
 	}
 
 	*:last-child {


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #5975 

## Relevant technical choices

Added a link color for links inside a Error Notice, as described in IB.

The solution in the IB did not cover the color change for the icon. Therefore I refactored how the icon is implemented. Instead of using a background image, I switched to a mask-image added to the `::after` element which has a `background-color` set to `currentColor`. In doing so icon gets the color link text assigned.

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [ ] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [x] Run the code.
- [x] Ensure the acceptance criteria are satisfied.
- [x] Reassess the implementation with the IB.
- [x] Ensure no unrelated changes are included.
- [x] Ensure CI checks pass.
- [x] Check Storybook where applicable.
- [x] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [x] Ensure the PR has the correct target branch.
- [x] Double-check that the PR is okay to be merged.
- [x] Ensure the corresponding issue has a ZenHub release assigned.
- [x] Add a changelog message to the issue.
