### PR TITLE
Followup: Set reference date in state instead of using global

### DIFF
--- a/assets/js/googlesitekit/datastore/user/date-range.js
+++ b/assets/js/googlesitekit/datastore/user/date-range.js
@@ -35,9 +35,7 @@ import {
 
 export const initialState = {
 	dateRange: 'last-28-days',
-	referenceDate: getDateString(
-		global._googlesitekitBaseData?.referenceDate || new Date()
-	),
+	referenceDate: getDateString( new Date() ),
 };
 
 /**

--- a/assets/js/googlesitekit/datastore/user/date-range.js
+++ b/assets/js/googlesitekit/datastore/user/date-range.js
@@ -35,7 +35,9 @@ import {
 
 export const initialState = {
 	dateRange: 'last-28-days',
-	referenceDate: getDateString( new Date() ),
+	referenceDate: getDateString(
+		global._googlesitekitBaseData?.referenceDate || new Date()
+	),
 };
 
 /**
@@ -199,9 +201,7 @@ export const selectors = {
 	 * @return {string} The current reference date as YYYY-MM-DD.
 	 */
 	getReferenceDate( state ) {
-		return (
-			global._googlesitekitBaseData?.referenceDate ?? state.referenceDate
-		);
+		return state.referenceDate;
 	},
 };
 

--- a/assets/js/googlesitekit/datastore/user/date-range.test.js
+++ b/assets/js/googlesitekit/datastore/user/date-range.test.js
@@ -314,6 +314,8 @@ describe( 'core/user date-range', () => {
 					referenceDate: '2023-09-01',
 				};
 
+				registry = createTestRegistry();
+
 				expect(
 					registry.select( CORE_USER ).getReferenceDate()
 				).toEqual( '2023-09-01' );

--- a/assets/js/googlesitekit/datastore/user/index.js
+++ b/assets/js/googlesitekit/datastore/user/index.js
@@ -65,6 +65,13 @@ export const {
 
 export const registerStore = ( registry ) => {
 	registry.registerStore( CORE_USER, store );
+
+	// If a reference date was set by the server, set it in the store.
+	if ( global._googlesitekitBaseData?.referenceDate ) {
+		registry
+			.dispatch( CORE_USER )
+			.setReferenceDate( global._googlesitekitBaseData.referenceDate );
+	}
 };
 
 export default store;


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #6782.

## Relevant technical choices

Because the `initialState` was set as soon as the module loaded, it read the value from the global on module load and we couldn't modify the global in jest tests to ensure the global was being read properly.

After discussing with @aaemnnosttv, we changed the approach to set the reference date in the store on the `registerStore` function of `core/user`.

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
