### PR TITLE
Remove step scrolling on user input questionnaire.

### DIFF
--- a/assets/js/components/user-input/UserInputQuestionnaire.js
+++ b/assets/js/components/user-input/UserInputQuestionnaire.js
@@ -98,9 +98,14 @@ export default function UserInputQuestionnaire() {
 	} = getUserInputAnswers();
 
 	const scrollToQuestion = () => {
-		global.document
-			?.querySelector( '.googlesitekit-user-input__header' )
-			?.scrollIntoView( { behavior: 'smooth' } );
+		// Using a consistent 24px padding across all devices to slightly reduce the padding gap.
+		// The intention is to scroll to the top of the page, revealing the answer header
+		// without unintentionally causing a scroll down, as might happen if scrolling to a specific selector.
+		global.scrollTo( {
+			top: 24,
+			left: 0,
+			behavior: 'smooth',
+		} );
 	};
 
 	const nextCallback = useCallback( () => {

--- a/assets/js/components/user-input/UserInputQuestionnaire.js
+++ b/assets/js/components/user-input/UserInputQuestionnaire.js
@@ -19,7 +19,7 @@
 /**
  * WordPress dependencies
  */
-import { useCallback, useEffect, useState } from '@wordpress/element';
+import { useCallback, useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -51,8 +51,6 @@ const steps = [ ...USER_INPUT_QUESTIONS_LIST, 'preview' ];
 export default function UserInputQuestionnaire() {
 	const viewContext = useViewContext();
 	const [ activeSlug, setActiveSlug ] = useQueryArg( 'question', steps[ 0 ] );
-	const [ shouldScrollToActiveQuestion, setShouldScrollToActiveQuestion ] =
-		useState( false );
 
 	const activeSlugIndex = steps.indexOf( activeSlug );
 	if ( activeSlugIndex === -1 ) {
@@ -126,17 +124,6 @@ export default function UserInputQuestionnaire() {
 			navigateTo( url.toString() );
 		}
 	}, [ gaEventCategory, saveUserInputSettings, dashboardURL, navigateTo ] );
-
-	useEffect( () => {
-		if ( ! shouldScrollToActiveQuestion ) {
-			setShouldScrollToActiveQuestion( true );
-			return;
-		}
-
-		global.document
-			?.querySelector( '.googlesitekit-user-input__header' )
-			?.scrollIntoView( { behavior: 'smooth' } );
-	}, [ activeSlug, shouldScrollToActiveQuestion ] );
 
 	const settingsProgress = (
 		<ProgressBar

--- a/assets/js/components/user-input/UserInputQuestionnaire.js
+++ b/assets/js/components/user-input/UserInputQuestionnaire.js
@@ -98,11 +98,8 @@ export default function UserInputQuestionnaire() {
 	} = getUserInputAnswers();
 
 	const scrollToQuestion = () => {
-		// Using a consistent 24px padding across all devices to slightly reduce the padding gap.
-		// The intention is to scroll to the top of the page, revealing the answer header
-		// without unintentionally causing a scroll down, as might happen if scrolling to a specific selector.
 		global.scrollTo( {
-			top: 24,
+			top: 0,
 			left: 0,
 			behavior: 'smooth',
 		} );

--- a/assets/js/components/user-input/UserInputQuestionnaire.js
+++ b/assets/js/components/user-input/UserInputQuestionnaire.js
@@ -97,6 +97,12 @@ export default function UserInputQuestionnaire() {
 		USER_INPUT_ANSWERS_POST_FREQUENCY,
 	} = getUserInputAnswers();
 
+	const scrollToQuestion = () => {
+		global.document
+			?.querySelector( '.googlesitekit-user-input__header' )
+			?.scrollIntoView( { behavior: 'smooth' } );
+	};
+
 	const nextCallback = useCallback( () => {
 		trackEvent(
 			gaEventCategory,
@@ -104,6 +110,7 @@ export default function UserInputQuestionnaire() {
 			steps[ activeSlugIndex ]
 		);
 		setActiveSlug( steps[ activeSlugIndex + 1 ] );
+		scrollToQuestion();
 	}, [ activeSlugIndex, gaEventCategory, setActiveSlug ] );
 
 	const backCallback = useCallback( () => {
@@ -113,6 +120,7 @@ export default function UserInputQuestionnaire() {
 			steps[ activeSlugIndex ]
 		);
 		setActiveSlug( steps[ activeSlugIndex - 1 ] );
+		scrollToQuestion();
 	}, [ activeSlugIndex, gaEventCategory, setActiveSlug ] );
 
 	const submitChanges = useCallback( async () => {


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #7750 

## Relevant technical choices

Implementation differs from IB, due to following [discussion](https://10up.slack.com/archives/CBKKQEBR9/p1699297488749469), scrolling has been kept around, but only for step transition (not for the page load)

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
