### PR TITLE
Bug/6924 prevent wp admin menu autoclose mk2

### DIFF
--- a/assets/js/components/AdminMenuTooltip/AdminMenuTooltip.js
+++ b/assets/js/components/AdminMenuTooltip/AdminMenuTooltip.js
@@ -25,8 +25,6 @@ export function AdminMenuTooltip( { onDismiss, tooltipStateKey, ...props } ) {
 				document
 					.getElementsByTagName( 'body' )[ 0 ]
 					.classList.remove( 'showmenu' );
-
-				// document.getElementById( 'wp-admin-bar-menu-toggle' )?.click();
 			}
 		}
 

--- a/assets/js/components/AdminMenuTooltip/AdminMenuTooltip.js
+++ b/assets/js/components/AdminMenuTooltip/AdminMenuTooltip.js
@@ -22,7 +22,11 @@ export function AdminMenuTooltip( { onDismiss, tooltipStateKey, ...props } ) {
 				document.querySelector( '#adminmenu' ).offsetHeight > 0;
 
 			if ( isAdminMenuOpen ) {
-				document.getElementById( 'wp-admin-bar-menu-toggle' )?.click();
+				document
+					.getElementsByTagName( 'body' )[ 0 ]
+					.classList.remove( 'showmenu' );
+
+				// document.getElementById( 'wp-admin-bar-menu-toggle' )?.click();
 			}
 		}
 

--- a/assets/js/components/AdminMenuTooltip/useShowTooltip.js
+++ b/assets/js/components/AdminMenuTooltip/useShowTooltip.js
@@ -20,7 +20,11 @@ export function useShowTooltip( tooltipStateKey ) {
 			);
 
 			if ( adminMenuToggle ) {
-				adminMenuToggle.click();
+				document
+					.getElementsByTagName( 'body' )[ 0 ]
+					.classList.add( 'showmenu' );
+
+				// adminMenuToggle.click();
 
 				// On iOS, at least, this is necessary, without it the settings menu item
 				// is not scrolled into view when the Tooltip is shown.

--- a/assets/js/components/AdminMenuTooltip/useShowTooltip.js
+++ b/assets/js/components/AdminMenuTooltip/useShowTooltip.js
@@ -24,10 +24,9 @@ export function useShowTooltip( tooltipStateKey ) {
 					.getElementsByTagName( 'body' )[ 0 ]
 					.classList.add( 'showmenu' );
 
-				// adminMenuToggle.click();
-
 				// On iOS, at least, this is necessary, without it the settings menu item
 				// is not scrolled into view when the Tooltip is shown.
+				// This may no longer be needed if we take the CSS approach, we'd need to check this on an iOS device.
 				await new Promise( ( resolve ) => {
 					setTimeout( resolve, 0 );
 				} );

--- a/assets/sass/components/global/_googlesitekit-page.scss
+++ b/assets/sass/components/global/_googlesitekit-page.scss
@@ -29,3 +29,14 @@
 		margin-top: 25px;
 	}
 }
+
+.showmenu {
+	#adminmenuback,
+	#adminmenuwrap {
+		display: block;
+	}
+
+	#wpbody {
+		right: -16em;
+	}
+}


### PR DESCRIPTION
## Summary

PoC of an alternative approach to https://github.com/google/site-kit-wp/pull/6996.
<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #6924 

## Relevant technical choices

<!-- Please describe your changes. -->

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [ ] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
