### PR TITLE
Fix fatal error with `Sort`

### DIFF
--- a/includes/Core/Util/Sort.php
+++ b/includes/Core/Util/Sort.php
@@ -32,10 +32,21 @@ class Sort {
 		usort(
 			$list,
 			function ( $a, $b ) use ( $orderby ) {
-				return strcasecmp(
-					$a[ $orderby ],
-					$b[ $orderby ]
-				);
+				if ( is_array( $a ) && is_array( $b ) ) {
+					return strcasecmp(
+						$a[ $orderby ],
+						$b[ $orderby ]
+					);
+				}
+
+				if ( is_object( $a ) && is_object( $b ) ) {
+					return strcasecmp(
+						$a->$orderby,
+						$b->$orderby
+					);
+				}
+
+				return 0;
 			}
 		);
 

--- a/tests/phpunit/integration/Core/Util/SortTest.php
+++ b/tests/phpunit/integration/Core/Util/SortTest.php
@@ -18,46 +18,64 @@ use Google\Site_Kit\Tests\TestCase;
  */
 class SortTest extends TestCase {
 
-	public function test_case_insensitive_list_sort() {
-		// Sorts an array correctly, ordered by the field 'firstname'.
-		$this->assertEquals(
-			Sort::case_insensitive_list_sort(
-				array(
-					array(
-						'firstname' => 'John',
-						'lastname'  => 'Doe',
-					),
-					array(
-						'firstname' => 'Harry',
-						'lastname'  => 'Smith',
-					),
-					array(
-						'firstname' => 'foo',
-						'lastname'  => 'bar',
-					),
-				),
-				'firstname'
+	public function data_lists() {
+		$unsorted_array_of_arrays = array(
+			array(
+				'firstname' => 'John',
+				'lastname'  => 'Doe',
 			),
 			array(
-				array(
-					'firstname' => 'foo',
-					'lastname'  => 'bar',
-				),
-				array(
-					'firstname' => 'Harry',
-					'lastname'  => 'Smith',
-				),
-				array(
-					'firstname' => 'John',
-					'lastname'  => 'Doe',
-				),
-			)
+				'firstname' => 'Harry',
+				'lastname'  => 'Smith',
+			),
+			array(
+				'firstname' => 'foo',
+				'lastname'  => 'bar',
+			),
 		);
 
-		// Sorts an array correctly, ordered by the field 'lastname'.
-		$this->assertEquals(
-			Sort::case_insensitive_list_sort(
+		$unsorted_array_of_objects = array(
+			(object) array(
+				'firstname' => 'John',
+				'lastname'  => 'Doe',
+			),
+			(object) array(
+				'firstname' => 'Harry',
+				'lastname'  => 'Smith',
+			),
+			(object) array(
+				'firstname' => 'foo',
+				'lastname'  => 'bar',
+			),
+		);
+
+		return array(
+			'sort array of arrays by firstname'  => array(
+				$unsorted_array_of_arrays,
+				'firstname',
 				array(
+					array(
+						'firstname' => 'foo',
+						'lastname'  => 'bar',
+					),
+					array(
+						'firstname' => 'Harry',
+						'lastname'  => 'Smith',
+					),
+					array(
+						'firstname' => 'John',
+						'lastname'  => 'Doe',
+					),
+				),
+			),
+			'sort array of arrays by lastname'   => array(
+				$unsorted_array_of_arrays,
+				'lastname',
+				array(
+					array(
+						'firstname' => 'foo',
+						'lastname'  => 'bar',
+					),
 					array(
 						'firstname' => 'John',
 						'lastname'  => 'Doe',
@@ -66,27 +84,61 @@ class SortTest extends TestCase {
 						'firstname' => 'Harry',
 						'lastname'  => 'Smith',
 					),
-					array(
+				),
+			),
+			'sort array of objects by firstname' => array(
+				$unsorted_array_of_objects,
+				'firstname',
+				array(
+					(object) array(
 						'firstname' => 'foo',
 						'lastname'  => 'bar',
 					),
+					(object) array(
+						'firstname' => 'Harry',
+						'lastname'  => 'Smith',
+					),
+					(object) array(
+						'firstname' => 'John',
+						'lastname'  => 'Doe',
+					),
 				),
-				'lastname'
 			),
-			array(
+			'sort array of objects by lastname'  => array(
+				$unsorted_array_of_objects,
+				'lastname',
 				array(
-					'firstname' => 'foo',
-					'lastname'  => 'bar',
+					(object) array(
+						'firstname' => 'foo',
+						'lastname'  => 'bar',
+					),
+					(object) array(
+						'firstname' => 'John',
+						'lastname'  => 'Doe',
+					),
+					(object) array(
+						'firstname' => 'Harry',
+						'lastname'  => 'Smith',
+					),
 				),
-				array(
-					'firstname' => 'John',
-					'lastname'  => 'Doe',
-				),
-				array(
-					'firstname' => 'Harry',
-					'lastname'  => 'Smith',
-				),
-			)
+			),
+		);
+	}
+
+	/**
+	 * @dataProvider data_lists
+	 *
+	 * @param array  $unsorted_array        The array/list to sort.
+	 * @param string $orderby               The field to sort the list by.
+	 * @param array  $expected_sorted_array The sorted array.
+	 */
+	public function test_case_insensitive_list_sort( $unsorted_array, $orderby, $expected_sorted_array ) {
+		$this->assertEquals(
+			Sort::case_insensitive_list_sort(
+				$unsorted_array,
+				$orderby
+			),
+			$expected_sorted_array
 		);
 	}
 }


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- https://github.com/google/site-kit-wp/issues/4853#issuecomment-1340944426

## Relevant technical choices

This PR fixes the reported fatal error when the `Sort` class tries to sort an array of multiple objects.

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
