### PR TITLE
Add caching to property ID request.

### DIFF
--- a/assets/js/googlesitekit/datastore/site/cache.js
+++ b/assets/js/googlesitekit/datastore/site/cache.js
@@ -25,47 +25,14 @@ import invariant from 'invariant';
  * Internal dependencies
  */
 import Data from 'googlesitekit-data';
-import { getItem, setItem } from '../../../googlesitekit/api/cache';
-import { CORE_SITE } from './constants';
-
-const { createReducer } = Data;
+import { setItem } from '../../../googlesitekit/api/cache';
 
 // Actions.
-const CACHE_GET_ITEM = 'CACHE_GET_ITEM';
-const CACHE_GET_ITEM_SAVE_TO_STORE = 'CACHE_GET_ITEM_SAVE_TO_STORE';
 const CACHE_SET_ITEM = 'CACHE_SET_ITEM';
 
-const baseInitialState = {
-	getItemCacheResults: {},
-};
+const baseInitialState = {};
 
 const baseActions = {
-	/**
-	 * Yields to cache `getItem` which fetches cached data using a key.
-	 *
-	 * @since n.e.x.t
-	 *
-	 * @param {string} key Name of cache key.
-	 * @return {Object} Redux-style action.
-	 */
-	*getCacheItem( key ) {
-		invariant( key, 'key is required' );
-
-		const result = yield {
-			type: CACHE_GET_ITEM,
-			payload: {
-				key,
-			},
-		};
-
-		return {
-			type: CACHE_GET_ITEM_SAVE_TO_STORE,
-			payload: {
-				key,
-				result,
-			},
-		};
-	},
 	/**
 	 * Yields to setItem function which sets cached data using a key.
 	 *
@@ -97,13 +64,6 @@ const baseActions = {
 
 // Base Controls
 export const baseControls = {
-	[ CACHE_GET_ITEM ]: async ( { payload } ) => {
-		const { key } = payload;
-
-		const result = await getItem( key );
-
-		return result;
-	},
 	[ CACHE_SET_ITEM ]: async ( { payload } ) => {
 		const { key, value, args } = payload;
 
@@ -111,52 +71,10 @@ export const baseControls = {
 	},
 };
 
-export const baseReducer = createReducer( ( state, { type, payload } ) => {
-	switch ( type ) {
-		case CACHE_GET_ITEM_SAVE_TO_STORE: {
-			const { key, result } = payload;
-
-			state.getItemCacheResults[ key ] = result;
-
-			return state;
-		}
-
-		default: {
-			return state;
-		}
-	}
-} );
-
-const baseResolvers = {
-	*getCacheItem( key ) {
-		const registry = yield Data.commonActions.getRegistry();
-
-		yield registry.dispatch( CORE_SITE ).getCacheItem( key );
-	},
-};
-
-const baseSelectors = {
-	/**
-	 * Returns a cached item from the cache.
-	 *
-	 * @since n.e.x.t
-	 *
-	 * @param {Object} state Data store's state.
-	 * @param {string} key   Cache key to get cached data for.
-	 * @return {Object|undefined} The returned value from `getItem` function. `undefined` while loading.
-	 */
-	getCacheItem: ( state, key ) => {
-		return state.getItemCacheResults[ key ];
-	},
-};
-
 const store = Data.combineStores( {
 	initialState: baseInitialState,
 	actions: baseActions,
 	controls: baseControls,
-	resolvers: baseResolvers,
-	reducer: baseReducer,
-	selectors: baseSelectors,
 } );
 
 export const initialState = store.initialState;

--- a/assets/js/googlesitekit/datastore/site/cache.test.js
+++ b/assets/js/googlesitekit/datastore/site/cache.test.js
@@ -22,9 +22,8 @@
 import {
 	createTestRegistry,
 	unsubscribeFromAll,
-	untilResolved,
 } from '../../../../../tests/js/utils';
