### PR TITLE
Use tertiary button in `KeyMetricsCTAFooter`

### DIFF
--- a/assets/js/components/KeyMetrics/KeyMetricsCTAFooter.js
+++ b/assets/js/components/KeyMetrics/KeyMetricsCTAFooter.js
@@ -29,16 +29,16 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
+import { Button } from 'googlesitekit-components';
 import { Cell, Row } from '../../material-components';
-import Link from '../Link';
 
 export default function KeyMetricsCTAFooter( { onActionClick = () => {} } ) {
 	return (
 		<Row className="googlesitekit-widget-key-metrics-footer">
 			<Cell size={ 12 }>
-				<Link onClick={ onActionClick }>
+				<Button tertiary onClick={ onActionClick }>
 					{ __( 'Maybe later', 'google-site-kit' ) }
-				</Link>
+				</Button>
 			</Cell>
 		</Row>
 	);

--- a/assets/js/components/KeyMetrics/KeyMetricsSetupCTAWidget.js
+++ b/assets/js/components/KeyMetrics/KeyMetricsSetupCTAWidget.js
@@ -154,6 +154,7 @@ function KeyMetricsSetupCTAWidget( { Widget, WidgetNull } ) {
 
 	return (
 		<Widget
+			className="googlesitekit-widget-key-metrics-cta"
 			noPadding
 			Footer={ () => (
 				<KeyMetricsCTAFooter onActionClick={ dismissCallback } />

--- a/assets/js/modules/analytics-4/components/widgets/ConnectGA4CTAWidget.js
+++ b/assets/js/modules/analytics-4/components/widgets/ConnectGA4CTAWidget.js
@@ -139,6 +139,7 @@ export default function ConnectGA4CTAWidget( { Widget, WidgetNull } ) {
 
 	return (
 		<Widget
+			className="googlesitekit-widget-key-metrics-cta"
 			noPadding
 			Footer={ () => (
 				<KeyMetricsCTAFooter

--- a/assets/sass/components/key-metrics/_googlesitekit-key-metrics-setup-cta.scss
+++ b/assets/sass/components/key-metrics/_googlesitekit-key-metrics-setup-cta.scss
@@ -136,10 +136,16 @@
 		}
 	}
 
-	.googlesitekit-widget-key-metrics-footer {
+	.googlesitekit-widget-key-metrics-cta {
 
-		button.googlesitekit-cta-link {
-			color: $c-surfaces-on-background-variant;
+		.googlesitekit-widget__footer {
+			padding-bottom: 6px;
+			padding-top: 6px;
+
+			@media (min-width: $bp-desktop) {
+				padding-bottom: 14px;
+				padding-top: 14px;
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- https://github.com/google/site-kit-wp/issues/7912#issuecomment-1883150961

## Relevant technical choices

This PR addressed the comment linked above by using the tertiary button variant in the Key Metrics CTA Footer.

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
