### PR TITLE
fix(Tag_Manager): Fixes PHP 8.1 `ltrim()` deprecation warnings

### DIFF
--- a/includes/Modules/Tag_Manager.php
+++ b/includes/Modules/Tag_Manager.php
@@ -210,7 +210,9 @@ final class Tag_Manager extends Module
 		// Remove any leading or trailing whitespace.
 		$name = trim( $name );
 		// Must not start with an underscore.
-		$name = ltrim( $name, '_' );
+		if ( ! empty( $name ) ) {
+			$name = ltrim( $name, '_' );
+		}
 		// Decode entities for special characters so that they are stripped properly.
 		$name = wp_specialchars_decode( $name, ENT_QUOTES );
 		// Convert accents to basic characters to prevent them from being stripped.


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

* Fixes #7809

## Relevant technical choices

<!-- Please describe your changes. -->

* Fixes an `ltrim()` deprecation warning in the Tag Manager module by adding a validation check.

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
