### PR TITLE
[Analytics] Prevent flicker in SettingsActiveModule Header when checking access

### DIFF
--- a/assets/js/components/settings/SettingsActiveModule/Header.js
+++ b/assets/js/components/settings/SettingsActiveModule/Header.js
@@ -287,12 +287,11 @@ export default function Header( { slug } ) {
 						<div
 							className={ classnames(
 								'googlesitekit-settings-module__status',
-								`googlesitekit-settings-module__status--${
-									showAsConnected
-										? 'connected'
-										: 'not-connected'
-								}`,
 								{
+									'googlesitekit-settings-module__status--connected':
+										showAsConnected,
+									'googlesitekit-settings-module__status--not-connected':
+										! showAsConnected,
 									'googlesitekit-settings-module__status--loading':
 										'analytics' === slug &&
 										! isGA4Connected &&
@@ -303,11 +302,15 @@ export default function Header( { slug } ) {
 						>
 							{ moduleStatus }
 							<span
-								className={ `googlesitekit-settings-module__status-icon googlesitekit-settings-module__status-icon--${
-									showAsConnected
-										? 'connected'
-										: 'not-connected'
-								}` }
+								className={ classnames(
+									'googlesitekit-settings-module__status-icon',
+									{
+										'googlesitekit-settings-module__status-icon--connected':
+											showAsConnected,
+										'googlesitekit-settings-module__status-icon--not-connected':
+											! showAsConnected,
+									}
+								) }
 							/>
 						</div>
 					</Cell>

--- a/assets/js/components/settings/SettingsActiveModule/Header.js
+++ b/assets/js/components/settings/SettingsActiveModule/Header.js
@@ -40,7 +40,7 @@ import { __, sprintf } from '@wordpress/i18n';
  * Internal dependencies
  */
 import Data from 'googlesitekit-data';
-import { Button } from 'googlesitekit-components';
+import { Button, ProgressBar } from 'googlesitekit-components';
 import { CORE_MODULES } from '../../../googlesitekit/modules/datastore/constants';
 import { EXPERIMENTAL_MODULES } from '../../dashboard-sharing/DashboardSharingSettings/constants';
 import { Grid, Row, Cell } from '../../../material-components';
@@ -96,6 +96,11 @@ export default function Header( { slug } ) {
 		}
 		return select( CORE_MODULES ).hasModuleAccess( 'analytics' );
 	} );
+	const hasResolvedAnalyticsAccess = useSelect( ( select ) =>
+		select( CORE_MODULES ).hasFinishedResolution( 'hasModuleAccess', [
+			'analytics',
+		] )
+	);
 
 	const { setValues } = useDispatch( CORE_FORMS );
 
@@ -276,13 +281,23 @@ export default function Header( { slug } ) {
 							slug === 'analytics' &&
 							! hasAnalyticsAccess &&
 							! isGA4Connected && (
-								<p className="googlesitekit-settings-module__status">
-									{ __(
-										'Google Analytics 4 is not connected',
-										'google-site-kit'
+								<Fragment>
+									{ hasResolvedAnalyticsAccess ? (
+										<p className="googlesitekit-settings-module__status">
+											{ __(
+												'Google Analytics 4 is not connected',
+												'google-site-kit'
+											) }
+											<span className="googlesitekit-settings-module__status-icon googlesitekit-settings-module__status-icon--not-connected" />
+										</p>
+									) : (
+										<ProgressBar
+											className="googlesitekit-settings-module__status-loading"
+											height={ 32 }
+											small
+										/>
 									) }
-									<span className="googlesitekit-settings-module__status-icon googlesitekit-settings-module__status-icon--not-connected" />
-								</p>
+								</Fragment>
 							) }
 
 						{ ! connected && (

--- a/assets/js/components/settings/SettingsActiveModule/Header.js
+++ b/assets/js/components/settings/SettingsActiveModule/Header.js
@@ -189,6 +189,68 @@ export default function Header( { slug } ) {
 		return null;
 	}
 
+	const connectedStatusMarkup = (
+		<p className="googlesitekit-settings-module__status">
+			{ __( 'Connected', 'google-site-kit' ) }
+
+			<span className="googlesitekit-settings-module__status-icon googlesitekit-settings-module__status-icon--connected" />
+		</p>
+	);
+
+	let moduleStatusMarkup;
+
+	if ( connected ) {
+		if ( 'analytics' === slug ) {
+			if ( isGA4Connected ) {
+				moduleStatusMarkup = connectedStatusMarkup;
+			} else if ( hasAnalyticsAccess ) {
+				moduleStatusMarkup = (
+					<Fragment>
+						<Button onClick={ handleConnectGA4ButtonClick }>
+							{ __(
+								'Connect Google Analytics 4',
+								'google-site-kit'
+							) }
+						</Button>
+						<span className="googlesitekit-settings-module__status-icon googlesitekit-settings-module__status-icon--not-connected" />
+					</Fragment>
+				);
+			} else if ( hasResolvedAnalyticsAccess ) {
+				moduleStatusMarkup = (
+					<p className="googlesitekit-settings-module__status">
+						{ __(
+							'Google Analytics 4 is not connected',
+							'google-site-kit'
+						) }
+						<span className="googlesitekit-settings-module__status-icon googlesitekit-settings-module__status-icon--not-connected" />
+					</p>
+				);
+			} else {
+				moduleStatusMarkup = (
+					<div className="googlesitekit-settings-module__status-loading">
+						<ProgressBar height={ 32 } small />
+						<span className="googlesitekit-settings-module__status-icon googlesitekit-settings-module__status-icon--not-connected" />
+					</div>
+				);
+			}
+		} else {
+			moduleStatusMarkup = connectedStatusMarkup;
+		}
+	} else {
+		moduleStatusMarkup = (
+			<Fragment>
+				<Button href={ adminReauthURL } onClick={ onActionClick }>
+					{ sprintf(
+						/* translators: %s: module name. */
+						__( 'Complete setup for %s', 'google-site-kit' ),
+						name
+					) }
+				</Button>
+				<span className="googlesitekit-settings-module__status-icon googlesitekit-settings-module__status-icon--not-connected" />
+			</Fragment>
+		);
+	}
+
 	return (
 		// eslint-disable-next-line jsx-a11y/click-events-have-key-events
 		<div
@@ -251,73 +313,7 @@ export default function Header( { slug } ) {
 						alignMiddle
 						mdAlignRight
 					>
-						{ connected &&
-							( slug !== 'analytics' || isGA4Connected ) && (
-								<p className="googlesitekit-settings-module__status">
-									{ __( 'Connected', 'google-site-kit' ) }
-
-									<span className="googlesitekit-settings-module__status-icon googlesitekit-settings-module__status-icon--connected" />
-								</p>
-							) }
-
-						{ connected &&
-							slug === 'analytics' &&
-							hasAnalyticsAccess &&
-							! isGA4Connected && (
-								<Fragment>
-									<Button
-										onClick={ handleConnectGA4ButtonClick }
-									>
-										{ __(
-											'Connect Google Analytics 4',
-											'google-site-kit'
-										) }
-									</Button>
-									<span className="googlesitekit-settings-module__status-icon googlesitekit-settings-module__status-icon--not-connected" />
-								</Fragment>
-							) }
-
-						{ connected &&
-							slug === 'analytics' &&
-							! hasAnalyticsAccess &&
-							! isGA4Connected && (
-								<Fragment>
-									{ hasResolvedAnalyticsAccess ? (
-										<p className="googlesitekit-settings-module__status">
-											{ __(
-												'Google Analytics 4 is not connected',
-												'google-site-kit'
-											) }
-											<span className="googlesitekit-settings-module__status-icon googlesitekit-settings-module__status-icon--not-connected" />
-										</p>
-									) : (
-										<ProgressBar
-											className="googlesitekit-settings-module__status-loading"
-											height={ 32 }
-											small
-										/>
-									) }
-								</Fragment>
-							) }
-
-						{ ! connected && (
-							<Fragment>
-								<Button
-									href={ adminReauthURL }
-									onClick={ onActionClick }
-								>
-									{ sprintf(
-										/* translators: %s: module name. */
-										__(
-											'Complete setup for %s',
-											'google-site-kit'
-										),
-										name
-									) }
-								</Button>
-								<span className="googlesitekit-settings-module__status-icon googlesitekit-settings-module__status-icon--not-connected" />
-							</Fragment>
-						) }
+						{ moduleStatusMarkup }
 					</Cell>
 				</Row>
 			</Grid>

--- a/assets/js/components/settings/SettingsActiveModule/Header.test.js
+++ b/assets/js/components/settings/SettingsActiveModule/Header.test.js
@@ -36,6 +36,7 @@ import {
 	createTestRegistry,
 	provideModules,
 	fireEvent,
+	waitFor,
 } from '../../../../../tests/js/test-utils';
 import { MODULES_ANALYTICS } from '../../../modules/analytics/datastore/constants';
 import { CORE_MODULES } from '../../../googlesitekit/modules/datastore/constants';
@@ -118,7 +119,7 @@ describe( 'Header', () => {
 		expect( button ).toHaveTextContent( 'Connect Google Analytics 4' );
 	} );
 
-	it( 'should not render the button to connect GA4 if Analytics is connected without access to it but GA4 is not', () => {
+	it( 'should not render the button to connect GA4 if Analytics is connected without access to it but GA4 is not', async () => {
 		registry
 			.dispatch( MODULES_ANALYTICS )
 			.receiveGetSettings( { ownerID: 100 } );
@@ -132,12 +133,16 @@ describe( 'Header', () => {
 			registry,
 		} );
 
-		expect(
-			container.querySelector( '.googlesitekit-settings-module__status' )
-		).toHaveTextContent( 'Google Analytics 4 is not connected' );
+		await waitFor( () => {
+			expect(
+				container.querySelector(
+					'.googlesitekit-settings-module__status'
+				)
+			).toHaveTextContent( 'Google Analytics 4 is not connected' );
+		} );
 	} );
 
-	it( 'should render a GA4 not connected status if Analytics is connected without access to it but GA4 is not', () => {
+	it( 'should render a GA4 not connected status if Analytics is connected without access to it but GA4 is not', async () => {
 		registry
 			.dispatch( MODULES_ANALYTICS )
 			.receiveGetSettings( { ownerID: 100 } );
@@ -151,9 +156,11 @@ describe( 'Header', () => {
 			registry,
 		} );
 
-		expect(
-			queryByRole( 'button', { name: /connect google analytics 4/i } )
-		).not.toBeInTheDocument();
+		await waitFor( () => {
+			expect(
+				queryByRole( 'button', { name: /connect google analytics 4/i } )
+			).not.toBeInTheDocument();
+		} );
 	} );
 
 	it( 'should open the tab when ENTER key is pressed', () => {

--- a/assets/js/modules/analytics/components/settings/GA4SettingsControls.js
+++ b/assets/js/modules/analytics/components/settings/GA4SettingsControls.js
@@ -88,12 +88,7 @@ export default function GA4SettingsControls( {
 		select( CORE_SITE ).getDocumentationLinkURL( 'ga4' )
 	);
 
-	const isGA4Connected = useSelect( ( select ) =>
-		select( CORE_MODULES ).isModuleConnected( 'analytics-4' )
-	);
-
-	const hasModuleAccess =
-		isGA4Connected && hasAnalyticsAccess && hasAnalytics4Access;
+	const hasModuleAccess = hasAnalyticsAccess && hasAnalytics4Access;
 
 	const {
 		matchAccountProperty,
@@ -283,7 +278,7 @@ export default function GA4SettingsControls( {
 			) }
 
 			<GA4SettingsNotice
-				isGA4Connected={ isGA4Connected }
+				isGA4Connected={ isModuleConnected }
 				hasAnalyticsAccess={ hasAnalyticsAccess }
 				hasAnalytics4Access={ hasAnalytics4Access }
 			/>

--- a/assets/sass/components/settings/_googlesitekit-settings-module.scss
+++ b/assets/sass/components/settings/_googlesitekit-settings-module.scss
@@ -116,6 +116,10 @@
 			.googlesitekit-settings-module__status {
 				padding: 8px 0;
 			}
+
+			.googlesitekit-settings-module__status-loading {
+				width: 150px;
+			}
 		}
 
 		.googlesitekit-settings-module__content {

--- a/assets/sass/components/settings/_googlesitekit-settings-module.scss
+++ b/assets/sass/components/settings/_googlesitekit-settings-module.scss
@@ -114,10 +114,17 @@
 			}
 
 			.googlesitekit-settings-module__status {
+
+				p {
+					margin: 0;
+				}
+			}
+
+			.googlesitekit-settings-module__status--connected {
 				padding: 8px 0;
 			}
 
-			.googlesitekit-settings-module__status-loading {
+			.googlesitekit-settings-module__status--loading {
 				align-items: center;
 				display: flex;
 				min-width: 150px;

--- a/assets/sass/components/settings/_googlesitekit-settings-module.scss
+++ b/assets/sass/components/settings/_googlesitekit-settings-module.scss
@@ -118,7 +118,9 @@
 			}
 
 			.googlesitekit-settings-module__status-loading {
-				width: 150px;
+				align-items: center;
+				display: flex;
+				min-width: 150px;
 			}
 		}
 

--- a/assets/sass/components/settings/_googlesitekit-settings-module.scss
+++ b/assets/sass/components/settings/_googlesitekit-settings-module.scss
@@ -124,10 +124,18 @@
 				padding: 8px 0;
 			}
 
+			.googlesitekit-settings-module__status--not-connected {
+
+				.mdc-button {
+					margin: -1.5px 0;
+				}
+			}
+
 			.googlesitekit-settings-module__status--loading {
 				align-items: center;
 				display: flex;
 				min-width: 150px;
+				padding: 0.5px 0;
 			}
 		}
 

--- a/assets/sass/components/settings/_googlesitekit-settings-module.scss
+++ b/assets/sass/components/settings/_googlesitekit-settings-module.scss
@@ -116,12 +116,8 @@
 			.googlesitekit-settings-module__status {
 
 				p {
-					margin: 0;
+					margin: 8px 0;
 				}
-			}
-
-			.googlesitekit-settings-module__status--connected {
-				padding: 8px 0;
 			}
 
 			.googlesitekit-settings-module__status--not-connected {


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- https://github.com/google/site-kit-wp/issues/5886#issuecomment-1335764490

## Relevant technical choices

This PR prevents the flicker reported [here](https://github.com/google/site-kit-wp/issues/5886#issuecomment-1335764490) by showing a progress bar when access is being checked for Analytics.

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
