### PR TITLE
Fix ModalDialog render error when provided subtitle is falsy.

### DIFF
--- a/assets/js/components/ModalDialog.js
+++ b/assets/js/components/ModalDialog.js
@@ -63,7 +63,10 @@ const ModalDialog = ( {
 			tabIndex="-1"
 		>
 			<DialogTitle>{ title }</DialogTitle>
-			{ subtitle && <p className="mdc-dialog__lead">{ subtitle }</p> }
+			{
+				// Ensure we don't render anything at all if subtitle is falsy, as Dialog expects all its children to be elements and a falsy value will result in an error.
+				subtitle ? <p className="mdc-dialog__lead">{ subtitle }</p> : []
+			}
 			<DialogContent>
 				{ hasProvides && (
 					<section


### PR DESCRIPTION
## Summary

This addresses the point that @eugene-manuilov raised [here](https://github.com/google/site-kit-wp/issues/6652#issuecomment-1599040436), ensuring the `ModalDialog` component renders correctly when the passed `subtitle` is falsy.

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #6652 

## Relevant technical choices

<!-- Please describe your changes. -->

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
