### PR TITLE
Simplify current product base path construction

### DIFF
--- a/includes/Core/Assets/Assets.php
+++ b/includes/Core/Assets/Assets.php
@@ -1092,7 +1092,7 @@ final class Assets {
 			$permastruct               = $wp_rewrite->get_extra_permastruct( 'product' );
 			$permalink_template        = home_url( $permastruct );
 			$product_url_path          = URL::parse( $permalink_template, PHP_URL_PATH );
-			list( $product_base_path ) = explode( '%product%', $product_url_path, 2 ) + array( '' );
+			list( $product_base_path ) = explode( '%product%', $product_url_path, 2 );
 			$product_base_paths[]      = $product_base_path;
 		}
 

--- a/includes/Core/Assets/Assets.php
+++ b/includes/Core/Assets/Assets.php
@@ -1073,6 +1073,10 @@ final class Assets {
 	 * @return array The array of product base paths.
 	 */
 	private function get_product_base_paths() {
+		if ( ! Feature_Flags::enabled( 'userInput' ) ) {
+			return array();
+		}
+
 		// Return early if permalinks are not used.
 		if ( ! get_option( 'permalink_structure' ) ) {
 			return array();

--- a/tests/phpunit/integration/Core/Assets/AssetsTest.php
+++ b/tests/phpunit/integration/Core/Assets/AssetsTest.php
@@ -221,11 +221,13 @@ class AssetsTest extends TestCase {
 	}
 
 	public function test_base_data__product_base_paths__no_permalink_structure() {
+		$this->enable_feature( 'userInput' );
 		$data = $this->get_inline_base_data();
 		$this->assertTrue( empty( $data['productBasePaths'] ) );
 	}
 
 	public function test_base_data__product_base_paths__empty() {
+		$this->enable_feature( 'userInput' );
 		update_option( 'permalink_structure', '/%postname%/' );
 
 		$data = $this->get_inline_base_data();
@@ -233,6 +235,7 @@ class AssetsTest extends TestCase {
 	}
 
 	public function test_base_data__product_base_paths__hidden_post_type() {
+		$this->enable_feature( 'userInput' );
 		update_option( 'permalink_structure', '/%postname%/' );
 
 		register_post_type( 'product', array( 'public' => false ) );
@@ -246,6 +249,7 @@ class AssetsTest extends TestCase {
 	 * @dataProvider data_product_base_paths
 	 */
 	public function test_base_data__product_base_paths( $post_type_args, $expected ) {
+		$this->enable_feature( 'userInput' );
 		update_option( 'permalink_structure', '/%postname%/' );
 
 		register_post_type( 'product', $post_type_args );

--- a/tests/phpunit/integration/Core/Assets/AssetsTest.php
+++ b/tests/phpunit/integration/Core/Assets/AssetsTest.php
@@ -265,10 +265,6 @@ class AssetsTest extends TestCase {
 		$this->assertEquals( $expected, $data['productBasePaths'] );
 	}
 
-	public function test_no_side_effects() {
-		$this->assertFalse( post_type_exists( 'product' ) );
-	}
-
 	public function data_product_base_paths() {
 		return array(
 			'public post type'    => array(

--- a/tests/phpunit/integration/Core/Assets/AssetsTest.php
+++ b/tests/phpunit/integration/Core/Assets/AssetsTest.php
@@ -62,6 +62,14 @@ class AssetsTest extends TestCase {
 		wp_styles()->queue       = array();
 	}
 
+	public function tear_down() {
+		parent::tear_down();
+		// Ensure registered post types are cleaned up.
+		if ( post_type_exists( 'product' ) ) {
+			unregister_post_type( 'product' );
+		}
+	}
+
 	public function test_register() {
 		$actions_to_test = array(
 			'admin_enqueue_scripts',
@@ -228,7 +236,7 @@ class AssetsTest extends TestCase {
 
 	public function test_base_data__product_base_paths__empty() {
 		$this->enable_feature( 'userInput' );
-		update_option( 'permalink_structure', '/%postname%/' );
+		$this->set_permalink_structure( '/%postname%/' );
 
 		$data = $this->get_inline_base_data();
 		$this->assertTrue( empty( $data['productBasePaths'] ) );
@@ -236,11 +244,10 @@ class AssetsTest extends TestCase {
 
 	public function test_base_data__product_base_paths__hidden_post_type() {
 		$this->enable_feature( 'userInput' );
-		update_option( 'permalink_structure', '/%postname%/' );
+		$this->set_permalink_structure( '/%postname%/' );
 
 		register_post_type( 'product', array( 'public' => false ) );
 		$data = $this->get_inline_base_data();
-		unregister_post_type( 'product' );
 
 		$this->assertTrue( empty( $data['productBasePaths'] ) );
 	}
@@ -250,13 +257,16 @@ class AssetsTest extends TestCase {
 	 */
 	public function test_base_data__product_base_paths( $post_type_args, $expected ) {
 		$this->enable_feature( 'userInput' );
-		update_option( 'permalink_structure', '/%postname%/' );
-
+		$this->set_permalink_structure( '/%postname%/' );
 		register_post_type( 'product', $post_type_args );
+
 		$data = $this->get_inline_base_data();
-		unregister_post_type( 'product' );
 
 		$this->assertEquals( $expected, $data['productBasePaths'] );
+	}
+
+	public function test_no_side_effects() {
+		$this->assertFalse( post_type_exists( 'product' ) );
 	}
 
 	public function data_product_base_paths() {


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #7389 

## Relevant technical choices

- Refactors the implementation for deriving the current product base paths (will enhance in #7390)

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
