### PR TITLE
Enhancement/6520 button tooltip delay

### DIFF
--- a/assets/js/components/DateRangeSelector.js
+++ b/assets/js/components/DateRangeSelector.js
@@ -108,6 +108,7 @@ export default function DateRangeSelector() {
 				aria-controls="date-range-selector-menu"
 				title={ __( 'Date range', 'google-site-kit' ) }
 				tooltip
+				tooltipEnterDelayInMS={ 500 }
 			>
 				{ currentDateRangeLabel }
 			</Button>

--- a/assets/js/components/EntitySearchInput.js
+++ b/assets/js/components/EntitySearchInput.js
@@ -141,6 +141,7 @@ function EntitySearchInput() {
 						title={ __( 'Close', 'google-site-kit' ) }
 						text
 						tooltip
+						tooltipEnterDelayInMS={ 500 }
 					/>
 				</div>
 			</div>
@@ -157,6 +158,7 @@ function EntitySearchInput() {
 				title={ __( 'Search', 'google-site-kit' ) }
 				trailingIcon={ <MagnifyingGlass width="20" height="20" /> }
 				tooltip
+				tooltipEnterDelayInMS={ 500 }
 			>
 				{ __( 'URL Search', 'google-site-kit' ) }
 			</Button>

--- a/assets/js/components/UserMenu/index.js
+++ b/assets/js/components/UserMenu/index.js
@@ -226,6 +226,7 @@ export default function UserMenu() {
 					aria-controls="user-menu"
 					aria-label={ __( 'Account', 'google-site-kit' ) }
 					tooltip
+					tooltipEnterDelayInMS={ 500 }
 					customizedTooltip={
 						<span aria-label={ accountLabel }>
 							<strong>

--- a/assets/js/components/ViewOnlyMenu/index.js
+++ b/assets/js/components/ViewOnlyMenu/index.js
@@ -97,6 +97,7 @@ export default function ViewOnlyMenu() {
 				aria-controls="view-only-menu"
 				aria-label={ __( 'View only', 'google-site-kit' ) }
 				tooltip
+				tooltipEnterDelayInMS={ 500 }
 			>
 				{ __( 'View only', 'google-site-kit' ) }
 			</Button>

--- a/assets/js/components/dashboard-sharing/DashboardSharingSettingsButton.js
+++ b/assets/js/components/dashboard-sharing/DashboardSharingSettingsButton.js
@@ -61,6 +61,7 @@ export default function DashboardSharingSettingsButton() {
 				className="googlesitekit-sharing-settings__button googlesitekit-header__dropdown googlesitekit-border-radius-round googlesitekit-button-icon"
 				onClick={ openDialog }
 				icon={ <ShareIcon width={ 20 } height={ 20 } /> }
+				tooltipEnterDelayInMS={ 500 }
 			/>
 
 			<DashboardSharingDialog />

--- a/assets/js/components/help/HelpMenu.js
+++ b/assets/js/components/help/HelpMenu.js
@@ -89,6 +89,7 @@ export default function HelpMenu( { children } ) {
 				icon={ <HelpIcon width="20" height="20" /> }
 				onClick={ handleMenu }
 				text
+				tooltipEnterDelayInMS={ 500 }
 			/>
 			<Menu
 				className="googlesitekit-width-auto"

--- a/assets/js/googlesitekit/components-gm2/Button.js
+++ b/assets/js/googlesitekit/components-gm2/Button.js
@@ -52,6 +52,7 @@ const Button = forwardRef(
 			customizedTooltip,
 			tooltip,
 			inverse,
+			tooltipEnterDelayInMS,
 			...extraProps
 		},
 		ref
@@ -120,7 +121,14 @@ const Button = forwardRef(
 			( icon && tooltipTitle && children === undefined )
 		) {
 			return (
-				<Tooltip title={ tooltipTitle }>{ ButtonComponent }</Tooltip>
+				<Tooltip
+					title={ tooltipTitle }
+					{ ...( tooltipEnterDelayInMS !== undefined
+						? { enterDelay: tooltipEnterDelayInMS }
+						: {} ) }
+				>
+					{ ButtonComponent }
+				</Tooltip>
 			);
 		}
 

--- a/assets/js/googlesitekit/components-gm2/Button.js
+++ b/assets/js/googlesitekit/components-gm2/Button.js
@@ -52,7 +52,7 @@ const Button = forwardRef(
 			customizedTooltip,
 			tooltip,
 			inverse,
-			tooltipEnterDelayInMS,
+			tooltipEnterDelayInMS = 100,
 			...extraProps
 		},
 		ref
@@ -123,9 +123,7 @@ const Button = forwardRef(
 			return (
 				<Tooltip
 					title={ tooltipTitle }
-					{ ...( tooltipEnterDelayInMS !== undefined
-						? { enterDelay: tooltipEnterDelayInMS }
-						: {} ) }
+					enterDelay={ tooltipEnterDelayInMS }
 				>
 					{ ButtonComponent }
 				</Tooltip>


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #6520 

## Relevant technical choices

enterDelay prop is not introduced directly in tooltip per IB, since tooltip component accepts spread props, so there was no need for it to be added explicitly. The button prop is updated. I also added tooltip delay on menu items not mentioned in IB, since these options probably arrived later after this issue was opened - so included are dashboard sharing menu item, as well as view only menu item from user with view only access.

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [x] Run the code.
- [x] Ensure the acceptance criteria are satisfied.
- [x] Reassess the implementation with the IB.
- [x] Ensure no unrelated changes are included.
- [x] Ensure CI checks pass.
- [x] Check Storybook where applicable.
- [x] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [x] Ensure the PR has the correct target branch.
- [x] Double-check that the PR is okay to be merged.
- [x] Ensure the corresponding issue has a ZenHub release assigned.
- [x] Add a changelog message to the issue.
