### PR TITLE
Add Analytics dashboard view to Site Health

### DIFF
--- a/includes/Modules/Analytics.php
+++ b/includes/Modules/Analytics.php
@@ -253,35 +253,39 @@ final class Analytics extends Module
 		$settings = $this->get_settings()->get();
 
 		$fields = array(
-			'analytics_dashboard_view' => array(
-				'label' => __( 'Analytics dashboard view', 'google-site-kit' ),
-				'value' => 'google-analytics-4' === $settings['dashboardView'] ? __( 'Google Analytics 4 view', 'google-site-kit' ) : __( 'Universal Analytics view', 'google-site-kit' ),
-				'debug' => $settings['dashboardView'],
-			),
-			'analytics_account_id'     => array(
+			'analytics_account_id'  => array(
 				'label' => __( 'Analytics account ID', 'google-site-kit' ),
 				'value' => $settings['accountID'],
 				'debug' => Debug_Data::redact_debug_value( $settings['accountID'] ),
 			),
-			'analytics_property_id'    => array(
+			'analytics_property_id' => array(
 				'label' => __( 'Analytics property ID', 'google-site-kit' ),
 				'value' => $settings['propertyID'],
 				'debug' => Debug_Data::redact_debug_value( $settings['propertyID'], 7 ),
 			),
-			'analytics_profile_id'     => array(
+			'analytics_profile_id'  => array(
 				'label' => __( 'Analytics view ID', 'google-site-kit' ),
 				'value' => $settings['profileID'],
 				'debug' => Debug_Data::redact_debug_value( $settings['profileID'] ),
 			),
-			'analytics_use_snippet'    => array(
+			'analytics_use_snippet' => array(
 				'label' => __( 'Analytics snippet placed', 'google-site-kit' ),
 				'value' => $settings['useSnippet'] ? __( 'Yes', 'google-site-kit' ) : __( 'No', 'google-site-kit' ),
 				'debug' => $settings['useSnippet'] ? 'yes' : 'no',
 			),
 		);
 
-		if ( ! Feature_Flags::enabled( 'ga4Reporting' ) ) {
-			unset( $fields['analytics_dashboard_view'] );
+		if ( Feature_Flags::enabled( 'ga4Reporting' ) ) {
+			$fields = array_merge(
+				array(
+					'analytics_dashboard_view' => array(
+						'label' => __( 'Analytics dashboard view', 'google-site-kit' ),
+						'value' => 'google-analytics-4' === $settings['dashboardView'] ? __( 'Google Analytics 4 view', 'google-site-kit' ) : __( 'Universal Analytics view', 'google-site-kit' ),
+						'debug' => $settings['dashboardView'],
+					),
+				),
+				$fields
+			);
 		}
 
 		return $fields;

--- a/includes/Modules/Analytics.php
+++ b/includes/Modules/Analytics.php
@@ -252,28 +252,39 @@ final class Analytics extends Module
 	public function get_debug_fields() {
 		$settings = $this->get_settings()->get();
 
-		return array(
-			'analytics_account_id'  => array(
+		$fields = array(
+			'analytics_dashboard_view' => array(
+				'label' => __( 'Analytics dashboard view', 'google-site-kit' ),
+				'value' => 'google-analytics-4' === $settings['dashboardView'] ? __( 'Google Analytics 4 view', 'google-site-kit' ) : __( 'Universal Analytics view', 'google-site-kit' ),
+				'debug' => $settings['dashboardView'],
+			),
+			'analytics_account_id'     => array(
 				'label' => __( 'Analytics account ID', 'google-site-kit' ),
 				'value' => $settings['accountID'],
 				'debug' => Debug_Data::redact_debug_value( $settings['accountID'] ),
 			),
-			'analytics_property_id' => array(
+			'analytics_property_id'    => array(
 				'label' => __( 'Analytics property ID', 'google-site-kit' ),
 				'value' => $settings['propertyID'],
 				'debug' => Debug_Data::redact_debug_value( $settings['propertyID'], 7 ),
 			),
-			'analytics_profile_id'  => array(
+			'analytics_profile_id'     => array(
 				'label' => __( 'Analytics view ID', 'google-site-kit' ),
 				'value' => $settings['profileID'],
 				'debug' => Debug_Data::redact_debug_value( $settings['profileID'] ),
 			),
-			'analytics_use_snippet' => array(
+			'analytics_use_snippet'    => array(
 				'label' => __( 'Analytics snippet placed', 'google-site-kit' ),
 				'value' => $settings['useSnippet'] ? __( 'Yes', 'google-site-kit' ) : __( 'No', 'google-site-kit' ),
 				'debug' => $settings['useSnippet'] ? 'yes' : 'no',
 			),
 		);
+
+		if ( ! Feature_Flags::enabled( 'ga4Reporting' ) ) {
+			unset( $fields['analytics_dashboard_view'] );
+		}
+
+		return $fields;
 	}
 
 	/**

--- a/tests/phpunit/integration/Modules/AnalyticsTest.php
+++ b/tests/phpunit/integration/Modules/AnalyticsTest.php
@@ -828,6 +828,37 @@ class AnalyticsTest extends TestCase {
 		$this->assertEquals( $configuration['ua_profile_id'], $settings['profileID'] );
 	}
 
+	public function test_get_debug_fields() {
+		$analytics = new Analytics( new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE ) );
+
+		$this->assertEqualSets(
+			array(
+				'analytics_account_id',
+				'analytics_property_id',
+				'analytics_profile_id',
+				'analytics_use_snippet',
+			),
+			array_keys( $analytics->get_debug_fields() )
+		);
+	}
+
+	public function test_get_debug_fields__ga4Reporting() {
+		$this->enable_feature( 'ga4Reporting' );
+
+		$analytics = new Analytics( new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE ) );
+
+		$this->assertEqualSets(
+			array(
+				'analytics_dashboard_view',
+				'analytics_account_id',
+				'analytics_property_id',
+				'analytics_profile_id',
+				'analytics_use_snippet',
+			),
+			array_keys( $analytics->get_debug_fields() )
+		);
+	}
+
 	/**
 	 * @return Module_With_Data_Available_State
 	 */


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #7119 

## Relevant technical choices

This PR adds the Analytics dashboard view to Site Health information.

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
