### PR TITLE
Fix condition for showing the Ads Conversion ID section on settings view page.

### DIFF
--- a/assets/js/modules/analytics/components/settings/OptionalSettingsView.js
+++ b/assets/js/modules/analytics/components/settings/OptionalSettingsView.js
@@ -69,7 +69,9 @@ export default function OptionalSettingsView() {
 
 	const showAdsConversionIDSettings =
 		canUseSnippet &&
-		( useSnippet || ( ga4ReportingEnabled && useGA4Snippet ) );
+		( ga4ReportingEnabled
+			? ( isUAConnected && useSnippet ) || useGA4Snippet
+			: useSnippet );
 
 	return (
 		<Fragment>


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #6875 

## Relevant technical choices

This addresses the issue that @mohitwp spotted [here](https://github.com/google/site-kit-wp/issues/6875#issuecomment-1592575876).

<!-- Please describe your changes. -->

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
