### PR TITLE
Remove bottom alignment from tiles with badge (Follow-Up).

### DIFF
--- a/assets/sass/components/key-metrics/_googlesitekit-km-widget-tile.scss
+++ b/assets/sass/components/key-metrics/_googlesitekit-km-widget-tile.scss
@@ -55,7 +55,6 @@
 	}
 
 	.googlesitekit-km-widget-tile--numeric {
-		height: 100%;
 
 		.googlesitekit-km-widget-tile__metric {
 			font-family: $f-secondary;
@@ -83,7 +82,6 @@
 	}
 
 	.googlesitekit-km-widget-tile--text {
-		height: 100%;
 
 		.googlesitekit-km-widget-tile__metric {
 			font-size: $fs-title-lg;


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #7769 

## Relevant technical choices

Follow up fix. Reverted the height which was bottom-aligning the content, as this looks inappropriate when error tile is present. Following the merge of  #7763 which will attend to the styling of error tiles, adjusting the desktop height of error tile to match other tiles height, alignment can be re-considered

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
