### PR TITLE
Add `await` to `trackEvent` call.

### DIFF
--- a/assets/js/modules/analytics/components/setup/SetupForm.js
+++ b/assets/js/modules/analytics/components/setup/SetupForm.js
@@ -113,7 +113,7 @@ export default function SetupForm( { finishSetup } ) {
 
 			if ( ! error ) {
 				if ( isEnhancedMeasurementEnabled === true ) {
-					trackEvent(
+					await trackEvent(
 						`${ viewContext }_analytics`,
 						'ga4_setup_enhanced_measurement_enabled'
 					);


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #7975

## Relevant technical choices

Added an `await` to our trackEvent call to ensure it's made before page navigation at the end of setup.

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
