### PR TITLE
PSI widget: Improve spacing between report title and value

### DIFF
--- a/assets/sass/components/dashboard/_googlesitekit-DashboardPageSpeed.scss
+++ b/assets/sass/components/dashboard/_googlesitekit-DashboardPageSpeed.scss
@@ -167,6 +167,7 @@
 	}
 
 	.googlesitekit-pagespeed-report__row {
+		gap: $grid-gap-desktop;
 		justify-content: space-between;
 
 		.googlesitekit-error-text p {

--- a/assets/sass/components/dashboard/_googlesitekit-ReportMetric.scss
+++ b/assets/sass/components/dashboard/_googlesitekit-ReportMetric.scss
@@ -18,10 +18,6 @@
 
 .googlesitekit-pagespeed-report-metric {
 
-	.googlesitekit-pagespeed-report-metric-value {
-		min-width: 100px;
-	}
-
 	.googlesitekit-pagespeed-report-metric-value-container {
 
 		align-items: flex-end;
@@ -31,7 +27,6 @@
 		justify-content: center;
 		letter-spacing: $ls-s;
 		line-height: $lh-body-md;
-		margin-left: $grid-gap-phone;
 		text-align: right;
 	}
 

--- a/assets/sass/components/dashboard/_googlesitekit-ReportMetric.scss
+++ b/assets/sass/components/dashboard/_googlesitekit-ReportMetric.scss
@@ -18,6 +18,10 @@
 
 .googlesitekit-pagespeed-report-metric {
 
+	.googlesitekit-pagespeed-report-metric-value {
+		min-width: 100px;
+	}
+
 	.googlesitekit-pagespeed-report-metric-value-container {
 
 		align-items: flex-end;
@@ -27,6 +31,7 @@
 		justify-content: center;
 		letter-spacing: $ls-s;
 		line-height: $lh-body-md;
+		margin-left: $grid-gap-phone;
 		text-align: right;
 	}
 


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- https://github.com/google/site-kit-wp/issues/7662#issuecomment-1783698106

## Relevant technical choices

This PR improves the responsiveness issue in the PSI widget as reported [here](https://github.com/google/site-kit-wp/issues/7662#issuecomment-1783698106).

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [x] Run the code.
- [x] Ensure the acceptance criteria are satisfied.
- [x] Reassess the implementation with the IB.
- [x] Ensure no unrelated changes are included.
- [x] Ensure CI checks pass.
- [x] Check Storybook where applicable.
- [x] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
