### PR TITLE
Prevent incorrect container lookup when selecting a new Google Tag via the Google Tag ID Mismatch Notification banner.

### DIFF
--- a/assets/js/modules/analytics-4/datastore/properties.js
+++ b/assets/js/modules/analytics-4/datastore/properties.js
@@ -497,11 +497,12 @@ const baseActions = {
 		const { googleTagAccountID, googleTagContainerID, googleTagID } =
 			response;
 
-		// Note that when plain actions are dispatched in a generator function action, they are handled asynchronously when they would normally be synchronous.
-		// This means that following the usual pattern of dispatching individual setter actions for the `googleTagAccountID`, `googleTagContainerID` and `googleTagID` settings
-		// each resulted in a rerender of the GoogleTagIDMismatchNotification component, thus resulting in an erroneous call to the GET:container-destinations endpoint with
-		// mismatched settings. To mitigate this, we dispatch a single action here to set all these settings at once. The same applies to the `setSettings()` call above.
-		// See https://github.com/google/site-kit-wp/issues/6784.
+		// Note that when plain actions are dispatched in a function where an await has occurred (this can be a regular async function that has awaited, or a generator function
+		// action that yields to an async action), they are handled asynchronously when they would normally be synchronous. This means that following the usual pattern of dispatching
+		// individual setter actions for the `googleTagAccountID`, `googleTagContainerID` and `googleTagID` settings each resulted in a rerender of the
+		// GoogleTagIDMismatchNotification component, thus resulting in an erroneous call to the GET:container-destinations endpoint with mismatched settings. To mitigate this, we
+		// dispatch a single action here to set all these settings at once. The same applies to the `setSettings()` call above.
+		// See issue https://github.com/google/site-kit-wp/issues/6784 and the PR https://github.com/google/site-kit-wp/pull/6814.
 		registry.dispatch( MODULES_ANALYTICS_4 ).setSettings( {
 			googleTagAccountID,
 			googleTagContainerID,

--- a/assets/js/modules/analytics-4/datastore/properties.js
+++ b/assets/js/modules/analytics-4/datastore/properties.js
@@ -477,13 +477,11 @@ const baseActions = {
 		}
 
 		if ( ! measurementID ) {
-			registry
-				.dispatch( MODULES_ANALYTICS_4 )
-				.setGoogleTagAccountID( '' );
-			registry
-				.dispatch( MODULES_ANALYTICS_4 )
-				.setGoogleTagContainerID( '' );
-			registry.dispatch( MODULES_ANALYTICS_4 ).setGoogleTagID( '' );
+			registry.dispatch( MODULES_ANALYTICS_4 ).setSettings( {
+				googleTagAccountID: '',
+				googleTagContainerID: '',
+				googleTagID: '',
+			} );
 			return;
 		}
 
@@ -499,13 +497,16 @@ const baseActions = {
 		const { googleTagAccountID, googleTagContainerID, googleTagID } =
 			response;
 
-		registry
-			.dispatch( MODULES_ANALYTICS_4 )
-			.setGoogleTagAccountID( googleTagAccountID );
-		registry
-			.dispatch( MODULES_ANALYTICS_4 )
-			.setGoogleTagContainerID( googleTagContainerID );
-		registry.dispatch( MODULES_ANALYTICS_4 ).setGoogleTagID( googleTagID );
+		// Note that when plain actions are dispatched in a generator function action, they are handled asynchronously when they would normally be synchronous.
+		// This means that following the usual pattern of dispatching individual setter actions for the `googleTagAccountID`, `googleTagContainerID` and `googleTagID` settings
+		// each resulted in a rerender of the GoogleTagIDMismatchNotification component, thus resulting in an erroneous call to the GET:container-destinations endpoint with
+		// mismatched settings. To mitigate this, we dispatch a single action here to set all these settings at once. The same applies to the `setSettings()` call above.
+		// See https://github.com/google/site-kit-wp/issues/6784.
+		registry.dispatch( MODULES_ANALYTICS_4 ).setSettings( {
+			googleTagAccountID,
+			googleTagContainerID,
+			googleTagID,
+		} );
 	},
 
 	/**


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #6784 

## Relevant technical choices

<!-- Please describe your changes. -->

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
