### PR TITLE
Enhance/#6938 - Don't show the dashboard view indicator if the feature flag is not enabled (follow-up)

### DIFF
--- a/assets/js/components/DashboardViewIndicator.js
+++ b/assets/js/components/DashboardViewIndicator.js
@@ -27,14 +27,16 @@ import { __ } from '@wordpress/i18n';
 import Data from 'googlesitekit-data';
 import Badge from './Badge';
 import { MODULES_ANALYTICS } from '../modules/analytics/datastore/constants';
+import { useFeature } from '../hooks/useFeature';
 const { useSelect } = Data;
 
 const DashboardViewIndicator = () => {
+	const ga4ReportingEnabled = useFeature( 'ga4Reporting' );
 	const isGA4DashboardView = useSelect( ( select ) =>
 		select( MODULES_ANALYTICS ).isGA4DashboardView()
 	);
 
-	if ( isGA4DashboardView === undefined ) {
+	if ( ! ga4ReportingEnabled || isGA4DashboardView === undefined ) {
 		return null;
 	}
 

--- a/assets/js/components/DashboardViewIndicator.stories.js
+++ b/assets/js/components/DashboardViewIndicator.stories.js
@@ -20,42 +20,52 @@
  * Internal dependencies
  */
 import DashboardViewIndicator from './DashboardViewIndicator';
-import {
-	createTestRegistry,
-	provideModules,
-	provideSiteInfo,
-	WithTestRegistry,
-} from '../../../tests/js/utils';
+import { provideModules, provideSiteInfo } from '../../../tests/js/utils';
 import {
 	DASHBOARD_VIEW_GA4,
 	DASHBOARD_VIEW_UA,
 	MODULES_ANALYTICS,
 } from '../modules/analytics/datastore/constants';
+import WithRegistrySetup from '../../../tests/js/WithRegistrySetup';
 
-const Template = ( { ...args } ) => <DashboardViewIndicator { ...args } />;
+const Template = () => <DashboardViewIndicator />;
 
 export const DashboardViewIndicatorUAView = Template.bind( {} );
 DashboardViewIndicatorUAView.storyName = 'Universal Analytics View';
-DashboardViewIndicatorUAView.args = {
-	setupRegistry: ( registry ) => {
-		registry.dispatch( MODULES_ANALYTICS ).setSettings( {
-			dashboardView: DASHBOARD_VIEW_UA,
-		} );
+DashboardViewIndicatorUAView.decorators = [
+	( Story ) => {
+		const setupRegistry = ( registry ) => {
+			registry.dispatch( MODULES_ANALYTICS ).setSettings( {
+				dashboardView: DASHBOARD_VIEW_UA,
+			} );
+		};
+		return (
+			<WithRegistrySetup func={ setupRegistry }>
+				<Story />
+			</WithRegistrySetup>
+		);
 	},
-};
+];
 DashboardViewIndicatorUAView.scenario = {
 	label: 'Components/DashboardViewIndicator/DashboardViewIndicatorUAView',
 };
 
 export const DashboardViewIndicatorGA4View = Template.bind( {} );
 DashboardViewIndicatorGA4View.storyName = 'Google Analytics 4 View';
-DashboardViewIndicatorGA4View.args = {
-	setupRegistry: ( registry ) => {
-		registry.dispatch( MODULES_ANALYTICS ).setSettings( {
-			dashboardView: DASHBOARD_VIEW_GA4,
-		} );
+DashboardViewIndicatorGA4View.decorators = [
+	( Story ) => {
+		const setupRegistry = ( registry ) => {
+			registry.dispatch( MODULES_ANALYTICS ).setSettings( {
+				dashboardView: DASHBOARD_VIEW_GA4,
+			} );
+		};
+		return (
+			<WithRegistrySetup func={ setupRegistry }>
+				<Story />
+			</WithRegistrySetup>
+		);
 	},
-};
+];
 DashboardViewIndicatorGA4View.scenario = {
 	label: 'Components/DashboardViewIndicator/DashboardViewIndicatorGA4View',
 };
@@ -64,31 +74,27 @@ export default {
 	title: 'Components/DashboardViewIndicator',
 	component: DashboardViewIndicator,
 	decorators: [
-		( Story, { args } ) => {
-			const registry = createTestRegistry();
-			provideSiteInfo( registry );
-			provideModules( registry, [
-				{
-					slug: 'analytics',
-					active: true,
-					connected: true,
-				},
-				{
-					slug: 'analytics-4',
-					active: true,
-					connected: true,
-				},
-			] );
-
-			args.setupRegistry?.( registry );
+		( Story ) => {
+			const setupRegistry = ( registry ) => {
+				provideSiteInfo( registry );
+				provideModules( registry, [
+					{
+						slug: 'analytics',
+						active: true,
+						connected: true,
+					},
+					{
+						slug: 'analytics-4',
+						active: true,
+						connected: true,
+					},
+				] );
+			};
 
 			return (
-				<WithTestRegistry
-					registry={ registry }
-					features={ [ 'ga4Reporting' ] }
-				>
+				<WithRegistrySetup func={ setupRegistry }>
 					<Story />
-				</WithTestRegistry>
+				</WithRegistrySetup>
 			);
 		},
 	],

--- a/assets/js/components/DashboardViewIndicator.stories.js
+++ b/assets/js/components/DashboardViewIndicator.stories.js
@@ -28,6 +28,7 @@ import {
 } from '../../../tests/js/utils';
 import {
 	DASHBOARD_VIEW_GA4,
+	DASHBOARD_VIEW_UA,
 	MODULES_ANALYTICS,
 } from '../modules/analytics/datastore/constants';
 
@@ -35,6 +36,13 @@ const Template = ( { ...args } ) => <DashboardViewIndicator { ...args } />;
 
 export const DashboardViewIndicatorUAView = Template.bind( {} );
 DashboardViewIndicatorUAView.storyName = 'Universal Analytics View';
+DashboardViewIndicatorUAView.args = {
+	setupRegistry: ( registry ) => {
+		registry.dispatch( MODULES_ANALYTICS ).setSettings( {
+			dashboardView: DASHBOARD_VIEW_UA,
+		} );
+	},
+};
 DashboardViewIndicatorUAView.scenario = {
 	label: 'Components/DashboardViewIndicator/DashboardViewIndicatorUAView',
 };
@@ -84,4 +92,5 @@ export default {
 			);
 		},
 	],
+	parameters: { features: [ 'ga4Reporting' ] },
 };

--- a/assets/js/components/DashboardViewIndicator.stories.js
+++ b/assets/js/components/DashboardViewIndicator.stories.js
@@ -48,9 +48,6 @@ DashboardViewIndicatorGA4View.args = {
 		} );
 	},
 };
