### PR TITLE
Fix key Metrics flicker from Admin Settings.

### DIFF
--- a/assets/js/components/settings/SettingsAdmin.js
+++ b/assets/js/components/settings/SettingsAdmin.js
@@ -92,7 +92,7 @@ export default function SettingsAdmin() {
 										goTo={ goTo }
 										noHeader
 										noFooter
-										settingsdView
+										settingsView
 										showIndividualCTAs
 									/>
 								</Grid>

--- a/assets/js/components/settings/SettingsAdmin.js
+++ b/assets/js/components/settings/SettingsAdmin.js
@@ -88,20 +88,11 @@ export default function SettingsAdmin() {
 						>
 							<div className="googlesitekit-settings-module googlesitekit-settings-module--active googlesitekit-settings-user-input">
 								<Grid>
-									<Row>
-										<Cell size={ 12 }>
-											<p className="googlesitekit-settings-user-input__heading">
-												{ __(
-													'Edit your answers for more personalized metrics:',
-													'google-site-kit'
-												) }
-											</p>
-										</Cell>
-									</Row>
 									<UserInputPreview
 										goTo={ goTo }
 										noHeader
 										noFooter
+										settingsdView
 										showIndividualCTAs
 									/>
 								</Grid>

--- a/assets/js/components/user-input/UserInputPreview.js
+++ b/assets/js/components/user-input/UserInputPreview.js
@@ -53,6 +53,7 @@ import ErrorNotice from '../ErrorNotice';
 import Link from '../Link';
 import CancelUserInputButton from './CancelUserInputButton';
 import { getErrorMessageForAnswer } from './util/validation';
+import { Row, Cell } from '../../material-components';
 const { useSelect } = Data;
 
 export default function UserInputPreview( props ) {
@@ -62,7 +63,7 @@ export default function UserInputPreview( props ) {
 		submitChanges,
 		error,
 		noHeader,
-		settingsdView = false,
+		settingsView = false,
 		showIndividualCTAs = false,
 	} = props;
 	const previewContainer = useRef();
@@ -155,13 +156,17 @@ export default function UserInputPreview( props ) {
 						{ __( 'Review your answers', 'google-site-kit' ) }
 					</p>
 				) }
-				{ settingsdView && (
-					<p className="googlesitekit-settings-user-input__heading">
-						{ __(
-							'Edit your answers for more personalized metrics:',
-							'google-site-kit'
-						) }
-					</p>
+				{ settingsView && (
+					<Row>
+						<Cell>
+							<p className="googlesitekit-settings-user-input__heading">
+								{ __(
+									'Edit your answers for more personalized metrics:',
+									'google-site-kit'
+								) }
+							</p>
+						</Cell>
+					</Row>
 				) }
 				<UserInputPreviewGroup
 					slug={ USER_INPUT_QUESTIONS_PURPOSE }
@@ -251,6 +256,6 @@ UserInputPreview.propTypes = {
 	redirectURL: PropTypes.string,
 	errors: PropTypes.object,
 	noHeader: PropTypes.bool,
-	settingsdView: PropTypes.bool,
+	settingsView: PropTypes.bool,
 	showIndividualCTAs: PropTypes.bool,
 };

--- a/assets/js/components/user-input/UserInputPreview.js
+++ b/assets/js/components/user-input/UserInputPreview.js
@@ -62,6 +62,7 @@ export default function UserInputPreview( props ) {
 		submitChanges,
 		error,
 		noHeader,
+		settingsdView = false,
 		showIndividualCTAs = false,
 	} = props;
 	const previewContainer = useRef();
@@ -154,6 +155,14 @@ export default function UserInputPreview( props ) {
 						{ __( 'Review your answers', 'google-site-kit' ) }
 					</p>
 				) }
+				{ settingsdView && (
+					<p className="googlesitekit-settings-user-input__heading">
+						{ __(
+							'Edit your answers for more personalized metrics:',
+							'google-site-kit'
+						) }
+					</p>
+				) }
 				<UserInputPreviewGroup
 					slug={ USER_INPUT_QUESTIONS_PURPOSE }
 					title={ __(
@@ -242,5 +251,6 @@ UserInputPreview.propTypes = {
 	redirectURL: PropTypes.string,
 	errors: PropTypes.object,
 	noHeader: PropTypes.bool,
+	settingsdView: PropTypes.bool,
 	showIndividualCTAs: PropTypes.bool,
 };


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #6428 

## Relevant technical choices

<!-- Please describe your changes. -->

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
