### PR TITLE
Remove Ad Blocking Recovery tag setting on deactivating AdSense.

### DIFF
--- a/includes/Modules/AdSense.php
+++ b/includes/Modules/AdSense.php
@@ -182,9 +182,14 @@ final class AdSense extends Module
 	 * Cleans up when the module is deactivated.
 	 *
 	 * @since 1.0.0
+	 * @since n.e.x.t Remove Ad Blocking Recovery Tag setting on deactivation.
 	 */
 	public function on_deactivation() {
 		$this->get_settings()->delete();
+
+		if ( $this->ad_blocking_recovery_tag->has() ) {
+			$this->ad_blocking_recovery_tag->delete();
+		}
 	}
 
 	/**

--- a/tests/phpunit/integration/Modules/AdSenseTest.php
+++ b/tests/phpunit/integration/Modules/AdSenseTest.php
@@ -400,12 +400,15 @@ class AdSenseTest extends TestCase {
 		$adsense = new AdSense( new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE ) );
 		$options = new Options( new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE ) );
 
-		$options->set( Settings::OPTION, 'test-value' );
+		$options->set( Settings::OPTION, 'test-value-settings' );
+		$options->set( Ad_Blocking_Recovery_Tag::OPTION, 'test-value-ad-blocking-recovery-tag' );
 		$this->assertOptionExists( Settings::OPTION );
+		$this->assertOptionExists( Ad_Blocking_Recovery_Tag::OPTION );
 
 		$adsense->on_deactivation();
 
 		$this->assertOptionNotExists( Settings::OPTION );
+		$this->assertOptionNotExists( Ad_Blocking_Recovery_Tag::OPTION );
 	}
 
 	public function test_get_datapoints() {


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #7286 

## Relevant technical choices

<!-- Please describe your changes. -->

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
