### PR TITLE
Introduce Ad Blocker Detection settings in `AdSense`

### DIFF
--- a/assets/js/modules/adsense/datastore/base.js
+++ b/assets/js/modules/adsense/datastore/base.js
@@ -37,6 +37,9 @@ const baseModuleStore = Modules.createModuleStore( 'adsense', {
 		'ownerID',
 		'webStoriesAdUnit',
 		'autoAdsDisabled',
+		'useAdBlockerDetectionSnippet',
+		'useAdBlockerDetectionErrorSnippet',
+		'adBlockingRecoverySetupStatus',
 	],
 	validateCanSubmitChanges,
 	validateIsSetupBlocked: ( select ) => {

--- a/includes/Modules/AdSense/Settings.php
+++ b/includes/Modules/AdSense/Settings.php
@@ -14,6 +14,7 @@ use Google\Site_Kit\Core\Modules\Module_Settings;
 use Google\Site_Kit\Core\Storage\Setting_With_Legacy_Keys_Trait;
 use Google\Site_Kit\Core\Storage\Setting_With_Owned_Keys_Interface;
 use Google\Site_Kit\Core\Storage\Setting_With_Owned_Keys_Trait;
+use Google\Site_Kit\Core\Util\Feature_Flags;
 
 /**
  * Class for AdSense settings.
@@ -149,7 +150,7 @@ class Settings extends Module_Settings implements Setting_With_Owned_Keys_Interf
 	 * @return array
 	 */
 	protected function get_default() {
-		return array(
+		$settings = array(
 			'ownerID'              => 0,
 			'accountID'            => '',
 			'autoAdsDisabled'      => array(),
@@ -161,6 +162,14 @@ class Settings extends Module_Settings implements Setting_With_Owned_Keys_Interf
 			'useSnippet'           => true,
 			'webStoriesAdUnit'     => '',
 		);
+
+		if ( Feature_Flags::enabled( 'adBlockerDetection' ) ) {
+			$settings['useAdBlockerDetectionSnippet']      = false;
+			$settings['useAdBlockerDetectionErrorSnippet'] = false;
+			$settings['adBlockingRecoverySetupStatus']     = '';
+		}
+
+		return $settings;
 	}
 
 	/**

--- a/includes/Modules/AdSense/Settings.php
+++ b/includes/Modules/AdSense/Settings.php
@@ -29,6 +29,12 @@ class Settings extends Module_Settings implements Setting_With_Owned_Keys_Interf
 	const OPTION = 'googlesitekit_adsense_settings';
 
 	/**
+	 * Various ad blocking recovery setup statuses.
+	 */
+	const AD_BLOCKING_RECOVERY_SETUP_STATUS_TAG_PLACED      = 'tag-placed';
+	const AD_BLOCKING_RECOVERY_SETUP_STATUS_SETUP_CONFIRMED = 'setup-confirmed';
+
+	/**
 	 * Legacy account statuses to be migrated on-the-fly.
 	 *
 	 * @since 1.9.0
@@ -202,14 +208,18 @@ class Settings extends Module_Settings implements Setting_With_Owned_Keys_Interf
 					if ( isset( $option['useAdBlockerDetectionErrorSnippet'] ) ) {
 						$option['useAdBlockerDetectionErrorSnippet'] = (bool) $option['useAdBlockerDetectionErrorSnippet'];
 					}
-					if ( isset( $option['adBlockingRecoverySetupStatus'] ) ) {
-						if ( ! in_array(
+					if (
+						isset( $option['adBlockingRecoverySetupStatus'] ) &&
+						! in_array(
 							$option['adBlockingRecoverySetupStatus'],
-							array( 'tag-placed', 'setup-confirmed' ),
+							array(
+								self::AD_BLOCKING_RECOVERY_SETUP_STATUS_TAG_PLACED,
+								self::AD_BLOCKING_RECOVERY_SETUP_STATUS_SETUP_CONFIRMED,
+							),
 							true
-						) ) {
-							$option['adBlockingRecoverySetupStatus'] = $this->get()['adBlockingRecoverySetupStatus'];
-						}
+						)
+					) {
+						$option['adBlockingRecoverySetupStatus'] = $this->get()['adBlockingRecoverySetupStatus'];
 					}
 				}
 			}

--- a/includes/Modules/AdSense/Settings.php
+++ b/includes/Modules/AdSense/Settings.php
@@ -194,6 +194,24 @@ class Settings extends Module_Settings implements Setting_With_Owned_Keys_Interf
 				if ( isset( $option['autoAdsDisabled'] ) ) {
 					$option['autoAdsDisabled'] = (array) $option['autoAdsDisabled'];
 				}
+
+				if ( Feature_Flags::enabled( 'adBlockerDetection' ) ) {
+					if ( isset( $option['useAdBlockerDetectionSnippet'] ) ) {
+						$option['useAdBlockerDetectionSnippet'] = (bool) $option['useAdBlockerDetectionSnippet'];
+					}
+					if ( isset( $option['useAdBlockerDetectionErrorSnippet'] ) ) {
+						$option['useAdBlockerDetectionErrorSnippet'] = (bool) $option['useAdBlockerDetectionErrorSnippet'];
+					}
+					if ( isset( $option['adBlockingRecoverySetupStatus'] ) ) {
+						if ( ! in_array(
+							$option['adBlockingRecoverySetupStatus'],
+							array( 'tag-placed', 'setup-confirmed' ),
+							true
+						) ) {
+							$option['adBlockingRecoverySetupStatus'] = $this->get()['adBlockingRecoverySetupStatus'];
+						}
+					}
+				}
 			}
 			return $option;
 		};

--- a/tests/phpunit/integration/Modules/AdSense/SettingsTest.php
+++ b/tests/phpunit/integration/Modules/AdSense/SettingsTest.php
@@ -70,6 +70,33 @@ class SettingsTest extends SettingsTestCase {
 		);
 	}
 
+	public function test_get_default_with_ad_blocker_detection() {
+		// Enable the `adBlockerDetection` feature flag.
+		$this->enable_feature( 'adBlockerDetection' );
+
+		$settings = new Settings( new Options( new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE ) ) );
+		$settings->register();
+
+		$this->assertEqualSetsWithIndex(
+			array(
+				'accountID'                         => '',
+				'clientID'                          => '',
+				'accountStatus'                     => '',
+				'siteStatus'                        => '',
+				'accountSetupComplete'              => false,
+				'siteSetupComplete'                 => false,
+				'useSnippet'                        => true,
+				'ownerID'                           => 0,
+				'webStoriesAdUnit'                  => '',
+				'autoAdsDisabled'                   => array(),
+				'useAdBlockerDetectionSnippet'      => false,
+				'useAdBlockerDetectionErrorSnippet' => false,
+				'adBlockingRecoverySetupStatus'     => '',
+			),
+			get_option( Settings::OPTION )
+		);
+	}
+
 	public function test_legacy_options() {
 		$legacy_option = array(
 			'account_id'        => 'test-account-id',


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #6960

## Relevant technical choices

This PR introduces Ad Blocker Detection settings to the `Adsense` module only when the `adBlockerDetection` feature flag is enabled.

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [x] Run the code.
- [x] Ensure the acceptance criteria are satisfied.
- [x] Reassess the implementation with the IB.
- [x] Ensure no unrelated changes are included.
- [x] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [x] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [x] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [x] Add a changelog message to the issue.
