### PR TITLE
Fix `AdBlockingRecoveryApp` setup status unresolved issue

### DIFF
--- a/assets/js/components/Stepper/Step.js
+++ b/assets/js/components/Stepper/Step.js
@@ -21,14 +21,21 @@
  */
 import PropTypes from 'prop-types';
 
-export default function Step( { children, title } ) {
+/**
+ * Internal dependencies
+ */
+import { STEP_STATUS } from './constants';
+
+export default function Step( { children, title, stepStatus } ) {
 	return (
 		<div className="googlesitekit-stepper__step-info">
 			<h2 className="googlesitekit-stepper__step-title">{ title }</h2>
 			<div className="googlesitekit-stepper__step-content-container">
-				<div className="googlesitekit-stepper__step-content">
-					{ children }
-				</div>
+				{ stepStatus === STEP_STATUS.ACTIVE && (
+					<div className="googlesitekit-stepper__step-content">
+						{ children }
+					</div>
+				) }
 			</div>
 		</div>
 	);
@@ -37,4 +44,5 @@ export default function Step( { children, title } ) {
 Step.propTypes = {
 	children: PropTypes.node.isRequired,
 	title: PropTypes.string.isRequired,
+	stepStatus: PropTypes.oneOf( Object.values( STEP_STATUS ) ),
 };

--- a/assets/js/components/Stepper/__snapshots__/index.test.js.snap
+++ b/assets/js/components/Stepper/__snapshots__/index.test.js.snap
@@ -31,13 +31,7 @@ exports[`Stepper should render all steps as completed when activeStep is greater
         </h2>
         <div
           class="googlesitekit-stepper__step-content-container"
-        >
-          <div
-            class="googlesitekit-stepper__step-content"
-          >
-            This is step 1.
-          </div>
-        </div>
+        />
       </div>
     </li>
     <li
@@ -63,13 +57,7 @@ exports[`Stepper should render all steps as completed when activeStep is greater
         </h2>
         <div
           class="googlesitekit-stepper__step-content-container"
-        >
-          <div
-            class="googlesitekit-stepper__step-content"
-          >
-            This is step 2.
-          </div>
-        </div>
+        />
       </div>
     </li>
   </ol>
@@ -107,13 +95,7 @@ exports[`Stepper should render all steps as upcoming when activeStep is negative
         </h2>
         <div
           class="googlesitekit-stepper__step-content-container"
-        >
-          <div
-            class="googlesitekit-stepper__step-content"
-          >
-            This is step 1.
-          </div>
-        </div>
+        />
       </div>
     </li>
     <li
@@ -139,13 +121,7 @@ exports[`Stepper should render all steps as upcoming when activeStep is negative
         </h2>
         <div
           class="googlesitekit-stepper__step-content-container"
-        >
-          <div
-            class="googlesitekit-stepper__step-content"
-          >
-            This is step 2.
-          </div>
-        </div>
+        />
       </div>
     </li>
   </ol>
@@ -183,13 +159,7 @@ exports[`Stepper should render all steps as upcoming when activeStep is not prov
         </h2>
         <div
           class="googlesitekit-stepper__step-content-container"
-        >
-          <div
-            class="googlesitekit-stepper__step-content"
-          >
-            This is step 1.
-          </div>
-        </div>
+        />
       </div>
     </li>
     <li
@@ -215,13 +185,7 @@ exports[`Stepper should render all steps as upcoming when activeStep is not prov
         </h2>
         <div
           class="googlesitekit-stepper__step-content-container"
-        >
-          <div
-            class="googlesitekit-stepper__step-content"
-          >
-            This is step 2.
-          </div>
-        </div>
+        />
       </div>
     </li>
   </ol>
@@ -291,13 +255,7 @@ exports[`Stepper should render the active step as active and display its content
         </h2>
         <div
           class="googlesitekit-stepper__step-content-container"
-        >
-          <div
-            class="googlesitekit-stepper__step-content"
-          >
-            This is step 2.
-          </div>
-        </div>
+        />
       </div>
     </li>
   </ol>
@@ -335,13 +293,7 @@ exports[`Stepper should render the active step as active and display its content
         </h2>
         <div
           class="googlesitekit-stepper__step-content-container"
-        >
-          <div
-            class="googlesitekit-stepper__step-content"
-          >
-            This is step 1.
-          </div>
-        </div>
+        />
       </div>
     </li>
     <li

--- a/assets/js/components/Stepper/index.js
+++ b/assets/js/components/Stepper/index.js
@@ -108,7 +108,7 @@ export default function Stepper( { children, activeStep, className } ) {
 								<div className="googlesitekit-stepper__step-progress-line"></div>
 							) }
 						</div>
-						{ cloneElement( child ) }
+						{ cloneElement( child, { stepStatus } ) }
 					</li>
 				);
 			} ) }

--- a/assets/js/modules/adsense/components/setup/AdBlockingRecoveryApp/SetupMain.js
+++ b/assets/js/modules/adsense/components/setup/AdBlockingRecoveryApp/SetupMain.js
@@ -17,7 +17,7 @@
 /**
  * WordPress dependencies
  */
-import { useCallback, useEffect, useMemo, useState } from '@wordpress/element';
+import { useCallback, useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -63,25 +63,16 @@ export default function SetupMain() {
 	const dashboardURL = useSelect( ( select ) =>
 		select( CORE_SITE ).getAdminURL( 'googlesitekit-dashboard' )
 	);
-	const adBlockingRecoverySetupStatus = useSelect( ( select ) =>
-		select( MODULES_ADSENSE ).getAdBlockingRecoverySetupStatus()
-	);
-
-	const {
-		saveSettings,
-		setAdBlockingRecoverySetupStatus,
-		setUseAdBlockingRecoverySnippet,
-		setUseAdBlockingRecoveryErrorSnippet,
-	} = useDispatch( MODULES_ADSENSE );
-	const { navigateTo } = useDispatch( CORE_LOCATION );
-
-	const initialActiveStep = useMemo( () => {
+	const initialActiveStep = useSelect( ( select ) => {
 		const statusStepMap = {
 			[ ENUM_AD_BLOCKING_RECOVERY_SETUP_STATUS.TAG_PLACED ]:
 				ENUM_AD_BLOCKING_RECOVERY_SETUP_STEP.CREATE_MESSAGE,
 			[ ENUM_AD_BLOCKING_RECOVERY_SETUP_STATUS.SETUP_CONFIRMED ]:
 				ENUM_AD_BLOCKING_RECOVERY_SETUP_STEP.COMPLETE,
 		};
+
+		const adBlockingRecoverySetupStatus =
+			select( MODULES_ADSENSE ).getAdBlockingRecoverySetupStatus();
 
 		if ( adBlockingRecoverySetupStatus === undefined ) {
 			return undefined;
@@ -91,7 +82,15 @@ export default function SetupMain() {
 			statusStepMap[ adBlockingRecoverySetupStatus ] ||
 			ENUM_AD_BLOCKING_RECOVERY_SETUP_STEP.PLACE_TAGS
 		);
-	}, [ adBlockingRecoverySetupStatus ] );
+	} );
+
+	const {
+		saveSettings,
+		setAdBlockingRecoverySetupStatus,
+		setUseAdBlockingRecoverySnippet,
+		setUseAdBlockingRecoveryErrorSnippet,
+	} = useDispatch( MODULES_ADSENSE );
+	const { navigateTo } = useDispatch( CORE_LOCATION );
 
 	const [ activeStep, setActiveStep ] = useState( initialActiveStep );
 
@@ -176,31 +175,29 @@ export default function SetupMain() {
 			</Grid>
 
 			<Content>
-				{ undefined !== adBlockingRecoverySetupStatus && (
-					<Stepper
-						activeStep={ activeStep }
-						className="googlesitekit-ad-blocking-recovery__steps"
+				<Stepper
+					activeStep={ activeStep }
+					className="googlesitekit-ad-blocking-recovery__steps"
+				>
+					<Step
+						title={ __(
+							'Enable ad blocking recovery message (required)',
+							'google-site-kit'
+						) }
+						className="googlesitekit-ad-blocking-recovery__step googlesitekit-ad-blocking-recovery__step-place-tags"
 					>
-						<Step
-							title={ __(
-								'Enable ad blocking recovery message (required)',
-								'google-site-kit'
-							) }
-							className="googlesitekit-ad-blocking-recovery__step googlesitekit-ad-blocking-recovery__step-place-tags"
-						>
-							<PlaceTagsStep setActiveStep={ setActiveStep } />
-						</Step>
-						<Step
-							title={ __(
-								'Create your site’s ad blocking recovery message (required)',
-								'google-site-kit'
-							) }
-							className="googlesitekit-ad-blocking-recovery__step googlesitekit-ad-blocking-recovery__step-create-message"
-						>
-							<CreateMessageStep />
-						</Step>
-					</Stepper>
-				) }
+						<PlaceTagsStep setActiveStep={ setActiveStep } />
+					</Step>
+					<Step
+						title={ __(
+							'Create your site’s ad blocking recovery message (required)',
+							'google-site-kit'
+						) }
+						className="googlesitekit-ad-blocking-recovery__step googlesitekit-ad-blocking-recovery__step-create-message"
+					>
+						<CreateMessageStep />
+					</Step>
+				</Stepper>
 			</Content>
 
 			<div className="googlesitekit-ad-blocking-recovery__footer googlesitekit-ad-blocking-recovery__buttons">

--- a/assets/js/modules/adsense/components/setup/AdBlockingRecoveryApp/SetupMain.js
+++ b/assets/js/modules/adsense/components/setup/AdBlockingRecoveryApp/SetupMain.js
@@ -17,7 +17,7 @@
 /**
  * WordPress dependencies
  */
-import { useCallback, useEffect, useState } from '@wordpress/element';
+import { useCallback, useEffect, useMemo, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -63,16 +63,25 @@ export default function SetupMain() {
 	const dashboardURL = useSelect( ( select ) =>
 		select( CORE_SITE ).getAdminURL( 'googlesitekit-dashboard' )
 	);
-	const initialActiveStep = useSelect( ( select ) => {
+	const adBlockingRecoverySetupStatus = useSelect( ( select ) =>
+		select( MODULES_ADSENSE ).getAdBlockingRecoverySetupStatus()
+	);
+
+	const {
+		saveSettings,
+		setAdBlockingRecoverySetupStatus,
+		setUseAdBlockingRecoverySnippet,
+		setUseAdBlockingRecoveryErrorSnippet,
+	} = useDispatch( MODULES_ADSENSE );
+	const { navigateTo } = useDispatch( CORE_LOCATION );
+
+	const initialActiveStep = useMemo( () => {
 		const statusStepMap = {
 			[ ENUM_AD_BLOCKING_RECOVERY_SETUP_STATUS.TAG_PLACED ]:
 				ENUM_AD_BLOCKING_RECOVERY_SETUP_STEP.CREATE_MESSAGE,
 			[ ENUM_AD_BLOCKING_RECOVERY_SETUP_STATUS.SETUP_CONFIRMED ]:
 				ENUM_AD_BLOCKING_RECOVERY_SETUP_STEP.COMPLETE,
 		};
-
-		const adBlockingRecoverySetupStatus =
-			select( MODULES_ADSENSE ).getAdBlockingRecoverySetupStatus();
 
 		if ( adBlockingRecoverySetupStatus === undefined ) {
 			return undefined;
@@ -82,15 +91,7 @@ export default function SetupMain() {
 			statusStepMap[ adBlockingRecoverySetupStatus ] ||
 			ENUM_AD_BLOCKING_RECOVERY_SETUP_STEP.PLACE_TAGS
 		);
-	} );
-
-	const {
-		saveSettings,
-		setAdBlockingRecoverySetupStatus,
-		setUseAdBlockingRecoverySnippet,
-		setUseAdBlockingRecoveryErrorSnippet,
-	} = useDispatch( MODULES_ADSENSE );
-	const { navigateTo } = useDispatch( CORE_LOCATION );
+	}, [ adBlockingRecoverySetupStatus ] );
 
 	const [ activeStep, setActiveStep ] = useState( initialActiveStep );
 
@@ -175,29 +176,31 @@ export default function SetupMain() {
 			</Grid>
 
 			<Content>
-				<Stepper
-					activeStep={ activeStep }
-					className="googlesitekit-ad-blocking-recovery__steps"
-				>
-					<Step
-						title={ __(
-							'Enable ad blocking recovery message (required)',
-							'google-site-kit'
-						) }
-						className="googlesitekit-ad-blocking-recovery__step googlesitekit-ad-blocking-recovery__step-place-tags"
+				{ undefined !== adBlockingRecoverySetupStatus && (
+					<Stepper
+						activeStep={ activeStep }
+						className="googlesitekit-ad-blocking-recovery__steps"
 					>
-						<PlaceTagsStep setActiveStep={ setActiveStep } />
-					</Step>
-					<Step
-						title={ __(
-							'Create your site’s ad blocking recovery message (required)',
-							'google-site-kit'
-						) }
-						className="googlesitekit-ad-blocking-recovery__step googlesitekit-ad-blocking-recovery__step-create-message"
-					>
-						<CreateMessageStep />
-					</Step>
-				</Stepper>
+						<Step
+							title={ __(
+								'Enable ad blocking recovery message (required)',
+								'google-site-kit'
+							) }
+							className="googlesitekit-ad-blocking-recovery__step googlesitekit-ad-blocking-recovery__step-place-tags"
+						>
+							<PlaceTagsStep setActiveStep={ setActiveStep } />
+						</Step>
+						<Step
+							title={ __(
+								'Create your site’s ad blocking recovery message (required)',
+								'google-site-kit'
+							) }
+							className="googlesitekit-ad-blocking-recovery__step googlesitekit-ad-blocking-recovery__step-create-message"
+						>
+							<CreateMessageStep />
+						</Step>
+					</Stepper>
+				) }
 			</Content>
 
 			<div className="googlesitekit-ad-blocking-recovery__footer googlesitekit-ad-blocking-recovery__buttons">


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- https://github.com/google/site-kit-wp/issues/7292#issuecomment-1824279743 (second point)

## Relevant technical choices

This PR aims to address the second point raised by the QA team [here](https://github.com/google/site-kit-wp/issues/7292#issuecomment-1824279743). The problem occurs because the ad blocking recovery setup status isn't resolved initially, causing the stepper to not function as expected.

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
