### PR TITLE
Don't show the Ads Conversion ID input if there are no UA properties.

### DIFF
--- a/assets/js/modules/analytics/components/common/AdsConversionIDTextField.js
+++ b/assets/js/modules/analytics/components/common/AdsConversionIDTextField.js
@@ -82,8 +82,9 @@ export default function AdsConversionIDTextField() {
 	// but only hide it if the value is valid otherwise the user will be blocked.
 	if (
 		isValidValue &&
-		! ( isUAEnabled && snippetEnabled ) &&
-		! ( ga4ReportingEnabled && ga4SnippetEnabled )
+		( ga4ReportingEnabled
+			? ! ( isUAEnabled && snippetEnabled ) && ! ga4SnippetEnabled
+			: ! snippetEnabled )
 	) {
 		return null;
 	}

--- a/assets/js/modules/analytics/components/common/AdsConversionIDTextField.js
+++ b/assets/js/modules/analytics/components/common/AdsConversionIDTextField.js
@@ -53,6 +53,13 @@ export default function AdsConversionIDTextField() {
 	const ga4SnippetEnabled = useSelect( ( select ) =>
 		select( MODULES_ANALYTICS_4 ).getUseSnippet()
 	);
+	const accountID = useSelect( ( select ) =>
+		select( MODULES_ANALYTICS ).getAccountID()
+	);
+	const hasUAProperties = useSelect(
+		( select ) =>
+			!! select( MODULES_ANALYTICS ).getProperties( accountID )?.length
+	);
 
 	const { setAdsConversionID } = useDispatch( MODULES_ANALYTICS );
 	const onChange = useCallback(
@@ -78,7 +85,7 @@ export default function AdsConversionIDTextField() {
 	// but only hide it if the value is valid otherwise the user will be blocked.
 	if (
 		isValidValue &&
-		! snippetEnabled &&
+		! ( hasUAProperties && snippetEnabled ) &&
 		! ( ga4ReportingEnabled && ga4SnippetEnabled )
 	) {
 		return null;

--- a/assets/js/modules/analytics/components/common/AdsConversionIDTextField.js
+++ b/assets/js/modules/analytics/components/common/AdsConversionIDTextField.js
@@ -32,7 +32,8 @@ import { __ } from '@wordpress/i18n';
  */
 import Data from 'googlesitekit-data';
 import { TextField, HelperText, Input } from '../../../../material-components';
-import { MODULES_ANALYTICS } from '../../datastore/constants';
+import { CORE_FORMS } from '../../../../googlesitekit/datastore/forms/constants';
+import { FORM_SETUP, MODULES_ANALYTICS } from '../../datastore/constants';
 import { MODULES_ANALYTICS_4 } from '../../../analytics-4/datastore/constants';
 import VisuallyHidden from '../../../../components/VisuallyHidden';
 import { isValidAdsConversionID } from '../../util';
@@ -53,12 +54,8 @@ export default function AdsConversionIDTextField() {
 	const ga4SnippetEnabled = useSelect( ( select ) =>
 		select( MODULES_ANALYTICS_4 ).getUseSnippet()
 	);
-	const accountID = useSelect( ( select ) =>
-		select( MODULES_ANALYTICS ).getAccountID()
-	);
-	const hasUAProperties = useSelect(
-		( select ) =>
-			!! select( MODULES_ANALYTICS ).getProperties( accountID )?.length
+	const isUAEnabled = useSelect( ( select ) =>
+		select( CORE_FORMS ).getValue( FORM_SETUP, 'enableUA' )
 	);
 
 	const { setAdsConversionID } = useDispatch( MODULES_ANALYTICS );
@@ -85,7 +82,7 @@ export default function AdsConversionIDTextField() {
 	// but only hide it if the value is valid otherwise the user will be blocked.
 	if (
 		isValidValue &&
-		! ( hasUAProperties && snippetEnabled ) &&
+		! ( isUAEnabled && snippetEnabled ) &&
 		! ( ga4ReportingEnabled && ga4SnippetEnabled )
 	) {
 		return null;


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #6875 

## Relevant technical choices

This looks like the most straightforward fix to the issue @mohitwp spotted [here](https://github.com/google/site-kit-wp/issues/6875#issuecomment-1586725752). I did consider a wider refactor to lift the related state up and share it with `EnableUniversalAnalytics`, but in the end it looked like this would complicate things further.

<!-- Please describe your changes. -->

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
