### PR TITLE
Show partial field data in PSI widget

### DIFF
--- a/assets/js/components/InfoTooltip.js
+++ b/assets/js/components/InfoTooltip.js
@@ -25,7 +25,7 @@ import PropTypes from 'prop-types';
  * Internal dependencies
  */
 import { Tooltip } from 'googlesitekit-components';
-import InfoIcon from '../../../svg/icons/info-green.svg';
+import InfoIcon from '../../svg/icons/info-green.svg';
 
 export default function InfoTooltip( { title } ) {
 	if ( ! title ) {
@@ -34,7 +34,8 @@ export default function InfoTooltip( { title } ) {
 
 	return (
 		<Tooltip
-			tooltipClassName="googlesitekit-km-widget-tile-title__tooltip"
+			className="googlesitekit-info-tooltip"
+			tooltipClassName="googlesitekit-info-tooltip__content"
 			title={ title }
 			placement="top"
 			enterTouchDelay={ 0 }

--- a/assets/js/components/KeyMetrics/MetricTileHeader.js
+++ b/assets/js/components/KeyMetrics/MetricTileHeader.js
@@ -24,7 +24,7 @@ import PropTypes from 'prop-types';
 /**
  * Internal dependencies
  */
-import InfoTooltip from './InfoTooltip';
+import InfoTooltip from '../InfoTooltip';
 
 export default function MetricTileHeader( { title, infoTooltip } ) {
 	return (

--- a/assets/js/modules/analytics-4/components/widgets/__snapshots__/TopCategoriesWidget.test.js.snap
+++ b/assets/js/modules/analytics-4/components/widgets/__snapshots__/TopCategoriesWidget.test.js.snap
@@ -20,7 +20,7 @@ exports[`TopCategoriesWidget renders correctly with the expected metrics 1`] = `
             Top categories by pageviews
           </h3>
           <span
-            class=""
+            class="googlesitekit-info-tooltip"
             title="Categories that your site visitors viewed the most"
           >
             <svg />

--- a/assets/js/modules/analytics-4/components/widgets/__snapshots__/TopCitiesWidget.test.js.snap
+++ b/assets/js/modules/analytics-4/components/widgets/__snapshots__/TopCitiesWidget.test.js.snap
@@ -20,7 +20,7 @@ exports[`TopCitiesWidget renders correctly with the expected metrics 1`] = `
             Top cities driving traffic
           </h3>
           <span
-            class=""
+            class="googlesitekit-info-tooltip"
             title="The cities where most of your visitors came from"
           >
             <svg />

--- a/assets/js/modules/analytics-4/components/widgets/__snapshots__/TopConvertingTrafficSourceWidget.test.js.snap
+++ b/assets/js/modules/analytics-4/components/widgets/__snapshots__/TopConvertingTrafficSourceWidget.test.js.snap
@@ -20,7 +20,7 @@ exports[`TopConvertingTrafficSourceWidget renders correctly with the expected me
             Top converting traffic source
           </h3>
           <span
-            class=""
+            class="googlesitekit-info-tooltip"
             title="Channel (e.g. social, paid, search) that brought in visitors who generated the most conversions"
           >
             <svg />

--- a/assets/js/modules/analytics-4/components/widgets/__snapshots__/TopCountriesWidget.test.js.snap
+++ b/assets/js/modules/analytics-4/components/widgets/__snapshots__/TopCountriesWidget.test.js.snap
@@ -20,7 +20,7 @@ exports[`TopCountriesWidget renders correctly with the expected metrics 1`] = `
             Top countries driving traffic
           </h3>
           <span
-            class=""
+            class="googlesitekit-info-tooltip"
             title="The countries where most of your visitors came from"
           >
             <svg />

--- a/assets/js/modules/analytics-4/components/widgets/__snapshots__/TopTrafficSourceWidget.test.js.snap
+++ b/assets/js/modules/analytics-4/components/widgets/__snapshots__/TopTrafficSourceWidget.test.js.snap
@@ -20,7 +20,7 @@ exports[`TopTrafficSourceWidget renders correctly with the expected metrics 1`] 
             Top traffic source
           </h3>
           <span
-            class=""
+            class="googlesitekit-info-tooltip"
             title="Channel (e.g. social, paid, search) that brought in the most visitors to your site"
           >
             <svg />
@@ -72,7 +72,7 @@ exports[`TopTrafficSourceWidget retries both reports when an error is encountere
           Top traffic source
         </h2>
         <span
-          class=""
+          class="googlesitekit-info-tooltip"
           title="Channel (e.g. social, paid, search) that brought in the most visitors to your site"
         >
           <svg />
@@ -140,7 +140,7 @@ exports[`TopTrafficSourceWidget retries both reports when an error is encountere
             Top traffic source
           </h3>
           <span
-            class=""
+            class="googlesitekit-info-tooltip"
             title="Channel (e.g. social, paid, search) that brought in the most visitors to your site"
           >
             <svg />

--- a/assets/js/modules/pagespeed-insights/components/common/FieldReportMetrics.js
+++ b/assets/js/modules/pagespeed-insights/components/common/FieldReportMetrics.js
@@ -137,6 +137,7 @@ export default function FieldReportMetrics( { data, error } ) {
 							lcpSeconds
 						) }
 						category={ largestContentfulPaint.category }
+						isUnavailable={ ! largestContentfulPaint }
 					/>
 					<ReportMetric
 						title={ _x(
@@ -150,6 +151,7 @@ export default function FieldReportMetrics( { data, error } ) {
 						) }
 						displayValue={ cls }
 						category={ cumulativeLayoutShift.category }
+						isUnavailable={ ! cumulativeLayoutShift }
 					/>
 					<ReportMetric
 						title={ _x(
@@ -167,6 +169,7 @@ export default function FieldReportMetrics( { data, error } ) {
 							firstInputDelay.percentile
 						) }
 						category={ firstInputDelay.category }
+						isUnavailable={ ! firstInputDelay }
 					/>
 					<ReportMetric
 						title={ _x(
@@ -187,6 +190,7 @@ export default function FieldReportMetrics( { data, error } ) {
 							interactionToNextPaint?.category || CATEGORY_AVERAGE
 						}
 						isLast
+						isUnavailable={ ! interactionToNextPaint }
 					/>
 				</tbody>
 			</table>

--- a/assets/js/modules/pagespeed-insights/components/common/FieldReportMetrics.js
+++ b/assets/js/modules/pagespeed-insights/components/common/FieldReportMetrics.js
@@ -88,10 +88,10 @@ export default function FieldReportMetrics( { data, error } ) {
 
 	// Convert milliseconds to seconds with 1 fraction digit.
 	const lcpSeconds = (
-		Math.round( largestContentfulPaint.percentile / 100 ) / 10
+		Math.round( largestContentfulPaint?.percentile / 100 ) / 10
 	).toFixed( 1 );
 	// Convert 2 digit score to a decimal between 0 and 1, with 2 fraction digits.
-	const cls = ( cumulativeLayoutShift.percentile / 100 ).toFixed( 2 );
+	const cls = ( cumulativeLayoutShift?.percentile / 100 ).toFixed( 2 );
 
 	return (
 		<div className="googlesitekit-pagespeed-insights-web-vitals-metrics">
@@ -136,7 +136,7 @@ export default function FieldReportMetrics( { data, error } ) {
 							_x( '%s s', 'duration', 'google-site-kit' ),
 							lcpSeconds
 						) }
-						category={ largestContentfulPaint.category }
+						category={ largestContentfulPaint?.category }
 						isUnavailable={ ! largestContentfulPaint }
 					/>
 					<ReportMetric
@@ -150,7 +150,7 @@ export default function FieldReportMetrics( { data, error } ) {
 							'google-site-kit'
 						) }
 						displayValue={ cls }
-						category={ cumulativeLayoutShift.category }
+						category={ cumulativeLayoutShift?.category }
 						isUnavailable={ ! cumulativeLayoutShift }
 					/>
 					<ReportMetric
@@ -166,9 +166,9 @@ export default function FieldReportMetrics( { data, error } ) {
 						displayValue={ sprintf(
 							/* translators: %s: number of milliseconds */
 							_x( '%s ms', 'duration', 'google-site-kit' ),
-							firstInputDelay.percentile
+							firstInputDelay?.percentile
 						) }
-						category={ firstInputDelay.category }
+						category={ firstInputDelay?.category }
 						isUnavailable={ ! firstInputDelay }
 					/>
 					<ReportMetric

--- a/assets/js/modules/pagespeed-insights/components/common/FieldReportMetrics.js
+++ b/assets/js/modules/pagespeed-insights/components/common/FieldReportMetrics.js
@@ -64,9 +64,10 @@ export default function FieldReportMetrics( { data, error } ) {
 	}
 
 	if (
-		! largestContentfulPaint ||
-		! cumulativeLayoutShift ||
-		! firstInputDelay
+		! largestContentfulPaint &&
+		! cumulativeLayoutShift &&
+		! firstInputDelay &&
+		! interactionToNextPaint
 	) {
 		return (
 			<div className="googlesitekit-pagespeed-insights-web-vitals-metrics googlesitekit-pagespeed-insights-web-vitals-metrics--field-data-unavailable">

--- a/assets/js/modules/pagespeed-insights/components/common/ReportMetric.js
+++ b/assets/js/modules/pagespeed-insights/components/common/ReportMetric.js
@@ -36,6 +36,7 @@ import {
 	CATEGORY_SLOW,
 } from '../../util/constants';
 import Badge from '../../../../components/Badge';
+import InfoTooltip from '../../../../components/InfoTooltip';
 
 export default function ReportMetric( {
 	title,
@@ -45,6 +46,7 @@ export default function ReportMetric( {
 	experimental,
 	isLast,
 	isHidden,
+	isUnavailable,
 } ) {
 	// Normalize the category case.
 	category = category.toLowerCase();
@@ -57,6 +59,8 @@ export default function ReportMetric( {
 				{
 					'googlesitekit-pagespeed-report__row--last': isLast,
 					'googlesitekit-pagespeed-report__row--hidden': isHidden,
+					'googlesitekit-pagespeed-report__row--unavailable':
+						isUnavailable,
 				}
 			) }
 		>
@@ -67,6 +71,14 @@ export default function ReportMetric( {
 						<Badge
 							label={ __( 'Experimental', 'google-site-kit' ) }
 							className="googlesitekit-pagespeed-report-metric__badge"
+						/>
+					) }
+					{ isUnavailable && (
+						<InfoTooltip
+							title={ __(
+								'Field data is still being gathered for this metric and will become available once your site gets sufficient traffic.',
+								'google-site-kit'
+							) }
 						/>
 					) }
 				</div>
@@ -80,10 +92,15 @@ export default function ReportMetric( {
 			>
 				<div className="googlesitekit-pagespeed-report-metric-value-container">
 					<div className="googlesitekit-pagespeed-report-metric-value__display-value">
-						{ displayValue }
+						{ isUnavailable ? '—' : displayValue }
 					</div>
 					<div className="googlesitekit-pagespeed-report-metric-value__rating">
-						{ category === CATEGORY_FAST && (
+						{ isUnavailable && (
+							<span>
+								{ __( 'gathering data', 'google-site-kit' ) }
+							</span>
+						) }
+						{ ! isUnavailable && category === CATEGORY_FAST && (
 							<span>
 								{ _x(
 									'Good',
@@ -92,7 +109,7 @@ export default function ReportMetric( {
 								) }
 							</span>
 						) }
-						{ category === CATEGORY_AVERAGE && (
+						{ ! isUnavailable && category === CATEGORY_AVERAGE && (
 							<span>
 								{ _x(
 									'Needs improvement',
@@ -101,7 +118,7 @@ export default function ReportMetric( {
 								) }
 							</span>
 						) }
-						{ category === CATEGORY_SLOW && (
+						{ ! isUnavailable && category === CATEGORY_SLOW && (
 							<span>
 								{ _x(
 									'Poor',

--- a/assets/js/modules/pagespeed-insights/components/common/ReportMetric.js
+++ b/assets/js/modules/pagespeed-insights/components/common/ReportMetric.js
@@ -49,7 +49,7 @@ export default function ReportMetric( {
 	isUnavailable,
 } ) {
 	// Normalize the category case.
-	category = category.toLowerCase();
+	category = category?.toLowerCase();
 
 	return (
 		<tr
@@ -88,7 +88,13 @@ export default function ReportMetric( {
 			</td>
 
 			<td
-				className={ `googlesitekit-pagespeed-report-metric-value googlesitekit-pagespeed-report-metric--${ category }` }
+				className={ classnames(
+					'googlesitekit-pagespeed-report-metric-value',
+					{
+						[ `googlesitekit-pagespeed-report-metric--${ category }` ]:
+							!! category,
+					}
+				) }
 			>
 				<div className="googlesitekit-pagespeed-report-metric-value-container">
 					<div className="googlesitekit-pagespeed-report-metric-value__display-value">
@@ -138,7 +144,7 @@ ReportMetric.propTypes = {
 	title: PropTypes.string.isRequired,
 	description: PropTypes.string.isRequired,
 	displayValue: PropTypes.string.isRequired,
-	category: PropTypes.string.isRequired,
+	category: PropTypes.string,
 	experimental: PropTypes.bool,
 	isLast: PropTypes.bool,
 	isHidden: PropTypes.bool,

--- a/assets/js/modules/pagespeed-insights/components/dashboard/DashboardPageSpeedWidget.stories.js
+++ b/assets/js/modules/pagespeed-insights/components/dashboard/DashboardPageSpeedWidget.stories.js
@@ -181,6 +181,37 @@ NoRecommendations.args = {
 	},
 };
 
+export const PartialFieldData = Template.bind( {} );
+PartialFieldData.storyName = 'Partial Field Data Available';
+PartialFieldData.args = {
+	setupRegistry: ( registry ) => {
+		const { dispatch } = registry;
+		dispatch( MODULES_PAGESPEED_INSIGHTS ).receiveGetReport(
+			fixtures.pagespeedMobilePartialFieldData,
+			{
+				url,
+				strategy: STRATEGY_MOBILE,
+			}
+		);
+		dispatch( MODULES_PAGESPEED_INSIGHTS ).finishResolution( 'getReport', [
+			url,
+			STRATEGY_MOBILE,
+		] );
+
+		dispatch( MODULES_PAGESPEED_INSIGHTS ).receiveGetReport(
+			fixtures.pagespeedDesktopPartialFieldData,
+			{
+				url,
+				strategy: STRATEGY_DESKTOP,
+			}
+		);
+		dispatch( MODULES_PAGESPEED_INSIGHTS ).finishResolution( 'getReport', [
+			url,
+			STRATEGY_DESKTOP,
+		] );
+	},
+};
+
 export const FieldDataUnavailable = Template.bind( {} );
 FieldDataUnavailable.storyName = 'Field Data Unavailable';
 FieldDataUnavailable.args = {

--- a/assets/js/modules/pagespeed-insights/datastore/__fixtures__/index.js
+++ b/assets/js/modules/pagespeed-insights/datastore/__fixtures__/index.js
@@ -50,6 +50,16 @@ const pagespeedMobileNoFieldDataNoStackPacks = omit(
 	pagespeedMobileNoFieldData,
 	'lighthouseResult.stackPacks'
 );
+const pagespeedDesktopPartialFieldData = omit( pagespeedDesktop, [
+	'loadingExperience.metrics.LARGEST_CONTENTFUL_PAINT_MS',
+	'loadingExperience.metrics.CUMULATIVE_LAYOUT_SHIFT_SCORE',
+	'loadingExperience.metrics.FIRST_INPUT_DELAY_MS',
+] );
+const pagespeedMobilePartialFieldData = omit( pagespeedMobile, [
+	'loadingExperience.metrics.LARGEST_CONTENTFUL_PAINT_MS',
+	'loadingExperience.metrics.CUMULATIVE_LAYOUT_SHIFT_SCORE',
+	'loadingExperience.metrics.FIRST_INPUT_DELAY_MS',
+] );
 
 export {
 	pagespeedDesktop,
@@ -60,4 +70,6 @@ export {
 	pagespeedMobileNoFieldData,
 	pagespeedMobileNoStackPacks,
 	pagespeedMobileNoFieldDataNoStackPacks,
+	pagespeedDesktopPartialFieldData,
+	pagespeedMobilePartialFieldData,
 };

--- a/assets/sass/admin.scss
+++ b/assets/sass/admin.scss
@@ -106,6 +106,7 @@
 @import "components/global/googlesitekit-header";
 @import "components/global/googlesitekit-help-menu-link";
 @import "components/global/googlesitekit-image-radio";
+@import "components/global/googlesitekit-info-tooltip";
 @import "components/global/googlesitekit-layout";
 @import "components/global/googlesitekit-logo";
 @import "components/global/googlesitekit-mini-chart";

--- a/assets/sass/components/dashboard/_googlesitekit-ReportMetric.scss
+++ b/assets/sass/components/dashboard/_googlesitekit-ReportMetric.scss
@@ -57,15 +57,30 @@
 }
 
 .googlesitekit-pagespeed-report-metric__title {
+	align-items: center;
 	color: $c-surfaces-on-surface;
+	column-gap: $grid-gap-phone / 2;
+	display: flex;
 	font-family: $f-secondary;
 	font-size: $fs-title-md;
 	font-weight: $fw-bold;
 	letter-spacing: 0.1px;
 	line-height: $lh-title-md;
+
+	.googlesitekit-info-tooltip {
+		display: inline-flex;
+	}
 }
 
 .googlesitekit-pagespeed-report-metric__badge {
 	margin-left: 6px;
 	vertical-align: bottom;
+}
+
+.googlesitekit-pagespeed-report__row--unavailable {
+	.googlesitekit-pagespeed-report-metric__title,
+	.googlesitekit-pagespeed-report-metric__description,
+	.googlesitekit-pagespeed-report-metric-value {
+		color: $c-jumbo;
+	}
 }

--- a/assets/sass/components/global/_googlesitekit-info-tooltip.scss
+++ b/assets/sass/components/global/_googlesitekit-info-tooltip.scss
@@ -1,5 +1,5 @@
 /**
- * MetricTileError component.
+ * InfoTooltip styles.
  *
  * Site Kit by Google, Copyright 2023 Google LLC
  *
@@ -16,28 +16,21 @@
  * limitations under the License.
  */
 
-/**
- * Internal dependencies
- */
-import CTA from '../notifications/CTA';
-import InfoTooltip from '../InfoTooltip';
+.googlesitekit-tooltip.MuiTooltip-tooltip.googlesitekit-info-tooltip__content {
+	border-radius: $br-xs;
+	font-family: $f-primary;
+	font-size: $fs-body-sm;
+	font-weight: $fw-normal;
+	letter-spacing: $ls-xs;
+	line-height: $lh-body-sm;
+	max-width: 160px;
+	padding: 12px;
 
-export default function MetricTileError( props ) {
-	const { children, headerText, infoTooltip, title } = props;
-
-	return (
-		<div className="googlesitekit-km-widget-tile--error">
-			<CTA
-				title={ title }
-				headerText={ headerText }
-				headerContent={
-					infoTooltip && <InfoTooltip title={ infoTooltip } />
-				}
-				description=""
-				error
-			>
-				{ children }
-			</CTA>
-		</div>
-	);
+	> button {
+		background: none;
+		border: none;
+		color: $c-surfaces-inverse-on-surface;
+		padding-right: 0;
+		text-decoration: underline;
+	}
 }

--- a/assets/sass/components/key-metrics/_googlesitekit-km-widget-tile.scss
+++ b/assets/sass/components/key-metrics/_googlesitekit-km-widget-tile.scss
@@ -16,25 +16,6 @@
  * limitations under the License.
  */
 
-.googlesitekit-tooltip.MuiTooltip-tooltip.googlesitekit-km-widget-tile-title__tooltip {
-	border-radius: $br-xs;
-	font-family: $f-primary;
-	font-size: $fs-body-sm;
-	font-weight: $fw-normal;
-	letter-spacing: $ls-xs;
-	line-height: $lh-body-sm;
-	max-width: 160px;
-	padding: 12px;
-
-	> button {
-		background: none;
-		border: none;
-		color: $c-surfaces-inverse-on-surface;
-		padding-right: 0;
-		text-decoration: underline;
-	}
-}
-
 .googlesitekit-plugin {
 
 	.googlesitekit-km-widget-tile {


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #7662 

## Relevant technical choices

This PR lets the PSI widget display partial field data.

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [x] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [x] Ensure the corresponding issue has a ZenHub release assigned.
- [x] Add a changelog message to the issue.
