### PR TITLE
Fix: tag manager settings stuck in loading state.

### DIFF
--- a/assets/js/modules/tagmanager/hooks/useGAPropertyIDEffect.js
+++ b/assets/js/modules/tagmanager/hooks/useGAPropertyIDEffect.js
@@ -39,7 +39,7 @@ export default function useGAPropertyIDEffect() {
 
 	useEffect( () => {
 		if (
-			!! tagmanagerExistingSettings &&
+			tagmanagerExistingSettings !== undefined &&
 			singleAnalyticsPropertyID !== undefined
 		) {
 			setGAPropertyID( singleAnalyticsPropertyID || '' );

--- a/assets/js/modules/tagmanager/hooks/useGAPropertyIDEffect.js
+++ b/assets/js/modules/tagmanager/hooks/useGAPropertyIDEffect.js
@@ -32,11 +32,21 @@ export default function useGAPropertyIDEffect() {
 	const singleAnalyticsPropertyID = useSelect( ( select ) =>
 		select( MODULES_TAGMANAGER ).getSingleAnalyticsPropertyID()
 	);
+	const tagmanagerExistingSettings = useSelect( ( select ) =>
+		select( MODULES_TAGMANAGER ).getSettings()
+	);
 	const { setGAPropertyID } = useDispatch( MODULES_TAGMANAGER );
 
 	useEffect( () => {
-		if ( singleAnalyticsPropertyID !== undefined ) {
+		if (
+			!! tagmanagerExistingSettings &&
+			singleAnalyticsPropertyID !== undefined
+		) {
 			setGAPropertyID( singleAnalyticsPropertyID || '' );
 		}
-	}, [ singleAnalyticsPropertyID, setGAPropertyID ] );
+	}, [
+		tagmanagerExistingSettings,
+		singleAnalyticsPropertyID,
+		setGAPropertyID,
+	] );
 }

--- a/assets/js/modules/tagmanager/hooks/useGAPropertyIDEffect.test.js
+++ b/assets/js/modules/tagmanager/hooks/useGAPropertyIDEffect.test.js
@@ -17,6 +17,11 @@
  */
 
 /**
+ * External dependencies
+ */
+import fetchMock from 'fetch-mock';
+
+/**
  * Internal dependencies
  */
 import { renderHook, actHook as act } from '../../../../../tests/js/test-utils';
@@ -27,36 +32,88 @@ import useGAPropertyIDEffect from './useGAPropertyIDEffect';
 
 describe( 'useGAPropertyIDEffect', () => {
 	let registry;
-	beforeEach( () => {
-		registry = createTestRegistry();
-		// Set settings to prevent fetch in resolver.
-		registry.dispatch( MODULES_TAGMANAGER ).receiveGetSettings( {} );
-		// Set set no existing tag.
-		registry.dispatch( MODULES_TAGMANAGER ).receiveGetExistingTag( null );
-	} );
 
-	it( 'sets the gaPropertyID with the current detected singular property ID in selected containers', async () => {
-		const { buildAndReceiveWebAndAMP } =
-			createBuildAndReceivers( registry );
-
-		const TEST_GA_PROPERTY_ID = 'UA-123456789-1';
-
-		buildAndReceiveWebAndAMP( {
-			webPropertyID: TEST_GA_PROPERTY_ID,
+	describe( 'with empty tagmanager settings store', () => {
+		beforeEach( () => {
+			registry = createTestRegistry();
 		} );
 
-		await act(
-			() =>
-				new Promise( ( resolve ) => {
-					renderHook( () => useGAPropertyIDEffect(), { registry } );
-					resolve();
-				} )
-		);
+		it( 'fetches settings from api before updating gaPropertyID', async () => {
+			fetchMock.getOnce(
+				/^\/google-site-kit\/v1\/modules\/tagmanager\/data\/settings/,
+				{
+					body: {},
+					status: 200,
+				}
+			);
 
-		const propertyID = registry
-			.select( MODULES_TAGMANAGER )
-			.getGAPropertyID();
+			let renderHookResponse;
 
-		expect( propertyID ).toBe( TEST_GA_PROPERTY_ID );
+			await act(
+				() =>
+					new Promise( ( resolve ) => {
+						renderHookResponse = renderHook(
+							() => useGAPropertyIDEffect(),
+							{
+								registry,
+							}
+						);
+						resolve();
+					} )
+			);
+
+			await renderHookResponse.waitForNextUpdate();
+
+			expect( fetchMock ).toHaveFetched(
+				new RegExp(
+					'^/google-site-kit/v1/modules/tagmanager/data/settings'
+				)
+			);
+
+			const propertyID = registry
+				.select( MODULES_TAGMANAGER )
+				.getGAPropertyID();
+
+			expect( propertyID ).toBe( '' );
+		} );
+	} );
+
+	describe( 'with tagmanager store setup', () => {
+		beforeEach( () => {
+			registry = createTestRegistry();
+			// Set settings to prevent fetch in resolver.
+			registry.dispatch( MODULES_TAGMANAGER ).receiveGetSettings( {} );
+			// Set set no existing tag.
+			registry
+				.dispatch( MODULES_TAGMANAGER )
+				.receiveGetExistingTag( null );
+		} );
+
+		it( 'sets the gaPropertyID with the current detected singular property ID in selected containers', async () => {
+			const { buildAndReceiveWebAndAMP } =
+				createBuildAndReceivers( registry );
+
+			const TEST_GA_PROPERTY_ID = 'UA-123456789-1';
+
+			buildAndReceiveWebAndAMP( {
+				webPropertyID: TEST_GA_PROPERTY_ID,
+			} );
+
+			await act(
+				() =>
+					new Promise( ( resolve ) => {
+						renderHook( () => useGAPropertyIDEffect(), {
+							registry,
+						} );
+						resolve();
+					} )
+			);
+
+			const propertyID = registry
+				.select( MODULES_TAGMANAGER )
+				.getGAPropertyID();
+
+			expect( propertyID ).toBe( TEST_GA_PROPERTY_ID );
+		} );
 	} );
 } );

--- a/assets/js/modules/tagmanager/hooks/useGAPropertyIDEffect.test.js
+++ b/assets/js/modules/tagmanager/hooks/useGAPropertyIDEffect.test.js
@@ -36,12 +36,12 @@ import useGAPropertyIDEffect from './useGAPropertyIDEffect';
 describe( 'useGAPropertyIDEffect', () => {
 	let registry;
 
-	describe( 'with empty tagmanager settings store', () => {
+	describe( 'with empty Tag Manager settings store', () => {
 		beforeEach( () => {
 			registry = createTestRegistry();
 		} );
 
-		it( 'fetches settings from api before updating gaPropertyID', async () => {
+		it( 'fetches settings from API before updating gaPropertyID', async () => {
 			fetchMock.getOnce(
 				/^\/google-site-kit\/v1\/modules\/tagmanager\/data\/settings/,
 				{

--- a/assets/js/modules/tagmanager/hooks/useGAPropertyIDEffect.test.js
+++ b/assets/js/modules/tagmanager/hooks/useGAPropertyIDEffect.test.js
@@ -41,7 +41,7 @@ describe( 'useGAPropertyIDEffect', () => {
 			registry = createTestRegistry();
 		} );
 
-		it( 'fetches settings from API before updating gaPropertyID', async () => {
+		it( 'fetches settings from API if the settings are empty', async () => {
 			fetchMock.getOnce(
 				/^\/google-site-kit\/v1\/modules\/tagmanager\/data\/settings/,
 				{
@@ -67,16 +67,10 @@ describe( 'useGAPropertyIDEffect', () => {
 					'^/google-site-kit/v1/modules/tagmanager/data/settings'
 				)
 			);
-
-			const propertyID = registry
-				.select( MODULES_TAGMANAGER )
-				.getGAPropertyID();
-
-			expect( propertyID ).toBe( '' );
 		} );
 	} );
 
-	describe( 'with tagmanager store setup', () => {
+	describe( 'with a populated Tag Manager store', () => {
 		beforeEach( () => {
 			registry = createTestRegistry();
 			// Set settings to prevent fetch in resolver.

--- a/assets/js/modules/tagmanager/hooks/useGAPropertyIDEffect.test.js
+++ b/assets/js/modules/tagmanager/hooks/useGAPropertyIDEffect.test.js
@@ -25,7 +25,10 @@ import fetchMock from 'fetch-mock';
  * Internal dependencies
  */
 import { renderHook, actHook as act } from '../../../../../tests/js/test-utils';
-import { createTestRegistry } from '../../../../../tests/js/utils';
+import {
+	createTestRegistry,
+	waitForDefaultTimeouts,
+} from '../../../../../tests/js/utils';
 import { MODULES_TAGMANAGER } from '../datastore/constants';
 import { createBuildAndReceivers } from '../datastore/__factories__/utils';
 import useGAPropertyIDEffect from './useGAPropertyIDEffect';
@@ -47,22 +50,17 @@ describe( 'useGAPropertyIDEffect', () => {
 				}
 			);
 
-			let renderHookResponse;
-
 			await act(
 				() =>
 					new Promise( ( resolve ) => {
-						renderHookResponse = renderHook(
-							() => useGAPropertyIDEffect(),
-							{
-								registry,
-							}
-						);
+						renderHook( () => useGAPropertyIDEffect(), {
+							registry,
+						} );
 						resolve();
 					} )
 			);
 
-			await renderHookResponse.waitForNextUpdate();
+			await act( waitForDefaultTimeouts );
 
 			expect( fetchMock ).toHaveFetched(
 				new RegExp(


### PR DESCRIPTION

## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #6464

## Relevant technical choices

* `setGAPropertyID` only when tagmanager settings not empty.
* Add tests for `useGAPropertyIDEffect` with empty tag manager settings.

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [x] Run the code.
- [x] Ensure the acceptance criteria are satisfied.
- [x] Reassess the implementation with the IB.
- [x] Ensure no unrelated changes are included.
- [x] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [x] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
