### PR TITLE
Set `'googlesitekit_post_categories'` dimension only when categories are found.

### DIFF
--- a/includes/Modules/Analytics_4.php
+++ b/includes/Modules/Analytics_4.php
@@ -1402,8 +1402,16 @@ final class Analytics_4 extends Module
 						$data[ $custom_dimension ] = $post->post_author;
 						break;
 					case 'googlesitekit_post_categories':
-						$cats                      = wp_get_post_categories( $post->ID, array( 'fields' => 'ids' ) );
-						$data[ $custom_dimension ] = ! is_wp_error( $cats ) ? implode( ',', $cats ) : '';
+						$categories = get_the_category( $post->ID );
+
+						if ( ! empty( $categories ) ) {
+							$get_category_ids = function( $category ) {
+								return $category->term_id;
+							};
+
+							$data[ $custom_dimension ] = implode( ',', array_map( $get_category_ids, $categories ) );
+						}
+
 						break;
 					case 'googlesitekit_post_date':
 						$data[ $custom_dimension ] = get_the_date( 'Ymd', $post );

--- a/includes/Modules/Analytics_4.php
+++ b/includes/Modules/Analytics_4.php
@@ -1405,11 +1405,9 @@ final class Analytics_4 extends Module
 						$categories = get_the_category( $post->ID );
 
 						if ( ! empty( $categories ) ) {
-							$get_category_ids = function( $category ) {
-								return $category->term_id;
-							};
+							$category_ids = wp_list_pluck( $categories, 'term_id' );
 
-							$data[ $custom_dimension ] = implode( ',', array_map( $get_category_ids, $categories ) );
+							$data[ $custom_dimension ] = implode( ',', $category_ids );
 						}
 
 						break;

--- a/tests/phpunit/integration/Modules/Analytics_4Test.php
+++ b/tests/phpunit/integration/Modules/Analytics_4Test.php
@@ -2851,7 +2851,7 @@ class Analytics_4Test extends TestCase {
 		$data     = $method->invoke( $this->analytics );
 		$this->assertEmpty( $data );
 
-		// Ensure the `'googlesitekit_post_categories'` key is not present in
+		// Ensure the `'googlesitekit_post_categories'` key is not present
 		// if the page does not return categories or encounters an error
 		// retrieving categories.
 		$this->assertFalse( array_key_exists( 'googlesitekit_post_categories', $data ) );

--- a/tests/phpunit/integration/Modules/Analytics_4Test.php
+++ b/tests/phpunit/integration/Modules/Analytics_4Test.php
@@ -2851,6 +2851,11 @@ class Analytics_4Test extends TestCase {
 		$data     = $method->invoke( $this->analytics );
 		$this->assertEmpty( $data );
 
+		// Ensure the `'googlesitekit_post_categories'` key is not present in
+		// if the page does not return categories or encounters an error
+		// retrieving categories.
+		$this->assertFalse( array_key_exists( 'googlesitekit_post_categories', $data ) );
+
 		// Change the current page to be singular.
 		$category1_id = $this->factory()->category->create();
 		$category2_id = $this->factory()->category->create();


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #7755

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [x] Run the code.
- [x] Ensure the acceptance criteria are satisfied.
- [x] Reassess the implementation with the IB.
- [x] Ensure no unrelated changes are included.
- [x] Ensure CI checks pass.
- [x] Check Storybook where applicable.
- [x] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [x] Ensure the PR has the correct target branch.
- [x] Double-check that the PR is okay to be merged.
- [x] Ensure the corresponding issue has a ZenHub release assigned.
- [x] Add a changelog message to the issue.
