### PR TITLE
Follow-up: Wait until survey trigger is complete

### DIFF
--- a/assets/js/googlesitekit/datastore/user/user-input-settings.js
+++ b/assets/js/googlesitekit/datastore/user/user-input-settings.js
@@ -182,7 +182,7 @@ const baseActions = {
 		) }`;
 
 		const { response, error } = yield Data.commonActions.await(
-			yield dispatch( CORE_USER ).triggerSurvey( triggerID )
+			dispatch( CORE_USER ).triggerSurvey( triggerID )
 		);
 
 		return { response, error };

--- a/assets/js/googlesitekit/datastore/user/user-input-settings.js
+++ b/assets/js/googlesitekit/datastore/user/user-input-settings.js
@@ -129,7 +129,7 @@ const baseActions = {
 		}
 
 		if ( ! error ) {
-			yield registry.dispatch( CORE_USER ).maybeTriggerUserInputSurvey();
+			yield baseActions.maybeTriggerUserInputSurvey();
 		}
 
 		yield {
@@ -162,8 +162,12 @@ const baseActions = {
 	 * @return {Object} Object with `response` and `error`.
 	 */
 	*maybeTriggerUserInputSurvey() {
-		const registry = yield Data.commonActions.getRegistry();
-		const settings = registry.select( CORE_USER ).getUserInputSettings();
+		const { __experimentalResolveSelect, dispatch } =
+			yield Data.commonActions.getRegistry();
+
+		const settings = yield Data.commonActions.await(
+			__experimentalResolveSelect( CORE_USER ).getUserInputSettings()
+		);
 
 		const settingsAnsweredOther = Object.keys( settings ).filter( ( key ) =>
 			settings[ key ].values.includes( 'other' )
@@ -177,9 +181,9 @@ const baseActions = {
 			'_'
 		) }`;
 
-		const { response, error } = yield registry
-			.dispatch( CORE_USER )
-			.triggerSurvey( triggerID );
+		const { response, error } = yield Data.commonActions.await(
+			yield dispatch( CORE_USER ).triggerSurvey( triggerID )
+		);
 
 		return { response, error };
 	},

--- a/assets/js/googlesitekit/datastore/user/user-input-settings.js
+++ b/assets/js/googlesitekit/datastore/user/user-input-settings.js
@@ -163,9 +163,9 @@ const baseActions = {
 	 */
 	*maybeTriggerUserInputSurvey() {
 		const { __experimentalResolveSelect, dispatch } =
-			yield Data.commonActions.getRegistry();
+			yield commonActions.getRegistry();
 
-		const settings = yield Data.commonActions.await(
+		const settings = yield commonActions.await(
 			__experimentalResolveSelect( CORE_USER ).getUserInputSettings()
 		);
 
@@ -181,7 +181,7 @@ const baseActions = {
 			'_'
 		) }`;
 
-		const { response, error } = yield Data.commonActions.await(
+		const { response, error } = yield commonActions.await(
 			dispatch( CORE_USER ).triggerSurvey( triggerID )
 		);
 

--- a/assets/js/googlesitekit/datastore/user/user-input-settings.test.js
+++ b/assets/js/googlesitekit/datastore/user/user-input-settings.test.js
@@ -213,18 +213,6 @@ describe( 'core/user user-input-settings', () => {
 					registry.select( CORE_USER ).getUserInputSettings()
 				).toEqual( settingsResponse );
 
-				await subscribeUntil( registry, () =>
-					registry
-						.select( CORE_USER )
-						.hasFinishedResolution( 'getSurveyTimeouts' )
-				);
-
-				await subscribeUntil( registry, () =>
-					registry
-						.select( CORE_USER )
-						.hasFinishedResolution( 'getUserInputSettings' )
-				);
-
 				expect( fetchMock ).toHaveFetched( surveyTriggerEndpoint, {
 					body: {
 						data: {

--- a/assets/js/googlesitekit/datastore/user/user-input-settings.test.js
+++ b/assets/js/googlesitekit/datastore/user/user-input-settings.test.js
@@ -293,7 +293,7 @@ describe( 'core/user user-input-settings', () => {
 				expect( fetchMock ).not.toHaveFetched( surveyTriggerEndpoint );
 			} );
 
-			it( 'should trigger survey if answers conatin "Other"', async () => {
+			it( 'should trigger survey if answers contain "Other"', async () => {
 				muteFetch( surveyTriggerEndpoint );
 
 				registry.dispatch( CORE_USER ).receiveGetSurveyTimeouts( [] );
@@ -302,19 +302,9 @@ describe( 'core/user user-input-settings', () => {
 					.dispatch( CORE_USER )
 					.setUserInputSetting( 'goals', [ 'other' ] );
 
-				registry.dispatch( CORE_USER ).maybeTriggerUserInputSurvey();
-
-				await subscribeUntil( registry, () =>
-					registry
-						.select( CORE_USER )
-						.hasFinishedResolution( 'getSurveyTimeouts' )
-				);
-
-				await subscribeUntil( registry, () =>
-					registry
-						.select( CORE_USER )
-						.hasFinishedResolution( 'getUserInputSettings' )
-				);
+				await registry
+					.dispatch( CORE_USER )
+					.maybeTriggerUserInputSurvey();
 
 				expect( fetchMock ).toHaveFetched( surveyTriggerEndpoint, {
 					body: {


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- https://github.com/google/site-kit-wp/issues/6180#issuecomment-1610805180

## Relevant technical choices

This follow-up PR aims to resolve [this issue](https://github.com/google/site-kit-wp/issues/6180#issuecomment-1610805180) reported by the QA team, where User Input completion navigates the user to the Site Kit dashboard, but doesn't wait for the survey trigger to complete. Thus, the survey trigger request is often cancelled.

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
