### PR TITLE
Enhance/#7706 - Remove the period from EM settings enabled copy (follow-up)

### DIFF
--- a/assets/js/modules/analytics-4/components/common/EnhancedMeasurementSwitch.js
+++ b/assets/js/modules/analytics-4/components/common/EnhancedMeasurementSwitch.js
@@ -108,7 +108,7 @@ export default function EnhancedMeasurementSwitch( {
 			) }
 			{ ! loading && isEnhancedMeasurementAlreadyEnabled && (
 				<p className="googlesitekit-margin-top-0">
-					Enhanced measurement is enabled for this web data stream.
+					Enhanced measurement is enabled for this web data stream
 				</p>
 			) }
 			{ ! loading && ! isEnhancedMeasurementAlreadyEnabled && (

--- a/assets/js/modules/analytics-4/components/common/EnhancedMeasurementSwitch.test.js
+++ b/assets/js/modules/analytics-4/components/common/EnhancedMeasurementSwitch.test.js
@@ -36,7 +36,7 @@ describe( 'EnhancedMeasurementSwitch', () => {
 
 		expect(
 			queryByText(
-				'Enhanced measurement is enabled for this web data stream.'
+				'Enhanced measurement is enabled for this web data stream'
 			)
 		).not.toBeInTheDocument();
 	} );
@@ -72,7 +72,7 @@ describe( 'EnhancedMeasurementSwitch', () => {
 
 		expect(
 			getByText(
-				'Enhanced measurement is enabled for this web data stream.'
+				'Enhanced measurement is enabled for this web data stream'
 			)
 		).toBeInTheDocument();
 

--- a/assets/js/modules/analytics-4/components/common/__snapshots__/EnhancedMeasurementSwitch.test.js.snap
+++ b/assets/js/modules/analytics-4/components/common/__snapshots__/EnhancedMeasurementSwitch.test.js.snap
@@ -8,7 +8,7 @@ exports[`EnhancedMeasurementSwitch should render correctly in the already enable
     <p
       class="googlesitekit-margin-top-0"
     >
-      Enhanced measurement is enabled for this web data stream.
+      Enhanced measurement is enabled for this web data stream
     </p>
     <p>
       This allows you to measure interactions with your content (e.g. file downloads, form completions, video views). 

--- a/assets/js/modules/analytics-4/components/settings/SettingsEnhancedMeasurementSwitch.test.js
+++ b/assets/js/modules/analytics-4/components/settings/SettingsEnhancedMeasurementSwitch.test.js
@@ -189,7 +189,7 @@ describe( 'SettingsEnhancedMeasurementSwitch', () => {
 
 		expect(
 			getByText(
-				'Enhanced measurement is enabled for this web data stream.'
+				'Enhanced measurement is enabled for this web data stream'
 			)
 		).toBeInTheDocument();
 	} );
@@ -472,7 +472,7 @@ describe( 'SettingsEnhancedMeasurementSwitch', () => {
 
 		expect(
 			getByText(
-				'Enhanced measurement is enabled for this web data stream.'
+				'Enhanced measurement is enabled for this web data stream'
 			)
 		).toBeInTheDocument();
 	} );
@@ -518,7 +518,7 @@ describe( 'SettingsEnhancedMeasurementSwitch', () => {
 
 		expect(
 			getByText(
-				'Enhanced measurement is enabled for this web data stream.'
+				'Enhanced measurement is enabled for this web data stream'
 			)
 		).toBeInTheDocument();
 	} );

--- a/assets/js/modules/analytics-4/components/settings/__snapshots__/SettingsEnhancedMeasurementSwitch.test.js.snap
+++ b/assets/js/modules/analytics-4/components/settings/__snapshots__/SettingsEnhancedMeasurementSwitch.test.js.snap
@@ -8,7 +8,7 @@ exports[`SettingsEnhancedMeasurementSwitch should not render the switch when enh
     <p
       class="googlesitekit-margin-top-0"
     >
-      Enhanced measurement is enabled for this web data stream.
+      Enhanced measurement is enabled for this web data stream
     </p>
     <p>
       This allows you to measure interactions with your content (e.g. file downloads, form completions, video views). 

--- a/assets/js/modules/analytics-4/components/setup/SetupEnhancedMeasurementSwitch.test.js
+++ b/assets/js/modules/analytics-4/components/setup/SetupEnhancedMeasurementSwitch.test.js
@@ -149,7 +149,7 @@ describe( 'SetupEnhancedMeasurementSwitch', () => {
 
 		expect(
 			getByText(
-				'Enhanced measurement is enabled for this web data stream.'
+				'Enhanced measurement is enabled for this web data stream'
 			)
 		).toBeInTheDocument();
 	} );
@@ -180,7 +180,7 @@ describe( 'SetupEnhancedMeasurementSwitch', () => {
 
 		expect(
 			queryByText(
-				'Enhanced measurement is enabled for this web data stream.'
+				'Enhanced measurement is enabled for this web data stream'
 			)
 		).not.toBeInTheDocument();
 	} );
@@ -416,7 +416,7 @@ describe( 'SetupEnhancedMeasurementSwitch', () => {
 
 			expect(
 				getByText(
-					'Enhanced measurement is enabled for this web data stream.'
+					'Enhanced measurement is enabled for this web data stream'
 				)
 			).toBeInTheDocument();
 

--- a/assets/js/modules/analytics-4/components/setup/__snapshots__/SetupEnhancedMeasurementSwitch.test.js.snap
+++ b/assets/js/modules/analytics-4/components/setup/__snapshots__/SetupEnhancedMeasurementSwitch.test.js.snap
@@ -10,7 +10,7 @@ exports[`SetupEnhancedMeasurementSwitch should not render the switch when enhanc
     <p
       class="googlesitekit-margin-top-0"
     >
-      Enhanced measurement is enabled for this web data stream.
+      Enhanced measurement is enabled for this web data stream
     </p>
     <p>
       This allows you to measure interactions with your content (e.g. file downloads, form completions, video views). 


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #7706 

## Relevant technical choices

* This follow-up PR removes the period from the phrase "Enhanced measurement is enabled for this web data stream" to maintain consistency with other text throughout the plugin. Please refer to the thrid observation of this [comment](https://github.com/google/site-kit-wp/issues/7706#issuecomment-1785233282).

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
