### PR TITLE
Improve error notification after OAuth error

### DIFF
--- a/assets/js/components/DashboardMainApp.js
+++ b/assets/js/components/DashboardMainApp.js
@@ -57,7 +57,10 @@ import {
 	ANCHOR_ID_SPEED,
 	ANCHOR_ID_TRAFFIC,
 } from '../googlesitekit/constants';
-import { CORE_USER } from '../googlesitekit/datastore/user/constants';
+import {
+	CORE_USER,
+	FORM_TEMPORARY_PERSIST_PERMISSION_ERROR,
+} from '../googlesitekit/datastore/user/constants';
 import { CORE_WIDGETS } from '../googlesitekit/widgets/datastore/constants';
 import { useFeature } from '../hooks/useFeature';
 import useViewOnly from '../hooks/useViewOnly';
@@ -100,10 +103,30 @@ export default function DashboardMainApp() {
 	const { createCustomDimensions } = useDispatch( MODULES_ANALYTICS_4 );
 	const { setValues } = useDispatch( CORE_FORMS );
 
+	const grantedScopes = useSelect( ( select ) =>
+		select( CORE_USER ).getGrantedScopes()
+	);
+	const persistedPermissionsError = useSelect( ( select ) =>
+		select( CORE_FORMS ).getValue(
+			FORM_TEMPORARY_PERSIST_PERMISSION_ERROR,
+			'permissionsError'
+		)
+	);
+	const hasReceivedGrantedScopes =
+		persistedPermissionsError?.data?.scopes?.some( ( scope ) =>
+			grantedScopes.includes( scope )
+		);
+
 	useMount( () => {
 		if ( ! viewOnlyDashboard ) {
 			// Render the current survey portal in 5 seconds after the initial rendering.
 			setTimeout( () => setShowSurveyPortal( true ), 5000 );
+		}
+
+		if ( hasReceivedGrantedScopes ) {
+			setValues( FORM_TEMPORARY_PERSIST_PERMISSION_ERROR, {
+				permissionsError: {},
+			} );
 		}
 	} );
 

--- a/assets/js/components/DashboardMainApp.js
+++ b/assets/js/components/DashboardMainApp.js
@@ -106,14 +106,14 @@ export default function DashboardMainApp() {
 	const grantedScopes = useSelect( ( select ) =>
 		select( CORE_USER ).getGrantedScopes()
 	);
-	const persistedPermissionsError = useSelect( ( select ) =>
+	const tempPersistedPermissionsError = useSelect( ( select ) =>
 		select( CORE_FORMS ).getValue(
 			FORM_TEMPORARY_PERSIST_PERMISSION_ERROR,
 			'permissionsError'
 		)
 	);
 	const hasReceivedGrantedScopes =
-		persistedPermissionsError?.data?.scopes?.some( ( scope ) =>
+		tempPersistedPermissionsError?.data?.scopes?.some( ( scope ) =>
 			grantedScopes.includes( scope )
 		);
 

--- a/assets/js/components/PermissionsModal/AuthenticatedPermissionsModal.js
+++ b/assets/js/components/PermissionsModal/AuthenticatedPermissionsModal.js
@@ -27,8 +27,12 @@ import { useEffect, useCallback } from '@wordpress/element';
  */
 import Data from 'googlesitekit-data';
 import ModalDialog from '../ModalDialog';
-import { CORE_USER } from '../../googlesitekit/datastore/user/constants';
+import { CORE_FORMS } from '../../googlesitekit/datastore/forms/constants';
 import { CORE_LOCATION } from '../../googlesitekit/datastore/location/constants';
+import {
+	CORE_USER,
+	FORM_TEMPORARY_PERSIST_PERMISSION_ERROR,
+} from '../../googlesitekit/datastore/user/constants';
 import { snapshotAllStores } from '../../googlesitekit/data/create-snapshot-store';
 import Portal from '../Portal';
 const { useSelect, useDispatch, useRegistry } = Data;
@@ -51,17 +55,23 @@ const AuthenticatedPermissionsModal = () => {
 
 	const { clearPermissionScopeError } = useDispatch( CORE_USER );
 	const { navigateTo } = useDispatch( CORE_LOCATION );
+	const { setValues } = useDispatch( CORE_FORMS );
 
 	const onCancel = useCallback( () => {
 		clearPermissionScopeError();
 	}, [ clearPermissionScopeError ] );
 
 	const onConfirm = useCallback( async () => {
+		// Temporary store permissions error, so data like scopes and `redirectURL`
+		// can be used in `Permission error` notification.
+		setValues( FORM_TEMPORARY_PERSIST_PERMISSION_ERROR, {
+			permissionsError,
+		} );
 		// If we have a datastores to snapshot before navigating away to the
 		// authorization page, do that first.
 		await snapshotAllStores( registry );
 		navigateTo( connectURL );
-	}, [ registry, connectURL, navigateTo ] );
+	}, [ registry, connectURL, navigateTo, permissionsError, setValues ] );
 
 	useEffect( () => {
 		// If error has flag to skip the modal, redirect to the authorization

--- a/assets/js/components/notifications/ErrorNotifications.js
+++ b/assets/js/components/notifications/ErrorNotifications.js
@@ -53,23 +53,23 @@ export default function ErrorNotifications() {
 	const setupErrorMessage = useSelect( ( select ) =>
 		select( CORE_SITE ).getSetupErrorMessage()
 	);
-	const persistedPermissionsError = useSelect( ( select ) =>
+	const tempPersistedPermissionsError = useSelect( ( select ) =>
 		select( CORE_FORMS ).getValue(
 			FORM_TEMPORARY_PERSIST_PERMISSION_ERROR,
 			'permissionsError'
 		)
 	);
 	const setupErrorRedoURL = useSelect( ( select ) => {
-		if ( persistedPermissionsError?.data ) {
+		if ( tempPersistedPermissionsError?.data ) {
 			return select( CORE_USER ).getConnectURL( {
-				additionalScopes: persistedPermissionsError?.data?.scopes,
+				additionalScopes: tempPersistedPermissionsError?.data?.scopes,
 				redirectURL:
-					persistedPermissionsError?.data?.redirectURL ||
+					tempPersistedPermissionsError?.data?.redirectURL ||
 					global.location.href,
 			} );
 		} else if (
 			setupErrorCode === 'access_denied' &&
-			! persistedPermissionsError?.data &&
+			! tempPersistedPermissionsError?.data &&
 			isAuthenticated
 		) {
 			return null;
@@ -98,9 +98,9 @@ export default function ErrorNotifications() {
 	if ( setupErrorCode === 'access_denied' ) {
 		title = __( 'Permissions Error', 'google-site-kit' );
 
-		if ( persistedPermissionsError?.data ) {
+		if ( tempPersistedPermissionsError?.data ) {
 			ctaLabel = __( 'Grant permission', 'google-site-kit' );
-		} else if ( ! persistedPermissionsError?.data && isAuthenticated ) {
+		} else if ( ! tempPersistedPermissionsError?.data && isAuthenticated ) {
 			ctaLabel = null;
 		}
 	}

--- a/assets/js/components/notifications/ErrorNotifications.js
+++ b/assets/js/components/notifications/ErrorNotifications.js
@@ -53,9 +53,6 @@ export default function ErrorNotifications() {
 	const setupErrorMessage = useSelect( ( select ) =>
 		select( CORE_SITE ).getSetupErrorMessage()
 	);
-	const existingPermissionError = useSelect( ( select ) =>
-		select( CORE_USER ).getPermissionScopeError()
-	);
 	const persistedPermissionsError = useSelect( ( select ) =>
 		select( CORE_FORMS ).getValue(
 			FORM_TEMPORARY_PERSIST_PERMISSION_ERROR,
@@ -70,14 +67,11 @@ export default function ErrorNotifications() {
 					persistedPermissionsError?.data?.redirectURL ||
 					global.location.href,
 			} );
-		}
-		if (
+		} else if (
 			setupErrorCode === 'access_denied' &&
 			! persistedPermissionsError?.data &&
-			existingPermissionError
+			isAuthenticated
 		) {
-			// If `existingPermissionError` have data it implies it is not due to the `plugin setup`, and CTA
-			// should not render. This is explained in more detail in comment bellow in hidding the label part.
 			return null;
 		}
 
@@ -103,16 +97,10 @@ export default function ErrorNotifications() {
 
 	if ( setupErrorCode === 'access_denied' ) {
 		title = __( 'Permissions Error', 'google-site-kit' );
+
 		if ( persistedPermissionsError?.data ) {
 			ctaLabel = __( 'Grant permission', 'google-site-kit' );
-		} else if (
-			! persistedPermissionsError?.data &&
-			existingPermissionError
-		) {
-			// If there is `existingPermissionError` it implies that the 'access denied' error isn't shown
-			// because of the plugin setup. If the plugin setup permission had been denied,
-			// this would be empty. Therefore, no call-to-action should be displayed at this point,
-			// as it would only request the generic analytics read permission without resolving the actual issue.
+		} else if ( ! persistedPermissionsError?.data && isAuthenticated ) {
 			ctaLabel = null;
 		}
 	}

--- a/assets/js/components/notifications/ErrorNotifications.stories.js
+++ b/assets/js/components/notifications/ErrorNotifications.stories.js
@@ -60,7 +60,9 @@ export const PluginSetupError = Template.bind( {} );
 PluginSetupError.storyName = 'Plugin Setup Error - Redo the plugin setup';
 PluginSetupError.args = {
 	setupRegistry: ( registry ) => {
-		provideUserAuthentication( registry );
+		provideUserAuthentication( registry, {
+			authenticated: false,
+		} );
 
 		provideSiteInfo( registry, {
 			setupErrorRedoURL: '#',
@@ -71,6 +73,25 @@ PluginSetupError.args = {
 	},
 };
 PluginSetupError.scenario = {
+	label: 'Global/ErrorNotifications/PluginSetupError',
+};
+
+export const PermissionError = Template.bind( {} );
+PermissionError.storyName =
+	'Permission Error - No permission is temporary persisted';
+PermissionError.args = {
+	setupRegistry: ( registry ) => {
+		provideUserAuthentication( registry );
+
+		provideSiteInfo( registry, {
+			setupErrorRedoURL: '#',
+			setupErrorCode: 'access_denied',
+			setupErrorMessage:
+				'Setup was interrupted because you did not grant the necessary permissions',
+		} );
+	},
+};
+PermissionError.scenario = {
 	label: 'Global/ErrorNotifications/PluginSetupError',
 };
 

--- a/assets/js/components/notifications/ErrorNotifications.stories.js
+++ b/assets/js/components/notifications/ErrorNotifications.stories.js
@@ -23,8 +23,11 @@ import ErrorNotifications from './ErrorNotifications';
 import WithRegistrySetup from '../../../../tests/js/WithRegistrySetup';
 import {
 	provideModules,
+	provideSiteInfo,
 	provideUserAuthentication,
 } from '../../../../tests/js/utils';
+import { FORM_TEMPORARY_PERSIST_PERMISSION_ERROR } from '../../googlesitekit/datastore/user/constants';
+import { CORE_FORMS } from '../../googlesitekit/datastore/forms/constants';
 
 function Template( { ...args } ) {
 	return <ErrorNotifications { ...args } />;
@@ -51,6 +54,56 @@ UnsatisfiedScopeGTESupport.args = {
 };
 UnsatisfiedScopeGTESupport.scenario = {
 	label: 'Global/ErrorNotifications/UnsatisfiedScopeGTESupport',
+};
+
+export const PluginSetupError = Template.bind( {} );
+PluginSetupError.storyName = 'Plugin Setup Error - Redo the plugin setup';
+PluginSetupError.args = {
+	setupRegistry: ( registry ) => {
+		provideUserAuthentication( registry );
+
+		provideSiteInfo( registry, {
+			setupErrorRedoURL: '#',
+			setupErrorCode: 'access_denied',
+			setupErrorMessage:
+				'Setup was interrupted because you did not grant the necessary permissions',
+		} );
+	},
+};
+PluginSetupError.scenario = {
+	label: 'Global/ErrorNotifications/PluginSetupError',
+};
+
+export const AdditionalScopeError = Template.bind( {} );
+AdditionalScopeError.storyName = 'Additional Scope Error - Grant Permission';
+AdditionalScopeError.args = {
+	setupRegistry: ( registry ) => {
+		provideUserAuthentication( registry );
+
+		const permissionsError = {
+			status: 403,
+			message: 'Additional scope',
+			data: {
+				scopes: [ 'https://www.googleapis.com/auth/analytics.edit' ],
+			},
+		};
+
+		registry
+			.dispatch( CORE_FORMS )
+			.setValues( FORM_TEMPORARY_PERSIST_PERMISSION_ERROR, {
+				permissionsError,
+			} );
+
+		provideSiteInfo( registry, {
+			setupErrorRedoURL: '#',
+			setupErrorCode: 'access_denied',
+			setupErrorMessage:
+				'Setup was interrupted because you did not grant the necessary permissions',
+		} );
+	},
+};
+AdditionalScopeError.scenario = {
+	label: 'Global/ErrorNotifications/AdditionalScopeError',
 };
 
 export default {

--- a/assets/js/components/notifications/ErrorNotifications.test.js
+++ b/assets/js/components/notifications/ErrorNotifications.test.js
@@ -27,8 +27,12 @@ import {
 	provideModules,
 	provideSiteInfo,
 } from '../../../../tests/js/test-utils';
-import { CORE_USER } from '../../googlesitekit/datastore/user/constants';
+import {
+	CORE_USER,
+	FORM_TEMPORARY_PERSIST_PERMISSION_ERROR,
+} from '../../googlesitekit/datastore/user/constants';
 import { CORE_SITE } from '../../googlesitekit/datastore/site/constants';
+import { CORE_FORMS } from '../../googlesitekit/datastore/forms/constants';
 
 describe( 'ErrorNotifications', () => {
 	let registry;
@@ -149,5 +153,78 @@ describe( 'ErrorNotifications', () => {
 			'Site Kit can’t access necessary data'
 		);
 		expect( container ).toMatchSnapshot();
+	} );
+
+	it( 'does render the redo setup CTA if initial Site Kit setup auth is not granted', () => {
+		provideUserAuthentication( registry );
+		provideSiteInfo( registry, {
+			setupErrorRedoURL: '#',
+			setupErrorCode: 'access_denied',
+			setupErrorMessage:
+				'Setup was interrupted because you did not grant the necessary permissions',
+		} );
+
+		const { container } = render( <ErrorNotifications />, {
+			registry,
+		} );
+
+		expect( container ).toHaveTextContent( 'Setup was interrupted' );
+		expect( container ).toHaveTextContent( 'Redo the plugin setup' );
+	} );
+
+	it( 'does not render the redo setup CTA if it is not due to the interuption of plugin setup and no permission is temporary persissted', () => {
+		provideUserAuthentication( registry );
+		provideSiteInfo( registry, {
+			setupErrorRedoURL: '#',
+			setupErrorCode: 'access_denied',
+			setupErrorMessage:
+				'Setup was interrupted because you did not grant the necessary permissions',
+		} );
+
+		registry.dispatch( CORE_USER ).setPermissionScopeError( {
+			status: 403,
+			message: 'Generic scope',
+			data: {
+				scopes: [
+					'https://www.googleapis.com/auth/analytics.readonly',
+				],
+			},
+		} );
+
+		const { container } = render( <ErrorNotifications />, {
+			registry,
+		} );
+
+		expect( container ).toHaveTextContent( 'Setup was interrupted' );
+		expect( container ).not.toHaveTextContent( 'Redo the plugin setup' );
+	} );
+
+	it( 'does render the grant permission CTA if additional permissions were not granted and permission is temporary persissted', () => {
+		provideUserAuthentication( registry );
+		provideSiteInfo( registry, {
+			setupErrorRedoURL: '#',
+			setupErrorCode: 'access_denied',
+			setupErrorMessage:
+				'Setup was interrupted because you did not grant the necessary permissions',
+		} );
+
+		registry
+			.dispatch( CORE_FORMS )
+			.setValues( FORM_TEMPORARY_PERSIST_PERMISSION_ERROR, {
+				status: 403,
+				message: 'Generic scope',
+				data: {
+					scopes: [
+						'https://www.googleapis.com/auth/analytics.edit',
+					],
+				},
+			} );
+
+		const { container } = render( <ErrorNotifications />, {
+			registry,
+		} );
+
+		expect( container ).toHaveTextContent( 'Setup was interrupted' );
+		expect( container ).not.toHaveTextContent( 'Grant permission' );
 	} );
 } );

--- a/assets/js/components/notifications/ErrorNotifications.test.js
+++ b/assets/js/components/notifications/ErrorNotifications.test.js
@@ -156,7 +156,9 @@ describe( 'ErrorNotifications', () => {
 	} );
 
 	it( 'does render the redo setup CTA if initial Site Kit setup auth is not granted', () => {
-		provideUserAuthentication( registry );
+		provideUserAuthentication( registry, {
+			authenticated: false,
+		} );
 		provideSiteInfo( registry, {
 			setupErrorRedoURL: '#',
 			setupErrorCode: 'access_denied',
@@ -175,20 +177,10 @@ describe( 'ErrorNotifications', () => {
 	it( 'does not render the redo setup CTA if it is not due to the interuption of plugin setup and no permission is temporary persissted', () => {
 		provideUserAuthentication( registry );
 		provideSiteInfo( registry, {
-			setupErrorRedoURL: '#',
 			setupErrorCode: 'access_denied',
 			setupErrorMessage:
 				'Setup was interrupted because you did not grant the necessary permissions',
-		} );
-
-		registry.dispatch( CORE_USER ).setPermissionScopeError( {
-			status: 403,
-			message: 'Generic scope',
-			data: {
-				scopes: [
-					'https://www.googleapis.com/auth/analytics.readonly',
-				],
-			},
+			setupErrorRedoURL: '#',
 		} );
 
 		const { container } = render( <ErrorNotifications />, {
@@ -202,10 +194,11 @@ describe( 'ErrorNotifications', () => {
 	it( 'does render the grant permission CTA if additional permissions were not granted and permission is temporary persissted', () => {
 		provideUserAuthentication( registry );
 		provideSiteInfo( registry, {
-			setupErrorRedoURL: '#',
+			isAuthenticated: true,
 			setupErrorCode: 'access_denied',
 			setupErrorMessage:
 				'Setup was interrupted because you did not grant the necessary permissions',
+			setupErrorRedoURL: '#',
 		} );
 
 		registry

--- a/assets/js/components/notifications/UnsatisfiedScopesAlert.js
+++ b/assets/js/components/notifications/UnsatisfiedScopesAlert.js
@@ -80,7 +80,7 @@ export default function UnsatisfiedScopesAlert() {
 			new RegExp( '//oauth2|action=googlesitekit_connect', 'i' )
 		)
 	);
-	const persistedPermissionsError = useSelect( ( select ) =>
+	const tempPersistedPermissionsError = useSelect( ( select ) =>
 		select( CORE_FORMS ).getValue(
 			FORM_TEMPORARY_PERSIST_PERMISSION_ERROR,
 			'permissionsError'
@@ -93,11 +93,12 @@ export default function UnsatisfiedScopesAlert() {
 	const connectURLData = {
 		redirectURL: global.location.href,
 	};
-	if ( persistedPermissionsError?.data ) {
+	if ( tempPersistedPermissionsError?.data ) {
 		connectURLData.additionalScopes =
-			persistedPermissionsError.data?.scopes;
+			tempPersistedPermissionsError.data?.scopes;
 		connectURLData.redirectURL =
-			persistedPermissionsError.data?.redirectURL || global.location.href;
+			tempPersistedPermissionsError.data?.redirectURL ||
+			global.location.href;
 	}
 
 	const connectURL = useSelect( ( select ) =>
@@ -151,7 +152,7 @@ export default function UnsatisfiedScopesAlert() {
 		'google-site-kit'
 	);
 	let ctaLabel = __( 'Redo setup', 'google-site-kit' );
-	if ( persistedPermissionsError?.data ) {
+	if ( tempPersistedPermissionsError?.data ) {
 		ctaLabel = __( 'Grant permission', 'google-site-kit' );
 	}
 

--- a/assets/js/components/notifications/UnsatisfiedScopesAlertGTE.js
+++ b/assets/js/components/notifications/UnsatisfiedScopesAlertGTE.js
@@ -27,15 +27,27 @@ import { __ } from '@wordpress/i18n';
 import Data from 'googlesitekit-data';
 import BannerNotification from './BannerNotification';
 import { CORE_SITE } from '../../googlesitekit/datastore/site/constants';
-import { CORE_USER } from '../../googlesitekit/datastore/user/constants';
+import {
+	CORE_USER,
+	FORM_TEMPORARY_PERSIST_PERMISSION_ERROR,
+} from '../../googlesitekit/datastore/user/constants';
 import { READ_SCOPE as TAGMANAGER_READ_SCOPE } from '../../modules/tagmanager/datastore/constants';
+import { CORE_FORMS } from '../../googlesitekit/datastore/forms/constants';
 const { useSelect } = Data;
 
 export default function UnsatisfiedScopesAlertGTE() {
+	const persistedPermissionsError = useSelect( ( select ) =>
+		select( CORE_FORMS ).getValue(
+			FORM_TEMPORARY_PERSIST_PERMISSION_ERROR,
+			'permissionsError'
+		)
+	);
 	const connectURL = useSelect( ( select ) =>
 		select( CORE_USER ).getConnectURL( {
 			additionalScopes: [ TAGMANAGER_READ_SCOPE ],
-			redirectURL: global.location.href,
+			redirectURL:
+				persistedPermissionsError?.data?.redirectURL ||
+				global.location.href,
 		} )
 	);
 

--- a/assets/js/components/notifications/UnsatisfiedScopesAlertGTE.js
+++ b/assets/js/components/notifications/UnsatisfiedScopesAlertGTE.js
@@ -36,7 +36,7 @@ import { CORE_FORMS } from '../../googlesitekit/datastore/forms/constants';
 const { useSelect } = Data;
 
 export default function UnsatisfiedScopesAlertGTE() {
-	const persistedPermissionsError = useSelect( ( select ) =>
+	const tempPersistedPermissionsError = useSelect( ( select ) =>
 		select( CORE_FORMS ).getValue(
 			FORM_TEMPORARY_PERSIST_PERMISSION_ERROR,
 			'permissionsError'
@@ -46,7 +46,7 @@ export default function UnsatisfiedScopesAlertGTE() {
 		select( CORE_USER ).getConnectURL( {
 			additionalScopes: [ TAGMANAGER_READ_SCOPE ],
 			redirectURL:
-				persistedPermissionsError?.data?.redirectURL ||
+				tempPersistedPermissionsError?.data?.redirectURL ||
 				global.location.href,
 		} )
 	);

--- a/assets/js/googlesitekit/datastore/user/constants.js
+++ b/assets/js/googlesitekit/datastore/user/constants.js
@@ -23,6 +23,9 @@ export const DISCONNECTED_REASON_CONNECTED_URL_MISMATCH =
 
 export const GLOBAL_SURVEYS_TIMEOUT_SLUG = '__global';
 
+export const FORM_TEMPORARY_PERSIST_PERMISSION_ERROR =
+	'temporary_persist_permission_error';
+
 // Permissions list.
 export const PERMISSION_AUTHENTICATE = 'googlesitekit_authenticate';
 export const PERMISSION_SETUP = 'googlesitekit_setup';


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #7597 

## Relevant technical choices

Deviation from IB:
* Used variable name `tempPersistedPermissionsError` instead of `permissionsError`, so it is not confused with `CORE_USER` state, and to better describe the value it holds.
* Included `isAuthenticated` in checks, as during implementation/testing, this was needed to satisfy all criteria and distinguish between plugin setup error and any other other permission error notification.

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
