### PR TITLE
Only render Key Metrics settings card when user input is enabled

### DIFF
--- a/assets/js/components/settings/SettingsAdmin.js
+++ b/assets/js/components/settings/SettingsAdmin.js
@@ -19,119 +19,27 @@
 /**
  * WordPress dependencies
  */
-import { useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { addQueryArgs } from '@wordpress/url';
 
 /**
  * Internal dependencies
  */
-import Data from 'googlesitekit-data';
-import { CORE_USER } from '../../googlesitekit/datastore/user/constants';
-import { CORE_SITE } from '../../googlesitekit/datastore/site/constants';
-import { CORE_LOCATION } from '../../googlesitekit/datastore/location/constants';
 import Layout from '../layout/Layout';
 import { Grid, Cell, Row } from '../../material-components';
 import OptIn from '../OptIn';
 import ResetButton from '../ResetButton';
-import UserInputPreview from '../user-input/UserInputPreview';
-import { USER_INPUT_QUESTIONS_LIST } from '../user-input/util/constants';
 import { useFeature } from '../../hooks/useFeature';
-import { trackEvent } from '../../util';
+import SettingsCardKeyMetrics from './SettingsCardKeyMetrics';
 import SettingsPlugin from './SettingsPlugin';
-import useViewContext from '../../hooks/useViewContext';
-import SettingsKeyMetrics from './SettingsKeyMetrics';
-import Link from '../Link';
-const { useSelect, useDispatch } = Data;
 
 export default function SettingsAdmin() {
-	const viewContext = useViewContext();
 	const userInputEnabled = useFeature( 'userInput' );
-	const isUserInputCompleted = useSelect(
-		( select ) =>
-			userInputEnabled && select( CORE_USER ).isUserInputCompleted()
-	);
-	const userInputURL = useSelect( ( select ) =>
-		select( CORE_SITE ).getAdminURL( 'googlesitekit-user-input' )
-	);
-
-	const { navigateTo } = useDispatch( CORE_LOCATION );
-	const goTo = ( questionIndex = 1 ) => {
-		const questionSlug = USER_INPUT_QUESTIONS_LIST[ questionIndex - 1 ];
-		if ( questionSlug ) {
-			trackEvent( viewContext, 'question_edit', questionSlug );
-
-			navigateTo(
-				addQueryArgs( userInputURL, {
-					question: questionSlug,
-					redirect_url: global.location.href,
-					single: 'settings', // Allows the user to edit a single question then return to the settings page.
-				} )
-			);
-		}
-	};
-
-	const hasUserPickedMetrics = useSelect( ( select ) =>
-		select( CORE_USER ).getUserPickedMetrics()
-	);
-	const ctaLabel = !! hasUserPickedMetrics?.length
-		? __( 'Set your site goals', 'google-site-kit' )
-		: __( 'Personalize your metrics', 'google-site-kit' );
-
-	useEffect( () => {
-		if ( isUserInputCompleted ) {
-			trackEvent( viewContext, 'summary_view' );
-		}
-	}, [ isUserInputCompleted, viewContext ] );
 
 	return (
 		<Row>
 			{ userInputEnabled && (
 				<Cell size={ 12 }>
-					<Layout
-						title={ __( 'Key metrics', 'google-site-kit' ) }
-						header
-						rounded
-					>
-						<div className="googlesitekit-settings-module googlesitekit-settings-module--active googlesitekit-settings-user-input">
-							<SettingsKeyMetrics />
-							<Grid>
-								{ isUserInputCompleted && (
-									<Row>
-										<Cell size={ 12 }>
-											<UserInputPreview
-												goTo={ goTo }
-												noHeader
-												noFooter
-												settingsView
-												showIndividualCTAs
-											/>
-										</Cell>
-									</Row>
-								) }
-								{ isUserInputCompleted === false && (
-									<Row>
-										<Cell
-											className="googlesitekit-user-input__notification"
-											size={ 12 }
-										>
-											<p>
-												<span>
-													{ __(
-														'Answer 3 quick questions to help us show the most relevant data for your site',
-														'google-site-kit'
-													) }
-												</span>
-											</p>
-											<Link href={ userInputURL }>
-												{ ctaLabel }
-											</Link>
-										</Cell>
-									</Row>
-								) }
-							</Grid>
-						</div>
-					</Layout>
+					<SettingsCardKeyMetrics />
 				</Cell>
 			) }
 

--- a/assets/js/components/settings/SettingsApp.test.js
+++ b/assets/js/components/settings/SettingsApp.test.js
@@ -58,10 +58,6 @@ describe( 'SettingsApp', () => {
 		registry
 			.dispatch( CORE_SITE )
 			.receiveGetAdminBarSettings( { enabled: true } );
-		registry.dispatch( CORE_USER ).receiveGetKeyMetricsSettings( {
-			widgetSlugs: [],
-			isWidgetHidden: false,
-		} );
 
 		provideSiteInfo( registry, {
 			proxySupportLinkURL: 'https://test.com',

--- a/assets/js/components/settings/SettingsCardKeyMetrics.js
+++ b/assets/js/components/settings/SettingsCardKeyMetrics.js
@@ -1,0 +1,124 @@
+/**
+ * Site Kit by Google, Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { useEffect } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { addQueryArgs } from '@wordpress/url';
+
+/**
+ * Internal dependencies
+ */
+import Data from 'googlesitekit-data';
+import { CORE_USER } from '../../googlesitekit/datastore/user/constants';
+import { CORE_SITE } from '../../googlesitekit/datastore/site/constants';
+import { CORE_LOCATION } from '../../googlesitekit/datastore/location/constants';
+import { USER_INPUT_QUESTIONS_LIST } from '../user-input/util/constants';
+import { trackEvent } from '../../util';
+import useViewContext from '../../hooks/useViewContext';
+import SettingsKeyMetrics from './SettingsKeyMetrics';
+import UserInputPreview from '../user-input/UserInputPreview';
+import Layout from '../layout/Layout';
+import { Grid, Cell, Row } from '../../material-components';
+import Link from '../Link';
+
+const { useSelect, useDispatch } = Data;
+
+export default function SettingsCardKeyMetrics() {
+	const viewContext = useViewContext();
+	const isUserInputCompleted = useSelect( ( select ) =>
+		select( CORE_USER ).isUserInputCompleted()
+	);
+	const userInputURL = useSelect( ( select ) =>
+		select( CORE_SITE ).getAdminURL( 'googlesitekit-user-input' )
+	);
+
+	useEffect( () => {
+		if ( isUserInputCompleted ) {
+			trackEvent( viewContext, 'summary_view' );
+		}
+	}, [ isUserInputCompleted, viewContext ] );
+
+	const { navigateTo } = useDispatch( CORE_LOCATION );
+	const goTo = ( questionIndex = 1 ) => {
+		const questionSlug = USER_INPUT_QUESTIONS_LIST[ questionIndex - 1 ];
+		if ( questionSlug ) {
+			trackEvent( viewContext, 'question_edit', questionSlug );
+
+			navigateTo(
+				addQueryArgs( userInputURL, {
+					question: questionSlug,
+					redirect_url: global.location.href,
+					single: 'settings', // Allows the user to edit a single question then return to the settings page.
+				} )
+			);
+		}
+	};
+
+	const hasUserPickedMetrics = useSelect( ( select ) =>
+		select( CORE_USER ).getUserPickedMetrics()
+	);
+
+	const ctaLabel = !! hasUserPickedMetrics?.length
+		? __( 'Set your site goals', 'google-site-kit' )
+		: __( 'Personalize your metrics', 'google-site-kit' );
+
+	return (
+		<Layout title={ __( 'Key metrics', 'google-site-kit' ) } header rounded>
+			<div className="googlesitekit-settings-module googlesitekit-settings-module--active googlesitekit-settings-user-input">
+				<SettingsKeyMetrics />
+
+				<Grid>
+					{ isUserInputCompleted && (
+						<Row>
+							<Cell size={ 12 }>
+								<UserInputPreview
+									goTo={ goTo }
+									noHeader
+									noFooter
+									settingsView
+									showIndividualCTAs
+								/>
+							</Cell>
+						</Row>
+					) }
+
+					{ isUserInputCompleted === false && (
+						<Row>
+							<Cell
+								className="googlesitekit-user-input__notification"
+								size={ 12 }
+							>
+								<p>
+									<span>
+										{ __(
+											'Answer 3 quick questions to help us show the most relevant data for your site',
+											'google-site-kit'
+										) }
+									</span>
+								</p>
+
+								<Link href={ userInputURL }>{ ctaLabel }</Link>
+							</Cell>
+						</Row>
+					) }
+				</Grid>
+			</div>
+		</Layout>
+	);
+}

--- a/assets/js/components/settings/SettingsModules.test.js
+++ b/assets/js/components/settings/SettingsModules.test.js
@@ -94,10 +94,6 @@ describe( 'SettingsModules', () => {
 			coreUserTrackingSettingsEndpointRegExp,
 			coreUserTrackingResponse
 		);
-		registry.dispatch( CORE_USER ).receiveGetKeyMetricsSettings( {
-			widgetSlugs: [],
-			isWidgetHidden: false,
-		} );
 
 		await registry.dispatch( CORE_USER ).setTrackingEnabled( false );
 

--- a/tests/e2e/specs/admin-tracking.test.js
+++ b/tests/e2e/specs/admin-tracking.test.js
@@ -50,16 +50,6 @@ describe( 'admin tracking', () => {
 		useRequestInterception( ( request ) => {
 			const url = request.url();
 			if (
-				url.match( '/google-site-kit/v1/core/user/data/key-metrics' )
-			) {
-				request.respond( {
-					status: 200,
-					body: JSON.stringify( {
-						widgetSlugs: [],
-						isWidgetHidden: false,
-					} ),
-				} );
-			} else if (
 				url.match(
 					'/google-site-kit/v1/modules/search-console/data/searchanalytics'
 				)

--- a/tests/e2e/specs/plugin-reset.test.js
+++ b/tests/e2e/specs/plugin-reset.test.js
@@ -15,7 +15,6 @@ import {
 	setClientConfig,
 	setSearchConsoleProperty,
 	setSiteVerification,
-	useRequestInterception,
 } from '../utils';
 
 describe( 'Plugin Reset', () => {
@@ -25,24 +24,6 @@ describe( 'Plugin Reset', () => {
 		await setAuthToken();
 		await setSiteVerification();
 		await setSearchConsoleProperty();
-
-		await page.setRequestInterception( true );
-		useRequestInterception( ( request ) => {
-			const url = request.url();
-			if (
-				url.match( '/google-site-kit/v1/core/user/data/key-metrics' )
-			) {
-				request.respond( {
-					status: 200,
-					body: JSON.stringify( {
-						widgetSlugs: [],
-						isWidgetHidden: false,
-					} ),
-				} );
-			} else {
-				request.continue();
-			}
-		} );
 	} );
 
 	beforeEach( async () => {


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #6262

## Relevant technical choices

- Fixes the error [identified during release QA](https://github.com/google/site-kit-wp/issues/7136#issuecomment-1594519238) due to selector side effects that should not be running when `userInput` is not enabled by extracting all of the related state and UI into a new component which is guarded by the feature
- Removes changes to various tests that aren't specific to key-metrics which seem to have been added due to this side-effect

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
