### PR TITLE
Enhance/#8048 - Add adsenseLinked and adSenseLinkedLastSyncedAt settings to modules/analytics-4 data store

### DIFF
--- a/assets/js/modules/analytics-4/datastore/__fixtures__/default-settings.json
+++ b/assets/js/modules/analytics-4/datastore/__fixtures__/default-settings.json
@@ -7,5 +7,7 @@
   "googleTagID": "",
   "googleTagAccountID": "",
   "googleTagContainerID": "",
-  "propertyCreateTime": 0
+  "propertyCreateTime": 0,
+  "adSenseLinked": false,
+  "adSenseLinkedLastSyncedAt": 0
 }

--- a/assets/js/modules/analytics-4/datastore/base.js
+++ b/assets/js/modules/analytics-4/datastore/base.js
@@ -43,6 +43,7 @@ const baseModuleStore = Modules.createModuleStore( 'analytics-4', {
 		'accountID',
 		'adsConversionID',
 		'adsenseLinked',
+		'adSenseLinkedLastSyncedAt',
 		'propertyID',
 		'webDataStreamID',
 		'measurementID',

--- a/assets/js/modules/analytics-4/datastore/base.js
+++ b/assets/js/modules/analytics-4/datastore/base.js
@@ -42,7 +42,7 @@ const baseModuleStore = Modules.createModuleStore( 'analytics-4', {
 	settingSlugs: [
 		'accountID',
 		'adsConversionID',
-		'adsenseLinked',
+		'adSenseLinked',
 		'adSenseLinkedLastSyncedAt',
 		'propertyID',
 		'webDataStreamID',


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #8048 

## Relevant technical choices

<!-- Please describe your changes. -->

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [x] Run the code.
- [x] Ensure the acceptance criteria are satisfied.
- [x] Reassess the implementation with the IB.
- [x] Ensure no unrelated changes are included.
- [x] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [x] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [x] Ensure the PR has the correct target branch.
- [x] Double-check that the PR is okay to be merged.
- [x] Ensure the corresponding issue has a ZenHub release assigned.
- [x] Add a changelog message to the issue.
