### PR TITLE
Update the Publish to WP GitHub actions to unzip from the tmp directory.

### DIFF
--- a/.github/workflows/zips.yml
+++ b/.github/workflows/zips.yml
@@ -132,6 +132,7 @@ jobs:
   upload-to-cloud-storage:
     name: Upload to GCS
     runs-on: ubuntu-latest
+    if: github.event_name != 'workflow_dispatch'
     needs: build-zips
     steps:
       - uses: actions/download-artifact@v3
@@ -232,12 +233,10 @@ jobs:
       - uses: actions/download-artifact@v3
         with:
           name: zip-files
-          path: ${{ github.ref }}
+          path: /tmp
       - name: Extract
         run: |
-          unzip google-site-kit.zip
-          mv google-site-kit/* .
-          rm -rf google-site-kit ./*.zip
+          unzip /tmp/google-site-kit.zip -d ${{ github.ref }}
           echo .distignore > .distignore
       - uses: 10up/action-wordpress-plugin-deploy@2.2.2
         with:


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #8092

## Relevant technical choices

<!-- Please describe your changes. -->
I implemented the if without `{{}}` and updated the `publish-to-wporg` step to unzip into the previous target directory directly. *I did not test this myself as I didn't want to mess about triggering WP build uploads.*

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
