### PR TITLE
Bug/#7417 - Update Module to `analytics-4` for GA4 Dashboard View Auto-Switching

### DIFF
--- a/assets/js/googlesitekit/datastore/user/permissions.js
+++ b/assets/js/googlesitekit/datastore/user/permissions.js
@@ -239,6 +239,14 @@ const baseSelectors = {
 		// shareable and the user has the "read shared module data"
 		// capability for.
 		return Object.values( modules ).reduce( ( slugs, module ) => {
+			if ( module.slug === 'analytics' && isGA4DashboardView ) {
+				return slugs;
+			}
+
+			if ( module.slug === 'analytics-4' && ! isGA4DashboardView ) {
+				return slugs;
+			}
+
 			const hasCapability = select( CORE_USER ).hasCapability(
 				PERMISSION_READ_SHARED_MODULE_DATA,
 				module.slug
@@ -303,9 +311,17 @@ const baseSelectors = {
 				return false;
 			}
 
+			const isGA4DashboardView =
+				select( MODULES_ANALYTICS ).isGA4DashboardView();
+
+			let capabilityModuleSlug = module.slug;
+			if ( capabilityModuleSlug === 'analytics' && isGA4DashboardView ) {
+				capabilityModuleSlug = 'analytics-4';
+			}
+
 			return select( CORE_USER ).hasCapability(
 				PERMISSION_READ_SHARED_MODULE_DATA,
-				module.slug
+				capabilityModuleSlug
 			);
 		}
 	),

--- a/assets/js/googlesitekit/datastore/user/permissions.js
+++ b/assets/js/googlesitekit/datastore/user/permissions.js
@@ -239,11 +239,10 @@ const baseSelectors = {
 		// shareable and the user has the "read shared module data"
 		// capability for.
 		return Object.values( modules ).reduce( ( slugs, module ) => {
-			if ( module.slug === 'analytics' && isGA4DashboardView ) {
-				return slugs;
-			}
-
-			if ( module.slug === 'analytics-4' && ! isGA4DashboardView ) {
+			if (
+				( module.slug === 'analytics' && isGA4DashboardView ) ||
+				( module.slug === 'analytics-4' && ! isGA4DashboardView )
+			) {
 				return slugs;
 			}
 

--- a/assets/js/googlesitekit/datastore/user/permissions.test.js
+++ b/assets/js/googlesitekit/datastore/user/permissions.test.js
@@ -387,7 +387,7 @@ describe( 'core/user authentication', () => {
 				] );
 			} );
 
-			it( 'should not include "analytics" module if the dashboardView is GA4', () => {
+			it( 'should not include `analytics` module if the dashboardView is GA4', () => {
 				enabledFeatures.add( 'ga4Reporting' );
 
 				registry
@@ -418,7 +418,7 @@ describe( 'core/user authentication', () => {
 				enabledFeatures.delete( 'ga4Reporting' );
 			} );
 
-			it( 'should not include "analytics-4" module if the dashboardView is UA', () => {
+			it( 'should not include `analytics-4` module if the dashboardView is UA', () => {
 				enabledFeatures.add( 'ga4Reporting' );
 
 				registry
@@ -566,13 +566,13 @@ describe( 'core/user authentication', () => {
 				expect( canViewSharedModule ).toBe( true );
 			} );
 
-			it( 'should change module slug to "analytics-4" when the `module.slug` is "analytics" and the dashboard view is GA4', () => {
+			it( 'should treat `analytics` as `analytics-4` when the dashboard view is GA4', () => {
 				enabledFeatures.add( 'ga4Reporting' );
 
 				registry.dispatch( CORE_USER ).receiveGetCapabilities( {
 					...capabilitiesWithPermission.permissions,
-					// Set `analytics` permission to `false` to ensure that the module slug is changed to "analytics-4".
-					// The selector will return `true` as the module slug is changed to "analytics-4".
+					// Set the `analytics` permission to `false` to help verify that the `analytics` module
+					// is indeed treated as `analytics-4` when the dashboard view is GA4.
 					'googlesitekit_read_shared_module_data::["analytics"]': false,
 				} );
 				registry.dispatch( CORE_MODULES ).receiveGetModules( [
@@ -596,7 +596,6 @@ describe( 'core/user authentication', () => {
 
 				expect( canViewSharedAnalytics ).toBe( false );
 
-				// Set the dashboard view to GA4 to change the module slug to "analytics-4".
 				registry.dispatch( MODULES_ANALYTICS ).receiveGetSettings( {
 					dashboardView: DASHBOARD_VIEW_GA4,
 				} );

--- a/assets/js/googlesitekit/modules/datastore/modules.js
+++ b/assets/js/googlesitekit/modules/datastore/modules.js
@@ -1393,7 +1393,18 @@ const baseSelectors = {
 			return undefined;
 		}
 
+		const isGA4DashboardView =
+			select( MODULES_ANALYTICS ).isGA4DashboardView();
+
 		return Object.keys( modules ).reduce( ( acc, slug ) => {
+			if ( slug === 'analytics' && isGA4DashboardView ) {
+				return acc;
+			}
+
+			if ( slug === 'analytics-4' && ! isGA4DashboardView ) {
+				return acc;
+			}
+
 			if ( modules[ slug ].shareable ) {
 				return { [ slug ]: modules[ slug ], ...acc };
 			}

--- a/assets/js/googlesitekit/modules/datastore/modules.js
+++ b/assets/js/googlesitekit/modules/datastore/modules.js
@@ -1397,11 +1397,10 @@ const baseSelectors = {
 			select( MODULES_ANALYTICS ).isGA4DashboardView();
 
 		return Object.keys( modules ).reduce( ( acc, slug ) => {
-			if ( slug === 'analytics' && isGA4DashboardView ) {
-				return acc;
-			}
-
-			if ( slug === 'analytics-4' && ! isGA4DashboardView ) {
+			if (
+				( slug === 'analytics' && isGA4DashboardView ) ||
+				( slug === 'analytics-4' && ! isGA4DashboardView )
+			) {
 				return acc;
 			}
 

--- a/assets/js/googlesitekit/modules/datastore/modules.test.js
+++ b/assets/js/googlesitekit/modules/datastore/modules.test.js
@@ -41,7 +41,11 @@ import {
 import FIXTURES, { withActive } from './__fixtures__';
 import { MODULES_SEARCH_CONSOLE } from '../../../modules/search-console/datastore/constants';
 import { CORE_USER } from '../../datastore/user/constants';
-import { DASHBOARD_VIEW_GA4 } from '../../../modules/analytics/datastore/constants';
+import {
+	DASHBOARD_VIEW_GA4,
+	DASHBOARD_VIEW_UA,
+	MODULES_ANALYTICS,
+} from '../../../modules/analytics/datastore/constants';
 
 describe( 'core/modules modules', () => {
 	const dashboardSharingDataBaseVar = '_googlesitekitDashboardSharingData';
@@ -2208,6 +2212,50 @@ describe( 'core/modules modules', () => {
 						( module ) => module.shareable
 					).length
 				).toEqual( Object.values( shareableModules ).length );
+			} );
+
+			it( 'should not include "analytics" module if the dashboard view is GA4', () => {
+				enabledFeatures.add( 'ga4Reporting' );
+
+				provideModuleRegistrations( registry );
+				registry
+					.dispatch( CORE_MODULES )
+					.receiveGetModules( [ ...FIXTURES, ...allModules ] );
+
+				registry.dispatch( MODULES_ANALYTICS ).receiveGetSettings( {
+					dashboardView: DASHBOARD_VIEW_GA4,
+				} );
+
+				const shareableModules = registry
+					.select( CORE_MODULES )
+					.getShareableModules();
+
+				expect( shareableModules ).not.toHaveProperty( 'analytics' );
+				expect( shareableModules ).toHaveProperty( 'analytics-4' );
+
+				enabledFeatures.delete( 'ga4Reporting' );
+			} );
+
+			it( 'should not include "analytics-4" module if the dashboard view is UA', () => {
+				enabledFeatures.add( 'ga4Reporting' );
+
+				provideModuleRegistrations( registry );
+				registry
+					.dispatch( CORE_MODULES )
+					.receiveGetModules( [ ...FIXTURES, ...allModules ] );
+
+				registry.dispatch( MODULES_ANALYTICS ).receiveGetSettings( {
+					dashboardView: DASHBOARD_VIEW_UA,
+				} );
+
+				const shareableModules = registry
+					.select( CORE_MODULES )
+					.getShareableModules();
+
+				expect( shareableModules ).not.toHaveProperty( 'analytics-4' );
+				expect( shareableModules ).toHaveProperty( 'analytics' );
+
+				enabledFeatures.delete( 'ga4Reporting' );
 			} );
 		} );
 	} );

--- a/assets/js/googlesitekit/modules/datastore/modules.test.js
+++ b/assets/js/googlesitekit/modules/datastore/modules.test.js
@@ -2214,7 +2214,7 @@ describe( 'core/modules modules', () => {
 				).toEqual( Object.values( shareableModules ).length );
 			} );
 
-			it( 'should not include "analytics" module if the dashboard view is GA4', () => {
+			it( 'should not include `analytics` module if the dashboard view is GA4', () => {
 				enabledFeatures.add( 'ga4Reporting' );
 
 				provideModuleRegistrations( registry );
@@ -2236,7 +2236,7 @@ describe( 'core/modules modules', () => {
 				enabledFeatures.delete( 'ga4Reporting' );
 			} );
 
-			it( 'should not include "analytics-4" module if the dashboard view is UA', () => {
+			it( 'should not include `analytics-4` module if the dashboard view is UA', () => {
 				enabledFeatures.add( 'ga4Reporting' );
 
 				provideModuleRegistrations( registry );

--- a/includes/Modules/Analytics.php
+++ b/includes/Modules/Analytics.php
@@ -423,12 +423,6 @@ final class Analytics extends Module
 	 */
 	protected function get_datapoint_definitions() {
 		$shareable = true;
-		// If ga4Reporting is enabled, the dashboard view controls which
-		// Analytics module is shareable.
-		if ( Feature_Flags::enabled( 'ga4Reporting' ) ) {
-			$settings  = $this->get_settings()->get();
-			$shareable = self::DASHBOARD_VIEW === $settings['dashboardView'];
-		}
 
 		$datapoints = array(
 			'GET:accounts-properties-profiles' => array( 'service' => 'analytics' ),

--- a/includes/Modules/Analytics_4.php
+++ b/includes/Modules/Analytics_4.php
@@ -289,12 +289,6 @@ final class Analytics_4 extends Module
 	protected function get_datapoint_definitions() {
 		// GA4 is only shareable if ga4Reporting is also enabled.
 		$shareable = Feature_Flags::enabled( 'ga4Reporting' );
-		if ( $shareable ) {
-			// The dashboard view setting is stored in the UA/original Analytics
-			// module, so fetch its settings to get the current dashboard view.
-			$analytics_settings = ( new Analytics_Settings( $this->options ) )->get();
-			$shareable          = self::DASHBOARD_VIEW === $analytics_settings['dashboardView'];
-		}
 
 		$datapoints = array(
 			'GET:account-summaries'              => array( 'service' => 'analyticsadmin' ),


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #7417 

## Relevant technical choices

<!-- Please describe your changes. -->

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [x] Run the code.
- [x] Ensure the acceptance criteria are satisfied.
- [x] Reassess the implementation with the IB.
- [x] Ensure no unrelated changes are included.
- [x] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [x] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [x] Ensure the PR has the correct target branch.
- [x] Double-check that the PR is okay to be merged.
- [x] Ensure the corresponding issue has a ZenHub release assigned.
- [x] Add a changelog message to the issue.
