### PR TITLE
Bug/#6862 - Remove duplicate viewable modules based on GA4 dashboard view

### DIFF
--- a/assets/js/googlesitekit/datastore/user/permissions.js
+++ b/assets/js/googlesitekit/datastore/user/permissions.js
@@ -30,6 +30,7 @@ import { CORE_USER, PERMISSION_READ_SHARED_MODULE_DATA } from './constants';
 import { CORE_MODULES } from '../../modules/datastore/constants';
 import { getMetaCapabilityPropertyName } from '../util/permissions';
 import { createFetchStore } from '../../data/create-fetch-store';
+import { MODULES_ANALYTICS } from '../../../modules/analytics/datastore/constants';
 const { createRegistrySelector } = Data;
 
 // Actions
@@ -221,31 +222,50 @@ const baseSelectors = {
 	 * Gets viewable module slugs of the current user.
 	 *
 	 * @since 1.72.0
+	 * @since n.e.x.t Filters out the duplicate module slugs if the user has both ‘analytics’ and ‘analytics-4’ and shows only one based on whether the user is viewing the GA4 dashboard.
 	 *
 	 * @return {(Array|undefined)} An array of viewable module slugs. `undefined` if `modules` are not loaded yet.
 	 */
 	getViewableModules: createRegistrySelector( ( select ) => () => {
 		const modules = select( CORE_MODULES ).getModules();
+		const isGA4DashboardView =
+			select( MODULES_ANALYTICS ).isGA4DashboardView();
 
-		if ( modules === undefined ) {
+		if ( modules === undefined || isGA4DashboardView === undefined ) {
 			return undefined;
 		}
 
 		// Return an array of module slugs for modules that are
 		// shareable and the user has the "read shared module data"
 		// capability for.
-		return Object.values( modules ).reduce( ( moduleSlugs, module ) => {
-			const hasCapability = select( CORE_USER ).hasCapability(
-				PERMISSION_READ_SHARED_MODULE_DATA,
-				module.slug
-			);
+		let moduleSlugs = Object.values( modules ).reduce(
+			( slugs, module ) => {
+				const hasCapability = select( CORE_USER ).hasCapability(
+					PERMISSION_READ_SHARED_MODULE_DATA,
+					module.slug
+				);
 
-			if ( module.shareable && hasCapability ) {
-				return [ ...moduleSlugs, module.slug ];
-			}
+				if ( module.shareable && hasCapability ) {
+					return [ ...slugs, module.slug ];
+				}
 
-			return moduleSlugs;
-		}, [] );
+				return slugs;
+			},
+			[]
+		);
+
+		// If both 'analytics' and 'analytics-4' modules are viewable by the user,
+		// remove one of them based on whether the user is viewing an Analytics 4 dashboard or not.
+		if (
+			moduleSlugs.includes( 'analytics' ) &&
+			moduleSlugs.includes( 'analytics-4' )
+		) {
+			moduleSlugs = isGA4DashboardView
+				? moduleSlugs.filter( ( slug ) => slug !== 'analytics' )
+				: moduleSlugs.filter( ( slug ) => slug !== 'analytics-4' );
+		}
+
+		return moduleSlugs;
 	} ),
 
 	/**


### PR DESCRIPTION
## Summary

Addresses issue:

- #6862 

## Relevant technical choices

<!-- Please describe your changes. -->

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [x] Run the code.
- [x] Ensure the acceptance criteria are satisfied.
- [x] Reassess the implementation with the IB.
- [x] Ensure no unrelated changes are included.
- [x] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [x] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
