### PR TITLE
Key Metrics HaTS survey triggers

### DIFF
--- a/assets/js/components/KeyMetrics/ChangeMetricsLink.js
+++ b/assets/js/components/KeyMetrics/ChangeMetricsLink.js
@@ -19,7 +19,7 @@
 /**
  * WordPress dependencies
  */
-import { useCallback } from '@wordpress/element';
+import { useCallback, Fragment } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -34,6 +34,7 @@ import PencilIcon from '../../../svg/icons/pencil-alt.svg';
 import { trackEvent } from '../../util';
 import useViewContext from '../../hooks/useViewContext';
 import { useChangeMetricsFeatureTourEffect } from './hooks/useChangeMetricsFeatureTourEffect';
+import SetupCompletedSurveyTrigger from './SetupCompletedSurveyTrigger';
 const { useSelect, useDispatch } = Data;
 
 export default function ChangeMetricsLink() {
@@ -59,13 +60,16 @@ export default function ChangeMetricsLink() {
 	}
 
 	return (
-		<Link
-			secondary
-			className="googlesitekit-km-change-metrics-cta"
-			onClick={ openMetricsSelectionPanel }
-		>
-			<PencilIcon width={ 22 } height={ 22 } />
-			{ __( 'Change Metrics', 'google-site-kit' ) }
-		</Link>
+		<Fragment>
+			<Link
+				secondary
+				className="googlesitekit-km-change-metrics-cta"
+				onClick={ openMetricsSelectionPanel }
+			>
+				<PencilIcon width={ 22 } height={ 22 } />
+				{ __( 'Change Metrics', 'google-site-kit' ) }
+			</Link>
+			<SetupCompletedSurveyTrigger />
+		</Fragment>
 	);
 }

--- a/assets/js/components/KeyMetrics/ChangeMetricsLink.js
+++ b/assets/js/components/KeyMetrics/ChangeMetricsLink.js
@@ -31,10 +31,10 @@ import { CORE_USER } from '../../googlesitekit/datastore/user/constants';
 import { KEY_METRICS_SELECTION_PANEL_OPENED_KEY } from './constants';
 import Link from '../Link';
 import PencilIcon from '../../../svg/icons/pencil-alt.svg';
+import SetupCompletedSurveyTrigger from './SetupCompletedSurveyTrigger';
 import { trackEvent } from '../../util';
 import useViewContext from '../../hooks/useViewContext';
 import { useChangeMetricsFeatureTourEffect } from './hooks/useChangeMetricsFeatureTourEffect';
