### PR TITLE
Don't attempt to sync GTE settings without the Tag Manager readonly scope.

### DIFF
--- a/assets/js/modules/analytics-4/datastore/properties.js
+++ b/assets/js/modules/analytics-4/datastore/properties.js
@@ -26,8 +26,10 @@ import invariant from 'invariant';
  */
 import API from 'googlesitekit-api';
 import Data from 'googlesitekit-data';
+import { CORE_USER } from '../../../googlesitekit/datastore/user/constants';
 import { CORE_SITE } from '../../../googlesitekit/datastore/site/constants';
 import { CORE_MODULES } from '../../../googlesitekit/modules/datastore/constants';
+import { READ_SCOPE as TAGMANAGER_READ_SCOPE } from '../../tagmanager/datastore/constants';
 import {
 	MODULES_ANALYTICS_4,
 	PROPERTY_CREATE,
@@ -504,6 +506,14 @@ const baseActions = {
 
 		const { select, dispatch, __experimentalResolveSelect } =
 			yield Data.commonActions.getRegistry();
+
+		const hasTagManagerReadScope = select( CORE_USER ).hasScope(
+			TAGMANAGER_READ_SCOPE
+		);
+
+		if ( ! hasTagManagerReadScope ) {
+			return;
+		}
 
 		// Wait for modules to be available before selecting.
 		yield Data.commonActions.await(

--- a/assets/js/modules/analytics-4/datastore/properties.test.js
+++ b/assets/js/modules/analytics-4/datastore/properties.test.js
@@ -30,9 +30,11 @@ import {
 	muteFetch,
 	provideModules,
 	provideSiteInfo,
+	provideUserAuthentication,
 	unsubscribeFromAll,
 	untilResolved,
 } from '../../../../../tests/js/utils';
+import { READ_SCOPE as TAGMANAGER_READ_SCOPE } from '../../tagmanager/datastore/constants';
 import {
 	MODULES_ANALYTICS_4,
 	PROPERTY_CREATE,
@@ -621,7 +623,43 @@ describe( 'modules/analytics-4 properties', () => {
 				enabledFeatures.add( 'gteSupport' );
 			} );
 
+			it( 'should not execute if the Tag Manager readonly scope is not granted', async () => {
+				provideUserAuthentication( registry );
+
+				provideModules( registry, [
+					{
+						slug: 'analytics-4',
+						active: true,
+						connected: true,
+					},
+				] );
+
+				registry.dispatch( MODULES_ANALYTICS_4 ).receiveGetSettings( {
+					measurementID: 'G-1A2BCD346E',
+					googleTagID: '',
+					googleTagLastSyncedAtMs: 0,
+				} );
+
+				await registry
+					.dispatch( MODULES_ANALYTICS_4 )
+					.syncGoogleTagSettings();
+
+				expect(
+					registry.select( MODULES_ANALYTICS_4 ).getGoogleTagID()
+				).toEqual( '' );
+
+				expect(
+					registry
+						.select( MODULES_ANALYTICS_4 )
+						.getGoogleTagLastSyncedAtMs()
+				).toEqual( 0 );
+			} );
+
 			it( 'should not execute if GA4 is not connected', async () => {
+				provideUserAuthentication( registry, {
+					grantedScopes: [ TAGMANAGER_READ_SCOPE ],
+				} );
+
 				provideModules( registry, [
 					{
 						slug: 'analytics-4',
@@ -652,6 +690,10 @@ describe( 'modules/analytics-4 properties', () => {
 			} );
 
 			it( 'should not execute if Google Tag settings already exist', async () => {
+				provideUserAuthentication( registry, {
+					grantedScopes: [ TAGMANAGER_READ_SCOPE ],
+				} );
+
 				provideModules( registry, [
 					{
 						slug: 'analytics-4',
@@ -682,6 +724,10 @@ describe( 'modules/analytics-4 properties', () => {
 			} );
 
 			it( 'should not execute if measurement ID is not set', async () => {
+				provideUserAuthentication( registry, {
+					grantedScopes: [ TAGMANAGER_READ_SCOPE ],
+				} );
+
 				provideModules( registry, [
 					{
 						slug: 'analytics-4',
@@ -711,6 +757,10 @@ describe( 'modules/analytics-4 properties', () => {
 			} );
 
 			it( 'should not execute if settings were synced less than an hour ago', async () => {
+				provideUserAuthentication( registry, {
+					grantedScopes: [ TAGMANAGER_READ_SCOPE ],
+				} );
+
 				provideModules( registry, [
 					{
 						slug: 'analytics-4',
@@ -745,6 +795,10 @@ describe( 'modules/analytics-4 properties', () => {
 			} );
 
 			it( 'dispatches a request to get and populate Google Tag settings', async () => {
+				provideUserAuthentication( registry, {
+					grantedScopes: [ TAGMANAGER_READ_SCOPE ],
+				} );
+
 				provideModules( registry, [
 					{
 						slug: 'analytics-4',

--- a/assets/js/modules/tagmanager/datastore/constants.js
+++ b/assets/js/modules/tagmanager/datastore/constants.js
@@ -28,6 +28,8 @@ export const CONTEXT_WEB = 'web';
 export const CONTEXT_AMP = 'amp';
 // Form ID for the module setup form.
 export const FORM_SETUP = 'tagmanagerSetup';
+// OAuth scope needed for viewing containers.
+export const READ_SCOPE = 'https://www.googleapis.com/auth/tagmanager.readonly';
 // OAuth scope needed for creating containers.
 export const EDIT_SCOPE =
 	'https://www.googleapis.com/auth/tagmanager.edit.containers';


### PR DESCRIPTION
## Summary

Addresses issue:

- #6082 

## Relevant technical choices

- As per the title, don't attempt to sync GTE settings without the Tag Manager readonly scope. For more details, see https://github.com/google/site-kit-wp/issues/6082#issuecomment-1440949314.

<!-- Please describe your changes. -->

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
