### PR TITLE
Place ad blocking recovery tag

### DIFF
--- a/includes/Modules/AdSense.php
+++ b/includes/Modules/AdSense.php
@@ -760,6 +760,11 @@ final class AdSense extends Module
 			$tag->use_guard( new Tag_Environment_Type_Guard() );
 
 			if ( $tag->can_register() ) {
+				$tag->set_use_ad_blocker_detection_snippet( $settings['useAdBlockerDetectionSnippet'] );
+				$tag->set_use_ad_blocker_detection_error_snippet(
+					$settings['useAdBlockerDetectionErrorSnippet']
+				);
+
 				$tag->register();
 			}
 		}

--- a/includes/Modules/AdSense/Web_Tag.php
+++ b/includes/Modules/AdSense/Web_Tag.php
@@ -27,6 +27,82 @@ class Web_Tag extends Module_Web_Tag {
 	use Method_Proxy_Trait, Tag_With_DNS_Prefetch_Trait;
 
 	/**
+	 * Whether or not to use ad blocker detection snippet.
+	 *
+	 * @since n.e.x.t
+	 * @var bool
+	 */
+	private $use_ad_blocker_detection_snippet;
+
+	/**
+	 * Whether or not to use ad blocker detection error snippet.
+	 *
+	 * @since n.e.x.t
+	 * @var bool
+	 */
+	private $use_ad_blocker_detection_error_snippet;
+
+	/**
+	 * Recovery tag HTML.
+	 *
+	 * @since n.e.x.t
+	 * @var string
+	 */
+	private $recovery_tag_html;
+
+	/**
+	 * Error protection HTML.
+	 *
+	 * @since n.e.x.t
+	 * @var string
+	 */
+	private $error_protection_html;
+
+	/**
+	 * Sets whether or not to use ad blocker detection snippet.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param bool $use_ad_blocker_detection_snippet Whether or not to use ad blocker detection snippet.
+	 */
+	public function set_use_ad_blocker_detection_snippet( $use_ad_blocker_detection_snippet ) {
+		$this->use_ad_blocker_detection_snippet = (bool) $use_ad_blocker_detection_snippet;
+	}
+
+	/**
+	 * Sets whether or not to use ad blocker detection error snippet.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param bool $use_ad_blocker_detection_error_snippet Whether or not to use ad blocker detection error snippet.
+	 */
+	public function set_use_ad_blocker_detection_error_snippet( $use_ad_blocker_detection_error_snippet ) {
+		$this->use_ad_blocker_detection_error_snippet = (bool) $use_ad_blocker_detection_error_snippet;
+	}
+
+	/**
+	 * Sets the recovery tag HTML.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param string $recovery_tag_html Recovery tag HTML.
+	 */
+	public function set_recovery_tag_html( $recovery_tag_html ) {
+		$this->recovery_tag_html = $recovery_tag_html;
+	}
+
+	/**
+	 * Sets the error protection HTML.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param string $error_protection_html Error protection HTML.
+	 */
+	public function set_error_protection_html( $error_protection_html ) {
+		$this->error_protection_html = $error_protection_html;
+	}
+
+	/**
 	 * Registers tag hooks.
 	 *
 	 * @since 1.24.0

--- a/includes/Modules/AdSense/Web_Tag.php
+++ b/includes/Modules/AdSense/Web_Tag.php
@@ -141,7 +141,8 @@ class Web_Tag extends Module_Web_Tag {
 			'crossorigin' => 'anonymous',
 		);
 
-		$adsense_attributes = $this->get_tag_blocked_on_consent_attribute_array();
+		$adsense_consent_attributes = $this->get_tag_blocked_on_consent_attribute_array();
+		$adsense_attributes         = $adsense_consent_attributes;
 
 		$auto_ads_opt = array();
 
@@ -170,6 +171,21 @@ class Web_Tag extends Module_Web_Tag {
 		printf( "\n<!-- %s -->\n", esc_html__( 'Google AdSense snippet added by Site Kit', 'google-site-kit' ) );
 		BC_Functions::wp_print_script_tag( array_merge( $adsense_script_attributes, $adsense_attributes ) );
 		printf( "\n<!-- %s -->\n", esc_html__( 'End Google AdSense snippet added by Site Kit', 'google-site-kit' ) );
+
+		if ( $this->use_ad_blocker_detection_snippet ) {
+			printf( "\n<!-- %s -->\n", esc_html__( 'Ad blocker detection snippet added by Site Kit', 'google-site-kit' ) );
+			BC_Functions::wp_print_inline_script_tag( $this->recovery_tag_html, $adsense_consent_attributes );
+			printf( "\n<!-- %s -->\n", esc_html__( 'End ad blocker detection snippet added by Site Kit', 'google-site-kit' ) );
+
+			if ( $this->use_ad_blocker_detection_error_snippet ) {
+				printf( "\n<!-- %s -->\n", esc_html__( 'Ad blocking recovery error protection snippet added by Site Kit', 'google-site-kit' ) );
+				BC_Functions::wp_print_inline_script_tag(
+					$this->error_protection_html,
+					$adsense_consent_attributes
+				);
+				printf( "\n<!-- %s -->\n", esc_html__( 'End ad blocking recovery error protection snippet added by Site Kit', 'google-site-kit' ) );
+			}
+		}
 	}
 
 }


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #6963 

## Relevant technical choices

This PR places the ad blocking recovery and error protection tags in the site.

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
