### PR TITLE
Restore original text in Google API connection health check error message

### DIFF
--- a/assets/js/components/setup/CompatibilityChecks/CompatibilityErrorNotice.js
+++ b/assets/js/components/setup/CompatibilityChecks/CompatibilityErrorNotice.js
@@ -94,6 +94,11 @@ export default function CompatibilityErrorNotice( { error } ) {
 	const documentationURL = useSelect( ( select ) => {
 		return select( CORE_SITE ).getDocumentationLinkURL( 'staging' );
 	} );
+	const googleAPIConnectionFailHelpURL = useSelect( ( select ) =>
+		select( CORE_SITE ).getErrorTroubleshootingLinkURL( {
+			code: ERROR_GOOGLE_API_CONNECTION_FAIL,
+		} )
+	);
 
 	switch ( error ) {
 		case ERROR_API_UNAVAILABLE:
@@ -158,15 +163,31 @@ export default function CompatibilityErrorNotice( { error } ) {
 			);
 		case ERROR_GOOGLE_API_CONNECTION_FAIL:
 			return (
-				<p>
-					{ createInterpolateElement(
-						__(
-							'Looks like your site is having a technical issue with requesting data from Google services. <GetHelpLink />',
+				<p
+					dangerouslySetInnerHTML={ sanitizeHTML(
+						`
+						${ __(
+							'Looks like your site is having a technical issue with requesting data from Google services.',
 							'google-site-kit'
-						),
-						{ GetHelpLink: <GetHelpLink errorCode={ error } /> }
+						) }
+						<br/>
+						${ sprintf(
+							/* translators: 1: Help URL, 2: Support Forum URL, 3: Error message */
+							__(
+								'<a href="%1$s">Click here</a> for more information, or to get more help, ask a question on our <a href="%2$s">support forum</a> and include the text of the original error message: %3$s',
+								'google-site-kit'
+							),
+							googleAPIConnectionFailHelpURL,
+							'https://wordpress.org/support/plugin/google-site-kit/',
+							`<br/>${ error }`
+						) }
+						`,
+						{
+							ALLOWED_TAGS: [ 'a', 'br' ],
+							ALLOWED_ATTR: [ 'href' ],
+						}
 					) }
-				</p>
+				/>
 			);
 		case ERROR_AMP_CDN_RESTRICTED:
 			return (


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- https://github.com/google/site-kit-wp/issues/7994#issuecomment-1875250153

## Relevant technical choices

This PR restores the original text in the error message that takes the user to the support forum.

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
