### PR TITLE
Remove `sanitize_callback` from `Ad_Blocking_Recovery_Tag` as it's an encrypted string.

### DIFF
--- a/includes/Modules/AdSense/Ad_Blocking_Recovery_Tag.php
+++ b/includes/Modules/AdSense/Ad_Blocking_Recovery_Tag.php
@@ -81,21 +81,4 @@ class Ad_Blocking_Recovery_Tag extends Setting {
 			'error_protection_code' => '',
 		);
 	}
-
-	/**
-	 * Gets the callback for sanitizing the ad blocking recovery tag before saving.
-	 *
-	 * @since 1.6.0
-	 *
-	 * @return callable|null
-	 */
-	protected function get_sanitize_callback() {
-		return function( $option ) {
-			if ( ! is_array( $option ) || ! isset( $option['tag'] ) || ! isset( $option['error_protection_code'] ) || ! is_string( $option['tag'] ) || ! is_string( $option['error_protection_code'] ) ) {
-				return $this->get_default();
-			}
-
-			return $option;
-		};
-	}
 }

--- a/tests/phpunit/integration/Modules/AdSense/Ad_Blocking_Recovery_TagTest.php
+++ b/tests/phpunit/integration/Modules/AdSense/Ad_Blocking_Recovery_TagTest.php
@@ -111,40 +111,6 @@ class Ad_Blocking_Recovery_TagTest extends SettingsTestCase {
 		$this->assertFalse( $this->ad_blocking_recovery_tag->set( $value ) );
 	}
 
-	/**
-	 * @dataProvider data_invalid_values
-	 *
-	 * @param mixed $value
-	 */
-	public function test_get_sanitize_callback_invlid_values( $value ) {
-		// Set the option to a good value.
-		update_option(
-			Ad_Blocking_Recovery_Tag::OPTION,
-			array(
-				'tag'                   => $this->test_recovery_tag,
-				'error_protection_code' => $this->test_error_protection_code,
-			)
-		);
-
-		// Get the option and check that it is set correctly.
-		$this->assertEqualSetsWithIndex(
-			array(
-				'tag'                   => $this->test_recovery_tag,
-				'error_protection_code' => $this->test_error_protection_code,
-			),
-			$this->ad_blocking_recovery_tag->get()
-		);
-
-		update_option( Ad_Blocking_Recovery_Tag::OPTION, $value );
-		$this->assertEqualSetsWithIndex(
-			array(
-				'tag'                   => '',
-				'error_protection_code' => '',
-			),
-			$this->ad_blocking_recovery_tag->get()
-		);
-	}
-
 	public function data_invalid_values() {
 		return array(
 			'non-array'      => array( 'test' ),


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #7156

## Relevant technical choices

This removes the `sanitize_callback` as it will be an encrypted string and can't realistically be verified. 

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [ ] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
