### PR TITLE
Ensure the Key Metrics Setup CTA widget can still be displayed.

### DIFF
--- a/assets/js/googlesitekit/datastore/user/constants.js
+++ b/assets/js/googlesitekit/datastore/user/constants.js
@@ -71,3 +71,8 @@ export const keyMetricsGA4Widgets = [
 	KM_ANALYTICS_TOP_COUNTRIES,
 	KM_ANALYTICS_TOP_TRAFFIC_SOURCE,
 ];
+
+export const allKeyMetricsTileWidgets = [
+	...keyMetricsGA4Widgets,
+	KM_SEARCH_CONSOLE_POPULAR_KEYWORDS,
+];

--- a/assets/js/googlesitekit/widgets/register-defaults.js
+++ b/assets/js/googlesitekit/widgets/register-defaults.js
@@ -27,7 +27,10 @@ import { __ } from '@wordpress/i18n';
  */
 import * as WIDGET_CONTEXTS from './default-contexts';
 import * as WIDGET_AREAS from './default-areas';
-import { CORE_USER } from '../datastore/user/constants';
+import {
+	CORE_USER,
+	allKeyMetricsTileWidgets,
+} from '../datastore/user/constants';
 import { WIDGET_AREA_STYLES } from './datastore/constants';
 import { isFeatureEnabled } from '../../features';
 import {
@@ -108,7 +111,7 @@ export function registerDefaults( widgetsAPI ) {
 				// See: https://github.com/google/site-kit-wp/issues/7435
 				if (
 					areaWidgets.length === 1 &&
-					areaWidgets[ 0 ].slug !== 'keyMetricsSetupCTA'
+					allKeyMetricsTileWidgets.includes( areaWidgets[ 0 ].slug )
 				) {
 					return [];
 				}

--- a/assets/js/googlesitekit/widgets/register-defaults.js
+++ b/assets/js/googlesitekit/widgets/register-defaults.js
@@ -103,10 +103,17 @@ export function registerDefaults( widgetsAPI ) {
 			priority: 1,
 			CTA: ChangeMetricsLink,
 			filterActiveWidgets( select, areaWidgets ) {
-				// Prevent showing only one widget in this area when
+				// Prevent showing only one widget tile in this area when
 				// only Search Console is shared.
 				// See: https://github.com/google/site-kit-wp/issues/7435
-				return areaWidgets.length === 1 ? [] : areaWidgets;
+				if (
+					areaWidgets.length === 1 &&
+					areaWidgets[ 0 ].slug !== 'keyMetricsSetupCTA'
+				) {
+					return [];
+				}
+
+				return areaWidgets;
 			},
 		},
 		CONTEXT_MAIN_DASHBOARD_KEY_METRICS


### PR DESCRIPTION
## Summary

This is a followup PR to address the issue described [here](https://github.com/google/site-kit-wp/pull/7595#discussion_r1331328311).

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #7435 

## Relevant technical choices

<!-- Please describe your changes. -->

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
