### PR TITLE
Restore focus to "Edit" button in User Input.

### DIFF
--- a/assets/js/components/user-input/UserInputPreviewGroup.js
+++ b/assets/js/components/user-input/UserInputPreviewGroup.js
@@ -25,7 +25,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { Fragment, useCallback } from '@wordpress/element';
+import { Fragment, useCallback, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -93,6 +93,7 @@ export default function UserInputPreviewGroup( {
 			setValues( {
 				[ USER_INPUT_CURRENTLY_EDITING_KEY ]: undefined,
 			} );
+			editButtonRef.current?.focus?.();
 		} else {
 			trackEvent( gaEventCategory, 'question_edit', slug );
 			setValues( {
@@ -107,6 +108,8 @@ export default function UserInputPreviewGroup( {
 	);
 
 	const answerHasError = hasErrorForAnswer( values );
+
+	const editButtonRef = useRef();
 
 	const submitChanges = useCallback( async () => {
 		if ( answerHasError ) {
@@ -174,6 +177,7 @@ export default function UserInputPreviewGroup( {
 				<Link
 					secondary
 					onClick={ handleOnEditClick }
+					ref={ editButtonRef }
 					disabled={
 						isScreenLoading ||
 						( !! currentlyEditingSlug && ! isEditing )


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #7748

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [x] Run the code.
- [x] Ensure the acceptance criteria are satisfied.
- [x] Reassess the implementation with the IB.
- [x] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [x] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [x] Ensure the PR has the correct target branch.
- [x] Double-check that the PR is okay to be merged.
- [x] Ensure the corresponding issue has a ZenHub release assigned.
- [x] Add a changelog message to the issue.
