### PR TITLE
Ensure all categories are strings before formatting.

### DIFF
--- a/assets/js/modules/analytics-4/components/widgets/TopCategoriesWidget.js
+++ b/assets/js/modules/analytics-4/components/widgets/TopCategoriesWidget.js
@@ -96,9 +96,13 @@ function TopCategoriesWidget( { Widget } ) {
 			field: 'dimensionValues',
 			Component: ( { fieldValue } ) => {
 				const [ categories ] = fieldValue;
+				let categoriesList = JSON.parse( categories.value );
+				if ( ! Array.isArray( categoriesList ) ) {
+					categoriesList = [];
+				}
 				const categoriesString = listFormat(
 					// All values _must_ be a string or format will throw an error.
-					JSON.parse( categories.value ).map( String ),
+					categoriesList.map( String ),
 					{ style: 'narrow' }
 				);
 

--- a/assets/js/modules/analytics-4/components/widgets/TopCategoriesWidget.js
+++ b/assets/js/modules/analytics-4/components/widgets/TopCategoriesWidget.js
@@ -97,7 +97,8 @@ function TopCategoriesWidget( { Widget } ) {
 			Component: ( { fieldValue } ) => {
 				const [ categories ] = fieldValue;
 				const categoriesString = listFormat(
-					JSON.parse( categories.value ),
+					// All values _must_ be a string or format will throw an error.
+					JSON.parse( categories.value ).map( String ),
 					{ style: 'narrow' }
 				);
 


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #7607

## Relevant technical choices

- Fixes a bug introduced in CR feedback remediation where a category ID as a non-string would cause an error to be thrown

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [ ] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
