### PR TITLE
Refactor / 6651 Replace Direct Usage of <TextField> Component Within Account Chooser Story

### DIFF
--- a/stories/accountchooser.stories.js
+++ b/stories/accountchooser.stories.js
@@ -17,11 +17,6 @@
  */
 
 /**
- * External dependencies
- */
-import TextField, { Input } from '@material/react-text-field';
-
-/**
  * WordPress dependencies
  */
 import { useState } from '@wordpress/element';
@@ -30,7 +25,7 @@ import { useState } from '@wordpress/element';
  * Internal dependencies
  */
 import Data from 'googlesitekit-data';
-import { Button } from 'googlesitekit-components';
+import { Button, TextField } from 'googlesitekit-components';
 import { CORE_USER } from '../assets/js/googlesitekit/datastore/user/constants';
 import { provideUserInfo } from '../tests/js/utils';
 const { useSelect, useRegistry } = Data;
@@ -60,17 +55,15 @@ export const AccountChooser = () => {
 				label="Google Account Email"
 				onChange={ onEmailChange }
 				outlined
-			>
-				<Input value={ email } />
-			</TextField>
+				value={ email }
+			/>
 
 			<TextField
 				label="Destination URL"
 				onChange={ ( { target } ) => setDestURL( target.value ) }
 				outlined
-			>
-				<Input value={ destURL } />
-			</TextField>
+				value={ destURL }
+			/>
 
 			<pre>{ accountChooserURL }</pre>
 			<Button href={ accountChooserURL } target="_blank">


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #6651

## Relevant technical choices

- Updated `stories/accountchooser.stories.js` to utilize new `<TexField>` component from `googlesitekit-components`.
    - The above was effected as a result of [this comment in the linked issue](https://github.com/google/site-kit-wp/issues/6651#issuecomment-1654607070).

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
