### PR TITLE
Sync owner ID between both Analytics modules

### DIFF
--- a/includes/Modules/Analytics.php
+++ b/includes/Modules/Analytics.php
@@ -44,6 +44,7 @@ use Google\Site_Kit\Modules\Analytics\Tag_Guard;
 use Google\Site_Kit\Modules\Analytics\Web_Tag;
 use Google\Site_Kit\Modules\Analytics\Proxy_AccountTicket;
 use Google\Site_Kit\Modules\Analytics\Advanced_Tracking;
+use Google\Site_Kit\Modules\Analytics_4\Settings as Analytics_4_Settings;
 use Google\Site_Kit_Dependencies\Google\Service\Analytics as Google_Service_Analytics;
 use Google\Site_Kit_Dependencies\Google\Service\AnalyticsReporting as Google_Service_AnalyticsReporting;
 use Google\Site_Kit_Dependencies\Google\Service\AnalyticsReporting\GetReportsRequest as Google_Service_AnalyticsReporting_GetReportsRequest;
@@ -142,6 +143,26 @@ final class Analytics extends Module
 				}
 			},
 			10,
+			2
+		);
+
+		// Ensure both Analytics modules always reference the same owner.
+		add_filter(
+			'pre_update_option_' . Analytics_4_Settings::OPTION,
+			function( $new_value, $old_value ) {
+				if ( $old_value['ownerID'] !== $new_value['ownerID'] ) {
+					$settings = $this->get_settings()->get();
+
+					if ( $settings['ownerID'] && $new_value['ownerID'] !== $settings['ownerID'] ) {
+						$this->get_settings()->merge(
+							array( 'ownerID' => $new_value['ownerID'] )
+						);
+					}
+				}
+
+				return $new_value;
+			},
+			20,
 			2
 		);
 

--- a/includes/Modules/Analytics_4.php
+++ b/includes/Modules/Analytics_4.php
@@ -125,6 +125,26 @@ final class Analytics_4 extends Module
 			10,
 			2
 		);
+
+		// Ensure both Analytics modules always reference the same owner.
+		add_filter(
+			'pre_update_option_' . Analytics_Settings::OPTION,
+			function( $new_value, $old_value ) {
+				if ( $old_value['ownerID'] !== $new_value['ownerID'] ) {
+					$settings = $this->get_settings()->get();
+
+					if ( $settings['ownerID'] && $new_value['ownerID'] !== $settings['ownerID'] ) {
+						$this->get_settings()->merge(
+							array( 'ownerID' => $new_value['ownerID'] )
+						);
+					}
+				}
+
+				return $new_value;
+			},
+			20,
+			2
+		);
 	}
 
 	/**


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #6465 

## Relevant technical choices

This PR aims to enable synchronization between `Analytics` and `Analytics_4` such that if the module owner ID is changed in other, the change is reflected on the other.

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
