### PR TITLE
Remove possible `null` from `stripos`.

### DIFF
--- a/includes/Core/REST_API/REST_Routes.php
+++ b/includes/Core/REST_API/REST_Routes.php
@@ -66,7 +66,7 @@ final class REST_Routes {
 						// arguments.
 
 						$unset_vars = ( $wp->request && stripos( $wp->request, trailingslashit( rest_get_url_prefix() ) . self::REST_ROOT ) !== false ) // Check regular permalinks.
-							|| ( empty( $wp->request ) && stripos( $this->context->input()->filter( INPUT_GET, 'rest_route' ), self::REST_ROOT ) !== false ); // Check plain permalinks.
+							|| ( empty( $wp->request ) && stripos( $this->context->input()->filter( INPUT_GET, 'rest_route' ) || '', self::REST_ROOT ) !== false ); // Check plain permalinks.
 
 						if ( $unset_vars ) {
 							// List of variable names to remove from public query variables list.


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #7147

## Relevant technical choices

I didn't quite catch in the original IB when reviewing this that `$this->context->input()->filter( INPUT_GET, 'rest_route' )` might be `null`, which is what I'm thinking caused this issue: https://github.com/google/site-kit-wp/issues/7147#issuecomment-1686193059

The IB mentioned to make sure we didn't pass `null`, but I interpretted that literally and then merged the PR, as in testing it worked fine for me—I couldn't get the error described in the issue to appear.

Anyhow, this should fix it.

Note for merge reviewers: this was already in the release so targets `main`. After merging, make sure to merge `main` back into `develop` so this fix is in `develop` 🙂

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [x] Run the code.
- [x] Ensure the acceptance criteria are satisfied.
- [x] Reassess the implementation with the IB.
- [x] Ensure no unrelated changes are included.
- [x] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [x] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [x] Ensure the PR has the correct target branch.
- [x] Double-check that the PR is okay to be merged.
- [x] Ensure the corresponding issue has a ZenHub release assigned.
- [x] Add a changelog message to the issue.
