### PR TITLE
Infrastructure/#5460 - Ignore React hook rules for E2E test files (follow-up)

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -119,7 +119,8 @@
       "rules": {
         "no-restricted-globals": [
           "off"
-        ]
+        ],
+        "react-hooks/rules-of-hooks": "off"
       }
     },
     {
@@ -144,14 +145,6 @@
         "filenames/match-exported": [
           "off"
         ]
-      }
-    },
-    {
-      "files": [
-        "tests/e2e/**/*.js"
-      ],
-      "rules": {
-          "react-hooks/rules-of-hooks": "off"
       }
     }
   ],

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -145,6 +145,14 @@
           "off"
         ]
       }
+    },
+    {
+      "files": [
+        "tests/e2e/**/*.js"
+      ],
+      "rules": {
+          "react-hooks/rules-of-hooks": "off"
+      }
     }
   ],
   "plugins": [

--- a/tests/e2e/utils/activate-amp-and-set-mode.js
+++ b/tests/e2e/utils/activate-amp-and-set-mode.js
@@ -65,7 +65,7 @@ export const activateAMPWithMode = async (
 			},
 		] );
 	} else {
-		// eslint-disable-next-line react-hooks/rules-of-hooks
+		// If no sharedRequestInterception is passed, we need to create a new request interception.
 		useRequestInterception( ( request ) => {
 			if ( request.url().match( '&amp_validate' ) ) {
 				request.respond( {

--- a/tests/e2e/utils/activate-amp-and-set-mode.js
+++ b/tests/e2e/utils/activate-amp-and-set-mode.js
@@ -43,6 +43,7 @@ export const allowedAMPModes = {
  * Activates AMP and set it to the correct mode.
  *
  * @since 1.10.0
+ * @since n.e.x.t Added request interception for AMP validation requests.
  *
  * @param {string}   mode                                      The mode to set AMP to. Possible value of standard, transitional or reader.
  * @param {Object}   sharedRequestInterception                 Object of methods that can be called to remove the added handler function from the page and add new request cases.
@@ -54,6 +55,10 @@ export const activateAMPWithMode = async (
 	mode,
 	sharedRequestInterception
 ) => {
+	// On newer versions of AMP, setting up AMP invokes a number of validation requests which add a large
+	// amount of time to the process and are ultimately unnecessary.
+	// To avoid this, we configure request interception for these to bypass them as needed.
+	// See https://github.com/google/site-kit-wp/issues/5460#issuecomment-1335180571
 	if ( sharedRequestInterception ) {
 		sharedRequestInterception.addRequestCases( [
 			{


### PR DESCRIPTION
## Summary

Addresses issue:

- #5460 

## Relevant technical choices

- Adds an ESLint rule to ignore the React hooks rules for E2E test files.

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
