### PR TITLE
Fix dynamic property declarations.

### DIFF
--- a/includes/Core/Authentication/Exception/Google_Proxy_Code_Exception.php
+++ b/includes/Core/Authentication/Exception/Google_Proxy_Code_Exception.php
@@ -25,9 +25,9 @@ class Google_Proxy_Code_Exception extends Exception {
 	/**
 	 * Temporary code for an undelegated proxy token.
 	 *
-	 * @since 1.0.0
+	 * @since n.e.x.t Explicitly declared; previously, it was dynamically declared.
 	 *
-	 * @var Access_Code
+	 * @var string
 	 */
 	protected $access_code;
 

--- a/includes/Core/Authentication/Exception/Google_Proxy_Code_Exception.php
+++ b/includes/Core/Authentication/Exception/Google_Proxy_Code_Exception.php
@@ -23,6 +23,15 @@ use Exception;
 class Google_Proxy_Code_Exception extends Exception {
 
 	/**
+	 * Temporary code for an undelegated proxy token.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @var Access_Code
+	 */
+	protected $access_code;
+
+	/**
 	 * Constructor.
 	 *
 	 * @since 1.0.0

--- a/includes/Core/Authentication/Setup.php
+++ b/includes/Core/Authentication/Setup.php
@@ -66,9 +66,9 @@ class Setup {
 	/**
 	 * Proxy support URL.
 	 *
-	 * @since 1.48.0
+	 * @since n.e.x.t Explicitly declared; previously, it was dynamically declared.
 	 *
-	 * @var Proxy_Support_Link_Url
+	 * @var string
 	 */
 	protected $proxy_support_link_url;
 

--- a/includes/Core/Authentication/Setup.php
+++ b/includes/Core/Authentication/Setup.php
@@ -64,6 +64,15 @@ class Setup {
 	protected $google_proxy;
 
 	/**
+	 * Proxy support URL.
+	 *
+	 * @since 1.48.0
+	 *
+	 * @var Proxy_Support_Link_Url
+	 */
+	protected $proxy_support_link_url;
+
+	/**
 	 * Credentials instance.
 	 *
 	 * @since 1.48.0

--- a/includes/Core/Modules/Tags/Module_Tag.php
+++ b/includes/Core/Modules/Tags/Module_Tag.php
@@ -25,6 +25,8 @@ abstract class Module_Tag extends Tag {
 	 * Module slug.
 	 *
 	 * @since 1.24.0
+	 * @since n.e.x.t Renamed from slug to module_slug.
+	 *
 	 * @var string
 	 */
 	protected $module_slug;

--- a/includes/Core/Modules/Tags/Module_Tag.php
+++ b/includes/Core/Modules/Tags/Module_Tag.php
@@ -27,7 +27,7 @@ abstract class Module_Tag extends Tag {
 	 * @since 1.24.0
 	 * @var string
 	 */
-	protected $slug;
+	protected $module_slug;
 
 	/**
 	 * Constructor.


### PR DESCRIPTION
## Summary

Addresses issue:

- #7202 

## Relevant technical choices

- Declared properties that were dynamically created in the code to comply with PHP 8.2 deprecation notices.
- Scanned remaining PHP files to confirm these were the only occurrences of dynamically declared properties.

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
