### PR TITLE
Add "get help" link to Google API connection health check error

### DIFF
--- a/assets/js/components/setup/CompatibilityChecks/CompatibilityErrorNotice.js
+++ b/assets/js/components/setup/CompatibilityChecks/CompatibilityErrorNotice.js
@@ -158,32 +158,15 @@ export default function CompatibilityErrorNotice( { error } ) {
 			);
 		case ERROR_GOOGLE_API_CONNECTION_FAIL:
 			return (
-				<p
-					dangerouslySetInnerHTML={ sanitizeHTML(
-						`
-						${ __(
-							'Looks like your site is having a technical issue with requesting data from Google services.',
+				<p>
+					{ createInterpolateElement(
+						__(
+							'Looks like your site is having a technical issue with requesting data from Google services. <GetHelpLink />',
 							'google-site-kit'
-						) }
-						<br/>
-						${
-							sprintf(
-								/* translators: 1: Support Forum URL, 2: Error message */ // eslint-disable-line indent
-								__(
-									'To get more help, ask a question on our <a href="%1$s">support forum</a> and include the text of the original error message: %2$s',
-									'google-site-kit'
-								), // eslint-disable-line indent
-								'https://wordpress.org/support/plugin/google-site-kit/', // eslint-disable-line indent
-								`<br/>${ error }` // eslint-disable-line indent
-							) /* eslint-disable-line indent */
-						}
-						`,
-						{
-							ALLOWED_TAGS: [ 'a', 'br' ],
-							ALLOWED_ATTR: [ 'href' ],
-						}
+						),
+						{ GetHelpLink: <GetHelpLink errorCode={ error } /> }
 					) }
-				/>
+				</p>
 			);
 		case ERROR_AMP_CDN_RESTRICTED:
 			return (

--- a/assets/js/components/setup/CompatibilityChecks/GetHelpLink.js
+++ b/assets/js/components/setup/CompatibilityChecks/GetHelpLink.js
@@ -36,12 +36,14 @@ import { CORE_SITE } from '../../../googlesitekit/datastore/site/constants';
 import {
 	ERROR_AMP_CDN_RESTRICTED,
 	ERROR_API_UNAVAILABLE,
+	ERROR_GOOGLE_API_CONNECTION_FAIL,
 	ERROR_TOKEN_MISMATCH,
 } from './constants';
 
 const errorCodes = {
 	[ ERROR_AMP_CDN_RESTRICTED ]: 'amp_cdn_restricted',
 	[ ERROR_API_UNAVAILABLE ]: 'check_api_unavailable',
+	[ ERROR_GOOGLE_API_CONNECTION_FAIL ]: 'google_api_connection_fail',
 	[ ERROR_TOKEN_MISMATCH ]: 'setup_token_mismatch',
 };
 


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #7994 

## Relevant technical choices

This PR adds a "get help" link to the Google API connection health check error.

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
