### PR TITLE
Allow reference date to be overriden on page load

### DIFF
--- a/assets/js/googlesitekit/datastore/user/date-range.js
+++ b/assets/js/googlesitekit/datastore/user/date-range.js
@@ -199,7 +199,9 @@ export const selectors = {
 	 * @return {string} The current reference date as YYYY-MM-DD.
 	 */
 	getReferenceDate( state ) {
-		return state.referenceDate;
+		return (
+			global._googlesitekitBaseData?.referenceDate ?? state.referenceDate
+		);
 	},
 };
 

--- a/assets/js/googlesitekit/datastore/user/date-range.test.js
+++ b/assets/js/googlesitekit/datastore/user/date-range.test.js
@@ -308,6 +308,16 @@ describe( 'core/user date-range', () => {
 					registry.select( CORE_USER ).getReferenceDate()
 				).toEqual( getDateString( new Date() ) );
 			} );
+
+			it( 'dhould return the reference date defined in global base data when available', () => {
+				global._googlesitekitBaseData = {
+					referenceDate: '2023-09-01',
+				};
+
+				expect(
+					registry.select( CORE_USER ).getReferenceDate()
+				).toEqual( '2023-09-01' );
+			} );
 		} );
 	} );
 } );

--- a/includes/Core/Assets/Assets.php
+++ b/includes/Core/Assets/Assets.php
@@ -716,6 +716,7 @@ final class Assets {
 			'webStoriesActive' => defined( 'WEBSTORIES_VERSION' ),
 			'postTypes'        => $this->get_post_types(),
 			'storagePrefix'    => $this->get_storage_prefix(),
+			'referenceDate'    => apply_filters( 'googlesitekit_reference_date', null ),
 		);
 
 		/**


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #6782

## Relevant technical choices

<!-- Please describe your changes. -->

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [ ] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
