### PR TITLE
Bug/6364 remove opt out code when no tag is set

### DIFF
--- a/includes/Modules/Analytics.php
+++ b/includes/Modules/Analytics.php
@@ -1150,14 +1150,15 @@ final class Analytics extends Module
 	 * @link https://developers.google.com/analytics/devguides/collection/analyticsjs/user-opt-out
 	 */
 	private function print_tracking_opt_out() {
-		if ( ! $this->is_tracking_disabled() ) {
-			return;
-		}
 		$settings    = $this->get_settings()->get();
 		$account_id  = $settings['accountID'];
 		$property_id = $settings['propertyID'];
 
 		if ( empty( $property_id ) ) {
+			return;
+		}
+
+		if ( ! $this->is_tracking_disabled() ) {
 			return;
 		}
 

--- a/includes/Modules/Analytics.php
+++ b/includes/Modules/Analytics.php
@@ -1157,6 +1157,10 @@ final class Analytics extends Module
 		$account_id  = $settings['accountID'];
 		$property_id = $settings['propertyID'];
 
+		if ( empty( $property_id ) ) {
+			return;
+		}
+
 		if ( $this->context->is_amp() ) : ?>
 			<!-- <?php esc_html_e( 'Google Analytics AMP opt-out snippet added by Site Kit', 'google-site-kit' ); ?> -->
 			<meta name="ga-opt-out" content="" id="__gaOptOutExtension">

--- a/tests/phpunit/integration/Modules/AnalyticsTest.php
+++ b/tests/phpunit/integration/Modules/AnalyticsTest.php
@@ -457,10 +457,14 @@ class AnalyticsTest extends TestCase {
 		// Confidence check.
 		$this->assertNotEmpty( $head_html );
 		// Whether or not tracking is disabled does not affect output of snippet.
-		if ( $settings['useSnippet'] ) {
+		if ( $settings['propertyID'] && $settings['useSnippet'] ) {
 			$this->assertStringContainsString( "id={$settings['propertyID']}", $head_html );
 		} else {
 			$this->assertStringNotContainsString( "id={$settings['propertyID']}", $head_html );
+		}
+
+		if ( ! $settings['propertyID'] ) {
+			$this->assertStringNotContainsString( 'ga-disable', $head_html );
 		}
 
 		$assert_opt_out_presence( $head_html );
@@ -528,6 +532,13 @@ class AnalyticsTest extends TestCase {
 				true,
 				$assert_contains_opt_out,
 				true,
+			),
+			// Analytics is enabled but not configured
+			array(
+				array_merge( $base_settings, array( 'propertyID' => '' ) ),
+				false,
+				$assert_not_contains_opt_out,
+				false,
 			),
 		);
 	}

--- a/tests/phpunit/integration/Modules/AnalyticsTest.php
+++ b/tests/phpunit/integration/Modules/AnalyticsTest.php
@@ -533,7 +533,7 @@ class AnalyticsTest extends TestCase {
 				$assert_contains_opt_out,
 				true,
 			),
-			// Analytics is enabled but not configured
+			// Analytics is enabled but not configured.
 			array(
 				array_merge( $base_settings, array( 'propertyID' => '' ) ),
 				false,


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #6364 

## Relevant technical choices

- Return early on `print_tracking_opt_out()` when `$property_id` empty so not opt-out code is printed.
- Add new test case for empty `propertyId` to `AnalyticsTest`.

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
