### PR TITLE
Add `Edit in Tag Manager`

### DIFF
--- a/assets/js/modules/tagmanager/components/settings/SettingsView.js
+++ b/assets/js/modules/tagmanager/components/settings/SettingsView.js
@@ -138,7 +138,7 @@ export default function SettingsView() {
 							<Link href={ editViewSettingsURL } external>
 								{ createInterpolateElement(
 									__(
-										'Edit <VisuallyHidden>publication </VisuallyHidden>in Tag Manager',
+										'Edit <VisuallyHidden>container </VisuallyHidden>in Tag Manager',
 										'google-site-kit'
 									),
 									{

--- a/assets/js/modules/tagmanager/components/settings/SettingsView.js
+++ b/assets/js/modules/tagmanager/components/settings/SettingsView.js
@@ -19,7 +19,7 @@
 /**
  * WordPress dependencies
  */
-import { Fragment } from '@wordpress/element';
+import { createInterpolateElement, Fragment } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -27,9 +27,12 @@ import { __ } from '@wordpress/i18n';
  */
 import Data from 'googlesitekit-data';
 import DisplaySetting from '../../../../components/DisplaySetting';
+import Link from '../../../../components/Link';
+import StoreErrorNotices from '../../../../components/StoreErrorNotices';
+import VisuallyHidden from '../../../../components/VisuallyHidden';
 import { CORE_SITE } from '../../../../googlesitekit/datastore/site/constants';
 import { MODULES_TAGMANAGER } from '../../datastore/constants';
-import StoreErrorNotices from '../../../../components/StoreErrorNotices';
+import { escapeURI } from '../../../../util/escape-uri';
 const { useSelect } = Data;
 
 export default function SettingsView() {
@@ -48,10 +51,22 @@ export default function SettingsView() {
 	const hasExistingTag = useSelect( ( select ) =>
 		select( MODULES_TAGMANAGER ).hasExistingTag()
 	);
-
 	const isAMP = useSelect( ( select ) => select( CORE_SITE ).isAMP() );
 	const isSecondaryAMP = useSelect( ( select ) =>
 		select( CORE_SITE ).isSecondaryAMP()
+	);
+	const internalContainerID = useSelect( ( select ) =>
+		select( MODULES_TAGMANAGER ).getInternalContainerID()
+	);
+	const internalAMPContainerID = useSelect( ( select ) =>
+		select( MODULES_TAGMANAGER ).getInternalAMPContainerID()
+	);
+	const editViewSettingsURL = useSelect( ( select ) =>
+		select( MODULES_TAGMANAGER ).getServiceURL( {
+			path: escapeURI`/container/accounts/${ accountID }/containers/${
+				isAMP ? internalAMPContainerID : internalContainerID
+			}`,
+		} )
 	);
 
 	return (
@@ -113,6 +128,24 @@ export default function SettingsView() {
 						</h5>
 						<p className="googlesitekit-settings-module__meta-item-data">
 							<DisplaySetting value={ ampContainerID } />
+						</p>
+					</div>
+				) }
+
+				{ editViewSettingsURL && (
+					<div className="googlesitekit-settings-module__meta-item googlesitekit-settings-module__meta-item--data-only">
+						<p className="googlesitekit-settings-module__meta-item-data googlesitekit-settings-module__meta-item-data--tiny">
+							<Link href={ editViewSettingsURL } external>
+								{ createInterpolateElement(
+									__(
+										'Edit <VisuallyHidden>publication </VisuallyHidden>in Tag Manager',
+										'google-site-kit'
+									),
+									{
+										VisuallyHidden: <VisuallyHidden />,
+									}
+								) }
+							</Link>
 						</p>
 					</div>
 				) }


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #5174 

## Relevant technical choices

This PR updates the Tag Manager `SettingsView` and adds an `Edit in Tag Manager` link like other modules.

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [x] Ensure the PR has the correct target branch.
- [x] Double-check that the PR is okay to be merged.
- [x] Ensure the corresponding issue has a ZenHub release assigned.
- [x] Add a changelog message to the issue.
