### PR TITLE
Enhance/#7278 - Dismiss GA4 tile banner.

### DIFF
--- a/assets/js/modules/analytics-4/components/widgets/ConnectGA4CTAWidget.js
+++ b/assets/js/modules/analytics-4/components/widgets/ConnectGA4CTAWidget.js
@@ -127,7 +127,17 @@ export default function ConnectGA4CTAWidget( { Widget, WidgetNull } ) {
 		isNavigatingToGA4URL,
 	] );
 
-	if ( ga4DependantKeyMetrics.length < 4 ) {
+	const isDismissed = useSelect( ( select ) =>
+		select( CORE_USER ).isItemDismissed(
+			KM_CONNECT_GA4_CTA_WIDGET_DISMISSED_ITEM_KEY
+		)
+	);
+
+	if (
+		isDismissed === undefined ||
+		isDismissed ||
+		ga4DependantKeyMetrics.length < 4
+	) {
 		return <WidgetNull />;
 	}
 

--- a/assets/js/modules/analytics-4/components/widgets/ConnectGA4CTAWidget.js
+++ b/assets/js/modules/analytics-4/components/widgets/ConnectGA4CTAWidget.js
@@ -134,8 +134,7 @@ export default function ConnectGA4CTAWidget( { Widget, WidgetNull } ) {
 	);
 
 	if (
-		isDismissed === undefined ||
-		isDismissed ||
+		isDismissed !== false ||
 		ga4DependantKeyMetrics.length < 4
 	) {
 		return <WidgetNull />;

--- a/assets/js/modules/analytics-4/components/widgets/ConnectGA4CTAWidget.js
+++ b/assets/js/modules/analytics-4/components/widgets/ConnectGA4CTAWidget.js
@@ -133,10 +133,7 @@ export default function ConnectGA4CTAWidget( { Widget, WidgetNull } ) {
 		)
 	);
 
-	if (
-		isDismissed !== false ||
-		ga4DependantKeyMetrics.length < 4
-	) {
+	if ( isDismissed !== false || ga4DependantKeyMetrics.length < 4 ) {
 		return <WidgetNull />;
 	}
 

--- a/assets/js/modules/analytics-4/components/widgets/ConnectGA4CTAWidget.test.js
+++ b/assets/js/modules/analytics-4/components/widgets/ConnectGA4CTAWidget.test.js
@@ -27,7 +27,9 @@ import {
 	KM_ANALYTICS_TOP_TRAFFIC_SOURCE,
 	KM_SEARCH_CONSOLE_POPULAR_KEYWORDS,
 	KM_ANALYTICS_ADSENSE_TOP_EARNING_CONTENT,
+	CORE_USER,
 } from '../../../../googlesitekit/datastore/user/constants';
+import { KM_CONNECT_GA4_CTA_WIDGET_DISMISSED_ITEM_KEY } from '../../constants';
 import {
 	render,
 	createTestRegistry,
@@ -79,6 +81,11 @@ describe( 'ConnectGA4CTAWidget', () => {
 		} );
 
 		provideKeyMetricsWidgetRegistrations( registry, keyMetricWidgets );
+		registry
+			.dispatch( CORE_USER )
+			.receiveGetDismissedItems( [
+				KM_CONNECT_GA4_CTA_WIDGET_DISMISSED_ITEM_KEY,
+			] );
 
 		const { container, waitForRegistry } = render(
 			<WidgetWithComponentProps />,
@@ -113,6 +120,7 @@ describe( 'ConnectGA4CTAWidget', () => {
 				{}
 			)
 		);
+		registry.dispatch( CORE_USER ).receiveGetDismissedItems( [] );
 
 		const { container, getByRole, waitForRegistry } = render(
 			<WidgetWithComponentProps />,


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #7278 

## Relevant technical choices

* This follow-up PR addresses the non-responsiveness of the "Maybe later" button in the Connect GA4 CTA Widget. With this fix, the button will function as intended, dismissing the widget upon click. Please refer to the `Issue 3` of this [QA observation](https://github.com/google/site-kit-wp/issues/7278#issuecomment-1740328727).

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
