### PR TITLE
Preload userInput rest routes only when feature flag is enabled.

### DIFF
--- a/includes/Core/User_Input/REST_User_Input_Controller.php
+++ b/includes/Core/User_Input/REST_User_Input_Controller.php
@@ -13,6 +13,7 @@ namespace Google\Site_Kit\Core\User_Input;
 use Google\Site_Kit\Core\Permissions\Permissions;
 use Google\Site_Kit\Core\REST_API\REST_Route;
 use Google\Site_Kit\Core\REST_API\REST_Routes;
+use Google\Site_Kit\Core\Util\Feature_Flags;
 use WP_Error;
 use WP_REST_Request;
 use WP_REST_Server;
@@ -58,17 +59,19 @@ class REST_User_Input_Controller {
 			}
 		);
 
-		add_filter(
-			'googlesitekit_apifetch_preload_paths',
-			function ( $paths ) {
-				return array_merge(
-					$paths,
-					array(
-						'/' . REST_Routes::REST_ROOT . '/core/user/data/user-input-settings',
-					)
-				);
-			}
-		);
+		if ( Feature_Flags::enabled( 'userInput' ) ) {
+			add_filter(
+				'googlesitekit_apifetch_preload_paths',
+				function ( $paths ) {
+					return array_merge(
+						$paths,
+						array(
+							'/' . REST_Routes::REST_ROOT . '/core/user/data/user-input-settings',
+						)
+					);
+				}
+			);
+		}
 	}
 
 	/**

--- a/tests/phpunit/integration/Core/User_Input/REST_User_Input_ControllerTest.php
+++ b/tests/phpunit/integration/Core/User_Input/REST_User_Input_ControllerTest.php
@@ -56,6 +56,8 @@ class REST_User_Input_ControllerTest extends TestCase {
 	}
 
 	public function test_register() {
+		$this->enable_feature( 'userInput' );
+
 		remove_all_filters( 'googlesitekit_rest_routes' );
 		remove_all_filters( 'googlesitekit_apifetch_preload_paths' );
 


### PR DESCRIPTION
## Summary

- #6233 

## Relevant technical choices

- Wrapped the preload filter registration into `if ( Feature_Flags::enabled( 'userInput' ) ) {`
- Updated the integration test to enable the `userInput` feature flag.

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
