### PR TITLE
Fix UA side-effect on WP dashboard

### DIFF
--- a/assets/js/components/wp-dashboard/WPDashboardWidgets.js
+++ b/assets/js/components/wp-dashboard/WPDashboardWidgets.js
@@ -119,12 +119,13 @@ export default function WPDashboardWidgets() {
 				}
 			) }
 		>
-			{ analyticsModuleActiveAndConnected && ! isGA4DashboardView && (
-				<Fragment>
-					<WPDashboardUniqueVisitorsWidget />
-					<WPDashboardSessionDurationWidget />
-				</Fragment>
-			) }
+			{ analyticsModuleActiveAndConnected &&
+				isGA4DashboardView === false && (
+					<Fragment>
+						<WPDashboardUniqueVisitorsWidget />
+						<WPDashboardSessionDurationWidget />
+					</Fragment>
+				) }
 
 			{ isGA4DashboardView && (
 				<Fragment>
@@ -142,12 +143,13 @@ export default function WPDashboardWidgets() {
 				</div>
 			) }
 
-			{ analyticsModuleActiveAndConnected && ! isGA4DashboardView && (
-				<Fragment>
-					<WPDashboardUniqueVisitorsChartWidget />
-					<WPDashboardPopularPagesWidget />
-				</Fragment>
-			) }
+			{ analyticsModuleActiveAndConnected &&
+				isGA4DashboardView === false && (
+					<Fragment>
+						<WPDashboardUniqueVisitorsChartWidget />
+						<WPDashboardPopularPagesWidget />
+					</Fragment>
+				) }
 
 			{ isGA4DashboardView && (
 				<Fragment>

--- a/assets/js/modules/search-console/components/common/AnalyticsStats.js
+++ b/assets/js/modules/search-console/components/common/AnalyticsStats.js
@@ -146,7 +146,7 @@ export default function AnalyticsStats( props ) {
 		];
 	}
 
-	if ( ! isGA4DashboardView ) {
+	if ( isGA4DashboardView === false ) {
 		dateMarkers = [
 			{
 				date: UA_CUTOFF_DATE,


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #7306

## Relevant technical choices

* `! isGA4DashboardView` is problematic because it will be `undefined` until the settings have been received – in this case it causes the not-GA4-path to be invoked by one or more renders before the setting is resolved and the condition becomes `false` (in the event of the dashboard view being GA4). Invoking the UA path causes `useSelect` hooks and their respective resolvers to fire, which triggers the related requests.

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [ ] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
