### PR TITLE
Enhance/#6962 - Introduce Setting toggles for Ad blocking recovery tags in AdSense settings

### DIFF
--- a/assets/js/modules/adsense/components/common/AdBlockingRecoveryCTA.test.js
+++ b/assets/js/modules/adsense/components/common/AdBlockingRecoveryCTA.test.js
@@ -31,7 +31,6 @@ import {
 	SITE_STATUS_ADDED,
 	SITE_STATUS_READY,
 } from '../../util';
-import { enabledFeatures } from '../../../../features';
 
 describe( 'AdBlockingRecoveryCTA', () => {
 	it.each( [
@@ -73,10 +72,10 @@ describe( 'AdBlockingRecoveryCTA', () => {
 			adBlockerDetectionEnabled
 		) => {
 			const { container } = render( <AdBlockingRecoveryCTA />, {
+				features: [].concat(
+					adBlockerDetectionEnabled ? 'adBlockerDetection' : []
+				),
 				setupRegistry: ( registry ) => {
-					if ( adBlockerDetectionEnabled ) {
-						enabledFeatures.add( 'adBlockerDetection' );
-					}
 					provideModules( registry, [
 						{
 							slug: 'adsense',
@@ -106,8 +105,8 @@ describe( 'AdBlockingRecoveryCTA', () => {
 
 	it( 'should render the CTA when Ad Blocking Recovery is not set up', () => {
 		const { container } = render( <AdBlockingRecoveryCTA />, {
+			features: [ 'adBlockerDetection' ],
 			setupRegistry: ( registry ) => {
-				enabledFeatures.add( 'adBlockerDetection' );
 				provideModules( registry, [
 					{
 						slug: 'adsense',

--- a/assets/js/modules/adsense/components/common/AdBlockingRecoveryToggle.js
+++ b/assets/js/modules/adsense/components/common/AdBlockingRecoveryToggle.js
@@ -45,10 +45,10 @@ const { useSelect, useDispatch } = Data;
 export default function AdBlockingRecoveryToggle() {
 	const adBlockerDetectionEnabled = useFeature( 'adBlockerDetection' );
 
-	const adBlockingDetectionSnippet = useSelect( ( select ) =>
+	const adBlockerDetectionSnippet = useSelect( ( select ) =>
 		select( MODULES_ADSENSE ).getUseAdBlockerDetectionSnippet()
 	);
-	const adBlockingDetectionErrorSnippet = useSelect( ( select ) =>
+	const adBlockerDetectionErrorSnippet = useSelect( ( select ) =>
 		select( MODULES_ADSENSE ).getUseAdBlockerDetectionErrorSnippet()
 	);
 	const adBlockingRecoverySetupStatus = useSelect( ( select ) =>
@@ -101,8 +101,8 @@ export default function AdBlockingRecoveryToggle() {
 		const initialToggleValues = {
 			// Set the initial toggle value to `undefined` if the saved value is `false`
 			// to prevent the SettingsNotice from showing up on mount.
-			adBlockingDetectionToggle: adBlockingDetectionSnippet || undefined,
-			adBlockingDetectionErrorToggle: adBlockingDetectionErrorSnippet,
+			adBlockingDetectionToggle: adBlockerDetectionSnippet || undefined,
+			adBlockingDetectionErrorToggle: adBlockerDetectionErrorSnippet,
 		};
 
 		setValues( AD_BLOCKING_FORM_SETTINGS, initialToggleValues );
@@ -146,7 +146,7 @@ export default function AdBlockingRecoveryToggle() {
 					</p>
 				</div>
 				{ ( adBlockingDetectionToggle ||
-					adBlockingDetectionSnippet ) && (
+					adBlockerDetectionSnippet ) && (
 					<div className="googlesitekit-settings-module__meta-item">
 						<Switch
 							label={ __(

--- a/assets/js/modules/adsense/components/common/AdBlockingRecoveryToggle.js
+++ b/assets/js/modules/adsense/components/common/AdBlockingRecoveryToggle.js
@@ -96,12 +96,14 @@ export default function AdBlockingRecoveryToggle() {
 	};
 
 	useMount( () => {
-		setValues( AD_BLOCKING_FORM_SETTINGS, {
-			adBlockerDetectionToggle: adBlockerDetectionSnippet,
-		} );
-		setValues( AD_BLOCKING_FORM_SETTINGS, {
+		const initialToggleValues = {
+			// Set the initial toggle value to `undefined` if the saved value is `false`
+			// to prevent the SettingsNotice from showing up on mount.
+			adBlockerDetectionToggle: adBlockerDetectionSnippet || undefined,
 			adBlockerDetectionErrorToggle: adBlockerDetectionErrorSnippet,
-		} );
+		};
+
+		setValues( AD_BLOCKING_FORM_SETTINGS, initialToggleValues );
 	} );
 
 	if ( ! adBlockerDetectionEnabled || ! adBlockingRecoverySetupStatus ) {

--- a/assets/js/modules/adsense/components/common/AdBlockingRecoveryToggle.js
+++ b/assets/js/modules/adsense/components/common/AdBlockingRecoveryToggle.js
@@ -1,0 +1,174 @@
+/**
+ * AdBlockingRecoveryToggle component.
+ *
+ * Site Kit by Google, Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import { useMount } from 'react-use';
+
+/**
+ * WordPress dependencies
+ */
+import { createInterpolateElement } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import Data from 'googlesitekit-data';
+import { Switch } from 'googlesitekit-components';
+import {
+	AD_BLOCKING_FORM_SETTINGS,
+	MODULES_ADSENSE,
+} from '../../datastore/constants';
+import Link from '../../../../components/Link';
+import SettingsNotice from '../../../../components/SettingsNotice/SettingsNotice';
+import { useFeature } from '../../../../hooks/useFeature';
+import { CORE_FORMS } from '../../../../googlesitekit/datastore/forms/constants';
+const { useSelect, useDispatch } = Data;
+
+export default function AdBlockingRecoveryToggle() {
+	const adBlockerDetectionEnabled = useFeature( 'adBlockerDetection' );
+
+	const adBlockerDetectionSnippet = useSelect( ( select ) =>
+		select( MODULES_ADSENSE ).getUseAdBlockerDetectionSnippet()
+	);
+	const adBlockerDetectionErrorSnippet = useSelect( ( select ) =>
+		select( MODULES_ADSENSE ).getUseAdBlockerDetectionErrorSnippet()
+	);
+	const adBlockingRecoverySetupStatus = useSelect( ( select ) =>
+		select( MODULES_ADSENSE ).getAdBlockingRecoverySetupStatus()
+	);
+	const adsenseAccountID = useSelect( ( select ) =>
+		select( MODULES_ADSENSE ).getAccountID()
+	);
+	const privacyMessagingURL = useSelect( ( select ) =>
+		select( MODULES_ADSENSE ).getServiceURL( {
+			path: `/${ adsenseAccountID }/privacymessaging/ad_blocking`,
+		} )
+	);
+	const adBlockerDetectionToggle = useSelect( ( select ) =>
+		select( CORE_FORMS ).getValue(
+			AD_BLOCKING_FORM_SETTINGS,
+			'adBlockerDetectionToggle'
+		)
+	);
+	const adBlockerDetectionErrorToggle = useSelect( ( select ) =>
+		select( CORE_FORMS ).getValue(
+			AD_BLOCKING_FORM_SETTINGS,
+			'adBlockerDetectionErrorToggle'
+		)
+	);
+
+	const { setValues } = useDispatch( CORE_FORMS );
+	const {
+		setUseAdBlockerDetectionSnippet,
+		setUseAdBlockerDetectionErrorSnippet,
+	} = useDispatch( MODULES_ADSENSE );
+
+	const handleDetectionToggleClick = () => {
+		setValues( AD_BLOCKING_FORM_SETTINGS, {
+			adBlockerDetectionToggle: ! adBlockerDetectionToggle,
+		} );
+		setUseAdBlockerDetectionSnippet( ! adBlockerDetectionToggle );
+	};
+
+	const handleErrorToggleClick = () => {
+		setValues( AD_BLOCKING_FORM_SETTINGS, {
+			adBlockerDetectionErrorToggle: ! adBlockerDetectionErrorToggle,
+		} );
+		setUseAdBlockerDetectionErrorSnippet( ! adBlockerDetectionErrorToggle );
+	};
+
+	useMount( () => {
+		setValues( AD_BLOCKING_FORM_SETTINGS, {
+			adBlockerDetectionToggle: adBlockerDetectionSnippet,
+		} );
+		setValues( AD_BLOCKING_FORM_SETTINGS, {
+			adBlockerDetectionErrorToggle: adBlockerDetectionErrorSnippet,
+		} );
+	} );
+
+	if ( ! adBlockerDetectionEnabled || ! adBlockingRecoverySetupStatus ) {
+		return null;
+	}
+
+	return (
+		<fieldset className="googlesitekit-settings-module__ad-blocking-recovery-toggles">
+			<legend className="googlesitekit-setup-module__text">
+				{ __( 'Ad blocking recovery', 'google-site-kit' ) }
+			</legend>
+			<div className="googlesitekit-settings-module__meta-items">
+				<div className="googlesitekit-settings-module__meta-item">
+					<Switch
+						label={ __(
+							'Place ad blocking recovery tag',
+							'google-site-kit'
+						) }
+						checked={ adBlockerDetectionToggle }
+						onClick={ handleDetectionToggleClick }
+						hideLabel={ false }
+					/>
+					<p>
+						{ createInterpolateElement(
+							__(
+								'Ad blocking recovery only works if you’ve also created and published a recovery message in AdSense. <a>Configure your message</a>',
+								'google-site-kit'
+							),
+							{
+								a: (
+									<Link
+										href={ privacyMessagingURL }
+										external
+									/>
+								),
+							}
+						) }
+					</p>
+				</div>
+				{ ( adBlockerDetectionToggle || adBlockerDetectionSnippet ) && (
+					<div className="googlesitekit-settings-module__meta-item">
+						<Switch
+							label={ __(
+								'Place error protection tag',
+								'google-site-kit'
+							) }
+							checked={ adBlockerDetectionErrorToggle }
+							onClick={ handleErrorToggleClick }
+							hideLabel={ false }
+						/>
+						<p>
+							{ __(
+								'If a site visitor’s ad blocker browser extension also blocks the standard ad blocking recovery tag, the error protection tag will show a non-customizable ad blocking recovery message to visitors when enabled.',
+								'google-site-kit'
+							) }
+						</p>
+					</div>
+				) }
+			</div>
+			{ adBlockerDetectionToggle === false && (
+				<SettingsNotice
+					notice={ __(
+						'The ad blocking recovery message won’t be displayed to visitors unless the tag is placed',
+						'google-site-kit'
+					) }
+				/>
+			) }
+		</fieldset>
+	);
+}

--- a/assets/js/modules/adsense/components/common/AdBlockingRecoveryToggle.js
+++ b/assets/js/modules/adsense/components/common/AdBlockingRecoveryToggle.js
@@ -45,10 +45,10 @@ const { useSelect, useDispatch } = Data;
 export default function AdBlockingRecoveryToggle() {
 	const adBlockerDetectionEnabled = useFeature( 'adBlockerDetection' );
 
-	const adBlockerDetectionSnippet = useSelect( ( select ) =>
+	const adBlockingDetectionSnippet = useSelect( ( select ) =>
 		select( MODULES_ADSENSE ).getUseAdBlockerDetectionSnippet()
 	);
-	const adBlockerDetectionErrorSnippet = useSelect( ( select ) =>
+	const adBlockingDetectionErrorSnippet = useSelect( ( select ) =>
 		select( MODULES_ADSENSE ).getUseAdBlockerDetectionErrorSnippet()
 	);
 	const adBlockingRecoverySetupStatus = useSelect( ( select ) =>
@@ -62,13 +62,13 @@ export default function AdBlockingRecoveryToggle() {
 			path: `/${ adsenseAccountID }/privacymessaging/ad_blocking`,
 		} )
 	);
-	const adBlockerDetectionToggle = useSelect( ( select ) =>
+	const adBlockingDetectionToggle = useSelect( ( select ) =>
 		select( CORE_FORMS ).getValue(
 			AD_BLOCKING_FORM_SETTINGS,
 			'adBlockerDetectionToggle'
 		)
 	);
-	const adBlockerDetectionErrorToggle = useSelect( ( select ) =>
+	const adBlockingDetectionErrorToggle = useSelect( ( select ) =>
 		select( CORE_FORMS ).getValue(
 			AD_BLOCKING_FORM_SETTINGS,
 			'adBlockerDetectionErrorToggle'
@@ -83,24 +83,26 @@ export default function AdBlockingRecoveryToggle() {
 
 	const handleDetectionToggleClick = () => {
 		setValues( AD_BLOCKING_FORM_SETTINGS, {
-			adBlockerDetectionToggle: ! adBlockerDetectionToggle,
+			adBlockerDetectionToggle: ! adBlockingDetectionToggle,
 		} );
-		setUseAdBlockerDetectionSnippet( ! adBlockerDetectionToggle );
+		setUseAdBlockerDetectionSnippet( ! adBlockingDetectionToggle );
 	};
 
 	const handleErrorToggleClick = () => {
 		setValues( AD_BLOCKING_FORM_SETTINGS, {
-			adBlockerDetectionErrorToggle: ! adBlockerDetectionErrorToggle,
+			adBlockerDetectionErrorToggle: ! adBlockingDetectionErrorToggle,
 		} );
-		setUseAdBlockerDetectionErrorSnippet( ! adBlockerDetectionErrorToggle );
+		setUseAdBlockerDetectionErrorSnippet(
+			! adBlockingDetectionErrorToggle
+		);
 	};
 
 	useMount( () => {
 		const initialToggleValues = {
 			// Set the initial toggle value to `undefined` if the saved value is `false`
 			// to prevent the SettingsNotice from showing up on mount.
-			adBlockerDetectionToggle: adBlockerDetectionSnippet || undefined,
-			adBlockerDetectionErrorToggle: adBlockerDetectionErrorSnippet,
+			adBlockerDetectionToggle: adBlockingDetectionSnippet || undefined,
+			adBlockerDetectionErrorToggle: adBlockingDetectionErrorSnippet,
 		};
 
 		setValues( AD_BLOCKING_FORM_SETTINGS, initialToggleValues );
@@ -122,7 +124,7 @@ export default function AdBlockingRecoveryToggle() {
 							'Place ad blocking recovery tag',
 							'google-site-kit'
 						) }
-						checked={ adBlockerDetectionToggle }
+						checked={ adBlockingDetectionToggle }
 						onClick={ handleDetectionToggleClick }
 						hideLabel={ false }
 					/>
@@ -143,14 +145,15 @@ export default function AdBlockingRecoveryToggle() {
 						) }
 					</p>
 				</div>
-				{ ( adBlockerDetectionToggle || adBlockerDetectionSnippet ) && (
+				{ ( adBlockingDetectionToggle ||
+					adBlockingDetectionSnippet ) && (
 					<div className="googlesitekit-settings-module__meta-item">
 						<Switch
 							label={ __(
 								'Place error protection tag',
 								'google-site-kit'
 							) }
-							checked={ adBlockerDetectionErrorToggle }
+							checked={ adBlockingDetectionErrorToggle }
 							onClick={ handleErrorToggleClick }
 							hideLabel={ false }
 						/>
@@ -163,7 +166,7 @@ export default function AdBlockingRecoveryToggle() {
 					</div>
 				) }
 			</div>
-			{ adBlockerDetectionToggle === false && (
+			{ adBlockingDetectionToggle === false && (
 				<SettingsNotice
 					notice={ __(
 						'The ad blocking recovery message won’t be displayed to visitors unless the tag is placed',

--- a/assets/js/modules/adsense/components/common/AdBlockingRecoveryToggle.js
+++ b/assets/js/modules/adsense/components/common/AdBlockingRecoveryToggle.js
@@ -65,13 +65,13 @@ export default function AdBlockingRecoveryToggle() {
 	const adBlockingDetectionToggle = useSelect( ( select ) =>
 		select( CORE_FORMS ).getValue(
 			AD_BLOCKING_FORM_SETTINGS,
-			'adBlockerDetectionToggle'
+			'adBlockingDetectionToggle'
 		)
 	);
 	const adBlockingDetectionErrorToggle = useSelect( ( select ) =>
 		select( CORE_FORMS ).getValue(
 			AD_BLOCKING_FORM_SETTINGS,
-			'adBlockerDetectionErrorToggle'
+			'adBlockingDetectionErrorToggle'
 		)
 	);
 
@@ -83,14 +83,14 @@ export default function AdBlockingRecoveryToggle() {
 
 	const handleDetectionToggleClick = () => {
 		setValues( AD_BLOCKING_FORM_SETTINGS, {
-			adBlockerDetectionToggle: ! adBlockingDetectionToggle,
+			adBlockingDetectionToggle: ! adBlockingDetectionToggle,
 		} );
 		setUseAdBlockerDetectionSnippet( ! adBlockingDetectionToggle );
 	};
 
 	const handleErrorToggleClick = () => {
 		setValues( AD_BLOCKING_FORM_SETTINGS, {
-			adBlockerDetectionErrorToggle: ! adBlockingDetectionErrorToggle,
+			adBlockingDetectionErrorToggle: ! adBlockingDetectionErrorToggle,
 		} );
 		setUseAdBlockerDetectionErrorSnippet(
 			! adBlockingDetectionErrorToggle
@@ -101,8 +101,8 @@ export default function AdBlockingRecoveryToggle() {
 		const initialToggleValues = {
 			// Set the initial toggle value to `undefined` if the saved value is `false`
 			// to prevent the SettingsNotice from showing up on mount.
-			adBlockerDetectionToggle: adBlockingDetectionSnippet || undefined,
-			adBlockerDetectionErrorToggle: adBlockingDetectionErrorSnippet,
+			adBlockingDetectionToggle: adBlockingDetectionSnippet || undefined,
+			adBlockingDetectionErrorToggle: adBlockingDetectionErrorSnippet,
 		};
 
 		setValues( AD_BLOCKING_FORM_SETTINGS, initialToggleValues );

--- a/assets/js/modules/adsense/components/common/AdBlockingRecoveryToggle.stories.js
+++ b/assets/js/modules/adsense/components/common/AdBlockingRecoveryToggle.stories.js
@@ -52,9 +52,25 @@ Ready.parameters = {
 	features: [ 'adBlockerDetection' ],
 };
 
-export const WithTogglesEnabled = Template.bind( {} );
-WithTogglesEnabled.storyName = 'With Toggles Enabled';
-WithTogglesEnabled.args = {
+export const WithAdBlockingRecoveryTagEnabled = Template.bind( {} );
+WithAdBlockingRecoveryTagEnabled.storyName =
+	'With Ad Blocking Recovery Tag Enabled';
+WithAdBlockingRecoveryTagEnabled.args = {
+	setupRegistry: ( registry ) => {
+		registry.dispatch( MODULES_ADSENSE ).receiveGetSettings( {
+			...validSettings,
+			useAdBlockerDetectionSnippet: true,
+			useAdBlockerDetectionErrorSnippet: false,
+		} );
+	},
+};
+WithAdBlockingRecoveryTagEnabled.parameters = {
+	features: [ 'adBlockerDetection' ],
+};
+
+export const WithBothTogglesEnabled = Template.bind( {} );
+WithBothTogglesEnabled.storyName = 'With Both The Toggles Enabled';
+WithBothTogglesEnabled.args = {
 	setupRegistry: ( registry ) => {
 		registry.dispatch( MODULES_ADSENSE ).receiveGetSettings( {
 			...validSettings,
@@ -63,7 +79,7 @@ WithTogglesEnabled.args = {
 		} );
 	},
 };
-WithTogglesEnabled.parameters = {
+WithBothTogglesEnabled.parameters = {
 	features: [ 'adBlockerDetection' ],
 };
 

--- a/assets/js/modules/adsense/components/common/AdBlockingRecoveryToggle.stories.js
+++ b/assets/js/modules/adsense/components/common/AdBlockingRecoveryToggle.stories.js
@@ -1,0 +1,93 @@
+/**
+ * AdBlockingRecoveryToggle Component Stories.
+ *
+ * Site Kit by Google, Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import { provideModules } from '../../../../../../tests/js/utils';
+import WithRegistrySetup from '../../../../../../tests/js/WithRegistrySetup';
+import {
+	AD_BLOCKING_RECOVERY_SETUP_STATUS_TAG_PLACED,
+	MODULES_ADSENSE,
+} from '../../datastore/constants';
+import { ACCOUNT_STATUS_READY, SITE_STATUS_READY } from '../../util';
+import AdBlockingRecoveryToggle from './AdBlockingRecoveryToggle';
+
+const Template = () => <AdBlockingRecoveryToggle />;
+
+const validSettings = {
+	accountID: 'pub-12345678',
+	clientID: 'ca-pub-12345678',
+	useSnippet: false,
+	accountStatus: ACCOUNT_STATUS_READY,
+	siteStatus: SITE_STATUS_READY,
+	adBlockingRecoverySetupStatus: AD_BLOCKING_RECOVERY_SETUP_STATUS_TAG_PLACED,
+};
+
+export const Ready = Template.bind( {} );
+Ready.storyName = 'Ready';
+Ready.args = {
+	setupRegistry: ( registry ) => {
+		registry
+			.dispatch( MODULES_ADSENSE )
+			.receiveGetSettings( validSettings );
+	},
+};
+Ready.parameters = {
+	features: [ 'adBlockerDetection' ],
+};
+
+export const WithTogglesEnabled = Template.bind( {} );
+WithTogglesEnabled.storyName = 'With Toggles Enabled';
+WithTogglesEnabled.args = {
+	setupRegistry: ( registry ) => {
+		registry.dispatch( MODULES_ADSENSE ).receiveGetSettings( {
+			...validSettings,
+			useAdBlockerDetectionSnippet: true,
+			useAdBlockerDetectionErrorSnippet: true,
+		} );
+	},
+};
+WithTogglesEnabled.parameters = {
+	features: [ 'adBlockerDetection' ],
+};
+
+export default {
+	title: 'Modules/AdSense/Components/AdBlockingRecoveryToggle',
+	decorators: [
+		( Story, { args } ) => {
+			const setupRegistry = ( registry ) => {
+				provideModules( registry, [
+					{
+						active: true,
+						connected: true,
+						slug: 'adsense',
+					},
+				] );
+
+				args?.setupRegistry( registry );
+			};
+
+			return (
+				<WithRegistrySetup func={ setupRegistry }>
+					<Story />
+				</WithRegistrySetup>
+			);
+		},
+	],
+};

--- a/assets/js/modules/adsense/components/common/AdBlockingRecoveryToggle.test.js
+++ b/assets/js/modules/adsense/components/common/AdBlockingRecoveryToggle.test.js
@@ -68,9 +68,7 @@ describe( 'AdBlockingRecoveryToggle', () => {
 				)
 			).toBeNull();
 
-			expect( container.textContent ).not.toContain(
-				'Ad blocking recovery'
-			);
+			expect( container ).toBeEmptyDOMElement();
 		}
 	);
 

--- a/assets/js/modules/adsense/components/common/AdBlockingRecoveryToggle.test.js
+++ b/assets/js/modules/adsense/components/common/AdBlockingRecoveryToggle.test.js
@@ -128,7 +128,7 @@ describe( 'AdBlockingRecoveryToggle', () => {
 		} );
 	} );
 
-	it( 'should render the Ad blocking recovery tag toggle unchecked', () => {
+	it( 'renders the Ad Blocking Recovery tag toggle unchecked and does not render the Error Protection tag toggle', () => {
 		const { getByLabelText, getAllByRole, queryByLabelText } = render(
 			<AdBlockingRecoveryToggle />,
 			{

--- a/assets/js/modules/adsense/components/common/AdBlockingRecoveryToggle.test.js
+++ b/assets/js/modules/adsense/components/common/AdBlockingRecoveryToggle.test.js
@@ -1,0 +1,111 @@
+/**
+ * AdBlockingRecoveryToggle component tests.
+ *
+ * Site Kit by Google, Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import AdBlockingRecoveryToggle from './AdBlockingRecoveryToggle';
+import { render, provideModules } from '../../../../../../tests/js/test-utils';
+import {
+	AD_BLOCKING_RECOVERY_SETUP_STATUS_TAG_PLACED,
+	MODULES_ADSENSE,
+} from '../../datastore/constants';
+import { ACCOUNT_STATUS_READY, SITE_STATUS_READY } from '../../util';
+import { enabledFeatures } from '../../../../features';
+
+describe( 'AdBlockingRecoveryToggle', () => {
+	const validSettings = {
+		accountID: 'pub-12345678',
+		clientID: 'ca-pub-12345678',
+		useSnippet: false,
+		accountStatus: ACCOUNT_STATUS_READY,
+		siteStatus: SITE_STATUS_READY,
+		adBlockingRecoverySetupStatus: '',
+	};
+
+	it.each( [
+		[ 'the Ad blocker detection feature flag is not enabled', false ],
+		[ 'Ad blocker recovery setup status is empty', true ],
+	] )(
+		'should not render the Ad blocking recovery toggle when %s',
+		( testName, adBlockerDetectionEnabled ) => {
+			const { container } = render( <AdBlockingRecoveryToggle />, {
+				setupRegistry: ( registry ) => {
+					if ( adBlockerDetectionEnabled ) {
+						enabledFeatures.add( 'adBlockerDetection' );
+					}
+					provideModules( registry, [
+						{
+							slug: 'adsense',
+							active: true,
+							connected: true,
+						},
+					] );
+					registry
+						.dispatch( MODULES_ADSENSE )
+						.receiveGetSettings( validSettings );
+				},
+			} );
+
+			expect(
+				container.querySelector(
+					'.googlesitekit-settings-module__ad-blocking-recovery-toggles'
+				)
+			).toBeNull();
+
+			expect( container.textContent ).not.toContain(
+				'Ad blocking recovery'
+			);
+		}
+	);
+
+	it( 'should render the Ad blocking recovery toggle when the conditions are met', () => {
+		const { container } = render( <AdBlockingRecoveryToggle />, {
+			setupRegistry: ( registry ) => {
+				enabledFeatures.add( 'adBlockerDetection' );
+				provideModules( registry, [
+					{
+						slug: 'adsense',
+						active: true,
+						connected: true,
+					},
+				] );
+				registry.dispatch( MODULES_ADSENSE ).receiveGetSettings( {
+					...validSettings,
+					adBlockingRecoverySetupStatus:
+						AD_BLOCKING_RECOVERY_SETUP_STATUS_TAG_PLACED,
+					useAdBlockerDetectionSnippet: true,
+					useAdBlockerDetectionErrorSnippet: true,
+				} );
+			},
+		} );
+
+		expect(
+			container.querySelector(
+				'.googlesitekit-settings-module__ad-blocking-recovery-toggles'
+			)
+		).not.toBeNull();
+
+		expect( container.textContent ).toContain( 'Ad blocking recovery' );
+		expect(
+			container.querySelector(
+				'.googlesitekit-settings-module__meta-item'
+			)
+		).toHaveTextContent( 'Place ad blocking recovery tag' );
+	} );
+} );

--- a/assets/js/modules/adsense/components/common/AdBlockingRecoveryToggle.test.js
+++ b/assets/js/modules/adsense/components/common/AdBlockingRecoveryToggle.test.js
@@ -30,7 +30,6 @@ import {
 	MODULES_ADSENSE,
 } from '../../datastore/constants';
 import { ACCOUNT_STATUS_READY, SITE_STATUS_READY } from '../../util';
-import { enabledFeatures } from '../../../../features';
 
 describe( 'AdBlockingRecoveryToggle', () => {
 	const validSettings = {
@@ -49,10 +48,10 @@ describe( 'AdBlockingRecoveryToggle', () => {
 		'should not render the Ad blocking recovery toggle when %s',
 		( testName, adBlockerDetectionEnabled ) => {
 			const { container } = render( <AdBlockingRecoveryToggle />, {
+				features: [].concat(
+					adBlockerDetectionEnabled ? 'adBlockerDetection' : []
+				),
 				setupRegistry: ( registry ) => {
-					if ( adBlockerDetectionEnabled ) {
-						enabledFeatures.add( 'adBlockerDetection' );
-					}
 					provideModules( registry, [
 						{
 							slug: 'adsense',
@@ -80,8 +79,8 @@ describe( 'AdBlockingRecoveryToggle', () => {
 		const { container, getByLabelText, getAllByRole } = render(
 			<AdBlockingRecoveryToggle />,
 			{
+				features: [ 'adBlockerDetection' ],
 				setupRegistry: ( registry ) => {
-					enabledFeatures.add( 'adBlockerDetection' );
 					provideModules( registry, [
 						{
 							slug: 'adsense',
@@ -132,8 +131,8 @@ describe( 'AdBlockingRecoveryToggle', () => {
 		const { getByLabelText, getAllByRole, queryByLabelText } = render(
 			<AdBlockingRecoveryToggle />,
 			{
+				features: [ 'adBlockerDetection' ],
 				setupRegistry: ( registry ) => {
-					enabledFeatures.add( 'adBlockerDetection' );
 					provideModules( registry, [
 						{
 							slug: 'adsense',
@@ -172,8 +171,8 @@ describe( 'AdBlockingRecoveryToggle', () => {
 		const { getByLabelText, getAllByRole, container } = render(
 			<AdBlockingRecoveryToggle />,
 			{
+				features: [ 'adBlockerDetection' ],
 				setupRegistry: ( registry ) => {
-					enabledFeatures.add( 'adBlockerDetection' );
 					provideModules( registry, [
 						{
 							slug: 'adsense',

--- a/assets/js/modules/adsense/components/common/index.js
+++ b/assets/js/modules/adsense/components/common/index.js
@@ -19,6 +19,7 @@
 export { default as AccountSelect } from './AccountSelect';
 export { default as AdBlockerWarning } from './AdBlockerWarning';
 export { default as AdBlockingRecoveryCTA } from './AdBlockingRecoveryCTA';
+export { default as AdBlockingRecoveryToggle } from './AdBlockingRecoveryToggle';
 export { default as ErrorNotices } from './ErrorNotices';
 export { default as SiteSteps } from './SiteSteps';
 export { default as UserProfile } from './UserProfile';

--- a/assets/js/modules/adsense/components/settings/SettingsForm.js
+++ b/assets/js/modules/adsense/components/settings/SettingsForm.js
@@ -33,6 +33,7 @@ import {
 	ErrorNotices,
 	UseSnippetSwitch,
 	AutoAdExclusionSwitches,
+	AdBlockingRecoveryToggle,
 } from '../common';
 import WebStoriesAdUnitSelect from '../common/WebStoriesAdUnitSelect';
 import Link from '../../../../components/Link';
@@ -125,6 +126,8 @@ export default function SettingsForm() {
 			<AutoAdExclusionSwitches />
 
 			<AdBlockingRecoveryCTA />
+
+			<AdBlockingRecoveryToggle />
 		</div>
 	);
 }

--- a/assets/js/modules/adsense/datastore/constants.js
+++ b/assets/js/modules/adsense/datastore/constants.js
@@ -33,3 +33,4 @@ export const AD_BLOCKING_RECOVERY_SETUP_STATUS_SETUP_CONFIRMED =
 
 export const AD_BLOCKING_RECOVERY_SETUP_SUCCESS_NOTIFICATION_ID =
 	'ad-blocking-recovery-setup-success';
+export const AD_BLOCKING_FORM_SETTINGS = 'adsenseAdBlockingFormSettings';

--- a/assets/sass/components/adsense/_googlesitekit-adsense-ad-blocking-recovery.scss
+++ b/assets/sass/components/adsense/_googlesitekit-adsense-ad-blocking-recovery.scss
@@ -129,4 +129,22 @@
 			}
 		}
 	}
+
+	.googlesitekit-settings-module__ad-blocking-recovery-toggles {
+		margin-top: 20px;
+
+		.googlesitekit-settings-module__meta-item {
+			margin-bottom: 0;
+
+			p {
+				left: 42px;
+				margin-top: 10px;
+				position: relative;
+			}
+		}
+
+		.googlesitekit-settings-notice {
+			margin-bottom: 0;
+		}
+	}
 }


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #6962 

## Relevant technical choices

<!-- Please describe your changes. -->

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
