### PR TITLE
Enhance/#6368 - Change Adsense approval timeframe

### DIFF
--- a/assets/js/modules/adsense/components/setup/SetupAccountSite/GettingReady.js
+++ b/assets/js/modules/adsense/components/setup/SetupAccountSite/GettingReady.js
@@ -55,7 +55,7 @@ export default function GettingReady() {
 	const heading = __( 'Your site is getting ready', 'google-site-kit' );
 
 	const description = __(
-		'This usually takes a few days, but in some cases can take up to 2 weeks. You’ll get an email from AdSense as soon as they have run some checks on your site.',
+		'This usually takes a few days, but in some cases can take a few weeks. You’ll get an email from AdSense as soon as they have run some checks on your site.',
 		'google-site-kit'
 	);
 


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #6368 

## Relevant technical choices

- There are no VRT scenarios for the Adsense setup stories to be updated.

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
