### PR TITLE
Wrap the GET:report datapoint definition in the ga4Reporting feature flag.

### DIFF
--- a/includes/Modules/Analytics_4.php
+++ b/includes/Modules/Analytics_4.php
@@ -212,7 +212,7 @@ final class Analytics_4 extends Module
 	 * @return array Map of datapoints to their definitions.
 	 */
 	protected function get_datapoint_definitions() {
-		return array(
+		$datapoints = array(
 			'GET:account-summaries'      => array( 'service' => 'analyticsadmin' ),
 			'GET:accounts'               => array( 'service' => 'analyticsadmin' ),
 			'GET:container-lookup'       => array( 'service' => 'tagmanager' ),
@@ -229,14 +229,19 @@ final class Analytics_4 extends Module
 			),
 			'GET:properties'             => array( 'service' => 'analyticsadmin' ),
 			'GET:property'               => array( 'service' => 'analyticsadmin' ),
-			'GET:report'                 => array(
-				'service'   => 'analyticsdata',
-				'shareable' => Feature_Flags::enabled( 'dashboardSharing' ),
-			),
 			'GET:webdatastreams'         => array( 'service' => 'analyticsadmin' ),
 			'GET:webdatastreams-batch'   => array( 'service' => 'analyticsadmin' ),
 			'GET:conversion-events'      => array( 'service' => 'analyticsadmin' ),
 		);
+
+		if ( Feature_Flags::enabled( 'ga4Reporting' ) ) {
+			$datapoints['GET:report'] = array(
+				'service'   => 'analyticsdata',
+				'shareable' => Feature_Flags::enabled( 'dashboardSharing' ),
+			);
+		}
+
+		return $datapoints;
 	}
 
 	/**

--- a/tests/phpunit/integration/Modules/Analytics_4Test.php
+++ b/tests/phpunit/integration/Modules/Analytics_4Test.php
@@ -97,6 +97,8 @@ class Analytics_4Test extends TestCase {
 	public function set_up() {
 		parent::set_up();
 
+		$this->enable_feature( 'ga4Reporting' );
+
 		$this->context        = new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE );
 		$options              = new Options( $this->context );
 		$this->user           = $this->factory()->user->create_and_get( array( 'role' => 'administrator' ) );


### PR DESCRIPTION

## Summary

This is to prevent the Analytics 4 module showing up in Dashboard Sharing Settings when the feature flag is not enabled, as a result of the shareable flag being set on the datapoint. This can be addressed in a followup issue.

![image (3)](https://user-images.githubusercontent.com/18395600/214036368-718876c5-f88b-4ab5-ac33-98575ec882be.png)


<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #6172 

## Relevant technical choices

<!-- Please describe your changes. -->

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [ ] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
