### PR TITLE
Prevent WP admin menu from autoclosing when showing tooltip.

### DIFF
--- a/tests/e2e/specs/modules/adsense/show-admin-menu-tooltip.test.js
+++ b/tests/e2e/specs/modules/adsense/show-admin-menu-tooltip.test.js
@@ -1,0 +1,109 @@
+/**
+ * WordPress dependencies
+ */
+import { activatePlugin, visitAdminPage } from '@wordpress/e2e-test-utils';
+
+/**
+ * Internal dependencies
+ */
+import {
+	setSiteVerification,
+	setSearchConsoleProperty,
+	useRequestInterception,
+	deactivateUtilityPlugins,
+} from '../../../utils';
+
+describe( 'Site Kit dashboard post search', () => {
+	beforeAll( async () => {
+		await activatePlugin( 'e2e-tests-proxy-auth-plugin' );
+		await setSiteVerification();
+		await setSearchConsoleProperty();
+
+		await page.setRequestInterception( true );
+		useRequestInterception( ( request ) => {
+			if (
+				request
+					.url()
+					.match(
+						'google-site-kit/v1/modules/search-console/data/searchanalytics'
+					)
+			) {
+				request.respond( { status: 200, body: JSON.stringify( [] ) } );
+			} else if (
+				request
+					.url()
+					.match(
+						'google-site-kit/v1/modules/pagespeed-insights/data/pagespeed'
+					)
+			) {
+				request.respond( { status: 200, body: JSON.stringify( {} ) } );
+			} else {
+				request.continue();
+			}
+		} );
+	} );
+
+	afterAll( async () => {
+		await deactivateUtilityPlugins();
+	} );
+
+	it( 'shows the admin menu when dismissing the AdSense Connect CTA and showing the tooltip while on a mobile viewport', async () => {
+		// This is a test to provide a safety net that will let us know if the hack introduced in #6924 stops working in a future WordPress release.
+
+		// Set the page to a mobile viewport, as the scenario we want to test is the case where the admin menu is initially hidden, and then shown in response to user interaction.
+		// The size 375x667 corresponds to the iPhone SE.
+		await page.setViewport( {
+			width: 375,
+			height: 667,
+		} );
+
+		await visitAdminPage( 'admin.php', 'page=googlesitekit-dashboard' );
+
+		const maybeLaterButtonSelector =
+			'.googlesitekit-setup__wrapper--adsense-connect button.googlesitekit-cta-link';
+
+		await page.waitForSelector( maybeLaterButtonSelector, {
+			text: 'Maybe later',
+		} );
+
+		// Click on the monetization tab to scroll the AdSense Connect CTA into view.
+		await page.click( '[data-context-id="monetization"]' );
+
+		// As our hack involves monkey-patching document.hasFocus() in our click handler to show the menu, we add a tag to the original document.hasFocus()
+		// so we can then check if it's been restored after the menu has been shown.
+		await page.evaluate( () => {
+			document.hasFocus.identityTag = 'this is the original hasFocus';
+		} );
+
+		await page.click( maybeLaterButtonSelector, {
+			text: 'Maybe later',
+		} );
+
+		// Use the same check as `useShowTooltip()` to determine whether the menu is open.
+		let isAdminMenuOpen = await page.evaluate( () => {
+			const element = document.querySelector( '#adminmenu' );
+			return element && element.offsetHeight > 0;
+		} );
+
+		expect( isAdminMenuOpen ).toBe( true );
+
+		// Wait for half a second and test again, to ensure the menu is not auto-closed.
+		await page.waitForTimeout( 500 );
+
+		isAdminMenuOpen = await page.evaluate( () => {
+			const element = document.querySelector( '#adminmenu' );
+			return element && element.offsetHeight > 0;
+		} );
+
+		expect( isAdminMenuOpen ).toBe( true );
+
+		const isOriginalHasFocus = await page.evaluate( () => {
+			return (
+				document.hasFocus.identityTag ===
+				'this is the original hasFocus'
+			);
+		} );
+
+		expect( isOriginalHasFocus ).toBe( true );
+	} );
+} );

--- a/tests/e2e/specs/modules/adsense/show-admin-menu-tooltip.test.js
+++ b/tests/e2e/specs/modules/adsense/show-admin-menu-tooltip.test.js
@@ -29,14 +29,6 @@ describe( 'Site Kit dashboard post search', () => {
 					)
 			) {
 				request.respond( { status: 200, body: JSON.stringify( [] ) } );
-			} else if (
-				request
-					.url()
-					.match(
-						'google-site-kit/v1/modules/pagespeed-insights/data/pagespeed'
-					)
-			) {
-				request.respond( { status: 200, body: JSON.stringify( {} ) } );
 			} else {
 				request.continue();
 			}


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #6924 

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
