### PR TITLE
Refactor with `hasModuleOwnershipOrAccess`

### DIFF
--- a/assets/js/modules/analytics-4/components/dashboard/ActivationBanner/ReminderBanner.js
+++ b/assets/js/modules/analytics-4/components/dashboard/ActivationBanner/ReminderBanner.js
@@ -48,7 +48,6 @@ import ErrorIcon from '../../../../../../svg/icons/error.svg';
 import ReminderBannerNoAccess from './ReminderBannerNoAccess';
 import { CORE_MODULES } from '../../../../../googlesitekit/modules/datastore/constants';
 import { Cell, Grid, Row } from '../../../../../material-components';
-import { MODULES_ANALYTICS } from '../../../../analytics/datastore/constants';
 import useViewContext from '../../../../../hooks/useViewContext';
 
 const { useSelect } = Data;
@@ -62,19 +61,10 @@ export default function ReminderBanner( {
 		if ( isDismissed ) {
 			return undefined;
 		}
-		const userID = select( CORE_USER ).getID();
-		const analyticsOwnerID = select( MODULES_ANALYTICS ).getOwnerID();
 
-		if ( userID === undefined || analyticsOwnerID === undefined ) {
-			return undefined;
-		}
-
-		if ( analyticsOwnerID === userID ) {
-			return true;
-		}
-
-		return select( CORE_MODULES ).hasModuleAccess( 'analytics' );
+		return select( CORE_MODULES ).hasModuleOwnershipOrAccess( 'analytics' );
 	} );
+
 	const isLoadingAnalyticsAccess = useSelect( ( select ) =>
 		select( CORE_MODULES ).isResolving( 'hasModuleAccess', [ 'analytics' ] )
 	);


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #6192 

## Relevant technical choices

* Replaces the last instance of where the functionality covered by the added `hasModuleOwnershipOrAccess` selector was implemented manually.

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
