### PR TITLE
Add basic component for setting rendered UI state.

### DIFF
--- a/assets/js/components/KeyMetrics/KeyMetricsSetupCTARenderedEffect.js
+++ b/assets/js/components/KeyMetrics/KeyMetricsSetupCTARenderedEffect.js
@@ -1,0 +1,40 @@
+/**
+ * Site Kit by Google, Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import { useEffectOnce } from 'react-use';
+
+/**
+ * Internal dependencies
+ */
+import Data from 'googlesitekit-data';
+import { CORE_UI } from '../../googlesitekit/datastore/ui/constants';
+const { useDispatch } = Data;
+
+export const UI_KEY_KEY_METRICS_SETUP_CTA_RENDERED =
+	'KEY_METRICS_SETUP_CTA_RENDERED';
+
+export default function KeyMetricsSetupCTARenderedEffect() {
+	const { setValue } = useDispatch( CORE_UI );
+
+	useEffectOnce( () => {
+		setValue( UI_KEY_KEY_METRICS_SETUP_CTA_RENDERED, true );
+	} );
+
+	return null;
+}

--- a/assets/js/components/KeyMetrics/KeyMetricsSetupCTAWidget.js
+++ b/assets/js/components/KeyMetrics/KeyMetricsSetupCTAWidget.js
@@ -53,6 +53,7 @@ import {
 } from '../AdminMenuTooltip';
 import { trackEvent } from '../../util';
 import useViewContext from '../../hooks/useViewContext';
+import KeyMetricsSetupCTARenderedEffect from './KeyMetricsSetupCTARenderedEffect';
 
 const { useDispatch, useSelect } = Data;
 
@@ -170,6 +171,7 @@ function KeyMetricsSetupCTAWidget( { Widget, WidgetNull } ) {
 				) }
 				actions={
 					<Fragment>
+						<KeyMetricsSetupCTARenderedEffect />
 						<Button
 							className="googlesitekit-key-metrics-cta-button"
 							href={ ctaLink }

--- a/assets/js/components/notifications/BannerNotifications.js
+++ b/assets/js/components/notifications/BannerNotifications.js
@@ -46,10 +46,13 @@ import GoogleTagIDMismatchNotification from './GoogleTagIDMismatchNotification';
 import SwitchedToGA4Banner from './SwitchedToGA4Banner';
 import WebDataStreamNotAvailableNotification from './WebDataStreamNotAvailableNotification';
 import AdBlockingRecoverySetupSuccessBannerNotification from './AdBlockingRecoverySetupSuccessBannerNotification';
+import { CORE_UI } from '../../googlesitekit/datastore/ui/constants';
+import { UI_KEY_KEY_METRICS_SETUP_CTA_RENDERED } from '../KeyMetrics/KeyMetricsSetupCTARenderedEffect';
 
 const { useSelect } = Data;
 
 export default function BannerNotifications() {
+	const keyMetricsEnabled = useFeature( 'keyMetrics' );
 	const enhancedMeasurementEnabled = useFeature( 'enhancedMeasurement' );
 	const viewOnly = useViewOnly();
 
@@ -72,6 +75,11 @@ export default function BannerNotifications() {
 
 	const hasMismatchedGoogleTagID = useSelect( ( select ) =>
 		select( MODULES_ANALYTICS_4 ).hasMismatchedGoogleTagID()
+	);
+	const keyMetricsSetupCTARendered = useSelect(
+		( select ) =>
+			keyMetricsEnabled &&
+			select( CORE_UI ).getValue( UI_KEY_KEY_METRICS_SETUP_CTA_RENDERED )
 	);
 
 	const isGA4ModuleOwner = useSelect( ( select ) => {
@@ -113,7 +121,7 @@ export default function BannerNotifications() {
 			{ analyticsModuleConnected && ga4ModuleConnected && (
 				<SwitchedToGA4Banner />
 			) }
-			{ enhancedMeasurementEnabled && (
+			{ enhancedMeasurementEnabled && ! keyMetricsSetupCTARendered && (
 				<EnhancedMeasurementActivationBanner />
 			) }
 			{ ga4ModuleConnected && hasGTMScope && isGA4ModuleOwner && (


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #7865 

## Relevant technical choices

- Uses component to encapsulate effect from rendering KM setup CTA rather than adding additional use-effect to duplicate checking conditions for when the component is being rendered
- State is specific to KM setup CTA being rendered, not about another component (EM banner), this way only `BannerNotifications` needs to consider this state

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
