### PR TITLE
Prevent GA tracking warning message

### DIFF
--- a/assets/js/util/tracking/createTrackEvent.js
+++ b/assets/js/util/tracking/createTrackEvent.js
@@ -65,7 +65,7 @@ export default function createTrackEvent(
 			dimension4: pluginVersion || '',
 			dimension5: Array.from( enabledFeatures ).join( ',' ),
 			dimension6: activeModules.join( ',' ),
-			dimension7: isAuthenticated ? 1 : 0,
+			dimension7: isAuthenticated ? '1' : '0',
 		};
 
 		return new Promise( ( resolve ) => {

--- a/assets/js/util/tracking/index.test.js
+++ b/assets/js/util/tracking/index.test.js
@@ -128,7 +128,7 @@ describe( 'trackEvent', () => {
 				dimension4: '1.2.3',
 				dimension5: 'feature1,feature2',
 				dimension6: '',
-				dimension7: 1,
+				dimension7: '1',
 			} )
 		);
 		expect( pushArgs[ 0 ][ 2 ] ).toHaveProperty( 'event_callback' );


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #6660 

## Relevant technical choices

This PR prevents a warning message in SK GA tracking where a dimension value is sent as a number instead of a string.

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
