### PR TITLE
Add user session scoped storage key prefix.

### DIFF
--- a/assets/js/googlesitekit/api/cache.js
+++ b/assets/js/googlesitekit/api/cache.js
@@ -22,21 +22,15 @@
 import { HOUR_IN_SECONDS } from '../../util';
 
 /**
- * Cache prefix scoped to user session and blog_id.
- *
- * @since n.e.x.t
- */
-const STORAGE_PREFIX = global._googlesitekitBaseData.storagePrefix;
-
-/**
  * Prefix used for all Site Kit keys.
  *
  * Anything not using this key should not be touched by this library.
  *
  * @since 1.5.0
+ * @since n.e.x.t Updated to include a user, session, and blog-specific hash.
  * @private
  */
-export const STORAGE_KEY_PREFIX = `googlesitekit_${ global.GOOGLESITEKIT_VERSION }_${ STORAGE_PREFIX }_`;
+export const STORAGE_KEY_PREFIX = `googlesitekit_${ global.GOOGLESITEKIT_VERSION }_${ global._googlesitekitBaseData.storagePrefix }_`;
 
 const defaultOrder = [ 'sessionStorage', 'localStorage' ];
 let storageBackend;

--- a/assets/js/googlesitekit/api/cache.js
+++ b/assets/js/googlesitekit/api/cache.js
@@ -22,6 +22,13 @@
 import { HOUR_IN_SECONDS } from '../../util';
 
 /**
+ * Cache prefix scoped to user session and blog_id.
+ *
+ * @since n.e.x.t
+ */
+const STORAGE_PREFIX = global._googlesitekitBaseData.storagePrefix;
+
+/**
  * Prefix used for all Site Kit keys.
  *
  * Anything not using this key should not be touched by this library.
@@ -29,7 +36,7 @@ import { HOUR_IN_SECONDS } from '../../util';
  * @since 1.5.0
  * @private
  */
-export const STORAGE_KEY_PREFIX = `googlesitekit_${ global.GOOGLESITEKIT_VERSION }_`;
+export const STORAGE_KEY_PREFIX = `googlesitekit_${ global.GOOGLESITEKIT_VERSION }_${ STORAGE_PREFIX }_`;
 
 const defaultOrder = [ 'sessionStorage', 'localStorage' ];
 let storageBackend;

--- a/includes/Core/Assets/Assets.php
+++ b/includes/Core/Assets/Assets.php
@@ -734,6 +734,7 @@ final class Assets {
 			'enabledFeatures'  => Feature_Flags::get_enabled_features(),
 			'webStoriesActive' => defined( 'WEBSTORIES_VERSION' ),
 			'postTypes'        => $this->get_post_types(),
+			'storagePrefix'    => $this->get_storage_prefix(),
 		);
 
 		/**
@@ -1033,5 +1034,24 @@ final class Assets {
 		if ( ! empty( $data ) && is_string( $data ) ) {
 			wp_scripts()->add_data( $handle, 'data', '/*googlesitekit*/ ' . $data );
 		}
+	}
+
+	/**
+	 * Gets the prefix for the client side cache key.
+	 *
+	 * Cache key is scoped to user session and blog_id to isolate the
+	 * cache between users and sites (in multisite).
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @return string
+	 */
+	private function get_storage_prefix() {
+		$current_user  = wp_get_current_user();
+		$auth_cookie   = wp_parse_auth_cookie();
+		$blog_id       = get_current_blog_id();
+		$session_token = $auth_cookie['token'] ? $auth_cookie['token'] : '';
+
+		return wp_hash( $current_user->user_login . '|' . $session_token . '|' . $blog_id );
 	}
 }

--- a/includes/Core/Assets/Assets.php
+++ b/includes/Core/Assets/Assets.php
@@ -1050,7 +1050,7 @@ final class Assets {
 		$current_user  = wp_get_current_user();
 		$auth_cookie   = wp_parse_auth_cookie();
 		$blog_id       = get_current_blog_id();
-		$session_token = $auth_cookie['token'] ? $auth_cookie['token'] : '';
+		$session_token = isset( $auth_cookie['token'] ) ? $auth_cookie['token'] : '';
 
 		return wp_hash( $current_user->user_login . '|' . $session_token . '|' . $blog_id );
 	}

--- a/tests/e2e/specs/api-cache.test.js
+++ b/tests/e2e/specs/api-cache.test.js
@@ -66,7 +66,7 @@ describe( 'API cache', () => {
 		await deactivatePlugin( 'e2e-tests-proxy-auth-plugin' );
 	} );
 
