### PR TITLE
Do not make report request immediately after creating custom dimension

### DIFF
--- a/assets/js/modules/analytics-4/datastore/custom-dimensions.js
+++ b/assets/js/modules/analytics-4/datastore/custom-dimensions.js
@@ -166,10 +166,22 @@ const baseActions = {
 		for ( const dimension of missingCustomDimensions ) {
 			const dimensionData = CUSTOM_DIMENSION_DEFINITIONS[ dimension ];
 			if ( dimensionData ) {
-				yield fetchCreateCustomDimensionStore.actions.fetchCreateCustomDimension(
-					propertyID,
-					dimensionData
-				);
+				const { error } =
+					yield fetchCreateCustomDimensionStore.actions.fetchCreateCustomDimension(
+						propertyID,
+						dimensionData
+					);
+
+				// If the custom dimension was created successfully, mark it as gathering
+				// data immediately so that it doesn't cause unnecessary report requests.
+				if ( ! error ) {
+					registry
+						.dispatch( MODULES_ANALYTICS_4 )
+						.receiveIsCustomDimensionGatheringData(
+							dimension,
+							true
+						);
+				}
 			}
 		}
 

--- a/assets/js/modules/analytics-4/datastore/custom-dimensions.test.js
+++ b/assets/js/modules/analytics-4/datastore/custom-dimensions.test.js
@@ -263,6 +263,17 @@ describe( 'modules/analytics-4 custom-dimensions', () => {
 						.select( MODULES_ANALYTICS_4 )
 						.getAvailableCustomDimensions()
 				).toEqual( customDimensionNames );
+
+				// Verify that the created custom dimensions are in a gathering data state.
+				customDimensionNames.forEach( ( customDimensionName ) => {
+					expect(
+						registry
+							.select( MODULES_ANALYTICS_4 )
+							.isCustomDimensionGatheringData(
+								customDimensionName
+							)
+					).toBe( true );
+				} );
 			} );
 		} );
 	} );


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #7794 

## Relevant technical choices

Currently, the key metric tiles that depend on custom dimensions make a report request immediately after the custom dimension is created. This can sometimes cause a race condition and cause the report request to fail due to not being able to find the custom dimension.

This first request is made by the gathering data state datastore partial to determine the custom dimension's gathering data state. Since it is obvious that the custom dimension will be in a gathering data state immediately after creation, this PR effectively sets this state after creation so that this initial request is not made.

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
