### PR TITLE
Fix logic for view-only users in "Insufficient permissions" errors

### DIFF
--- a/assets/js/components/ReportError.js
+++ b/assets/js/components/ReportError.js
@@ -69,7 +69,7 @@ export default function ReportError( { moduleSlug, error } ) {
 			err.selectorData.name === 'getReport'
 	);
 
-	const showRetry = !! retryableErrors.length && ! isViewOnly;
+	const showRetry = !! retryableErrors.length;
 
 	const errorTroubleshootingLinkURL = useSelect( ( select ) => {
 		const err = {

--- a/assets/js/components/ReportError.js
+++ b/assets/js/components/ReportError.js
@@ -88,22 +88,24 @@ export default function ReportError( { moduleSlug, error } ) {
 	let title;
 
 	const getMessage = ( err ) => {
-		if ( isViewOnly ) {
-			title = sprintf(
-				/* translators: %s: module name */
-				__( 'Access lost to %s', 'google-site-kit' ),
-				module?.name
-			);
-			return sprintf(
-				/* translators: %s: module name */
-				__(
-					'The administrator sharing this module with you has lost access to the %s service, so you won’t be able to see stats from it on the Site Kit dashboard. You can contact them or another administrator to restore access.',
-					'google-site-kit'
-				),
-				module?.name
-			);
-		}
 		if ( isInsufficientPermissionsError( err ) ) {
+			if ( isViewOnly ) {
+				title = sprintf(
+					/* translators: %s: module name */
+					__( 'Access lost to %s', 'google-site-kit' ),
+					module?.name
+				);
+
+				return sprintf(
+					/* translators: %s: module name */
+					__(
+						'The administrator sharing this module with you has lost access to the %s service, so you won’t be able to see stats from it on the Site Kit dashboard. You can contact them or another administrator to restore access.',
+						'google-site-kit'
+					),
+					module?.name
+				);
+			}
+
 			title = sprintf(
 				/* translators: %s: module name */
 				__( 'Insufficient permissions in %s', 'google-site-kit' ),

--- a/assets/js/components/ReportError.stories.js
+++ b/assets/js/components/ReportError.stories.js
@@ -115,6 +115,21 @@ ReportErrorWithInsufficientPermissionsWithRequestAccess.args = {
 	},
 };
 
+export const ReportErrorWithInsufficientPermissionsForViewOnlyUser =
+	Template.bind( {} );
+ReportErrorWithInsufficientPermissionsForViewOnlyUser.storyName =
+	'ReportError with insufficient permissions for view-only user';
+ReportErrorWithInsufficientPermissionsForViewOnlyUser.args = {
+	error: {
+		code: 'test-error-code',
+		message: 'Test error message',
+		data: {
+			reason: ERROR_REASON_INSUFFICIENT_PERMISSIONS,
+		},
+	},
+	viewContext: VIEW_CONTEXT_MAIN_DASHBOARD_VIEW_ONLY,
+};
+
 export const ReportErrorWithRetryButton = Template.bind( {} );
 ReportErrorWithRetryButton.storyName = 'ReportError with Retry Button';
 ReportErrorWithRetryButton.args = {
@@ -137,6 +152,7 @@ ReportErrorWithRetryButton.args = {
 			storeName: MODULES_ANALYTICS,
 		},
 	},
+	viewContext: VIEW_CONTEXT_MAIN_DASHBOARD_VIEW_ONLY,
 };
 
 export const MultipleReportErrorsWithRetryButton = Template.bind( {} );
@@ -250,15 +266,6 @@ MultipleUniqueReportErrorsWithRetryButtonWith.args = {
 			},
 		},
 	],
-};
-
-export const ReportErrorViewOnlyMode = Template.bind( {} );
-ReportErrorViewOnlyMode.storyName = 'ReportError with ViewOnly Mode';
-ReportErrorViewOnlyMode.args = {
-	error: {
-		code: 'test-error-code',
-	},
-	viewContext: VIEW_CONTEXT_MAIN_DASHBOARD_VIEW_ONLY,
 };
 
 export default {

--- a/assets/js/components/ReportError.test.js
+++ b/assets/js/components/ReportError.test.js
@@ -237,6 +237,79 @@ describe( 'ReportError', () => {
 		);
 	} );
 
+	it( 'renders alternate error for non-authenticated users when ERROR_REASON_INSUFFICIENT_PERMISSIONS is provided as reason', () => {
+		const { container } = render(
+			<ReportError
+				moduleSlug={ moduleName }
+				error={ {
+					code: 'test-error-code',
+					message: 'Test error message',
+					data: {
+						reason: ERROR_REASON_INSUFFICIENT_PERMISSIONS,
+					},
+				} }
+			/>,
+			{
+				registry,
+				viewContext: VIEW_CONTEXT_MAIN_DASHBOARD_VIEW_ONLY,
+			}
+		);
+
+		expect( container.querySelector( 'h3' ).textContent ).toEqual(
+			'Access lost to Test Module'
+		);
+	} );
+
+	it( 'should not render the `Request access` button even if it exists for a non-authenticated user', () => {
+		const userData = {
+			id: 1,
+			email: 'admin@example.com',
+			name: 'admin',
+			picture: 'https://path/to/image',
+		};
+		provideModules( registry, [
+			{
+				active: true,
+				connected: true,
+				slug: 'analytics',
+			},
+		] );
+		provideModuleRegistrations( registry );
+		provideUserInfo( registry, userData );
+
+		const [ accountID, internalWebPropertyID, profileID ] = [
+			'12345',
+			'34567',
+			'56789',
+		];
+
+		registry.dispatch( MODULES_ANALYTICS ).setAccountID( accountID );
+		registry
+			.dispatch( MODULES_ANALYTICS )
+			.setInternalWebPropertyID( internalWebPropertyID );
+		registry.dispatch( MODULES_ANALYTICS ).setProfileID( profileID );
+
+		const { queryByText } = render(
+			<ReportError
+				moduleSlug="analytics"
+				error={ {
+					code: 'test-error-code',
+					message: 'Test error message',
+					data: {
+						reason: ERROR_REASON_INSUFFICIENT_PERMISSIONS,
+					},
+				} }
+			/>,
+			{
+				registry,
+				viewContext: VIEW_CONTEXT_MAIN_DASHBOARD_VIEW_ONLY,
+			}
+		);
+
+		// Verify the `Request access` button is rendered.
+		expect( queryByText( /request access/i ) ).not.toBeInTheDocument();
+	} );
+
 	it( "should not render the `Retry` button if the error's `selectorData.name` is not `getReport`", () => {
 		const { queryByText } = render(
 			<ReportError
@@ -368,37 +441,6 @@ describe( 'ReportError', () => {
 		);
 
 		expect( getByRole( 'button', { name: /retry/i } ) ).toBeInTheDocument();
-	} );
-
-	it( 'should not render the `Retry` button for a view-only user', () => {
-		const { queryByText } = render(
-			<ReportError
-				moduleSlug={ moduleName }
-				error={ {
-					code: 'test-error-code',
-					message: 'Test error message',
-					data: {},
-					selectorData: {
-						args: [
-							{
-								dimensions: [ 'ga:date' ],
-								metrics: [ { expression: 'ga:users' } ],
-								startDate: '2020-08-11',
-								endDate: '2020-09-07',
-							},
-						],
-						name: 'getReport',
-						storeName: MODULES_ANALYTICS,
-					},
-				} }
-			/>,
-			{
-				registry,
-				viewContext: VIEW_CONTEXT_MAIN_DASHBOARD_VIEW_ONLY,
-			}
-		);
-
-		expect( queryByText( /retry/i ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'should dispatch the `invalidateResolution` action for each retry-able error', () => {

--- a/assets/js/components/ReportError.test.js
+++ b/assets/js/components/ReportError.test.js
@@ -260,7 +260,7 @@ describe( 'ReportError', () => {
 		);
 	} );
 
-	it( 'should not render the `Request access` button even if it exists for a non-authenticated user', () => {
+	it( 'should not render the `Request access` button for an insufficient permission error when the user is not authenticated', () => {
 		const userData = {
 			id: 1,
 			email: 'admin@example.com',
@@ -306,7 +306,7 @@ describe( 'ReportError', () => {
 			}
 		);
 
-		// Verify the `Request access` button is rendered.
+		// Verify the `Request access` button is not rendered.
 		expect( queryByText( /request access/i ) ).not.toBeInTheDocument();
 	} );
 


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- https://github.com/google/site-kit-wp/issues/6201#issuecomment-1353490574

## Relevant technical choices

This PR addresses the above comment and fixes the logic for view-only users to be changed only in case it is an "Insufficient permissions" error.

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
