### PR TITLE
Move Tab and TabBar to `googlesitekit-components`

### DIFF
--- a/assets/js/components/DeviceSizeTabBar.js
+++ b/assets/js/components/DeviceSizeTabBar.js
@@ -19,8 +19,6 @@
 /**
  * External dependencies
  */
-import Tab from '@material/react-tab';
-import TabBar from '@material/react-tab-bar';
 import PropTypes from 'prop-types';
 
 /**
@@ -32,6 +30,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
+import { Tab, TabBar } from 'googlesitekit-components';
 import DeviceSizeMobileIcon from '../../svg/icons/device-size-mobile-icon.svg';
 import DeviceSizeDesktopIcon from '../../svg/icons/device-size-desktop-icon.svg';
 

--- a/assets/js/components/settings/SettingsApp.js
+++ b/assets/js/components/settings/SettingsApp.js
@@ -19,8 +19,6 @@
 /**
  * External dependencies
  */
-import Tab from '@material/react-tab';
-import TabBar from '@material/react-tab-bar';
 import { withRouter, Link, useLocation } from 'react-router-dom';
 
 /**
@@ -32,6 +30,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
+import { Tab, TabBar } from 'googlesitekit-components';
 import Header from '../Header';
 import PageHeader from '../PageHeader';
 import Layout from '../layout/Layout';

--- a/assets/js/googlesitekit-components-gm2.js
+++ b/assets/js/googlesitekit-components-gm2.js
@@ -41,6 +41,8 @@ export const {
 	Radio,
 	SpinnerButton,
 	Switch,
+	Tab,
+	TabBar,
 	TextField,
 	Tooltip,
 } = Components;

--- a/assets/js/googlesitekit/components-gm2/index.js
+++ b/assets/js/googlesitekit/components-gm2/index.js
@@ -16,11 +16,16 @@
  * limitations under the License.
  */
 
+/**
+ * External dependencies
+ */
 import Dialog, {
 	DialogTitle,
 	DialogContent,
 	DialogFooter,
 } from '@material/react-dialog';
+import Tab from '@material/react-tab';
+import TabBar from '@material/react-tab-bar';
 
 /**
  * Internal dependencies
@@ -51,6 +56,8 @@ const Components = {
 	Radio,
 	SpinnerButton,
 	Switch,
+	Tab,
+	TabBar,
 	TextField,
 	Tooltip,
 };

--- a/assets/js/googlesitekit/components-gm3/Tab.js
+++ b/assets/js/googlesitekit/components-gm3/Tab.js
@@ -1,7 +1,7 @@
 /**
- * Public components entrypoint.
+ * Tab component.
  *
- * Site Kit by Google, Copyright 2022 Google LLC
+ * Site Kit by Google, Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,33 +16,6 @@
  * limitations under the License.
  */
 
