### PR TITLE
Follow-up tweaks to Auto Updates change

### DIFF
--- a/assets/js/components/notifications/EnableAutoUpdateBannerNotification.js
+++ b/assets/js/components/notifications/EnableAutoUpdateBannerNotification.js
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import BannerNotification from './BannerNotification';
 
 /**
  * WordPress dependencies
@@ -37,6 +36,7 @@ import {
 import { getItem, setItem } from '../../googlesitekit/api/cache';
 import SpinnerButton from '../SpinnerButton';
 import ErrorNotice from '../ErrorNotice';
+import BannerNotification from './BannerNotification';
 
 const { useSelect, useDispatch } = Data;
 

--- a/assets/js/googlesitekit/datastore/site/info.js
+++ b/assets/js/googlesitekit/datastore/site/info.js
@@ -97,8 +97,8 @@ export const actions = {
 	 */
 	setSiteKitAutoUpdatesEnabled( siteKitAutoUpdatesEnabled ) {
 		invariant(
-			siteKitAutoUpdatesEnabled,
-			'siteKitAutoUpdatesEnabled is required.'
+			typeof siteKitAutoUpdatesEnabled === 'boolean',
+			'siteKitAutoUpdatesEnabled must be a boolean.'
 		);
 
 		return {

--- a/assets/js/googlesitekit/datastore/site/info.test.js
+++ b/assets/js/googlesitekit/datastore/site/info.test.js
@@ -91,6 +91,54 @@ describe( 'core/site site info', () => {
 				} );
 			} );
 		} );
