### PR TITLE
Force in view when activating ga4Reporting tour from SwitchedToGA4Banner

### DIFF
--- a/assets/js/components/notifications/SwitchedToGA4Banner.js
+++ b/assets/js/components/notifications/SwitchedToGA4Banner.js
@@ -59,6 +59,7 @@ export default function SwitchedToGA4Banner() {
 
 	const { setValue } = useDispatch( CORE_UI );
 	const handleCTAClick = () => {
+		setValue( 'forceInView', true );
 		setValue( 'showGA4ReportingTour', true );
 	};
 


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #6558

## Relevant technical choices

* Note it's still possible for the tour to crash when navigating to the second step very quickly (see #7031)

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
