### PR TITLE
Fix inconsistent metrics selection panel.

### DIFF
--- a/assets/sass/components/global/_googlesitekit-side-sheet.scss
+++ b/assets/sass/components/global/_googlesitekit-side-sheet.scss
@@ -30,7 +30,7 @@
 		width: 100%;
 		z-index: $z-index-sk-side-sheet;
 
-		@media (min-width: $bp-tablet) {
+		@media (min-width: $bp-nonMobile) {
 			width: 400px;
 		}
 


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #7474 

## Relevant technical choices

<!-- Please describe your changes. -->
- Changed the `min-width` property to ensure the metrics selection panel is full-width at a 600px viewport.

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [x] Run the code.
- [x] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [x] Ensure no unrelated changes are included.
- [x] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [x] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [x] Ensure the PR has the correct target branch.
- [x] Double-check that the PR is okay to be merged.
- [x] Ensure the corresponding issue has a ZenHub release assigned.
- [x] Add a changelog message to the issue.
