### PR TITLE
Fix module recovery without UA connected

### DIFF
--- a/assets/js/components/notifications/ZeroDataStateNotifications/index.js
+++ b/assets/js/components/notifications/ZeroDataStateNotifications/index.js
@@ -75,7 +75,9 @@ export default function ZeroDataStateNotifications() {
 			return undefined;
 		}
 
-		return Object.keys( recoverableModules ).includes( 'analytics' );
+		return Object.keys( recoverableModules ).includes(
+			isGA4DashboardView ? 'analytics-4' : 'analytics'
+		);
 	} );
 	const showRecoverableSearchConsole = useSelect( ( select ) => {
 		if ( ! viewOnly ) {

--- a/assets/js/googlesitekit/modules/datastore/modules.js
+++ b/assets/js/googlesitekit/modules/datastore/modules.js
@@ -750,11 +750,29 @@ const baseResolvers = {
 			registry.__experimentalResolveSelect( CORE_MODULES ).getModules()
 		);
 
+		if ( modules?.analytics?.recoverable ) {
+			yield Data.commonActions.await(
+				registry
+					.__experimentalResolveSelect( MODULES_ANALYTICS )
+					.getSettings()
+			);
+		}
+
 		const recoverableModules = Object.entries( modules || {} ).reduce(
 			( moduleList, [ moduleSlug, module ] ) => {
 				if ( module.recoverable && ! module.internal ) {
-					moduleList.push( moduleSlug );
+					if (
+						moduleSlug === 'analytics' &&
+						registry
+							.select( MODULES_ANALYTICS )
+							.isGA4DashboardView()
+					) {
+						moduleList.push( 'analytics-4' );
+					} else {
+						moduleList.push( moduleSlug );
+					}
 				}
+
 				return moduleList;
 			},
 			[]

--- a/assets/js/googlesitekit/modules/datastore/modules.test.js
+++ b/assets/js/googlesitekit/modules/datastore/modules.test.js
@@ -1938,14 +1938,10 @@ describe( 'core/modules modules', () => {
 					}
 				);
 
-				fetchMock.getOnce(
+				muteFetch(
 					new RegExp(
 						'^/google-site-kit/v1/modules/analytics/data/settings'
-					),
-					{
-						body: {},
-						status: 200,
-					}
+					)
 				);
 
 				const initialRecoverableModules = registry

--- a/assets/js/googlesitekit/modules/datastore/modules.test.js
+++ b/assets/js/googlesitekit/modules/datastore/modules.test.js
@@ -2011,6 +2011,14 @@ describe( 'core/modules modules', () => {
 						'slug'
 					)
 				);
+
+				expect( Object.keys( recoverableModules ) ).toContain(
+					'analytics-4'
+				);
+
+				expect( Object.keys( recoverableModules ) ).not.toContain(
+					'analytics-4'
+				);
 			} );
 		} );
 

--- a/assets/js/modules/search-console/components/dashboard/SearchFunnelWidgetGA4/index.js
+++ b/assets/js/modules/search-console/components/dashboard/SearchFunnelWidgetGA4/index.js
@@ -119,7 +119,7 @@ const SearchFunnelWidgetGA4 = ( { Widget, WidgetReportError } ) => {
 			return undefined;
 		}
 
-		return Object.keys( recoverableModules ).includes( 'analytics' );
+		return Object.keys( recoverableModules ).includes( 'analytics-4' );
 	} );
 
 	const ga4ConversionsData = useInViewSelect( ( select ) => {

--- a/includes/Core/Modules/REST_Modules_Controller.php
+++ b/includes/Core/Modules/REST_Modules_Controller.php
@@ -14,6 +14,8 @@ use Google\Site_Kit\Core\Permissions\Permissions;
 use Google\Site_Kit\Core\REST_API\REST_Routes;
 use Google\Site_Kit\Core\REST_API\REST_Route;
 use Google\Site_Kit\Core\REST_API\Exception\Invalid_Datapoint_Exception;
+use Google\Site_Kit\Modules\Analytics;
+use Google\Site_Kit\Modules\Analytics_4;
 use WP_REST_Server;
 use WP_REST_Request;
 use WP_REST_Response;
@@ -684,6 +686,27 @@ class REST_Modules_Controller {
 										)
 									);
 									continue;
+								}
+
+								// Since currently the Analytics_4 module doesn't have an ownerID setting,
+								// it uses the ownerID from Analytics as the source of truth. Hence,
+								// instead of updating ownerID for Analytics_4, we should be updating that
+								// of Analytics.
+								if ( Analytics_4::MODULE_SLUG === $slug ) {
+									try {
+										$module = $this->modules->get_module( Analytics::MODULE_SLUG );
+									} catch ( Exception $e ) {
+										$response = $this->handle_module_recovery_error(
+											$slug,
+											$response,
+											new WP_Error(
+												'invalid_module_slug',
+												$e->getMessage(),
+												array( 'status' => 404 )
+											)
+										);
+										continue;
+									}
 								}
 
 								// Update the module's ownerID to the ID of the user making the request.


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #6861 

## Relevant technical choices

This PR fixes an issue where the module recovery doesn't work with the Analytics module set up without UA.

### Difference from the IB

While this is not mentioned in the IB, the `modules/data/recover-modules` endpoint needed to be updated so that if the recovering slug is `analytics-4`, it updates the owner ID for the `Analytics` module. This is because after #6846, the `ownerID` setting was removed from `Analytics_4` and `ownerID` from `Analytics` is being used as the source of truth for both.

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
