### PR TITLE
Fix the link color on SK WordPress dashboard widgets.

### DIFF
--- a/assets/sass/base/_defaults.scss
+++ b/assets/sass/base/_defaults.scss
@@ -114,6 +114,7 @@
 		text-decoration: none;
 
 		&:hover {
+			color: $c-link;
 			text-decoration: underline;
 		}
 

--- a/assets/sass/components/global/_googlesitekit-cta-link.scss
+++ b/assets/sass/components/global/_googlesitekit-cta-link.scss
@@ -18,7 +18,6 @@
 
 .googlesitekit-cta-link {
 	align-items: center;
-	color: $c-link;
 	cursor: pointer;
 	display: inline-flex;
 	font-family: inherit;
@@ -33,11 +32,17 @@
 	}
 
 	&:hover {
-		color: $c-link;
-		text-decoration: underline;
-
 		svg {
 			fill: currentColor;
+		}
+	}
+
+	.googlesitekit-page & {
+		color: $c-link;
+
+		&:hover {
+			color: $c-link;
+			text-decoration: underline;
 		}
 	}
 


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #7139

## Relevant technical choices

<!-- Please describe your changes. -->
 - Implemented as in IB. I had to split the svg hover styles to satisfy the stylelint rule [no-descending-specificity](https://stylelint.io/user-guide/rules/no-descending-specificity/).
 - I also added the color to the `:hover` link state in the `_default.scss` file as this prevented the need for updating the VRT and gave consistency across all links in the plugin while still allowing the dashboard to inherit it's link color.

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