-import { clearCache, getItem, setItem } from '../../../googlesitekit/api/cache';
+import { clearCache, getItem } from '../../../googlesitekit/api/cache';
 import { CORE_SITE } from './constants';
 
 describe( 'core/site client side cache', () => {
@@ -41,14 +40,6 @@ describe( 'core/site client side cache', () => {
 	describe( 'actions', () => {
 		beforeEach( async () => {
 			await clearCache();
-		} );
-
-		describe( 'getCacheItem', () => {
-			it( 'requires key param', async () => {
-				await expect( async () => {
-					await registry.dispatch( CORE_SITE ).getCacheItem();
-				} ).rejects.toThrow( 'key is required' );
-			} );
 		} );
 
 		describe( 'setCacheItem', () => {
@@ -80,71 +71,6 @@ describe( 'core/site client side cache', () => {
 
 				expect( result.cacheHit ).toEqual( true );
 				expect( result.value ).toEqual( 'value' );
-			} );
-		} );
-	} );
-
-	describe( 'selectors', () => {
-		beforeEach( async () => {
-			await clearCache();
-		} );
-
-		describe( 'getCacheItem', () => {
-			it( 'returns a cached result', async () => {
-				await setItem( 'cache-set-key', 'value', {
-					timestamp: Date.now(),
-				} );
-
-				registry.select( CORE_SITE ).getCacheItem( 'cache-set-key' );
-
-				await untilResolved( registry, CORE_SITE ).getCacheItem(
-					'cache-set-key'
-				);
-
-				const result = registry
-					.select( CORE_SITE )
-					.getCacheItem( 'cache-set-key' );
-
-				expect( result.cacheHit ).toEqual( true );
-				expect( result.value ).toEqual( 'value' );
-			} );
-
-			it( 'returns undefined while loading, then return a result', async () => {
-				await setItem( 'cache-set-key', 'value', {
-					timestamp: Date.now(),
-				} );
-
-				const initialResult = registry
-					.select( CORE_SITE )
-					.getCacheItem( 'cache-set-key' );
-
-				expect( initialResult ).toBeUndefined();
-
-				await untilResolved( registry, CORE_SITE ).getCacheItem(
-					'cache-set-key'
-				);
-
-				const result = registry
-					.select( CORE_SITE )
-					.getCacheItem( 'cache-set-key' );
-
-				expect( result.cacheHit ).toEqual( true );
-				expect( result.value ).toEqual( 'value' );
-			} );
-
-			it( 'returns no cache hit if no value exists in the cache', async () => {
-				registry.select( CORE_SITE ).getCacheItem( 'cache-set-key' );
-
-				await untilResolved( registry, CORE_SITE ).getCacheItem(
-					'cache-set-key'
-				);
-
-				const result = registry
-					.select( CORE_SITE )
-					.getCacheItem( 'cache-set-key' );
-
-				expect( result.cacheHit ).toEqual( false );
-				expect( result.value ).toEqual( undefined );
 			} );
 		} );
 	} );

--- a/assets/js/googlesitekit/datastore/site/cache.test.js
+++ b/assets/js/googlesitekit/datastore/site/cache.test.js
@@ -22,8 +22,9 @@
 import {
 	createTestRegistry,
 	unsubscribeFromAll,
+	untilResolved,
 } from '../../../../../tests/js/utils';
-import { clearCache, getItem } from '../../../googlesitekit/api/cache';
+import { clearCache, getItem, setItem } from '../../../googlesitekit/api/cache';
 import { CORE_SITE } from './constants';
 
 describe( 'core/site client side cache', () => {
@@ -38,22 +39,32 @@ describe( 'core/site client side cache', () => {
 	} );
 
 	describe( 'actions', () => {
+		beforeEach( async () => {
+			await clearCache();
+		} );
+
+		describe( 'getCacheItem', () => {
+			it( 'requires key param', async () => {
+				await expect( async () => {
+					await registry.dispatch( CORE_SITE ).getCacheItem();
+				} ).rejects.toThrow( 'key is required' );
+			} );
+		} );
+
 		describe( 'setCacheItem', () => {
-			it( 'require key param', async () => {
+			it( 'requires `key` param', async () => {
 				await expect( async () => {
 					await registry.dispatch( CORE_SITE ).setCacheItem();
 				} ).rejects.toThrow( 'key is required' );
 			} );
 
-			it( 'require value param', async () => {
+			it( 'requires `value` param', async () => {
 				await expect( async () => {
 					await registry.dispatch( CORE_SITE ).setCacheItem( 'key' );
 				} ).rejects.toThrow( 'value is required' );
 			} );
 
-			it( 'set cache item', async () => {
-				await clearCache();
-
+			it( 'sets cache item', async () => {
 				const initialResult = await getItem( 'cache-set-key' );
 
 				expect( initialResult.cacheHit ).toEqual( false );
@@ -69,6 +80,71 @@ describe( 'core/site client side cache', () => {
 
 				expect( result.cacheHit ).toEqual( true );
 				expect( result.value ).toEqual( 'value' );
+			} );
+		} );
+	} );
+
+	describe( 'selectors', () => {
+		beforeEach( async () => {
+			await clearCache();
+		} );
+
+		describe( 'getCacheItem', () => {
+			it( 'returns a cached result', async () => {
+				await setItem( 'cache-set-key', 'value', {
+					timestamp: Date.now(),
+				} );
+
+				registry.select( CORE_SITE ).getCacheItem( 'cache-set-key' );
+
+				await untilResolved( registry, CORE_SITE ).getCacheItem(
+					'cache-set-key'
+				);
+
+				const result = registry
+					.select( CORE_SITE )
+					.getCacheItem( 'cache-set-key' );
+
+				expect( result.cacheHit ).toEqual( true );
+				expect( result.value ).toEqual( 'value' );
+			} );
+
+			it( 'returns undefined while loading, then return a result', async () => {
+				await setItem( 'cache-set-key', 'value', {
+					timestamp: Date.now(),
+				} );
+
+				const initialResult = registry
+					.select( CORE_SITE )
+					.getCacheItem( 'cache-set-key' );
+
+				expect( initialResult ).toBeUndefined();
+
+				await untilResolved( registry, CORE_SITE ).getCacheItem(
+					'cache-set-key'
+				);
+
+				const result = registry
+					.select( CORE_SITE )
+					.getCacheItem( 'cache-set-key' );
+
+				expect( result.cacheHit ).toEqual( true );
+				expect( result.value ).toEqual( 'value' );
+			} );
+
+			it( 'returns no cache hit if no value exists in the cache', async () => {
+				registry.select( CORE_SITE ).getCacheItem( 'cache-set-key' );
+
+				await untilResolved( registry, CORE_SITE ).getCacheItem(
+					'cache-set-key'
+				);
+
+				const result = registry
+					.select( CORE_SITE )
+					.getCacheItem( 'cache-set-key' );
+
+				expect( result.cacheHit ).toEqual( false );
+				expect( result.value ).toEqual( undefined );
 			} );
 		} );
 	} );

--- a/assets/js/modules/analytics-4/datastore/custom-dimensions-gathering-data.test.js
+++ b/assets/js/modules/analytics-4/datastore/custom-dimensions-gathering-data.test.js
@@ -23,6 +23,7 @@ import { properties } from './__fixtures__';
 import { CORE_USER } from '../../../googlesitekit/datastore/user/constants';
 import { MODULES_ANALYTICS_4 } from './constants';
 import { getPreviousDate, stringToDate } from '../../../util';
+import { CORE_MODULES } from '../../../googlesitekit/modules/datastore/constants';
 
 let {
 	createTestRegistry,
@@ -49,6 +50,13 @@ describe( 'modules/analytics-4 custom-dimensions-gathering-data', () => {
 		registry.dispatch( MODULES_ANALYTICS_4 ).setSettings( {
 			availableCustomDimensions: [ customDimension ],
 		} );
+
+		registry
+			.dispatch( CORE_MODULES )
+			.receiveCheckModuleAccess(
+				{ access: true },
+				{ slug: 'analytics-4' }
+			);
 	}
 
 	let registry;

--- a/assets/js/modules/analytics-4/datastore/properties.js
+++ b/assets/js/modules/analytics-4/datastore/properties.js
@@ -732,7 +732,9 @@ const baseResolvers = {
 		}
 
 		const cachedPropertyCreateTime = yield Data.commonActions.await(
-			getItem( `ga4-property-create-time-${ propertyID }` )
+			getItem(
+				`analytics4-properties-getPropertyCreateTime${ propertyID }`
+			)
 		);
 
 		if ( cachedPropertyCreateTime.cacheHit ) {
@@ -752,7 +754,7 @@ const baseResolvers = {
 		// Cache this value for 1 hour (the default cache time).
 		yield Data.commonActions.await(
 			setItem(
-				`ga4-property-create-time-${ propertyID }`,
+				`analytics4-properties-getPropertyCreateTime${ propertyID }`,
 				property?.createTime
 			)
 		);

--- a/assets/js/modules/analytics-4/datastore/properties.js
+++ b/assets/js/modules/analytics-4/datastore/properties.js
@@ -735,7 +735,7 @@ const baseResolvers = {
 
 		const cachedPropertyCreateTime = yield Data.commonActions.await(
 			getItem(
-				`analytics4-properties-getPropertyCreateTime${ propertyID }`
+				`analytics4-properties-getPropertyCreateTime-${ propertyID }`
 			)
 		);
 
@@ -756,7 +756,7 @@ const baseResolvers = {
 		// Cache this value for 1 hour (the default cache time).
 		yield Data.commonActions.await(
 			setItem(
-				`analytics4-properties-getPropertyCreateTime${ propertyID }`,
+				`analytics4-properties-getPropertyCreateTime-${ propertyID }`,
 				property?.createTime
 			)
 		);

--- a/assets/js/modules/analytics-4/datastore/properties.js
+++ b/assets/js/modules/analytics-4/datastore/properties.js
@@ -723,11 +723,13 @@ const baseResolvers = {
 			return;
 		}
 
-		const hasModuleAccess = registry
-			.select( CORE_MODULES )
-			.hasModuleAccess( 'analytics-4' );
+		const hasModuleAccess = yield Data.commonActions.await(
+			registry
+				.__experimentalResolveSelect( CORE_MODULES )
+				.hasModuleAccess( 'analytics-4' )
+		);
 
-		if ( ! hasModuleAccess ) {
+		if ( hasModuleAccess === false ) {
 			return;
 		}
 

--- a/assets/js/modules/analytics-4/datastore/properties.test.js
+++ b/assets/js/modules/analytics-4/datastore/properties.test.js
@@ -42,6 +42,8 @@ import {
 	WEBDATASTREAM_CREATE,
 } from './constants';
 import * as fixtures from './__fixtures__';
+import { getItem, setItem } from '../../../googlesitekit/api/cache';
+import { CORE_MODULES } from '../../../googlesitekit/modules/datastore/constants';
 
 describe( 'modules/analytics-4 properties', () => {
 	let registry;
@@ -1338,6 +1340,13 @@ describe( 'modules/analytics-4 properties', () => {
 
 		describe( 'getPropertyCreateTime', () => {
 			it( 'should use a resolver to fetch the current property if create time is not set yet', async () => {
+				registry
+					.dispatch( CORE_MODULES )
+					.receiveCheckModuleAccess(
+						{ access: true },
+						{ slug: 'analytics-4' }
+					);
+
 				fetchMock.get( propertyEndpoint, {
 					body: fixtures.properties[ 0 ],
 					status: 200,
@@ -1370,6 +1379,85 @@ describe( 'modules/analytics-4 properties', () => {
 					new Date( fixtures.properties[ 0 ].createTime ).getTime()
 				);
 				expect( fetchMock ).toHaveFetchedTimes( 1 );
+			} );
+
+			it( 'should cache the current property when fetched', async () => {
+				registry
+					.dispatch( CORE_MODULES )
+					.receiveCheckModuleAccess(
+						{ access: true },
+						{ slug: 'analytics-4' }
+					);
+
+				fetchMock.get( propertyEndpoint, {
+					body: fixtures.properties[ 0 ],
+					status: 200,
+				} );
+
+				const propertyID = '12345';
+				registry
+					.dispatch( MODULES_ANALYTICS_4 )
+					.setPropertyID( propertyID );
+
+				const initalPropertyCreateTime = registry
+					.select( MODULES_ANALYTICS_4 )
+					.getPropertyCreateTime();
+
+				expect( initalPropertyCreateTime ).toBeUndefined();
+
+				await untilResolved(
+					registry,
+					MODULES_ANALYTICS_4
+				).getPropertyCreateTime();
+				expect( fetchMock ).toHaveFetched( propertyEndpoint, {
+					query: { propertyID },
+				} );
+
+				const propertyCreateTimeInCache = await getItem(
+					`ga4-property-create-time-${ propertyID }`
+				);
+
+				expect( propertyCreateTimeInCache.cacheHit ).toBe( true );
+				expect( propertyCreateTimeInCache.value ).toEqual(
+					fixtures.properties[ 0 ].createTime
+				);
+				expect( fetchMock ).toHaveFetchedTimes( 1 );
+			} );
+
+			it( 'should not make a request to the API if the property is cached', async () => {
+				const propertyID = fixtures.properties[ 0 ]._id;
+
+				const settings = {
+					propertyID,
+					webDataStreamID: '1000',
+					measurementID: 'abcd',
+					propertyCreateTime: 123456789,
+				};
+
+				await setItem(
+					`ga4-property-create-time-${ propertyID }`,
+					settings
+				);
+
+				provideUserAuthentication( registry );
+
+				registry
+					.dispatch( MODULES_ANALYTICS_4 )
+					.receiveGetSettings( settings );
+
+				registry.select( MODULES_ANALYTICS_4 ).getPropertyCreateTime();
+				await untilResolved(
+					registry,
+					MODULES_ANALYTICS_4
+				).getPropertyCreateTime();
+
+				const propertyCreateTime = registry
+					.select( MODULES_ANALYTICS_4 )
+					.getPropertyCreateTime();
+				expect( propertyCreateTime ).toBe(
+					settings.propertyCreateTime
+				);
+				expect( fetchMock ).toHaveFetchedTimes( 0 );
 			} );
 
 			it( 'should not fetch the property if the propertyCreateTime is already set', async () => {

--- a/assets/js/modules/analytics-4/datastore/properties.test.js
+++ b/assets/js/modules/analytics-4/datastore/properties.test.js
@@ -1414,7 +1414,7 @@ describe( 'modules/analytics-4 properties', () => {
 				} );
 
 				const propertyCreateTimeInCache = await getItem(
-					`analytics4-properties-getPropertyCreateTime${ propertyID }`
+					`analytics4-properties-getPropertyCreateTime-${ propertyID }`
 				);
 
 				expect( propertyCreateTimeInCache.cacheHit ).toBe( true );
@@ -1435,7 +1435,7 @@ describe( 'modules/analytics-4 properties', () => {
 				};
 
 				await setItem(
-					`analytics4-properties-getPropertyCreateTime${ propertyID }`,
+					`analytics4-properties-getPropertyCreateTime-${ propertyID }`,
 					settings
 				);
 

--- a/assets/js/modules/analytics-4/datastore/properties.test.js
+++ b/assets/js/modules/analytics-4/datastore/properties.test.js
@@ -1414,7 +1414,7 @@ describe( 'modules/analytics-4 properties', () => {
 				} );
 
 				const propertyCreateTimeInCache = await getItem(
-					`ga4-property-create-time-${ propertyID }`
+					`analytics4-properties-getPropertyCreateTime${ propertyID }`
 				);
 
 				expect( propertyCreateTimeInCache.cacheHit ).toBe( true );
@@ -1435,7 +1435,7 @@ describe( 'modules/analytics-4 properties', () => {
 				};
 
 				await setItem(
-					`ga4-property-create-time-${ propertyID }`,
+					`analytics4-properties-getPropertyCreateTime${ propertyID }`,
 					settings
 				);
 

--- a/assets/js/modules/analytics-4/datastore/report.test.js
+++ b/assets/js/modules/analytics-4/datastore/report.test.js
@@ -34,6 +34,7 @@ import {
 import { DAY_IN_SECONDS } from '../../../util';
 import { isZeroReport } from '../utils';
 import * as fixtures from './__fixtures__';
+import { CORE_MODULES } from '../../../googlesitekit/modules/datastore/constants';
 
 describe( 'modules/analytics-4 report', () => {
 	let registry;
@@ -44,6 +45,13 @@ describe( 'modules/analytics-4 report', () => {
 
 	beforeEach( () => {
 		registry = createTestRegistry();
+
+		registry
+			.dispatch( CORE_MODULES )
+			.receiveCheckModuleAccess(
+				{ access: true },
+				{ slug: 'analytics-4' }
+			);
 	} );
 
 	afterEach( () => {

--- a/assets/js/modules/analytics-4/utils/data-mock.js
+++ b/assets/js/modules/analytics-4/utils/data-mock.js
@@ -32,6 +32,7 @@ import { map, reduce, take, toArray, mergeMap } from 'rxjs/operators';
 import { MODULES_ANALYTICS_4 } from '../datastore/constants';
 import { isValidDateString } from '../../../util';
 import { stringToDate } from '../../../util/date-range/string-to-date';
+import { CORE_MODULES } from '../../../googlesitekit/modules/datastore/constants';
 
 export const STRATEGY_CARTESIAN = 'cartesian';
 export const STRATEGY_ZIP = 'zip';
@@ -691,6 +692,10 @@ export function getAnalytics4MockResponse(
  * @param {Object}           options  Report options.
  */
 export function provideAnalytics4MockReport( registry, options ) {
+	registry
+		.dispatch( CORE_MODULES )
+		.receiveCheckModuleAccess( { access: true }, { slug: 'analytics-4' } );
+
 	registry
 		.dispatch( MODULES_ANALYTICS_4 )
 		.receiveGetReport( getAnalytics4MockResponse( options ), { options } );

--- a/assets/js/modules/analytics-4/utils/withCustomDimensions.test.js
+++ b/assets/js/modules/analytics-4/utils/withCustomDimensions.test.js
@@ -37,6 +37,7 @@ import { MODULES_ANALYTICS_4 } from '../datastore/constants';
 import { CORE_USER } from '../../../googlesitekit/datastore/user/constants';
 import { withWidgetComponentProps } from '../../../googlesitekit/widgets/util';
 import withCustomDimensions from './withCustomDimensions';
+import { CORE_MODULES } from '../../../googlesitekit/modules/datastore/constants';
 
 describe( 'withCustomDimensions', () => {
 	let registry;
@@ -60,6 +61,14 @@ describe( 'withCustomDimensions', () => {
 				connected: true,
 			},
 		] );
+
+		registry
+			.dispatch( CORE_MODULES )
+			.receiveCheckModuleAccess(
+				{ access: true },
+				{ slug: 'analytics-4' }
+			);
+
 		registry
 			.dispatch( MODULES_ANALYTICS_4 )
 			.receiveIsGatheringData( false );

--- a/assets/js/modules/analytics/components/dashboard/DashboardAllTrafficWidgetGA4/indexEntityDashboard.stories.js
+++ b/assets/js/modules/analytics/components/dashboard/DashboardAllTrafficWidgetGA4/indexEntityDashboard.stories.js
@@ -201,14 +201,14 @@ export const EntityDashboardDataUnavailable = Template.bind( {} );
 EntityDashboardDataUnavailable.storyName = 'Data Unavailable';
 EntityDashboardDataUnavailable.args = {
 	setupRegistry: ( registry ) => {
-		allTrafficReportOptions.forEach( ( options ) => {
-			registry
-				.dispatch( CORE_MODULES )
-				.receiveCheckModuleAccess(
-					{ access: true },
-					{ slug: 'analytics-4' }
-				);
+		registry
+			.dispatch( CORE_MODULES )
+			.receiveCheckModuleAccess(
+				{ access: true },
+				{ slug: 'analytics-4' }
+			);
 
+		allTrafficReportOptions.forEach( ( options ) => {
 			registry
 				.dispatch( MODULES_ANALYTICS_4 )
 				.receiveGetReport( {}, { options } );
@@ -235,20 +235,21 @@ EntityDashboardDataUnavailable.args = {
 };
 EntityDashboardDataUnavailable.scenario = {
 	label: 'Modules/Analytics/Widgets/DashboardAllTrafficWidgetGA4/EntityDashboard/DataUnavailable',
+	delay: 200,
 };
 
 export const EntityDashboardZeroData = Template.bind( {} );
 EntityDashboardZeroData.storyName = 'Zero Data';
 EntityDashboardZeroData.args = {
 	setupRegistry: ( registry ) => {
-		allTrafficReportOptions.forEach( ( options ) => {
-			registry
-				.dispatch( CORE_MODULES )
-				.receiveCheckModuleAccess(
-					{ access: true },
-					{ slug: 'analytics-4' }
-				);
+		registry
+			.dispatch( CORE_MODULES )
+			.receiveCheckModuleAccess(
+				{ access: true },
+				{ slug: 'analytics-4' }
+			);
 
+		allTrafficReportOptions.forEach( ( options ) => {
 			registry
 				.dispatch( MODULES_ANALYTICS_4 )
 				.receiveGetReport(
@@ -282,6 +283,7 @@ EntityDashboardZeroData.args = {
 };
 EntityDashboardZeroData.scenario = {
 	label: 'Modules/Analytics/Widgets/DashboardAllTrafficWidgetGA4/EntityDashboard/ZeroData',
+	delay: 200,
 };
 
 export const EntityDashboardError = Template.bind( {} );

--- a/assets/js/modules/analytics/components/dashboard/DashboardAllTrafficWidgetGA4/indexEntityDashboard.stories.js
+++ b/assets/js/modules/analytics/components/dashboard/DashboardAllTrafficWidgetGA4/indexEntityDashboard.stories.js
@@ -37,6 +37,7 @@ import { MODULES_ANALYTICS_4 } from '../../../../analytics-4/datastore/constants
 import * as __fixtures__ from '../../../../analytics-4/datastore/__fixtures__';
 import { replaceValuesInAnalytics4ReportWithZeroData } from '../../../../../../../.storybook/utils/zeroReports';
 import DashboardAllTrafficWidgetGA4 from '.';
+import { CORE_MODULES } from '../../../../../googlesitekit/modules/datastore/constants';
 
 function limitResponseToSingleDate( analyticsResponse ) {
 	const findFirstDateRangeRow = ( dateRange ) =>
@@ -202,6 +203,13 @@ EntityDashboardDataUnavailable.args = {
 	setupRegistry: ( registry ) => {
 		allTrafficReportOptions.forEach( ( options ) => {
 			registry
+				.dispatch( CORE_MODULES )
+				.receiveCheckModuleAccess(
+					{ access: true },
+					{ slug: 'analytics-4' }
+				);
+
+			registry
 				.dispatch( MODULES_ANALYTICS_4 )
 				.receiveGetReport( {}, { options } );
 		} );
@@ -234,6 +242,13 @@ EntityDashboardZeroData.storyName = 'Zero Data';
 EntityDashboardZeroData.args = {
 	setupRegistry: ( registry ) => {
 		allTrafficReportOptions.forEach( ( options ) => {
+			registry
+				.dispatch( CORE_MODULES )
+				.receiveCheckModuleAccess(
+					{ access: true },
+					{ slug: 'analytics-4' }
+				);
+
 			registry
 				.dispatch( MODULES_ANALYTICS_4 )
 				.receiveGetReport(
@@ -298,6 +313,13 @@ EntityDashboardOneRowOfData.storyName = 'One row of data';
 EntityDashboardOneRowOfData.args = {
 	setupRegistry: ( registry ) => {
 		allTrafficReportOptions.slice( 0, 3 ).forEach( ( options ) => {
+			registry
+				.dispatch( CORE_MODULES )
+				.receiveCheckModuleAccess(
+					{ access: true },
+					{ slug: 'analytics-4' }
+				);
+
 			registry
 				.dispatch( MODULES_ANALYTICS_4 )
 				.receiveGetReport(

--- a/assets/js/modules/analytics/components/dashboard/DashboardAllTrafficWidgetGA4/indexMainDashboard.stories.js
+++ b/assets/js/modules/analytics/components/dashboard/DashboardAllTrafficWidgetGA4/indexMainDashboard.stories.js
@@ -37,6 +37,7 @@ import { MODULES_ANALYTICS_4 } from '../../../../analytics-4/datastore/constants
 import * as __fixtures__ from '../../../../analytics-4/datastore/__fixtures__';
 import { replaceValuesInAnalytics4ReportWithZeroData } from '../../../../../../../.storybook/utils/zeroReports';
 import DashboardAllTrafficWidgetGA4 from '.';
+import { CORE_MODULES } from '../../../../../googlesitekit/modules/datastore/constants';
 
 function limitResponseToSingleDate( analyticsResponse ) {
 	const findFirstDateRangeRow = ( dateRange ) =>
@@ -205,6 +206,13 @@ MainDashboardDataUnavailable.args = {
 	setupRegistry: ( registry ) => {
 		allTrafficReportOptions.forEach( ( options ) => {
 			registry
+				.dispatch( CORE_MODULES )
+				.receiveCheckModuleAccess(
+					{ access: true },
+					{ slug: 'analytics-4' }
+				);
+
+			registry
 				.dispatch( MODULES_ANALYTICS_4 )
 				.receiveGetReport( {}, { options } );
 
@@ -239,6 +247,13 @@ MainDashboardZeroData.storyName = 'Zero Data';
 MainDashboardZeroData.args = {
 	setupRegistry: ( registry ) => {
 		allTrafficReportOptions.forEach( ( options ) => {
+			registry
+				.dispatch( CORE_MODULES )
+				.receiveCheckModuleAccess(
+					{ access: true },
+					{ slug: 'analytics-4' }
+				);
+
 			registry
 				.dispatch( MODULES_ANALYTICS_4 )
 				.receiveGetReport(
@@ -303,6 +318,13 @@ MainDashboardOneRowOfData.storyName = 'One row of data';
 MainDashboardOneRowOfData.args = {
 	setupRegistry: ( registry ) => {
 		allTrafficReportOptions.slice( 0, 3 ).forEach( ( options ) => {
+			registry
+				.dispatch( CORE_MODULES )
+				.receiveCheckModuleAccess(
+					{ access: true },
+					{ slug: 'analytics-4' }
+				);
+
 			registry
 				.dispatch( MODULES_ANALYTICS_4 )
 				.receiveGetReport(

--- a/assets/js/modules/analytics/components/dashboard/DashboardAllTrafficWidgetGA4/indexMainDashboard.stories.js
+++ b/assets/js/modules/analytics/components/dashboard/DashboardAllTrafficWidgetGA4/indexMainDashboard.stories.js
@@ -204,14 +204,14 @@ export const MainDashboardDataUnavailable = Template.bind( {} );
 MainDashboardDataUnavailable.storyName = 'Data Unavailable';
 MainDashboardDataUnavailable.args = {
 	setupRegistry: ( registry ) => {
-		allTrafficReportOptions.forEach( ( options ) => {
-			registry
-				.dispatch( CORE_MODULES )
-				.receiveCheckModuleAccess(
-					{ access: true },
-					{ slug: 'analytics-4' }
-				);
+		registry
+			.dispatch( CORE_MODULES )
+			.receiveCheckModuleAccess(
+				{ access: true },
+				{ slug: 'analytics-4' }
+			);
 
+		allTrafficReportOptions.forEach( ( options ) => {
 			registry
 				.dispatch( MODULES_ANALYTICS_4 )
 				.receiveGetReport( {}, { options } );
@@ -240,20 +240,21 @@ MainDashboardDataUnavailable.args = {
 };
 MainDashboardDataUnavailable.scenario = {
 	label: 'Modules/Analytics/Widgets/DashboardAllTrafficWidgetGA4/MainDashboard/DataUnavailable',
+	delay: 200,
 };
 
 export const MainDashboardZeroData = Template.bind( {} );
 MainDashboardZeroData.storyName = 'Zero Data';
 MainDashboardZeroData.args = {
 	setupRegistry: ( registry ) => {
-		allTrafficReportOptions.forEach( ( options ) => {
-			registry
-				.dispatch( CORE_MODULES )
-				.receiveCheckModuleAccess(
-					{ access: true },
-					{ slug: 'analytics-4' }
-				);
+		registry
+			.dispatch( CORE_MODULES )
+			.receiveCheckModuleAccess(
+				{ access: true },
+				{ slug: 'analytics-4' }
+			);
 
+		allTrafficReportOptions.forEach( ( options ) => {
 			registry
 				.dispatch( MODULES_ANALYTICS_4 )
 				.receiveGetReport(
@@ -287,6 +288,7 @@ MainDashboardZeroData.args = {
 };
 MainDashboardZeroData.scenario = {
 	label: 'Modules/Analytics/Widgets/DashboardAllTrafficWidgetGA4/MainDashboard/ZeroData',
+	delay: 200,
 };
 
 export const MainDashboardError = Template.bind( {} );

--- a/includes/Modules/Analytics_4/Synchronize_Property.php
+++ b/includes/Modules/Analytics_4/Synchronize_Property.php
@@ -101,7 +101,11 @@ class Synchronize_Property {
 		$cron_already_scheduled = wp_next_scheduled( self::CRON_SYNCHRONIZE_PROPERTY );
 
 		if ( ! $create_time_has_value && $analytics_4_connected && ! $cron_already_scheduled ) {
-			wp_schedule_single_event( time(), self::CRON_SYNCHRONIZE_PROPERTY );
+			wp_schedule_single_event(
+				// Schedule the task to run in 30 minutes.
+				time() + ( 30 * MINUTE_IN_SECONDS ),
+				self::CRON_SYNCHRONIZE_PROPERTY
+			);
 		}
 	}
 


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #8062

## Relevant technical choices

I originally coded a more complex `getCacheItem` selector + resolver + action + control route as mentioned in the IB, but then realised we could just use `commonActions.await( getItem( key ) )`, so I updated the approach to use that, it's much simpler :smile:

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