-/**
- * Internal dependencies
- */
-import Components from './googlesitekit/components-gm3';
-
-if ( typeof global.googlesitekit === 'undefined' ) {
-	global.googlesitekit = {};
+export default function Tab() {
+	return null;
 }
-
-global.googlesitekit.components = Components;
-
-export const {
-	Button,
-	Checkbox,
-	Chip,
-	CircularProgress,
-	Dialog,
-	DialogTitle,
-	DialogContent,
-	DialogFooter,
-	Menu,
-	ProgressBar,
-	Radio,
-	SpinnerButton,
-	Switch,
-	Tab,
-	TabBar,
-	TextField,
-	Tooltip,
-} = Components;

--- a/assets/js/googlesitekit/components-gm3/TabBar.js
+++ b/assets/js/googlesitekit/components-gm3/TabBar.js
@@ -1,7 +1,7 @@
 /**
- * Public components entrypoint.
+ * TabBar component.
  *
- * Site Kit by Google, Copyright 2022 Google LLC
+ * Site Kit by Google, Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,33 +16,6 @@
  * limitations under the License.
  */
 
-/**
- * Internal dependencies
- */
-import Components from './googlesitekit/components-gm3';
-
-if ( typeof global.googlesitekit === 'undefined' ) {
-	global.googlesitekit = {};
+export default function TabBar() {
+	return null;
 }
-
-global.googlesitekit.components = Components;
-
-export const {
-	Button,
-	Checkbox,
-	Chip,
-	CircularProgress,
-	Dialog,
-	DialogTitle,
-	DialogContent,
-	DialogFooter,
-	Menu,
-	ProgressBar,
-	Radio,
-	SpinnerButton,
-	Switch,
-	Tab,
-	TabBar,
-	TextField,
-	Tooltip,
-} = Components;

--- a/assets/js/googlesitekit/components-gm3/index.js
+++ b/assets/js/googlesitekit/components-gm3/index.js
@@ -32,6 +32,8 @@ import ProgressBar from './ProgressBar';
 import Radio from './Radio';
 import SpinnerButton from './SpinnerButton';
 import Switch from './Switch';
+import Tab from './Tab';
+import TabBar from './TabBar';
 import TextField from './TextField';
 import Tooltip from './Tooltip';
 
@@ -49,6 +51,8 @@ const Components = {
 	Radio,
 	SpinnerButton,
 	Switch,
+	Tab,
+	TabBar,
 	TextField,
 	Tooltip,
 };

--- a/assets/js/modules/analytics/components/dashboard/DashboardAllTrafficWidget/DimensionTabs.js
+++ b/assets/js/modules/analytics/components/dashboard/DashboardAllTrafficWidget/DimensionTabs.js
@@ -20,8 +20,6 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
-import Tab from '@material/react-tab';
-import TabBar from '@material/react-tab-bar';
 
 /**
  * WordPress dependencies
@@ -32,6 +30,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
+import { Tab, TabBar } from 'googlesitekit-components';
 import Data from 'googlesitekit-data';
 import { CORE_UI } from '../../../../../googlesitekit/datastore/ui/constants';
 import {

--- a/assets/js/modules/analytics/components/dashboard/DashboardAllTrafficWidgetGA4/DimensionTabs.js
+++ b/assets/js/modules/analytics/components/dashboard/DashboardAllTrafficWidgetGA4/DimensionTabs.js
@@ -20,8 +20,6 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
-import Tab from '@material/react-tab';
-import TabBar from '@material/react-tab-bar';
 
 /**
  * WordPress dependencies
@@ -32,6 +30,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
+import { Tab, TabBar } from 'googlesitekit-components';
 import Data from 'googlesitekit-data';
 import { CORE_UI } from '../../../../../googlesitekit/datastore/ui/constants';
 import {

--- a/assets/js/modules/pagespeed-insights/components/dashboard/DashboardPageSpeed.js
+++ b/assets/js/modules/pagespeed-insights/components/dashboard/DashboardPageSpeed.js
@@ -20,8 +20,6 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import Tab from '@material/react-tab';
-import TabBar from '@material/react-tab-bar';
 import { useIntersection } from 'react-use';
 
 /**
@@ -33,9 +31,9 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
+import { Button, ProgressBar, Tab, TabBar } from 'googlesitekit-components';
 import API from 'googlesitekit-api';
 import Data from 'googlesitekit-data';
-import { Button, ProgressBar } from 'googlesitekit-components';
 import DeviceSizeTabBar from '../../../../components/DeviceSizeTabBar';
 import Link from '../../../../components/Link';
 import LabReportMetrics from '../common/LabReportMetrics';

--- a/assets/js/modules/pagespeed-insights/components/dashboard/DashboardPageSpeed.js
+++ b/assets/js/modules/pagespeed-insights/components/dashboard/DashboardPageSpeed.js
@@ -31,8 +31,8 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { Button, ProgressBar, Tab, TabBar } from 'googlesitekit-components';
 import API from 'googlesitekit-api';
+import { Button, ProgressBar, Tab, TabBar } from 'googlesitekit-components';
 import Data from 'googlesitekit-data';
 import DeviceSizeTabBar from '../../../../components/DeviceSizeTabBar';
 import Link from '../../../../components/Link';

--- a/stories/settings.stories.js
+++ b/stories/settings.stories.js
@@ -20,8 +20,6 @@
  * External dependencies
  */
 import { storiesOf } from '@storybook/react';
-import Tab from '@material/react-tab';
-import TabBar from '@material/react-tab-bar';
 
 /**
  * WordPress dependencies
@@ -31,6 +29,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
+import { Tab, TabBar } from 'googlesitekit-components';
 import SettingsModules from '../assets/js/components/settings/SettingsModules';
 import Layout from '../assets/js/components/layout/Layout';
 import SettingsAdmin from '../assets/js/components/settings/SettingsAdmin';


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #6654 

## Relevant technical choices

<!-- Please describe your changes. -->

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [x] Run the code.
- [x] Ensure the acceptance criteria are satisfied.
- [x] Reassess the implementation with the IB.
- [x] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [x] Check Storybook where applicable.
- [x] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
