### PR TITLE
Bug/#7044 - Prevent rendering the post-switched to GA4 banner if no GA4 access

### DIFF
--- a/assets/js/components/notifications/SwitchedToGA4Banner.js
+++ b/assets/js/components/notifications/SwitchedToGA4Banner.js
@@ -30,6 +30,7 @@ import { __ } from '@wordpress/i18n';
  */
 import Data from 'googlesitekit-data';
 import GA4SuccessGreenSVG from '../../../svg/graphics/ga4-success-green.svg';
+import { CORE_MODULES } from '../../googlesitekit/modules/datastore/constants';
 import { CORE_USER } from '../../googlesitekit/datastore/user/constants';
 import { CORE_UI } from '../../googlesitekit/datastore/ui/constants';
 import { MODULES_ANALYTICS } from '../../modules/analytics/datastore/constants';
@@ -71,6 +72,10 @@ export default function SwitchedToGA4Banner() {
 		return isValidPropertyID( propertyID );
 	} );
 
+	const hasAnalytics4Access = useSelect( ( select ) =>
+		select( CORE_MODULES ).hasModuleOwnershipOrAccess( 'analytics-4' )
+	);
+
 	const eventCategory = `${ viewContext }_ga4-display-success-notification`;
 
 	const handleOnView = useCallback( () => {
@@ -97,6 +102,7 @@ export default function SwitchedToGA4Banner() {
 		! isGA4DashboardView ||
 		isTourDismissed === undefined ||
 		isTourDismissed ||
+		! hasAnalytics4Access ||
 		showGA4ReportingTour
 	) {
 		return null;

--- a/assets/js/components/notifications/SwitchedToGA4Banner.stories.js
+++ b/assets/js/components/notifications/SwitchedToGA4Banner.stories.js
@@ -22,8 +22,10 @@ import {
 	DASHBOARD_VIEW_GA4,
 	MODULES_ANALYTICS,
 } from '../../modules/analytics/datastore/constants';
+import { MODULES_ANALYTICS_4 } from '../../modules/analytics-4/datastore/constants';
 import {
 	createTestRegistry,
+	provideModuleRegistrations,
 	provideModules,
 	provideSiteInfo,
 	WithTestRegistry,
@@ -78,11 +80,16 @@ export default {
 					connected: true,
 				},
 			] );
+			provideModuleRegistrations( registry );
 
 			registry.dispatch( CORE_USER ).receiveGetDismissedTours( [] );
 			registry.dispatch( MODULES_ANALYTICS ).setSettings( {
 				propertyID: 'UA-99999-9',
 				dashboardView: DASHBOARD_VIEW_GA4,
+				ownerID: 1,
+			} );
+			registry.dispatch( MODULES_ANALYTICS_4 ).setSettings( {
+				ownerID: 1,
 			} );
 
 			args.setupRegistry?.( registry );


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #7044 

## Relevant technical choices

<!-- Please describe your changes. -->

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [x] Run the code.
- [x] Ensure the acceptance criteria are satisfied.
- [x] Reassess the implementation with the IB.
- [x] Ensure no unrelated changes are included.
- [x] Ensure CI checks pass.
- [x] Check Storybook where applicable.
- [x] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [x] Ensure the PR has the correct target branch.
- [x] Double-check that the PR is okay to be merged.
- [x] Ensure the corresponding issue has a ZenHub release assigned.
- [x] Add a changelog message to the issue.
