### PR TITLE
Add REST datapoint for GA4 conversion events

### DIFF
--- a/includes/Modules/Analytics_4.php
+++ b/includes/Modules/Analytics_4.php
@@ -235,6 +235,7 @@ final class Analytics_4 extends Module
 			),
 			'GET:webdatastreams'         => array( 'service' => 'analyticsadmin' ),
 			'GET:webdatastreams-batch'   => array( 'service' => 'analyticsadmin' ),
+			'GET:conversion-events'      => array( 'service' => 'analyticsadmin' ),
 		);
 	}
 
@@ -502,6 +503,22 @@ final class Analytics_4 extends Module
 				return $this->get_tagmanager_service()->accounts_containers_destinations->listAccountsContainersDestinations(
 					"accounts/{$data['accountID']}/containers/{$data['internalContainerID']}"
 				);
+			case 'GET:conversion-events':
+				if ( ! isset( $data['propertyID'] ) ) {
+					return new WP_Error(
+						'missing_required_param',
+						/* translators: %s: Missing parameter name */
+						sprintf( __( 'Request parameter is empty: %s.', 'google-site-kit' ), 'propertyID' ),
+						array( 'status' => 400 )
+					);
+				}
+
+				$analyticsadmin = $this->get_service( 'analyticsadmin' );
+				$property_id    = self::normalize_property_id( $data['propertyID'] );
+
+				return $analyticsadmin
+					->properties_conversionEvents // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+					->listPropertiesConversionEvents( $property_id );
 		}
 
 		return parent::create_data_request( $data );
@@ -555,6 +572,8 @@ final class Analytics_4 extends Module
 				return self::parse_webdatastreams_batch( $response );
 			case 'GET:container-destinations':
 				return (array) $response->getDestination();
+			case 'GET:conversion-events':
+				return (array) $response->getConversionEvents();
 		}
 
 		return parent::parse_data_response( $data, $response );

--- a/tests/phpunit/integration/Modules/Analytics_4Test.php
+++ b/tests/phpunit/integration/Modules/Analytics_4Test.php
@@ -244,6 +244,7 @@ class Analytics_4Test extends TestCase {
 				'accounts',
 				'container-lookup',
 				'container-destinations',
+				'conversion-events',
 				'create-property',
 				'create-webdatastream',
 				'properties',

--- a/tests/phpunit/integration/Modules/Analytics_4Test.php
+++ b/tests/phpunit/integration/Modules/Analytics_4Test.php
@@ -32,8 +32,10 @@ use Google\Site_Kit\Tests\Core\Modules\Module_With_Settings_ContractTests;
 use Google\Site_Kit\Tests\FakeHttpClient;
 use Google\Site_Kit\Tests\TestCase;
 use Google\Site_Kit\Tests\UserAuthenticationTrait;
+use Google\Site_Kit_Dependencies\Google\Service\GoogleAnalyticsAdmin\GoogleAnalyticsAdminV1betaConversionEvent;
 use Google\Site_Kit_Dependencies\Google\Service\GoogleAnalyticsAdmin\GoogleAnalyticsAdminV1betaDataStream;
 use Google\Site_Kit_Dependencies\Google\Service\GoogleAnalyticsAdmin\GoogleAnalyticsAdminV1betaDataStreamWebStreamData;
+use Google\Site_Kit_Dependencies\Google\Service\GoogleAnalyticsAdmin\GoogleAnalyticsAdminV1betaListConversionEventsResponse;
 use Google\Site_Kit_Dependencies\GuzzleHttp\Message\Request;
 use Google\Site_Kit_Dependencies\GuzzleHttp\Message\Response;
 use Google\Site_Kit_Dependencies\GuzzleHttp\Stream\Stream;
@@ -934,7 +936,7 @@ class Analytics_4Test extends TestCase {
 		$this->assertNotWPError( $data );
 
 		// Verify the conversion events are returned by checking an event name.
-		$this->assertEquals( 'some-event', $data['modelData'][0]['eventName'] );
+		$this->assertEquals( 'some-event', $data[0]['eventName'] );
 
 		// Verify the request URL and params were correctly generated.
 		$this->assertCount( 1, $this->request_handler_calls );
@@ -1040,19 +1042,18 @@ class Analytics_4Test extends TestCase {
 						);
 
 					case "/v1beta/properties/$property_id/conversionEvents":
-						// Return a mock conversion event.
+						$conversion_event = new GoogleAnalyticsAdminV1betaConversionEvent();
+						$conversion_event->setName( "properties/$property_id/conversionEvents/some-name" );
+						$conversion_event->setEventName( 'some-event' );
+
+						$conversion_events = new GoogleAnalyticsAdminV1betaListConversionEventsResponse();
+						$conversion_events->setConversionEvents( array( $conversion_event ) );
+
 						return new Response(
 							200,
 							array(),
 							Stream::factory(
-								json_encode(
-									array(
-										array(
-											'eventName' => 'some-event',
-											'name'      => "properties/$property_id/conversionEvents/some-name",
-										),
-									)
-								)
+								json_encode( $conversion_events )
 							)
 						);
 


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #6348 

## Relevant technical choices

This PR adds REST datapoint for GA4 conversion events.

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
