### PR TITLE
Use event names to prevent collisions.

### DIFF
--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -46,7 +46,7 @@ on:
       - ready_for_review
 
 concurrency:
-  group: storybook-${{ github.event_name }}-${{ github.ref }}
+  group: storybook-${{ github.event_name }}-${{ github.ref || 'unknown-ref' }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -46,7 +46,7 @@ on:
       - ready_for_review
 
 concurrency:
-  group: storybook-${{ github.ref }}
+  group: storybook-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -46,7 +46,7 @@ on:
       - ready_for_review
 
 concurrency:
-  group: storybook-${{ github.event_name }}-${{ github.ref || 'unknown-ref' }}
+  group: storybook-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/zips.yml
+++ b/.github/workflows/zips.yml
@@ -59,7 +59,7 @@ on:
       - ready_for_review
 
 concurrency:
-  group: zips-${{ github.ref }}
+  group: zips-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/zips.yml
+++ b/.github/workflows/zips.yml
@@ -59,7 +59,7 @@ on:
       - ready_for_review
 
 concurrency:
-  group: zips-${{ github.event_name }}-${{ github.ref }}
+  group: zips-${{ github.event_name }}-${{ github.ref || 'unknown-ref' }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/zips.yml
+++ b/.github/workflows/zips.yml
@@ -59,7 +59,7 @@ on:
       - ready_for_review
 
 concurrency:
-  group: zips-${{ github.event_name }}-${{ github.ref || 'unknown-ref' }}
+  group: zips-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/zips.yml
+++ b/.github/workflows/zips.yml
@@ -65,6 +65,7 @@ concurrency:
 env:
   GCS_BUCKET: site-kit-github-artifacts
   GCS_ROOT_PATH: builds
+  TEST: fake-env
 
 jobs:
   build-zips:

--- a/.github/workflows/zips.yml
+++ b/.github/workflows/zips.yml
@@ -65,7 +65,6 @@ concurrency:
 env:
   GCS_BUCKET: site-kit-github-artifacts
   GCS_ROOT_PATH: builds
-  TEST: fake-env
 
 jobs:
   build-zips:


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #7806

## Relevant technical choices

After some research, it turns out that for some of our events that trigger workflows might either be missing `${{ github.ref }}` (causing it to expire ALL events that match `storybook-` or have the same ref and are causing collisions when we push to `main`. Sometimes might happen when `develop` and `main` have the same refs too 🤔 

Actions are still cancelled with this setup in the same PR/branch, see: https://github.com/google/site-kit-wp/actions/runs/6734629639?pr=7814

![CleanShot 2023-11-02 at 15 21 36](https://github.com/google/site-kit-wp/assets/90871/6579569e-4feb-498f-b7be-e50b7627610b)

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
