### PR TITLE
Infrastructure/#5460 - E2E intercept AMP validate requests

### DIFF
--- a/tests/e2e/specs/amp/admin-bar.test.js
+++ b/tests/e2e/specs/amp/admin-bar.test.js
@@ -28,53 +28,54 @@ import {
 	activateAMPWithMode,
 	deactivateUtilityPlugins,
 	setupSiteKit,
-	useRequestInterception,
+	useSharedRequestInterception,
 } from '../../utils';
 import * as adminBarMockResponses from '../modules/analytics/fixtures/admin-bar';
 
 let mockBatchResponse;
 
 describe( 'AMP Admin Bar compatibility', () => {
-	beforeAll( async () => {
-		await setupSiteKit();
-		await activateAMPWithMode( 'primary' );
+	let sharedRequestInterception;
 
+	beforeAll( async () => {
 		await page.setRequestInterception( true );
-		useRequestInterception( ( request ) => {
-			if (
-				request
-					.url()
-					.match(
-						'google-site-kit/v1/modules/search-console/data/searchanalytics?'
-					)
-			) {
-				request.respond( {
+		sharedRequestInterception = useSharedRequestInterception( [
+			{
+				isMatch: ( request ) =>
+					request
+						.url()
+						.match(
+							'google-site-kit/v1/modules/search-console/data/searchanalytics?'
+						),
+				getResponse: () => ( {
 					status: 200,
 					body: JSON.stringify(
 						mockBatchResponse[
 							'modules::search-console::searchanalytics::e74216dd17533dcb67fa2d433c23467c'
 						]
 					),
-				} );
-			} else if (
-				request
-					.url()
-					.match(
-						'google-site-kit/v1/modules/analytics/data/report?'
-					)
-			) {
-				request.respond( {
+				} ),
+			},
+			{
+				isMatch: ( request ) =>
+					request
+						.url()
+						.match(
+							'google-site-kit/v1/modules/analytics/data/report?'
+						),
+				getResponse: () => ( {
 					status: 200,
 					body: JSON.stringify(
 						mockBatchResponse[
 							'modules::analytics::report::db20ba9afa3000cd79e2888048a1700c'
 						]
 					),
-				} );
-			} else {
-				request.continue();
-			}
-		} );
+				} ),
+			},
+		] );
+
+		await setupSiteKit();
+		await activateAMPWithMode( 'primary', sharedRequestInterception );
 	} );
 
 	beforeEach( async () => {

--- a/tests/e2e/specs/modules/optimize/activation.test.js
+++ b/tests/e2e/specs/modules/optimize/activation.test.js
@@ -36,7 +36,7 @@ import {
 	setSiteVerification,
 	setupAnalytics,
 	step,
-	useRequestInterception,
+	useSharedRequestInterception,
 } from '../../../utils';
 
 async function proceedToOptimizeSetup() {
@@ -86,54 +86,72 @@ describe( 'Optimize Activation', () => {
 		} );
 	}
 
+	let sharedRequestInterception;
+
 	beforeAll( async () => {
 		await page.setRequestInterception( true );
-		useRequestInterception( ( request ) => {
-			if (
-				request
-					.url()
-					.match(
-						'/wp-json/google-site-kit/v1/modules/analytics/data/report?'
-					)
-			) {
-				request.respond( {
+		sharedRequestInterception = useSharedRequestInterception( [
+			{
+				isMatch: ( request ) =>
+					request
+						.url()
+						.match(
+							'/wp-json/google-site-kit/v1/modules/analytics/data/report?'
+						),
+				getResponse: () => ( {
 					status: 200,
 					body: JSON.stringify( [ { placeholder_response: true } ] ),
-				} );
-			} else if (
-				request
-					.url()
-					.match(
-						'google-site-kit/v1/modules/search-console/data/searchanalytics'
-					)
-			) {
-				request.respond( { status: 200, body: JSON.stringify( [] ) } );
-			} else if (
-				request
-					.url()
-					.match(
-						'google-site-kit/v1/modules/pagespeed-insights/data/pagespeed'
-					)
-			) {
-				request.respond( { status: 200, body: JSON.stringify( {} ) } );
-			} else if (
-				request
-					.url()
-					.match( 'google-site-kit/v1/modules/analytics/data/goals' )
-			) {
-				request.respond( { status: 200, body: JSON.stringify( {} ) } );
-			} else if (
-				request
-					.url()
-					.match(
-						'google-site-kit/v1/core/modules/data/check-access'
-					)
-			) {
-				request.respond( { status: 200, body: JSON.stringify( {} ) } );
-			} else {
-				request.continue();
-			}
-		} );
+				} ),
+			},
+			{
+				isMatch: ( request ) =>
+					request
+						.url()
+						.match(
+							'google-site-kit/v1/modules/search-console/data/searchanalytics'
+						),
+				getResponse: () => ( {
+					status: 200,
+					body: JSON.stringify( [] ),
+				} ),
+			},
+			{
+				isMatch: ( request ) =>
+					request
+						.url()
+						.match(
+							'google-site-kit/v1/modules/pagespeed-insights/data/pagespeed'
+						),
+				getResponse: () => ( {
+					status: 200,
+					body: JSON.stringify( {} ),
+				} ),
+			},
+			{
+				isMatch: ( request ) =>
+					request
+						.url()
+						.match(
+							'google-site-kit/v1/modules/analytics/data/goals'
+						),
+				getResponse: () => ( {
+					status: 200,
+					body: JSON.stringify( {} ),
+				} ),
+			},
+			{
+				isMatch: ( request ) =>
+					request
+						.url()
+						.match(
+							'google-site-kit/v1/core/modules/data/check-access'
+						),
+				getResponse: () => ( {
+					status: 200,
+					body: JSON.stringify( {} ),
+				} ),
+			},
+		] );
 	} );
 
 	beforeEach( async () => {
@@ -226,7 +244,7 @@ describe( 'Optimize Activation', () => {
 
 	describe( 'Settings with AMP enabled', () => {
 		beforeEach( async () => {
-			await activateAMPWithMode( 'primary' );
+			await activateAMPWithMode( 'primary', sharedRequestInterception );
 			await setupAnalytics( { useSnippet: true } );
 			await proceedToOptimizeSetup();
 		} );
@@ -248,7 +266,7 @@ describe( 'Optimize Activation', () => {
 
 	describe( 'Homepage AMP', () => {
 		beforeEach( async () => {
-			await activateAMPWithMode( 'primary' );
+			await activateAMPWithMode( 'primary', sharedRequestInterception );
 			await setupAnalytics();
 		} );
 

--- a/tests/e2e/utils/activate-amp-and-set-mode.js
+++ b/tests/e2e/utils/activate-amp-and-set-mode.js
@@ -66,7 +66,14 @@ export const activateAMPWithMode = async (
 		] );
 	} else {
 		// eslint-disable-next-line react-hooks/rules-of-hooks
-		useRequestInterception( () => {} );
+		useRequestInterception( ( request ) => {
+			if ( request.url().match( '&amp_validate' ) ) {
+				request.respond( {
+					status: 200,
+					body: JSON.stringify( {} ),
+				} );
+			}
+		} );
 	}
 	await activatePlugin( 'amp' );
 	await setAMPMode( mode );

--- a/tests/e2e/utils/activate-amp-and-set-mode.js
+++ b/tests/e2e/utils/activate-amp-and-set-mode.js
@@ -26,6 +26,7 @@ import { activatePlugin, visitAdminPage } from '@wordpress/e2e-test-utils';
  */
 import { createWaitForFetchRequests } from './create-wait-for-fetch-requests';
 import { pageWait } from './page-wait';
+import { useRequestInterception } from './use-request-interception';
 
 /**
  * The allow list of AMP modes.
@@ -43,9 +44,30 @@ export const allowedAMPModes = {
  *
  * @since 1.10.0
  *
- * @param {string} mode The mode to set AMP to. Possible value of standard, transitional or reader.
+ * @param {string}   mode                                      The mode to set AMP to. Possible value of standard, transitional or reader.
+ * @param {Object}   sharedRequestInterception                 Object of methods that can be called to remove the added handler function from the page and add new request cases.
+ * @param {Function} sharedRequestInterception.cleanUp         Removes the request handler function from the page.
+ * @param {Function} sharedRequestInterception.addRequestCases Adds new request cases to the request handler function.
+ * @return {Promise<void>} Promise that resolves when AMP is activated and set to the correct mode.
  */
-export const activateAMPWithMode = async ( mode ) => {
+export const activateAMPWithMode = async (
+	mode,
+	sharedRequestInterception
+) => {
+	if ( sharedRequestInterception ) {
+		sharedRequestInterception.addRequestCases( [
+			{
+				isMatch: ( request ) => request.url().match( '&amp_validate' ),
+				getResponse: () => ( {
+					status: 200,
+					body: JSON.stringify( {} ),
+				} ),
+			},
+		] );
+	} else {
+		// eslint-disable-next-line react-hooks/rules-of-hooks
+		useRequestInterception( () => {} );
+	}
 	await activatePlugin( 'amp' );
 	await setAMPMode( mode );
 };

--- a/tests/e2e/utils/index.js
+++ b/tests/e2e/utils/index.js
@@ -42,6 +42,7 @@ export { switchDateRange } from './switch-date-range';
 export { testClientConfig } from './test-client-config';
 export { testSiteNotification } from './test-site-notification';
 export { useRequestInterception } from './use-request-interception';
+export { useSharedRequestInterception } from './use-request-interception';
 export { wpApiFetch } from './wp-api-fetch';
 export * from './features';
 export * from './step-and-screenshot';

--- a/tests/e2e/utils/use-request-interception.js
+++ b/tests/e2e/utils/use-request-interception.js
@@ -27,6 +27,7 @@ export function useRequestInterception( callback ) {
 	};
 }
 
+// TODO: Remove this function and it's usages as part of #6433.
 /**
  * Adds shared request handler for intercepting requests.
  *

--- a/tests/e2e/utils/use-request-interception.js
+++ b/tests/e2e/utils/use-request-interception.js
@@ -37,7 +37,7 @@ export function useRequestInterception( callback ) {
  * @since n.e.x.t
  *
  * @param {Array.<{isMatch: Function, getResponse: Function}>} requestCases An array of request cases to add to the shared request interception.
- * @return {Object} Functions that can be called to remove the added handler function from the page and add new request cases.
+ * @return {Object} Methods that can be called to remove the added handler function from the page and add new request cases.
  */
 export function useSharedRequestInterception( requestCases ) {
 	const cases = [ ...requestCases ];
@@ -61,7 +61,7 @@ export function useSharedRequestInterception( requestCases ) {
 	page.on( 'request', requestHandler );
 
 	return {
-		cleanup: () => page.off( 'request', requestHandler ),
+		cleanUp: () => page.off( 'request', requestHandler ),
 		addRequestCases: ( newCases ) => {
 			cases.push( ...newCases );
 		},

--- a/tests/e2e/utils/use-request-interception.js
+++ b/tests/e2e/utils/use-request-interception.js
@@ -52,7 +52,7 @@ export function useSharedRequestInterception( requestCases ) {
 		} );
 
 		if ( requestCase ) {
-			request.respond( requestCase.getResponse() );
+			request.respond( requestCase.getResponse( request ) );
 		} else {
 			request.continue();
 		}

--- a/tests/e2e/utils/use-request-interception.js
+++ b/tests/e2e/utils/use-request-interception.js
@@ -26,3 +26,44 @@ export function useRequestInterception( callback ) {
 		page.off( 'request', requestHandler );
 	};
 }
+
+/**
+ * Adds shared request handler for intercepting requests.
+ *
+ * Used intercept HTTP requests during tests with a custom handler function.
+ * Returns a function that, when called, stops further request
+ * handling/interception.
+ *
+ * @since n.e.x.t
+ *
+ * @param {Array.<{isMatch: Function, getResponse: Function}>} requestCases An array of request cases to add to the shared request interception.
+ * @return {Object} Functions that can be called to remove the added handler function from the page and add new request cases.
+ */
+export function useSharedRequestInterception( requestCases ) {
+	const cases = [ ...requestCases ];
+	const requestHandler = ( request ) => {
+		// Prevent errors for requests that happen after interception is disabled.
+		if ( ! request._allowInterception ) {
+			return;
+		}
+
+		const requestCase = cases.find( ( { isMatch } ) => {
+			return isMatch( request );
+		} );
+
+		if ( requestCase ) {
+			request.respond( requestCase.getResponse() );
+		} else {
+			request.continue();
+		}
+	};
+
+	page.on( 'request', requestHandler );
+
+	return {
+		cleanup: () => page.off( 'request', requestHandler ),
+		addRequestCases: ( newCases ) => {
+			cases.push( ...newCases );
+		},
+	};
+}


### PR DESCRIPTION
## Summary

Addresses issue:

- #5460 

## Relevant technical choices

Note for the code reviewers: There is a bug in the Puppeteer version we use with the `page.off("request", requestHandler)` clean-up function. Due to that, this PR uses a different approach to speed up the tests that use the `activateAMPWithMode` function. I have created a separate issue to upgrade the Puppeteer to the latest version.

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
