### PR TITLE
Avoid ignoring all platform dependencies when upgrading PHPUnit

### DIFF
--- a/.github/workflows/php-tests-wp-latest-php-8-0.yml
+++ b/.github/workflows/php-tests-wp-latest-php-8-0.yml
@@ -76,7 +76,9 @@ jobs:
       - name: Composer Install
         run: composer install --no-interaction --no-progress
       - name: Update PHPUnit
-        run: composer update phpunit/phpunit --with-dependencies --ignore-platform-reqs --no-scripts
+        run: |
+          composer config --unset platform.php
+          composer update phpunit/phpunit --with-dependencies --no-scripts
       - name: Set up PHP test data
         run: tests/phpunit/bin/install-wp-tests.sh ${MYSQL_DATABASE} ${MYSQL_USER} ${MYSQL_PASSWORD} ${DB_HOST}:${DB_PORT} ${WP_VERSION}
       - name: Run Unit Tests


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #6418 

## Relevant technical choices

- By default, we configure Composer to always install dependencies that are compatible with our minimum supported version of PHP (currently 5.6). This works well for dependencies needed by the distributable version of the plugin but is problematic for many dependencies needed in development such as PHPUnit. In order to run our tests on PHP 8, we need to run a newer version of PHPUnit but this is prevented by the same `platform.php` configuration value. For this reason, we've intentionally ignored it in our CI jobs that run these tests but only for the purpose of upgrading PHPUnit (and its dependencies) – all other dependencies still install the 5.6 compatible versions. Currently we leverage Composer's [`--ignore-platform-reqs`](https://getcomposer.org/doc/03-cli.md#update-u-upgrade) flag to bypass this limitation which has worked fine so far, but this goes a bit too far and allows Composer to install dependencies which require PHP 8.1 (or above) which it is smart enough to know aren't compatible in the current environment, but we've instructed it to ignore this. To remedy this, all we need to do is temporarily remove our `platform.php` configuration and _not use_ the `--ignore-platform-reqs` flag so that Composer resolves the dependencies to install using versions compatible with the current environment's PHP version as it would normally. This technically modifies our `composer.json` but that's fine as a temporary modification that we don't commit, and that it only runs for upgrading PHPUnit and its dependencies.

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
