### PR TITLE
WP activation fails on multisite

### DIFF
--- a/includes/Core/Storage/Data_Encryption.php
+++ b/includes/Core/Storage/Data_Encryption.php
@@ -83,19 +83,23 @@ final class Data_Encryption {
 	 * @return string|bool Decrypted value, or false on failure.
 	 */
 	public function decrypt( $raw_value ) {
-		if ( ! extension_loaded( 'openssl' ) ) {
+		if ( ! extension_loaded( 'openssl' ) || ! is_string( $raw_value ) ) {
 			return $raw_value;
 		}
 
-		$raw_value = base64_decode( $raw_value, true );
+		$decoded_value = base64_decode( $raw_value, true );
+
+		if ( false === $decoded_value ) {
+			return $raw_value;
+		}
 
 		$method = 'aes-256-ctr';
 		$ivlen  = openssl_cipher_iv_length( $method );
-		$iv     = substr( $raw_value, 0, $ivlen );
+		$iv     = substr( $decoded_value, 0, $ivlen );
 
-		$raw_value = substr( $raw_value, $ivlen );
+		$decoded_value = substr( $decoded_value, $ivlen );
 
-		$value = openssl_decrypt( $raw_value, $method, $this->key, 0, $iv );
+		$value = openssl_decrypt( $decoded_value, $method, $this->key, 0, $iv );
 		if ( ! $value || substr( $value, - strlen( $this->salt ) ) !== $this->salt ) {
 			return false;
 		}

--- a/includes/Core/Storage/Data_Encryption.php
+++ b/includes/Core/Storage/Data_Encryption.php
@@ -10,6 +10,8 @@
 
 namespace Google\Site_Kit\Core\Storage;
 
+use Google\Site_Kit\Core\Util\Build_Mode;
+
 /**
  * Class responsible for encrypting and decrypting data.
  *
@@ -81,6 +83,7 @@ final class Data_Encryption {
 	 *
 	 * @param string $raw_value Value to decrypt.
 	 * @return string|bool Decrypted value, or false on failure.
+	 * @throws \Exception If the value fails to decode.
 	 */
 	public function decrypt( $raw_value ) {
 		if ( ! extension_loaded( 'openssl' ) || ! is_string( $raw_value ) ) {
@@ -90,6 +93,16 @@ final class Data_Encryption {
 		$decoded_value = base64_decode( $raw_value, true );
 
 		if ( false === $decoded_value ) {
+			if ( 'development' === Build_Mode::get_mode() ) {
+				throw new \Exception(
+					sprintf(
+						/* translators: %s: raw value */
+						__( 'Failed to decode base64 value. Raw value: %s', 'google-site-kit' ),
+						$raw_value
+					)
+				);
+			}
+
 			return $raw_value;
 		}
 

--- a/includes/Core/Storage/Data_Encryption.php
+++ b/includes/Core/Storage/Data_Encryption.php
@@ -10,8 +10,6 @@
 
 namespace Google\Site_Kit\Core\Storage;
 
-use Google\Site_Kit\Core\Util\Build_Mode;
-
 /**
  * Class responsible for encrypting and decrypting data.
  *

--- a/includes/Core/Storage/Data_Encryption.php
+++ b/includes/Core/Storage/Data_Encryption.php
@@ -90,9 +90,6 @@ final class Data_Encryption {
 		$decoded_value = base64_decode( $raw_value, true );
 
 		if ( false === $decoded_value ) {
-			// phpcs:ignore
-			error_log( "Failed to decode base64 value. Raw value: $raw_value" );
-
 			return $raw_value;
 		}
 

--- a/includes/Core/Storage/Data_Encryption.php
+++ b/includes/Core/Storage/Data_Encryption.php
@@ -83,7 +83,6 @@ final class Data_Encryption {
 	 *
 	 * @param string $raw_value Value to decrypt.
 	 * @return string|bool Decrypted value, or false on failure.
-	 * @throws \Exception If the value fails to decode.
 	 */
 	public function decrypt( $raw_value ) {
 		if ( ! extension_loaded( 'openssl' ) || ! is_string( $raw_value ) ) {
@@ -93,15 +92,8 @@ final class Data_Encryption {
 		$decoded_value = base64_decode( $raw_value, true );
 
 		if ( false === $decoded_value ) {
-			if ( 'development' === Build_Mode::get_mode() ) {
-				throw new \Exception(
-					sprintf(
-						/* translators: %s: raw value */
-						__( 'Failed to decode base64 value. Raw value: %s', 'google-site-kit' ),
-						$raw_value
-					)
-				);
-			}
+			// phpcs:ignore
+			error_log( "Failed to decode base64 value. Raw value: $raw_value" );
 
 			return $raw_value;
 		}

--- a/includes/Core/Storage/Options.php
+++ b/includes/Core/Storage/Options.php
@@ -51,8 +51,8 @@ final class Options implements Options_Interface {
 	 * @return bool True if value set, false otherwise.
 	 */
 	public function has( $option ) {
-		// Call without getting the value to ensure 'notoptions' cache is fresh for the option.
-		$this->get( $option );
+		// Call for option to ensure 'notoptions' cache is fresh for the option.
+		$value = $this->get( $option );
 
 		if ( $this->context->is_network_mode() ) {
 			$network_id = get_current_network_id();
@@ -61,11 +61,13 @@ final class Options implements Options_Interface {
 			$notoptions = wp_cache_get( 'notoptions', 'options' );
 		}
 
-		// If `notoptions` cache is not available, query the database.
-		// This happens in `wp-activate` in multisite environments.
+		// Check for `notoptions` cache. If unavailable, query the database.
+		// This is particularly happening when `WP_INSTALLING` is true,
+		// which includes `wp-activate.php` in multisite setups and certain
+		// other multisite-related functions.
 		// See: https://github.com/google/site-kit-wp/issues/7653.
 		if ( false === $notoptions ) {
-			return (bool) $this->get( $option );
+			return (bool) $value;
 		}
 
 		return ! isset( $notoptions[ $option ] );

--- a/includes/Core/Storage/Options.php
+++ b/includes/Core/Storage/Options.php
@@ -61,9 +61,9 @@ final class Options implements Options_Interface {
 			$notoptions = wp_cache_get( 'notoptions', 'options' );
 		}
 
-		// If notoptions cache is not available yet, which is so far
-		// happening only on wp-activate in multisite env,
-		// query the database for value. See https://github.com/google/site-kit-wp/issues/7653.
+		// If `notoptions` cache is not available, query the database.
+		// This happens in `wp-activate` in multisite environments.
+		// See: https://github.com/google/site-kit-wp/issues/7653.
 		if ( false === $notoptions ) {
 			return (bool) $this->get( $option );
 		}

--- a/includes/Core/Storage/Options.php
+++ b/includes/Core/Storage/Options.php
@@ -61,6 +61,13 @@ final class Options implements Options_Interface {
 			$notoptions = wp_cache_get( 'notoptions', 'options' );
 		}
 
+		// If notoptions cache is not available yet, which is so far
+		// happening only on wp-activate in multisite env,
+		// query the database for value. See https://github.com/google/site-kit-wp/issues/7653.
+		if ( false === $notoptions ) {
+			return (bool) $this->get( $option );
+		}
+
 		return ! isset( $notoptions[ $option ] );
 	}
 

--- a/includes/Modules/AdSense.php
+++ b/includes/Modules/AdSense.php
@@ -187,9 +187,7 @@ final class AdSense extends Module
 	public function on_deactivation() {
 		$this->get_settings()->delete();
 
-		if ( $this->ad_blocking_recovery_tag->has() ) {
-			$this->ad_blocking_recovery_tag->delete();
-		}
+		$this->ad_blocking_recovery_tag->delete();
 	}
 
 	/**

--- a/tests/phpunit/includes/Core/Storage/Base64_Encryption.php
+++ b/tests/phpunit/includes/Core/Storage/Base64_Encryption.php
@@ -37,6 +37,10 @@ class Base64_Encryption {
 	 * @return bool|string
 	 */
 	public function decrypt( $value ) {
+		if ( ! is_string( $value ) ) {
+			return $value;
+		}
+
 		return base64_decode( $value );
 	}
 }

--- a/tests/phpunit/integration/Core/Storage/Data_EncryptionTest.php
+++ b/tests/phpunit/integration/Core/Storage/Data_EncryptionTest.php
@@ -53,5 +53,17 @@ class Data_EncryptionTest extends TestCase {
 		$decrypted_value = $encryption->decrypt( $encrypted_value );
 
 		$this->assertEquals( 'test-value', $decrypted_value );
+
+		// Test with non string value, it should return original array
+		$array_value     = array( 'key' => 'value' );
+		$decrypted_value = $encryption->decrypt( $array_value );
+
+		$this->assertEquals( $array_value, $decrypted_value );
+
+		// Test with string value, it should not decrypt it, but return original value
+		$string_value    = 'test-value';
+		$decrypted_value = $encryption->decrypt( $string_value );
+
+		$this->assertEquals( $string_value, $decrypted_value );
 	}
 }

--- a/tests/phpunit/integration/Core/Storage/Data_EncryptionTest.php
+++ b/tests/phpunit/integration/Core/Storage/Data_EncryptionTest.php
@@ -54,13 +54,13 @@ class Data_EncryptionTest extends TestCase {
 
 		$this->assertEquals( 'test-value', $decrypted_value );
 
-		// Test with non string value, it should return original array
+		// Test with non string value, it should return the original value.
 		$array_value     = array( 'key' => 'value' );
 		$decrypted_value = $encryption->decrypt( $array_value );
 
 		$this->assertEquals( $array_value, $decrypted_value );
 
-		// Test with string value, it should not decrypt it, but return original value
+		// Non-encrypted strings should be returned unmodified, without errors.
 		$string_value    = 'test-value';
 		$decrypted_value = $encryption->decrypt( $string_value );
 

--- a/tests/phpunit/integration/Core/Storage/Encrypted_OptionsTest.php
+++ b/tests/phpunit/integration/Core/Storage/Encrypted_OptionsTest.php
@@ -30,6 +30,9 @@ class Encrypted_OptionsTest extends TestCase {
 
 		update_option( 'test-serialized-option', base64_encode( serialize( array( 'test-value' ) ) ) );
 		$this->assertEquals( array( 'test-value' ), $encrypted_options->get( 'test-serialized-option' ) );
+
+		update_option( 'test-unserialized-array-option', array( 'test-value' ) );
+		$this->assertEquals( array( 'test-value' ), $encrypted_options->get( 'test-unserialized-array-option' ) );
 	}
 
 	public function test_set() {


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #7653 

## Relevant technical choices

I also added safeguard for decrypt method in `tests/phpunit/includes/Core/Storage/Base64_Encryption.php`

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
