### PR TITLE
Fix date range handling in getAnalytics4MockResponse.

### DIFF
--- a/assets/js/modules/analytics-4/utils/__fixtures__/mocked-report-fixed-value-dimension.json
+++ b/assets/js/modules/analytics-4/utils/__fixtures__/mocked-report-fixed-value-dimension.json
@@ -7,7 +7,7 @@
 		{ "name": "totalUsers", "type": "TYPE_INTEGER" },
 		{ "name": "averageSessionDuration", "type": "TYPE_SECONDS" }
 	],
-	"rowCount": 10,
+	"rowCount": 20,
 	"rows": [
 		{
 			"dimensionValues": [
@@ -78,6 +78,76 @@
 				{ "value": "date_range_1" }
 			],
 			"metricValues": [ { "value": "21" }, { "value": "45" } ]
+		},
+		{
+			"dimensionValues": [
+				{ "value": "Affiliates" },
+				{ "value": "date_range_0" }
+			],
+			"metricValues": [ { "value": "66" }, { "value": "48" } ]
+		},
+		{
+			"dimensionValues": [
+				{ "value": "Affiliates" },
+				{ "value": "date_range_1" }
+			],
+			"metricValues": [ { "value": "16" }, { "value": "13" } ]
+		},
+		{
+			"dimensionValues": [
+				{ "value": "Referral" },
+				{ "value": "date_range_0" }
+			],
+			"metricValues": [ { "value": "45" }, { "value": "20" } ]
+		},
+		{
+			"dimensionValues": [
+				{ "value": "Referral" },
+				{ "value": "date_range_1" }
+			],
+			"metricValues": [ { "value": "23" }, { "value": "55" } ]
+		},
+		{
+			"dimensionValues": [
+				{ "value": "Paid Search" },
+				{ "value": "date_range_0" }
+			],
+			"metricValues": [ { "value": "38" }, { "value": "40" } ]
+		},
+		{
+			"dimensionValues": [
+				{ "value": "Paid Search" },
+				{ "value": "date_range_1" }
+			],
+			"metricValues": [ { "value": "19" }, { "value": "45" } ]
+		},
+		{
+			"dimensionValues": [
+				{ "value": "Video" },
+				{ "value": "date_range_0" }
+			],
+			"metricValues": [ { "value": "74" }, { "value": "28" } ]
+		},
+		{
+			"dimensionValues": [
+				{ "value": "Video" },
+				{ "value": "date_range_1" }
+			],
+			"metricValues": [ { "value": "53" }, { "value": "7" } ]
+		},
+		{
+			"dimensionValues": [
+				{ "value": "Display" },
+				{ "value": "date_range_0" }
+			],
+			"metricValues": [ { "value": "83" }, { "value": "8" } ]
+		},
+		{
+			"dimensionValues": [
+				{ "value": "Display" },
+				{ "value": "date_range_1" }
+			],
+			"metricValues": [ { "value": "72" }, { "value": "34" } ]
 		}
 	],
 	"totals": [
@@ -86,14 +156,14 @@
 				{ "value": "RESERVED_TOTAL" },
 				{ "value": "date_range_0" }
 			],
-			"metricValues": [ { "value": "38" }, { "value": "43" } ]
+			"metricValues": [ { "value": "83" }, { "value": "8" } ]
 		},
 		{
 			"dimensionValues": [
 				{ "value": "RESERVED_TOTAL" },
 				{ "value": "date_range_1" }
 			],
-			"metricValues": [ { "value": "21" }, { "value": "45" } ]
+			"metricValues": [ { "value": "72" }, { "value": "34" } ]
 		}
 	],
 	"minimums": [
@@ -118,14 +188,14 @@
 				{ "value": "RESERVED_MAX" },
 				{ "value": "date_range_0" }
 			],
-			"metricValues": [ { "value": "38" }, { "value": "43" } ]
+			"metricValues": [ { "value": "83" }, { "value": "8" } ]
 		},
 		{
 			"dimensionValues": [
 				{ "value": "RESERVED_MAX" },
 				{ "value": "date_range_1" }
 			],
-			"metricValues": [ { "value": "21" }, { "value": "45" } ]
+			"metricValues": [ { "value": "72" }, { "value": "34" } ]
 		}
 	],
 	"metadata": { "currencyCode": "USD", "timeZone": "America/Los_Angeles" },