-DashboardViewIndicatorGA4View.parameters = {
-	features: [ 'ga4Reporting' ],
-};
 DashboardViewIndicatorGA4View.scenario = {
 	label: 'Components/DashboardViewIndicator/DashboardViewIndicatorGA4View',
 };
@@ -78,7 +75,10 @@ export default {
 			args.setupRegistry?.( registry );
 
 			return (
-				<WithTestRegistry registry={ registry }>
+				<WithTestRegistry
+					registry={ registry }
+					features={ [ 'ga4Reporting' ] }
+				>
 					<Story />
 				</WithTestRegistry>
 			);

--- a/assets/js/components/DashboardViewIndicator.stories.js
+++ b/assets/js/components/DashboardViewIndicator.stories.js
@@ -32,40 +32,26 @@ const Template = () => <DashboardViewIndicator />;
 
 export const DashboardViewIndicatorUAView = Template.bind( {} );
 DashboardViewIndicatorUAView.storyName = 'Universal Analytics View';
-DashboardViewIndicatorUAView.decorators = [
-	( Story ) => {
-		const setupRegistry = ( registry ) => {
-			registry.dispatch( MODULES_ANALYTICS ).setSettings( {
-				dashboardView: DASHBOARD_VIEW_UA,
-			} );
-		};
-		return (
-			<WithRegistrySetup func={ setupRegistry }>
-				<Story />
-			</WithRegistrySetup>
-		);
+DashboardViewIndicatorUAView.args = {
+	setupRegistry: ( registry ) => {
+		registry.dispatch( MODULES_ANALYTICS ).setSettings( {
+			dashboardView: DASHBOARD_VIEW_UA,
+		} );
 	},
-];
+};
 DashboardViewIndicatorUAView.scenario = {
 	label: 'Components/DashboardViewIndicator/DashboardViewIndicatorUAView',
 };
 
 export const DashboardViewIndicatorGA4View = Template.bind( {} );
 DashboardViewIndicatorGA4View.storyName = 'Google Analytics 4 View';
-DashboardViewIndicatorGA4View.decorators = [
-	( Story ) => {
-		const setupRegistry = ( registry ) => {
-			registry.dispatch( MODULES_ANALYTICS ).setSettings( {
-				dashboardView: DASHBOARD_VIEW_GA4,
-			} );
-		};
-		return (
-			<WithRegistrySetup func={ setupRegistry }>
-				<Story />
-			</WithRegistrySetup>
-		);
+DashboardViewIndicatorGA4View.args = {
+	setupRegistry: ( registry ) => {
+		registry.dispatch( MODULES_ANALYTICS ).setSettings( {
+			dashboardView: DASHBOARD_VIEW_GA4,
+		} );
 	},
-];
+};
 DashboardViewIndicatorGA4View.scenario = {
 	label: 'Components/DashboardViewIndicator/DashboardViewIndicatorGA4View',
 };
@@ -74,7 +60,7 @@ export default {
 	title: 'Components/DashboardViewIndicator',
 	component: DashboardViewIndicator,
 	decorators: [
-		( Story ) => {
+		( Story, { args } ) => {
 			const setupRegistry = ( registry ) => {
 				provideSiteInfo( registry );
 				provideModules( registry, [
@@ -89,6 +75,8 @@ export default {
 						connected: true,
 					},
 				] );
+
+				args.setupRegistry?.( registry );
 			};
 
 			return (


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #6938 

## Relevant technical choices

- This PR hides the Dashboard View Indicator if the `ga4Reporting` feature flag is not enabled.

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
