### PR TITLE
Add prerequisites for GA4 Reporting components followup.

### DIFF
--- a/assets/js/modules/analytics-4/datastore/report.js
+++ b/assets/js/modules/analytics-4/datastore/report.js
@@ -175,6 +175,11 @@ const baseSelectors = {
 		}
 
 		const propertyID = select( MODULES_ANALYTICS_4 ).getPropertyID();
+
+		if ( propertyID === undefined ) {
+			return undefined;
+		}
+
 		const property =
 			select( MODULES_ANALYTICS_4 ).getProperty( propertyID );
 

--- a/assets/js/modules/analytics-4/datastore/report.js
+++ b/assets/js/modules/analytics-4/datastore/report.js
@@ -232,6 +232,17 @@ const baseSelectors = {
 			return undefined;
 		}
 
+		const hasReportError = select(
+			MODULES_ANALYTICS_4
+		).getErrorForSelector( 'getReport', [ args ] );
+
+		// If there is an error, return false, to be aligned with the behaviour of the UA isGatheringData selector,
+		// but with a more explicit check, i.e. checking for a report error rather than a non-successful response shape.
+		// TODO: In future we should consider changing this selector so it returns a distinct value for errors, or throws an error.
+		if ( hasReportError ) {
+			return false;
+		}
+
 		return isZeroReport( report );
 	} ),
 };

--- a/assets/js/modules/analytics-4/datastore/report.test.js
+++ b/assets/js/modules/analytics-4/datastore/report.test.js
@@ -133,7 +133,9 @@ describe( 'modules/analytics-4 report', () => {
 				};
 
 				fetchMock.getOnce(
-					/^\/google-site-kit\/v1\/modules\/analytics-4\/data\/report/,
+					new RegExp(
+						'^/google-site-kit/v1/modules/analytics-4/data/report'
+					),
 					{
 						body: response,
 						status: 500,
@@ -193,6 +195,37 @@ describe( 'modules/analytics-4 report', () => {
 				);
 
 				expect( isGatheringData() ).toBe( false );
+			} );
+
+			it( 'should return FALSE if the report request fails', async () => {
+				const response = {
+					code: 'internal_server_error',
+					message: 'Internal server error',
+					data: { status: 500 },
+				};
+
+				fetchMock.getOnce(
+					new RegExp(
+						'^/google-site-kit/v1/modules/analytics-4/data/report'
+					),
+					{
+						body: response,
+						status: 500,
+					}
+				);
+
+				const { isGatheringData } =
+					registry.select( MODULES_ANALYTICS_4 );
+
+				expect( isGatheringData() ).toBeUndefined();
+
+				await subscribeUntil(
+					registry,
+					() => isGatheringData() !== undefined
+				);
+
+				expect( isGatheringData() ).toBe( false );
+				expect( console ).toHaveErrored();
 			} );
 
 			describe.each( [
@@ -333,6 +366,36 @@ describe( 'modules/analytics-4 report', () => {
 
 				// Wait for resolvers to run.
 				await waitForDefaultTimeouts();
+			} );
+
+			it( 'should return FALSE if the report request fails', async () => {
+				const response = {
+					code: 'internal_server_error',
+					message: 'Internal server error',
+					data: { status: 500 },
+				};
+
+				fetchMock.getOnce(
+					new RegExp(
+						'^/google-site-kit/v1/modules/analytics-4/data/report'
+					),
+					{
+						body: response,
+						status: 500,
+					}
+				);
+
+				const { hasZeroData } = registry.select( MODULES_ANALYTICS_4 );
+
+				expect( hasZeroData() ).toBeUndefined();
+
+				await subscribeUntil(
+					registry,
+					() => hasZeroData() !== undefined
+				);
+
+				expect( hasZeroData() ).toBe( false );
+				expect( console ).toHaveErrored();
 			} );
 
 			it( 'should return TRUE if isZeroReport is true', async () => {

--- a/assets/js/modules/analytics-4/datastore/report.test.js
+++ b/assets/js/modules/analytics-4/datastore/report.test.js
@@ -217,10 +217,28 @@ describe( 'modules/analytics-4 report', () => {
 							body,
 						}
 					);
+				} );
 
-					registry
-						.dispatch( MODULES_ANALYTICS_4 )
-						.receiveGetSettings( {} );
+				it( 'should return undefined if getSettings is not resolved yet', async () => {
+					freezeFetch(
+						new RegExp(
+							'^/google-site-kit/v1/modules/analytics-4/data/settings'
+						)
+					);
+
+					const { isGatheringData } =
+						registry.select( MODULES_ANALYTICS_4 );
+
+					expect( isGatheringData() ).toBeUndefined();
+
+					// Wait for resolvers to run.
+					await waitForDefaultTimeouts();
+
+					// Verify that isGatheringData still returns undefined.
+					expect( isGatheringData() ).toBeUndefined();
+
+					// Wait for resolvers to run following the second call to isGatheringData to avoid the test failing due to the second async attempt to fetch settings.
+					await waitForDefaultTimeouts();
 				} );
 
 				it( 'should return TRUE if the connnected GA4 property is under two days old', async () => {
@@ -234,6 +252,10 @@ describe( 'modules/analytics-4 report', () => {
 						createTime,
 					};
 					const propertyID = property._id;
+
+					registry
+						.dispatch( MODULES_ANALYTICS_4 )
+						.receiveGetSettings( {} );
 
 					registry
 						.dispatch( MODULES_ANALYTICS_4 )
@@ -267,6 +289,10 @@ describe( 'modules/analytics-4 report', () => {
 						createTime,
 					};
 					const propertyID = property._id;
+
+					registry
+						.dispatch( MODULES_ANALYTICS_4 )
+						.receiveGetSettings( {} );
 
 					registry
 						.dispatch( MODULES_ANALYTICS_4 )

--- a/assets/js/modules/analytics-4/datastore/report.test.js
+++ b/assets/js/modules/analytics-4/datastore/report.test.js
@@ -226,18 +226,20 @@ describe( 'modules/analytics-4 report', () => {
 						)
 					);
 
-					const { isGatheringData } =
+					const { isGatheringData, hasZeroData } =
 						registry.select( MODULES_ANALYTICS_4 );
 
+					// The first call to isGatheringData returns undefined because the call to hasZeroData returns undefined.
 					expect( isGatheringData() ).toBeUndefined();
+					expect( hasZeroData() ).toBeUndefined();
 
 					// Wait for resolvers to run.
 					await waitForDefaultTimeouts();
 
-					// Verify that isGatheringData still returns undefined.
+					// Verify that isGatheringData still returns undefined due to getSettings not being resolved yet, while hasZeroData now returns true.
 					expect( isGatheringData() ).toBeUndefined();
+					expect( hasZeroData() ).toBe( true );
 
-					// Wait for resolvers to run following the second call to isGatheringData to avoid the test failing due to the second async attempt to fetch settings.
 					await waitForDefaultTimeouts();
 				} );
 


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #6559 

## Relevant technical choices

- Add fix to ensure GA4 `isGatheringData()` works when `getSettings()` is not resolved..
- Return `false` from `hasZeroData()` when the report has an error, to be aligned in terms of behaviour with the UA version.

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [ ] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
