### PR TITLE
Fix loading analytics settings (Follow-up).

### DIFF
--- a/assets/js/modules/analytics/components/settings/SettingsForm.js
+++ b/assets/js/modules/analytics/components/settings/SettingsForm.js
@@ -25,7 +25,6 @@ import { Fragment } from '@wordpress/element';
  * Internal dependencies
  */
 import Data from 'googlesitekit-data';
-import { ProgressBar } from 'googlesitekit-components';
 import { AdsConversionIDTextField, TrackingExclusionSwitches } from '../common';
 import { CORE_MODULES } from '../../../../googlesitekit/modules/datastore/constants';
 import { MODULES_ANALYTICS } from '../../datastore/constants';
@@ -50,15 +49,7 @@ export default function SettingsForm( {
 		select( MODULES_ANALYTICS ).getAccountID()
 	);
 
-	const gtmContainersResolved = useSelect( ( select ) =>
-		select( MODULES_ANALYTICS ).hasFinishedLoadingGTMContainers()
-	);
-
 	const showTrackingExclusion = isGA4Connected || isUAConnected;
-
-	if ( ! gtmContainersResolved ) {
-		return <ProgressBar />;
-	}
 
 	return (
 		<Fragment>


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #6856 

## Relevant technical choices

Follow-up PR to fix loading issue on the analytics settings. The parts removed, are not needed any more, as GTM component was used in GA4 absence, and then removed with the feature flag. The loading was stuck because resolution for action checking for the tag manager live container lookup to finish (`gtmContainersResolved `), which was never fired in the first place, because the `analyticsSinglePropertyID` selector was removed as unreachable in condition, which was valid if GA4 feature flag was not present, and this selector was responsible for calls to the live container lookup happening further in the resolver. Hence, loading was stuck in progress bar component.

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
