### PR TITLE
Update E2E PHP error ignore mechanism

### DIFF
--- a/tests/e2e/config/wordpress-debug-log/index.js
+++ b/tests/e2e/config/wordpress-debug-log/index.js
@@ -129,9 +129,13 @@ async function assertEmptyDebugLog() {
 	// before the entries are recorded and result in a false success.
 	await page.waitForTimeout( 1000 );
 
+	// Filter out lines that are ignored.
 	const filteredDebugLog = debugLogData.filter( ( line ) => {
 		const lineWithoutTimestamp = line.replace( /^\[[^\]]+\]\s+/, '' );
-		return ! ignoreList.includes( lineWithoutTimestamp );
+
+		return ignoreList.some( ( ignoreLine ) =>
+			lineWithoutTimestamp.startsWith( ignoreLine )
+		);
 	} );
 
 	if ( filteredDebugLog.length ) {

--- a/tests/e2e/config/wordpress-debug-log/index.js
+++ b/tests/e2e/config/wordpress-debug-log/index.js
@@ -133,7 +133,7 @@ async function assertEmptyDebugLog() {
 	const filteredDebugLog = debugLogData.filter( ( line ) => {
 		const lineWithoutTimestamp = line.replace( /^\[[^\]]+\]\s+/, '' );
 
-		return ignoreList.some( ( ignoreLine ) =>
+		return ! ignoreList.some( ( ignoreLine ) =>
 			lineWithoutTimestamp.startsWith( ignoreLine )
 		);
 	} );

--- a/tests/e2e/config/wordpress-debug-log/log-ignore-list.js
+++ b/tests/e2e/config/wordpress-debug-log/log-ignore-list.js
@@ -6,24 +6,19 @@
 export const logIgnoreList = {
 	'5.2.16': [
 		// Deprecated syntax or function calls which are fixed in later WP versions.
-		'PHP Deprecated:  Function get_magic_quotes_gpc() is deprecated in /var/www/html/wp-includes/load.php on line 926',
-		'PHP Deprecated:  Function get_magic_quotes_gpc() is deprecated in /var/www/html/wp-includes/formatting.php on line 2697',
-		'PHP Deprecated:  Function get_magic_quotes_gpc() is deprecated in /var/www/html/wp-includes/formatting.php on line 4803',
-		'PHP Deprecated:  Array and string offset access syntax with curly braces is deprecated in /var/www/html/wp-includes/class-wp-editor.php on line 749',
-		'PHP Deprecated:  Array and string offset access syntax with curly braces is deprecated in /var/www/html/wp-includes/class-wp-editor.php on line 750',
-		'PHP Deprecated:  implode(): Passing glue string after array is deprecated. Swap the parameters in /var/www/html/wp-includes/SimplePie/Parse/Date.php on line 545',
-		'PHP Deprecated:  implode(): Passing glue string after array is deprecated. Swap the parameters in /var/www/html/wp-includes/SimplePie/Parse/Date.php on line 546',
+		'PHP Deprecated:  Function get_magic_quotes_gpc() is deprecated in /var/www/html/wp-includes/load.php on line',
+		'PHP Deprecated:  Function get_magic_quotes_gpc() is deprecated in /var/www/html/wp-includes/formatting.php on line',
+		'PHP Deprecated:  Array and string offset access syntax with curly braces is deprecated in /var/www/html/wp-includes/class-wp-editor.php on line',
+		'PHP Deprecated:  implode(): Passing glue string after array is deprecated. Swap the parameters in /var/www/html/wp-includes/SimplePie/Parse/Date.php on line',
 
 		// These are guarded against in later WP versions.
-		'PHP Notice:  Trying to access array offset on value of type bool in /var/www/html/wp-admin/includes/update.php on line 673',
-		'PHP Notice:  Trying to access array offset on value of type null in /var/www/html/wp-includes/rest-api/class-wp-rest-request.php on line 337',
-		'PHP Notice:  Trying to access array offset on value of type bool in /var/www/html/wp-includes/theme.php on line 2360',
+		'PHP Notice:  Trying to access array offset on value of type bool in /var/www/html/wp-admin/includes/update.php on line',
+		'PHP Notice:  Trying to access array offset on value of type null in /var/www/html/wp-includes/rest-api/class-wp-rest-request.php on line',
+		'PHP Notice:  Trying to access array offset on value of type bool in /var/www/html/wp-includes/theme.php on line',
 	],
 	nightly: [
-		// Can be removed once WordPress AMP Plugin removes the deprecated function
-		// call.
-		//
+		// Can be removed once WordPress AMP Plugin removes the deprecated function call.
 		// See: https://github.com/ampproject/amp-wp/issues/7619
-		'PHP Deprecated:  Function _admin_bar_bump_cb is deprecated since version 6.4.0! Use wp_enqueue_admin_bar_bump_styles instead. in /var/www/html/wp-includes/functions.php on line 6032',
+		'PHP Deprecated:  Function _admin_bar_bump_cb is deprecated since version 6.4.0! Use wp_enqueue_admin_bar_bump_styles instead. in /var/www/html/wp-includes/functions.php',
 	],
 };

--- a/tests/e2e/config/wordpress-debug-log/log-ignore-list.js
+++ b/tests/e2e/config/wordpress-debug-log/log-ignore-list.js
@@ -6,15 +6,15 @@
 export const logIgnoreList = {
 	'5.2.16': [
 		// Deprecated syntax or function calls which are fixed in later WP versions.
-		'PHP Deprecated:  Function get_magic_quotes_gpc() is deprecated in /var/www/html/wp-includes/load.php on line',
-		'PHP Deprecated:  Function get_magic_quotes_gpc() is deprecated in /var/www/html/wp-includes/formatting.php on line',
-		'PHP Deprecated:  Array and string offset access syntax with curly braces is deprecated in /var/www/html/wp-includes/class-wp-editor.php on line',
-		'PHP Deprecated:  implode(): Passing glue string after array is deprecated. Swap the parameters in /var/www/html/wp-includes/SimplePie/Parse/Date.php on line',
+		'PHP Deprecated:  Function get_magic_quotes_gpc() is deprecated in /var/www/html/wp-includes/load.php',
+		'PHP Deprecated:  Function get_magic_quotes_gpc() is deprecated in /var/www/html/wp-includes/formatting.php',
+		'PHP Deprecated:  Array and string offset access syntax with curly braces is deprecated in /var/www/html/wp-includes/class-wp-editor.php',
+		'PHP Deprecated:  implode(): Passing glue string after array is deprecated. Swap the parameters in /var/www/html/wp-includes/SimplePie/Parse/Date.php',
 
 		// These are guarded against in later WP versions.
-		'PHP Notice:  Trying to access array offset on value of type bool in /var/www/html/wp-admin/includes/update.php on line',
-		'PHP Notice:  Trying to access array offset on value of type null in /var/www/html/wp-includes/rest-api/class-wp-rest-request.php on line',
-		'PHP Notice:  Trying to access array offset on value of type bool in /var/www/html/wp-includes/theme.php on line',
+		'PHP Notice:  Trying to access array offset on value of type bool in /var/www/html/wp-admin/includes/update.php',
+		'PHP Notice:  Trying to access array offset on value of type null in /var/www/html/wp-includes/rest-api/class-wp-rest-request.php',
+		'PHP Notice:  Trying to access array offset on value of type bool in /var/www/html/wp-includes/theme.php',
 	],
 	nightly: [
 		// Can be removed once WordPress AMP Plugin removes the deprecated function call.


### PR DESCRIPTION
## Summary

Follow up

Addresses issue:

- #7632 

## Relevant technical choices

This PR updates the ignore/allow-list functionality of our PHP Error/notice checks in E2E to make them less fragile due to insignificant differences in the message logged – specifically which line in the source code it was triggered from. Without this, a single line change difference in the source where a message is triggered will cause the message to not be ignored when it should.

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
