### PR TITLE
Enhance/#7822 - Add space between the comma separated custom dimensions list in the Site Health

### DIFF
--- a/includes/Modules/Analytics_4.php
+++ b/includes/Modules/Analytics_4.php
@@ -354,8 +354,16 @@ final class Analytics_4 extends Module
 		if ( Feature_Flags::enabled( 'keyMetrics' ) ) {
 			$debug_fields['analytics_4_available_custom_dimensions'] = array(
 				'label' => __( 'Analytics 4 available custom dimensions', 'google-site-kit' ),
-				'value' => empty( $settings['availableCustomDimensions'] ) ? __( 'None', 'google-site-kit' ) : implode( ',', $settings['availableCustomDimensions'] ),
-				'debug' => empty( $settings['availableCustomDimensions'] ) ? 'none' : implode( ',', $settings['availableCustomDimensions'] ),
+				'value' => empty( $settings['availableCustomDimensions'] )
+					? __( 'None', 'google-site-kit' )
+					: join(
+						/* translators: used between list items, there is a space after the comma */
+						__( ', ', 'google-site-kit' ),
+						$settings['availableCustomDimensions']
+					),
+				'debug' => empty( $settings['availableCustomDimensions'] )
+					? 'none'
+					: join( ', ', $settings['availableCustomDimensions'] ),
 			);
 		}
 


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #7822 

## Relevant technical choices

<!-- Please describe your changes. -->

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [x] Run the code.
- [x] Ensure the acceptance criteria are satisfied.
- [x] Reassess the implementation with the IB.
- [x] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [x] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [x] Ensure the PR has the correct target branch.
- [x] Double-check that the PR is okay to be merged.
- [x] Ensure the corresponding issue has a ZenHub release assigned.
- [x] Add a changelog message to the issue.
