### PR TITLE
Fix GA4 `PropertySelect`

### DIFF
--- a/assets/js/modules/analytics-4/datastore/properties.js
+++ b/assets/js/modules/analytics-4/datastore/properties.js
@@ -198,7 +198,7 @@ const baseActions = {
 
 			const webdatastream = registry
 				.select( MODULES_ANALYTICS_4 )
-				.getMatchingWebDataStream( propertyID );
+				.getMatchingWebDataStreamByPropertyID( propertyID );
 
 			if ( webdatastream ) {
 				registry

--- a/assets/js/modules/analytics-4/datastore/webdatastreams.js
+++ b/assets/js/modules/analytics-4/datastore/webdatastreams.js
@@ -182,7 +182,7 @@ const baseActions = {
 		const registry = yield Data.commonActions.getRegistry();
 		return registry
 			.select( MODULES_ANALYTICS_4 )
-			.getMatchingWebDataStream( propertyID );
+			.getMatchingWebDataStreamByPropertyID( propertyID );
 	},
 
 	/**
@@ -279,21 +279,21 @@ const baseSelectors = {
 	},
 
 	/**
-	 * Gets matched web data stream for selected property.
+	 * Gets matched web data stream from a list of web data streams.
 	 *
 	 * @since 1.31.0
+	 * @since n.e.x.t Updated to match a data stream from a list of provided web data streams.
 	 *
-	 * @param {Object} state      Data store's state.
-	 * @param {string} propertyID The GA4 property ID to find matched web data stream.
-	 * @return {(Object|null|undefined)} A web data stream object if found, otherwise null; `undefined` if web data streams are not loaded.
+	 * @param {Object} state       Data store's state.
+	 * @param {Array}  datastreams A list of web data streams.
+	 * @return {(Object|null)} A web data stream object if found, otherwise null.
 	 */
 	getMatchingWebDataStream: createRegistrySelector(
-		( select ) => ( state, propertyID ) => {
-			const datastreams =
-				select( MODULES_ANALYTICS_4 ).getWebDataStreams( propertyID );
-			if ( datastreams === undefined ) {
-				return undefined;
-			}
+		( select ) => ( _state, datastreams ) => {
+			invariant(
+				Array.isArray( datastreams ),
+				'datastreams must be an array.'
+			);
 
 			for ( const datastream of datastreams ) {
 				if (
@@ -307,6 +307,33 @@ const baseSelectors = {
 			}
 
 			return null;
+		}
+	),
+
+	/**
+	 * Gets matched web data stream for selected property.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param {Object} state      Data store's state.
+	 * @param {string} propertyID The GA4 property ID to find matched web data stream.
+	 * @return {(Object|null|undefined)} A web data stream object if found, otherwise null; `undefined` if web data streams are not loaded.
+	 */
+	getMatchingWebDataStreamByPropertyID: createRegistrySelector(
+		( select ) => ( _state, propertyID ) => {
+			const datastreams =
+				select( MODULES_ANALYTICS_4 ).getWebDataStreams( propertyID );
+
+			if ( datastreams === undefined ) {
+				return undefined;
+			}
+
+			const matchingDataStream =
+				select( MODULES_ANALYTICS_4 ).getMatchingWebDataStream(
+					datastreams
+				);
+
+			return matchingDataStream || null;
 		}
 	),
 

--- a/assets/js/modules/analytics-4/datastore/webdatastreams.test.js
+++ b/assets/js/modules/analytics-4/datastore/webdatastreams.test.js
@@ -274,6 +274,51 @@ describe( 'modules/analytics-4 webdatastreams', () => {
 
 		describe( 'getMatchingWebDataStream', () => {
 			const webDataStreams = [ webDataStreamDotCom, webDataStreamDotOrg ];
+
+			it( 'should return NULL when no datastreams are matched', () => {
+				provideSiteInfo( registry, {
+					referenceSiteURL: 'http://example.net',
+				} );
+
+				const datastream = registry
+					.select( MODULES_ANALYTICS_4 )
+					.getMatchingWebDataStream( webDataStreams );
+
+				expect( datastream ).toBeNull();
+			} );
+
+			it( 'should return the correct datastream when reference site URL matches exactly', () => {
+				provideSiteInfo( registry, {
+					referenceSiteURL: 'http://example.com',
+				} );
+
+				const datastream = registry
+					.select( MODULES_ANALYTICS_4 )
+					.getMatchingWebDataStream( webDataStreams );
+
+				expect( datastream ).toEqual( webDataStreamDotCom );
+			} );
+
+			it.each( [
+				[ 'protocol differences', 'https://example.org' ],
+				[ '"www." prefix', 'http://www.example.org' ],
+				[ 'trailing slash', 'https://www.example.org/' ],
+			] )(
+				'should return the correct datastream ignoring %s',
+				( _, referenceSiteURL ) => {
+					provideSiteInfo( registry, { referenceSiteURL } );
+
+					const datastream = registry
+						.select( MODULES_ANALYTICS_4 )
+						.getMatchingWebDataStream( webDataStreams );
+
+					expect( datastream ).toEqual( webDataStreamDotOrg );
+				}
+			);
+		} );
+
+		describe( 'getMatchingWebDataStreamByPropertyID', () => {
+			const webDataStreams = [ webDataStreamDotCom, webDataStreamDotOrg ];
 			const propertyID = '12345';
 
 			it( 'should return undefined if web data streams arent loaded yet', () => {
@@ -281,7 +326,7 @@ describe( 'modules/analytics-4 webdatastreams', () => {
 
 				const datastream = registry
 					.select( MODULES_ANALYTICS_4 )
-					.getMatchingWebDataStream( propertyID );
+					.getMatchingWebDataStreamByPropertyID( propertyID );
 				expect( datastream ).toBeUndefined();
 			} );
 
@@ -295,7 +340,7 @@ describe( 'modules/analytics-4 webdatastreams', () => {
 
 				const datastream = registry
 					.select( MODULES_ANALYTICS_4 )
-					.getMatchingWebDataStream( propertyID );
+					.getMatchingWebDataStreamByPropertyID( propertyID );
 				expect( datastream ).toBeNull();
 			} );
 
@@ -309,7 +354,7 @@ describe( 'modules/analytics-4 webdatastreams', () => {
 
 				const datastream = registry
 					.select( MODULES_ANALYTICS_4 )
-					.getMatchingWebDataStream( propertyID );
+					.getMatchingWebDataStreamByPropertyID( propertyID );
 				expect( datastream ).toEqual( webDataStreamDotCom );
 			} );
 
@@ -329,7 +374,7 @@ describe( 'modules/analytics-4 webdatastreams', () => {
 
 					const datastream = registry
 						.select( MODULES_ANALYTICS_4 )
-						.getMatchingWebDataStream( propertyID );
+						.getMatchingWebDataStreamByPropertyID( propertyID );
 					expect( datastream ).toEqual( webDataStreamDotOrg );
 				}
 			);


### PR DESCRIPTION
Update `getMatchingWebDataStream` and create `getMatchingWebDataStreamByPropertyID`.

## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #6293 

## Relevant technical choices

This PR fixes the GA4 Property Select which shows a wrong measurement ID for the property.

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
