### PR TITLE
Remove GitHub Personal Access Tokens from zip builds.

### DIFF
--- a/.github/workflows/zips.yml
+++ b/.github/workflows/zips.yml
@@ -122,7 +122,6 @@ jobs:
           # GitHub Wikis use this term as their main branch; this cannot be
           # changed so we need to continue using it for now.
           ref: master
-          token: ${{ secrets.GITHUB_PERSONAL_ACCESS_TOKEN }}
       - name: Download artifacts
         uses: actions/download-artifact@v1
         with:
@@ -154,7 +153,6 @@ jobs:
           # GitHub Wikis use this term as their main branch; this cannot be
           # changed so we need to continue using it for now.
           ref: master
-          token: ${{ secrets.GITHUB_PERSONAL_ACCESS_TOKEN }}
       - name: Prune PR files
         run: |
           rm -rf "refs/pull/${{ github.event.pull_request.number }}"


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #6315

## Relevant technical choices

Removed Personal Access Token because it is not needed for these actions.

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
