### PR TITLE
Place Google Tag ID if available instead of GA4 tag

### DIFF
--- a/includes/Modules/Analytics_4.php
+++ b/includes/Modules/Analytics_4.php
@@ -643,7 +643,7 @@ final class Analytics_4 extends Module
 
 		$settings = $this->get_settings()->get();
 
-		if ( Feature_Flags::enabled( 'gteSupport' ) && isset( $settings['googleTagID'] ) ) {
+		if ( Feature_Flags::enabled( 'gteSupport' ) && ! empty( $settings['googleTagID'] ) ) {
 			$tag = new Web_Tag( $settings['googleTagID'], self::MODULE_SLUG );
 		} else {
 			$tag = new Web_Tag( $settings['measurementID'], self::MODULE_SLUG );

--- a/includes/Modules/Analytics_4.php
+++ b/includes/Modules/Analytics_4.php
@@ -642,7 +642,12 @@ final class Analytics_4 extends Module
 		}
 
 		$settings = $this->get_settings()->get();
-		$tag      = new Web_Tag( $settings['measurementID'], self::MODULE_SLUG );
+
+		if ( Feature_Flags::enabled( 'gteSupport' ) && isset( $settings['googleTagID'] ) ) {
+			$tag = new Web_Tag( $settings['googleTagID'], self::MODULE_SLUG );
+		} else {
+			$tag = new Web_Tag( $settings['measurementID'], self::MODULE_SLUG );
+		}
 
 		if ( $tag->is_tag_blocked() ) {
 			return;


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #6080 

## Relevant technical choices

This PR amends the GA4 tag placement logic so that it places the Google Tag ID if available.

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [x] Run the code.
- [x] Ensure the acceptance criteria are satisfied.
- [x] Reassess the implementation with the IB.
- [x] Ensure no unrelated changes are included.
- [x] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [x] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [x] Ensure the PR has the correct target branch.
- [x] Double-check that the PR is okay to be merged.
- [x] Ensure the corresponding issue has a ZenHub release assigned.
- [x] Add a changelog message to the issue.
