### PR TITLE
Fix reported and discovered issues with Ad Blocking Recovery existing tag

### DIFF
--- a/assets/js/modules/adsense/components/common/AdBlockingRecoveryCTA.js
+++ b/assets/js/modules/adsense/components/common/AdBlockingRecoveryCTA.js
@@ -53,6 +53,7 @@ export default function AdBlockingRecoveryCTA() {
 	);
 
 	if (
+		hasExistingAdBlockingRecoveryTag === undefined ||
 		hasExistingAdBlockingRecoveryTag ||
 		adBlockingRecoverySetupStatus !== '' ||
 		accountStatus !== ACCOUNT_STATUS_READY ||

--- a/assets/js/modules/adsense/components/common/AdBlockingRecoveryToggle.js
+++ b/assets/js/modules/adsense/components/common/AdBlockingRecoveryToggle.js
@@ -184,14 +184,15 @@ export default function AdBlockingRecoveryToggle() {
 					</div>
 				) }
 			</div>
-			{ adBlockingRecoveryToggle === false && (
-				<SettingsNotice
-					notice={ __(
-						'The ad blocking recovery message won’t be displayed to visitors unless the tag is placed',
-						'google-site-kit'
-					) }
-				/>
-			) }
+			{ ! existingAdBlockingRecoveryTag &&
+				adBlockingRecoveryToggle === false && (
+					<SettingsNotice
+						notice={ __(
+							'The ad blocking recovery message won’t be displayed to visitors unless the tag is placed',
+							'google-site-kit'
+						) }
+					/>
+				) }
 			{ existingAdBlockingRecoveryTag && (
 				<SettingsNotice
 					notice={ existingAdBlockingRecoveryTagMessage }

--- a/assets/js/modules/adsense/components/common/AdBlockingRecoveryToggle.js
+++ b/assets/js/modules/adsense/components/common/AdBlockingRecoveryToggle.js
@@ -164,11 +164,6 @@ export default function AdBlockingRecoveryToggle() {
 						) }
 					</p>
 				</div>
-				{ existingAdBlockingRecoveryTag && (
-					<SettingsNotice
-						notice={ existingAdBlockingRecoveryTagMessage }
-					/>
-				) }
 				{ ( adBlockingRecoveryToggle || adBlockingRecoverySnippet ) && (
 					<div className="googlesitekit-settings-module__meta-item">
 						<Switch
@@ -195,6 +190,11 @@ export default function AdBlockingRecoveryToggle() {
 						'The ad blocking recovery message won’t be displayed to visitors unless the tag is placed',
 						'google-site-kit'
 					) }
+				/>
+			) }
+			{ existingAdBlockingRecoveryTag && (
+				<SettingsNotice
+					notice={ existingAdBlockingRecoveryTagMessage }
 				/>
 			) }
 		</fieldset>