+
+		describe( 'setSiteKitAutoUpdatesEnabled', () => {
+			it( 'requires a boolean argument', () => {
+				expect( () => {
+					registry
+						.dispatch( CORE_SITE )
+						.setSiteKitAutoUpdatesEnabled();
+				} ).toThrow( 'siteKitAutoUpdatesEnabled must be a boolean.' );
+
+				expect( () => {
+					registry
+						.dispatch( CORE_SITE )
+						.setSiteKitAutoUpdatesEnabled( undefined );
+				} ).toThrow( 'siteKitAutoUpdatesEnabled must be a boolean.' );
+
+				expect( () => {
+					registry
+						.dispatch( CORE_SITE )
+						.setSiteKitAutoUpdatesEnabled( 0 );
+				} ).toThrow( 'siteKitAutoUpdatesEnabled must be a boolean.' );
+
+				expect( () => {
+					registry
+						.dispatch( CORE_SITE )
+						.setSiteKitAutoUpdatesEnabled( true );
+
+					registry
+						.dispatch( CORE_SITE )
+						.setSiteKitAutoUpdatesEnabled( false );
+				} ).not.toThrow(
+					'siteKitAutoUpdatesEnabled must be a boolean.'
+				);
+			} );
+
+			it( 'receives and sets site info ', async () => {
+				await registry
+					.dispatch( CORE_SITE )
+					.receiveSiteInfo( { ...baseInfo, ...entityInfo } );
+
+				expect(
+					registry.select( CORE_SITE ).getSiteInfo()
+				).toMatchObject( {
+					...baseInfo,
+					...entityInfo,
+					currentEntityID: 4,
+				} );
+			} );
+		} );
 	} );
 
 	describe( 'selectors', () => {

--- a/assets/js/googlesitekit/datastore/site/info.test.js
+++ b/assets/js/googlesitekit/datastore/site/info.test.js
@@ -93,6 +93,24 @@ describe( 'core/site site info', () => {
 		} );
 
 		describe( 'setSiteKitAutoUpdatesEnabled', () => {
+			it( 'sets the siteKitAutoUpdatesEnabled property', () => {
+				registry
+					.dispatch( CORE_SITE )
+					.setSiteKitAutoUpdatesEnabled( true );
+
+				expect(
+					registry.select( CORE_SITE ).getSiteKitAutoUpdatesEnabled()
+				).toBe( true );
+
+				registry
+					.dispatch( CORE_SITE )
+					.setSiteKitAutoUpdatesEnabled( false );
+
+				expect(
+					registry.select( CORE_SITE ).getSiteKitAutoUpdatesEnabled()
+				).toBe( false );
+			} );
+
 			it( 'requires a boolean argument', () => {
 				expect( () => {
 					registry
@@ -123,20 +141,6 @@ describe( 'core/site site info', () => {
 				} ).not.toThrow(
 					'siteKitAutoUpdatesEnabled must be a boolean.'
 				);
-			} );
-
-			it( 'receives and sets site info ', async () => {
-				await registry
-					.dispatch( CORE_SITE )
-					.receiveSiteInfo( { ...baseInfo, ...entityInfo } );
-
-				expect(
-					registry.select( CORE_SITE ).getSiteInfo()
-				).toMatchObject( {
-					...baseInfo,
-					...entityInfo,
-					currentEntityID: 4,
-				} );
 			} );
 		} );
 	} );

--- a/tests/phpunit/integration/Core/Util/Auto_UpdatesTest.php
+++ b/tests/phpunit/integration/Core/Util/Auto_UpdatesTest.php
@@ -1,9 +1,9 @@
 <?php
 /**
- * Google_URL_Matcher_TraitTest
+ * Auto Updates tests.
  *
  * @package   Google\Site_Kit\Tests\Core\Util
- * @copyright 2021 Google LLC
+ * @copyright 2023 Google LLC
  * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
  * @link      https://sitekit.withgoogle.com
  */

--- a/tests/phpunit/integration/Core/Util/Auto_UpdatesTest.php
+++ b/tests/phpunit/integration/Core/Util/Auto_UpdatesTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Auto Updates tests.
+ * Auto_UpdatesTest.
  *
  * @package   Google\Site_Kit\Tests\Core\Util
  * @copyright 2023 Google LLC
@@ -46,10 +46,10 @@ class Auto_UpdatesTest extends TestCase {
 	}
 
 	/**
-	 * Forced auto updates are available for WP >= 5.6 only, so we test
-	 * for a function only available in WordPress 5.6 or greater.
+	 * Auto updates are available for WP >= 5.5 only, so we test
+	 * for a function only available in WordPress 5.5 or greater.
 	 *
-	 * @requires function wp_is_auto_update_forced_for_item
+	 * @requires function wp_is_auto_update_enabled_for_type
 	 */
 	public function test_sitekit_autoupdates_disabled() {
 		$this->assertFalse( Auto_Updates::is_sitekit_autoupdates_enabled() );
@@ -60,10 +60,10 @@ class Auto_UpdatesTest extends TestCase {
 	}
 
 	/**
-	 * Forced auto updates are available for WP >= 5.6 only, so we test
-	 * for a function only available in WordPress 5.6 or greater.
+	 * Auto updates are available for WP >= 5.5 only, so we test
+	 * for a function only available in WordPress 5.5 or greater.
 	 *
-	 * @requires function wp_is_auto_update_forced_for_item
+	 * @requires function wp_is_auto_update_enabled_for_type
 	 */
 	public function test_sitekit_autoupdates_enabled() {
 		update_site_option( 'auto_update_plugins', array( 'other-plugin.php', GOOGLESITEKIT_PLUGIN_BASENAME ) );

--- a/tests/phpunit/integration/Core/Util/Auto_UpdatesTest.php
+++ b/tests/phpunit/integration/Core/Util/Auto_UpdatesTest.php
@@ -17,12 +17,13 @@ use Google\Site_Kit\Tests\TestCase;
  * @group Util
  */
 class Auto_UpdatesTest extends TestCase {
+	/**
+	 * Forced auto updates are available for WP >= 5.6 only, so we test
+	 * for a function only available in WordPress 5.6 or greater.
+	 *
+	 * @requires function wp_is_auto_update_forced_for_item
+	 */
 	public function test_sitekit_autoupdate_forced() {
-		// Forced auto updates are available for WP >= 5.6 only.
-		if ( version_compare( get_bloginfo( 'version' ), '5.6', '<' ) ) {
-			return;
-		}
-
 		// By default, auto updates are not forced to either be enabled
 		// or disabled.
 		$this->assertSame( Auto_Updates::AUTO_UPDATE_NOT_FORCED, Auto_Updates::sitekit_forced_autoupdates_status() );
@@ -44,12 +45,13 @@ class Auto_UpdatesTest extends TestCase {
 		remove_filter( 'auto_update_plugin', '__return_false' );
 	}
 
+	/**
+	 * Forced auto updates are available for WP >= 5.6 only, so we test
+	 * for a function only available in WordPress 5.6 or greater.
+	 *
+	 * @requires function wp_is_auto_update_forced_for_item
+	 */
 	public function test_sitekit_autoupdates_disabled() {
-		// Forced auto updates are available for WP >= 5.6 only.
-		if ( ! self::auto_updates_available() ) {
-			return;
-		}
-
 		$this->assertFalse( Auto_Updates::is_sitekit_autoupdates_enabled() );
 
 		update_site_option( 'auto_update_plugins', array( 'other-plugin.php' ) );
@@ -57,22 +59,16 @@ class Auto_UpdatesTest extends TestCase {
 		$this->assertFalse( Auto_Updates::is_sitekit_autoupdates_enabled() );
 	}
 
+	/**
+	 * Forced auto updates are available for WP >= 5.6 only, so we test
+	 * for a function only available in WordPress 5.6 or greater.
+	 *
+	 * @requires function wp_is_auto_update_forced_for_item
+	 */
 	public function test_sitekit_autoupdates_enabled() {
-		// Forced auto updates are available for WP >= 5.6 only.
-		if ( ! self::auto_updates_available() ) {
-			return;
-		}
-
 		update_site_option( 'auto_update_plugins', array( 'other-plugin.php', GOOGLESITEKIT_PLUGIN_BASENAME ) );
 
 		$this->assertTrue( Auto_Updates::is_sitekit_autoupdates_enabled() );
-	}
-
-	/**
-	 * Verify if auto-updates are available for the current WordPress version.
-	 */
-	private function auto_updates_available() {
-		return version_compare( get_bloginfo( 'version' ), '5.5', '>=' );
 	}
 }
 


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #5853.

## Relevant technical choices

Added unit tests for the action that previously would have errored if we called it with a (valid) `false` param.

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
