### PR TITLE
solved #6202

### DIFF
--- a/assets/js/components/settings/SettingsActiveModule/Footer.js
+++ b/assets/js/components/settings/SettingsActiveModule/Footer.js
@@ -47,7 +47,11 @@ import { clearCache } from '../../../googlesitekit/api/cache';
 import { CORE_UI } from '../../../googlesitekit/datastore/ui/constants';
 import { CORE_USER } from '../../../googlesitekit/datastore/user/constants';
 import useViewContext from '../../../hooks/useViewContext';
+import { useSelector, useDispatch } from 'react-redux';
+import { getModuleStoreName } from './selectors';
+
 const { useDispatch, useSelect } = Data;
+
 
 export default function Footer( props ) {
 	const { slug } = props;
@@ -100,7 +104,10 @@ export default function Footer( props ) {
 	} );
 
 	const { submitChanges } = useDispatch( CORE_MODULES );
-	const { clearErrors } = useDispatch( `modules/${ slug }` );
+	const moduleStoreName = useSelector(getModuleStoreName(slug));
+        const { clearErrors } = useDispatch(moduleStoreName);
+
+
 	const { setValue } = useDispatch( CORE_UI );
 
 	const hasSettings = !! module?.SettingsEditComponent;


### PR DESCRIPTION
Replace the following interpolated string with the result of a call to getModuleStoreName().

## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #

## Relevant technical choices

<!-- Please describe your changes. -->

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [x] Run the code.
- [x] Ensure the acceptance criteria are satisfied.
- [x] Reassess the implementation with the IB.
- [x] Ensure no unrelated changes are included.
- [x] Ensure CI checks pass.
- [x] Check Storybook where applicable.
- [x] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [x] Ensure the PR has the correct target branch.
- [x] Double-check that the PR is okay to be merged.
- [x] Ensure the corresponding issue has a ZenHub release assigned.
- [x] Add a changelog message to the issue.
