### PR TITLE
Fix GA4 setup tooltip React error

### DIFF
--- a/assets/js/modules/analytics-4/components/common/PropertySelect.js
+++ b/assets/js/modules/analytics-4/components/common/PropertySelect.js
@@ -152,6 +152,8 @@ export default function PropertySelect( props ) {
 				className,
 				{
 					'mdc-select--invalid': ! isValidSelection,
+					'googlesitekit-analytics-4__select-property--loaded':
+						! isDisabled && ! isLoading,
 				}
 			) }
 			label={ __( 'Property', 'google-site-kit' ) }

--- a/assets/js/modules/analytics/components/settings/GA4SettingsControls.js
+++ b/assets/js/modules/analytics/components/settings/GA4SettingsControls.js
@@ -126,7 +126,7 @@ export default function GA4SettingsControls( props ) {
 									zIndex: 9999,
 								},
 							} }
-							target=".googlesitekit-analytics-4__select-property"
+							target=".googlesitekit-analytics-4__select-property:not( .mdc-select--disabled )"
 							onDismiss={ onDismissTooltip }
 							cta={
 								<Button

--- a/assets/js/modules/analytics/components/settings/GA4SettingsControls.js
+++ b/assets/js/modules/analytics/components/settings/GA4SettingsControls.js
@@ -126,7 +126,7 @@ export default function GA4SettingsControls( props ) {
 									zIndex: 9999,
 								},
 							} }
-							target=".googlesitekit-analytics-4__select-property:not( .mdc-select--disabled )"
+							target=".googlesitekit-analytics-4__select-property--loaded"
 							onDismiss={ onDismissTooltip }
 							cta={
 								<Button


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #6832 

## Relevant technical choices

This aims to fix the issue described in #6832 where the tooltip tries to render when the property select is disabled, but then is replaced by a progress bar. The solution is to render the tooltip only when the property select is not in a disabled state.

While the proposed solution in the IB works, I think the concern raised [here](https://github.com/google/site-kit-wp/issues/6832#issuecomment-1500556682) makes sense, and there is a possibility that we might encounter a race condition in the future.

As a result, I've gone with a slightly different approach, added a class when the `<PropertySelect />` has fully loaded (not disabled and not loading), and rendered the tooltip based on this new class.

Let me know if this looks good, thanks!

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
