### PR TITLE
Improve Metrics Selection Panel initial focus

### DIFF
--- a/assets/js/components/KeyMetrics/MetricsSelectionPanel/index.js
+++ b/assets/js/components/KeyMetrics/MetricsSelectionPanel/index.js
@@ -74,6 +74,9 @@ export default function MetricsSelectionPanel() {
 			isOpen={ isOpen }
 			onOpen={ onSideSheetOpen }
 			closeFn={ sideSheetCloseFn }
+			focusTrapOptions={ {
+				initialFocus: '.googlesitekit-accordion__header',
+			} }
 		>
 			<Header />
 			<Metrics savedMetrics={ savedViewableMetrics } />

--- a/assets/js/components/SideSheet.js
+++ b/assets/js/components/SideSheet.js
@@ -47,6 +47,7 @@ export default function SideSheet( {
 	isOpen,
 	onOpen = () => {},
 	closeFn = () => {},
+	focusTrapOptions = {},
 } ) {
 	const sideSheetRef = useRef();
 
@@ -74,6 +75,7 @@ export default function SideSheet( {
 				active={ !! isOpen }
 				focusTrapOptions={ {
 					fallbackFocus: 'body',
+					...focusTrapOptions,
 				} }
 			>
 				<section
@@ -104,4 +106,5 @@ SideSheet.propTypes = {
 	isOpen: PropTypes.bool,
 	onOpen: PropTypes.func,
 	closeFn: PropTypes.func,
+	focusTrapOptions: PropTypes.object,
 };


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #7485 

## Relevant technical choices

This PR aims to change the initial focus in the Metrics Selection Panel to the first metric.

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
