### PR TITLE
Add CTA for users with incomplete User Input answers in settings page.

### DIFF
--- a/assets/js/components/notifications/UserInputSettings.js
+++ b/assets/js/components/notifications/UserInputSettings.js
@@ -35,7 +35,11 @@ import BannerNotification from './BannerNotification';
 import { getTimeInSeconds } from '../../util';
 import { CORE_USER } from '../../googlesitekit/datastore/user/constants';
 import { CORE_SITE } from '../../googlesitekit/datastore/site/constants';
+import { CORE_MODULES } from '../../googlesitekit/modules/datastore/constants';
+import { MODULES_SEARCH_CONSOLE } from '../../modules/search-console/datastore/constants';
+import { MODULES_ANALYTICS } from '../../modules/analytics/datastore/constants';
 import UserInputPromptSVG from '../../../svg/graphics/user-input-prompt.svg';
+import Link from '../Link';
 const { useSelect } = Data;
 
 export default function UserInputSettings( {
@@ -51,8 +55,28 @@ export default function UserInputSettings( {
 	const userInputState = useSelect( ( select ) =>
 		select( CORE_USER ).getUserInputState()
 	);
+	const analyticsModuleConnected = useSelect( ( select ) =>
+		select( CORE_MODULES ).isModuleConnected( 'analytics' )
+	);
+	const searchConsoleModuleConnected = useSelect( ( select ) =>
+		select( CORE_MODULES ).isModuleConnected( 'search-console' )
+	);
+	const searchConsoleIsGatheringData = useSelect( ( select ) =>
+		select( MODULES_SEARCH_CONSOLE ).isGatheringData()
+	);
+	const analyticsIsGatheringData = useSelect( ( select ) =>
+		select( MODULES_ANALYTICS ).isGatheringData()
+	);
 
 	if ( userInputState === 'completed' ) {
+		return null;
+	}
+
+	if ( ! analyticsModuleConnected || ! searchConsoleModuleConnected ) {
+		return null;
+	}
+
+	if ( analyticsIsGatheringData || searchConsoleIsGatheringData ) {
 		return null;
 	}
 
@@ -70,9 +94,11 @@ export default function UserInputSettings( {
 			) }
 			format="large"
 			dismissExpires={ getTimeInSeconds( 'hour' ) * 3 }
-			ctaLink={ ctaLink }
-			ctaLabel={ __( 'Let’s go', 'google-site-kit' ) }
-			onCTAClick={ onCTAClick }
+			ctaComponent={
+				<Link href={ ctaLink } onClick={ onCTAClick }>
+					{ __( 'Let’s go', 'google-site-kit' ) }
+				</Link>
+			}
 			dismiss={ __( 'Remind me later', 'google-site-kit' ) }
 			WinImageSVG={ UserInputPromptSVG }
 			isDismissible={ isDismissible }

--- a/assets/js/components/notifications/UserInputSettings.js
+++ b/assets/js/components/notifications/UserInputSettings.js
@@ -96,7 +96,7 @@ export default function UserInputSettings( {
 			dismissExpires={ getTimeInSeconds( 'hour' ) * 3 }
 			ctaComponent={
 				<Link href={ ctaLink } onClick={ onCTAClick }>
-					{ __( 'Let’s go', 'google-site-kit' ) }
+					{ __( 'Personalize your metrics', 'google-site-kit' ) }
 				</Link>
 			}
 			dismiss={ __( 'Remind me later', 'google-site-kit' ) }

--- a/tests/e2e/specs/user-input-questions.test.js
+++ b/tests/e2e/specs/user-input-questions.test.js
@@ -34,6 +34,7 @@ import {
 	pageWait,
 	step,
 	setSearchConsoleProperty,
+	setupAnalytics,
 } from '../utils';
 
 describe( 'User Input Settings', () => {
@@ -121,6 +122,7 @@ describe( 'User Input Settings', () => {
 			'e2e-tests-user-input-settings-api-mock'
 		);
 		await setSearchConsoleProperty();
+		await page.setRequestInterception( true );
 	} );
 
 	afterEach( async () => {
@@ -146,18 +148,26 @@ describe( 'User Input Settings', () => {
 
 	it( 'should offer to enter input settings for existing users', async () => {
 		await setupSiteKit();
+		await page.setRequestInterception( false );
+		await setupAnalytics();
+		await page.setRequestInterception( true );
+		await setSearchConsoleProperty();
 
 		await step(
 			'visit admin dashboard',
 			visitAdminPage( 'admin.php', 'page=googlesitekit-dashboard' )
 		);
 
+		await page.waitForSelector( '.googlesitekit-user-input__notification' );
+
 		await step( 'click on CTA button and wait for navigation', async () => {
 			await page.waitForSelector(
 				'.googlesitekit-user-input__notification'
 			);
 			await Promise.all( [
-				expect( page ).toClick( '.googlesitekit-notification__cta' ),
+				expect( page ).toClick(
+					'.googlesitekit-user-input__notification .googlesitekit-cta-link'
+				),
 				page.waitForNavigation(),
 			] );
 		} );
@@ -167,6 +177,10 @@ describe( 'User Input Settings', () => {
 
 	it( 'should let existing users enter input settings from the settings page', async () => {
 		await setupSiteKit();
+		await page.setRequestInterception( false );
+		await setupAnalytics();
+		await page.setRequestInterception( true );
+		await setSearchConsoleProperty();
 
 		await step( 'visit admin settings', async () => {
 			await visitAdminPage( 'admin.php', 'page=googlesitekit-settings' );
@@ -182,7 +196,9 @@ describe( 'User Input Settings', () => {
 				'.googlesitekit-user-input__notification'
 			);
 			await Promise.all( [
-				expect( page ).toClick( '.googlesitekit-notification__cta' ),
+				expect( page ).toClick(
+					'.googlesitekit-user-input__notification .googlesitekit-cta-link'
+				),
 				page.waitForNavigation(),
 			] );
 		} );


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #5895 

## Relevant technical choices
- Adds conditions to only show CTA if analytics AND search-console are connected but not gathering data.
- Refactored CTA link to use new Figma design.
- Update existing e2e tests.

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
