### PR TITLE
Fix User Input question missing scope

### DIFF
--- a/assets/js/googlesitekit/datastore/user/user-input-settings.js
+++ b/assets/js/googlesitekit/datastore/user/user-input-settings.js
@@ -203,7 +203,7 @@ export const baseControls = {
 					registry.select( CORE_USER ).getUserInputSettings() || {};
 
 				settings[ settingID ] = {
-					...( ( settings || {} )[ settingID ] || {} ),
+					...( settings?.[ settingID ] || {} ),
 					values,
 				};
 

--- a/assets/js/googlesitekit/datastore/user/user-input-settings.js
+++ b/assets/js/googlesitekit/datastore/user/user-input-settings.js
@@ -202,7 +202,10 @@ export const baseControls = {
 				const settings =
 					registry.select( CORE_USER ).getUserInputSettings() || {};
 
-				settings[ settingID ] = { values };
+				settings[ settingID ] = {
+					...( ( settings || {} )[ settingID ] || {} ),
+					values,
+				};
 
 				return setItem( CACHE_KEY_NAME, settings );
 			}


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- https://github.com/google/site-kit-wp/issues/5898#issuecomment-1347943055

## Relevant technical choices

This PR resolves an issue mentioned in the above linked comment, which was saving the answers in the browser cache (session storage), but wasn't storing the question `scope` along with it. This was making the `scope` `undefined` whenever the answers were synced with the cache.

This only happens when the user input is not in a `completed` state. More information [here](https://github.com/google/site-kit-wp/issues/5898#issuecomment-1348103728).

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
