### PR TITLE
(POC) Fix custom dimensions not syncing issue

### DIFF
--- a/assets/js/modules/analytics-4/datastore/custom-dimensions-gathering-data.js
+++ b/assets/js/modules/analytics-4/datastore/custom-dimensions-gathering-data.js
@@ -27,10 +27,11 @@ import invariant from 'invariant';
 import API from 'googlesitekit-api';
 import Data from 'googlesitekit-data';
 import { CORE_USER } from '../../../googlesitekit/datastore/user/constants';
+import { CUSTOM_DIMENSION_DEFINITIONS, MODULES_ANALYTICS_4 } from './constants';
 import { createFetchStore } from '../../../googlesitekit/data/create-fetch-store';
 import { createReducer } from '../../../googlesitekit/data/create-reducer';
 import { getDateString } from '../../../util';
-import { CUSTOM_DIMENSION_DEFINITIONS, MODULES_ANALYTICS_4 } from './constants';
+import { isInvalidCustomDimensionError } from '../utils/custom-dimensions';
 
 const { createRegistrySelector } = Data;
 
@@ -115,7 +116,7 @@ const baseActions = {
 	 * @param {string} customDimension Custom dimension slug.
 	 */
 	*checkCustomDimensionDataAvailability( customDimension ) {
-		const { select, __experimentalResolveSelect } =
+		const { select, __experimentalResolveSelect, dispatch } =
 			yield Data.commonActions.getRegistry();
 
 		yield Data.commonActions.await(
@@ -180,12 +181,29 @@ const baseActions = {
 			)
 		);
 
-		const hasReportError = !! select(
-			MODULES_ANALYTICS_4
-		).getErrorForSelector( 'getReport', [ reportArgs ] );
+		const reportError = select( MODULES_ANALYTICS_4 ).getErrorForSelector(
+			'getReport',
+			[ reportArgs ]
+		);
+
+		// Sync available custom dimensions.
+		if ( isInvalidCustomDimensionError( reportError ) ) {
+			dispatch( MODULES_ANALYTICS_4 ).clearError( 'getReport', [
+				reportArgs,
+			] );
+
+			dispatch( MODULES_ANALYTICS_4 )
+				.fetchSyncAvailableCustomDimensions()
+				.then( () => {
+					dispatch( MODULES_ANALYTICS_4 ).invalidateResolution(
+						'getReport',
+						[ reportArgs ]
+					);
+				} );
+		}
 
 		const isGatheringData =
-			hasReportError ||
+			!! reportError ||
 			! report?.rows?.length ||
 			// If the only dimension value is '(not set)', then there is no data. See https://support.google.com/analytics/answer/13504892.
 			( report.rowCount === 1 &&

--- a/includes/Modules/Analytics_4.php
+++ b/includes/Modules/Analytics_4.php
@@ -1183,6 +1183,22 @@ final class Analytics_4 extends Module
 					)
 				);
 
+				// Reset the data available state for custom dimensions that are no longer available.
+				$missing_custom_dimensions_with_data_available = array_diff(
+					array_keys(
+						array_filter(
+							$this->custom_dimensions_data_available->get_data_availability()
+						)
+					),
+					$matching_dimensions
+				);
+
+				if ( count( $missing_custom_dimensions_with_data_available ) > 0 ) {
+					$this->custom_dimensions_data_available->reset_data_available(
+						$missing_custom_dimensions_with_data_available
+					);
+				}
+
 				return $matching_dimensions;
 		}
 

--- a/includes/Modules/Analytics_4/Custom_Dimensions_Data_Available.php
+++ b/includes/Modules/Analytics_4/Custom_Dimensions_Data_Available.php
@@ -111,9 +111,13 @@ class Custom_Dimensions_Data_Available {
 	 * Resets the data available state for all custom dimensions.
 	 *
 	 * @since n.e.x.t
+	 *
+	 * @param array $custom_dimensions Optional. List of custom dimension slugs to reset.
 	 */
-	public function reset_data_available() {
-		foreach ( self::CUSTOM_DIMENSION_SLUGS as $custom_dimension ) {
+	public function reset_data_available(
+		$custom_dimensions = self::CUSTOM_DIMENSION_SLUGS
+	) {
+		foreach ( $custom_dimensions as $custom_dimension ) {
 			$this->transients->delete( $this->get_data_available_transient_name( $custom_dimension ) );
 		}
 	}


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #7815

## Relevant technical choices

This PR aims to address the issue reported [here](https://github.com/google/site-kit-wp/issues/7815) where the list of available custom dimensions does not sync and does not show the missing custom dimensions error after the report request fails.

While this is observed as a part of the QAB for #7601, this is actually a regression introduced as a part of #7638, where the gathering data state report request structure is different from the report request structure for the widget, and thus our `withCustomDimensions` HOC cannot detect the error.

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
