### PR TITLE
Don't request `createTime` on shared dashboard in view-only mode.

### DIFF
--- a/assets/js/modules/analytics/components/dashboard/DashboardAllTrafficWidgetGA4/UserCountGraph.js
+++ b/assets/js/modules/analytics/components/dashboard/DashboardAllTrafficWidgetGA4/UserCountGraph.js
@@ -44,6 +44,7 @@ import { stringToDate } from '../../../../../util/date-range/string-to-date';
 import { createZeroDataRow } from './utils';
 import { MODULES_ANALYTICS_4 } from '../../../../analytics-4/datastore/constants';
 import { getDateString } from '../../../../../util';
+import useViewOnly from '../../../../../hooks/useViewOnly';
 const { useSelect } = Data;
 
 const X_SMALL_ONLY_MEDIA_QUERY = '(max-width: 450px)';
@@ -53,6 +54,8 @@ const X_LARGE_AND_ABOVE_MEDIA_QUERY = '(min-width: 1281px)';
 
 export default function UserCountGraph( props ) {
 	const { loaded, error, report, gatheringData } = props;
+
+	const isViewOnly = useViewOnly();
 
 	const { startDate, endDate } = useSelect( ( select ) =>
 		select( CORE_USER ).getDateRangeDates( {
@@ -99,7 +102,7 @@ export default function UserCountGraph( props ) {
 		select( MODULES_ANALYTICS_4 ).getPropertyID()
 	);
 	const property = useSelect( ( select ) =>
-		propertyID
+		propertyID && ! isViewOnly
 			? select( MODULES_ANALYTICS_4 ).getProperty( propertyID )
 			: null
 	);

--- a/assets/js/modules/analytics/components/dashboard/DashboardAllTrafficWidgetGA4/UserCountGraph.js
+++ b/assets/js/modules/analytics/components/dashboard/DashboardAllTrafficWidgetGA4/UserCountGraph.js
@@ -98,14 +98,20 @@ export default function UserCountGraph( props ) {
 		};
 	}, [] );
 
-	const propertyID = useSelect( ( select ) =>
-		select( MODULES_ANALYTICS_4 ).getPropertyID()
-	);
-	const property = useSelect( ( select ) =>
-		propertyID && ! isViewOnly
-			? select( MODULES_ANALYTICS_4 ).getProperty( propertyID )
-			: null
-	);
+	const property = useSelect( ( select ) => {
+		if ( isViewOnly ) {
+			return null;
+		}
+
+		const propertyID = select( MODULES_ANALYTICS_4 ).getPropertyID();
+
+		if ( ! propertyID ) {
+			return null;
+		}
+
+		return select( MODULES_ANALYTICS_4 ).getProperty( propertyID );
+	} );
+
 	const propertyCreatedDate = property?.createTime
 		? getDateString( new Date( property.createTime ) )
 		: null;

--- a/assets/js/modules/search-console/components/common/AnalyticsStats.js
+++ b/assets/js/modules/search-console/components/common/AnalyticsStats.js
@@ -39,6 +39,7 @@ import { UA_CUTOFF_DATE } from '../../../analytics/constants';
 import { MODULES_ANALYTICS } from '../../../analytics/datastore/constants';
 import { MODULES_ANALYTICS_4 } from '../../../analytics-4/datastore/constants';
 import { getDateString } from '../../../../util';
+import useViewOnly from '../../../../hooks/useViewOnly';
 const { useSelect } = Data;
 
 /**
@@ -103,6 +104,8 @@ export default function AnalyticsStats( props ) {
 		moduleSlug,
 	} = props;
 
+	const isViewOnly = useViewOnly();
+
 	const analyticsModuleConnected = useSelect( ( select ) =>
 		select( CORE_MODULES ).isModuleConnected( moduleSlug )
 	);
@@ -119,7 +122,7 @@ export default function AnalyticsStats( props ) {
 			: null
 	);
 	const property = useSelect( ( select ) =>
-		propertyID
+		propertyID && ! isViewOnly
 			? select( MODULES_ANALYTICS_4 ).getProperty( propertyID )
 			: null
 	);

--- a/assets/js/modules/search-console/components/common/AnalyticsStats.js
+++ b/assets/js/modules/search-console/components/common/AnalyticsStats.js
@@ -116,16 +116,20 @@ export default function AnalyticsStats( props ) {
 		select( MODULES_ANALYTICS ).isGA4DashboardView()
 	);
 
-	const propertyID = useSelect( ( select ) =>
-		isGA4DashboardView
-			? select( MODULES_ANALYTICS_4 ).getPropertyID()
-			: null
-	);
-	const property = useSelect( ( select ) =>
-		propertyID && ! isViewOnly
-			? select( MODULES_ANALYTICS_4 ).getProperty( propertyID )
-			: null
-	);
+	const property = useSelect( ( select ) => {
+		if ( isViewOnly || isGA4DashboardView ) {
+			return null;
+		}
+
+		const propertyID = select( MODULES_ANALYTICS_4 ).getPropertyID();
+
+		if ( ! propertyID ) {
+			return null;
+		}
+
+		return select( MODULES_ANALYTICS_4 ).getProperty( propertyID );
+	} );
+
 	const propertyCreatedDate = property?.createTime
 		? getDateString( new Date( property.createTime ) )
 		: null;


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #6572.

## Relevant technical choices

Prevents API requests to non-shared APIs on the view-only dashboard when viewing GA4 data.

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
