### PR TITLE
Fix infinite loop in `withCustomDimensions` HOC

### DIFF
--- a/assets/js/modules/analytics-4/utils/custom-dimensions.js
+++ b/assets/js/modules/analytics-4/utils/custom-dimensions.js
@@ -42,3 +42,18 @@ export const provideCustomDimensionError = (
 		.dispatch( MODULES_ANALYTICS_4 )
 		.receiveError( error, 'createCustomDimension', options );
 };
+
+/**
+ * Checks whether the given error is an invalid custom dimension error.
+ *
+ * @since n.e.x.t
+ *
+ * @param {Object} error Error object instance.
+ * @return {boolean} `true` if it is an invalid custom dimension error, otherwise `false`.
+ */
+export function isInvalidCustomDimensionError( error ) {
+	return (
+		error?.code === 400 &&
+		error?.message?.includes( 'is not a valid dimension' )
+	);
+}

--- a/assets/js/modules/analytics-4/utils/withCustomDimensions.js
+++ b/assets/js/modules/analytics-4/utils/withCustomDimensions.js
@@ -54,6 +54,7 @@ import {
 	ERROR_CODE_MISSING_REQUIRED_SCOPE,
 	isInsufficientPermissionsError,
 } from '../../../util/errors';
+import { isInvalidCustomDimensionError } from './custom-dimensions';
 const { useSelect, useDispatch } = Data;
 
 export default function withCustomDimensions( options = {} ) {
@@ -235,7 +236,7 @@ export default function withCustomDimensions( options = {} ) {
 			useEffect( () => {
 				if (
 					! customDimensions ||
-					reportError?.data?.reason !== 'badRequest' ||
+					! isInvalidCustomDimensionError( reportError ) ||
 					isSyncingAvailableCustomDimensions
 				) {
 					return;
@@ -256,7 +257,7 @@ export default function withCustomDimensions( options = {} ) {
 				fetchSyncAvailableCustomDimensions,
 				invalidateResolution,
 				isSyncingAvailableCustomDimensions,
-				reportError?.data?.reason,
+				reportError,
 				reportOptions,
 			] );
 


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #7601 

## Relevant technical choices

We currently use an `error.reason` of `badRequest` to determine if a report request was made with unavailable custom dimensions, and use that to sync the list of available custom dimensions. `badRequest` is a very generic error and has a high potential to create an infinite loop. This PR solves that by checking for a specific error message that occurs due to invalid custom dimensions.

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
