### PR TITLE
Avoid changing questionnaire "Apply changes" button title while answers are being saved.

### DIFF
--- a/assets/js/components/user-input/UserInputPreviewGroup.js
+++ b/assets/js/components/user-input/UserInputPreviewGroup.js
@@ -260,13 +260,12 @@ export default function UserInputPreviewGroup( {
 									}
 									isSaving={ isScreenLoading }
 								>
-									{ hasSettingChanged &&
-										__(
-											'Apply changes',
-											'google-site-kit'
-										) }
-									{ ! hasSettingChanged &&
-										__( 'Save', 'google-site-kit' ) }
+									{ hasSettingChanged || isSavingSettings
+										? __(
+												'Apply changes',
+												'google-site-kit'
+										  )
+										: __( 'Save', 'google-site-kit' ) }
 								</SpinnerButton>
 								<Link
 									disabled={ isScreenLoading }


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #7546 

## Relevant technical choices

Include a check for `isSavingSettings` in the conditions for the "Apply changes"/"Save" button title to fix the defect raised here: https://github.com/google/site-kit-wp/issues/7546#issuecomment-1880564186

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [x] Run the code.
- [x] Ensure the acceptance criteria are satisfied.
- [x] Reassess the implementation with the IB.
- [x] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [x] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
