### PR TITLE
Track `confirm_notification` event in all scenarios

### DIFF
--- a/assets/js/modules/analytics-4/components/dashboard/EnhancedMeasurementActivationBanner/SetupBanner.js
+++ b/assets/js/modules/analytics-4/components/dashboard/EnhancedMeasurementActivationBanner/SetupBanner.js
@@ -100,10 +100,15 @@ export default function SetupBanner( props ) {
 			return;
 		}
 
+		trackEvent(
+			`${ viewContext }_enhanced-measurement-notification`,
+			'confirm_notification'
+		);
+
 		// Ask the parent component to show the success banner.
 		// This should be called last because it will unmount this component.
 		onSubmitSuccess();
-	}, [ setValues, submitChanges, onSubmitSuccess ] );
+	}, [ setValues, submitChanges, viewContext, onSubmitSuccess ] );
 
 	const handleSubmitChanges = useCallback( async () => {
 		const scopes = [];
@@ -134,14 +139,8 @@ export default function SetupBanner( props ) {
 			return;
 		}
 
-		trackEvent(
-			`${ viewContext }_enhanced-measurement-notification`,
-			'confirm_notification'
-		);
-
 		await commonSubmitChanges();
 	}, [
-		viewContext,
 		hasEditScope,
 		commonSubmitChanges,
 		setPermissionScopeError,


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #7974 

## Relevant technical choices

This PR updates the opt-in GA tracking to track an event in all scenarios when the Enhanced Measurement setup banner succeeds.

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
