### PR TITLE
Enhancement/6928 documentation url changes

### DIFF
--- a/assets/js/components/notifications/SwitchGA4DashboardViewNotification.js
+++ b/assets/js/components/notifications/SwitchGA4DashboardViewNotification.js
@@ -41,7 +41,9 @@ export default function SwitchGA4DashboardViewNotification() {
 	);
 
 	const ga4DocumentationURL = useSelect( ( select ) =>
-		select( CORE_SITE ).getDocumentationLinkURL( 'ga4' )
+		select( CORE_SITE ).getDocumentationLinkURL(
+			'using-the-site-kit-dashboard-with-ga4'
+		)
 	);
 
 	const { setDashboardView, saveSettings } = useDispatch( MODULES_ANALYTICS );

--- a/assets/js/components/setup/SetupUsingProxyWithSignIn.test.js
+++ b/assets/js/components/setup/SetupUsingProxyWithSignIn.test.js
@@ -23,6 +23,7 @@ import {
 	provideUserAuthentication,
 	provideUserInfo,
 	provideUserCapabilities,
+	provideSiteInfo,
 	muteFetch,
 } from '../../../../tests/js/test-utils';
 import coreModulesFixture from '../../googlesitekit/modules/datastore/__fixtures__';
@@ -47,6 +48,7 @@ describe( 'SetupUsingProxyWithSignIn', () => {
 		provideUserInfo( registry );
 		provideUserAuthentication( registry );
 		provideUserCapabilities( registry );
+		provideSiteInfo( registry );
 		registry.dispatch( CORE_USER ).receiveConnectURL( 'test-url' );
 
 		muteFetch(

--- a/assets/js/components/setup/__snapshots__/SetupUsingProxyWithSignIn.test.js.snap
+++ b/assets/js/components/setup/__snapshots__/SetupUsingProxyWithSignIn.test.js.snap
@@ -17,7 +17,7 @@ exports[`SetupUsingProxyWithSignIn should not render the Activate Analytics noti
           <a
             aria-label="Go to dashboard"
             class="googlesitekit-cta-link googlesitekit-header__logo-link"
-            href=""
+            href="http://example.com/wp-admin/admin.php?page=googlesitekit-dashboard"
           >
             <div
               aria-hidden="true"
@@ -69,7 +69,7 @@ exports[`SetupUsingProxyWithSignIn should not render the Activate Analytics noti
                   <a
                     aria-label="Fix common issues (opens in a new tab)"
                     class="googlesitekit-cta-link mdc-list-item__text"
-                    href="undefined?doc=fix-common-issues"
+                    href="https://sitekit.withgoogle.com/support/?doc=fix-common-issues"
                     rel="noopener noreferrer"
                     role="menuitem"
                     tabindex="-1"
@@ -171,6 +171,27 @@ exports[`SetupUsingProxyWithSignIn should not render the Activate Analytics noti
                         wapuu.wordpress@gmail.com
                       </p>
                     </div>
+                  </div>
+                </li>
+                <li
+                  class="mdc-list-item"
+                  id="manage-sites"
+                  role="menuitem"
+                  tabindex="-1"
+                >
+                  <div
+                    class="googlesitekit-user-menu__item"
+                  >
+                    <div
+                      class="googlesitekit-user-menu__item-icon"
+                    >
+                      <svg />
+                    </div>
+                    <span
+                      class="googlesitekit-user-menu__item-label"
+                    >
+                      Manage Sites
+                    </span>
                   </div>
                 </li>
                 <li
@@ -285,8 +306,10 @@ exports[`SetupUsingProxyWithSignIn should not render the Activate Analytics noti
                     <div
                       class="googlesitekit-start-setup-wrap"
                     >
-                      <button
+                      <a
                         class="mdc-button googlesitekit-start-setup mdc-button--raised"
+                        href="https://sitekit.withgoogle.com/site-management/setup/"
+                        role="button"
                         target="_self"
                       >
                         <span
@@ -294,7 +317,7 @@ exports[`SetupUsingProxyWithSignIn should not render the Activate Analytics noti
                         >
                           Sign in with Google
                         </span>
-                      </button>
+                      </a>
                     </div>
                   </div>
                 </div>
@@ -325,7 +348,7 @@ exports[`SetupUsingProxyWithSignIn should render the setup page, including the A
           <a
             aria-label="Go to dashboard"
             class="googlesitekit-cta-link googlesitekit-header__logo-link"
-            href=""
+            href="http://example.com/wp-admin/admin.php?page=googlesitekit-dashboard"
           >
             <div
               aria-hidden="true"
@@ -377,7 +400,7 @@ exports[`SetupUsingProxyWithSignIn should render the setup page, including the A
                   <a
                     aria-label="Fix common issues (opens in a new tab)"
                     class="googlesitekit-cta-link mdc-list-item__text"
-                    href="undefined?doc=fix-common-issues"
+                    href="https://sitekit.withgoogle.com/support/?doc=fix-common-issues"
                     rel="noopener noreferrer"
                     role="menuitem"
                     tabindex="-1"
@@ -479,6 +502,27 @@ exports[`SetupUsingProxyWithSignIn should render the setup page, including the A
                         wapuu.wordpress@gmail.com
                       </p>
                     </div>
+                  </div>
+                </li>
+                <li
+                  class="mdc-list-item"
+                  id="manage-sites"
+                  role="menuitem"
+                  tabindex="-1"
+                >
+                  <div
+                    class="googlesitekit-user-menu__item"
+                  >
+                    <div
+                      class="googlesitekit-user-menu__item-icon"
+                    >
+                      <svg />
+                    </div>
+                    <span
+                      class="googlesitekit-user-menu__item-label"
+                    >
+                      Manage Sites
+                    </span>
                   </div>
                 </li>
                 <li
@@ -649,8 +693,10 @@ exports[`SetupUsingProxyWithSignIn should render the setup page, including the A
                     <div
                       class="googlesitekit-start-setup-wrap"
                     >
-                      <button
+                      <a
                         class="mdc-button googlesitekit-start-setup mdc-button--raised"
+                        href="https://sitekit.withgoogle.com/site-management/setup/"
+                        role="button"
                         target="_self"
                       >
                         <span
@@ -658,7 +704,7 @@ exports[`SetupUsingProxyWithSignIn should render the setup page, including the A
                         >
                           Sign in with Google
                         </span>
-                      </button>
+                      </a>
                     </div>
                   </div>
                 </div>

--- a/assets/js/googlesitekit/datastore/site/urls.js
+++ b/assets/js/googlesitekit/datastore/site/urls.js
@@ -22,6 +22,11 @@
 import invariant from 'invariant';
 
 /**
+ * WordPress dependencies
+ */
+import { addQueryArgs } from '@wordpress/url';
+
+/**
  * Internal dependencies
  */
 import Data from 'googlesitekit-data';
@@ -113,19 +118,22 @@ export const selectors = {
 	 * Gets the Site Kit documentation URL.
 	 *
 	 * @since 1.80.0
+	 * @since n.e.x.t Added the anchor parameter.
 	 *
-	 * @param {Object} state Data store's state.
-	 * @param {string} slug  The slug of the documentation page.
+	 * @param {Object} state  Data store's state.
+	 * @param {string} slug   The slug of the documentation page.
+	 * @param {string} anchor The anchor on the documentation page.
 	 * @return {string} The Site Kit support URL.
 	 */
 	getDocumentationLinkURL: createRegistrySelector(
-		( select ) => ( state, slug ) => {
+		( select ) => ( state, slug, anchor ) => {
 			invariant( slug, 'A slug is required.' );
 
 			const proxySupportLink =
 				select( CORE_SITE ).getProxySupportLinkURL();
 
-			return `${ proxySupportLink }?doc=${ encodeURIComponent( slug ) }`;
+			const url = addQueryArgs( proxySupportLink, { doc: slug } );
+			return url + ( anchor ? `#${ anchor }` : '' );
 		}
 	),
 
@@ -142,24 +150,19 @@ export const selectors = {
 		( select ) => ( state, error ) => {
 			invariant( error, 'An error is required.' );
 
+			const { id, code, message } = error;
 			const proxySupportLink =
 				select( CORE_SITE ).getProxySupportLinkURL();
 
-			if ( error.id && ! isNumeric( error.id ) ) {
-				return `${ proxySupportLink }?error_id=${ encodeURIComponent(
-					error.id
-				) }`;
+			if ( id && ! isNumeric( id ) ) {
+				return addQueryArgs( proxySupportLink, { error_id: id } );
 			}
 
-			if ( error.code && ! isNumeric( error.code ) ) {
-				return `${ proxySupportLink }?error_id=${ encodeURIComponent(
-					error.code
-				) }`;
+			if ( code && ! isNumeric( code ) ) {
+				return addQueryArgs( proxySupportLink, { error_id: code } );
 			}
 
-			return `${ proxySupportLink }?error=${ encodeURIComponent(
-				error.message
-			) }`;
+			return addQueryArgs( proxySupportLink, { error: message } );
 		}
 	),
 

--- a/assets/js/googlesitekit/datastore/site/urls.js
+++ b/assets/js/googlesitekit/datastore/site/urls.js
@@ -118,22 +118,19 @@ export const selectors = {
 	 * Gets the Site Kit documentation URL.
 	 *
 	 * @since 1.80.0
-	 * @since n.e.x.t Added the anchor parameter.
 	 *
-	 * @param {Object} state  Data store's state.
-	 * @param {string} slug   The slug of the documentation page.
-	 * @param {string} anchor The anchor on the documentation page.
+	 * @param {Object} state Data store's state.
+	 * @param {string} slug  The slug of the documentation page.
 	 * @return {string} The Site Kit support URL.
 	 */
 	getDocumentationLinkURL: createRegistrySelector(
-		( select ) => ( state, slug, anchor ) => {
+		( select ) => ( state, slug ) => {
 			invariant( slug, 'A slug is required.' );
 
 			const proxySupportLink =
 				select( CORE_SITE ).getProxySupportLinkURL();
 
-			const url = addQueryArgs( proxySupportLink, { doc: slug } );
-			return url + ( anchor ? `#${ anchor }` : '' );
+			return addQueryArgs( proxySupportLink, { doc: slug } );
 		}
 	),
 

--- a/assets/js/googlesitekit/datastore/site/urls.test.js
+++ b/assets/js/googlesitekit/datastore/site/urls.test.js
@@ -102,6 +102,19 @@ describe( 'core/site urls', () => {
 					`https://example.com/support/?doc=${ testSlug }`
 				);
 			} );
+
+			it( 'should return the correct documentation URL with a hash for the given documnation page slug and anchor', () => {
+				const testSlug = 'test-slug';
+				const testAnchor = 'test-anchor';
+
+				const url = registry
+					.select( CORE_SITE )
+					.getDocumentationLinkURL( testSlug, testAnchor );
+
+				expect( url ).toBe(
+					`https://example.com/support/?doc=${ testSlug }#${ testAnchor }`
+				);
+			} );
 		} );
 
 		describe( 'getErrorTroubleshootingLinkURL', () => {

--- a/assets/js/googlesitekit/datastore/site/urls.test.js
+++ b/assets/js/googlesitekit/datastore/site/urls.test.js
@@ -21,6 +21,7 @@
  */
 import {
 	createTestRegistry,
+	provideSiteInfo,
 	unsubscribeFromAll,
 } from '../../../../../tests/js/utils';
 import { CORE_SITE } from './constants';
@@ -78,6 +79,12 @@ describe( 'core/site urls', () => {
 		} );
 
 		describe( 'getDocumentationLinkURL', () => {
+			beforeEach( () => {
+				provideSiteInfo( registry, {
+					proxySupportLinkURL: 'https://example.com/support/',
+				} );
+			} );
+
 			it( 'should throw an error if the slug is omitted', () => {
 				expect( () =>
 					registry.select( CORE_SITE ).getDocumentationLinkURL()
@@ -87,19 +94,23 @@ describe( 'core/site urls', () => {
 			it( 'should return the correct documentation URL given a documentation slug', () => {
 				const testSlug = 'test-slug';
 
-				const baseURL = registry
-					.select( CORE_SITE )
-					.getProxySupportLinkURL();
-
 				const url = registry
 					.select( CORE_SITE )
 					.getDocumentationLinkURL( testSlug );
 
-				expect( url ).toBe( `${ baseURL }?doc=${ testSlug }` );
+				expect( url ).toBe(
+					`https://example.com/support/?doc=${ testSlug }`
+				);
 			} );
 		} );
 
 		describe( 'getErrorTroubleshootingLinkURL', () => {
+			beforeEach( () => {
+				provideSiteInfo( registry, {
+					proxySupportLinkURL: 'https://example.com/support/',
+				} );
+			} );
+
 			const testError = {
 				data: {
 					reason: 'Data Error',
@@ -134,48 +145,36 @@ describe( 'core/site urls', () => {
 			} );
 
 			it( 'should return the support link with the error message if no code or id is given', () => {
-				const baseURL = registry
-					.select( CORE_SITE )
-					.getProxySupportLinkURL();
-
 				const url = registry
 					.select( CORE_SITE )
 					.getErrorTroubleshootingLinkURL( testErrorWithMessage );
 
 				expect( url ).toBe(
-					`${ baseURL }?error=${ encodeURIComponent(
+					`https://example.com/support/?error=${ encodeURIComponent(
 						testErrorWithMessage.message
 					) }`
 				);
 			} );
 
 			it( 'should return the support link with the error code if the error code is given', () => {
-				const baseURL = registry
-					.select( CORE_SITE )
-					.getProxySupportLinkURL();
-
 				const url = registry
 					.select( CORE_SITE )
 					.getErrorTroubleshootingLinkURL( testErrorWithCode );
 
 				expect( url ).toBe(
-					`${ baseURL }?error_id=${ encodeURIComponent(
+					`https://example.com/support/?error_id=${ encodeURIComponent(
 						testErrorWithCode.code
 					) }`
 				);
 			} );
 
 			it( 'should return the support link with the error id if the error id is given', () => {
-				const baseURL = registry
-					.select( CORE_SITE )
-					.getProxySupportLinkURL();
-
 				const url = registry
 					.select( CORE_SITE )
 					.getErrorTroubleshootingLinkURL( testErrorWithID );
 
 				expect( url ).toBe(
-					`${ baseURL }?error_id=${ encodeURIComponent(
+					`https://example.com/support/?error_id=${ encodeURIComponent(
 						testErrorWithID.id
 					) }`
 				);
@@ -187,16 +186,12 @@ describe( 'core/site urls', () => {
 					code: 123,
 				};
 
-				const baseURL = registry
-					.select( CORE_SITE )
-					.getProxySupportLinkURL();
-
 				const url = registry
 					.select( CORE_SITE )
 					.getErrorTroubleshootingLinkURL( testErrorWithNumericCode );
 
 				expect( url ).toBe(
-					`${ baseURL }?error=${ encodeURIComponent(
+					`https://example.com/support/?error=${ encodeURIComponent(
 						testErrorWithNumericCode.message
 					) }`
 				);
@@ -208,16 +203,12 @@ describe( 'core/site urls', () => {
 					code: '',
 				};
 
-				const baseURL = registry
-					.select( CORE_SITE )
-					.getProxySupportLinkURL();
-
 				const url = registry
 					.select( CORE_SITE )
 					.getErrorTroubleshootingLinkURL( testErrorWithNumericCode );
 
 				expect( url ).toBe(
-					`${ baseURL }?error=${ encodeURIComponent(
+					`https://example.com/support/?error=${ encodeURIComponent(
 						testErrorWithNumericCode.message
 					) }`
 				);
@@ -229,16 +220,12 @@ describe( 'core/site urls', () => {
 					id: 123,
 				};
 
-				const baseURL = registry
-					.select( CORE_SITE )
-					.getProxySupportLinkURL();
-
 				const url = registry
 					.select( CORE_SITE )
 					.getErrorTroubleshootingLinkURL( testErrorWithNumericID );
 
 				expect( url ).toBe(
-					`${ baseURL }?error=${ encodeURIComponent(
+					`https://example.com/support/?error=${ encodeURIComponent(
 						testErrorWithNumericID.message
 					) }`
 				);
@@ -250,16 +237,12 @@ describe( 'core/site urls', () => {
 					id: '123',
 				};
 
-				const baseURL = registry
-					.select( CORE_SITE )
-					.getProxySupportLinkURL();
-
 				const url = registry
 					.select( CORE_SITE )
 					.getErrorTroubleshootingLinkURL( testErrorWithNumericID );
 
 				expect( url ).toBe(
-					`${ baseURL }?error=${ encodeURIComponent(
+					`https://example.com/support/?error=${ encodeURIComponent(
 						testErrorWithNumericID.message
 					) }`
 				);
@@ -271,16 +254,12 @@ describe( 'core/site urls', () => {
 					code: '123',
 				};
 
-				const baseURL = registry
-					.select( CORE_SITE )
-					.getProxySupportLinkURL();
-
 				const url = registry
 					.select( CORE_SITE )
 					.getErrorTroubleshootingLinkURL( testErrorWithNumericCode );
 
 				expect( url ).toBe(
-					`${ baseURL }?error=${ encodeURIComponent(
+					`https://example.com/support/?error=${ encodeURIComponent(
 						testErrorWithNumericCode.message
 					) }`
 				);

--- a/assets/js/googlesitekit/datastore/site/urls.test.js
+++ b/assets/js/googlesitekit/datastore/site/urls.test.js
@@ -102,19 +102,6 @@ describe( 'core/site urls', () => {
 					`https://example.com/support/?doc=${ testSlug }`
 				);
 			} );
-
-			it( 'should return the correct documentation URL with a hash for the given documnation page slug and anchor', () => {
-				const testSlug = 'test-slug';
-				const testAnchor = 'test-anchor';
-
-				const url = registry
-					.select( CORE_SITE )
-					.getDocumentationLinkURL( testSlug, testAnchor );
-
-				expect( url ).toBe(
-					`https://example.com/support/?doc=${ testSlug }#${ testAnchor }`
-				);
-			} );
 		} );
 
 		describe( 'getErrorTroubleshootingLinkURL', () => {


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #6928 

## Relevant technical choices

* The original IB said that we would need to make changes in the `getDocumentationLinkURL` selector. I implemented those changes, but then it turned out that it wouldn't work. So, I reverted my changes, but left some useful refactoring there.

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
