### PR TITLE
Add module name to screenreader label for settings edit.

### DIFF
--- a/assets/js/components/settings/SettingsActiveModule/Footer.js
+++ b/assets/js/components/settings/SettingsActiveModule/Footer.js
@@ -211,6 +211,11 @@ export default function Footer( props ) {
 				className="googlesitekit-settings-module__edit-button"
 				to={ `/connected-services/${ slug }/edit` }
 				onClick={ handleEdit }
+				aria-label={ sprintf(
+					/* translators: %s: module name */
+					__( 'Edit %s settings', 'google-site-kit' ),
+					name
+				) }
 			>
 				{ __( 'Edit', 'google-site-kit' ) }
 				<PencilIcon


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #6642

## Relevant technical choices

Used `aria-label` instead of the `aria-hidden` and `<VisuallyHidden>` approach mentioned in the IB, as this one is more concise and works as well 🙂

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
