### PR TITLE
Replace AdSenseConnect Buttons with SpinnerButtons.

### DIFF
--- a/assets/js/modules/adsense/components/common/AdSenseConnectCTA/index.js
+++ b/assets/js/modules/adsense/components/common/AdSenseConnectCTA/index.js
@@ -38,7 +38,7 @@ import {
  * Internal dependencies
  */
 import Data from 'googlesitekit-data';
-import { Button } from 'googlesitekit-components';
+import { SpinnerButton } from 'googlesitekit-components';
 import { MODULES_ADSENSE } from '../../../datastore/constants';
 import { Grid, Row, Cell } from '../../../../../material-components';
 import { CORE_SITE } from '../../../../../googlesitekit/datastore/site/constants';
@@ -79,6 +79,14 @@ export default function AdSenseConnectCTA( { onDismissModule } ) {
 	);
 	const adSenseModuleConnected = useSelect( ( select ) =>
 		select( CORE_MODULES ).isModuleConnected( 'adsense' )
+	);
+
+	const isConnectingAdSense = useSelect(
+		( select ) =>
+			select( CORE_MODULES ).isFetchingSetModuleActivation(
+				'adsense',
+				true
+			) || select( CORE_LOCATION ).isNavigatingTo( adminReauthURL )
 	);
 
 	const handleConnect = useCallback( async () => {
@@ -128,20 +136,25 @@ export default function AdSenseConnectCTA( { onDismissModule } ) {
 					<Cell { ...cellProps }>
 						<div className="googlesitekit-setup-module__action">
 							{ ! adSenseModuleActive && (
-								<Button onClick={ handleConnect }>
+								<SpinnerButton
+									onClick={ handleConnect }
+									isSaving={ isConnectingAdSense }
+								>
 									{ __( 'Connect now', 'google-site-kit' ) }
-								</Button>
+								</SpinnerButton>
 							) }
 
-							{ adSenseModuleActive &&
-								! adSenseModuleConnected && (
-									<Button onClick={ handleCompleteSetup }>
-										{ __(
-											'Complete setup',
-											'google-site-kit'
-										) }
-									</Button>
-								) }
+							{ adSenseModuleActive && ! adSenseModuleConnected && (
+								<SpinnerButton
+									onClick={ handleCompleteSetup }
+									isSaving={ isConnectingAdSense }
+								>
+									{ __(
+										'Complete setup',
+										'google-site-kit'
+									) }
+								</SpinnerButton>
+							) }
 
 							<Link onClick={ handleDismissModule }>
 								{ __( 'Maybe later', 'google-site-kit' ) }

--- a/assets/js/modules/adsense/components/common/AdSenseConnectCTA/index.js
+++ b/assets/js/modules/adsense/components/common/AdSenseConnectCTA/index.js
@@ -81,13 +81,22 @@ export default function AdSenseConnectCTA( { onDismissModule } ) {
 		select( CORE_MODULES ).isModuleConnected( 'adsense' )
 	);
 
-	const isConnectingAdSense = useSelect(
-		( select ) =>
-			select( CORE_MODULES ).isFetchingSetModuleActivation(
-				'adsense',
-				true
-			) || select( CORE_LOCATION ).isNavigatingTo( adminReauthURL )
-	);
+	const isConnectingAdSense = useSelect( ( select ) => {
+		const isFetching = select( CORE_MODULES ).isFetchingSetModuleActivation(
+			'adsense',
+			true
+		);
+
+		if ( isFetching ) {
+			return true;
+		}
+
+		if ( ! adminReauthURL ) {
+			return false;
+		}
+
+		return select( CORE_LOCATION ).isNavigatingTo( adminReauthURL );
+	} );
 
 	const handleConnect = useCallback( async () => {
 		const { response, error } = await activateModule( 'adsense' );


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #7385

## Relevant technical choices

Followed the IB. Replaced `Button` with `SpinnerButton` and added the loading state.

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [x] Run the code.
- [x] Ensure the acceptance criteria are satisfied.
- [x] Reassess the implementation with the IB.
- [x] Ensure no unrelated changes are included.
- [x] Ensure CI checks pass.
- [x] Check Storybook where applicable.
- [x] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