--- a/assets/js/modules/adsense/components/common/AdBlockingRecoveryToggle.js
+++ b/assets/js/modules/adsense/components/common/AdBlockingRecoveryToggle.js
@@ -25,7 +25,7 @@ import { useMount } from 'react-use';
  * WordPress dependencies
  */
 import { createInterpolateElement } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -39,6 +39,7 @@ import {
 import Link from '../../../../components/Link';
 import SettingsNotice from '../../../../components/SettingsNotice/SettingsNotice';
 import { CORE_FORMS } from '../../../../googlesitekit/datastore/forms/constants';
+import { parseAccountIDFromExistingTag } from '../../util';
 const { useSelect, useDispatch } = Data;
 
 export default function AdBlockingRecoveryToggle() {
@@ -51,12 +52,15 @@ export default function AdBlockingRecoveryToggle() {
 	const adBlockingRecoverySetupStatus = useSelect( ( select ) =>
 		select( MODULES_ADSENSE ).getAdBlockingRecoverySetupStatus()
 	);
-	const adsenseAccountID = useSelect( ( select ) =>
+	const existingAdBlockingRecoveryTag = useSelect( ( select ) =>
+		select( MODULES_ADSENSE ).getExistingAdBlockingRecoveryTag()
+	);
+	const accountID = useSelect( ( select ) =>
 		select( MODULES_ADSENSE ).getAccountID()
 	);
 	const privacyMessagingURL = useSelect( ( select ) =>
 		select( MODULES_ADSENSE ).getServiceURL( {
-			path: `/${ adsenseAccountID }/privacymessaging/ad_blocking`,
+			path: `/${ accountID }/privacymessaging/ad_blocking`,
 		} )
 	);
 	const adBlockingRecoveryToggle = useSelect( ( select ) =>
@@ -103,6 +107,26 @@ export default function AdBlockingRecoveryToggle() {
 		setValues( AD_BLOCKING_FORM_SETTINGS, initialToggleValues );
 	} );
 
+	let existingAdBlockingRecoveryTagMessage;
+	if (
+		existingAdBlockingRecoveryTag &&
+		existingAdBlockingRecoveryTag === accountID
+	) {
+		existingAdBlockingRecoveryTagMessage = __(
+			'You’ve already got an Ad Blocking Recovery code on your site. We recommend you use Site Kit to manage this to get the most out of AdSense.',
+			'google-site-kit'
+		);
+	} else if ( existingAdBlockingRecoveryTag ) {
+		existingAdBlockingRecoveryTagMessage = sprintf(
+			/* translators: %s: account ID */
+			__(
+				'Site Kit detected Ad Blocking Recovery code for a different account %s on your site. For a better ad blocking recovery experience, you should remove Ad Blocking Recovery code that’s not linked to this AdSense account.',
+				'google-site-kit'
+			),
+			parseAccountIDFromExistingTag( existingAdBlockingRecoveryTag )
+		);
+	}
+
 	if ( ! adBlockingRecoverySetupStatus ) {
 		return null;
 	}
@@ -140,6 +164,11 @@ export default function AdBlockingRecoveryToggle() {
 						) }
 					</p>
 				</div>
+				{ existingAdBlockingRecoveryTag && (
+					<SettingsNotice
+						notice={ existingAdBlockingRecoveryTagMessage }
+					/>
+				) }
 				{ ( adBlockingRecoveryToggle || adBlockingRecoverySnippet ) && (
 					<div className="googlesitekit-settings-module__meta-item">
 						<Switch

--- a/assets/js/modules/adsense/components/common/AdBlockingRecoveryToggle.stories.js
+++ b/assets/js/modules/adsense/components/common/AdBlockingRecoveryToggle.stories.js
@@ -19,7 +19,10 @@
 /**
  * Internal dependencies
  */
-import { provideModules } from '../../../../../../tests/js/utils';
+import {
+	provideModules,
+	provideSiteInfo,
+} from '../../../../../../tests/js/utils';
 import WithRegistrySetup from '../../../../../../tests/js/WithRegistrySetup';
 import {
 	ENUM_AD_BLOCKING_RECOVERY_SETUP_STATUS,
@@ -75,6 +78,40 @@ WithBothTogglesEnabled.args = {
 	},
 };
 
+export const WithExistingAdBlockingRecoveryTag = Template.bind( {} );
+WithExistingAdBlockingRecoveryTag.storyName =
+	'With Existing Ad Blocking Recovery Tag from same account';
+WithExistingAdBlockingRecoveryTag.args = {
+	setupRegistry: ( registry ) => {
+		registry.dispatch( MODULES_ADSENSE ).receiveGetSettings( {
+			...validSettings,
+			useAdBlockingRecoverySnippet: true,
+			useAdBlockingRecoveryErrorSnippet: false,
+		} );
+		registry
+			.dispatch( MODULES_ADSENSE )
+			.receiveGetExistingAdBlockingRecoveryTag( validSettings.accountID );
+	},
+};
+
+export const WithExistingAdBlockingRecoveryTagDifferentAccount = Template.bind(
+	{}
+);
+WithExistingAdBlockingRecoveryTagDifferentAccount.storyName =
+	'With Existing Ad Blocking Recovery Tag from different account';
+WithExistingAdBlockingRecoveryTagDifferentAccount.args = {
+	setupRegistry: ( registry ) => {
+		registry.dispatch( MODULES_ADSENSE ).receiveGetSettings( {
+			...validSettings,
+			useAdBlockingRecoverySnippet: true,
+			useAdBlockingRecoveryErrorSnippet: false,
+		} );
+		registry
+			.dispatch( MODULES_ADSENSE )
+			.receiveGetExistingAdBlockingRecoveryTag( 'pub-87654321' );
+	},
+};
+
 export default {
 	title: 'Modules/AdSense/Components/AdBlockingRecoveryToggle',
 	decorators: [
@@ -87,6 +124,7 @@ export default {
 						slug: 'adsense',
 					},
 				] );
+				provideSiteInfo( registry );
 
 				args?.setupRegistry( registry );
 			};

--- a/assets/js/modules/adsense/components/common/AdBlockingRecoveryToggle.test.js
+++ b/assets/js/modules/adsense/components/common/AdBlockingRecoveryToggle.test.js
@@ -24,6 +24,7 @@ import {
 	render,
 	provideModules,
 	fireEvent,
+	provideSiteInfo,
 } from '../../../../../../tests/js/test-utils';
 import {
 	ENUM_AD_BLOCKING_RECOVERY_SETUP_STATUS,
@@ -51,6 +52,7 @@ describe( 'AdBlockingRecoveryToggle', () => {
 						connected: true,
 					},
 				] );
+				provideSiteInfo( registry );
 				registry
 					.dispatch( MODULES_ADSENSE )
 					.receiveGetSettings( validSettings );
@@ -78,6 +80,7 @@ describe( 'AdBlockingRecoveryToggle', () => {
 							connected: true,
 						},
 					] );
+					provideSiteInfo( registry );
 					registry.dispatch( MODULES_ADSENSE ).receiveGetSettings( {
 						...validSettings,
 						adBlockingRecoverySetupStatus:
@@ -129,6 +132,7 @@ describe( 'AdBlockingRecoveryToggle', () => {
 							connected: true,
 						},
 					] );
+					provideSiteInfo( registry );
 					registry.dispatch( MODULES_ADSENSE ).receiveGetSettings( {
 						...validSettings,
 						adBlockingRecoverySetupStatus:
@@ -156,6 +160,74 @@ describe( 'AdBlockingRecoveryToggle', () => {
 		).not.toBeInTheDocument();
 	} );
 
+	it( 'should render the same account existing tag notice there is an existing ad blocking recovery tag for the same account', () => {
+		const { container } = render( <AdBlockingRecoveryToggle />, {
+			setupRegistry: ( registry ) => {
+				provideModules( registry, [
+					{
+						slug: 'adsense',
+						active: true,
+						connected: true,
+					},
+				] );
+				provideSiteInfo( registry );
+				registry.dispatch( MODULES_ADSENSE ).receiveGetSettings( {
+					...validSettings,
+					adBlockingRecoverySetupStatus:
+						ENUM_AD_BLOCKING_RECOVERY_SETUP_STATUS.TAG_PLACED,
+					useAdBlockingRecoverySnippet: true,
+					useAdBlockingRecoveryErrorSnippet: false,
+				} );
+				registry
+					.dispatch( MODULES_ADSENSE )
+					.receiveGetExistingAdBlockingRecoveryTag(
+						validSettings.accountID
+					);
+			},
+		} );
+
+		// Verify that the notice is rendered.
+		expect(
+			container.querySelector( '.googlesitekit-settings-notice__text' )
+		).toHaveTextContent(
+			'You’ve already got an Ad Blocking Recovery code on your site. We recommend you use Site Kit to manage this to get the most out of AdSense.'
+		);
+	} );
+
+	it( 'should render the different account existing tag notice there is an existing ad blocking recovery tag for a different account', () => {
+		const { container } = render( <AdBlockingRecoveryToggle />, {
+			setupRegistry: ( registry ) => {
+				provideModules( registry, [
+					{
+						slug: 'adsense',
+						active: true,
+						connected: true,
+					},
+				] );
+				provideSiteInfo( registry );
+				registry.dispatch( MODULES_ADSENSE ).receiveGetSettings( {
+					...validSettings,
+					adBlockingRecoverySetupStatus:
+						ENUM_AD_BLOCKING_RECOVERY_SETUP_STATUS.TAG_PLACED,
+					useAdBlockingRecoverySnippet: true,
+					useAdBlockingRecoveryErrorSnippet: false,
+				} );
+				registry
+					.dispatch( MODULES_ADSENSE )
+					.receiveGetExistingAdBlockingRecoveryTag(
+						'pub-1234567890123456'
+					);
+			},
+		} );
+
+		// Verify that the notice is rendered.
+		expect(
+			container.querySelector( '.googlesitekit-settings-notice__text' )
+		).toHaveTextContent(
+			'Site Kit detected Ad Blocking Recovery code for a different account pub-1234567890123456 on your site. For a better ad blocking recovery experience, you should remove Ad Blocking Recovery code that’s not linked to this AdSense account.'
+		);
+	} );
+
 	it( 'should render the notice when the user unchecks the ad blocking recovery tag toggle', () => {
 		const { getByLabelText, getAllByRole, container } = render(
 			<AdBlockingRecoveryToggle />,
@@ -168,6 +240,7 @@ describe( 'AdBlockingRecoveryToggle', () => {
 							connected: true,
 						},
 					] );
+					provideSiteInfo( registry );
 					registry.dispatch( MODULES_ADSENSE ).receiveGetSettings( {
 						...validSettings,
 						adBlockingRecoverySetupStatus:
@@ -207,6 +280,65 @@ describe( 'AdBlockingRecoveryToggle', () => {
 		expect(
 			container.querySelector( '.googlesitekit-settings-notice__text' )
 		).toHaveTextContent(
+			'The ad blocking recovery message won’t be displayed to visitors unless the tag is placed'
+		);
+	} );
+
+	it( 'should not render the notice when the user unchecks the ad blocking recovery tag toggle but there is an existing ad blocking recovery tag', () => {
+		const { getByLabelText, getAllByRole, container } = render(
+			<AdBlockingRecoveryToggle />,
+			{
+				setupRegistry: ( registry ) => {
+					provideModules( registry, [
+						{
+							slug: 'adsense',
+							active: true,
+							connected: true,
+						},
+					] );
+					provideSiteInfo( registry );
+					registry.dispatch( MODULES_ADSENSE ).receiveGetSettings( {
+						...validSettings,
+						adBlockingRecoverySetupStatus:
+							ENUM_AD_BLOCKING_RECOVERY_SETUP_STATUS.TAG_PLACED,
+						useAdBlockingRecoverySnippet: true,
+						useAdBlockingRecoveryErrorSnippet: false,
+					} );
+					registry
+						.dispatch( MODULES_ADSENSE )
+						.receiveGetExistingAdBlockingRecoveryTag(
+							'pub-87654321'
+						);
+				},
+			}
+		);
+
+		expect(
+			getByLabelText( /Place ad blocking recovery tag/i )
+		).toBeInTheDocument();
+
+		const recoveryTagSwitchElements = getAllByRole( 'switch', {
+			name: /place ad blocking recovery tag/i,
+		} );
+		// Verify that the switch is checked initially.
+		recoveryTagSwitchElements.forEach( ( switchEl ) => {
+			expect( switchEl ).toBeChecked();
+		} );
+		// Verify that the notice is not rendered.
+		expect( container ).not.toHaveTextContent(
+			'The ad blocking recovery message won’t be displayed to visitors unless the tag is placed'
+		);
+
+		// Uncheck the switch.
+		fireEvent.click( container.querySelector( '.mdc-switch' ) );
+
+		// Verify that the switch is unchecked.
+		recoveryTagSwitchElements.forEach( ( switchEl ) => {
+			expect( switchEl ).not.toBeChecked();
+		} );
+
+		// Verify that the notice is rendered.
+		expect( container ).not.toHaveTextContent(
 			'The ad blocking recovery message won’t be displayed to visitors unless the tag is placed'
 		);
 	} );

--- a/assets/js/modules/adsense/components/settings/SettingsForm.js
+++ b/assets/js/modules/adsense/components/settings/SettingsForm.js
@@ -57,6 +57,13 @@ export default function SettingsForm() {
 	const hasResolvedGetExistingTag = useSelect( ( select ) =>
 		select( MODULES_ADSENSE ).hasFinishedResolution( 'getExistingTag' )
 	);
+
+	// This is called here to ensure that the progress bar is displayed while
+	// the Ad Blocking Recovery existing tag is being resolved to prevent a
+	// layout shift.
+	useSelect( ( select ) =>
+		select( MODULES_ADSENSE ).getExistingAdBlockingRecoveryTag()
+	);
 	const hasResolvedGetExistingAdBlockingRecoveryTag = useSelect( ( select ) =>
 		select( MODULES_ADSENSE ).hasFinishedResolution(
 			'getExistingAdBlockingRecoveryTag'

--- a/assets/js/modules/adsense/components/settings/SettingsForm.js
+++ b/assets/js/modules/adsense/components/settings/SettingsForm.js
@@ -28,10 +28,7 @@ import { Fragment } from '@wordpress/element';
 import Data from 'googlesitekit-data';
 import { ProgressBar } from 'googlesitekit-components';
 import { MODULES_ADSENSE } from '../../datastore/constants';
-import {
-	parseAccountID,
-	parseAccountIDFromExistingTag,
-} from '../../util/parsing';
+import { parseAccountID } from '../../util/parsing';
 import {
 	ErrorNotices,
 	UseSnippetSwitch,
@@ -42,7 +39,6 @@ import WebStoriesAdUnitSelect from '../common/WebStoriesAdUnitSelect';
 import Link from '../../../../components/Link';
 import { CORE_SITE } from '../../../../googlesitekit/datastore/site/constants';
 import AdBlockingRecoveryCTA from '../common/AdBlockingRecoveryCTA';
-import SettingsNotice from '../../../../components/SettingsNotice/SettingsNotice';
 import { useFeature } from '../../../../hooks/useFeature';
 const { useSelect } = Data;
 
@@ -52,9 +48,6 @@ export default function SettingsForm() {
 	const webStoriesActive = useSelect( ( select ) =>
 		select( CORE_SITE ).isWebStoriesActive()
 	);
-	const accountID = useSelect( ( select ) =>
-		select( MODULES_ADSENSE ).getAccountID()
-	);
 	const clientID = useSelect( ( select ) =>
 		select( MODULES_ADSENSE ).getClientID()
 	);
@@ -63,9 +56,6 @@ export default function SettingsForm() {
 	);
 	const hasResolvedGetExistingTag = useSelect( ( select ) =>
 		select( MODULES_ADSENSE ).hasFinishedResolution( 'getExistingTag' )
-	);
-	const existingAdBlockingRecoveryTag = useSelect( ( select ) =>
-		select( MODULES_ADSENSE ).getExistingAdBlockingRecoveryTag()
 	);
 	const hasResolvedGetExistingAdBlockingRecoveryTag = useSelect( ( select ) =>
 		select( MODULES_ADSENSE ).hasFinishedResolution(
@@ -110,26 +100,6 @@ export default function SettingsForm() {
 		);
 	}
 
-	let existingAdBlockingRecoveryTagMessage;
-	if (
-		existingAdBlockingRecoveryTag &&
-		existingAdBlockingRecoveryTag === accountID
-	) {
-		existingAdBlockingRecoveryTagMessage = __(
-			'You’ve already got an Ad Blocking Recovery code on your site. We recommend you use Site Kit to manage this to get the most out of AdSense.',
-			'google-site-kit'
-		);
-	} else if ( existingAdBlockingRecoveryTag ) {
-		existingAdBlockingRecoveryTagMessage = sprintf(
-			/* translators: %s: account ID */
-			__(
-				'Site Kit detected Ad Blocking Recovery code for a different account %s on your site. For a better ad blocking recovery experience, you should remove Ad Blocking Recovery code that’s not linked to this AdSense account.',
-				'google-site-kit'
-			),
-			parseAccountIDFromExistingTag( existingAdBlockingRecoveryTag )
-		);
-	}
-
 	const supportURL =
 		'https://support.google.com/adsense/answer/10175505#create-an-ad-unit-for-web-stories';
 
@@ -165,12 +135,6 @@ export default function SettingsForm() {
 			) }
 
 			<AutoAdExclusionSwitches />
-
-			{ existingAdBlockingRecoveryTag && (
-				<SettingsNotice
-					notice={ existingAdBlockingRecoveryTagMessage }
-				/>
-			) }
 
 			{ adBlockerDetectionEnabled && (
 				<Fragment>

--- a/assets/js/modules/adsense/datastore/ad-blocking-recovery.js
+++ b/assets/js/modules/adsense/datastore/ad-blocking-recovery.js
@@ -148,11 +148,9 @@ const resolvers = {
 			const fetchedAdBlockingRecoveryTag =
 				yield actions.fetchGetExistingAdBlockingRecoveryTag();
 
-			yield registry
-				.dispatch( MODULES_ADSENSE )
-				.receiveGetExistingAdBlockingRecoveryTag(
-					fetchedAdBlockingRecoveryTag
-				);
+			yield actions.receiveGetExistingAdBlockingRecoveryTag(
+				fetchedAdBlockingRecoveryTag
+			);
 		}
 	},
 };

--- a/assets/js/modules/adsense/util/ad-blocking-recovery-tag-matcher.js
+++ b/assets/js/modules/adsense/util/ad-blocking-recovery-tag-matcher.js
@@ -17,10 +17,6 @@
  */
 
 export default [
-	// Detect google_ad_client.
-	/google_ad_client: ?["|'](.*?)["|']/,
-	// Detect auto-ads tags.
-	/<(?:script|amp-auto-ads) [^>]*data-ad-client="([^"]+)"/,
 	// Detect the src URL in script tag and capture the accountID.
 	/<script async src="https:\/\/fundingchoicesmessages\.google\.com\/i\/(.*?)\?ers=/,
 ];


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #6967 

## Relevant technical choices

1. Fix the tag matcher regex for ABR tag.
2. Place the Settings Notice on right place.
3. Do not show the general unchecked notice when the existing ABR tag notice is being displayed.
4. Don't prematurely render the Ad Blocking Recovery CTA when existing tag is not loaded yet. 

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
