### PR TITLE
Avoid feature flag check in Settings get_default().

### DIFF
--- a/includes/Modules/AdSense/Settings.php
+++ b/includes/Modules/AdSense/Settings.php
@@ -152,30 +152,26 @@ class Settings extends Module_Settings implements Setting_With_Owned_Keys_Interf
 	 * Gets the default value.
 	 *
 	 * @since 1.2.0
+	 * @since n.e.x.t Added settings for the AdSense Blocker Detection feature.
 	 *
 	 * @return array
 	 */
 	protected function get_default() {
-		$settings = array(
-			'ownerID'              => 0,
-			'accountID'            => '',
-			'autoAdsDisabled'      => array(),
-			'clientID'             => '',
-			'accountStatus'        => '',
-			'siteStatus'           => '',
-			'accountSetupComplete' => false,
-			'siteSetupComplete'    => false,
-			'useSnippet'           => true,
-			'webStoriesAdUnit'     => '',
+		return array(
+			'ownerID'                           => 0,
+			'accountID'                         => '',
+			'autoAdsDisabled'                   => array(),
+			'clientID'                          => '',
+			'accountStatus'                     => '',
+			'siteStatus'                        => '',
+			'accountSetupComplete'              => false,
+			'siteSetupComplete'                 => false,
+			'useSnippet'                        => true,
+			'webStoriesAdUnit'                  => '',
+			'useAdBlockerDetectionSnippet'      => false,
+			'useAdBlockerDetectionErrorSnippet' => false,
+			'adBlockingRecoverySetupStatus'     => '',
 		);
-
-		if ( Feature_Flags::enabled( 'adBlockerDetection' ) ) {
-			$settings['useAdBlockerDetectionSnippet']      = false;
-			$settings['useAdBlockerDetectionErrorSnippet'] = false;
-			$settings['adBlockingRecoverySetupStatus']     = '';
-		}
-
-		return $settings;
 	}
 
 	/**


### PR DESCRIPTION
This was being called too early causing problems elsewhere.

## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #6960 

## Relevant technical choices

<!-- Please describe your changes. -->

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
