### PR TITLE
Add a expiration date to set data available.

### DIFF
--- a/includes/Core/Modules/Module_With_Data_Available_State_Trait.php
+++ b/includes/Core/Modules/Module_With_Data_Available_State_Trait.php
@@ -49,7 +49,7 @@ trait Module_With_Data_Available_State_Trait {
 	 * @return bool True on success, false otherwise.
 	 */
 	public function set_data_available() {
-		// TODO: Remove the expiration time the gathering data state on error is sorted out.
+		// TODO: Remove the expiration time once the gathering data state on error is sorted out.
 		// See: https://github.com/google/site-kit-wp/issues/6698 for more details.
 		return $this->transients->set( $this->get_data_available_transient_name(), true, 3600 );
 	}

--- a/includes/Core/Modules/Module_With_Data_Available_State_Trait.php
+++ b/includes/Core/Modules/Module_With_Data_Available_State_Trait.php
@@ -49,7 +49,9 @@ trait Module_With_Data_Available_State_Trait {
 	 * @return bool True on success, false otherwise.
 	 */
 	public function set_data_available() {
-		return $this->transients->set( $this->get_data_available_transient_name(), true );
+		// TODO: Remove the expiration time the gathering data state on error is sorted out.
+		// See: https://github.com/google/site-kit-wp/issues/6698 for more details.
+		return $this->transients->set( $this->get_data_available_transient_name(), true, 3600 );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #5933 

## Relevant technical choices

This temporarily adds a expiration timer to persistence to a potential incorrect state is not persisted for too long. See #6698  

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
