### PR TITLE
Fix the incorrect AdSense setting name in the AdSense settings view stories.

### DIFF
--- a/stories/module-adsense-settings.stories.js
+++ b/stories/module-adsense-settings.stories.js
@@ -154,7 +154,7 @@ storiesOf( 'AdSense Module/Settings', module )
 			registry.dispatch( MODULES_ADSENSE ).receiveGetSettings( {
 				...completeSettings,
 				adBlockingRecoverySetupStatus: 'tag-placed',
-				adBlockingRecoverySnippet: true,
+				useAdBlockingRecoverySnippet: true,
 			} );
 
 			return (
@@ -175,7 +175,7 @@ storiesOf( 'AdSense Module/Settings', module )
 			registry.dispatch( MODULES_ADSENSE ).receiveGetSettings( {
 				...completeSettings,
 				adBlockingRecoverySetupStatus: 'setup-confirmed',
-				adBlockingRecoverySnippet: false,
+				useAdBlockingRecoverySnippet: false,
 			} );
 
 			return (


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #7213

## Relevant technical choices

<!-- Please describe your changes. -->

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [ ] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
