### PR TITLE
De-initialise existing Google Charts global on Site Kit screens.

### DIFF
--- a/assets/js/components/GoogleChart/index.js
+++ b/assets/js/components/GoogleChart/index.js
@@ -134,6 +134,16 @@ export default function GoogleChart( props ) {
 			return;
 		}
 
+		// If we're on a Site Kit screen, we want "priority" over the
+		// `google.charts` global so we don't render a bunch of charts errors,
+		// see: https://github.com/google/site-kit-wp/issues/6439#issuecomment-1404491940
+		//
+		// The only way to do this is to remove the `google.charts` global
+		// and allow the `react-google-charts` library to re-initialize it.
+		if ( isSiteKitScreen( viewContext ) && global?.google?.charts ) {
+			global.google.charts = undefined;
+		}
+
 		if ( ! isSiteKitScreen( viewContext ) && global?.google?.charts ) {
 			setValue( 'googleChartsCollisionError', true );
 		} else {


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #6439

## Relevant technical choices

It looks like some plugins are actually initialising Google Charts library indiscriminately, even when they aren't using it, causing the errors mentioned in https://github.com/google/site-kit-wp/issues/6439#issuecomment-1404491940.

The best option here, and probably for future bugs like this, is to re-initialise the Google Charts library ourselves when we first load a chart on a Site Kit-only screen like the Dashboard. It's brute-force but in my testing seems good.

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