--- a/assets/js/modules/analytics-4/utils/__fixtures__/mocked-report-fixed-value-dimension.json
+++ b/assets/js/modules/analytics-4/utils/__fixtures__/mocked-report-fixed-value-dimension.json
@@ -1,5 +1,8 @@
 {
-	"dimensionHeaders": [ { "name": "date" }, { "name": "dateRange" } ],
+	"dimensionHeaders": [
+		{ "name": "sessionDefaultChannelGrouping" },
+		{ "name": "dateRange" }
+	],
 	"metricHeaders": [
 		{ "name": "totalUsers", "type": "TYPE_INTEGER" },
 		{ "name": "averageSessionDuration", "type": "TYPE_SECONDS" }
@@ -8,70 +11,70 @@
 	"rows": [
 		{
 			"dimensionValues": [
-				{ "value": "20201201" },
+				{ "value": "Direct" },
 				{ "value": "date_range_0" }
 			],
 			"metricValues": [ { "value": "55" }, { "value": "8" } ]
 		},
 		{
 			"dimensionValues": [
-				{ "value": "20201201" },
+				{ "value": "Direct" },
 				{ "value": "date_range_1" }
 			],
 			"metricValues": [ { "value": "3" }, { "value": "8" } ]
 		},
 		{
 			"dimensionValues": [
-				{ "value": "20201202" },
+				{ "value": "Organic Search" },
 				{ "value": "date_range_0" }
 			],
 			"metricValues": [ { "value": "17" }, { "value": "23" } ]
 		},
 		{
 			"dimensionValues": [
-				{ "value": "20201202" },
+				{ "value": "Organic Search" },
 				{ "value": "date_range_1" }
 			],
 			"metricValues": [ { "value": "10" }, { "value": "44" } ]
 		},
 		{
 			"dimensionValues": [
-				{ "value": "20201203" },
+				{ "value": "Paid Social" },
 				{ "value": "date_range_0" }
 			],
 			"metricValues": [ { "value": "89" }, { "value": "37" } ]
 		},
 		{
 			"dimensionValues": [
-				{ "value": "20201203" },
+				{ "value": "Paid Social" },
 				{ "value": "date_range_1" }
 			],
 			"metricValues": [ { "value": "98" }, { "value": "4" } ]
 		},
 		{
 			"dimensionValues": [
-				{ "value": "20201204" },
+				{ "value": "Organic Social" },
 				{ "value": "date_range_0" }
 			],
 			"metricValues": [ { "value": "27" }, { "value": "55" } ]
 		},
 		{
 			"dimensionValues": [
-				{ "value": "20201204" },
+				{ "value": "Organic Social" },
 				{ "value": "date_range_1" }
 			],
 			"metricValues": [ { "value": "86" }, { "value": "32" } ]
 		},
 		{
 			"dimensionValues": [
-				{ "value": "20201205" },
+				{ "value": "Email" },
 				{ "value": "date_range_0" }
 			],
 			"metricValues": [ { "value": "38" }, { "value": "43" } ]
 		},
 		{
 			"dimensionValues": [
-				{ "value": "20201205" },
+				{ "value": "Email" },
 				{ "value": "date_range_1" }
 			],
 			"metricValues": [ { "value": "21" }, { "value": "45" } ]

--- a/assets/js/modules/analytics-4/utils/__fixtures__/mocked-report-multiple-dimensions.json
+++ b/assets/js/modules/analytics-4/utils/__fixtures__/mocked-report-multiple-dimensions.json
@@ -1,0 +1,550 @@
+{
+	"dimensionHeaders": [
+		{ "name": "deviceCategory" },
+		{ "name": "sessionDefaultChannelGrouping" },
+		{ "name": "dateRange" }
+	],
+	"metricHeaders": [
+		{ "name": "totalUsers", "type": "TYPE_INTEGER" },
+		{ "name": "averageSessionDuration", "type": "TYPE_SECONDS" }
+	],
+	"rowCount": 60,
+	"rows": [
+		{
+			"dimensionValues": [
+				{ "value": "Desktop" },
+				{ "value": "Direct" },
+				{ "value": "date_range_0" }
+			],
+			"metricValues": [ { "value": "55" }, { "value": "8" } ]
+		},
+		{
+			"dimensionValues": [
+				{ "value": "Desktop" },
+				{ "value": "Direct" },
+				{ "value": "date_range_1" }
+			],
+			"metricValues": [ { "value": "3" }, { "value": "8" } ]
+		},
+		{
+			"dimensionValues": [
+				{ "value": "Desktop" },
+				{ "value": "Organic Search" },
+				{ "value": "date_range_0" }
+			],
+			"metricValues": [ { "value": "17" }, { "value": "23" } ]
+		},
+		{
+			"dimensionValues": [
+				{ "value": "Desktop" },
+				{ "value": "Organic Search" },
+				{ "value": "date_range_1" }
+			],
+			"metricValues": [ { "value": "10" }, { "value": "44" } ]
+		},
+		{
+			"dimensionValues": [
+				{ "value": "Desktop" },
+				{ "value": "Paid Social" },
+				{ "value": "date_range_0" }
+			],
+			"metricValues": [ { "value": "89" }, { "value": "37" } ]
+		},
+		{
+			"dimensionValues": [
+				{ "value": "Desktop" },
+				{ "value": "Paid Social" },
+				{ "value": "date_range_1" }
+			],
+			"metricValues": [ { "value": "98" }, { "value": "4" } ]
+		},
+		{
+			"dimensionValues": [
+				{ "value": "Desktop" },
+				{ "value": "Organic Social" },
+				{ "value": "date_range_0" }
+			],
+			"metricValues": [ { "value": "27" }, { "value": "55" } ]
+		},
+		{
+			"dimensionValues": [
+				{ "value": "Desktop" },
+				{ "value": "Organic Social" },
+				{ "value": "date_range_1" }
+			],
+			"metricValues": [ { "value": "86" }, { "value": "32" } ]
+		},
+		{
+			"dimensionValues": [
+				{ "value": "Desktop" },
+				{ "value": "Email" },
+				{ "value": "date_range_0" }
+			],
+			"metricValues": [ { "value": "38" }, { "value": "43" } ]
+		},
+		{
+			"dimensionValues": [
+				{ "value": "Desktop" },
+				{ "value": "Email" },
+				{ "value": "date_range_1" }
+			],
+			"metricValues": [ { "value": "21" }, { "value": "45" } ]
+		},
+		{
+			"dimensionValues": [
+				{ "value": "Desktop" },
+				{ "value": "Affiliates" },
+				{ "value": "date_range_0" }
+			],
+			"metricValues": [ { "value": "66" }, { "value": "48" } ]
+		},
+		{
+			"dimensionValues": [
+				{ "value": "Desktop" },
+				{ "value": "Affiliates" },
+				{ "value": "date_range_1" }
+			],
+			"metricValues": [ { "value": "16" }, { "value": "13" } ]
+		},
+		{
+			"dimensionValues": [
+				{ "value": "Desktop" },
+				{ "value": "Referral" },
+				{ "value": "date_range_0" }
+			],
+			"metricValues": [ { "value": "45" }, { "value": "20" } ]
+		},
+		{
+			"dimensionValues": [
+				{ "value": "Desktop" },
+				{ "value": "Referral" },
+				{ "value": "date_range_1" }
+			],
+			"metricValues": [ { "value": "23" }, { "value": "55" } ]
+		},
+		{
+			"dimensionValues": [
+				{ "value": "Desktop" },
+				{ "value": "Paid Search" },
+				{ "value": "date_range_0" }
+			],
+			"metricValues": [ { "value": "38" }, { "value": "40" } ]
+		},
+		{
+			"dimensionValues": [
+				{ "value": "Desktop" },
+				{ "value": "Paid Search" },
+				{ "value": "date_range_1" }
+			],
+			"metricValues": [ { "value": "19" }, { "value": "45" } ]
+		},
+		{
+			"dimensionValues": [
+				{ "value": "Desktop" },
+				{ "value": "Video" },
+				{ "value": "date_range_0" }
+			],
+			"metricValues": [ { "value": "74" }, { "value": "28" } ]
+		},
+		{
+			"dimensionValues": [
+				{ "value": "Desktop" },
+				{ "value": "Video" },
+				{ "value": "date_range_1" }
+			],
+			"metricValues": [ { "value": "53" }, { "value": "7" } ]
+		},
+		{
+			"dimensionValues": [
+				{ "value": "Desktop" },
+				{ "value": "Display" },
+				{ "value": "date_range_0" }
+			],
+			"metricValues": [ { "value": "83" }, { "value": "8" } ]
+		},
+		{
+			"dimensionValues": [
+				{ "value": "Desktop" },
+				{ "value": "Display" },
+				{ "value": "date_range_1" }
+			],
+			"metricValues": [ { "value": "72" }, { "value": "34" } ]
+		},
+		{
+			"dimensionValues": [
+				{ "value": "Tablet" },
+				{ "value": "Direct" },
+				{ "value": "date_range_0" }
+			],
+			"metricValues": [ { "value": "79" }, { "value": "33" } ]
+		},
+		{
+			"dimensionValues": [
+				{ "value": "Tablet" },
+				{ "value": "Direct" },
+				{ "value": "date_range_1" }
+			],
+			"metricValues": [ { "value": "93" }, { "value": "36" } ]
+		},
+		{
+			"dimensionValues": [
+				{ "value": "Tablet" },
+				{ "value": "Organic Search" },
+				{ "value": "date_range_0" }
+			],
+			"metricValues": [ { "value": "95" }, { "value": "54" } ]
+		},
+		{
+			"dimensionValues": [
+				{ "value": "Tablet" },
+				{ "value": "Organic Search" },
+				{ "value": "date_range_1" }
+			],
+			"metricValues": [ { "value": "53" }, { "value": "35" } ]
+		},
+		{
+			"dimensionValues": [
+				{ "value": "Tablet" },
+				{ "value": "Paid Social" },
+				{ "value": "date_range_0" }
+			],
+			"metricValues": [ { "value": "56" }, { "value": "42" } ]
+		},
+		{
+			"dimensionValues": [
+				{ "value": "Tablet" },
+				{ "value": "Paid Social" },
+				{ "value": "date_range_1" }
+			],
+			"metricValues": [ { "value": "49" }, { "value": "49" } ]
+		},
+		{
+			"dimensionValues": [
+				{ "value": "Tablet" },
+				{ "value": "Organic Social" },
+				{ "value": "date_range_0" }
+			],
+			"metricValues": [ { "value": "80" }, { "value": "3" } ]
+		},
+		{
+			"dimensionValues": [
+				{ "value": "Tablet" },
+				{ "value": "Organic Social" },
+				{ "value": "date_range_1" }
+			],
+			"metricValues": [ { "value": "64" }, { "value": "33" } ]
+		},
+		{
+			"dimensionValues": [
+				{ "value": "Tablet" },
+				{ "value": "Email" },
+				{ "value": "date_range_0" }
+			],
+			"metricValues": [ { "value": "2" }, { "value": "21" } ]
+		},
+		{
+			"dimensionValues": [
+				{ "value": "Tablet" },
+				{ "value": "Email" },
+				{ "value": "date_range_1" }
+			],
+			"metricValues": [ { "value": "23" }, { "value": "1" } ]
+		},
+		{
+			"dimensionValues": [
+				{ "value": "Tablet" },
+				{ "value": "Affiliates" },
+				{ "value": "date_range_0" }
+			],
+			"metricValues": [ { "value": "59" }, { "value": "58" } ]
+		},
+		{
+			"dimensionValues": [
+				{ "value": "Tablet" },
+				{ "value": "Affiliates" },
+				{ "value": "date_range_1" }
+			],
+			"metricValues": [ { "value": "22" }, { "value": "40" } ]
+		},
+		{
+			"dimensionValues": [
+				{ "value": "Tablet" },
+				{ "value": "Referral" },
+				{ "value": "date_range_0" }
+			],
+			"metricValues": [ { "value": "4" }, { "value": "13" } ]
+		},
+		{
+			"dimensionValues": [
+				{ "value": "Tablet" },
+				{ "value": "Referral" },
+				{ "value": "date_range_1" }
+			],
+			"metricValues": [ { "value": "46" }, { "value": "41" } ]
+		},
+		{
+			"dimensionValues": [
+				{ "value": "Tablet" },
+				{ "value": "Paid Search" },
+				{ "value": "date_range_0" }
+			],
+			"metricValues": [ { "value": "40" }, { "value": "58" } ]
+		},
+		{
+			"dimensionValues": [
+				{ "value": "Tablet" },
+				{ "value": "Paid Search" },
+				{ "value": "date_range_1" }
+			],
+			"metricValues": [ { "value": "96" }, { "value": "43" } ]
+		},
+		{
+			"dimensionValues": [
+				{ "value": "Tablet" },
+				{ "value": "Video" },
+				{ "value": "date_range_0" }
+			],
+			"metricValues": [ { "value": "84" }, { "value": "24" } ]
+		},
+		{
+			"dimensionValues": [
+				{ "value": "Tablet" },
+				{ "value": "Video" },
+				{ "value": "date_range_1" }
+			],
+			"metricValues": [ { "value": "83" }, { "value": "31" } ]
+		},
+		{
+			"dimensionValues": [
+				{ "value": "Tablet" },
+				{ "value": "Display" },
+				{ "value": "date_range_0" }
+			],
+			"metricValues": [ { "value": "9" }, { "value": "7" } ]
+		},
+		{
+			"dimensionValues": [
+				{ "value": "Tablet" },
+				{ "value": "Display" },
+				{ "value": "date_range_1" }
+			],
+			"metricValues": [ { "value": "85" }, { "value": "35" } ]
+		},
+		{
+			"dimensionValues": [
+				{ "value": "Mobile" },
+				{ "value": "Direct" },
+				{ "value": "date_range_0" }
+			],
+			"metricValues": [ { "value": "67" }, { "value": "60" } ]
+		},
+		{
+			"dimensionValues": [
+				{ "value": "Mobile" },
+				{ "value": "Direct" },
+				{ "value": "date_range_1" }
+			],
+			"metricValues": [ { "value": "9" }, { "value": "50" } ]
+		},
+		{
+			"dimensionValues": [
+				{ "value": "Mobile" },
+				{ "value": "Organic Search" },
+				{ "value": "date_range_0" }
+			],
+			"metricValues": [ { "value": "28" }, { "value": "49" } ]
+		},
+		{
+			"dimensionValues": [
+				{ "value": "Mobile" },
+				{ "value": "Organic Search" },
+				{ "value": "date_range_1" }
+			],
+			"metricValues": [ { "value": "50" }, { "value": "51" } ]
+		},
+		{
+			"dimensionValues": [
+				{ "value": "Mobile" },
+				{ "value": "Paid Social" },
+				{ "value": "date_range_0" }
+			],
+			"metricValues": [ { "value": "74" }, { "value": "15" } ]
+		},
+		{
+			"dimensionValues": [
+				{ "value": "Mobile" },
+				{ "value": "Paid Social" },
+				{ "value": "date_range_1" }
+			],
+			"metricValues": [ { "value": "86" }, { "value": "17" } ]
+		},
+		{
+			"dimensionValues": [
+				{ "value": "Mobile" },
+				{ "value": "Organic Social" },
+				{ "value": "date_range_0" }
+			],
+			"metricValues": [ { "value": "3" }, { "value": "45" } ]
+		},
+		{
+			"dimensionValues": [
+				{ "value": "Mobile" },
+				{ "value": "Organic Social" },
+				{ "value": "date_range_1" }
+			],
+			"metricValues": [ { "value": "89" }, { "value": "48" } ]
+		},
+		{
+			"dimensionValues": [
+				{ "value": "Mobile" },
+				{ "value": "Email" },
+				{ "value": "date_range_0" }
+			],
+			"metricValues": [ { "value": "53" }, { "value": "28" } ]
+		},
+		{
+			"dimensionValues": [
+				{ "value": "Mobile" },
+				{ "value": "Email" },
+				{ "value": "date_range_1" }
+			],
+			"metricValues": [ { "value": "77" }, { "value": "18" } ]
+		},
+		{
+			"dimensionValues": [
+				{ "value": "Mobile" },
+				{ "value": "Affiliates" },
+				{ "value": "date_range_0" }
+			],
+			"metricValues": [ { "value": "72" }, { "value": "1" } ]
+		},
+		{
+			"dimensionValues": [
+				{ "value": "Mobile" },
+				{ "value": "Affiliates" },
+				{ "value": "date_range_1" }
+			],
+			"metricValues": [ { "value": "88" }, { "value": "5" } ]
+		},
+		{
+			"dimensionValues": [
+				{ "value": "Mobile" },
+				{ "value": "Referral" },
+				{ "value": "date_range_0" }
+			],
+			"metricValues": [ { "value": "62" }, { "value": "0" } ]
+		},
+		{
+			"dimensionValues": [
+				{ "value": "Mobile" },
+				{ "value": "Referral" },
+				{ "value": "date_range_1" }
+			],
+			"metricValues": [ { "value": "48" }, { "value": "29" } ]
+		},
+		{
+			"dimensionValues": [
+				{ "value": "Mobile" },
+				{ "value": "Paid Search" },
+				{ "value": "date_range_0" }
+			],
+			"metricValues": [ { "value": "24" }, { "value": "31" } ]
+		},
+		{
+			"dimensionValues": [
+				{ "value": "Mobile" },
+				{ "value": "Paid Search" },
+				{ "value": "date_range_1" }
+			],
+			"metricValues": [ { "value": "94" }, { "value": "48" } ]
+		},
+		{
+			"dimensionValues": [
+				{ "value": "Mobile" },
+				{ "value": "Video" },
+				{ "value": "date_range_0" }
+			],
+			"metricValues": [ { "value": "71" }, { "value": "21" } ]
+		},
+		{
+			"dimensionValues": [
+				{ "value": "Mobile" },
+				{ "value": "Video" },
+				{ "value": "date_range_1" }
+			],
+			"metricValues": [ { "value": "72" }, { "value": "34" } ]
+		},
+		{
+			"dimensionValues": [
+				{ "value": "Mobile" },
+				{ "value": "Display" },
+				{ "value": "date_range_0" }
+			],
+			"metricValues": [ { "value": "32" }, { "value": "18" } ]
+		},
+		{
+			"dimensionValues": [
+				{ "value": "Mobile" },
+				{ "value": "Display" },
+				{ "value": "date_range_1" }
+			],
+			"metricValues": [ { "value": "32" }, { "value": "8" } ]
+		}
+	],
+	"totals": [
+		{
+			"dimensionValues": [
+				{ "value": "RESERVED_TOTAL" },
+				{ "value": "RESERVED_TOTAL" },
+				{ "value": "date_range_0" }
+			],
+			"metricValues": [ { "value": "32" }, { "value": "18" } ]
+		},
+		{
+			"dimensionValues": [
+				{ "value": "RESERVED_TOTAL" },
+				{ "value": "RESERVED_TOTAL" },
+				{ "value": "date_range_1" }
+			],
+			"metricValues": [ { "value": "32" }, { "value": "8" } ]
+		}
+	],
+	"minimums": [
+		{
+			"dimensionValues": [
+				{ "value": "RESERVED_MIN" },
+				{ "value": "RESERVED_MIN" },
+				{ "value": "date_range_0" }
+			],
+			"metricValues": [ { "value": "55" }, { "value": "8" } ]
+		},
+		{
+			"dimensionValues": [
+				{ "value": "RESERVED_MIN" },
+				{ "value": "RESERVED_MIN" },
+				{ "value": "date_range_1" }
+			],
+			"metricValues": [ { "value": "3" }, { "value": "8" } ]
+		}
+	],
+	"maximums": [
+		{
+			"dimensionValues": [
+				{ "value": "RESERVED_MAX" },
+				{ "value": "RESERVED_MAX" },
+				{ "value": "date_range_0" }
+			],
+			"metricValues": [ { "value": "32" }, { "value": "18" } ]
+		},
+		{
+			"dimensionValues": [
+				{ "value": "RESERVED_MAX" },
+				{ "value": "RESERVED_MAX" },
+				{ "value": "date_range_1" }
+			],
+			"metricValues": [ { "value": "32" }, { "value": "8" } ]
+		}
+	],
+	"metadata": { "currencyCode": "USD", "timeZone": "America/Los_Angeles" },
+	"kind": "analyticsData#runReport"
+}

--- a/assets/js/modules/analytics-4/utils/data-mock.js
+++ b/assets/js/modules/analytics-4/utils/data-mock.js
@@ -416,7 +416,7 @@ export function getAnalytics4MockResponse( options ) {
 	// First we merge all streams into one which will emit each set of dimension values as an array.
 	merge( ...streams.map( ( stream ) => stream.pipe( toArray() ) ) )
 		.pipe(
-			// Then we convert the stream to an array...
+			// Then we convert the resulting stream to an array...
 			toArray(),
 			// So that we can pass it to the cartesianProduct function to generate all possible combinations of dimension values.
 			// Using mergeMap here ensures the resulting set of values will be emitted as a new stream.

--- a/assets/js/modules/analytics-4/utils/data-mock.js
+++ b/assets/js/modules/analytics-4/utils/data-mock.js
@@ -413,14 +413,17 @@ export function getAnalytics4MockResponse( options ) {
 	];
 
 	// Process the streams of dimension values and add generated rows to the report data object.
+	// First we merge all streams into one which will emit each set of dimension values as an array.
 	merge( ...streams.map( ( stream ) => stream.pipe( toArray() ) ) )
 		.pipe(
+			// Then we convert the stream to an array...
 			toArray(),
-			mergeMap( ( dimensionArrays ) =>
-				cartesianProduct( dimensionArrays )
-			)
+			// So that we can pass it to the cartesianProduct function to generate all possible combinations of dimension values.
+			// Using mergeMap here ensures the resulting set of values will be emitted as a new stream.
+			mergeMap( cartesianProduct ),
+			// Then we apply the remaining operations to generate a row for each combination of dimension values.
+			...ops
 		)
-		.pipe( ...ops )
 		.subscribe( ( rows ) => {
 			data.rows = rows;
 			data.rowCount = rows.length;

--- a/assets/js/modules/analytics-4/utils/data-mock.js
+++ b/assets/js/modules/analytics-4/utils/data-mock.js
@@ -350,25 +350,11 @@ export function getAnalytics4MockResponse( options ) {
 
 			// Generates a stream (an array) of dates when the dimension is date.
 			if ( dimension === 'date' ) {
-				streams.push(
-					new Observable( ( observer ) => {
-						dateRange.forEach( ( date ) => {
-							observer.next( date );
-						} );
-
-						observer.complete();
-					} )
-				);
+				streams.push( from( dateRange ) );
 			}
 
 			if ( dimension === 'dateRange' ) {
-				streams.push(
-					new Observable( ( observer ) => {
-						observer.next( 'date_range_0' );
-						observer.next( 'date_range_1' );
-						observer.complete();
-					} )
-				);
+				streams.push( from( [ 'date_range_0', 'date_range_1' ] ) );
 			}
 		} else if (
 			dimension &&
@@ -430,16 +416,9 @@ export function getAnalytics4MockResponse( options ) {
 	merge( ...streams.map( ( stream ) => stream.pipe( toArray() ) ) )
 		.pipe(
 			toArray(),
-			mergeMap( ( dimensionArrays ) => {
-				return new Observable( ( observer ) => {
-					cartesianProduct( dimensionArrays ).forEach(
-						( dimensionCombination ) => {
-							observer.next( dimensionCombination );
-						}
-					);
-					observer.complete();
-				} );
-			} )
+			mergeMap( ( dimensionArrays ) =>
+				cartesianProduct( dimensionArrays )
+			)
 		)
 		.pipe( ...ops )
 		.subscribe( ( rows ) => {

--- a/assets/js/modules/analytics-4/utils/data-mock.js
+++ b/assets/js/modules/analytics-4/utils/data-mock.js
@@ -395,18 +395,8 @@ export function getAnalytics4MockResponse( options ) {
 			dimension &&
 			Array.isArray( ANALYTICS_4_DIMENSION_OPTIONS[ dimension ] )
 		) {
-			// Generates a stream (an array) of dimension values using the array of values for the current dimension.
-			streams.push(
-				new Observable( ( observer ) => {
-					ANALYTICS_4_DIMENSION_OPTIONS[ dimension ].forEach(
-						( val ) => {
-							observer.next( val );
-						}
-					);
-
-					observer.complete();
-				} )
-			);
+			// Uses predefined array of dimension values to create a stream (an array) from.
+			streams.push( from( ANALYTICS_4_DIMENSION_OPTIONS[ dimension ] ) );
 		} else {
 			// In case when a dimension is not provided or is not recognized, we use NULL to create a stream (an array) with just one value.
 			streams.push( from( [ null ] ) );

--- a/assets/js/modules/analytics-4/utils/data-mock.js
+++ b/assets/js/modules/analytics-4/utils/data-mock.js
@@ -260,6 +260,7 @@ export function getAnalytics4MockResponse( options ) {
 		'a valid endDate is required.'
 	);
 
+	// Ensure we don't mutate the passed options to avoid unexpected side effects for the caller.
 	const args = cloneDeep( options );
 
 	const originalSeedValue = faker.seedValue;
@@ -474,6 +475,8 @@ export function getAnalytics4MockResponse( options ) {
 					: []
 			);
 
+			// For maximums and totals, if we have a date range the second to last row will be date_range_0 and the last row will be date_range_1.
+			// When there is no date range we only need to use the last row.
 			const firstItemIndex = rows.length - ( hasDateRange ? 2 : 1 );
 
 			data.maximums = [

--- a/assets/js/modules/analytics-4/utils/data-mock.test.js
+++ b/assets/js/modules/analytics-4/utils/data-mock.test.js
@@ -23,6 +23,7 @@ import { getAnalytics4MockResponse } from './data-mock';
 import mockedReportResponse from './__fixtures__/mocked-report.json';
 import mockedReportMultipleDateRangesResponse from './__fixtures__/mocked-report-multiple-date-ranges.json';
 import mockedReportFixedValueDimensionResponse from './__fixtures__/mocked-report-fixed-value-dimension.json';
+import mockedReportMultipleDimensionResponse from './__fixtures__/mocked-report-multiple-dimensions.json';
 
 describe( 'getAnalytics4MockResponse', () => {
 	it( 'throws if called without report options', () => {
@@ -110,7 +111,30 @@ describe( 'getAnalytics4MockResponse', () => {
 		expect( report ).toEqual( mockedReportFixedValueDimensionResponse );
 
 		// Verify the correct number of rows for the date ranges.
-		expect( report.rows ).toHaveLength( 10 );
+		expect( report.rows ).toHaveLength( 20 );
+	} );
+
+	it( 'generates a valid report using a multiple dimensions', () => {
+		const report = getAnalytics4MockResponse( {
+			startDate: '2020-12-01',
+			endDate: '2020-12-03',
+			compareStartDate: '2020-12-04',
+			compareEndDate: '2020-12-05',
+			metrics: [
+				{
+					name: 'totalUsers',
+				},
+				{
+					name: 'averageSessionDuration',
+				},
+			],
+			dimensions: [ 'deviceCategory', 'sessionDefaultChannelGrouping' ],
+		} );
+
+		expect( report ).toEqual( mockedReportMultipleDimensionResponse );
+
+		// Verify the correct number of rows for the date ranges.
+		expect( report.rows ).toHaveLength( 60 );
 	} );
 
 	it( 'generates the same number of rows for each date range in a multi-date range report', () => {

--- a/assets/js/modules/analytics-4/utils/data-mock.test.js
+++ b/assets/js/modules/analytics-4/utils/data-mock.test.js
@@ -22,6 +22,7 @@
 import { getAnalytics4MockResponse } from './data-mock';
 import mockedReportResponse from './__fixtures__/mocked-report.json';
 import mockedReportMultipleDateRangesResponse from './__fixtures__/mocked-report-multiple-date-ranges.json';
+import mockedReportFixedValueDimensionResponse from './__fixtures__/mocked-report-fixed-value-dimension.json';
 
 describe( 'getAnalytics4MockResponse', () => {
 	it( 'throws if called without report options', () => {
@@ -84,6 +85,29 @@ describe( 'getAnalytics4MockResponse', () => {
 		} );
 
 		expect( report ).toEqual( mockedReportMultipleDateRangesResponse );
+
+		// Verify the correct number of rows for the date ranges.
+		expect( report.rows ).toHaveLength( 10 );
+	} );
+
+	it( 'generates a valid report using a dimension with a fixed set of values', () => {
+		const report = getAnalytics4MockResponse( {
+			startDate: '2020-12-01',
+			endDate: '2020-12-03',
+			compareStartDate: '2020-12-04',
+			compareEndDate: '2020-12-05',
+			metrics: [
+				{
+					name: 'totalUsers',
+				},
+				{
+					name: 'averageSessionDuration',
+				},
+			],
+			dimensions: [ 'sessionDefaultChannelGrouping' ],
+		} );
+
+		expect( report ).toEqual( mockedReportFixedValueDimensionResponse );
 
 		// Verify the correct number of rows for the date ranges.
 		expect( report.rows ).toHaveLength( 10 );


### PR DESCRIPTION
## Summary

- Fix date range handling in `getAnalytics4MockResponse`.
- Also, avoid mutating passed report options.

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #6174 

## Relevant technical choices

This is bringing necessary changes in that were discovered during the first proper usage of the mock data utility in #6126 (see PR https://github.com/google/site-kit-wp/pull/6514).

<!-- Please describe your changes. -->

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [ ] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
