### PR TITLE
Fix Double Banner On OAuth Cancel (Follow-up).

### DIFF
--- a/assets/js/components/Header.js
+++ b/assets/js/components/Header.js
@@ -41,6 +41,7 @@ import { Grid, Row, Cell } from '../material-components';
 import DashboardNavigation from './DashboardNavigation';
 import EntityHeader from './EntityHeader';
 import ViewOnlyMenu from './ViewOnlyMenu';
+import SetupErrorNotification from './notifications/SetupErrorNotification';
 import useViewOnly from '../hooks/useViewOnly';
 import useDashboardType from '../hooks/useDashboardType';
 import Link from './Link';
@@ -110,6 +111,7 @@ const Header = ( { children, subHeader, showNavigation } ) => {
 
 			<div className="googlesitekit-subheader" ref={ subHeaderRef }>
 				<ErrorNotifications />
+				<SetupErrorNotification />
 				{ subHeader }
 			</div>
 

--- a/assets/js/components/notifications/SetupErrorNotification.js
+++ b/assets/js/components/notifications/SetupErrorNotification.js
@@ -1,0 +1,59 @@
+/**
+ * SetupErrorNotification component.
+ *
+ * Site Kit by Google, Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import Data from 'googlesitekit-data';
+import BannerNotification from './BannerNotification';
+import { CORE_SITE } from '../../googlesitekit/datastore/site/constants';
+const { useSelect } = Data;
+
+export default function SetupErrorNotification() {
+	// These will be `null` if no errors exist.
+	const setupErrorMessage = useSelect( ( select ) =>
+		select( CORE_SITE ).getSetupErrorMessage()
+	);
+	const setupErrorRedoURL = useSelect( ( select ) =>
+		select( CORE_SITE ).getSetupErrorRedoURL()
+	);
+
+	if ( ! setupErrorMessage ) {
+		return null;
+	}
+
+	return (
+		<BannerNotification
+			id="setup_error"
+			type="win-error"
+			title={ __(
+				'Oops! There was a problem during set up. Please try again.',
+				'google-site-kit'
+			) }
+			description={ setupErrorMessage }
+			isDismissible={ false }
+			ctaLabel={ __( 'Redo the plugin setup', 'google-site-kit' ) }
+			ctaLink={ setupErrorRedoURL }
+		/>
+	);
+}

--- a/assets/js/components/setup/SetupUsingProxyWithSignIn.js
+++ b/assets/js/components/setup/SetupUsingProxyWithSignIn.js
@@ -121,13 +121,6 @@ export default function SetupUsingProxyWithSignIn() {
 	const hasViewableModules = useSelect(
 		( select ) => !! select( CORE_USER ).getViewableModules()?.length
 	);
-	// These will be `null` if no errors exist.
-	const setupErrorMessage = useSelect( ( select ) =>
-		select( CORE_SITE ).getSetupErrorMessage()
-	);
-	const setupErrorRedoURL = useSelect( ( select ) =>
-		select( CORE_SITE ).getSetupErrorRedoURL()
-	);
 
 	const { dismissItem } = useDispatch( CORE_USER );
 	const { navigateTo } = useDispatch( CORE_LOCATION );
@@ -249,23 +242,6 @@ export default function SetupUsingProxyWithSignIn() {
 			<Header>
 				<HelpMenu />
 			</Header>
-			{ setupErrorMessage && (
-				<BannerNotification
-					id="setup_error"
-					type="win-error"
-					title={ __(
-						'Oops! There was a problem during set up. Please try again.',
-						'google-site-kit'
-					) }
-					description={ setupErrorMessage }
-					isDismissible={ false }
-					ctaLabel={ __(
-						'Redo the plugin setup',
-						'google-site-kit'
-					) }
-					ctaLink={ setupErrorRedoURL }
-				/>
-			) }
 			{ getQueryArg( location.href, 'notification' ) ===
 				'reset_success' && (
 				<BannerNotification


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #7597 

## Relevant technical choices

Since the #6634 consolidated notifications in one place, there was additional error that was generated from `assets/js/components/setup/SetupUsingProxyWithSignIn.js` separately only for Site kit setup error, rendering it bellow the sub-header. I extracted it into new component and included it with other errors/notifications.

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