-	it( 'isolate client storage between users', async () => {
+	it( 'isolates client storage between users', async () => {
 		const firstTestNotification = { ...testSiteNotification };
 		const secondTestNotification = {
 			...testSiteNotification,

--- a/tests/e2e/specs/api-cache.test.js
+++ b/tests/e2e/specs/api-cache.test.js
@@ -70,7 +70,7 @@ describe( 'API cache', () => {
 			dismissLabel: 'test dismiss site notification 2',
 		};
 
-		// create dummy first notification
+		// create first notification
 		await wpApiFetch( {
 			path: 'google-site-kit/v1/e2e/core/site/notifications',
 			method: 'post',
@@ -90,7 +90,7 @@ describe( 'API cache', () => {
 			}
 		);
 
-		// create dummy second notification
+		// create second notification
 		await wpApiFetch( {
 			path: 'google-site-kit/v1/e2e/core/site/notifications',
 			method: 'post',

--- a/tests/e2e/specs/api-cache.test.js
+++ b/tests/e2e/specs/api-cache.test.js
@@ -1,0 +1,124 @@
+/**
+ * API caching functions tests.
+ *
+ * Site Kit by Google, Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import {
+	activatePlugin,
+	deactivatePlugin,
+	visitAdminPage,
+} from '@wordpress/e2e-test-utils';
+
+/**
+ * Internal dependencies
+ */
+import {
+	safeLoginUser,
+	setSearchConsoleProperty,
+	setSiteVerification,
+	testSiteNotification,
+	useRequestInterception,
+	wpApiFetch,
+} from '../utils';
+
+const goToSiteKitDashboard = async () => {
+	await visitAdminPage( 'admin.php', 'page=googlesitekit-dashboard' );
+};
+
+describe( 'API cache', () => {
+	beforeAll( async () => {
+		await page.setRequestInterception( true );
+		useRequestInterception( ( request ) => {
+			const url = request.url();
+			if ( url.match( 'search-console/data/searchanalytics' ) ) {
+				request.respond( { status: 200, body: '[]' } );
+			} else if ( url.match( 'pagespeed-insights/data/pagespeed' ) ) {
+				request.respond( { status: 200, body: '{}' } );
+			} else if ( url.match( 'user/data/survey-timeouts' ) ) {
+				request.respond( { status: 200, body: '[]' } );
+			} else {
+				request.continue();
+			}
+		} );
+
+		await activatePlugin( 'e2e-tests-proxy-auth-plugin' );
+		await setSiteVerification();
+		await setSearchConsoleProperty();
+	} );
+
+	afterAll( async () => {
+		await deactivatePlugin( 'e2e-tests-proxy-auth-plugin' );
+	} );
+
+	it( 'isolate client storage between users', async () => {
+		const firstTestNotification = { ...testSiteNotification };
+		const secondTestNotification = {
+			...testSiteNotification,
+			id: 'test-notification-2',
+			title: 'Test notification title 2',
+			dismissLabel: 'test dismiss site notification 2',
+		};
+
+		// create dummy first notification
+		await wpApiFetch( {
+			path: 'google-site-kit/v1/e2e/core/site/notifications',
+			method: 'post',
+			data: firstTestNotification,
+		} );
+
+		await goToSiteKitDashboard();
+
+		await page.waitForSelector(
+			`#${ firstTestNotification.id }.googlesitekit-publisher-win--is-open`
+		);
+
+		await expect( page ).toClick(
+			'.googlesitekit-publisher-win .mdc-button span',
+			{
+				text: firstTestNotification.dismissLabel,
+			}
+		);
+
+		// create dummy second notification
+		await wpApiFetch( {
+			path: 'google-site-kit/v1/e2e/core/site/notifications',
+			method: 'post',
+			data: secondTestNotification,
+		} );
+
+		// delete all cookies
+		await page._client.send( 'Network.clearBrowserCookies' );
+
+		await safeLoginUser( 'admin', 'password' );
+
+		await goToSiteKitDashboard();
+
+		// Ensure the second notification is displayed.
+		await page.waitForSelector(
+			`#${ secondTestNotification.id }.googlesitekit-publisher-win--is-open`
+		);
+
+		await expect( page ).toMatchElement(
+			'.googlesitekit-publisher-win__title',
+			{
+				text: secondTestNotification.title,
+			}
+		);
+	} );
+} );

--- a/tests/e2e/specs/api-cache.test.js
+++ b/tests/e2e/specs/api-cache.test.js
@@ -19,23 +19,20 @@
 /**
  * WordPress dependencies
  */
-import {
-	activatePlugin,
-	deactivatePlugin,
-	visitAdminPage,
-} from '@wordpress/e2e-test-utils';
+import { visitAdminPage } from '@wordpress/e2e-test-utils';
 
 /**
  * Internal dependencies
  */
 import {
+	resetSiteKit,
 	safeLoginUser,
-	setSearchConsoleProperty,
-	setSiteVerification,
+	setupSiteKit,
 	testSiteNotification,
 	useRequestInterception,
 	wpApiFetch,
 } from '../utils';
+import { deleteAuthCookie } from '../utils/delete-auth-cookie';
 
 const goToSiteKitDashboard = async () => {
 	await visitAdminPage( 'admin.php', 'page=googlesitekit-dashboard' );
@@ -57,13 +54,11 @@ describe( 'API cache', () => {
 			}
 		} );
 
-		await activatePlugin( 'e2e-tests-proxy-auth-plugin' );
-		await setSiteVerification();
-		await setSearchConsoleProperty();
+		await setupSiteKit();
 	} );
 
 	afterAll( async () => {
-		await deactivatePlugin( 'e2e-tests-proxy-auth-plugin' );
+		await resetSiteKit();
 	} );
 
 	it( 'isolates client storage between users', async () => {
@@ -102,8 +97,8 @@ describe( 'API cache', () => {
 			data: secondTestNotification,
 		} );
 
-		// delete all cookies
-		await page._client.send( 'Network.clearBrowserCookies' );
+		// delete auth cookie to sign out the current user
+		await deleteAuthCookie();
 
 		await safeLoginUser( 'admin', 'password' );
 

--- a/tests/e2e/specs/api-cache.test.js
+++ b/tests/e2e/specs/api-cache.test.js
@@ -61,7 +61,7 @@ describe( 'API cache', () => {
 		await resetSiteKit();
 	} );
 
-	it( 'isolates client storage between users', async () => {
+	it( 'isolates client storage between sessions', async () => {
 		const firstTestNotification = { ...testSiteNotification };
 		const secondTestNotification = {
 			...testSiteNotification,

--- a/tests/e2e/utils/delete-auth-cookie.js
+++ b/tests/e2e/utils/delete-auth-cookie.js
@@ -1,4 +1,22 @@
 /**
+ * `deleteAuthCookie` utility.
+ *
+ * Site Kit by Google, Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
  * Deletes authentication cookies to sign out the current user.
  */
 export async function deleteAuthCookie() {

--- a/tests/e2e/utils/delete-auth-cookie.js
+++ b/tests/e2e/utils/delete-auth-cookie.js
@@ -1,0 +1,9 @@
+/**
+ * Deletes authentication cookies to sign out the current user.
+ */
+export async function deleteAuthCookie() {
+	const cookies = ( await page.cookies() )
+		.filter( ( cookie ) => cookie.name.match( /^wordpress_/ ) )
+		.filter( ( cookie ) => cookie.name !== 'wordpress_test_cookie' );
+	await page.deleteCookie( ...cookies );
+}

--- a/tests/e2e/utils/logout-user.js
+++ b/tests/e2e/utils/logout-user.js
@@ -2,15 +2,13 @@
  * WordPress dependencies
  */
 import { createURL, isCurrentURL } from '@wordpress/e2e-test-utils';
+import { deleteAuthCookie } from './delete-auth-cookie';
 
 /**
  * Deletes authentication cookies to sign out the current user.
  */
 export async function logoutUser() {
-	const cookies = ( await page.cookies() )
-		.filter( ( cookie ) => cookie.name.match( /^wordpress_/ ) )
-		.filter( ( cookie ) => cookie.name !== 'wordpress_test_cookie' );
-	await page.deleteCookie( ...cookies );
+	await deleteAuthCookie();
 
 	if ( ! isCurrentURL( 'wp-login.php' ) ) {
 		await page.goto( createURL( 'wp-login.php' ) );

--- a/tests/e2e/utils/logout-user.js
+++ b/tests/e2e/utils/logout-user.js
@@ -2,6 +2,10 @@
  * WordPress dependencies
  */
 import { createURL, isCurrentURL } from '@wordpress/e2e-test-utils';
+
+/**
+ * Internal dependencies
+ */
 import { deleteAuthCookie } from './delete-auth-cookie';
 
 /**


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #6240 

## Relevant technical choices

- Followed IB
- Adds `storagePrefix` scoped to user session and blog_id to `_googlesitekitBaseData`.
- Uses `storagePrefix` to generate `STORAGE_KEY_PREFIX`.
- Adds new E2E test to verify cache key is scoped to user session.
- Verified the newly added E2E tests fail when storage key is not scoped to user session.

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
