### PR TITLE
Fix typo in the getAnalyticsConfigByMeasurementIDs selector.

### DIFF
--- a/assets/js/modules/analytics-4/datastore/webdatastreams.js
+++ b/assets/js/modules/analytics-4/datastore/webdatastreams.js
@@ -455,13 +455,20 @@ const baseSelectors = {
 				return null;
 			}
 
+			// eslint-disable-next-line @wordpress/no-unused-vars-before-return
 			const datastreams =
 				select( MODULES_ANALYTICS_4 ).getWebDataStreamsBatch(
 					propertyIDs
 				);
 
+			const resolvedDataStreams = select(
+				MODULES_ANALYTICS_4
+			).hasFinishedResolution( 'getWebDataStreamsBatch', [
+				propertyIDs,
+			] );
+
 			// Return undefined if web data streams haven't been resolved yet.
-			if ( datastreams === undefined ) {
+			if ( ! resolvedDataStreams ) {
 				return undefined;
 			}
 

--- a/assets/js/modules/analytics-4/datastore/webdatastreams.js
+++ b/assets/js/modules/analytics-4/datastore/webdatastreams.js
@@ -473,11 +473,11 @@ const baseSelectors = {
 				}
 
 				for ( const datastream of datastreams[ propertyID ] ) {
-					const { _id: webDataStreamID, webDataStream } = datastream;
+					const { _id: webDataStreamID, webStreamData } = datastream;
 					const {
 						defaultUri: defaultURI,
 						measurementId: measurementID, // eslint-disable-line sitekit/acronym-case
-					} = webDataStream;
+					} = webStreamData;
 
 					if ( ! measurementIDs.includes( measurementID ) ) {
 						continue;

--- a/assets/js/modules/analytics-4/datastore/webdatastreams.test.js
+++ b/assets/js/modules/analytics-4/datastore/webdatastreams.test.js
@@ -733,6 +733,11 @@ describe( 'modules/analytics-4 webdatastreams', () => {
 					.receiveGetWebDataStreamsBatch( datastreams, {
 						propertyIDs,
 					} );
+				registry
+					.dispatch( MODULES_ANALYTICS_4 )
+					.finishResolution( 'getWebDataStreamsBatch', [
+						propertyIDs,
+					] );
 
 				const config = registry
 					.select( MODULES_ANALYTICS_4 )
@@ -758,6 +763,11 @@ describe( 'modules/analytics-4 webdatastreams', () => {
 					.receiveGetWebDataStreamsBatch( datastreams, {
 						propertyIDs,
 					} );
+				registry
+					.dispatch( MODULES_ANALYTICS_4 )
+					.finishResolution( 'getWebDataStreamsBatch', [
+						propertyIDs,
+					] );
 
 				const config = registry
 					.select( MODULES_ANALYTICS_4 )
@@ -783,6 +793,11 @@ describe( 'modules/analytics-4 webdatastreams', () => {
 					.receiveGetWebDataStreamsBatch( datastreams, {
 						propertyIDs,
 					} );
+				registry
+					.dispatch( MODULES_ANALYTICS_4 )
+					.finishResolution( 'getWebDataStreamsBatch', [
+						propertyIDs,
+					] );
 
 				const config = registry
 					.select( MODULES_ANALYTICS_4 )
@@ -803,6 +818,11 @@ describe( 'modules/analytics-4 webdatastreams', () => {
 					.receiveGetWebDataStreamsBatch( datastreams, {
 						propertyIDs,
 					} );
+				registry
+					.dispatch( MODULES_ANALYTICS_4 )
+					.finishResolution( 'getWebDataStreamsBatch', [
+						propertyIDs,
+					] );
 
 				const config = registry
 					.select( MODULES_ANALYTICS_4 )

--- a/assets/js/modules/analytics-4/datastore/webdatastreams.test.js
+++ b/assets/js/modules/analytics-4/datastore/webdatastreams.test.js
@@ -645,14 +645,14 @@ describe( 'modules/analytics-4 webdatastreams', () => {
 				1122334455: [
 					{
 						_id: '110',
-						webDataStream: {
+						webStreamData: {
 							defaultUri: 'http://example-1.test',
 							measurementId: 'G-1101', // eslint-disable-line sitekit/acronym-case
 						},
 					},
 					{
 						_id: '111',
-						webDataStream: {
+						webStreamData: {
 							defaultUri: 'http://example-2.test',
 							measurementId: 'G-1102', // eslint-disable-line sitekit/acronym-case
 						},
@@ -661,14 +661,14 @@ describe( 'modules/analytics-4 webdatastreams', () => {
 				1122334465: [
 					{
 						_id: '112',
-						webDataStream: {
+						webStreamData: {
 							defaultUri: 'http://example-3.test',
 							measurementId: 'G-1103', // eslint-disable-line sitekit/acronym-case
 						},
 					},
 					{
 						_id: '113',
-						webDataStream: {
+						webStreamData: {
 							defaultUri: 'http://example-4.test',
 							measurementId: 'G-1104', // eslint-disable-line sitekit/acronym-case
 						},
@@ -677,21 +677,21 @@ describe( 'modules/analytics-4 webdatastreams', () => {
 				1122334475: [
 					{
 						_id: '114',
-						webDataStream: {
+						webStreamData: {
 							defaultUri: 'http://example-5.test',
 							measurementId: 'G-1105', // eslint-disable-line sitekit/acronym-case
 						},
 					},
 					{
 						_id: '115',
-						webDataStream: {
+						webStreamData: {
 							defaultUri: 'http://example.com',
 							measurementId: 'G-1106', // eslint-disable-line sitekit/acronym-case
 						},
 					},
 					{
 						_id: '116',
-						webDataStream: {
+						webStreamData: {
 							defaultUri: 'http://example-7.test',
 							measurementId: 'G-1107', // eslint-disable-line sitekit/acronym-case
 						},


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #6372 

## Relevant technical choices

<!-- Please describe your changes. -->

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [ ] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
