### PR TITLE
Use HTML tooltips for all Line Charts.

### DIFF
--- a/assets/js/components/GoogleChart/utils.js
+++ b/assets/js/components/GoogleChart/utils.js
@@ -148,9 +148,11 @@ export const getChartOptions = (
 		if ( ! options?.vAxis?.viewWindow?.min ) {
 			set( chartOptions, 'vAxis.viewWindow.min', 0 );
 		}
+
 		if ( ! options?.vAxis?.viewWindow?.max ) {
 			set( chartOptions, 'vAxis.viewWindow.max', 100 );
 		}
+
 		if ( ! options?.hAxis?.viewWindow?.min ) {
 			set(
 				chartOptions,
@@ -159,6 +161,7 @@ export const getChartOptions = (
 			);
 			delete chartOptions.hAxis.ticks;
 		}
+
 		if ( ! options?.hAxis?.viewWindow?.max ) {
 			set(
 				chartOptions,
@@ -166,6 +169,14 @@ export const getChartOptions = (
 				stringToDate( endDate )
 			);
 			delete chartOptions.hAxis.ticks;
+		}
+	}
+
+	if ( chartType === 'LineChart' ) {
+		// eslint-disable-next-line sitekit/acronym-case
+		if ( options?.tooltip?.isHtml === undefined ) {
+			set( chartOptions, 'tooltip.isHtml', true );
+			set( chartOptions, 'tooltip.trigger', 'both' );
 		}
 	}
 

--- a/assets/sass/components/global/_googlesitekit-chart.scss
+++ b/assets/sass/components/global/_googlesitekit-chart.scss
@@ -53,6 +53,20 @@
 	}
 }
 
+.googlesitekit-chart--LineChart div.google-visualization-tooltip {
+
+	height: fit-content !important;
+	width: fit-content !important;
+
+	.google-visualization-tooltip-item-list {
+		margin: 0.5em 0;
+	}
+
+	.google-visualization-tooltip-item {
+		margin: 0;
+	}
+}
+
 .googlesitekit-chart--PieChart svg {
 	// Required to make sure annotations/labels on the PieChart don't get
 	// cut off in certain viewports.

--- a/assets/sass/components/global/_googlesitekit-chart.scss
+++ b/assets/sass/components/global/_googlesitekit-chart.scss
@@ -54,7 +54,9 @@
 }
 
 .googlesitekit-chart--LineChart div.google-visualization-tooltip {
-
+	// `!important` is required here because we're overridding inline styles
+	// on a Google Charts SVG element.
+	// This is the only way to have this style override the inline style.
 	height: fit-content !important;
 	width: fit-content !important;
 


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #6911

## Relevant technical choices

This approach only sets the chart's tooltips to be HTML if they aren't already explicitly set. This allows other charts to maintain their existing styles—though right now most other charts render fine as HTML and don't have defaults, so these get used.

The CSS changes ensure the style of the new HTML tooltips match the old non-HTML ones as close as possible.

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [x] Run the code.
- [x] Ensure the acceptance criteria are satisfied.
- [x] Reassess the implementation with the IB.
- [x] Ensure no unrelated changes are included.
- [x] Ensure CI checks pass.
- [x] Check Storybook where applicable.
- [x] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [x] Ensure the PR has the correct target branch.
- [x] Double-check that the PR is okay to be merged.
- [x] Ensure the corresponding issue has a ZenHub release assigned.
- [x] Add a changelog message to the issue.
