### PR TITLE
Enhance/#6953 - Use `getReferenceDate()` instead of `Date.now()` - Follow-up

### DIFF
--- a/assets/js/modules/adsense/components/dashboard/AdBlockingRecoveryWidget.js
+++ b/assets/js/modules/adsense/components/dashboard/AdBlockingRecoveryWidget.js
@@ -44,7 +44,7 @@ import {
 } from '../../../../components/AdminMenuTooltip';
 import { CORE_MODULES } from '../../../../googlesitekit/modules/datastore/constants';
 import { MODULES_ADSENSE } from '../../datastore/constants';
-import { WEEK_IN_SECONDS } from '../../../../util';
+import { WEEK_IN_SECONDS, stringToDate } from '../../../../util';
 import { ACCOUNT_STATUS_READY, SITE_STATUS_READY } from '../../util';
 import useViewOnly from '../../../../hooks/useViewOnly';
 import {
@@ -105,6 +105,9 @@ export default function AdBlockingRecoveryWidget( { Widget, WidgetNull } ) {
 	const recoveryPageURL = useSelect( ( select ) =>
 		select( CORE_SITE ).getAdminURL( 'googlesitekit-ad-blocking-recovery' )
 	);
+	const referenceDate = useSelect( ( select ) =>
+		select( CORE_USER ).getReferenceDate()
+	);
 
 	const { dismissItem } = useDispatch( CORE_USER );
 	const dismissCallback = async () => {
@@ -128,8 +131,18 @@ export default function AdBlockingRecoveryWidget( { Widget, WidgetNull } ) {
 		);
 	}
 
-	const threeWeeksInSeconds = WEEK_IN_SECONDS * 3;
-	const nowInSeconds = Math.floor( Date.now() / 1000 );
+	// const date = new Date();
+	// date.setDate( date.getDate() - 3 );
+
+	// global.console.log( {
+	// 	referenceDate: stringToDate( referenceDate ),
+	// 	setupCompletedTimestamp: new Date(
+	// 		setupCompletedTimestamp * 1000
+	// 	).getTime(),
+	// 	threeWeeksAgo:
+	// 		stringToDate( referenceDate ).getTime() -
+	// 		WEEK_IN_SECONDS * 3 * 1000,
+	// } );
 
 	const shouldShowWidget =
 		! viewOnlyDashboard &&
@@ -139,7 +152,9 @@ export default function AdBlockingRecoveryWidget( { Widget, WidgetNull } ) {
 		accountStatus === ACCOUNT_STATUS_READY &&
 		siteStatus === SITE_STATUS_READY &&
 		( ! setupCompletedTimestamp ||
-			nowInSeconds - setupCompletedTimestamp >= threeWeeksInSeconds );
+			new Date( setupCompletedTimestamp * 1000 ).getTime() >=
+				stringToDate( referenceDate ).getTime() -
+					WEEK_IN_SECONDS * 3 * 1000 );
 
 	if ( ! shouldShowWidget ) {
 		return <WidgetNull />;

--- a/assets/js/modules/adsense/components/dashboard/AdBlockingRecoveryWidget.js
+++ b/assets/js/modules/adsense/components/dashboard/AdBlockingRecoveryWidget.js
@@ -131,18 +131,9 @@ export default function AdBlockingRecoveryWidget( { Widget, WidgetNull } ) {
 		);
 	}
 
-	// const date = new Date();
-	// date.setDate( date.getDate() - 3 );
-
-	// global.console.log( {
-	// 	referenceDate: stringToDate( referenceDate ),
-	// 	setupCompletedTimestamp: new Date(
-	// 		setupCompletedTimestamp * 1000
-	// 	).getTime(),
-	// 	threeWeeksAgo:
-	// 		stringToDate( referenceDate ).getTime() -
-	// 		WEEK_IN_SECONDS * 3 * 1000,
-	// } );
+	const nowInMilliseconds = stringToDate( referenceDate ).getTime();
+	const completionTimeInMilliseconds = setupCompletedTimestamp * 1000;
+	const threeWeeksInMilliseconds = WEEK_IN_SECONDS * 3 * 1000;
 
 	const shouldShowWidget =
 		! viewOnlyDashboard &&
@@ -152,9 +143,8 @@ export default function AdBlockingRecoveryWidget( { Widget, WidgetNull } ) {
 		accountStatus === ACCOUNT_STATUS_READY &&
 		siteStatus === SITE_STATUS_READY &&
 		( ! setupCompletedTimestamp ||
-			new Date( setupCompletedTimestamp * 1000 ).getTime() >=
-				stringToDate( referenceDate ).getTime() -
-					WEEK_IN_SECONDS * 3 * 1000 );
+			nowInMilliseconds - completionTimeInMilliseconds >=
+				threeWeeksInMilliseconds );
 
 	if ( ! shouldShowWidget ) {
 		return <WidgetNull />;

--- a/assets/js/modules/adsense/components/dashboard/AdBlockingRecoveryWidget.test.js
+++ b/assets/js/modules/adsense/components/dashboard/AdBlockingRecoveryWidget.test.js
@@ -42,11 +42,15 @@ import {
 	SITE_STATUS_READY,
 } from '../../util';
 import { getWidgetComponentProps } from '../../../../googlesitekit/widgets/util';
+import { stringToDate } from '../../../../util';
 
 describe( 'AdSenseConnectCTA', () => {
 	let registry;
-	const timestampThreeWeeksAgo = '1685576083'; // Unix timestamp for 2023-06-01
-	const timestampLessThanThreeWeeksAgo = '1685662483'; // Unix timestamp for 2023-06-02
+	const referenceDate = '2023-06-22';
+	const timestampThreeWeeksPrior =
+		stringToDate( '2023-06-01' ).getTime() / 1000;
+	const timestampLessThanThreeWeeksPrior =
+		stringToDate( '2023-06-02' ).getTime() / 1000;
 	const validSettings = {
 		accountID: 'pub-12345678',
 		clientID: 'ca-pub-12345678',
@@ -71,7 +75,7 @@ describe( 'AdSenseConnectCTA', () => {
 				slug: 'adsense',
 			},
 		] );
-		registry.dispatch( CORE_USER ).setReferenceDate( '2023-06-15' );
+		registry.dispatch( CORE_USER ).setReferenceDate( referenceDate );
 		registry.dispatch( CORE_USER ).receiveGetDismissedItems( [] );
 	} );
 
@@ -88,7 +92,7 @@ describe( 'AdSenseConnectCTA', () => {
 				'',
 				false,
 				false,
-				timestampThreeWeeksAgo,
+				timestampThreeWeeksPrior,
 			],
 			[
 				'notification is dismissed',
@@ -97,7 +101,7 @@ describe( 'AdSenseConnectCTA', () => {
 				'',
 				true,
 				true,
-				timestampThreeWeeksAgo,
+				timestampThreeWeeksPrior,
 			],
 			[
 				'the Adsense account status is not ready',
@@ -106,7 +110,7 @@ describe( 'AdSenseConnectCTA', () => {
 				'',
 				true,
 				false,
-				timestampThreeWeeksAgo,
+				timestampThreeWeeksPrior,
 			],
 			[
 				'the Adsense site status is not ready',
@@ -115,7 +119,7 @@ describe( 'AdSenseConnectCTA', () => {
 				'',
 				true,
 				false,
-				timestampThreeWeeksAgo,
+				timestampThreeWeeksPrior,
 			],
 			[
 				'the Ad blocking recovery status is an empty string',
@@ -124,7 +128,7 @@ describe( 'AdSenseConnectCTA', () => {
 				'',
 				true,
 				false,
-				timestampThreeWeeksAgo,
+				timestampThreeWeeksPrior,
 			],
 			[
 				'the setup completed timestamp is less than three weeks',
@@ -133,7 +137,7 @@ describe( 'AdSenseConnectCTA', () => {
 				ENUM_AD_BLOCKING_RECOVERY_SETUP_STATUS.SETUP_CONFIRMED,
 				true,
 				false,
-				timestampLessThanThreeWeeksAgo,
+				timestampLessThanThreeWeeksPrior,
 			],
 		] )(
 			'should not render the widget when %s',
@@ -203,10 +207,9 @@ describe( 'AdSenseConnectCTA', () => {
 		} );
 
 		it( 'should render the widget for the site with a setup completion time of more than three weeks', () => {
-			registry.dispatch( CORE_USER ).setReferenceDate( '2023-06-25' );
 			registry.dispatch( MODULES_ADSENSE ).receiveGetSettings( {
 				...validSettings,
-				setupCompletedTimestamp: timestampThreeWeeksAgo,
+				setupCompletedTimestamp: timestampThreeWeeksPrior,
 			} );
 
 			const { container } = render(

--- a/assets/js/modules/adsense/components/dashboard/AdBlockingRecoveryWidget.test.js
+++ b/assets/js/modules/adsense/components/dashboard/AdBlockingRecoveryWidget.test.js
@@ -42,14 +42,11 @@ import {
 	SITE_STATUS_READY,
 } from '../../util';
 import { getWidgetComponentProps } from '../../../../googlesitekit/widgets/util';
-import { WEEK_IN_SECONDS, DAY_IN_SECONDS } from '../../../../util';
 
 describe( 'AdSenseConnectCTA', () => {
 	let registry;
-	const timestampThreeWeeksAgo =
-		Math.floor( Date.now() / 1000 ) - WEEK_IN_SECONDS * 3;
-	const timestampLessThanThreeWeeksAgo =
-		timestampThreeWeeksAgo + DAY_IN_SECONDS;
+	const timestampThreeWeeksAgo = '1685576083'; // Unix timestamp for 2023-06-01
+	const timestampLessThanThreeWeeksAgo = '1685662483'; // Unix timestamp for 2023-06-02
 	const validSettings = {
 		accountID: 'pub-12345678',
 		clientID: 'ca-pub-12345678',
@@ -74,6 +71,7 @@ describe( 'AdSenseConnectCTA', () => {
 				slug: 'adsense',
 			},
 		] );
+		registry.dispatch( CORE_USER ).setReferenceDate( '2023-06-15' );
 		registry.dispatch( CORE_USER ).receiveGetDismissedItems( [] );
 	} );
 
@@ -205,6 +203,7 @@ describe( 'AdSenseConnectCTA', () => {
 		} );
 
 		it( 'should render the widget for the site with a setup completion time of more than three weeks', () => {
+			registry.dispatch( CORE_USER ).setReferenceDate( '2023-06-25' );
 			registry.dispatch( MODULES_ADSENSE ).receiveGetSettings( {
 				...validSettings,
 				setupCompletedTimestamp: timestampThreeWeeksAgo,


### PR DESCRIPTION
## Summary

Addresses issue:

- #6953 

## Relevant technical choices

* This PR addresses the comment by using `getReferenceDate()` instead of `Date.now()`.
* Uses `setReferenceDate()` instead of `Date.now()` in the unit tests.

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
