### PR TITLE
Register analytics-4 module on client with storeName.

### DIFF
--- a/assets/js/components/settings/SettingsActiveModule/Header.test.js
+++ b/assets/js/components/settings/SettingsActiveModule/Header.test.js
@@ -38,6 +38,7 @@ import {
 	fireEvent,
 	waitFor,
 	provideUserInfo,
+	provideModuleRegistrations,
 } from '../../../../../tests/js/test-utils';
 import { MODULES_ANALYTICS } from '../../../modules/analytics/datastore/constants';
 import { CORE_MODULES } from '../../../googlesitekit/modules/datastore/constants';
@@ -72,7 +73,6 @@ describe( 'Header', () => {
 				slug: 'analytics',
 				active: true,
 				connected: true,
-				storeName: MODULES_ANALYTICS,
 			},
 			{
 				slug: 'pagespeed-insights',
@@ -92,6 +92,7 @@ describe( 'Header', () => {
 				connected: false,
 			},
 		] );
+		provideModuleRegistrations( registry );
 		registry.dispatch( CORE_USER ).receiveGetAuthentication( {} );
 	} );
 

--- a/assets/js/googlesitekit-modules-analytics-4.js
+++ b/assets/js/googlesitekit-modules-analytics-4.js
@@ -20,6 +20,8 @@
  * Internal dependencies
  */
 import Data from 'googlesitekit-data';
-import { registerStore } from './modules/analytics-4';
+import Modules from 'googlesitekit-modules';
+import { registerStore, registerModule } from './modules/analytics-4';
 
 registerStore( Data );
+registerModule( Modules );

--- a/assets/js/modules/analytics-4/index.js
+++ b/assets/js/modules/analytics-4/index.js
@@ -16,4 +16,15 @@
  * limitations under the License.
  */
 
+/**
+ * Internal dependencies
+ */
+import { MODULES_ANALYTICS_4 } from './datastore/constants';
+
 export { registerStore } from './datastore';
+
+export const registerModule = ( modules ) => {
+	modules.registerModule( 'analytics-4', {
+		storeName: MODULES_ANALYTICS_4,
+	} );
+};

--- a/assets/js/modules/analytics/components/settings/SettingsEdit.test.js
+++ b/assets/js/modules/analytics/components/settings/SettingsEdit.test.js
@@ -34,6 +34,7 @@ import {
 	provideSiteInfo,
 	waitForDefaultTimeouts,
 	provideUserInfo,
+	provideModuleRegistrations,
 } from '../../../../../../tests/js/utils';
 import * as ga4Fixtures from '../../../analytics-4/datastore/__fixtures__';
 
@@ -65,7 +66,6 @@ describe( 'SettingsEdit', () => {
 				slug: 'analytics',
 				active: true,
 				connected: true,
-				storeName: MODULES_ANALYTICS,
 			},
 		] );
 
@@ -128,6 +128,7 @@ describe( 'SettingsEdit', () => {
 	} );
 
 	it( 'does not set the account ID or property ID of an existing tag when present', async () => {
+		provideModuleRegistrations( registry );
 		fetchMock.get( new RegExp( 'tagmanager/data/settings' ), { body: {} } );
 		fetchMock.getOnce(
 			new RegExp(

--- a/assets/js/modules/tagmanager/components/settings/SettingsEdit.test.js
+++ b/assets/js/modules/tagmanager/components/settings/SettingsEdit.test.js
@@ -20,6 +20,8 @@
  * Internal dependencies
  */
 import {
+	provideModuleRegistrations,
+	provideModules,
 	provideSiteInfo,
 	provideUserInfo,
 } from '../../../../../../tests/js/utils';
@@ -32,7 +34,6 @@ import {
 	AMP_MODE_SECONDARY,
 } from '../../../../googlesitekit/datastore/site/constants';
 import { CORE_MODULES } from '../../../../googlesitekit/modules/datastore/constants';
-import { withActive } from '../../../../googlesitekit/modules/datastore/__fixtures__';
 import { CORE_FORMS } from '../../../../googlesitekit/datastore/forms/constants';
 import {
 	MODULES_TAGMANAGER,
@@ -73,15 +74,8 @@ describe( 'SettingsEdit', () => {
 		provideSiteInfo( registry, { siteName } );
 		provideUserInfo( registry );
 
-		registry
-			.dispatch( CORE_MODULES )
-			.receiveGetModules(
-				withActive( 'tagmanager' ).map( ( module ) =>
-					module.slug !== 'tagmanager'
-						? module
-						: { ...module, storeName: MODULES_TAGMANAGER }
-				)
-			);
+		provideModules( registry, [ { slug: 'tagmanager', active: true } ] );
+		provideModuleRegistrations( registry );
 
 		registry.dispatch( MODULES_TAGMANAGER ).setSettings( {} );
 		registry.dispatch( MODULES_TAGMANAGER ).setOwnerID( 1 );


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #6192

## Relevant technical choices

* The main change here is the addition of the store registration for GA4
* Client side store registration is optional, but necessary for any module we want to use with `getModuleStoreName` via `core/modules`
* The rest of this are cleanup/fixes for some related improper use where `storeName` was being received in via `receiveGetModules` which worked but was incorrect as this is only intended to receive server-side definitions
* Other changes simplify where the existing tests were a bit unnecessarily verbose

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
