### PR TITLE
Search queries appear as links on View only dashboard #8025 is fixed successfully.

### DIFF
--- a/assets/js/modules/search-console/components/dashboard/DashboardPopularKeywordsWidget.js
+++ b/assets/js/modules/search-console/components/dashboard/DashboardPopularKeywordsWidget.js
@@ -160,13 +160,16 @@ export default function DashboardPopularKeywordsWidget( props ) {
 				} );
 
 				return (
-					<Link
+					<div>
+						{searchAnalyticsURL?<Link
 						href={ searchAnalyticsURL }
 						external
 						hideExternalIndicator
 					>
 						{ fieldValue }
-					</Link>
+					</Link>:<div>{fieldValue}</div>}
+					
+					</div>
 				);
 			},
 		},

--- a/assets/js/modules/search-console/components/dashboard/DashboardPopularKeywordsWidget.js
+++ b/assets/js/modules/search-console/components/dashboard/DashboardPopularKeywordsWidget.js
@@ -161,13 +161,13 @@ export default function DashboardPopularKeywordsWidget( props ) {
 
 				return (
 					<div>
-						{searchAnalyticsURL?<Link
+						{searchAnalyticsURL?(<Link
 						href={ searchAnalyticsURL }
 						external
 						hideExternalIndicator
 					>
 						{ fieldValue }
-					</Link>:<div>{fieldValue}</div>}
+					</Link>):(<div>{fieldValue}</div>)}
 					
 					</div>
 				);


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:
Search queries appear as links on View only dashboard #8025
The issue is the Link tag always need to have the "href" even though it is undefined so it is appearing as the link.
- #

## Relevant technical choices

<!-- Please describe your changes. -->
I conditional rendered the tag depending on the user permissions , if user has only read-only i will render the <div> element if they have all permissions the <Link> will be rendered .

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [ ] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
