### PR TITLE
Enhance/#7598 - Fix failing E2E tests (follow-up)

### DIFF
--- a/includes/Modules/Analytics_4/Settings.php
+++ b/includes/Modules/Analytics_4/Settings.php
@@ -93,26 +93,21 @@ class Settings extends Module_Settings implements Setting_With_Owned_Keys_Interf
 	 * @return array
 	 */
 	protected function get_default() {
-		$options = array(
-			'ownerID'                 => 0,
+		return array(
+			'ownerID'                   => 0,
 			// TODO: These can be uncommented when Analytics and Analytics 4 modules are officially separated.
-			/* 'accountID'            => '', */ // phpcs:ignore Squiz.PHP.CommentedOutCode.Found
-			/* 'adsConversionID'      => '', */ // phpcs:ignore Squiz.PHP.CommentedOutCode.Found
-			'propertyID'              => '',
-			'webDataStreamID'         => '',
-			'measurementID'           => '',
-			'useSnippet'              => true,
-			'googleTagID'             => '',
-			'googleTagAccountID'      => '',
-			'googleTagContainerID'    => '',
-			'googleTagLastSyncedAtMs' => 0,
+			/* 'accountID'              => '', */ // phpcs:ignore Squiz.PHP.CommentedOutCode.Found
+			/* 'adsConversionID'        => '', */ // phpcs:ignore Squiz.PHP.CommentedOutCode.Found
+			'propertyID'                => '',
+			'webDataStreamID'           => '',
+			'measurementID'             => '',
+			'useSnippet'                => true,
+			'googleTagID'               => '',
+			'googleTagAccountID'        => '',
+			'googleTagContainerID'      => '',
+			'googleTagLastSyncedAtMs'   => 0,
+			'availableCustomDimensions' => null,
 		);
-
-		if ( Feature_Flags::enabled( 'newsKeyMetrics' ) ) {
-			$options['availableCustomDimensions'] = null;
-		}
-
-		return $options;
 	}
 
 	/**

--- a/tests/phpunit/integration/Modules/Analytics_4/SettingsTest.php
+++ b/tests/phpunit/integration/Modules/Analytics_4/SettingsTest.php
@@ -66,29 +66,6 @@ class SettingsTest extends SettingsTestCase {
 		$this->assertEqualSetsWithIndex(
 			array(
 				// TODO: These can be uncommented when Analytics and Analytics 4 modules are officially separated.
-				// 'accountID'       => '',
-				// 'adsConversionID' => '',
-				'propertyID'              => '',
-				'webDataStreamID'         => '',
-				'measurementID'           => '',
-				'useSnippet'              => true,
-				'ownerID'                 => 0,
-				'googleTagID'             => '',
-				'googleTagAccountID'      => '',
-				'googleTagContainerID'    => '',
-				'googleTagLastSyncedAtMs' => 0,
-			),
-			get_option( Settings::OPTION )
-		);
-	}
-
-	public function test_get_default__news_key_metrics() {
-		$this->enable_feature( 'newsKeyMetrics' );
-		$this->settings->register();
-
-		$this->assertEqualSetsWithIndex(
-			array(
-				// TODO: These can be uncommented when Analytics and Analytics 4 modules are officially separated.
 				// 'accountID'              => '',
 				// 'adsConversionID'        => '',
 				'propertyID'                => '',

--- a/tests/phpunit/integration/Modules/Analytics_4Test.php
+++ b/tests/phpunit/integration/Modules/Analytics_4Test.php
@@ -291,16 +291,17 @@ class Analytics_4Test extends TestCase {
 
 		$this->assertEqualSetsWithIndex(
 			array(
-				'accountID'               => $account_id,
-				'propertyID'              => '',
-				'webDataStreamID'         => '',
-				'measurementID'           => '',
-				'ownerID'                 => 0,
-				'useSnippet'              => true,
-				'googleTagID'             => '',
-				'googleTagAccountID'      => '',
-				'googleTagContainerID'    => '',
-				'googleTagLastSyncedAtMs' => 0,
+				'accountID'                 => $account_id,
+				'propertyID'                => '',
+				'webDataStreamID'           => '',
+				'measurementID'             => '',
+				'ownerID'                   => 0,
+				'useSnippet'                => true,
+				'googleTagID'               => '',
+				'googleTagAccountID'        => '',
+				'googleTagContainerID'      => '',
+				'googleTagLastSyncedAtMs'   => 0,
+				'availableCustomDimensions' => null,
 			),
 			$options->get( Settings::OPTION )
 		);
@@ -309,16 +310,17 @@ class Analytics_4Test extends TestCase {
 
 		$this->assertEqualSetsWithIndex(
 			array(
-				'accountID'               => $account_id,
-				'propertyID'              => $property_id,
-				'webDataStreamID'         => $webdatastream_id,
-				'measurementID'           => $measurement_id,
-				'ownerID'                 => 0,
-				'useSnippet'              => true,
-				'googleTagID'             => 'GT-123',
-				'googleTagAccountID'      => $google_tag_account_id,
-				'googleTagContainerID'    => $google_tag_container_id,
-				'googleTagLastSyncedAtMs' => 0,
+				'accountID'                 => $account_id,
+				'propertyID'                => $property_id,
+				'webDataStreamID'           => $webdatastream_id,
+				'measurementID'             => $measurement_id,
+				'ownerID'                   => 0,
+				'useSnippet'                => true,
+				'googleTagID'               => 'GT-123',
+				'googleTagAccountID'        => $google_tag_account_id,
+				'googleTagContainerID'      => $google_tag_container_id,
+				'googleTagLastSyncedAtMs'   => 0,
+				'availableCustomDimensions' => null,
 			),
 			$options->get( Settings::OPTION )
 		);
@@ -424,16 +426,17 @@ class Analytics_4Test extends TestCase {
 
 		$this->assertEqualSetsWithIndex(
 			array(
-				'accountID'               => $account_id,
-				'propertyID'              => '',
-				'webDataStreamID'         => '',
-				'measurementID'           => '',
-				'ownerID'                 => 0,
-				'useSnippet'              => true,
-				'googleTagID'             => '',
-				'googleTagAccountID'      => '',
-				'googleTagContainerID'    => '',
-				'googleTagLastSyncedAtMs' => 0,
+				'accountID'                 => $account_id,
+				'propertyID'                => '',
+				'webDataStreamID'           => '',
+				'measurementID'             => '',
+				'ownerID'                   => 0,
+				'useSnippet'                => true,
+				'googleTagID'               => '',
+				'googleTagAccountID'        => '',
+				'googleTagContainerID'      => '',
+				'googleTagLastSyncedAtMs'   => 0,
+				'availableCustomDimensions' => null,
 			),
 			$options->get( Settings::OPTION )
 		);
@@ -537,16 +540,17 @@ class Analytics_4Test extends TestCase {
 
 		$this->assertEqualSetsWithIndex(
 			array(
-				'accountID'               => $account_id,
-				'propertyID'              => '',
-				'webDataStreamID'         => '',
-				'measurementID'           => '',
-				'ownerID'                 => 0,
-				'useSnippet'              => true,
-				'googleTagID'             => '',
-				'googleTagAccountID'      => '',
-				'googleTagContainerID'    => '',
-				'googleTagLastSyncedAtMs' => 0,
+				'accountID'                 => $account_id,
+				'propertyID'                => '',
+				'webDataStreamID'           => '',
+				'measurementID'             => '',
+				'ownerID'                   => 0,
+				'useSnippet'                => true,
+				'googleTagID'               => '',
+				'googleTagAccountID'        => '',
+				'googleTagContainerID'      => '',
+				'googleTagLastSyncedAtMs'   => 0,
+				'availableCustomDimensions' => null,
 			),
 			$options->get( Settings::OPTION )
 		);
@@ -557,16 +561,17 @@ class Analytics_4Test extends TestCase {
 
 		$this->assertEqualSetsWithIndex(
 			array(
-				'accountID'               => $account_id,
-				'propertyID'              => $property_id,
-				'webDataStreamID'         => $webdatastream_id,
-				'measurementID'           => $measurement_id,
-				'ownerID'                 => 0,
-				'useSnippet'              => true,
-				'googleTagID'             => '',
-				'googleTagAccountID'      => '',
-				'googleTagContainerID'    => '',
-				'googleTagLastSyncedAtMs' => 0,
+				'accountID'                 => $account_id,
+				'propertyID'                => $property_id,
+				'webDataStreamID'           => $webdatastream_id,
+				'measurementID'             => $measurement_id,
+				'ownerID'                   => 0,
+				'useSnippet'                => true,
+				'googleTagID'               => '',
+				'googleTagAccountID'        => '',
+				'googleTagContainerID'      => '',
+				'googleTagLastSyncedAtMs'   => 0,
+				'availableCustomDimensions' => null,
 			),
 			$options->get( Settings::OPTION )
 		);


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #7598 

## Relevant technical choices

- This follow-up PR addresses the e2e test failures from conditionally setting the `availableCustomDimensions` option when the `newsKeyMetrics` feature flag is enabled.
- Made setting the `availableCustomDimensions` default value unconditional to maintain consistency and prevent e2e test failures.

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
