### PR TITLE
Alphabetize Google Analytics profiles.

### DIFF
--- a/includes/Core/Util/Sort.php
+++ b/includes/Core/Util/Sort.php
@@ -28,7 +28,7 @@ class Sort {
 	 *
 	 * @return array The sorted list.
 	 */
-	public static function case_insensitive_list_sort( $list, $orderby ) {
+	public static function case_insensitive_list_sort( array $list, $orderby ) {
 		usort(
 			$list,
 			function ( $a, $b ) use ( $orderby ) {

--- a/includes/Core/Util/Sort.php
+++ b/includes/Core/Util/Sort.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Class Google\Site_Kit\Core\Util\Sort
+ *
+ * @package   Google\Site_Kit\Core\Util
+ * @copyright 2022 Google LLC
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
+ * @link      https://sitekit.withgoogle.com
+ */
+
+namespace Google\Site_Kit\Core\Util;
+
+/**
+ * Utility class for sorting lists.
+ *
+ * @since n.e.x.t
+ * @access private
+ * @ignore
+ */
+class Sort {
+	/**
+	 * Sorts the provided list in a case-insensitive manner.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param array  $list    The list to sort.
+	 * @param string $orderby The field by which the list should be ordered by.
+	 * @param string $order   The direction of the sort. Either 'ASC' or 'DESC'. Default is 'ASC'.
+	 *
+	 * @return array The sorted list.
+	 */
+	public static function case_insensitive_list_sort( $list, $orderby, $order = 'ASC' ) {
+		usort(
+			$list,
+			function ( $a, $b ) use ( $orderby, $order ) {
+				if ( 'DESC' === $order ) {
+					return strcasecmp(
+						$b[ $orderby ],
+						$a[ $orderby ]
+					);
+				}
+
+				return strcasecmp(
+					$a[ $orderby ],
+					$b[ $orderby ]
+				);
+			}
+		);
+
+		return $list;
+	}
+}

--- a/includes/Core/Util/Sort.php
+++ b/includes/Core/Util/Sort.php
@@ -25,21 +25,13 @@ class Sort {
 	 *
 	 * @param array  $list    The list to sort.
 	 * @param string $orderby The field by which the list should be ordered by.
-	 * @param string $order   The direction of the sort. Either 'ASC' or 'DESC'. Default is 'ASC'.
 	 *
 	 * @return array The sorted list.
 	 */
-	public static function case_insensitive_list_sort( $list, $orderby, $order = 'ASC' ) {
+	public static function case_insensitive_list_sort( $list, $orderby ) {
 		usort(
 			$list,
-			function ( $a, $b ) use ( $orderby, $order ) {
-				if ( 'DESC' === $order ) {
-					return strcasecmp(
-						$b[ $orderby ],
-						$a[ $orderby ]
-					);
-				}
-
+			function ( $a, $b ) use ( $orderby ) {
 				return strcasecmp(
 					$a[ $orderby ],
 					$b[ $orderby ]

--- a/includes/Modules/AdSense.php
+++ b/includes/Modules/AdSense.php
@@ -404,8 +404,7 @@ final class AdSense extends Module
 				return wp_list_sort(
 					array_map( array( self::class, 'filter_account_with_ids' ), $accounts ),
 					'displayName',
-					'ASC',
-					true
+					'ASC'
 				);
 			case 'GET:adunits':
 				return array_map( array( self::class, 'filter_adunit_with_ids' ), $response->getAdUnits() );

--- a/includes/Modules/AdSense.php
+++ b/includes/Modules/AdSense.php
@@ -401,7 +401,12 @@ final class AdSense extends Module
 		switch ( "{$data->method}:{$data->datapoint}" ) {
 			case 'GET:accounts':
 				$accounts = array_filter( $response->getAccounts(), array( self::class, 'is_account_not_closed' ) );
-				return array_map( array( self::class, 'filter_account_with_ids' ), $accounts );
+				return wp_list_sort(
+					array_map( array( self::class, 'filter_account_with_ids' ), $accounts ),
+					'displayName',
+					'ASC',
+					true
+				);
 			case 'GET:adunits':
 				return array_map( array( self::class, 'filter_adunit_with_ids' ), $response->getAdUnits() );
 			case 'GET:alerts':

--- a/includes/Modules/AdSense.php
+++ b/includes/Modules/AdSense.php
@@ -45,6 +45,7 @@ use Google\Site_Kit_Dependencies\Google\Service\Adsense as Google_Service_Adsens
 use Google\Site_Kit_Dependencies\Google\Service\Adsense\Alert as Google_Service_Adsense_Alert;
 use Google\Site_Kit_Dependencies\Psr\Http\Message\RequestInterface;
 use Exception;
+use Google\Site_Kit\Core\Util\Sort;
 use Google\Site_Kit\Core\Util\URL;
 use WP_Error;
 
@@ -401,17 +402,10 @@ final class AdSense extends Module
 		switch ( "{$data->method}:{$data->datapoint}" ) {
 			case 'GET:accounts':
 				$accounts = array_filter( $response->getAccounts(), array( self::class, 'is_account_not_closed' ) );
-				$accounts = array_map( array( self::class, 'filter_account_with_ids' ), $accounts );
-				usort(
-					$accounts,
-					function ( $a, $b ) {
-							return strcasecmp(
-								$a['displayName'],
-								$b['displayName']
-							);
-					}
+				return Sort::case_insensitive_list_sort(
+					array_map( array( self::class, 'filter_account_with_ids' ), $accounts ),
+					'displayName'
 				);
-				return $accounts;
 			case 'GET:adunits':
 				return array_map( array( self::class, 'filter_adunit_with_ids' ), $response->getAdUnits() );
 			case 'GET:alerts':

--- a/includes/Modules/AdSense.php
+++ b/includes/Modules/AdSense.php
@@ -401,11 +401,17 @@ final class AdSense extends Module
 		switch ( "{$data->method}:{$data->datapoint}" ) {
 			case 'GET:accounts':
 				$accounts = array_filter( $response->getAccounts(), array( self::class, 'is_account_not_closed' ) );
-				return wp_list_sort(
-					array_map( array( self::class, 'filter_account_with_ids' ), $accounts ),
-					'displayName',
-					'ASC'
+				$accounts = array_map( array( self::class, 'filter_account_with_ids' ), $accounts );
+				usort(
+					$accounts,
+					function ( $a, $b ) {
+							return strcasecmp(
+								$a['displayName'],
+								$b['displayName']
+							);
+					}
 				);
+				return $accounts;
 			case 'GET:adunits':
 				return array_map( array( self::class, 'filter_adunit_with_ids' ), $response->getAdUnits() );
 			case 'GET:alerts':

--- a/includes/Modules/Analytics.php
+++ b/includes/Modules/Analytics.php
@@ -777,6 +777,12 @@ final class Analytics extends Module
 			case 'GET:accounts-properties-profiles':
 				/* @var Google_Service_Analytics_Accounts $response listManagementAccounts response. */
 				$accounts            = (array) $response->getItems();
+				$accounts            = wp_list_sort(
+					$accounts,
+					'name',
+					'ASC',
+					true
+				);
 				$account_ids         = array_map(
 					function ( Google_Service_Analytics_Account $account ) {
 						return $account->getId();
@@ -829,11 +835,23 @@ final class Analytics extends Module
 			case 'GET:profiles':
 				// TODO: Parse this response to a regular array.
 				$response = $response->getItems();
+				$response = wp_list_sort(
+					$response,
+					'name',
+					'ASC',
+					true
+				);
 
 				return $response;
 			case 'GET:properties-profiles':
 				/* @var Google_Service_Analytics_Webproperties $response listManagementWebproperties response. */
 				$properties     = (array) $response->getItems();
+				$properties     = wp_list_sort(
+					$properties,
+					'name',
+					'ASC',
+					true
+				);
 				$found_property = null;
 				$response       = array(
 					'properties' => $properties,

--- a/includes/Modules/Analytics.php
+++ b/includes/Modules/Analytics.php
@@ -780,8 +780,7 @@ final class Analytics extends Module
 				$accounts            = wp_list_sort(
 					$accounts,
 					'name',
-					'ASC',
-					true
+					'ASC'
 				);
 				$account_ids         = array_map(
 					function ( Google_Service_Analytics_Account $account ) {
@@ -838,8 +837,7 @@ final class Analytics extends Module
 				$response = wp_list_sort(
 					$response,
 					'name',
-					'ASC',
-					true
+					'ASC'
 				);
 
 				return $response;
@@ -849,8 +847,7 @@ final class Analytics extends Module
 				$properties     = wp_list_sort(
 					$properties,
 					'name',
-					'ASC',
-					true
+					'ASC'
 				);
 				$found_property = null;
 				$response       = array(

--- a/includes/Modules/Analytics.php
+++ b/includes/Modules/Analytics.php
@@ -64,6 +64,7 @@ use WP_Error;
 use Exception;
 use Google\Site_Kit\Core\Modules\Module_With_Service_Entity;
 use Google\Site_Kit\Core\Util\BC_Functions;
+use Google\Site_Kit\Core\Util\Sort;
 use Google\Site_Kit\Core\Util\URL;
 
 /**
@@ -776,15 +777,9 @@ final class Analytics extends Module
 		switch ( "{$data->method}:{$data->datapoint}" ) {
 			case 'GET:accounts-properties-profiles':
 				/* @var Google_Service_Analytics_Accounts $response listManagementAccounts response. */
-				$accounts = (array) $response->getItems();
-				usort(
-					$accounts,
-					function ( $a, $b ) {
-							return strcasecmp(
-								$a['name'],
-								$b['name']
-							);
-					}
+				$accounts            = Sort::case_insensitive_list_sort(
+					(array) $response->getItems(),
+					'name'
 				);
 				$account_ids         = array_map(
 					function ( Google_Service_Analytics_Account $account ) {
@@ -837,28 +832,16 @@ final class Analytics extends Module
 				break;
 			case 'GET:profiles':
 				// TODO: Parse this response to a regular array.
-				$response = $response->getItems();
-				usort(
-					$response,
-					function ( $a, $b ) {
-							return strcasecmp(
-								$a['name'],
-								$b['name']
-							);
-					}
+				$response = Sort::case_insensitive_list_sort(
+					$response->getItems(),
+					'name'
 				);
 				return $response;
 			case 'GET:properties-profiles':
 				/* @var Google_Service_Analytics_Webproperties $response listManagementWebproperties response. */
-				$properties = (array) $response->getItems();
-				usort(
-					$properties,
-					function ( $a, $b ) {
-							return strcasecmp(
-								$a['name'],
-								$b['name']
-							);
-					}
+				$properties     = Sort::case_insensitive_list_sort(
+					(array) $response->getItems(),
+					'name'
 				);
 				$found_property = null;
 				$response       = array(

--- a/includes/Modules/Analytics.php
+++ b/includes/Modules/Analytics.php
@@ -776,11 +776,15 @@ final class Analytics extends Module
 		switch ( "{$data->method}:{$data->datapoint}" ) {
 			case 'GET:accounts-properties-profiles':
 				/* @var Google_Service_Analytics_Accounts $response listManagementAccounts response. */
-				$accounts            = (array) $response->getItems();
-				$accounts            = wp_list_sort(
+				$accounts = (array) $response->getItems();
+				usort(
 					$accounts,
-					'name',
-					'ASC'
+					function ( $a, $b ) {
+							return strcasecmp(
+								$a['name'],
+								$b['name']
+							);
+					}
 				);
 				$account_ids         = array_map(
 					function ( Google_Service_Analytics_Account $account ) {
@@ -834,20 +838,27 @@ final class Analytics extends Module
 			case 'GET:profiles':
 				// TODO: Parse this response to a regular array.
 				$response = $response->getItems();
-				$response = wp_list_sort(
+				usort(
 					$response,
-					'name',
-					'ASC'
+					function ( $a, $b ) {
+							return strcasecmp(
+								$a['name'],
+								$b['name']
+							);
+					}
 				);
-
 				return $response;
 			case 'GET:properties-profiles':
 				/* @var Google_Service_Analytics_Webproperties $response listManagementWebproperties response. */
-				$properties     = (array) $response->getItems();
-				$properties     = wp_list_sort(
+				$properties = (array) $response->getItems();
+				usort(
 					$properties,
-					'name',
-					'ASC'
+					function ( $a, $b ) {
+							return strcasecmp(
+								$a['name'],
+								$b['name']
+							);
+					}
 				);
 				$found_property = null;
 				$response       = array(

--- a/includes/Modules/Analytics_4.php
+++ b/includes/Modules/Analytics_4.php
@@ -480,7 +480,12 @@ final class Analytics_4 extends Module
 			case 'POST:create-webdatastream':
 				return self::filter_webdatastream_with_ids( $response );
 			case 'GET:properties':
-				return array_map( array( self::class, 'filter_property_with_ids' ), $response->getProperties() );
+				return wp_list_sort(
+					array_map( array( self::class, 'filter_property_with_ids' ), $response->getProperties() ),
+					'displayName',
+					'ASC',
+					true
+				);
 			case 'GET:property':
 				return self::filter_property_with_ids( $response );
 			case 'GET:webdatastreams':

--- a/includes/Modules/Analytics_4.php
+++ b/includes/Modules/Analytics_4.php
@@ -483,8 +483,7 @@ final class Analytics_4 extends Module
 				return wp_list_sort(
 					array_map( array( self::class, 'filter_property_with_ids' ), $response->getProperties() ),
 					'displayName',
-					'ASC',
-					true
+					'ASC'
 				);
 			case 'GET:property':
 				return self::filter_property_with_ids( $response );

--- a/includes/Modules/Analytics_4.php
+++ b/includes/Modules/Analytics_4.php
@@ -34,6 +34,7 @@ use Google\Site_Kit\Core\Tags\Guards\Tag_Verify_Guard;
 use Google\Site_Kit\Core\Util\BC_Functions;
 use Google\Site_Kit\Core\Util\Debug_Data;
 use Google\Site_Kit\Core\Util\Method_Proxy_Trait;
+use Google\Site_Kit\Core\Util\Sort;
 use Google\Site_Kit\Core\Util\URL;
 use Google\Site_Kit\Modules\Analytics\Settings as Analytics_Settings;
 use Google\Site_Kit\Modules\Analytics_4\Settings;
@@ -480,17 +481,10 @@ final class Analytics_4 extends Module
 			case 'POST:create-webdatastream':
 				return self::filter_webdatastream_with_ids( $response );
 			case 'GET:properties':
-				$properties = array_map( array( self::class, 'filter_property_with_ids' ), $response->getProperties() );
-				usort(
-					$properties,
-					function ( $a, $b ) {
-							return strcasecmp(
-								$a['displayName'],
-								$b['displayName']
-							);
-					}
+				return Sort::case_insensitive_list_sort(
+					array_map( array( self::class, 'filter_property_with_ids' ), $response->getProperties() ),
+					'displayName'
 				);
-				return $properties;
 			case 'GET:property':
 				return self::filter_property_with_ids( $response );
 			case 'GET:webdatastreams':

--- a/includes/Modules/Analytics_4.php
+++ b/includes/Modules/Analytics_4.php
@@ -480,11 +480,17 @@ final class Analytics_4 extends Module
 			case 'POST:create-webdatastream':
 				return self::filter_webdatastream_with_ids( $response );
 			case 'GET:properties':
-				return wp_list_sort(
-					array_map( array( self::class, 'filter_property_with_ids' ), $response->getProperties() ),
-					'displayName',
-					'ASC'
+				$properties = array_map( array( self::class, 'filter_property_with_ids' ), $response->getProperties() );
+				usort(
+					$properties,
+					function ( $a, $b ) {
+							return strcasecmp(
+								$a['displayName'],
+								$b['displayName']
+							);
+					}
 				);
+				return $properties;
 			case 'GET:property':
 				return self::filter_property_with_ids( $response );
 			case 'GET:webdatastreams':

--- a/includes/Modules/Search_Console.php
+++ b/includes/Modules/Search_Console.php
@@ -42,6 +42,7 @@ use Google\Site_Kit_Dependencies\Psr\Http\Message\ResponseInterface;
 use Google\Site_Kit_Dependencies\Psr\Http\Message\RequestInterface;
 use WP_Error;
 use Exception;
+use Google\Site_Kit\Core\Util\Sort;
 
 /**
  * Class representing the Search Console module.
@@ -285,18 +286,11 @@ final class Search_Console extends Module
 		switch ( "{$data->method}:{$data->datapoint}" ) {
 			case 'GET:matched-sites':
 				/* @var Google_Service_SearchConsole_SitesListResponse $response Response object. */
-				$entries = $this->map_sites( (array) $response->getSiteEntry() );
-				usort(
-					$entries,
-					function ( $a, $b ) {
-							return strcasecmp(
-								$a['name'],
-								$b['name']
-							);
-					}
+				$entries     = Sort::case_insensitive_list_sort(
+					$this->map_sites( (array) $response->getSiteEntry() ),
+					'name'
 				);
-				$strict = filter_var( $data['strict'], FILTER_VALIDATE_BOOLEAN );
-
+				$strict      = filter_var( $data['strict'], FILTER_VALIDATE_BOOLEAN );
 				$current_url = $this->context->get_reference_site_url();
 				if ( ! $strict ) {
 					$current_url = untrailingslashit( $current_url );

--- a/includes/Modules/Search_Console.php
+++ b/includes/Modules/Search_Console.php
@@ -289,8 +289,7 @@ final class Search_Console extends Module
 				$entries = wp_list_sort(
 					$entries,
 					'name',
-					'ASC',
-					true
+					'ASC'
 				);
 				$strict  = filter_var( $data['strict'], FILTER_VALIDATE_BOOLEAN );
 

--- a/includes/Modules/Search_Console.php
+++ b/includes/Modules/Search_Console.php
@@ -286,6 +286,12 @@ final class Search_Console extends Module
 			case 'GET:matched-sites':
 				/* @var Google_Service_SearchConsole_SitesListResponse $response Response object. */
 				$entries = $this->map_sites( (array) $response->getSiteEntry() );
+				$entries = wp_list_sort(
+					$entries,
+					'name',
+					'ASC',
+					true
+				);
 				$strict  = filter_var( $data['strict'], FILTER_VALIDATE_BOOLEAN );
 
 				$current_url = $this->context->get_reference_site_url();

--- a/includes/Modules/Search_Console.php
+++ b/includes/Modules/Search_Console.php
@@ -286,12 +286,16 @@ final class Search_Console extends Module
 			case 'GET:matched-sites':
 				/* @var Google_Service_SearchConsole_SitesListResponse $response Response object. */
 				$entries = $this->map_sites( (array) $response->getSiteEntry() );
-				$entries = wp_list_sort(
+				usort(
 					$entries,
-					'name',
-					'ASC'
+					function ( $a, $b ) {
+							return strcasecmp(
+								$a['name'],
+								$b['name']
+							);
+					}
 				);
-				$strict  = filter_var( $data['strict'], FILTER_VALIDATE_BOOLEAN );
+				$strict = filter_var( $data['strict'], FILTER_VALIDATE_BOOLEAN );
 
 				$current_url = $this->context->get_reference_site_url();
 				if ( ! $strict ) {

--- a/includes/Modules/Tag_Manager.php
+++ b/includes/Modules/Tag_Manager.php
@@ -35,6 +35,7 @@ use Google\Site_Kit\Core\Tags\Guards\Tag_Verify_Guard;
 use Google\Site_Kit\Core\Util\BC_Functions;
 use Google\Site_Kit\Core\Util\Debug_Data;
 use Google\Site_Kit\Core\Util\Method_Proxy_Trait;
+use Google\Site_Kit\Core\Util\Sort;
 use Google\Site_Kit\Core\Util\URL;
 use Google\Site_Kit\Modules\Tag_Manager\AMP_Tag;
 use Google\Site_Kit\Modules\Tag_Manager\Settings;
@@ -385,28 +386,15 @@ final class Tag_Manager extends Module
 		switch ( "{$data->method}:{$data->datapoint}" ) {
 			case 'GET:accounts':
 				/* @var Google_Service_TagManager_ListAccountsResponse $response List accounts response. */
-				$accounts = $response->getAccount();
-				usort(
-					$accounts,
-					function ( $a, $b ) {
-							return strcasecmp(
-								$a['name'],
-								$b['name']
-							);
-					}
+				return Sort::case_insensitive_list_sort(
+					$response->getAccount(),
+					'name'
 				);
-				return $accounts;
 			case 'GET:accounts-containers':
 				/* @var Google_Service_TagManager_ListAccountsResponse $response List accounts response. */
-				$accounts = $response->getAccount();
-				usort(
-					$accounts,
-					function ( $a, $b ) {
-							return strcasecmp(
-								$a['name'],
-								$b['name']
-							);
-					}
+				$accounts = Sort::case_insensitive_list_sort(
+					$response->getAccount(),
+					'name'
 				);
 				$response = array(
 					// TODO: Parse this response to a regular array.
@@ -445,18 +433,11 @@ final class Tag_Manager extends Module
 						return array_intersect( (array) $usage_context, $container->getUsageContext() );
 					}
 				);
-				$containers = array_values( $containers );
-				usort(
-					$containers,
-					function ( $a, $b ) {
-							return strcasecmp(
-								$a['name'],
-								$b['name']
-							);
-					}
-				);
 
-				return $containers;
+				return Sort::case_insensitive_list_sort(
+					array_values( $containers ),
+					'name'
+				);
 		}
 
 		return parent::parse_data_response( $data, $response );

--- a/includes/Modules/Tag_Manager.php
+++ b/includes/Modules/Tag_Manager.php
@@ -385,12 +385,22 @@ final class Tag_Manager extends Module
 		switch ( "{$data->method}:{$data->datapoint}" ) {
 			case 'GET:accounts':
 				/* @var Google_Service_TagManager_ListAccountsResponse $response List accounts response. */
-				return $response->getAccount();
+				return wp_list_sort(
+					$response->getAccount(),
+					'name',
+					'ASC',
+					true
+				);
 			case 'GET:accounts-containers':
 				/* @var Google_Service_TagManager_ListAccountsResponse $response List accounts response. */
 				$response = array(
 					// TODO: Parse this response to a regular array.
-					'accounts'   => $response->getAccount(),
+					'accounts'   => wp_list_sort(
+						$response->getAccount(),
+						'name',
+						'ASC',
+						true
+					),
 					'containers' => array(),
 				);
 				if ( 0 === count( $response['accounts'] ) ) {
@@ -426,7 +436,12 @@ final class Tag_Manager extends Module
 					}
 				);
 
-				return array_values( $containers );
+				return wp_list_sort(
+					array_values( $containers ),
+					'name',
+					'ASC',
+					true
+				);
 		}
 
 		return parent::parse_data_response( $data, $response );

--- a/includes/Modules/Tag_Manager.php
+++ b/includes/Modules/Tag_Manager.php
@@ -388,8 +388,7 @@ final class Tag_Manager extends Module
 				return wp_list_sort(
 					$response->getAccount(),
 					'name',
-					'ASC',
-					true
+					'ASC'
 				);
 			case 'GET:accounts-containers':
 				/* @var Google_Service_TagManager_ListAccountsResponse $response List accounts response. */
@@ -398,8 +397,7 @@ final class Tag_Manager extends Module
 					'accounts'   => wp_list_sort(
 						$response->getAccount(),
 						'name',
-						'ASC',
-						true
+						'ASC'
 					),
 					'containers' => array(),
 				);
@@ -439,8 +437,7 @@ final class Tag_Manager extends Module
 				return wp_list_sort(
 					array_values( $containers ),
 					'name',
-					'ASC',
-					true
+					'ASC'
 				);
 		}
 

--- a/includes/Modules/Tag_Manager.php
+++ b/includes/Modules/Tag_Manager.php
@@ -385,20 +385,32 @@ final class Tag_Manager extends Module
 		switch ( "{$data->method}:{$data->datapoint}" ) {
 			case 'GET:accounts':
 				/* @var Google_Service_TagManager_ListAccountsResponse $response List accounts response. */
-				return wp_list_sort(
-					$response->getAccount(),
-					'name',
-					'ASC'
+				$accounts = $response->getAccount();
+				usort(
+					$accounts,
+					function ( $a, $b ) {
+							return strcasecmp(
+								$a['name'],
+								$b['name']
+							);
+					}
 				);
+				return $accounts;
 			case 'GET:accounts-containers':
 				/* @var Google_Service_TagManager_ListAccountsResponse $response List accounts response. */
+				$accounts = $response->getAccount();
+				usort(
+					$accounts,
+					function ( $a, $b ) {
+							return strcasecmp(
+								$a['name'],
+								$b['name']
+							);
+					}
+				);
 				$response = array(
 					// TODO: Parse this response to a regular array.
-					'accounts'   => wp_list_sort(
-						$response->getAccount(),
-						'name',
-						'ASC'
-					),
+					'accounts'   => $accounts,
 					'containers' => array(),
 				);
 				if ( 0 === count( $response['accounts'] ) ) {
@@ -433,12 +445,18 @@ final class Tag_Manager extends Module
 						return array_intersect( (array) $usage_context, $container->getUsageContext() );
 					}
 				);
-
-				return wp_list_sort(
-					array_values( $containers ),
-					'name',
-					'ASC'
+				$containers = array_values( $containers );
+				usort(
+					$containers,
+					function ( $a, $b ) {
+							return strcasecmp(
+								$a['name'],
+								$b['name']
+							);
+					}
 				);
+
+				return $containers;
 		}
 
 		return parent::parse_data_response( $data, $response );

--- a/tests/phpunit/integration/Core/Util/SortTest.php
+++ b/tests/phpunit/integration/Core/Util/SortTest.php
@@ -17,74 +17,76 @@ use Google\Site_Kit\Tests\TestCase;
  * @group Util
  */
 class SortTest extends TestCase {
-	/**
-	 * Sample unsorted array.
-	 * @var array
-	 */
-	private static $unsorted_array = array(
-		array(
-			'firstname' => 'John',
-			'lastname'  => 'Doe',
-		),
-		array(
-			'firstname' => 'Harry',
-			'lastname'  => 'Smith',
-		),
-		array(
-			'firstname' => 'foo',
-			'lastname'  => 'bar',
-		),
-	);
-
-	/**
-	 * Array sorted, ordered by 'firstname` in 'ASC' order.
-	 * @var array
-	 */
-	private static $sorted_array_firstname_asc = array(
-		array(
-			'firstname' => 'foo',
-			'lastname'  => 'bar',
-		),
-		array(
-			'firstname' => 'Harry',
-			'lastname'  => 'Smith',
-		),
-		array(
-			'firstname' => 'John',
-			'lastname'  => 'Doe',
-		),
-	);
-
-	/**
-	 * Array sorted, ordered by 'lastname` in 'DESC' order.
-	 * @var array
-	 */
-	private static $sorted_array_lastname_desc = array(
-		array(
-			'firstname' => 'Harry',
-			'lastname'  => 'Smith',
-		),
-		array(
-			'firstname' => 'John',
-			'lastname'  => 'Doe',
-		),
-		array(
-			'firstname' => 'foo',
-			'lastname'  => 'bar',
-		),
-	);
 
 	public function test_case_insensitive_list_sort() {
-		// Sorts array correctly, ordered by 'firstname` in 'ASC' order.
+		// Sorts an array correctly, ordered by the field 'firstname'.
 		$this->assertEquals(
-			Sort::case_insensitive_list_sort( static::$unsorted_array, 'firstname', 'ASC' ),
-			static::$sorted_array_firstname_asc
+			Sort::case_insensitive_list_sort(
+				array(
+					array(
+						'firstname' => 'John',
+						'lastname'  => 'Doe',
+					),
+					array(
+						'firstname' => 'Harry',
+						'lastname'  => 'Smith',
+					),
+					array(
+						'firstname' => 'foo',
+						'lastname'  => 'bar',
+					),
+				),
+				'firstname'
+			),
+			array(
+				array(
+					'firstname' => 'foo',
+					'lastname'  => 'bar',
+				),
+				array(
+					'firstname' => 'Harry',
+					'lastname'  => 'Smith',
+				),
+				array(
+					'firstname' => 'John',
+					'lastname'  => 'Doe',
+				),
+			)
 		);
 
-		// Sorts array correctly, ordered by 'lastname` in 'DESC' order.
+		// Sorts an array correctly, ordered by the field 'lastname'.
 		$this->assertEquals(
-			Sort::case_insensitive_list_sort( static::$unsorted_array, 'lastname', 'DESC' ),
-			static::$sorted_array_lastname_desc
+			Sort::case_insensitive_list_sort(
+				array(
+					array(
+						'firstname' => 'John',
+						'lastname'  => 'Doe',
+					),
+					array(
+						'firstname' => 'Harry',
+						'lastname'  => 'Smith',
+					),
+					array(
+						'firstname' => 'foo',
+						'lastname'  => 'bar',
+					),
+				),
+				'lastname'
+			),
+			array(
+				array(
+					'firstname' => 'foo',
+					'lastname'  => 'bar',
+				),
+				array(
+					'firstname' => 'John',
+					'lastname'  => 'Doe',
+				),
+				array(
+					'firstname' => 'Harry',
+					'lastname'  => 'Smith',
+				),
+			)
 		);
 	}
 }

--- a/tests/phpunit/integration/Core/Util/SortTest.php
+++ b/tests/phpunit/integration/Core/Util/SortTest.php
@@ -17,19 +17,74 @@ use Google\Site_Kit\Tests\TestCase;
  * @group Util
  */
 class SortTest extends TestCase {
-
 	/**
-	 * Asset arguments.
+	 * Sample unsorted array.
 	 * @var array
 	 */
-	protected $unsorted_array = array(
+	private static $unsorted_array = array(
+		array(
+			'firstname' => 'John',
+			'lastname'  => 'Doe',
+		),
+		array(
+			'firstname' => 'Harry',
+			'lastname'  => 'Smith',
+		),
+		array(
+			'firstname' => 'foo',
+			'lastname'  => 'bar',
+		),
+	);
+
+	/**
+	 * Array sorted, ordered by 'firstname` in 'ASC' order.
+	 * @var array
+	 */
+	private static $sorted_array_firstname_asc = array(
+		array(
+			'firstname' => 'foo',
+			'lastname'  => 'bar',
+		),
+		array(
+			'firstname' => 'Harry',
+			'lastname'  => 'Smith',
+		),
 		array(
 			'firstname' => 'John',
 			'lastname'  => 'Doe',
 		),
 	);
 
-	public function test_case_insensitive_list_sort() {
+	/**
+	 * Array sorted, ordered by 'lastname` in 'DESC' order.
+	 * @var array
+	 */
+	private static $sorted_array_lastname_desc = array(
+		array(
+			'firstname' => 'Harry',
+			'lastname'  => 'Smith',
+		),
+		array(
+			'firstname' => 'John',
+			'lastname'  => 'Doe',
+		),
+		array(
+			'firstname' => 'foo',
+			'lastname'  => 'bar',
+		),
+	);
 
+	public function test_case_insensitive_list_sort() {
+		// Sorts array correctly, ordered by 'firstname` in 'ASC' order.
+		$this->assertEquals(
+			Sort::case_insensitive_list_sort( static::$unsorted_array, 'firstname', 'ASC' ),
+			static::$sorted_array_firstname_asc
+		);
+
+		// Sorts array correctly, ordered by 'lastname` in 'DESC' order.
+		$this->assertEquals(
+			Sort::case_insensitive_list_sort( static::$unsorted_array, 'lastname', 'DESC' ),
+			static::$sorted_array_lastname_desc
+		);
 	}
 }

--- a/tests/phpunit/integration/Core/Util/SortTest.php
+++ b/tests/phpunit/integration/Core/Util/SortTest.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * SortTest
+ *
+ * @package   Google\Site_Kit\Tests\Core\Util
+ * @copyright 2022 Google LLC
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
+ * @link      https://sitekit.withgoogle.com
+ */
+
+namespace Google\Site_Kit\Tests\Core\Util;
+
+use Google\Site_Kit\Core\Util\Sort;
+use Google\Site_Kit\Tests\TestCase;
+
+/**
+ * @group Util
+ */
+class SortTest extends TestCase {
+
+	/**
+	 * Asset arguments.
+	 * @var array
+	 */
+	protected $unsorted_array = array(
+		array(
+			'firstname' => 'John',
+			'lastname'  => 'Doe',
+		),
+	);
+
+	public function test_case_insensitive_list_sort() {
+
+	}
+}


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #4853 

## Relevant technical choices

`preserve_keys` should be set to default otherwise TypeError appears

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [x] Run the code.
- [x] Ensure the acceptance criteria are satisfied.
- [x] Reassess the implementation with the IB.
- [x] Ensure no unrelated changes are included.
- [x] Ensure CI checks pass.
- [x] Check Storybook where applicable.
- [x] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [x] Ensure the PR has the correct target branch.
- [x] Double-check that the PR is okay to be merged.
- [x] Ensure the corresponding issue has a ZenHub release assigned.
- [x] Add a changelog message to the issue.
