### PR TITLE
Enhance/#6217 - Remove percentage in graph tooltip

### DIFF
--- a/assets/js/modules/search-console/components/dashboard/SearchFunnelWidgetGA4/index.js
+++ b/assets/js/modules/search-console/components/dashboard/SearchFunnelWidgetGA4/index.js
@@ -39,7 +39,6 @@ import {
 import { DATE_RANGE_OFFSET as DATE_RANGE_OFFSET_ANALYTICS } from '../../../../analytics/datastore/constants';
 import { CORE_SITE } from '../../../../../googlesitekit/datastore/site/constants';
 import { CORE_USER } from '../../../../../googlesitekit/datastore/user/constants';
-import { numFmt } from '../../../../../util';
 import PreviewBlock from '../../../../../components/PreviewBlock';
 import Header from '../SearchFunnelWidget/Header';
 import Footer from '../SearchFunnelWidget/Footer';
@@ -468,12 +467,7 @@ const SearchFunnelWidgetGA4 = ( { Widget, WidgetReportError } ) => {
 						] }
 						dataFormats={ [
 							( x ) => parseFloat( x ).toLocaleString(),
-							( x ) =>
-								numFmt( x / 100, {
-									style: 'percent',
-									signDisplay: 'never',
-									maximumFractionDigits: 2,
-								} ),
+							( x ) => parseFloat( x ).toLocaleString(),
 						] }
 						statsColor={
 							SearchFunnelWidgetGA4.metrics[ selectedStats ].color


### PR DESCRIPTION
## Summary

Addresses issue:

- #6217 

## Relevant technical choices

- This PR removes the `%` from the chart tooltip for the `Engaged Sessions`. Please take a look at this [comment.](https://github.com/google/site-kit-wp/issues/6217#issuecomment-1456261734)

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
