### PR TITLE
Inline edit answer interface for User Input Settings

### DIFF
--- a/assets/js/components/settings/SettingsAdmin.js
+++ b/assets/js/components/settings/SettingsAdmin.js
@@ -102,7 +102,11 @@ export default function SettingsAdmin() {
 										</Cell>
 									</Row>
 
-									<UserInputPreview goTo={ goTo } noFooter />
+									<UserInputPreview
+										goTo={ goTo }
+										noFooter
+										showIndividualCTAs
+									/>
 								</Grid>
 							</div>
 						</Layout>

--- a/assets/js/components/user-input/UserInputPreview.js
+++ b/assets/js/components/user-input/UserInputPreview.js
@@ -41,7 +41,14 @@ import ErrorNotice from '../ErrorNotice';
 const { useSelect } = Data;
 
 export default function UserInputPreview( props ) {
-	const { noFooter, goTo, submitChanges, error } = props;
+	const {
+		noFooter,
+		goTo,
+		submitChanges,
+		error,
+		showIndividualCTAs = false,
+	} = props;
+
 	const previewContainer = useRef();
 	const settings = useSelect( ( select ) =>
 		select( CORE_USER ).getUserInputSettings()
@@ -84,6 +91,7 @@ export default function UserInputPreview( props ) {
 				edit={ goTo.bind( null, 1, 'user-input' ) }
 				values={ settings?.purpose?.values || [] }
 				options={ USER_INPUT_ANSWERS_PURPOSE }
+				showIndividualCTAs={ showIndividualCTAs }
 			/>
 
 			<UserInputPreviewGroup
@@ -95,6 +103,7 @@ export default function UserInputPreview( props ) {
 				edit={ goTo.bind( null, 2, 'user-input' ) }
 				values={ settings?.postFrequency?.values || [] }
 				options={ USER_INPUT_ANSWERS_POST_FREQUENCY }
+				showIndividualCTAs={ showIndividualCTAs }
 			/>
 
 			<UserInputPreviewGroup
@@ -106,6 +115,7 @@ export default function UserInputPreview( props ) {
 				edit={ goTo.bind( null, 3, 'user-input' ) }
 				values={ settings?.goals?.values || [] }
 				options={ USER_INPUT_ANSWERS_GOALS }
+				showIndividualCTAs={ showIndividualCTAs }
 			/>
 
 			{ error && <ErrorNotice error={ error } /> }
@@ -134,4 +144,5 @@ UserInputPreview.propTypes = {
 	goTo: PropTypes.func.isRequired,
 	redirectURL: PropTypes.string,
 	errors: PropTypes.object,
+	showIndividualCTAs: PropTypes.bool,
 };

--- a/assets/js/googlesitekit/datastore/user/user-input-settings.js
+++ b/assets/js/googlesitekit/datastore/user/user-input-settings.js
@@ -21,6 +21,8 @@
  */
 import invariant from 'invariant';
 import isPlainObject from 'lodash/isPlainObject';
+import isEqual from 'lodash/isEqual';
+import pick from 'lodash/pick';
 
 /**
  * Internal dependencies
@@ -37,7 +39,7 @@ const { receiveError, clearError } = errorStoreActions;
 const CACHE_KEY_NAME = 'userInputSettings';
 
 function fetchStoreReducerCallback( state, inputSettings ) {
-	return { ...state, inputSettings };
+	return { ...state, inputSettings, savedInputSettings: inputSettings };
 }
 
 const fetchGetUserInputSettingsStore = createFetchStore( {
@@ -71,6 +73,7 @@ const SET_USER_INPUT_SETTINGS_SAVING_FLAG =
 const baseInitialState = {
 	inputSettings: undefined,
 	isSavingInputSettings: false,
+	savedInputSettings: undefined,
 };
 
 const baseActions = {
@@ -322,6 +325,52 @@ const baseSelectors = {
 			return settings[ settingID ]?.author;
 		}
 	),
+
+	/**
+	 * Indicates whether the current user input settings have changed from what is saved.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param {Object}     state Data store's state.
+	 * @param {Array|null} keys  Settings keys to check; if not provided, all settings are checked.
+	 * @return {boolean} True if the settings have changed, false otherwise.
+	 */
+	haveUserInputSettingsChanged( state, keys = null ) {
+		const { inputSettings, savedInputSettings } = state;
+
+		if ( keys ) {
+			return ! isEqual(
+				pick( inputSettings, keys ),
+				pick( savedInputSettings, keys )
+			);
+		}
+
+		return ! isEqual( inputSettings, savedInputSettings );
+	},
+
+	/**
+	 * Indicates whether the provided user input setting has changed from what is saved.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param {Object} state   Data store's state.
+	 * @param {string} setting The setting we want to check for saved changes.
+	 * @return {boolean} True if the settings have changed, false otherwise.
+	 */
+	hasUserInputSettingChanged( state, setting ) {
+		invariant( setting, 'setting is required.' );
+
+		const { inputSettings, savedInputSettings } = state;
+
+		if ( ! inputSettings || ! savedInputSettings ) {
+			return false;
+		}
+
+		return ! isEqual(
+			inputSettings[ setting ],
+			savedInputSettings[ setting ]
+		);
+	},
 };
 
 const store = Data.combineStores(


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #5897 

## Relevant technical choices

This PR updates the User Input part of the Admin Settings UI to use the new inline edit answer interface.

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
