### PR TITLE
Remove ga4ActivationBanner feature flag.

### DIFF
--- a/assets/js/components/notifications/BannerNotifications.js
+++ b/assets/js/components/notifications/BannerNotifications.js
@@ -54,7 +54,6 @@ const { useSelect } = Data;
 export default function BannerNotifications() {
 	const dashboardSharingEnabled = useFeature( 'dashboardSharing' );
 	const userInputEnabled = useFeature( 'userInput' );
-	const ga4ActivationBannerEnabled = useFeature( 'ga4ActivationBanner' );
 	const gteSupportEnabled = useFeature( 'gteSupport' );
 	const ga4ReportingEnabled = useFeature( 'ga4Reporting' );
 	const adBlockerDetectionEnabled = useFeature( 'adBlockerDetection' );
@@ -113,7 +112,7 @@ export default function BannerNotifications() {
 			{ ga4ReportingEnabled &&
 				analyticsModuleConnected &&
 				ga4ModuleConnected && <SwitchedToGA4Banner /> }
-			{ ga4ActivationBannerEnabled && <ActivationBanner /> }
+			{ <ActivationBanner /> }
 			{ gteSupportEnabled &&
 				ga4ModuleConnected &&
 				hasGTMScope &&

--- a/assets/js/components/notifications/BannerNotifications.js
+++ b/assets/js/components/notifications/BannerNotifications.js
@@ -112,7 +112,7 @@ export default function BannerNotifications() {
 			{ ga4ReportingEnabled &&
 				analyticsModuleConnected &&
 				ga4ModuleConnected && <SwitchedToGA4Banner /> }
-			{ <ActivationBanner /> }
+			<ActivationBanner />
 			{ gteSupportEnabled &&
 				ga4ModuleConnected &&
 				hasGTMScope &&

--- a/assets/js/components/notifications/EntityBannerNotifications.js
+++ b/assets/js/components/notifications/EntityBannerNotifications.js
@@ -24,18 +24,16 @@ import { Fragment } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import { useFeature } from '../../hooks/useFeature';
 import { ActivationBanner } from '../../modules/analytics-4/components/dashboard';
 import ZeroDataNotifications from './ZeroDataStateNotifications';
 import useViewOnly from '../../hooks/useViewOnly';
 
 export default function EntityBannerNotifications() {
 	const viewOnly = useViewOnly();
-	const ga4ActivationBannerEnabled = useFeature( 'ga4ActivationBanner' );
 
 	return (
 		<Fragment>
-			{ ! viewOnly && ga4ActivationBannerEnabled && <ActivationBanner /> }
+			{ ! viewOnly && <ActivationBanner /> }
 			<ZeroDataNotifications />
 		</Fragment>
 	);

--- a/feature-flags.json
+++ b/feature-flags.json
@@ -2,7 +2,6 @@
 	"adBlockerDetection",
 	"adsenseSetupV2",
 	"dashboardSharing",
-	"ga4ActivationBanner",
 	"ga4Reporting",
 	"gm3Components",
 	"gteSupport",

--- a/tests/e2e/specs/user-input-questions.test.js
+++ b/tests/e2e/specs/user-input-questions.test.js
@@ -35,8 +35,8 @@ import {
 	step,
 	setSearchConsoleProperty,
 	setupAnalytics,
+	setupAnalytics4,
 } from '../utils';
-import { setupAnalytics4 } from '../utils/setup-analytics';
 
 describe( 'User Input Settings', () => {
 	async function fillInInputSettings() {

--- a/tests/e2e/specs/user-input-questions.test.js
+++ b/tests/e2e/specs/user-input-questions.test.js
@@ -36,6 +36,7 @@ import {
 	setSearchConsoleProperty,
 	setupAnalytics,
 } from '../utils';
+import { setupAnalytics4 } from '../utils/setup-analytics';
 
 describe( 'User Input Settings', () => {
 	async function fillInInputSettings() {
@@ -127,6 +128,7 @@ describe( 'User Input Settings', () => {
 		await setupSiteKit();
 		await page.setRequestInterception( false );
 		await setupAnalytics();
+		await setupAnalytics4();
 		await page.setRequestInterception( true );
 		await setSearchConsoleProperty();
 
@@ -156,6 +158,7 @@ describe( 'User Input Settings', () => {
 		await setupSiteKit();
 		await page.setRequestInterception( false );
 		await setupAnalytics();
+		await setupAnalytics4();
 		await page.setRequestInterception( true );
 		await setSearchConsoleProperty();
 

--- a/tests/e2e/utils/index.js
+++ b/tests/e2e/utils/index.js
@@ -36,7 +36,7 @@ export { setEditPostFeature } from './set-edit-post-feature';
 export { setSearchConsoleProperty } from './set-search-console-property';
 export { setSiteVerification } from './set-site-verification';
 export { setupAdSense } from './setup-adsense';
-export { setupAnalytics } from './setup-analytics';
+export { setupAnalytics, setupAnalytics4 } from './setup-analytics';
 export { setupSiteKit } from './setup-site-kit';
 export { switchDateRange } from './switch-date-range';
 export { testClientConfig } from './test-client-config';

--- a/tests/e2e/utils/setup-analytics.js
+++ b/tests/e2e/utils/setup-analytics.js
@@ -13,7 +13,7 @@ const defaultAnalyticsSettings = {
 
 const defaultAnalytics4Settings = {
 	propertyID: '500',
-	webDataStreamID: '500',
+	webDataStreamID: '600',
 	measurementID: 'G-700',
 	useSnippet: true,
 };

--- a/tests/e2e/utils/setup-analytics.js
+++ b/tests/e2e/utils/setup-analytics.js
@@ -11,6 +11,18 @@ const defaultSettings = {
 	useSnippet: true,
 };
 
+const defaultAnalytics4Settings = {
+	// ownerID: 1,
+	propertyID: '500',
+	webDataStreamID: '500',
+	measurementID: 'G-700',
+	useSnippet: true,
+	// googleTagID: 'GT-800',
+	// googleTagAccountID: '900',
+	// googleTagContainerID: '1000',
+	// googleTagLastSyncedAtMs: 1687783271577,
+};
+
 /**
  * Activates the Analytics module and complete the setup process.
  *
@@ -37,6 +49,14 @@ export async function setupAnalytics( settingsOverrides = {} ) {
 		path: 'google-site-kit/v1/modules/analytics/data/settings',
 		data: {
 			data: settings,
+		},
+	} );
+
+	await wpApiFetch( {
+		method: 'post',
+		path: 'google-site-kit/v1/modules/analytics-4/data/settings',
+		data: {
+			data: defaultAnalytics4Settings,
 		},
 	} );
 }

--- a/tests/e2e/utils/setup-analytics.js
+++ b/tests/e2e/utils/setup-analytics.js
@@ -3,7 +3,7 @@
  */
 import { wpApiFetch } from './wp-api-fetch';
 
-const defaultSettings = {
+const defaultAnalyticsSettings = {
 	accountID: 100,
 	propertyID: 200,
 	profileID: 300,
@@ -12,19 +12,14 @@ const defaultSettings = {
 };
 
 const defaultAnalytics4Settings = {
-	// ownerID: 1,
 	propertyID: '500',
 	webDataStreamID: '500',
 	measurementID: 'G-700',
 	useSnippet: true,
-	// googleTagID: 'GT-800',
-	// googleTagAccountID: '900',
-	// googleTagContainerID: '1000',
-	// googleTagLastSyncedAtMs: 1687783271577,
 };
 
 /**
- * Activates the Analytics module and complete the setup process.
+ * Activates the Analytics module and completes the UA setup process.
  *
  * @since 1.0.0
  *
@@ -32,7 +27,7 @@ const defaultAnalytics4Settings = {
  */
 export async function setupAnalytics( settingsOverrides = {} ) {
 	const settings = {
-		...defaultSettings,
+		...defaultAnalyticsSettings,
 		...settingsOverrides,
 	};
 	// Activate the module.
@@ -51,12 +46,34 @@ export async function setupAnalytics( settingsOverrides = {} ) {
 			data: settings,
 		},
 	} );
+}
 
+/**
+ * Activates the Analytics module and completes the GA4 setup process.
+ *
+ * @since n.e.x.t
+ *
+ * @param {Object} settingsOverrides Optional settings to override the defaults.
+ */
+export async function setupAnalytics4( settingsOverrides = {} ) {
+	const settings = {
+		...defaultAnalytics4Settings,
+		...settingsOverrides,
+	};
+	// Activate the module.
+	await wpApiFetch( {
+		method: 'post',
+		path: 'google-site-kit/v1/core/modules/data/activation',
+		data: {
+			data: { slug: 'analytics', active: true },
+		},
+	} );
+	// Set placeholder connection data.
 	await wpApiFetch( {
 		method: 'post',
 		path: 'google-site-kit/v1/modules/analytics-4/data/settings',
 		data: {
-			data: defaultAnalytics4Settings,
+			data: settings,
 		},
 	} );
 }


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #7076 

## Relevant technical choices

- Added an E2E utility function, `setupAnalytics4()`, and called it to ensure the GA4 Activation Banner does not get in the way of the User Input tests.

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
