### PR TITLE
Use the `whenActive` HOC to determine Key Metric widget rendering.

### DIFF
--- a/assets/js/components/KeyMetrics/ConnectModuleCTATile.js
+++ b/assets/js/components/KeyMetrics/ConnectModuleCTATile.js
@@ -36,11 +36,14 @@ import Link from '../Link';
 
 const { useSelect } = Data;
 
-export default function ConnectModuleCTATile( { Icon, moduleSlug, Widget } ) {
+export default function ConnectModuleCTATile( { moduleSlug } ) {
 	const handleConnectModule = useActivateModuleCallback( moduleSlug );
 
 	const module = useSelect( ( select ) =>
 		select( CORE_MODULES ).getModule( moduleSlug )
+	);
+	const Icon = useSelect( ( select ) =>
+		select( CORE_MODULES ).getModuleIcon( moduleSlug )
 	);
 
 	if ( ! module ) {
@@ -48,14 +51,14 @@ export default function ConnectModuleCTATile( { Icon, moduleSlug, Widget } ) {
 	}
 
 	return (
-		<Widget
-			className="googlesitekit-widget--connectModuleCTATile"
-			noPadding
-		>
+		<div className="googlesitekit-widget--connectModuleCTATile">
 			<div className="googlesitekit-km-connect-module-cta-tile">
-				<div className="googlesitekit-km-connect-module-cta-tile__icon">
-					<Icon width="32" height="32" />
-				</div>
+				{ Icon && (
+					<div className="googlesitekit-km-connect-module-cta-tile__icon">
+						<Icon width="32" height="32" />
+					</div>
+				) }
+
 				<div className="googlesitekit-km-connect-module-cta-tile__content">
 					<p className="googlesitekit-km-connect-module-cta-tile__text">
 						{ sprintf(
@@ -76,12 +79,10 @@ export default function ConnectModuleCTATile( { Icon, moduleSlug, Widget } ) {
 					</Link>
 				</div>
 			</div>
-		</Widget>
+		</div>
 	);
 }
 
 ConnectModuleCTATile.propTypes = {
-	Icon: propTypes.elementType.isRequired,
 	moduleSlug: propTypes.string.isRequired,
-	Widget: propTypes.elementType.isRequired,
 };

--- a/assets/js/googlesitekit/widgets/util/get-widget-component-props.js
+++ b/assets/js/googlesitekit/widgets/util/get-widget-component-props.js
@@ -42,6 +42,7 @@ export const getWidgetComponentProps = memize( ( widgetSlug ) => {
 	// Scope widget-specific components to the widget instance so that the
 	// component does not need to (re-)specify the widget slug.
 	return {
+		widgetSlug,
 		Widget: withWidgetSlug( widgetSlug )( Widget ),
 		WidgetRecoverableModules: withWidgetSlug( widgetSlug )(
 			WidgetRecoverableModules

--- a/assets/js/googlesitekit/widgets/util/get-widget-component-props.js
+++ b/assets/js/googlesitekit/widgets/util/get-widget-component-props.js
@@ -34,6 +34,7 @@ import WidgetRecoverableModules from '../components/WidgetRecoverableModules';
  * Gets the props to pass to a widget's component.
  *
  * @since 1.25.0
+ * @since n.e.x.t Added `widgetSlug` to the returned props.
  *
  * @param {string} widgetSlug The widget's slug.
  * @return {Object} Props to pass to the widget component.

--- a/assets/js/modules/analytics-4/components/widgets/ConnectGA4CTATileWidget.js
+++ b/assets/js/modules/analytics-4/components/widgets/ConnectGA4CTATileWidget.js
@@ -22,57 +22,24 @@
 import PropTypes from 'prop-types';
 
 /**
+ * WordPress dependencies
+ */
+import { useRef } from '@wordpress/element';
+
+/**
  * Internal dependencies
  */
-import Data from 'googlesitekit-data';
-import AnalyticsIcon from '../../../../../svg/graphics/analytics.svg';
 import ConnectModuleCTATile from '../../../../components/KeyMetrics/ConnectModuleCTATile';
-import { CORE_MODULES } from '../../../../googlesitekit/modules/datastore/constants';
-import {
-	CORE_USER,
-	keyMetricsGA4Widgets,
-} from '../../../../googlesitekit/datastore/user/constants';
+import useWidgetStateEffect from '../../../../googlesitekit/widgets/hooks/useWidgetStateEffect';
+export default function ConnectGA4CTATileWidget( props ) {
+	const { widgetSlug } = props;
+	// Note: `analytics` is used as the slug here since GA4 "depends" on it.
+	const { current: metadata } = useRef( { moduleSlug: 'analytics' } );
+	useWidgetStateEffect( widgetSlug, ConnectModuleCTATile, metadata );
 
-const { useSelect } = Data;
-
-export default function ConnectGA4CTATileWidget( { Widget, WidgetNull } ) {
-	const isGA4ModuleConnected = useSelect( ( select ) =>
-		select( CORE_MODULES ).isModuleConnected( 'analytics-4' )
-	);
-
-	const keyMetrics = useSelect( ( select ) => {
-		if ( isGA4ModuleConnected !== false ) {
-			return;
-		}
-		return select( CORE_USER ).getKeyMetrics();
-	} );
-
-	let hideWidget = true;
-
-	if ( keyMetrics?.length > 0 ) {
-		const kmAnalyticsWidgetCount = keyMetrics.filter( ( keyMetric ) =>
-			keyMetricsGA4Widgets.includes( keyMetric )
-		).length;
-
-		if ( kmAnalyticsWidgetCount > 0 && kmAnalyticsWidgetCount < 3 ) {
-			hideWidget = false;
-		}
-	}
-
-	if ( isGA4ModuleConnected !== false || hideWidget ) {
-		return <WidgetNull />;
-	}
-
-	return (
-		<ConnectModuleCTATile
-			Icon={ AnalyticsIcon }
-			moduleSlug="analytics"
-			Widget={ Widget }
-		/>
-	);
+	return <ConnectModuleCTATile moduleSlug="analytics4" />;
 }
 
 ConnectGA4CTATileWidget.propTypes = {
-	Widget: PropTypes.elementType.isRequired,
-	WidgetNull: PropTypes.elementType.isRequired,
+	widgetSlug: PropTypes.string.isRequired,
 };

--- a/assets/js/modules/analytics-4/components/widgets/ConnectGA4CTATileWidget.js
+++ b/assets/js/modules/analytics-4/components/widgets/ConnectGA4CTATileWidget.js
@@ -24,17 +24,18 @@ import PropTypes from 'prop-types';
 /**
  * WordPress dependencies
  */
-import { useRef } from '@wordpress/element';
+import { useMemo } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import ConnectModuleCTATile from '../../../../components/KeyMetrics/ConnectModuleCTATile';
 import useWidgetStateEffect from '../../../../googlesitekit/widgets/hooks/useWidgetStateEffect';
-export default function ConnectGA4CTATileWidget( props ) {
-	const { widgetSlug } = props;
+
+export default function ConnectGA4CTATileWidget( { widgetSlug } ) {
 	// Note: `analytics` is used as the slug here since GA4 "depends" on it.
-	const { current: metadata } = useRef( { moduleSlug: 'analytics' } );
+	const metadata = useMemo( () => ( { moduleSlug: 'analytics' } ), [] );
+
 	useWidgetStateEffect( widgetSlug, ConnectModuleCTATile, metadata );
 
 	return <ConnectModuleCTATile moduleSlug="analytics4" />;

--- a/assets/js/modules/analytics-4/components/widgets/EngagedTrafficSourceWidget.js
+++ b/assets/js/modules/analytics-4/components/widgets/EngagedTrafficSourceWidget.js
@@ -38,9 +38,11 @@ import {
 } from '../../datastore/constants';
 import { MetricTileText } from '../../../../components/KeyMetrics';
 import { numFmt } from '../../../../util';
+import ConnectGA4CTATileWidget from './ConnectGA4CTATileWidget';
+import whenActive from '../../../../util/when-active';
 const { useSelect, useInViewSelect } = Data;
 
-export default function EngagedTrafficSourceWidget( props ) {
+function EngagedTrafficSourceWidget( props ) {
 	const { Widget } = props;
 
 	const dates = useSelect( ( select ) =>
@@ -118,3 +120,8 @@ EngagedTrafficSourceWidget.propTypes = {
 	Widget: PropTypes.elementType.isRequired,
 	WidgetNull: PropTypes.elementType.isRequired,
 };
+
+export default whenActive( {
+	moduleName: 'analytics-4',
+	FallbackComponent: ConnectGA4CTATileWidget,
+} )( EngagedTrafficSourceWidget );

--- a/assets/js/modules/analytics-4/components/widgets/LoyalVisitorsWidget.js
+++ b/assets/js/modules/analytics-4/components/widgets/LoyalVisitorsWidget.js
@@ -38,10 +38,12 @@ import {
 } from '../../datastore/constants';
 import { MetricTileNumeric } from '../../../../components/KeyMetrics';
 import { numFmt } from '../../../../util';
+import whenActive from '../../../../util/when-active';
+import ConnectGA4CTATileWidget from './ConnectGA4CTATileWidget';
 
 const { useSelect, useInViewSelect } = Data;
 
-export default function LoyalVisitorsWidget( { Widget } ) {
+function LoyalVisitorsWidget( { Widget } ) {
 	const dates = useSelect( ( select ) =>
 		select( CORE_USER ).getDateRangeDates( {
 			offsetDays: DATE_RANGE_OFFSET,
@@ -121,3 +123,8 @@ export default function LoyalVisitorsWidget( { Widget } ) {
 LoyalVisitorsWidget.propTypes = {
 	Widget: PropTypes.elementType.isRequired,
 };
+
+export default whenActive( {
+	moduleName: 'analytics-4',
+	FallbackComponent: ConnectGA4CTATileWidget,
+} )( LoyalVisitorsWidget );

--- a/assets/js/modules/analytics-4/components/widgets/NewVisitorsWidget.js
+++ b/assets/js/modules/analytics-4/components/widgets/NewVisitorsWidget.js
@@ -38,10 +38,12 @@ import {
 } from '../../datastore/constants';
 import { MetricTileNumeric } from '../../../../components/KeyMetrics';
 import { numFmt } from '../../../../util/i18n';
+import whenActive from '../../../../util/when-active';
+import ConnectGA4CTATileWidget from './ConnectGA4CTATileWidget';
 
 const { useSelect, useInViewSelect } = Data;
 
-export default function NewVisitorsWidget( { Widget } ) {
+function NewVisitorsWidget( { Widget } ) {
 	const dates = useSelect( ( select ) =>
 		select( CORE_USER ).getDateRangeDates( {
 			offsetDays: DATE_RANGE_OFFSET,
@@ -107,3 +109,8 @@ export default function NewVisitorsWidget( { Widget } ) {
 NewVisitorsWidget.propTypes = {
 	Widget: PropTypes.elementType.isRequired,
 };
+
+export default whenActive( {
+	moduleName: 'analytics-4',
+	FallbackComponent: ConnectGA4CTATileWidget,
+} )( NewVisitorsWidget );

--- a/assets/js/modules/analytics-4/components/widgets/PopularContentWidget.js
+++ b/assets/js/modules/analytics-4/components/widgets/PopularContentWidget.js
@@ -40,9 +40,11 @@ import { MetricTileTable } from '../../../../components/KeyMetrics';
 import Link from '../../../../components/Link';
 import { ZeroDataMessage } from '../../../analytics/components/common';
 import { getFullURL, numFmt } from '../../../../util';
+import whenActive from '../../../../util/when-active';
+import ConnectGA4CTATileWidget from './ConnectGA4CTATileWidget';
 const { useSelect, useInViewSelect } = Data;
 
-export default function PopularContentWidget( props ) {
+function PopularContentWidget( props ) {
 	const { Widget } = props;
 
 	const siteURL = useSelect( ( select ) =>
@@ -128,3 +130,8 @@ PopularContentWidget.propTypes = {
 	Widget: PropTypes.elementType.isRequired,
 	WidgetNull: PropTypes.elementType.isRequired,
 };
+
+export default whenActive( {
+	moduleName: 'analytics-4',
+	FallbackComponent: ConnectGA4CTATileWidget,
+} )( PopularContentWidget );

--- a/assets/js/modules/analytics-4/components/widgets/PopularProductsWidget.js
+++ b/assets/js/modules/analytics-4/components/widgets/PopularProductsWidget.js
@@ -21,7 +21,13 @@
  */
 import PropTypes from 'prop-types';
 
-export default function PopularProductsWidget( { Widget } ) {
+/**
+ * Internal dependencies
+ */
+import whenActive from '../../../../util/when-active';
+import ConnectGA4CTATileWidget from './ConnectGA4CTATileWidget';
+
+function PopularProductsWidget( { Widget } ) {
 	return (
 		<Widget>
 			<div>TODO: UI for PopularProductsWidget</div>
@@ -31,5 +37,9 @@ export default function PopularProductsWidget( { Widget } ) {
 
 PopularProductsWidget.propTypes = {
 	Widget: PropTypes.elementType.isRequired,
-	WidgetNull: PropTypes.elementType.isRequired,
 };
+
+export default whenActive( {
+	moduleName: 'analytics-4',
+	FallbackComponent: ConnectGA4CTATileWidget,
+} )( PopularProductsWidget );

--- a/assets/js/modules/analytics-4/components/widgets/TopCitiesWidget.js
+++ b/assets/js/modules/analytics-4/components/widgets/TopCitiesWidget.js
@@ -41,9 +41,11 @@ import {
 	MetricTileTable,
 	MetricTileTablePlainText,
 } from '../../../../components/KeyMetrics';
+import whenActive from '../../../../util/when-active';
+import ConnectGA4CTATileWidget from './ConnectGA4CTATileWidget';
 const { useSelect, useInViewSelect } = Data;
 
-export default function TopCitiesWidget( { Widget } ) {
+function TopCitiesWidget( { Widget } ) {
 	const dates = useSelect( ( select ) =>
 		select( CORE_USER ).getDateRangeDates( {
 			offsetDays: DATE_RANGE_OFFSET,
@@ -118,3 +120,8 @@ export default function TopCitiesWidget( { Widget } ) {
 TopCitiesWidget.propTypes = {
 	Widget: PropTypes.elementType.isRequired,
 };
+
+export default whenActive( {
+	moduleName: 'analytics-4',
+	FallbackComponent: ConnectGA4CTATileWidget,
+} )( TopCitiesWidget );

--- a/assets/js/modules/analytics-4/components/widgets/TopConvertingTrafficSourceWidget.js
+++ b/assets/js/modules/analytics-4/components/widgets/TopConvertingTrafficSourceWidget.js
@@ -38,10 +38,12 @@ import {
 import { useInViewSelect } from '../../../../hooks/useInViewSelect';
 import MetricTileText from '../../../../components/KeyMetrics/MetricTileText';
 import { numFmt } from '../../../../util';
+import whenActive from '../../../../util/when-active';
+import ConnectGA4CTATileWidget from './ConnectGA4CTATileWidget';
 
 const { useSelect } = Data;
 
-export default function TopConvertingTrafficSourceWidget( { Widget } ) {
+function TopConvertingTrafficSourceWidget( { Widget } ) {
 	const dates = useSelect( ( select ) =>
 		select( CORE_USER ).getDateRangeDates( {
 			offsetDays: DATE_RANGE_OFFSET,
@@ -125,5 +127,9 @@ export default function TopConvertingTrafficSourceWidget( { Widget } ) {
 
 TopConvertingTrafficSourceWidget.propTypes = {
 	Widget: PropTypes.elementType.isRequired,
-	WidgetNull: PropTypes.elementType.isRequired,
 };
+
+export default whenActive( {
+	moduleName: 'analytics-4',
+	FallbackComponent: ConnectGA4CTATileWidget,
+} )( TopConvertingTrafficSourceWidget );

--- a/assets/js/modules/analytics-4/components/widgets/TopCountriesWidget.js
+++ b/assets/js/modules/analytics-4/components/widgets/TopCountriesWidget.js
@@ -21,7 +21,13 @@
  */
 import PropTypes from 'prop-types';
 
-export default function TopCountriesWidget( { Widget } ) {
+/**
+ * Internal dependencies
+ */
+import whenActive from '../../../../util/when-active';
+import ConnectGA4CTATileWidget from './ConnectGA4CTATileWidget';
+
+function TopCountriesWidget( { Widget } ) {
 	return (
 		<Widget>
 			<div>TODO: UI for TopCountriesWidget</div>
@@ -31,5 +37,9 @@ export default function TopCountriesWidget( { Widget } ) {
 
 TopCountriesWidget.propTypes = {
 	Widget: PropTypes.elementType.isRequired,
-	WidgetNull: PropTypes.elementType.isRequired,
 };
+
+export default whenActive( {
+	moduleName: 'analytics-4',
+	FallbackComponent: ConnectGA4CTATileWidget,
+} )( TopCountriesWidget );

--- a/assets/js/modules/analytics-4/components/widgets/TopTrafficSourceWidget.js
+++ b/assets/js/modules/analytics-4/components/widgets/TopTrafficSourceWidget.js
@@ -38,10 +38,12 @@ import {
 } from '../../datastore/constants';
 import { numFmt } from '../../../../util';
 import { get } from 'lodash';
+import whenActive from '../../../../util/when-active';
+import ConnectGA4CTATileWidget from './ConnectGA4CTATileWidget';
 
 const { useSelect, useInViewSelect } = Data;
 
-export default function TopTrafficSourceWidget( { Widget } ) {
+function TopTrafficSourceWidget( { Widget } ) {
 	const dates = useSelect( ( select ) =>
 		select( CORE_USER ).getDateRangeDates( {
 			offsetDays: DATE_RANGE_OFFSET,
@@ -166,3 +168,8 @@ TopTrafficSourceWidget.propTypes = {
 	Widget: PropTypes.elementType.isRequired,
 	WidgetNull: PropTypes.elementType.isRequired,
 };
+
+export default whenActive( {
+	moduleName: 'analytics-4',
+	FallbackComponent: ConnectGA4CTATileWidget,
+} )( TopTrafficSourceWidget );

--- a/assets/js/modules/analytics-4/index.js
+++ b/assets/js/modules/analytics-4/index.js
@@ -20,7 +20,6 @@
  * Internal dependencies
  */
 import {
-	ConnectGA4CTATileWidget,
 	EngagedTrafficSourceWidget,
 	LoyalVisitorsWidget,
 	NewVisitorsWidget,
@@ -30,12 +29,10 @@ import {
 	TopCountriesWidget,
 	TopTrafficSourceWidget,
 	TopConvertingTrafficSourceWidget,
-	ConnectGA4CTAWidget,
 } from './components/widgets';
 import AnalyticsIcon from '../../../svg/graphics/analytics.svg';
 import { MODULES_ANALYTICS_4 } from './datastore/constants';
 import { AREA_MAIN_DASHBOARD_KEY_METRICS_PRIMARY } from '../../googlesitekit/widgets/default-areas';
-import { CORE_MODULES } from '../../googlesitekit/modules/datastore/constants';
 import {
 	CORE_USER,
 	KM_ANALYTICS_ENGAGED_TRAFFIC_SOURCE,
@@ -48,7 +45,6 @@ import {
 	KM_ANALYTICS_TOP_COUNTRIES,
 	KM_ANALYTICS_TOP_TRAFFIC_SOURCE,
 } from '../../googlesitekit/datastore/user/constants';
-import { KM_CONNECT_GA4_CTA_WIDGET_DISMISSED_ITEM_KEY } from './constants';
 import { isFeatureEnabled } from '../../features';
 
 export { registerStore } from './datastore';
@@ -65,18 +61,6 @@ export const registerWidgets = ( widgets ) => {
 		/*
 		 * Key metrics widgets.
 		 */
-		widgets.registerWidget(
-			'keyMetricsConnectGA4CTATile',
-			{
-				Component: ConnectGA4CTATileWidget,
-				width: widgets.WIDGET_WIDTHS.QUARTER,
-				priority: 1,
-				wrapWidget: false,
-				modules: [ 'analytics-4' ],
-			},
-			[ AREA_MAIN_DASHBOARD_KEY_METRICS_PRIMARY ]
-		);
-
 		widgets.registerWidget(
 			KM_ANALYTICS_LOYAL_VISITORS,
 			{
@@ -217,40 +201,6 @@ export const registerWidgets = ( widgets ) => {
 					select( CORE_USER ).isKeyMetricActive(
 						KM_ANALYTICS_TOP_CONVERTING_TRAFFIC_SOURCE
 					),
-			},
-			[ AREA_MAIN_DASHBOARD_KEY_METRICS_PRIMARY ]
-		);
-
-		widgets.registerWidget(
-			'keyMetricsConnectGA4CTA',
-			{
-				Component: ConnectGA4CTAWidget,
-				width: [ widgets.WIDGET_WIDTHS.FULL ],
-				priority: 1,
-				wrapWidget: false,
-				modules: [ 'analytics-4' ],
-				isActive: ( select ) => {
-					const isCTADismissed = select( CORE_USER ).isItemDismissed(
-						KM_CONNECT_GA4_CTA_WIDGET_DISMISSED_ITEM_KEY
-					);
-					const isUserInputCompleted =
-						select( CORE_USER ).isUserInputCompleted();
-					const isGA4Connected =
-						select( CORE_MODULES ).isModuleConnected(
-							'analytics-4'
-						);
-
-					return (
-						! [
-							isCTADismissed,
-							isUserInputCompleted,
-							isGA4Connected,
-						].includes( undefined ) &&
-						! isCTADismissed &&
-						isUserInputCompleted &&
-						! isGA4Connected
-					);
-				},
 			},
 			[ AREA_MAIN_DASHBOARD_KEY_METRICS_PRIMARY ]
 		);

--- a/assets/js/modules/search-console/components/widgets/PopularKeywordsWidget.js
+++ b/assets/js/modules/search-console/components/widgets/PopularKeywordsWidget.js
@@ -41,10 +41,11 @@ import Link from '../../../../components/Link';
 import useViewOnly from '../../../../hooks/useViewOnly';
 import { MetricTileTable } from '../../../../components/KeyMetrics';
 import { ZeroDataMessage } from '../common';
+import whenActive from '../../../../util/when-active';
 
 const { useSelect, useInViewSelect } = Data;
 
-export default function PopularKeywordsWidget( { Widget } ) {
+function PopularKeywordsWidget( { Widget } ) {
 	const viewOnlyDashboard = useViewOnly();
 
 	const dates = useSelect( ( select ) =>
@@ -134,5 +135,8 @@ export default function PopularKeywordsWidget( { Widget } ) {
 
 PopularKeywordsWidget.propTypes = {
 	Widget: PropTypes.elementType.isRequired,
-	WidgetNull: PropTypes.elementType.isRequired,
 };
+
+export default whenActive( {
+	moduleName: 'search-console',
+} )( PopularKeywordsWidget );


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #7337 

## Relevant technical choices

<!-- Please describe your changes. -->

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
