### PR TITLE
Remove userInput related flags and code from Google_Proxy class.

### DIFF
--- a/includes/Core/Authentication/Google_Proxy.php
+++ b/includes/Core/Authentication/Google_Proxy.php
@@ -37,7 +37,6 @@ class Google_Proxy {
 	const OAUTH2_DELETE_SITE_URI    = '/o/oauth2/delete-site/';
 	const SETUP_URI                 = '/v2/site-management/setup/';
 	const PERMISSIONS_URI           = '/site-management/permissions/';
-	const USER_INPUT_SETTINGS_URI   = '/site-management/settings/';
 	const FEATURES_URI              = '/site-management/features/';
 	const SURVEY_TRIGGER_URI        = '/survey/trigger/';
 	const SURVEY_EVENT_URI          = '/survey/event/';
@@ -111,19 +110,11 @@ class Google_Proxy {
 		$supports = array(
 			'credentials_retrieval',
 			'short_verification_token',
-			// Informs the proxy the user input feature is generally supported.
-			'user_input_flow',
 		);
 
 		$home_path = URL::parse( $this->context->get_canonical_home_url(), PHP_URL_PATH );
 		if ( ! $home_path || '/' === $home_path ) {
 			$supports[] = 'file_verification';
-		}
-
-		// Informs the proxy the user input feature is already enabled locally.
-		// TODO: Remove once the feature is fully rolled out.
-		if ( Feature_Flags::enabled( 'userInput' ) ) {
-			$supports[] = 'user_input_flow_feature';
 		}
 
 		return $supports;
@@ -483,36 +474,6 @@ class Google_Proxy {
 		}
 
 		return $redirect_to;
-	}
-
-	/**
-	 * Synchronizes user input settings with the proxy.
-	 *
-	 * @since 1.27.0
-	 *
-	 * @param Credentials $credentials  Credentials instance.
-	 * @param string      $access_token Access token.
-	 * @param array|null  $settings     Settings array.
-	 * @return array|WP_Error Response of the wp_remote_post request.
-	 */
-	public function sync_user_input_settings( Credentials $credentials, $access_token, $settings = null ) {
-		$body = array();
-		if ( ! empty( $settings ) ) {
-			$body = array(
-				'settings'       => $settings,
-				'client_user_id' => (string) get_current_user_id(),
-			);
-		}
-
-		return $this->request(
-			self::USER_INPUT_SETTINGS_URI,
-			$credentials,
-			array(
-				'json_request' => true,
-				'access_token' => $access_token,
-				'body'         => $body,
-			)
-		);
 	}
 
 	/**


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #6505 

## Relevant technical choices

<!-- Please describe your changes. -->

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
