### PR TITLE
Regularly sync Google profile data

### DIFF
--- a/includes/Core/Authentication/Authentication.php
+++ b/includes/Core/Authentication/Authentication.php
@@ -406,6 +406,26 @@ final class Authentication {
 				$this->maybe_refresh_token_for_screen( $this->context->input()->filter( INPUT_POST, 'screen_id' ) );
 			}
 		);
+
+		// Regularly synchronize Google profile data.
+		add_action(
+			'googlesitekit_reauthorize_user',
+			function() {
+				if ( ! $this->profile->has() ) {
+					return;
+				}
+
+				$profile_data = $this->profile->get();
+
+				if ( ! isset( $profile_data['last_updated'] ) ) {
+					return;
+				}
+
+				if ( time() - $profile_data['last_updated'] > DAY_IN_SECONDS ) {
+					$this->get_oauth_client()->refresh_profile_data( 30 * MINUTE_IN_SECONDS );
+				}
+			}
+		);
 	}
 
 	/**

--- a/includes/Core/Authentication/Authentication.php
+++ b/includes/Core/Authentication/Authentication.php
@@ -417,11 +417,10 @@ final class Authentication {
 
 				$profile_data = $this->profile->get();
 
-				if ( ! isset( $profile_data['last_updated'] ) ) {
-					return;
-				}
-
-				if ( time() - $profile_data['last_updated'] > DAY_IN_SECONDS ) {
+				if (
+					! isset( $profile_data['last_updated'] ) ||
+					time() - $profile_data['last_updated'] > DAY_IN_SECONDS
+				) {
 					$this->get_oauth_client()->refresh_profile_data( 30 * MINUTE_IN_SECONDS );
 				}
 			}

--- a/includes/Core/Authentication/Clients/OAuth_Client.php
+++ b/includes/Core/Authentication/Clients/OAuth_Client.php
@@ -535,9 +535,10 @@ final class OAuth_Client extends OAuth_Client_Base {
 			if ( isset( $response['emailAddresses'][0]['value'], $response['photos'][0]['url'], $response['names'][0]['displayName'] ) ) {
 				$this->profile->set(
 					array(
-						'email'     => $response['emailAddresses'][0]['value'],
-						'photo'     => $response['photos'][0]['url'],
-						'full_name' => $response['names'][0]['displayName'],
+						'email'        => $response['emailAddresses'][0]['value'],
+						'photo'        => $response['photos'][0]['url'],
+						'full_name'    => $response['names'][0]['displayName'],
+						'last_updated' => time(),
 					)
 				);
 			}

--- a/tests/phpunit/integration/Core/Authentication/AuthenticationTest.php
+++ b/tests/phpunit/integration/Core/Authentication/AuthenticationTest.php
@@ -205,11 +205,6 @@ class AuthenticationTest extends TestCase {
 		remove_all_actions( 'googlesitekit_reauthorize_user' );
 		$auth->register();
 
-		// We cannot test that the hook has not been added to 'googlesitekit_authorize_user'
-		// since the `register` method also adds another unrelated callback to it unconditionally.
-		// That should be fine though since we're covering the integration below.
-		$this->assertFalse( has_action( 'googlesitekit_reauthorize_user' ) );
-
 		// Response is not used here, so just pass an array.
 		do_action( 'googlesitekit_authorize_user', array(), array(), array() );
 		do_action( 'googlesitekit_reauthorize_user', array() );


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #6003 

## Relevant technical choices

This PR makes Site Kit sync Google profile data on a regular basis.

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
