### PR TITLE
Reimplement allowed_redirect_hosts for unicode without relying on mbstring

### DIFF
--- a/includes/Core/Authentication/Authentication.php
+++ b/includes/Core/Authentication/Authentication.php
@@ -1002,6 +1002,23 @@ final class Authentication {
 		$hosts[] = 'accounts.google.com';
 		$hosts[] = URL::parse( $this->google_proxy->url(), PHP_URL_HOST );
 
+		// In the case of IDNs, ensure the ASCII and non-ASCII domains
+		// are treated as allowable origins.
+		$admin_hostname = URL::parse( admin_url(), PHP_URL_HOST );
+
+		// See \Requests_IDNAEncoder::is_ascii.
+		$is_ascii = preg_match( '/(?:[^\x00-\x7F])/', $admin_hostname ) !== 1;
+
+		// If this host is already an ASCII-only string, it's either
+		// not an IDN or it's an ASCII-formatted IDN.
+		// We only need to intervene if it is non-ASCII.
+		if ( ! $is_ascii ) {
+			// If this host is an IDN in Unicode format, we need to add the
+			// urlencoded versions of the domain to the `$hosts` array,
+			// because this is what will be used for redirects.
+			$hosts[] = rawurlencode( $admin_hostname );
+		}
+
 		return $hosts;
 	}
 

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -87,29 +87,6 @@ final class Plugin {
 			return;
 		}
 
-		// In the case of IDNs, ensure the ASCII and non-ASCII domains
-		// are treated as allowable origins.
-		add_filter(
-			'allowed_redirect_hosts',
-			function( $hosts ) {
-				$wpp = wp_parse_url( home_url() );
-
-				// If this host is already an ASCII-only string, it's either
-				// not an IDN or it's an ASCII-formatted IDN. Either way: we
-				// can return the existing `$hosts` array unmodified.
-				if ( mb_check_encoding( $wpp['host'], 'ASCII' ) ) {
-					return $hosts;
-				}
-
-				// If this host is an IDN in Unicode format, we need to add the
-				// urlencoded versions of the domain to the `$hosts` array,
-				// because this is what will be used for redirects.
-				$hosts[] = rawurlencode( $wpp['host'] );
-
-				return $hosts;
-			}
-		);
-
 		// REST route to set up a temporary tag to verify meta tag output works reliably.
 		add_filter(
 			'googlesitekit_rest_routes',

--- a/tests/phpunit/integration/Core/Authentication/AuthenticationTest.php
+++ b/tests/phpunit/integration/Core/Authentication/AuthenticationTest.php
@@ -28,6 +28,7 @@ use Google\Site_Kit\Core\Permissions\Permissions;
 use Google\Site_Kit\Core\Storage\Options;
 use Google\Site_Kit\Core\Storage\User_Options;
 use Google\Site_Kit\Core\User_Input\User_Input;
+use Google\Site_Kit\Core\Util\URL;
 use Google\Site_Kit\Modules\PageSpeed_Insights\Settings as PageSpeed_Insights_Settings;
 use Google\Site_Kit\Modules\Search_Console\Settings as Search_Console_Settings;
 use Google\Site_Kit\Tests\Exception\RedirectException;
@@ -1087,6 +1088,41 @@ class AuthenticationTest extends TestCase {
 		$this->assertEquals( '42', $js_inline_wp_version['version'] );
 		$this->assertEquals( '42', $js_inline_wp_version['major'] );
 		$this->assertEquals( '0', $js_inline_wp_version['minor'] );
+	}
+
+	/**
+	 * @param string $site_url
+	 * @param string? $expected_redirect
+	 * @dataProvider data_site_urls
+	 */
+	public function test_allowed_redirect_hosts( $site_url, $expected_redirect ) {
+		remove_all_filters( 'allowed_redirect_hosts' );
+		$authentication = new Authentication( new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE ) );
+		$authentication->register();
+
+		if ( null === $expected_redirect ) {
+			$expected_redirect = $site_url;
+		}
+
+		update_option( 'home', $site_url );
+		update_option( 'siteurl', $site_url );
+
+		try {
+			wp_safe_redirect( $site_url ); // phpcs:ignore WordPressVIPMinimum.Security.ExitAfterRedirect.NoExit
+			$this->fail( 'Expected redirection to site URL!' );
+		} catch ( RedirectException $redirect ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
+			// The test will fail if this isn't thrown so we can continue below.
+		}
+
+		$this->assertEquals( $expected_redirect, $redirect->get_location() );
+	}
+
+	public function data_site_urls() {
+		return array(
+			'common ascii'   => array( 'https://example.com', null ),
+			'punycode ascii' => array( 'https://xn--xmpl-loa2a55a.test', null ),
+			'unicode'        => array( 'https://éxämplę.test', 'https://' . rawurlencode( 'éxämplę.test' ) ),
+		);
 	}
 
 	protected function get_user_option_keys() {


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #6524

## Relevant technical choices

<!-- Please describe your changes. -->

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
