### PR TITLE
Enhanced Measurement Banner: Ensure setup step is restored if there is an error

### DIFF
--- a/assets/js/modules/analytics-4/components/dashboard/EnhancedMeasurementActivationBanner/index.js
+++ b/assets/js/modules/analytics-4/components/dashboard/EnhancedMeasurementActivationBanner/index.js
@@ -149,11 +149,7 @@ function EnhancedMeasurementActivationBanner() {
 
 		if ( error ) {
 			setErrorNotice( error );
-
-			if ( step !== ACTIVATION_STEP_SETUP ) {
-				setStep( ACTIVATION_STEP_SETUP );
-			}
-
+			setStep( ACTIVATION_STEP_SETUP );
 			return;
 		}
 
@@ -163,7 +159,7 @@ function EnhancedMeasurementActivationBanner() {
 		);
 
 		setStep( ACTIVATION_STEP_SUCCESS );
-	}, [ setValues, submitChanges, viewContext, step ] );
+	}, [ setValues, submitChanges, viewContext ] );
 
 	useEffect( () => {
 		if (

--- a/assets/js/modules/analytics-4/components/dashboard/EnhancedMeasurementActivationBanner/index.js
+++ b/assets/js/modules/analytics-4/components/dashboard/EnhancedMeasurementActivationBanner/index.js
@@ -188,7 +188,7 @@ function EnhancedMeasurementActivationBanner() {
 		if ( autoSubmit && hasEditScope ) {
 			handleAutoSubmit();
 		}
-	}, [ hasEditScope, setValues, handleSubmit, autoSubmit, step ] );
+	}, [ hasEditScope, setValues, handleSubmit, autoSubmit ] );
 
 	if ( isTooltipVisible ) {
 		return (


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- https://github.com/google/site-kit-wp/issues/7853#issuecomment-1903790910

## Relevant technical choices

In the above-linked comment, while addressing QA feedback, I discovered that the functionality for the Enhanced Measurement setup banner to return to the "setup" step from the "in progress" step in the event of an error is not working as expected.

It seems there is some sort of a race condition when we check for the current step, so, in this PR, we've removed this condition and unconditionally set it to change state.

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
