### PR TITLE
Enhance/6117 - Update improper use of yield in data stores

### DIFF
--- a/assets/js/googlesitekit/datastore/site/registry-key.js
+++ b/assets/js/googlesitekit/datastore/site/registry-key.js
@@ -76,7 +76,7 @@ const resolvers = {
 
 		if ( ! registryKey ) {
 			registryKey = uuidv4();
-			yield registry.dispatch( CORE_SITE ).setRegistryKey( registryKey );
+			registry.dispatch( CORE_SITE ).setRegistryKey( registryKey );
 		}
 	},
 };

--- a/assets/js/googlesitekit/datastore/user/permissions.js
+++ b/assets/js/googlesitekit/datastore/user/permissions.js
@@ -119,7 +119,7 @@ const baseActions = {
 			yield fetchGetCapabilitiesStore.actions.fetchGetCapabilities();
 
 		if ( error ) {
-			yield dispatch( CORE_USER ).setPermissionScopeError( error );
+			dispatch( CORE_USER ).setPermissionScopeError( error );
 		}
 
 		return { response, error };

--- a/assets/js/googlesitekit/datastore/user/surveys.js
+++ b/assets/js/googlesitekit/datastore/user/surveys.js
@@ -222,9 +222,8 @@ const baseActions = {
 						setTimeout( resolve, 30000 );
 					} );
 
-					yield dispatch( CORE_USER ).setSurveyTimeout(
-						triggerID,
-						ttl
+					yield Data.commonActions.await(
+						dispatch( CORE_USER ).setSurveyTimeout( triggerID, ttl )
 					);
 				}
 			}

--- a/assets/js/googlesitekit/modules/datastore/modules.js
+++ b/assets/js/googlesitekit/modules/datastore/modules.js
@@ -487,7 +487,9 @@ const baseActions = {
 					select( CORE_MODULES ).getModuleStoreName( slug );
 
 				// Reload the module's settings from the server.
-				yield dispatch( storeName ).fetchGetSettings();
+				yield Data.commonActions.await(
+					dispatch( storeName ).fetchGetSettings()
+				);
 			}
 
 			if ( successfulRecoveries.length ) {
@@ -496,13 +498,15 @@ const baseActions = {
 
 				// Having reloaded the modules from the server, ensure the list of recoverable modules is also refreshed,
 				// as the recoverable modules list is derived from the main list of modules.
-				yield dispatch( CORE_MODULES ).invalidateResolution(
+				dispatch( CORE_MODULES ).invalidateResolution(
 					'getRecoverableModules',
 					[]
 				);
 
 				// Refresh user capabilities from the server.
-				yield dispatch( CORE_USER ).refreshCapabilities();
+				yield Data.commonActions.await(
+					dispatch( CORE_USER ).refreshCapabilities()
+				);
 			}
 
 			return { response };


### PR DESCRIPTION
## Summary

Addresses issue:

- #6117 

## Relevant technical choices

- The IB states to invoke `actions.someAction()` directly if the action is from the same store. However, it doesn't work.
- In such cases, if it's a non-async action, we just had to remove the `yield` and dispatch the action as implemented in this PR.

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
