### PR TITLE
Fix Ad Blocking Recovery Widget showing up for a moment when existing tag is present

### DIFF
--- a/assets/js/modules/adsense/components/dashboard/AdBlockingRecoveryWidget.js
+++ b/assets/js/modules/adsense/components/dashboard/AdBlockingRecoveryWidget.js
@@ -142,7 +142,7 @@ export default function AdBlockingRecoveryWidget( { Widget, WidgetNull } ) {
 	const shouldShowWidget =
 		! viewOnlyDashboard &&
 		adSenseModuleConnected &&
-		! hasExistingAdBlockingRecoveryTag &&
+		hasExistingAdBlockingRecoveryTag === false &&
 		isDismissed === false &&
 		adBlockingRecoverySetupStatus === '' &&
 		accountStatus === ACCOUNT_STATUS_READY &&

--- a/assets/js/modules/adsense/components/dashboard/AdBlockingRecoveryWidget.stories.js
+++ b/assets/js/modules/adsense/components/dashboard/AdBlockingRecoveryWidget.stories.js
@@ -55,6 +55,10 @@ Ready.args = {
 		registry
 			.dispatch( MODULES_ADSENSE )
 			.receiveGetSettings( validSettings );
+
+		registry
+			.dispatch( MODULES_ADSENSE )
+			.receiveGetExistingAdBlockingRecoveryTag( null );
 	},
 };
 Ready.scenario = {

--- a/assets/js/modules/adsense/components/dashboard/AdBlockingRecoveryWidget.test.js
+++ b/assets/js/modules/adsense/components/dashboard/AdBlockingRecoveryWidget.test.js
@@ -220,6 +220,10 @@ describe( 'AdBlockingRecoveryWidget', () => {
 				.dispatch( MODULES_ADSENSE )
 				.receiveGetSettings( validSettings );
 
+			registry
+				.dispatch( MODULES_ADSENSE )
+				.receiveGetExistingAdBlockingRecoveryTag( null );
+
 			const { container } = render(
 				<AdBlockingRecoveryWidget
 					Widget={ Widget }
@@ -239,6 +243,10 @@ describe( 'AdBlockingRecoveryWidget', () => {
 				...validSettings,
 				setupCompletedTimestamp: timestampThreeWeeksPrior,
 			} );
+
+			registry
+				.dispatch( MODULES_ADSENSE )
+				.receiveGetExistingAdBlockingRecoveryTag( null );
 
 			const { container } = render(
 				<AdBlockingRecoveryWidget


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #6967 

## Relevant technical choices

<!-- Please describe your changes. -->

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
