### PR TITLE
[User Input] Remove text field from `Other` options

### DIFF
--- a/assets/js/components/user-input/UserInputPreviewGroup.js
+++ b/assets/js/components/user-input/UserInputPreviewGroup.js
@@ -24,7 +24,7 @@ import PropTypes from 'prop-types';
 /**
  * WordPress dependencies
  */
-import { __, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -40,10 +40,6 @@ export default function UserInputPreviewGroup( {
 } ) {
 	const trim = ( value ) => value.trim();
 	const notEmpty = ( value ) => value.length > 0;
-
-	const sprintfTemplate =
-		/* translators: %s: other option */
-		questionNumber < 5 ? __( 'Other: %s', 'google-site-kit' ) : '%s';
 
 	return (
 		<div className="googlesitekit-user-input__preview-group">
@@ -65,8 +61,7 @@ export default function UserInputPreviewGroup( {
 							key={ value }
 							className="googlesitekit-user-input__preview-answer"
 						>
-							{ options[ value ] ||
-								sprintf( sprintfTemplate, value ) }
+							{ options[ value ] }
 						</div>
 					) ) }
 			</div>

--- a/assets/js/components/user-input/util/constants.js
+++ b/assets/js/components/user-input/util/constants.js
@@ -56,12 +56,14 @@ export function getUserInputAnswers() {
 				'Share a business card or portfolio to represent me or my company online',
 				'google-site-kit'
 			),
+			other: __( 'Other', 'google-site-kit' ),
 		},
 		USER_INPUT_ANSWERS_POST_FREQUENCY: {
 			never: __( 'Never', 'google-site-kit' ),
 			daily: __( 'Daily', 'google-site-kit' ),
 			weekly: __( 'Weekly', 'google-site-kit' ),
 			monthly: __( 'Monthly', 'google-site-kit' ),
+			other: __( 'Other', 'google-site-kit' ),
 		},
 		USER_INPUT_ANSWERS_GOALS: {
 			retaining_visitors: __(
@@ -97,6 +99,7 @@ export function getUserInputAnswers() {
 				'Encouragement to post more frequently',
 				'google-site-kit'
 			),
+			other: __( 'Other', 'google-site-kit' ),
 		},
 	};
 }

--- a/assets/sass/components/user-input/googlesitekit-user-input-controls.scss
+++ b/assets/sass/components/user-input/googlesitekit-user-input-controls.scss
@@ -31,23 +31,6 @@
 			padding: 3px 0;
 		}
 
-		.mdc-text-field {
-			background-color: transparent;
-			height: 36px;
-			margin: 0 1rem;
-			max-width: 250px;
-			width: calc(100% - 2rem);
-
-			input {
-				border: none;
-				padding: 0;
-
-				&:placeholder-shown {
-					text-overflow: ellipsis;
-				}
-			}
-		}
-
 		label {
 			color: $c-surfaces-on-background;
 			font-size: $fs-body-md;
@@ -57,21 +40,6 @@
 			@media (min-width: $bp-tablet) {
 				padding: 10px 0;
 			}
-		}
-
-		.mdc-text-field--disabled,
-		.mdc-checkbox--disabled,
-		.mdc-checkbox--disabled + label {
-			opacity: 0.25;
-		}
-	}
-
-	.googlesitekit-user-input__select-option-text-field {
-		flex: 1;
-
-		.mdc-text-field--error .mdc-line-ripple--active {
-			background-color: $c-black;
-			opacity: 1;
 		}
 	}
 


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #6181 

## Relevant technical choices

This PR removes the text field from the `Other` options in the User Input questions.

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [x] Run the code.
- [x] Ensure the acceptance criteria are satisfied.
- [x] Reassess the implementation with the IB.
- [x] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [x] Check Storybook where applicable.
- [x] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [x] Ensure the PR has the correct target branch.
- [x] Double-check that the PR is okay to be merged.
- [x] Ensure the corresponding issue has a ZenHub release assigned.
- [x] Add a changelog message to the issue.
