### PR TITLE
Do not dismiss tour if there was a missing step

### DIFF
--- a/assets/js/components/TourTooltips.js
+++ b/assets/js/components/TourTooltips.js
@@ -27,6 +27,7 @@ import PropTypes from 'prop-types';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -100,6 +101,9 @@ export default function TourTooltips( {
 
 	const viewContext = useViewContext();
 
+	const [ hasMissingTargetError, setHasMissingTargetError ] =
+		useState( false );
+
 	const stepIndex = useSelect( ( select ) =>
 		select( CORE_UI ).getValue( stepKey )
 	);
@@ -126,8 +130,11 @@ export default function TourTooltips( {
 			'googlesitekit-showing-feature-tour',
 			`googlesitekit-showing-feature-tour--${ tourID }`
 		);
+
 		// Dismiss tour to avoid unwanted repeat viewing.
-		dismissTour( tourID );
+		if ( ! hasMissingTargetError ) {
+			dismissTour( tourID );
+		}
 	};
 
 	const trackAllTourEvents = ( {
@@ -209,6 +216,10 @@ export default function TourTooltips( {
 		const shouldCloseFromButtonClick =
 			hasCloseAction && type === EVENTS.STEP_AFTER;
 		const shouldEndTour = isFinishedOrSkipped || shouldCloseFromButtonClick;
+
+		if ( EVENTS.TARGET_NOT_FOUND === type ) {
+			setHasMissingTargetError( true );
+		}
 
 		// Center the target in the viewport when transitioning to the step.
 		if ( EVENTS.STEP_BEFORE === type ) {


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #7036 

## Relevant technical choices

This PR prevents dismissing a feature tour if there was a missing step.

### Difference from IB

Unfortunately, the proposed solution in the IB no longer works. At the time of writing the IB, the feature tour would only get dismissed if the last step was missing. If a step in between was missing, it would skip to the next available step.

However, during execution, if a feature tour step is missing, it moves back to the previous step, crashes, and dismisses the tour.

This PR makes Site Kit not dismiss a tour at all if any of the step's target is missing.

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
