### PR TITLE
Enhance/#7740 - Remove Change Metrics link when the Key Metrics Setup CTA is visible

### DIFF
--- a/assets/js/components/KeyMetrics/ChangeMetricsLink.js
+++ b/assets/js/components/KeyMetrics/ChangeMetricsLink.js
@@ -50,7 +50,7 @@ export default function ChangeMetricsLink() {
 	}, [ setValue, viewContext ] );
 
 	const renderChangeMetricLink =
-		Array.isArray( keyMetrics ) || keyMetrics?.length > 0;
+		Array.isArray( keyMetrics ) && keyMetrics?.length > 0;
 
 	useChangeMetricsFeatureTourEffect( renderChangeMetricLink );
 

--- a/assets/js/components/KeyMetrics/ChangeMetricsLink.test.js
+++ b/assets/js/components/KeyMetrics/ChangeMetricsLink.test.js
@@ -56,6 +56,10 @@ describe( 'ChangeMetricsLink', () => {
 	it( 'should not render if no key metrics are selected', () => {
 		provideKeyMetrics( registry, { widgetSlugs: [] } );
 
+		registry
+			.dispatch( 'core/user' )
+			.setUserInputSetting( 'purpose', [ 'test-purpose' ] );
+
 		const { queryByRole } = render( <ChangeMetricsLink />, { registry } );
 
 		const button = queryByRole( 'button' );

--- a/assets/js/components/KeyMetrics/ChangeMetricsLink.test.js
+++ b/assets/js/components/KeyMetrics/ChangeMetricsLink.test.js
@@ -56,10 +56,6 @@ describe( 'ChangeMetricsLink', () => {
 	it( 'should not render if no key metrics are selected', () => {
 		provideKeyMetrics( registry, { widgetSlugs: [] } );
 
-		registry
-			.dispatch( 'core/user' )
-			.setUserInputSetting( 'purpose', [ 'test-purpose' ] );
-
 		const { queryByRole } = render( <ChangeMetricsLink />, { registry } );
 
 		const button = queryByRole( 'button' );


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #7740

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [x] Run the code.
- [x] Ensure the acceptance criteria are satisfied.
- [x] Reassess the implementation with the IB.
- [x] Ensure no unrelated changes are included.
- [x] Ensure CI checks pass.
- [x] Check Storybook where applicable.
- [x] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
