### PR TITLE
Fix tooltip overlapping.

### DIFF
--- a/assets/js/modules/analytics/components/settings/GA4SettingsControls.js
+++ b/assets/js/modules/analytics/components/settings/GA4SettingsControls.js
@@ -201,7 +201,7 @@ export default function GA4SettingsControls( {
 									) }
 									styles={ {
 										options: {
-											zIndex: 10,
+											zIndex: 9999,
 										},
 									} }
 									target=".googlesitekit-analytics-4__select-property"

--- a/assets/sass/components/global/_googlesitekit-header.scss
+++ b/assets/sass/components/global/_googlesitekit-header.scss
@@ -41,7 +41,7 @@
 		right: 0;
 		top: 0;
 		transition: box-shadow $t-default ease-in-out;
-		z-index: 12;
+		z-index: 10000;
 
 		.wp-responsive-open & {
 			margin-left: -18px;


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #5938 

## Relevant technical choices

Changing https://github.com/google/site-kit-wp/pull/6425 implementation to fit the tooltip's z-index between the new header's `z-index: 10000`  and `#adminmenuwrap `'s `z-index: 9990`

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
