### PR TITLE
Bug/#7395 - Fix Key Metrics widgets layout at 600px viewport width

### DIFF
--- a/assets/sass/components/key-metrics/_googlesitekit-km-widget-tile.scss
+++ b/assets/sass/components/key-metrics/_googlesitekit-km-widget-tile.scss
@@ -42,7 +42,7 @@
 		justify-content: space-between;
 		padding: $grid-gap-phone;
 
-		@media (min-width: $bp-tablet) {
+		@media (min-width: $bp-nonMobile) {
 			flex-direction: column;
 			padding: 18px 24px;
 		}
@@ -68,7 +68,7 @@
 			align-items: flex-start;
 			display: flex;
 			gap: 8px;
-			@media (min-width: $bp-tablet) {
+			@media (min-width: $bp-nonMobile) {
 				align-items: center;
 			}
 		}
@@ -79,7 +79,7 @@
 			font-family: $f-secondary;
 			font-size: $fs-headline-lg;
 			margin-top: -8px;
-			@media (min-width: $bp-tablet) {
+			@media (min-width: $bp-nonMobile) {
 				margin: 0;
 			}
 		}
@@ -95,7 +95,7 @@
 			font-weight: 500;
 
 			margin-top: -8px;
-			@media (min-width: $bp-tablet) {
+			@media (min-width: $bp-nonMobile) {
 				margin: 5px 0 0;
 			}
 		}
@@ -110,7 +110,7 @@
 		.googlesitekit-km-widget-tile__title {
 			padding-right: 12px;
 
-			@media (min-width: $bp-tablet) {
+			@media (min-width: $bp-nonMobile) {
 				padding-right: 0;
 			}
 		}


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #7395 

## Relevant technical choices

<!-- Please describe your changes. -->

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [x] Run the code.
- [x] Ensure the acceptance criteria are satisfied.
- [x] Reassess the implementation with the IB.
- [x] Ensure no unrelated changes are included.
- [x] Ensure CI checks pass.
- [x] Check Storybook where applicable.
- [x] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [x] Ensure the PR has the correct target branch.
- [x] Double-check that the PR is okay to be merged.
- [x] Ensure the corresponding issue has a ZenHub release assigned.
- [x] Add a changelog message to the issue.
