### PR TITLE
[Tag Manager] Add different edit links for web and AMP containers

### DIFF
--- a/assets/js/modules/tagmanager/components/settings/SettingsView.js
+++ b/assets/js/modules/tagmanager/components/settings/SettingsView.js
@@ -20,7 +20,7 @@
  * WordPress dependencies
  */
 import { createInterpolateElement, Fragment } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -61,11 +61,14 @@ export default function SettingsView() {
 	const internalAMPContainerID = useSelect( ( select ) =>
 		select( MODULES_TAGMANAGER ).getInternalAMPContainerID()
 	);
-	const editViewSettingsURL = useSelect( ( select ) =>
+	const editWebContainerURL = useSelect( ( select ) =>
 		select( MODULES_TAGMANAGER ).getServiceURL( {
-			path: escapeURI`/container/accounts/${ accountID }/containers/${
-				isAMP ? internalAMPContainerID : internalContainerID
-			}`,
+			path: escapeURI`/container/accounts/${ accountID }/containers/${ internalContainerID }`,
+		} )
+	);
+	const editAMPContainerURL = useSelect( ( select ) =>
+		select( MODULES_TAGMANAGER ).getServiceURL( {
+			path: escapeURI`/container/accounts/${ accountID }/containers/${ internalAMPContainerID }`,
 		} )
 	);
 
@@ -87,67 +90,121 @@ export default function SettingsView() {
 				</div>
 
 				{ ( ! isAMP || isSecondaryAMP ) && (
-					<div className="googlesitekit-settings-module__meta-item">
-						<h5 className="googlesitekit-settings-module__meta-item-type">
-							{ isSecondaryAMP && (
-								<span>
-									{ __(
-										'Web Container ID',
-										'google-site-kit'
-									) }
-								</span>
-							) }
-							{ ! isSecondaryAMP && (
-								<span>
-									{ __( 'Container ID', 'google-site-kit' ) }
-								</span>
-							) }
-						</h5>
-						<p className="googlesitekit-settings-module__meta-item-data">
-							<DisplaySetting value={ containerID } />
-						</p>
-					</div>
+					<Fragment>
+						<div className="googlesitekit-settings-module__meta-item">
+							<h5 className="googlesitekit-settings-module__meta-item-type">
+								{ isSecondaryAMP && (
+									<span>
+										{ __(
+											'Web Container ID',
+											'google-site-kit'
+										) }
+									</span>
+								) }
+								{ ! isSecondaryAMP && (
+									<span>
+										{ __(
+											'Container ID',
+											'google-site-kit'
+										) }
+									</span>
+								) }
+							</h5>
+							<p className="googlesitekit-settings-module__meta-item-data">
+								<DisplaySetting value={ containerID } />
+							</p>
+						</div>
+						{ editWebContainerURL && (
+							<div className="googlesitekit-settings-module__meta-item googlesitekit-settings-module__meta-item--data-only">
+								<p className="googlesitekit-settings-module__meta-item-data googlesitekit-settings-module__meta-item-data--tiny">
+									<Link href={ editWebContainerURL } external>
+										{ createInterpolateElement(
+											sprintf(
+												/* translators: %s: Appropriate container term. */
+												__(
+													'Edit <VisuallyHidden>%s </VisuallyHidden>in Tag Manager',
+													'google-site-kit'
+												),
+												isSecondaryAMP
+													? __(
+															'web container',
+															'google-site-kit'
+													  )
+													: __(
+															'container',
+															'google-site-kit'
+													  )
+											),
+											{
+												VisuallyHidden: (
+													<VisuallyHidden />
+												),
+											}
+										) }
+									</Link>
+								</p>
+							</div>
+						) }
+					</Fragment>
 				) }
 
 				{ isAMP && (
-					<div className="googlesitekit-settings-module__meta-item">
-						<h5 className="googlesitekit-settings-module__meta-item-type">
-							{ isSecondaryAMP && (
-								<span>
-									{ __(
-										'AMP Container ID',
-										'google-site-kit'
-									) }
-								</span>
-							) }
-							{ ! isSecondaryAMP && (
-								<span>
-									{ __( 'Container ID', 'google-site-kit' ) }
-								</span>
-							) }
-						</h5>
-						<p className="googlesitekit-settings-module__meta-item-data">
-							<DisplaySetting value={ ampContainerID } />
-						</p>
-					</div>
-				) }
-
-				{ editViewSettingsURL && (
-					<div className="googlesitekit-settings-module__meta-item googlesitekit-settings-module__meta-item--data-only">
-						<p className="googlesitekit-settings-module__meta-item-data googlesitekit-settings-module__meta-item-data--tiny">
-							<Link href={ editViewSettingsURL } external>
-								{ createInterpolateElement(
-									__(
-										'Edit <VisuallyHidden>container </VisuallyHidden>in Tag Manager',
-										'google-site-kit'
-									),
-									{
-										VisuallyHidden: <VisuallyHidden />,
-									}
+					<Fragment>
+						<div className="googlesitekit-settings-module__meta-item">
+							<h5 className="googlesitekit-settings-module__meta-item-type">
+								{ isSecondaryAMP && (
+									<span>
+										{ __(
+											'AMP Container ID',
+											'google-site-kit'
+										) }
+									</span>
 								) }
-							</Link>
-						</p>
-					</div>
+								{ ! isSecondaryAMP && (
+									<span>
+										{ __(
+											'Container ID',
+											'google-site-kit'
+										) }
+									</span>
+								) }
+							</h5>
+							<p className="googlesitekit-settings-module__meta-item-data">
+								<DisplaySetting value={ ampContainerID } />
+							</p>
+						</div>
+						{ editAMPContainerURL && (
+							<div className="googlesitekit-settings-module__meta-item googlesitekit-settings-module__meta-item--data-only">
+								<p className="googlesitekit-settings-module__meta-item-data googlesitekit-settings-module__meta-item-data--tiny">
+									<Link href={ editAMPContainerURL } external>
+										{ createInterpolateElement(
+											sprintf(
+												/* translators: %s: Appropriate container term. */
+												__(
+													'Edit <VisuallyHidden>%s </VisuallyHidden>in Tag Manager',
+													'google-site-kit'
+												),
+												isSecondaryAMP
+													? __(
+															'AMP container',
+															'google-site-kit'
+													  )
+													: __(
+															'container',
+															'google-site-kit'
+													  )
+											),
+											{
+												VisuallyHidden: (
+													<VisuallyHidden />
+												),
+											}
+										) }
+									</Link>
+								</p>
+							</div>
+						) }
+					</Fragment>
 				) }
 			</div>
 


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #5174 

## Relevant technical choices

This PR addresses the first point in [this comment](https://github.com/google/site-kit-wp/issues/5174#issuecomment-1323766979) and adds different links for web and AMP containers (if both are available) in the Tag Manager Settings View.

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [x] Run the code.
- [x] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
