### PR TITLE
Fix calculation of the sticky header height to account for non-sticky header scenario.

### DIFF
--- a/assets/js/util/scroll.js
+++ b/assets/js/util/scroll.js
@@ -76,6 +76,23 @@ export function getHeaderHeight( breakpoint ) {
 export function getHeaderHeightWithoutNav( breakpoint ) {
 	let headerHeight = 0;
 
+	// When the Joyride overlay is present, Site Kit's header is not sticky.
+	const isSiteKitHeaderSticky = ! document.querySelector(
+		'.react-joyride__overlay'
+	);
+
+	if ( ! isSiteKitHeaderSticky ) {
+		// If the Site Kit header is not sticky, we only need to calculate the height of the sticky WordPress admin bar.
+		// Furthermore, the WordPress admin bar is only sticky for breakpoints larger than BREAKPOINT_SMALL. If it's also not sticky then we can return a height of 0.
+		const wpAdminBar = document.querySelector( '#wpadminbar' );
+
+		if ( wpAdminBar && breakpoint !== BREAKPOINT_SMALL ) {
+			return wpAdminBar.offsetHeight;
+		}
+
+		return 0;
+	}
+
 	const header = document.querySelector( '.googlesitekit-header' );
 	if ( header ) {
 		headerHeight =


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #6109 

## Relevant technical choices

Chose to determine the Joyride overlay presence by querying for the element, rather than attempting to determine via application state, as it's simpler and can be encapsulated within the existing `getHeaderHeightWithoutNav()` utility function.

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