-import SetupCompletedSurveyTrigger from './SetupCompletedSurveyTrigger';
 const { useSelect, useDispatch } = Data;
 
 export default function ChangeMetricsLink() {

--- a/assets/js/components/KeyMetrics/ChangeMetricsLink.test.js
+++ b/assets/js/components/KeyMetrics/ChangeMetricsLink.test.js
@@ -27,14 +27,14 @@ import {
 	render,
 	waitFor,
 } from '../../../../tests/js/test-utils';
-import { CORE_UI } from '../../googlesitekit/datastore/ui/constants';
-import { KEY_METRICS_SELECTION_PANEL_OPENED_KEY } from './constants';
-import ChangeMetricsLink from './ChangeMetricsLink';
 import {
 	mockSurveyEndpoints,
 	surveyTimeoutEndpoint,
 	surveyTriggerEndpoint,
 } from '../../../../tests/js/mock-survey-endpoints';
+import { CORE_UI } from '../../googlesitekit/datastore/ui/constants';
+import { KEY_METRICS_SELECTION_PANEL_OPENED_KEY } from './constants';
+import ChangeMetricsLink from './ChangeMetricsLink';
 
 describe( 'ChangeMetricsLink', () => {
 	let registry;

--- a/assets/js/components/KeyMetrics/ChangeMetricsLink.test.js
+++ b/assets/js/components/KeyMetrics/ChangeMetricsLink.test.js
@@ -30,7 +30,10 @@ import {
 import { CORE_UI } from '../../googlesitekit/datastore/ui/constants';
 import { KEY_METRICS_SELECTION_PANEL_OPENED_KEY } from './constants';
 import ChangeMetricsLink from './ChangeMetricsLink';
-import { mockSurveyEndpoints } from '../../../../tests/js/mock-survey-endpoints';
+import {
+	mockSurveyEndpoints,
+	surveyTriggerEndpoint,
+} from '../../../../tests/js/mock-survey-endpoints';
 
 describe( 'ChangeMetricsLink', () => {
 	let registry;
@@ -102,14 +105,9 @@ describe( 'ChangeMetricsLink', () => {
 		provideSiteInfo( registry, { keyMetricsSetupCompletedBy: 42 } );
 		provideUserInfo( registry, { id: 42 } );
 		provideUserAuthentication( registry );
-		mockSurveyEndpoints( registry );
+		mockSurveyEndpoints();
 
 		render( <ChangeMetricsLink />, { registry } );
-
-		// Should also trigger a survey view.
-		const surveyTriggerEndpoint = new RegExp(
-			'^/google-site-kit/v1/core/user/data/survey-trigger'
-		);
 
 		await waitFor( () =>
 			expect( fetchMock ).toHaveFetched( surveyTriggerEndpoint, {

--- a/assets/js/components/KeyMetrics/ChangeMetricsLink.test.js
+++ b/assets/js/components/KeyMetrics/ChangeMetricsLink.test.js
@@ -100,7 +100,7 @@ describe( 'ChangeMetricsLink', () => {
 		).toBe( true );
 	} );
 
-	it( 'should trigger a survey when the key metrics setup is compleyed by current user', async () => {
+	it( 'should trigger a survey when the key metrics setup is completed by current user', async () => {
 		provideKeyMetrics( registry, { widgetSlugs: [ 'metricA' ] } );
 		provideSiteInfo( registry, { keyMetricsSetupCompletedBy: 42 } );
 		provideUserInfo( registry, { id: 42 } );

--- a/assets/js/components/KeyMetrics/KeyMetricsCTAContent.js
+++ b/assets/js/components/KeyMetrics/KeyMetricsCTAContent.js
@@ -22,7 +22,6 @@
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { useEffect, useRef, useState } from '@wordpress/element';
-import { useIntersection } from 'react-use';
 
 /**
  * Internal dependencies
@@ -33,6 +32,7 @@ import { BREAKPOINT_SMALL, useBreakpoint } from '../../hooks/useBreakpoint';
 import useViewContext from '../../hooks/useViewContext';
 import { DAY_IN_SECONDS, trackEvent } from '../../util';
 import SurveyViewTrigger from '../surveys/SurveyViewTrigger';
+import { useInView } from '../../hooks/useInView';
 
 export default function KeyMetricsCTAContent( {
 	className,
@@ -44,13 +44,9 @@ export default function KeyMetricsCTAContent( {
 	const trackingRef = useRef();
 	const breakpoint = useBreakpoint();
 	const viewContext = useViewContext();
+	const inView = useInView();
 	const isMobileBreakpoint = breakpoint === BREAKPOINT_SMALL;
-
-	const intersectionEntry = useIntersection( trackingRef, {
-		threshold: 0.25,
-	} );
 	const [ hasBeenInView, setHasBeenInView ] = useState( false );
-	const inView = !! intersectionEntry?.intersectionRatio;
 	useEffect( () => {
 		if ( inView && ! hasBeenInView && ga4Connected ) {
 			trackEvent(

--- a/assets/js/components/KeyMetrics/KeyMetricsCTAContent.js
+++ b/assets/js/components/KeyMetrics/KeyMetricsCTAContent.js
@@ -28,10 +28,10 @@ import { useEffect, useRef, useState } from '@wordpress/element';
  */
 import { Cell, Grid, Row } from '../../material-components';
 import GhostCardsSVG from './GhostCards';
-import { BREAKPOINT_SMALL, useBreakpoint } from '../../hooks/useBreakpoint';
-import useViewContext from '../../hooks/useViewContext';
-import { DAY_IN_SECONDS, trackEvent } from '../../util';
 import SurveyViewTrigger from '../surveys/SurveyViewTrigger';
+import { BREAKPOINT_SMALL, useBreakpoint } from '../../hooks/useBreakpoint';
+import { DAY_IN_SECONDS, trackEvent } from '../../util';
+import useViewContext from '../../hooks/useViewContext';
 import { useInView } from '../../hooks/useInView';
 
 export default function KeyMetricsCTAContent( {

--- a/assets/js/components/KeyMetrics/KeyMetricsCTAContent.js
+++ b/assets/js/components/KeyMetrics/KeyMetricsCTAContent.js
@@ -35,9 +35,9 @@ import Data from 'googlesitekit-data';
 import { CORE_SITE } from '../../googlesitekit/datastore/site/constants';
 import { CORE_USER } from '../../googlesitekit/datastore/user/constants';
 import { BREAKPOINT_SMALL, useBreakpoint } from '../../hooks/useBreakpoint';
+import { DAY_IN_SECONDS, trackEvent } from '../../util';
 import useViewContext from '../../hooks/useViewContext';
 import { Cell, Grid, Row } from '../../material-components';
-import { DAY_IN_SECONDS, trackEvent } from '../../util';
 import GhostCardsSVG from './GhostCards';
 
 const { useDispatch, useSelect } = Data;

--- a/assets/js/components/KeyMetrics/KeyMetricsCTAContent.js
+++ b/assets/js/components/KeyMetrics/KeyMetricsCTAContent.js
@@ -31,7 +31,8 @@ import { Cell, Grid, Row } from '../../material-components';
 import GhostCardsSVG from './GhostCards';
 import { BREAKPOINT_SMALL, useBreakpoint } from '../../hooks/useBreakpoint';
 import useViewContext from '../../hooks/useViewContext';
-import { trackEvent } from '../../util';
+import { DAY_IN_SECONDS, trackEvent } from '../../util';
+import SurveyViewTrigger from '../surveys/SurveyViewTrigger';
 
 export default function KeyMetricsCTAContent( {
 	className,
@@ -100,6 +101,12 @@ export default function KeyMetricsCTAContent( {
 					) }
 				</Row>
 			</Grid>
+			{ inView && (
+				<SurveyViewTrigger
+					triggerID="view_kmw_setup_cta"
+					ttl={ DAY_IN_SECONDS }
+				/>
+			) }
 		</section>
 	);
 }

--- a/assets/js/components/KeyMetrics/KeyMetricsSetupCTAWidget.test.js
+++ b/assets/js/components/KeyMetrics/KeyMetricsSetupCTAWidget.test.js
@@ -38,7 +38,10 @@ import {
 	waitFor,
 } from '../../../../tests/js/test-utils';
 import { KEY_METRICS_SETUP_CTA_WIDGET_SLUG } from './constants';
-import { mockSurveyEndpoints } from '../../../../tests/js/mock-survey-endpoints';
+import {
+	mockSurveyEndpoints,
+	surveyTriggerEndpoint,
+} from '../../../../tests/js/mock-survey-endpoints';
 
 describe( 'KeyMetricsSetupCTAWidget', () => {
 	let registry;
@@ -200,7 +203,7 @@ describe( 'KeyMetricsSetupCTAWidget', () => {
 	} );
 
 	it( 'does render the CTA when SC and GA4 are both connected', async () => {
-		mockSurveyEndpoints( registry );
+		mockSurveyEndpoints();
 
 		await registry
 			.dispatch( CORE_USER )
@@ -251,10 +254,6 @@ describe( 'KeyMetricsSetupCTAWidget', () => {
 		);
 
 		// Should also trigger a survey view.
-		const surveyTriggerEndpoint = new RegExp(
-			'^/google-site-kit/v1/core/user/data/survey-trigger'
-		);
-
 		await waitFor( () =>
 			expect( fetchMock ).toHaveFetched( surveyTriggerEndpoint, {
 				body: {
@@ -317,7 +316,7 @@ describe( 'KeyMetricsSetupCTAWidget', () => {
 			}
 		);
 
-		mockSurveyEndpoints( registry );
+		mockSurveyEndpoints();
 
 		await registry
 			.dispatch( CORE_USER )

--- a/assets/js/components/KeyMetrics/KeyMetricsSetupCTAWidget.test.js
+++ b/assets/js/components/KeyMetrics/KeyMetricsSetupCTAWidget.test.js
@@ -21,6 +21,7 @@
  */
 import KeyMetricsSetupCTAWidget from './KeyMetricsSetupCTAWidget';
 import { CORE_USER } from '../../googlesitekit/datastore/user/constants';
+import { KEY_METRICS_SETUP_CTA_WIDGET_SLUG } from './constants';
 import { MODULES_ANALYTICS_4 } from '../../modules/analytics-4/datastore/constants';
 import { MODULES_SEARCH_CONSOLE } from '../../modules/search-console/datastore/constants';
 import { getWidgetComponentProps } from '../../googlesitekit/widgets/util';
@@ -37,7 +38,6 @@ import {
 	fireEvent,
 	waitFor,
 } from '../../../../tests/js/test-utils';
-import { KEY_METRICS_SETUP_CTA_WIDGET_SLUG } from './constants';
 import {
 	mockSurveyEndpoints,
 	surveyTriggerEndpoint,

--- a/assets/js/components/KeyMetrics/KeyMetricsSetupCTAWidget.test.js
+++ b/assets/js/components/KeyMetrics/KeyMetricsSetupCTAWidget.test.js
@@ -17,6 +17,11 @@
  */
 
 /**
+ * External dependencies
+ */
+import { useIntersection as mockUseIntersection } from 'react-use';
+
+/**
  * Internal dependencies
  */
 import KeyMetricsSetupCTAWidget from './KeyMetricsSetupCTAWidget';
@@ -42,6 +47,11 @@ import {
 	mockSurveyEndpoints,
 	surveyTriggerEndpoint,
 } from '../../../../tests/js/mock-survey-endpoints';
+
+jest.mock( 'react-use' );
+mockUseIntersection.mockImplementation( () => ( {
+	intersectionRatio: 1,
+} ) );
 
 describe( 'KeyMetricsSetupCTAWidget', () => {
 	let registry;

--- a/assets/js/components/KeyMetrics/KeyMetricsSetupCTAWidget.test.js
+++ b/assets/js/components/KeyMetrics/KeyMetricsSetupCTAWidget.test.js
@@ -35,8 +35,10 @@ import {
 	provideUserAuthentication,
 	getAnalytics4HasZeroDataReportOptions,
 	fireEvent,
+	waitFor,
 } from '../../../../tests/js/test-utils';
 import { KEY_METRICS_SETUP_CTA_WIDGET_SLUG } from './constants';
+import { mockSurveyEndpoints } from '../../../../tests/js/mock-survey-endpoints';
 
 describe( 'KeyMetricsSetupCTAWidget', () => {
 	let registry;
@@ -198,6 +200,8 @@ describe( 'KeyMetricsSetupCTAWidget', () => {
 	} );
 
 	it( 'does render the CTA when SC and GA4 are both connected', async () => {
+		mockSurveyEndpoints( registry );
+
 		await registry
 			.dispatch( CORE_USER )
 			.receiveIsUserInputCompleted( false );
@@ -244,6 +248,19 @@ describe( 'KeyMetricsSetupCTAWidget', () => {
 		expect( button ).toHaveAttribute(
 			'href',
 			'http://example.com/wp-admin/admin.php?page=googlesitekit-user-input'
+		);
+
+		// Should also trigger a survey view.
+		const surveyTriggerEndpoint = new RegExp(
+			'^/google-site-kit/v1/core/user/data/survey-trigger'
+		);
+
+		await waitFor( () =>
+			expect( fetchMock ).toHaveFetched( surveyTriggerEndpoint, {
+				body: {
+					data: { triggerID: 'view_kmw_setup_cta' },
+				},
+			} )
 		);
 	} );
 
@@ -299,6 +316,8 @@ describe( 'KeyMetricsSetupCTAWidget', () => {
 				status: 200,
 			}
 		);
+
+		mockSurveyEndpoints( registry );
 
 		await registry
 			.dispatch( CORE_USER )

--- a/assets/js/components/KeyMetrics/SetupCompletedSurveyTrigger.js
+++ b/assets/js/components/KeyMetrics/SetupCompletedSurveyTrigger.js
@@ -17,6 +17,11 @@
  */
 
 /**
+ * WordPress dependencies
+ */
+import { Fragment } from '@wordpress/element';
+
+/**
  * Internal dependencies
  */
 import Data from 'googlesitekit-data';
@@ -40,17 +45,19 @@ export default function SetupCompletedSurveyTrigger() {
 		select( CORE_USER ).getID()
 	);
 
-	if (
-		! isKeyMetricsSetupCompleted ||
-		isKeyMetricsSetupCompletedBy !== currentUserID
-	) {
+	if ( ! isKeyMetricsSetupCompleted ) {
 		return null;
 	}
 
 	return (
-		<SurveyViewTrigger
-			triggerID="view_kmw_setup_completed"
-			ttl={ DAY_IN_SECONDS }
-		/>
+		<Fragment>
+			<SurveyViewTrigger triggerID="view_kmw" ttl={ DAY_IN_SECONDS } />
+			{ isKeyMetricsSetupCompletedBy === currentUserID && (
+				<SurveyViewTrigger
+					triggerID="view_kmw_setup_completed"
+					ttl={ DAY_IN_SECONDS }
+				/>
+			) }
+		</Fragment>
 	);
 }

--- a/assets/js/components/KeyMetrics/SetupCompletedSurveyTrigger.js
+++ b/assets/js/components/KeyMetrics/SetupCompletedSurveyTrigger.js
@@ -1,0 +1,56 @@
+/**
+ * Key Metrics SetupCompletedSurveyTrigger component.
+ *
+ * Site Kit by Google, Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import Data from 'googlesitekit-data';
+import { CORE_SITE } from '../../googlesitekit/datastore/site/constants';
+import SurveyViewTrigger from '../surveys/SurveyViewTrigger';
+import { DAY_IN_SECONDS } from '../../util';
+import { CORE_USER } from '../../googlesitekit/datastore/user/constants';
+
+const { useSelect } = Data;
+
+export default function SetupCompletedSurveyTrigger() {
+	const isKeyMetricsSetupCompleted = useSelect( ( select ) =>
+		select( CORE_SITE ).isKeyMetricsSetupCompleted()
+	);
+
+	const isKeyMetricsSetupCompletedBy = useSelect( ( select ) =>
+		select( CORE_SITE ).getKeyMetricsSetupCompletedBy()
+	);
+
+	const currentUserID = useSelect( ( select ) =>
+		select( CORE_USER ).getID()
+	);
+
+	if (
+		! isKeyMetricsSetupCompleted ||
+		isKeyMetricsSetupCompletedBy !== currentUserID
+	) {
+		return null;
+	}
+
+	return (
+		<SurveyViewTrigger
+			triggerID="view_kmw_setup_completed"
+			ttl={ DAY_IN_SECONDS }
+		/>
+	);
+}

--- a/assets/js/components/KeyMetrics/SetupCompletedSurveyTrigger.js
+++ b/assets/js/components/KeyMetrics/SetupCompletedSurveyTrigger.js
@@ -26,9 +26,9 @@ import { Fragment } from '@wordpress/element';
  */
 import Data from 'googlesitekit-data';
 import { CORE_SITE } from '../../googlesitekit/datastore/site/constants';
-import SurveyViewTrigger from '../surveys/SurveyViewTrigger';
-import { DAY_IN_SECONDS } from '../../util';
 import { CORE_USER } from '../../googlesitekit/datastore/user/constants';
+import { DAY_IN_SECONDS } from '../../util';
+import SurveyViewTrigger from '../surveys/SurveyViewTrigger';
 
 const { useSelect } = Data;
 

--- a/assets/js/components/notifications/AdBlockingRecoverySetupSuccessBannerNotification.test.js
+++ b/assets/js/components/notifications/AdBlockingRecoverySetupSuccessBannerNotification.test.js
@@ -33,6 +33,10 @@ import {
 	render,
 	waitFor,
 } from '../../../../tests/js/test-utils';
+import {
+	mockSurveyEndpoints,
+	surveyTriggerEndpoint,
+} from '../../../../tests/js/mock-survey-endpoints';
 import { VIEW_CONTEXT_MAIN_DASHBOARD } from '../../googlesitekit/constants';
 import {
 	ENUM_AD_BLOCKING_RECOVERY_SETUP_STATUS,
@@ -40,10 +44,6 @@ import {
 } from '../../modules/adsense/datastore/constants';
 import * as tracking from '../../util/tracking';
 import AdBlockingRecoverySetupSuccessBannerNotification from './AdBlockingRecoverySetupSuccessBannerNotification';
-import {
-	mockSurveyEndpoints,
-	surveyTriggerEndpoint,
-} from '../../../../tests/js/mock-survey-endpoints';
 
 const mockTrackEvent = jest.spyOn( tracking, 'trackEvent' );
 mockTrackEvent.mockImplementation( () => Promise.resolve() );

--- a/assets/js/components/notifications/AdBlockingRecoverySetupSuccessBannerNotification.test.js
+++ b/assets/js/components/notifications/AdBlockingRecoverySetupSuccessBannerNotification.test.js
@@ -40,7 +40,10 @@ import {
 } from '../../modules/adsense/datastore/constants';
 import * as tracking from '../../util/tracking';
 import AdBlockingRecoverySetupSuccessBannerNotification from './AdBlockingRecoverySetupSuccessBannerNotification';
-import { mockSurveyEndpoints } from '../../../../tests/js/mock-survey-endpoints';
+import {
+	mockSurveyEndpoints,
+	surveyTriggerEndpoint,
+} from '../../../../tests/js/mock-survey-endpoints';
 
 const mockTrackEvent = jest.spyOn( tracking, 'trackEvent' );
 mockTrackEvent.mockImplementation( () => Promise.resolve() );
@@ -99,7 +102,7 @@ describe( 'AdBlockingRecoverySetupSuccessBannerNotification', () => {
 			}
 		);
 
-		mockSurveyEndpoints( registry );
+		mockSurveyEndpoints();
 
 		registry
 			.dispatch( MODULES_ADSENSE )
@@ -135,10 +138,6 @@ describe( 'AdBlockingRecoverySetupSuccessBannerNotification', () => {
 		);
 
 		// The survey trigger endpoint should be called.
-		const surveyTriggerEndpoint = new RegExp(
-			'^/google-site-kit/v1/core/user/data/survey-trigger'
-		);
-
 		await waitFor( () =>
 			expect( fetchMock ).toHaveFetched( surveyTriggerEndpoint, {
 				body: {

--- a/assets/js/components/settings/SettingsCardKeyMetrics.js
+++ b/assets/js/components/settings/SettingsCardKeyMetrics.js
@@ -1,4 +1,6 @@
 /**
+ * SettingsCardKeyMetrics component.
+ *
  * Site Kit by Google, Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/assets/js/components/settings/SettingsCardKeyMetrics.js
+++ b/assets/js/components/settings/SettingsCardKeyMetrics.js
@@ -30,12 +30,12 @@ import { CORE_USER } from '../../googlesitekit/datastore/user/constants';
 import { CORE_SITE } from '../../googlesitekit/datastore/site/constants';
 import { DAY_IN_SECONDS, trackEvent } from '../../util';
 import useViewContext from '../../hooks/useViewContext';
+import { useInView } from '../../hooks/useInView';
 import SettingsKeyMetrics from './SettingsKeyMetrics';
 import UserInputPreview from '../user-input/UserInputPreview';
 import Layout from '../layout/Layout';
 import { Grid, Cell, Row } from '../../material-components';
 import Link from '../Link';
-import { useInView } from '../../hooks/useInView';
 import SurveyViewTrigger from '../surveys/SurveyViewTrigger';
 
 const { useSelect } = Data;

--- a/assets/js/components/settings/SettingsCardKeyMetrics.js
+++ b/assets/js/components/settings/SettingsCardKeyMetrics.js
@@ -26,18 +26,21 @@ import { __ } from '@wordpress/i18n';
 import Data from 'googlesitekit-data';
 import { CORE_USER } from '../../googlesitekit/datastore/user/constants';
 import { CORE_SITE } from '../../googlesitekit/datastore/site/constants';
-import { trackEvent } from '../../util';
+import { DAY_IN_SECONDS, trackEvent } from '../../util';
 import useViewContext from '../../hooks/useViewContext';
 import SettingsKeyMetrics from './SettingsKeyMetrics';
 import UserInputPreview from '../user-input/UserInputPreview';
 import Layout from '../layout/Layout';
 import { Grid, Cell, Row } from '../../material-components';
 import Link from '../Link';
+import { useInView } from '../../hooks/useInView';
+import SurveyViewTrigger from '../surveys/SurveyViewTrigger';
 
 const { useSelect } = Data;
 
 export default function SettingsCardKeyMetrics() {
 	const viewContext = useViewContext();
+	const inView = useInView();
 	const isUserInputCompleted = useSelect( ( select ) =>
 		select( CORE_USER ).isUserInputCompleted()
 	);
@@ -92,6 +95,12 @@ export default function SettingsCardKeyMetrics() {
 
 								<Link href={ userInputURL }>{ ctaLabel }</Link>
 							</Cell>
+							{ inView && (
+								<SurveyViewTrigger
+									triggerID="view_kmw_setup_cta"
+									ttl={ DAY_IN_SECONDS }
+								/>
+							) }
 						</Row>
 					) }
 				</Grid>

--- a/assets/js/components/settings/SettingsCardKeyMetrics.test.js
+++ b/assets/js/components/settings/SettingsCardKeyMetrics.test.js
@@ -35,7 +35,6 @@ describe( 'SettingsCardKeyMetrics', () => {
 
 	beforeEach( () => {
 		registry = createTestRegistry();
-		// provideSiteInfo( registry, { homeURL: 'http://example.com' } );
 	} );
 
 	it( 'should trigger a survey when the Key Metrics Setup CTA is in view', async () => {

--- a/assets/js/components/settings/SettingsCardKeyMetrics.test.js
+++ b/assets/js/components/settings/SettingsCardKeyMetrics.test.js
@@ -16,7 +16,10 @@
  * limitations under the License.
  */
 
-import { mockSurveyEndpoints } from '../../../../tests/js/mock-survey-endpoints';
+import {
+	mockSurveyEndpoints,
+	surveyTriggerEndpoint,
+} from '../../../../tests/js/mock-survey-endpoints';
 import { render, waitFor } from '../../../../tests/js/test-utils';
 import {
 	createTestRegistry,
@@ -36,7 +39,7 @@ describe( 'SettingsCardKeyMetrics', () => {
 	} );
 
 	it( 'should trigger a survey when the Key Metrics Setup CTA is in view', async () => {
-		mockSurveyEndpoints( registry );
+		mockSurveyEndpoints();
 		provideUserAuthentication( registry );
 		provideSiteInfo( registry );
 
@@ -51,10 +54,6 @@ describe( 'SettingsCardKeyMetrics', () => {
 		render( <SettingsCardKeyMetrics />, {
 			registry,
 		} );
-
-		const surveyTriggerEndpoint = new RegExp(
-			'^/google-site-kit/v1/core/user/data/survey-trigger'
-		);
 
 		await waitFor( () =>
 			expect( fetchMock ).toHaveFetched( surveyTriggerEndpoint, {

--- a/assets/js/components/settings/SettingsCardKeyMetrics.test.js
+++ b/assets/js/components/settings/SettingsCardKeyMetrics.test.js
@@ -1,0 +1,67 @@
+/**
+ * SettingsCardKeyMetrics component tests.
+ *
+ * Site Kit by Google, Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { mockSurveyEndpoints } from '../../../../tests/js/mock-survey-endpoints';
+import { render, waitFor } from '../../../../tests/js/test-utils';
+import {
+	createTestRegistry,
+	muteFetch,
+	provideSiteInfo,
+	provideUserAuthentication,
+} from '../../../../tests/js/utils';
+import { CORE_USER } from '../../googlesitekit/datastore/user/constants';
+import SettingsCardKeyMetrics from './SettingsCardKeyMetrics';
+
+describe( 'SettingsCardKeyMetrics', () => {
+	let registry;
+
+	beforeEach( () => {
+		registry = createTestRegistry();
+		// provideSiteInfo( registry, { homeURL: 'http://example.com' } );
+	} );
+
+	it( 'should trigger a survey when the Key Metrics Setup CTA is in view', async () => {
+		mockSurveyEndpoints( registry );
+		provideUserAuthentication( registry );
+		provideSiteInfo( registry );
+
+		muteFetch(
+			new RegExp( '^/google-site-kit/v1/core/user/data/key-metrics' )
+		);
+
+		await registry
+			.dispatch( CORE_USER )
+			.receiveIsUserInputCompleted( false );
+
+		render( <SettingsCardKeyMetrics />, {
+			registry,
+		} );
+
+		const surveyTriggerEndpoint = new RegExp(
+			'^/google-site-kit/v1/core/user/data/survey-trigger'
+		);
+
+		await waitFor( () =>
+			expect( fetchMock ).toHaveFetched( surveyTriggerEndpoint, {
+				body: {
+					data: { triggerID: 'view_kmw_setup_cta' },
+				},
+			} )
+		);
+	} );
+} );

--- a/assets/js/googlesitekit/datastore/user/surveys.test.js
+++ b/assets/js/googlesitekit/datastore/user/surveys.test.js
@@ -26,6 +26,12 @@ import {
 	muteFetch,
 	provideUserAuthentication,
 } from '../../../../../tests/js/utils';
+import {
+	surveyEventEndpoint,
+	surveyTimeoutEndpoint,
+	surveyTimeoutsEndpoint,
+	surveyTriggerEndpoint,
+} from '../../../../../tests/js/mock-survey-endpoints';
 
 describe( 'core/user surveys', () => {
 	let registry;
@@ -41,19 +47,6 @@ describe( 'core/user surveys', () => {
 			session_token: '1234',
 		},
 	};
-
-	const surveyTriggerEndpoint = new RegExp(
-		'^/google-site-kit/v1/core/user/data/survey-trigger'
-	);
-	const surveyEventEndpoint = new RegExp(
-		'^/google-site-kit/v1/core/user/data/survey-event'
-	);
-	const surveyTimeoutEndpoint = new RegExp(
-		'^/google-site-kit/v1/core/user/data/survey-timeout'
-	);
-	const surveyTimeoutsEndpoint = new RegExp(
-		'^/google-site-kit/v1/core/user/data/survey-timeouts'
-	);
 
 	describe( 'actions', () => {
 		describe( 'setSurveyTimeout', () => {

--- a/assets/js/googlesitekit/datastore/user/user-input-settings.test.js
+++ b/assets/js/googlesitekit/datastore/user/user-input-settings.test.js
@@ -28,8 +28,8 @@ import {
 	unsubscribeFromAll,
 	untilResolved,
 } from '../../../../../tests/js/utils';
-import { CORE_USER } from './constants';
 import { surveyTriggerEndpoint } from '../../../../../tests/js/mock-survey-endpoints';
+import { CORE_USER } from './constants';
 
 describe( 'core/user user-input-settings', () => {
 	let registry;

--- a/assets/js/googlesitekit/datastore/user/user-input-settings.test.js
+++ b/assets/js/googlesitekit/datastore/user/user-input-settings.test.js
@@ -29,6 +29,7 @@ import {
 	untilResolved,
 } from '../../../../../tests/js/utils';
 import { CORE_USER } from './constants';
+import { surveyTriggerEndpoint } from '../../../../../tests/js/mock-survey-endpoints';
 
 describe( 'core/user user-input-settings', () => {
 	let registry;
@@ -57,9 +58,6 @@ describe( 'core/user user-input-settings', () => {
 			coreUserInputSettingsExpectedResponse.postFrequency.values,
 		goals: coreUserInputSettingsExpectedResponse.goals.values,
 	};
-	const surveyTriggerEndpoint = new RegExp(
-		'^/google-site-kit/v1/core/user/data/survey-trigger'
-	);
 
 	beforeAll( () => {
 		API.setUsingCache( false );

--- a/assets/js/modules/adsense/components/dashboard/AdBlockingRecoverySetupCTAWidget.test.js
+++ b/assets/js/modules/adsense/components/dashboard/AdBlockingRecoverySetupCTAWidget.test.js
@@ -21,7 +21,10 @@
  */
 import fetchMock from 'fetch-mock';
 import { mockLocation } from '../../../../../../tests/js/mock-browser-utils';
-import { mockSurveyEndpoints } from '../../../../../../tests/js/mock-survey-endpoints';
+import {
+	mockSurveyEndpoints,
+	surveyTriggerEndpoint,
+} from '../../../../../../tests/js/mock-survey-endpoints';
 import {
 	act,
 	createTestRegistry,
@@ -79,7 +82,7 @@ describe( 'AdBlockingRecoverySetupCTAWidget', () => {
 
 	beforeEach( () => {
 		mockTrackEvent.mockClear();
-		mockSurveyEndpoints( registry );
+		mockSurveyEndpoints();
 		registry = createTestRegistry();
 		provideSiteInfo( registry );
 		provideUserAuthentication( registry );
@@ -310,10 +313,6 @@ describe( 'AdBlockingRecoverySetupCTAWidget', () => {
 					registry,
 					viewContext: VIEW_CONTEXT_MAIN_DASHBOARD,
 				}
-			);
-
-			const surveyTriggerEndpoint = new RegExp(
-				'^/google-site-kit/v1/core/user/data/survey-trigger'
 			);
 
 			await waitFor( () =>

--- a/assets/js/modules/adsense/components/settings/AdBlockingRecoverySetupCTANotice.test.js
+++ b/assets/js/modules/adsense/components/settings/AdBlockingRecoverySetupCTANotice.test.js
@@ -20,7 +20,10 @@
  * Internal dependencies
  */
 import { mockLocation } from '../../../../../../tests/js/mock-browser-utils';
-import { mockSurveyEndpoints } from '../../../../../../tests/js/mock-survey-endpoints';
+import {
+	mockSurveyEndpoints,
+	surveyTriggerEndpoint,
+} from '../../../../../../tests/js/mock-survey-endpoints';
 import {
 	act,
 	createTestRegistry,
@@ -230,10 +233,6 @@ describe( 'AdBlockingRecoverySetupCTANotice', () => {
 		render( <AdBlockingRecoverySetupCTANotice />, {
 			registry,
 		} );
-
-		const surveyTriggerEndpoint = new RegExp(
-			'^/google-site-kit/v1/core/user/data/survey-trigger'
-		);
 
 		await waitFor( () =>
 			expect( fetchMock ).toHaveFetched( surveyTriggerEndpoint, {

--- a/assets/js/modules/analytics-4/components/dashboard/EnhancedMeasurementActivationBanner/SetupBanner.test.js
+++ b/assets/js/modules/analytics-4/components/dashboard/EnhancedMeasurementActivationBanner/SetupBanner.test.js
@@ -31,6 +31,7 @@ import {
 	provideSiteInfo,
 	waitFor,
 } from '../../../../../../../tests/js/test-utils';
+import { mockSurveyEndpoints } from '../../../../../../../tests/js/mock-survey-endpoints';
 import { CORE_FORMS } from '../../../../../googlesitekit/datastore/forms/constants';
 import {
 	EDIT_SCOPE,
@@ -39,7 +40,6 @@ import {
 import { MODULES_ANALYTICS_4 } from '../../../datastore/constants';
 import { ENHANCED_MEASUREMENT_ACTIVATION_BANNER_DISMISSED_ITEM_KEY } from '../../../constants';
 import SetupBanner from './SetupBanner';
-import { mockSurveyEndpoints } from '../../../../../../../tests/js/mock-survey-endpoints';
 
 describe( 'SetupBanner', () => {
 	const propertyID = '1000';

--- a/assets/js/modules/analytics-4/components/dashboard/EnhancedMeasurementActivationBanner/SetupBanner.test.js
+++ b/assets/js/modules/analytics-4/components/dashboard/EnhancedMeasurementActivationBanner/SetupBanner.test.js
@@ -39,6 +39,7 @@ import {
 import { MODULES_ANALYTICS_4 } from '../../../datastore/constants';
 import { ENHANCED_MEASUREMENT_ACTIVATION_BANNER_DISMISSED_ITEM_KEY } from '../../../constants';
 import SetupBanner from './SetupBanner';
+import { mockSurveyEndpoints } from '../../../../../../../tests/js/mock-survey-endpoints';
 
 describe( 'SetupBanner', () => {
 	const propertyID = '1000';
@@ -125,27 +126,7 @@ describe( 'SetupBanner', () => {
 	} );
 
 	it( 'should render correctly when the user does not have the edit scope granted', () => {
-		const surveyTriggerEndpoint = new RegExp(
-			'^/google-site-kit/v1/core/user/data/survey-trigger'
-		);
-		const surveyTimeoutEndpoint = new RegExp(
-			'^/google-site-kit/v1/core/user/data/survey-timeout'
-		);
-
-		fetchMock.postOnce( surveyTriggerEndpoint, {
-			status: 200,
-			body: {},
-		} );
-
-		fetchMock.getOnce( surveyTimeoutEndpoint, {
-			status: 200,
-			body: {},
-		} );
-
-		fetchMock.postOnce( surveyTimeoutEndpoint, {
-			status: 200,
-			body: {},
-		} );
+		mockSurveyEndpoints();
 
 		provideSiteInfo( registry, {
 			usingProxy: true,

--- a/tests/js/mock-survey-endpoints.js
+++ b/tests/js/mock-survey-endpoints.js
@@ -14,19 +14,28 @@
  * limitations under the License.
  */
 
+export const surveyTriggerEndpoint = new RegExp(
+	'^/google-site-kit/v1/core/user/data/survey-trigger'
+);
+
+export const surveyEventEndpoint = new RegExp(
+	'^/google-site-kit/v1/core/user/data/survey-event'
+);
+
+export const surveyTimeoutEndpoint = new RegExp(
+	'^/google-site-kit/v1/core/user/data/survey-timeout'
+);
+
+export const surveyTimeoutsEndpoint = new RegExp(
+	'^/google-site-kit/v1/core/user/data/survey-timeouts'
+);
+
 /**
  * Mocks the survey endpoints.
  *
  * @since 1.111.1
  */
 export const mockSurveyEndpoints = () => {
-	const surveyTriggerEndpoint = new RegExp(
-		'^/google-site-kit/v1/core/user/data/survey-trigger'
-	);
-	const surveyTimeoutEndpoint = new RegExp(
-		'^/google-site-kit/v1/core/user/data/survey-timeout'
-	);
-
 	fetchMock.postOnce( surveyTriggerEndpoint, {
 		status: 200,
 		body: {},


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #7724

## Relevant technical choices

In addition to adding survey triggers for key metrics along with tests, this PR also cleans up and consolidates survey endpoints in a single place and fixes couple instance of ghost parameters on `mockSurveyEndpoints` function calls. 

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [ ] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [x] Run the code.
- [x] Ensure the acceptance criteria are satisfied.
- [x] Reassess the implementation with the IB.
- [x] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [x] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [x] Ensure the PR has the correct target branch.
- [x] Double-check that the PR is okay to be merged.
- [x] Ensure the corresponding issue has a ZenHub release assigned.
- [x] Add a changelog message to the issue.
