### PR TITLE
Update autoloader to avoid loading non-existing classes

### DIFF
--- a/includes/loader.php
+++ b/includes/loader.php
@@ -33,9 +33,10 @@ function autoload_classes() {
 			if (
 				// Only handle classes defined in our class maps.
 				isset( $class_map[ $class ] )
-				// Only load core Site Kit classes or others that exist (e.g. polyfills).
+				// Only load Site Kit classes or others that exist (e.g. polyfills).
 				&& (
-					'Google\\Site_Kit' === substr( $class, 0, 15 )
+					0 === strpos( $class, 'Google\\Site_Kit\\' )
+					|| 0 === strpos( $class, 'Google\\Site_Kit_Dependencies\\' )
 					|| file_exists( $class_map[ $class ] )
 				)
 			) {

--- a/includes/loader.php
+++ b/includes/loader.php
@@ -30,7 +30,15 @@ function autoload_classes() {
 
 	spl_autoload_register(
 		function ( $class ) use ( $class_map ) {
-			if ( isset( $class_map[ $class ] ) ) {
+			if (
+				// Only handle classes defined in our class maps.
+				isset( $class_map[ $class ] )
+				// Only load core Site Kit classes or others that exist (e.g. polyfills).
+				&& (
+					'Google\\Site_Kit' === substr( $class, 0, 15 )
+					|| file_exists( $class_map[ $class ] )
+				)
+			) {
 				require_once $class_map[ $class ];
 			}
 		},


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #6887

## Relevant technical choices

- Restores the condition removed in https://github.com/google/site-kit-wp/pull/6581/files#diff-067193c915671062a08eb302c679c0beddb7154eb4d3c7db7feda18d78da4c4c
- Adds condition for non-Site Kit classes to check file exists

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
