### PR TITLE
Enhance/5886 - Update Analytics settings header

### DIFF
--- a/assets/js/components/settings/SettingsActiveModule/Header.js
+++ b/assets/js/components/settings/SettingsActiveModule/Header.js
@@ -50,7 +50,11 @@ import Badge from '../../Badge';
 import { trackEvent } from '../../../util';
 import useViewContext from '../../../hooks/useViewContext';
 import { CORE_FORMS } from '../../../googlesitekit/datastore/forms/constants';
-import { FORM_SETUP } from '../../../modules/analytics/datastore/constants';
+import {
+	FORM_SETUP,
+	MODULES_ANALYTICS,
+} from '../../../modules/analytics/datastore/constants';
+import { CORE_USER } from '../../../googlesitekit/datastore/user/constants';
 const { useSelect, useDispatch } = Data;
 
 export default function Header( { slug } ) {
@@ -76,6 +80,22 @@ export default function Header( { slug } ) {
 	const isGA4Connected = useSelect( ( select ) =>
 		select( CORE_MODULES ).isModuleConnected( 'analytics-4' )
 	);
+
+	const loggedInUserID = useSelect( ( select ) =>
+		select( CORE_USER ).getID()
+	);
+	const hasAnalyticsAccess = useSelect( ( select ) => {
+		if ( ! ( slug === 'analytics' && module?.connected ) ) {
+			return false;
+		}
+
+		const moduleOwnerID = select( MODULES_ANALYTICS ).getOwnerID();
+
+		if ( moduleOwnerID === loggedInUserID ) {
+			return true;
+		}
+		return select( CORE_MODULES ).hasModuleAccess( 'analytics' );
+	} );
 
 	const { setValues } = useDispatch( CORE_FORMS );
 
@@ -237,6 +257,7 @@ export default function Header( { slug } ) {
 
 						{ connected &&
 							slug === 'analytics' &&
+							hasAnalyticsAccess &&
 							! isGA4Connected && (
 								<Fragment>
 									<Button
@@ -249,6 +270,19 @@ export default function Header( { slug } ) {
 									</Button>
 									<span className="googlesitekit-settings-module__status-icon googlesitekit-settings-module__status-icon--not-connected" />
 								</Fragment>
+							) }
+
+						{ connected &&
+							slug === 'analytics' &&
+							! hasAnalyticsAccess &&
+							! isGA4Connected && (
+								<p className="googlesitekit-settings-module__status">
+									{ __(
+										'Google Analytics 4 is not connected',
+										'google-site-kit'
+									) }
+									<span className="googlesitekit-settings-module__status-icon googlesitekit-settings-module__status-icon--not-connected" />
+								</p>
 							) }
 
 						{ ! connected && (

--- a/assets/js/components/settings/SettingsActiveModule/Header.test.js
+++ b/assets/js/components/settings/SettingsActiveModule/Header.test.js
@@ -37,6 +37,8 @@ import {
 	provideModules,
 	fireEvent,
 } from '../../../../../tests/js/test-utils';
+import { MODULES_ANALYTICS } from '../../../modules/analytics/datastore/constants';
+import { CORE_MODULES } from '../../../googlesitekit/modules/datastore/constants';
 
 describe( 'Header', () => {
 	const history = createHashHistory();
@@ -85,6 +87,7 @@ describe( 'Header', () => {
 				connected: false,
 			},
 		] );
+		registry.dispatch( MODULES_ANALYTICS ).receiveGetSettings( {} );
 	} );
 
 	it( 'should render "Connected" for a connected module', () => {
@@ -113,6 +116,44 @@ describe( 'Header', () => {
 		const button = queryByRole( 'button' );
 		expect( button ).toBeInTheDocument();
 		expect( button ).toHaveTextContent( 'Connect Google Analytics 4' );
+	} );
+
+	it( 'should not render the button to connect GA4 if Analytics is connected without access to it but GA4 is not', () => {
+		registry
+			.dispatch( MODULES_ANALYTICS )
+			.receiveGetSettings( { ownerID: 100 } );
+		registry
+			.dispatch( CORE_MODULES )
+			.receiveCheckModuleAccess(
+				{ access: false },
+				{ slug: 'analytics' }
+			);
+		const { container } = render( <Header slug="analytics" />, {
+			registry,
+		} );
+
+		expect(
+			container.querySelector( '.googlesitekit-settings-module__status' )
+		).toHaveTextContent( 'Google Analytics 4 is not connected' );
+	} );
+
+	it( 'should render a GA4 not connected status if Analytics is connected without access to it but GA4 is not', () => {
+		registry
+			.dispatch( MODULES_ANALYTICS )
+			.receiveGetSettings( { ownerID: 100 } );
+		registry
+			.dispatch( CORE_MODULES )
+			.receiveCheckModuleAccess(
+				{ access: false },
+				{ slug: 'analytics' }
+			);
+		const { queryByRole } = render( <Header slug="analytics" />, {
+			registry,
+		} );
+
+		expect(
+			queryByRole( 'button', { name: /connect google analytics 4/i } )
+		).not.toBeInTheDocument();
 	} );
 
 	it( 'should open the tab when ENTER key is pressed', () => {

--- a/assets/js/components/settings/SettingsActiveModule/index.test.js
+++ b/assets/js/components/settings/SettingsActiveModule/index.test.js
@@ -34,6 +34,7 @@ import {
 	act,
 } from '../../../../../tests/js/test-utils';
 import { CORE_MODULES } from '../../../googlesitekit/modules/datastore/constants';
+import { MODULES_ANALYTICS } from '../../../modules/analytics/datastore/constants';
 
 describe( 'SettingsModule', () => {
 	const SettingsModuleWithWrapper = ( { slug = 'analytics' } ) => (
@@ -93,6 +94,7 @@ describe( 'SettingsModule', () => {
 				),
 			},
 		] );
+		registry.dispatch( MODULES_ANALYTICS ).receiveGetSettings( {} );
 	} );
 
 	it( 'should display SettingsViewComponent when on module view route', () => {


### PR DESCRIPTION
## Summary

Addresses issue:

- #5886 

## Relevant technical choices

- This PR hides the `Connect Google Analytics 4` CTA for the users who don't have Analytics access; instead shows a status `Google Analytics 4 is not connected`. Please refer to this [comment](https://github.com/google/site-kit-wp/issues/5886#issuecomment-1334119936) for more details.

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
