### PR TITLE
Fix type passed to `wp_is_auto_update_forced_for_item`

### DIFF
--- a/includes/Core/Util/Auto_Updates.php
+++ b/includes/Core/Util/Auto_Updates.php
@@ -93,7 +93,7 @@ class Auto_Updates {
 	 *
 	 * @since 1.93.0
 	 *
-	 * @return AUTO_UPDATE_FORCED_ENABLED | AUTO_UPDATE_FORCED_DISABLED | AUTO_UPDATE_NOT_FORCED
+	 * @return bool|null
 	 */
 	public static function sitekit_forced_autoupdates_status() {
 		if ( ! function_exists( 'wp_is_auto_update_forced_for_item' ) ) {
@@ -102,7 +102,7 @@ class Auto_Updates {
 
 		$sitekit_plugin_data = get_plugin_data( GOOGLESITEKIT_PLUGIN_MAIN_FILE );
 
-		$is_auto_update_forced_for_sitekit = wp_is_auto_update_forced_for_item( 'plugin', null, $sitekit_plugin_data );
+		$is_auto_update_forced_for_sitekit = wp_is_auto_update_forced_for_item( 'plugin', null, (object) $sitekit_plugin_data );
 
 		if ( true === $is_auto_update_forced_for_sitekit ) {
 			return self::AUTO_UPDATE_FORCED_ENABLED;

--- a/tests/phpunit/integration/Core/Util/Auto_UpdatesTest.php
+++ b/tests/phpunit/integration/Core/Util/Auto_UpdatesTest.php
@@ -11,6 +11,7 @@
 namespace Google\Site_Kit\Tests\Core\Util;
 
 use Google\Site_Kit\Core\Util\Auto_Updates;
+use Google\Site_Kit\Tests\MethodSpy;
 use Google\Site_Kit\Tests\TestCase;
 
 /**
@@ -69,6 +70,22 @@ class Auto_UpdatesTest extends TestCase {
 		update_site_option( 'auto_update_plugins', array( 'other-plugin.php', GOOGLESITEKIT_PLUGIN_BASENAME ) );
 
 		$this->assertTrue( Auto_Updates::is_sitekit_autoupdates_enabled() );
+	}
+
+	/**
+	 * @requires function wp_is_auto_update_forced_for_item
+	 * @link https://github.com/google/site-kit-wp/issues/6624
+	 */
+	public function test_sitekit_forced_autoupdates_status() {
+		$spy = new MethodSpy();
+		add_filter( 'auto_update_plugin', array( $spy, 'callback' ), 10, 2 );
+
+		Auto_Updates::sitekit_forced_autoupdates_status();
+
+		$this->assertCount( 1, $spy->invocations['callback'] );
+		list( $update, $item ) = $spy->invocations['callback'][0];
+		$this->assertNull( $update );
+		$this->assertInternalType( 'object', $item );
 	}
 }
 

--- a/tests/phpunit/integration/Core/Util/Auto_UpdatesTest.php
+++ b/tests/phpunit/integration/Core/Util/Auto_UpdatesTest.php
@@ -85,7 +85,7 @@ class Auto_UpdatesTest extends TestCase {
 		$this->assertCount( 1, $spy->invocations['callback'] );
 		list( $update, $item ) = $spy->invocations['callback'][0];
 		$this->assertNull( $update );
-		$this->assertInternalType( 'object', $item );
+		$this->assertIsObject( $item );
 	}
 }
 


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #6624 

## Relevant technical choices

<!-- Please describe your changes. -->

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
