### PR TITLE
Create the Prompt class and datastore to handle multiple dismiss logic.

### DIFF
--- a/assets/js/googlesitekit/datastore/user/index.js
+++ b/assets/js/googlesitekit/datastore/user/index.js
@@ -31,6 +31,7 @@ import keyMetrics from './key-metrics';
 import notifications from './notifications';
 import nonces from './nonces';
 import permissions from './permissions';
+import prompts from './prompts';
 import surveys from './surveys';
 import tracking from './tracking';
 import userInfo from './user-info';
@@ -47,6 +48,7 @@ const store = Data.combineStores(
 	keyMetrics,
 	notifications,
 	permissions,
+	prompts,
 	nonces,
 	surveys,
 	tracking,

--- a/assets/js/googlesitekit/datastore/user/prompts.js
+++ b/assets/js/googlesitekit/datastore/user/prompts.js
@@ -1,0 +1,216 @@
+/**
+ * `core/user` data store: dismissed prompts
+ *
+ * Site Kit by Google, Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import invariant from 'invariant';
+
+/**
+ * Internal dependencies
+ */
+import API from 'googlesitekit-api';
+import Data from 'googlesitekit-data';
+import { CORE_USER } from './constants';
+import { createFetchStore } from '../../data/create-fetch-store';
+import { createValidatedAction } from '../../data/utils';
+
+const { createRegistrySelector, commonActions } = Data;
+const { getRegistry } = commonActions;
+
+function reducerCallback( state, dismissedPrompts ) {
+	return {
+		...state,
+		dismissedPrompts:
+			typeof dismissedPrompts === 'object' ? dismissedPrompts : {},
+	};
+}
+
+const fetchGetDismissedPromptsStore = createFetchStore( {
+	baseName: 'getDismissedPrompts',
+	controlCallback: () =>
+		API.get( 'core', 'user', 'dismissed-prompts', {}, { useCache: false } ),
+	reducerCallback,
+} );
+
+const fetchDismissPromptStore = createFetchStore( {
+	baseName: 'dismissPrompt',
+	controlCallback: ( { slug, expiresInSeconds } ) =>
+		API.set( 'core', 'user', 'dismiss-prompt', {
+			slug,
+			expiration: expiresInSeconds,
+		} ),
+	reducerCallback,
+	argsToParams: ( slug, expiresInSeconds = 0 ) => {
+		return { slug, expiresInSeconds };
+	},
+	validateParams: ( { slug, expiresInSeconds } = {} ) => {
+		invariant( slug, 'slug is required.' );
+		invariant(
+			Number.isInteger( expiresInSeconds ),
+			'expiresInSeconds must be an integer.'
+		);
+	},
+} );
+
+const baseInitialState = {
+	dismissedPrompts: undefined,
+};
+
+const baseActions = {
+	/**
+	 * Dismisses the given prompt by slug.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param {string} slug                       Prompt slug to dismiss.
+	 * @param {Object} options                    Dismiss prompt options.
+	 * @param {number} [options.expiresInSeconds] Optional. An integer number of seconds for expiry. 0 denotes permanent dismissal.
+	 * @return {Object} Generator instance.
+	 */
+	dismissPrompt: createValidatedAction(
+		( slug, options = {} ) => {
+			const { expiresInSeconds = 0 } = options;
+			invariant( slug, 'A tour slug is required to dismiss a tour.' );
+			invariant(
+				Number.isInteger( expiresInSeconds ),
+				'expiresInSeconds must be an integer.'
+			);
+		},
+		function* ( slug, options = {} ) {
+			const { expiresInSeconds = 0 } = options;
+
+			return yield fetchDismissPromptStore.actions.fetchDismissPrompt(
+				slug,
+				expiresInSeconds
+			);
+		}
+	),
+};
+
+const baseResolvers = {
+	*getDismissedPrompts() {
+		const { select } = yield getRegistry();
+		const dismissedPrompts = select( CORE_USER ).getDismissedPrompts();
+
+		if ( dismissedPrompts === undefined ) {
+			yield fetchGetDismissedPromptsStore.actions.fetchGetDismissedPrompts();
+		}
+	},
+};
+
+const baseSelectors = {
+	/**
+	 * Gets the list of dismissed prompts.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param {Object} state Data store's state.
+	 * @return {(string[]|undefined)} Array of dismissed prompt keys, `undefined` if there are none.
+	 */
+	getDismissedPrompts( state ) {
+		if ( state.dismissedPrompts === undefined ) {
+			return undefined;
+		}
+
+		const currentTimeInSeconds = Math.floor( Date.now() / 1000 );
+		return Object.entries( state.dismissedPrompts ).reduce(
+			( acc, [ slug, { expires } ] ) => {
+				if ( expires === 0 || expires > currentTimeInSeconds ) {
+					acc.push( slug );
+				}
+				return acc;
+			},
+			[]
+		);
+	},
+
+	/**
+	 * Gets the count of a dismissed prompt.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param {Object} state Data store's state.
+	 * @param {string} slug  Prompt slug.
+	 * @return {(number|undefined)} Count of the prompt, `undefined` if there are none.
+	 */
+	getPromptDismissCount: createRegistrySelector( () => ( state, slug ) => {
+		if ( ! state.dismissedPrompts ) {
+			return undefined;
+		}
+
+		return state.dismissedPrompts[ slug ]?.count || 0;
+	} ),
+
+	/**
+	 * Determines whether the prompt is dismissed or not.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param {Object} state Data store's state.
+	 * @param {string} slug  Prompt slug.
+	 * @return {(boolean|undefined)} TRUE if dismissed, otherwise FALSE, `undefined` if not resolved yet.
+	 */
+	isPromptDismissed: createRegistrySelector(
+		( select ) => ( state, slug ) => {
+			return select( CORE_USER ).getDismissedPrompts()?.includes( slug );
+		}
+	),
+
+	/**
+	 * Checks whether or not the prompt is being dismissed for the given slug.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param {Object} state Data store's state.
+	 * @param {string} slug  Prompt slug.
+	 * @return {boolean} True if the prompt is being dismissed, otherwise false.
+	 */
+	isDismissingPrompt: createRegistrySelector(
+		( select ) => ( state, slug ) => {
+			return select( CORE_USER ).isFetchingDismissPrompt( slug );
+		}
+	),
+};
+
+export const {
+	actions,
+	controls,
+	initialState,
+	reducer,
+	resolvers,
+	selectors,
+} = Data.combineStores(
+	{
+		initialState: baseInitialState,
+		actions: baseActions,
+		resolvers: baseResolvers,
+		selectors: baseSelectors,
+	},
+	fetchDismissPromptStore,
+	fetchGetDismissedPromptsStore
+);
+
+export default {
+	actions,
+	controls,
+	initialState,
+	reducer,
+	resolvers,
+	selectors,
+};

--- a/assets/js/googlesitekit/datastore/user/prompts.test.js
+++ b/assets/js/googlesitekit/datastore/user/prompts.test.js
@@ -1,0 +1,284 @@
+/**
+ * `core/user` data store: dismissed prompts tests.
+ *
+ * Site Kit by Google, Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import { CORE_USER } from './constants';
+import {
+	createTestRegistry,
+	muteFetch,
+	untilResolved,
+} from '../../../../../tests/js/utils';
+
+describe( 'core/user dismissed-prompts', () => {
+	const fetchGetDismissedPrompts = new RegExp(
+		'^/google-site-kit/v1/core/user/data/dismissed-prompts'
+	);
+	const fetchDismissPrompt = new RegExp(
+		'^/google-site-kit/v1/core/user/data/dismiss-prompt'
+	);
+
+	let registry;
+
+	beforeEach( () => {
+		registry = createTestRegistry();
+	} );
+
+	describe( 'actions', () => {
+		describe( 'dismissPrompt', () => {
+			it( 'should save settings and return new dismissed prompts', async () => {
+				fetchMock.postOnce( fetchDismissPrompt, {
+					body: {
+						foo: { expires: 0, count: 1 },
+						bar: { expires: 0, count: 1 },
+					},
+				} );
+
+				await registry
+					.dispatch( CORE_USER )
+					.dismissPrompt( 'baz', { expiresInSeconds: 3 } );
+
+				// Ensure the proper body parameters were sent.
+				expect( fetchMock ).toHaveFetched( fetchDismissPrompt, {
+					body: {
+						data: {
+							slug: 'baz',
+							expiration: 3,
+						},
+					},
+				} );
+
+				const dismissedPrompts = registry
+					.select( CORE_USER )
+					.getDismissedPrompts();
+				expect( dismissedPrompts ).toEqual( [ 'foo', 'bar' ] );
+				expect( fetchMock ).toHaveFetchedTimes( 1 );
+			} );
+
+			it( 'should dispatch an error if the request fails', async () => {
+				const response = {
+					code: 'internal_server_error',
+					message: 'Internal server error',
+					data: { status: 500 },
+				};
+
+				fetchMock.post( fetchDismissPrompt, {
+					body: response,
+					status: 500,
+				} );
+
+				await registry.dispatch( CORE_USER ).dismissPrompt( 'baz' );
+				expect(
+					registry
+						.select( CORE_USER )
+						.getErrorForAction( 'dismissPrompt', [ 'baz', 0 ] )
+				).toMatchObject( response );
+				expect( console ).toHaveErrored();
+			} );
+		} );
+	} );
+
+	describe( 'selectors', () => {
+		describe( 'getDismissedPrompts', () => {
+			it( 'should return undefined until resolved', async () => {
+				muteFetch( fetchGetDismissedPrompts, { body: {} } );
+				expect(
+					registry.select( CORE_USER ).getDismissedPrompts()
+				).toBeUndefined();
+				await untilResolved(
+					registry,
+					CORE_USER
+				).getDismissedPrompts();
+			} );
+
+			it( 'should return dismissed prompts received from API', async () => {
+				fetchMock.getOnce( fetchGetDismissedPrompts, {
+					body: {
+						foo: { expires: 0, count: 1 },
+						bar: { expires: 0, count: 1 },
+					},
+				} );
+
+				const dismissedPrompts = registry
+					.select( CORE_USER )
+					.getDismissedPrompts();
+				expect( dismissedPrompts ).toBeUndefined();
+
+				await untilResolved(
+					registry,
+					CORE_USER
+				).getDismissedPrompts();
+
+				expect(
+					registry.select( CORE_USER ).getDismissedPrompts()
+				).toEqual( [ 'foo', 'bar' ] );
+				expect( fetchMock ).toHaveFetched();
+			} );
+
+			it( 'should not return dismissed prompts once they have expired', async () => {
+				const currentTimeInSeconds = Math.floor( Date.now() / 1000 );
+
+				fetchMock.getOnce( fetchGetDismissedPrompts, {
+					body: {
+						foo: { expires: 0, count: 1 },
+						bar: { expires: currentTimeInSeconds + 2000, count: 1 },
+						baz: { expires: currentTimeInSeconds - 2000, count: 1 },
+					},
+				} );
+
+				const dismissedPrompts = registry
+					.select( CORE_USER )
+					.getDismissedPrompts();
+				expect( dismissedPrompts ).toBeUndefined();
+
+				await untilResolved(
+					registry,
+					CORE_USER
+				).getDismissedPrompts();
+
+				expect(
+					registry.select( CORE_USER ).getDismissedPrompts()
+				).toEqual( [ 'foo', 'bar' ] );
+				expect( fetchMock ).toHaveFetched();
+			} );
+
+			it( 'should throw an error', async () => {
+				const response = {
+					code: 'internal_server_error',
+					message: 'Internal server error',
+					data: { status: 500 },
+				};
+
+				fetchMock.getOnce( fetchGetDismissedPrompts, {
+					body: response,
+					status: 500,
+				} );
+
+				const dismissedPrompts = registry
+					.select( CORE_USER )
+					.getDismissedPrompts();
+				expect( dismissedPrompts ).toBeUndefined();
+
+				await untilResolved(
+					registry,
+					CORE_USER
+				).getDismissedPrompts();
+
+				registry.select( CORE_USER ).getDismissedPrompts();
+
+				const error = registry
+					.select( CORE_USER )
+					.getErrorForSelector( 'getDismissedPrompts' );
+				expect( error ).toMatchObject( response );
+
+				expect( fetchMock ).toHaveFetchedTimes( 1 );
+				expect( console ).toHaveErrored();
+			} );
+		} );
+
+		describe( 'getPromptDismissCount', () => {
+			it( 'should return undefined until resolved', () => {
+				fetchMock.getOnce( fetchGetDismissedPrompts, { body: {} } );
+				expect(
+					registry.select( CORE_USER ).getPromptDismissCount( 'foo' )
+				).toBeUndefined();
+			} );
+
+			it( 'should return the count of the prompt', () => {
+				registry.dispatch( CORE_USER ).receiveGetDismissedPrompts( {
+					foo: { expires: 0, count: 1 },
+					bar: { expires: 0, count: 2 },
+				} );
+				expect(
+					registry.select( CORE_USER ).getPromptDismissCount( 'foo' )
+				).toBe( 1 );
+				expect(
+					registry.select( CORE_USER ).getPromptDismissCount( 'bar' )
+				).toBe( 2 );
+			} );
+		} );
+
+		describe( 'isPromptDismissed', () => {
+			it( 'should return undefined if getDismissedPrompts selector is not resolved yet', async () => {
+				fetchMock.getOnce( fetchGetDismissedPrompts, { body: {} } );
+				expect(
+					registry.select( CORE_USER ).isPromptDismissed( 'foo' )
+				).toBeUndefined();
+				await untilResolved(
+					registry,
+					CORE_USER
+				).getDismissedPrompts();
+			} );
+
+			it( 'should return TRUE if the prompt is dismissed', () => {
+				registry.dispatch( CORE_USER ).receiveGetDismissedPrompts( {
+					foo: { expires: 0, count: 1 },
+					bar: { expires: 0, count: 1 },
+				} );
+				expect(
+					registry.select( CORE_USER ).isPromptDismissed( 'foo' )
+				).toBe( true );
+			} );
+
+			it( 'should return FALSE if the prompt is not dismissed', () => {
+				registry.dispatch( CORE_USER ).receiveGetDismissedPrompts( {
+					foo: { expires: 0, count: 1 },
+					bar: { expires: 0, count: 1 },
+				} );
+				expect(
+					registry.select( CORE_USER ).isPromptDismissed( 'baz' )
+				).toBe( false );
+			} );
+		} );
+
+		describe( 'isDismissingPrompt', () => {
+			it( 'returns true while prompt dismissal is in progress', () => {
+				const slug = 'foo-bar';
+
+				muteFetch( fetchDismissPrompt );
+
+				expect(
+					registry.select( CORE_USER ).isDismissingPrompt( slug )
+				).toBe( false );
+
+				registry.dispatch( CORE_USER ).dismissPrompt( slug );
+
+				expect(
+					registry.select( CORE_USER ).isDismissingPrompt( slug )
+				).toBe( true );
+			} );
+
+			it( 'returns false while prompt dismissal is over', async () => {
+				const slug = 'foo-bar';
+
+				fetchMock.postOnce( fetchDismissPrompt, { body: [ slug ] } );
+
+				expect(
+					registry.select( CORE_USER ).isDismissingPrompt( slug )
+				).toBe( false );
+
+				await registry.dispatch( CORE_USER ).dismissPrompt( slug );
+
+				expect(
+					registry.select( CORE_USER ).isDismissingPrompt( slug )
+				).toBe( false );
+			} );
+		} );
+	} );
+} );

--- a/includes/Core/Prompts/Dismissed_Prompts.php
+++ b/includes/Core/Prompts/Dismissed_Prompts.php
@@ -1,0 +1,139 @@
+<?php
+/**
+ * Class Google\Site_Kit\Core\Prompts\Dismissed_Prompts
+ *
+ * @package   Google\Site_Kit\Core\Prompts
+ * @copyright 2024 Google LLC
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
+ * @link      https://sitekit.withgoogle.com
+ */
+
+namespace Google\Site_Kit\Core\Prompts;
+
+use Google\Site_Kit\Core\Storage\User_Setting;
+
+/**
+ * Class for representing a user's dismissed prompts.
+ *
+ * @since n.e.x.t
+ * @access private
+ * @ignore
+ */
+class Dismissed_Prompts extends User_Setting {
+
+	/**
+	 * The user option name for this setting.
+	 *
+	 * @note This option is prefixed differently so that it will persist across disconnect/reset.
+	 */
+	const OPTION = 'googlesitekitpersistent_dismissed_prompts';
+
+	const DISMISS_PROMPT_PERMANENTLY = 0;
+
+	/**
+	 * Adds one prompt to the list of dismissed prompts or updates the triggered count.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param string $prompt             Prompt to dismiss.
+	 * @param int    $expires_in_seconds TTL for the prompt.
+	 */
+	public function add( $prompt, $expires_in_seconds = self::DISMISS_PROMPT_PERMANENTLY ) {
+		$prompts = $this->get();
+
+		if ( array_key_exists( $prompt, $prompts ) ) {
+			$prompts[ $prompt ]['expires'] = $expires_in_seconds ? time() + $expires_in_seconds : 0;
+			$prompts[ $prompt ]['count']   = $prompts[ $prompt ]['count'] + 1;
+		} else {
+			$prompts[ $prompt ] = array(
+				'expires' => $expires_in_seconds ? time() + $expires_in_seconds : 0,
+				'count'   => 1,
+			);
+		}
+
+		$this->set( $prompts );
+	}
+
+	/**
+	 * Removes one or more prompts from the list of dismissed prompts.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param string $prompt Item to remove.
+	 */
+	public function remove( $prompt ) {
+		$prompts = $this->get();
+
+		// If the prompt is not in dismissed prompts, there's nothing to do.
+		if ( ! array_key_exists( $prompt, $prompts ) ) {
+			return;
+		}
+
+		unset( $prompts[ $prompt ] );
+
+		$this->set( $prompts );
+	}
+
+	/**
+	 * Gets the value of the setting.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @return array Value set for the option, or default if not set.
+	 */
+	public function get() {
+		$value = parent::get();
+		return is_array( $value ) ? $value : $this->get_default();
+	}
+
+	/**
+	 * Gets the expected value type.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @return string The type name.
+	 */
+	protected function get_type() {
+		return 'array';
+	}
+
+	/**
+	 * Gets the default value.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @return array The default value.
+	 */
+	protected function get_default() {
+		return array();
+	}
+
+	/**
+	 * Gets the callback for sanitizing the setting's value before saving.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @return callable Sanitize callback.
+	 */
+	protected function get_sanitize_callback() {
+		return function ( $prompts ) {
+			if ( ! is_array( $prompts ) ) {
+				return $this->get_default();
+			}
+
+			$sanitized_prompts = array();
+
+			foreach ( $prompts as $prompt => $data ) {
+				if ( is_array( $data ) && isset( $data['expires'], $data['count'] ) && is_numeric( $data['expires'] ) && is_numeric( $data['count'] ) ) {
+					$sanitized_prompts[ $prompt ] = array(
+						'expires' => $data['expires'],
+						'count'   => $data['count'],
+					);
+				}
+			}
+
+			return $sanitized_prompts;
+		};
+	}
+
+}

--- a/includes/Core/Prompts/Prompts.php
+++ b/includes/Core/Prompts/Prompts.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * Class Google\Site_Kit\Core\Prompts\Prompts
+ *
+ * @package   Google\Site_Kit\Core\Prompts
+ * @copyright 2024 Google LLC
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
+ * @link      https://sitekit.withgoogle.com
+ */
+
+namespace Google\Site_Kit\Core\Prompts;
+
+use Google\Site_Kit\Context;
+use Google\Site_Kit\Core\Storage\User_Options;
+
+/**
+ * Class for handling prompts.
+ *
+ * @since n.e.x.t
+ * @access private
+ * @ignore
+ */
+class Prompts {
+
+	/**
+	 * Dismissed_Prompts instance.
+	 *
+	 * @since n.e.x.t
+	 * @var Dismissed_Prompts
+	 */
+	protected $dismissed_prompts;
+
+	/**
+	 * REST_Prompts_Controller instance.
+	 *
+	 * @since n.e.x.t
+	 * @var REST_Prompts_Controller
+	 */
+	protected $rest_controller;
+
+	/**
+	 * Constructor.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param Context      $context Plugin context.
+	 * @param User_Options $user_options Optional. User option API. Default is a new instance.
+	 */
+	public function __construct( Context $context, User_Options $user_options = null ) {
+		$this->dismissed_prompts = new Dismissed_Prompts( $user_options ?: new User_Options( $context ) );
+		$this->rest_controller   = new REST_Prompts_Controller( $this->dismissed_prompts );
+	}
+
+	/**
+	 * Gets the reference to the Dismissed_Prompts instance.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @return Dismissed_Prompts An instance of the Dismissed_Prompts class.
+	 */
+	public function get_dismissed_prompts() {
+		return $this->dismissed_prompts;
+	}
+
+	/**
+	 * Registers functionality through WordPress hooks.
+	 *
+	 * @since n.e.x.t
+	 */
+	public function register() {
+		$this->dismissed_prompts->register();
+		$this->rest_controller->register();
+	}
+
+}

--- a/includes/Core/Prompts/REST_Prompts_Controller.php
+++ b/includes/Core/Prompts/REST_Prompts_Controller.php
@@ -1,0 +1,135 @@
+<?php
+/**
+ * Class Google\Site_Kit\Core\Prompts\REST_Prompts_Controller
+ *
+ * @package   Google\Site_Kit\Core\Prompts
+ * @copyright 2024 Google LLC
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
+ * @link      https://sitekit.withgoogle.com
+ */
+
+namespace Google\Site_Kit\Core\Prompts;
+
+use Google\Site_Kit\Core\Permissions\Permissions;
+use Google\Site_Kit\Core\REST_API\REST_Route;
+use Google\Site_Kit\Core\REST_API\REST_Routes;
+use WP_Error;
+use WP_REST_Request;
+use WP_REST_Response;
+use WP_REST_Server;
+
+/**
+ * Class for handling dismissed prompts rest routes.
+ *
+ * @since n.e.x.t
+ * @access private
+ * @ignore
+ */
+class REST_Prompts_Controller {
+
+	/**
+	 * Dismissed_Prompts instance.
+	 *
+	 * @since n.e.x.t
+	 * @var Dismissed_Prompts
+	 */
+	protected $dismissed_prompts;
+
+	/**
+	 * Constructor.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param Dismissed_Prompts $dismissed_prompts Dismissed prompts instance.
+	 */
+	public function __construct( Dismissed_Prompts $dismissed_prompts ) {
+		$this->dismissed_prompts = $dismissed_prompts;
+	}
+
+	/**
+	 * Registers functionality through WordPress hooks.
+	 *
+	 * @since n.e.x.t
+	 */
+	public function register() {
+		add_filter(
+			'googlesitekit_rest_routes',
+			function ( $routes ) {
+				return array_merge( $routes, $this->get_rest_routes() );
+			}
+		);
+
+		add_filter(
+			'googlesitekit_apifetch_preload_paths',
+			function ( $paths ) {
+				return array_merge(
+					$paths,
+					array(
+						'/' . REST_Routes::REST_ROOT . '/core/user/data/dismissed-prompts',
+					)
+				);
+			}
+		);
+	}
+
+	/**
+	 * Gets REST route instances.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @return REST_Route[] List of REST_Route objects.
+	 */
+	protected function get_rest_routes() {
+		$can_dismiss_prompt = function() {
+			return current_user_can( Permissions::VIEW_SPLASH ) || current_user_can( Permissions::VIEW_DASHBOARD );
+		};
+
+		return array(
+			new REST_Route(
+				'core/user/data/dismissed-prompts',
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => function () {
+						return new WP_REST_Response( $this->dismissed_prompts->get() );
+					},
+					'permission_callback' => $can_dismiss_prompt,
+				)
+			),
+			new REST_Route(
+				'core/user/data/dismiss-prompt',
+				array(
+					'methods'             => WP_REST_Server::CREATABLE,
+					'callback'            => function ( WP_REST_Request $request ) {
+						$data = $request['data'];
+
+						if ( empty( $data['slug'] ) ) {
+							return new WP_Error(
+								'missing_required_param',
+								/* translators: %s: Missing parameter name */
+								sprintf( __( 'Request parameter is empty: %s.', 'google-site-kit' ), 'slug' ),
+								array( 'status' => 400 )
+							);
+						}
+
+						$expiration = Dismissed_Prompts::DISMISS_PROMPT_PERMANENTLY;
+						if ( isset( $data['expiration'] ) && intval( $data['expiration'] ) > 0 ) {
+							$expiration = $data['expiration'];
+						}
+
+						$this->dismissed_prompts->add( $data['slug'], $expiration );
+
+						return new WP_REST_Response( $this->dismissed_prompts->get() );
+					},
+					'permission_callback' => $can_dismiss_prompt,
+					'args'                => array(
+						'data' => array(
+							'type'     => 'object',
+							'required' => true,
+						),
+					),
+				)
+			),
+		);
+	}
+
+}

--- a/includes/Core/Util/Reset.php
+++ b/includes/Core/Util/Reset.php
@@ -266,6 +266,9 @@ class Reset {
 			wp_die( esc_html__( 'You don’t have permissions to set up Site Kit.', 'google-site-kit' ), 403 );
 		}
 
+		// Call hooks on plugin reset. This is used to reset the ad blocking recovery notification.
+		do_action( 'googlesitekit_reset' );
+
 		$this->all();
 		$this->maybe_hard_reset();
 

--- a/includes/Core/Util/Reset.php
+++ b/includes/Core/Util/Reset.php
@@ -241,6 +241,9 @@ class Reset {
 							$this->all();
 							$this->maybe_hard_reset();
 
+							// Call hooks on plugin reset. This is used to reset the ad blocking recovery notification.
+							do_action( 'googlesitekit_reset' );
+
 							return new WP_REST_Response( true );
 						},
 						'permission_callback' => $can_setup,

--- a/includes/Modules/AdSense.php
+++ b/includes/Modules/AdSense.php
@@ -1137,7 +1137,7 @@ final class AdSense extends Module
 	 *
 	 * @since n.e.x.t
 	 */
-	private function reset_ad_blocking_recovery_notification() {
+	public function reset_ad_blocking_recovery_notification() {
 		$dismissed_prompts = ( new Dismissed_Prompts( $this->user_options ) );
 
 		$current_dismissals = $dismissed_prompts->get();

--- a/includes/Modules/AdSense.php
+++ b/includes/Modules/AdSense.php
@@ -54,6 +54,7 @@ use Google\Site_Kit\Core\Modules\AdSense\Tag_Matchers;
 use Google\Site_Kit\Core\Modules\Module_With_Tag;
 use Google\Site_Kit\Core\Modules\Module_With_Tag_Trait;
 use Google\Site_Kit\Core\Modules\Tags\Module_Tag_Matchers;
+use Google\Site_Kit\Core\Prompts\Dismissed_Prompts;
 use Google\Site_Kit\Core\Site_Health\Debug_Data;
 use Google\Site_Kit\Core\Storage\Encrypted_Options;
 use Google\Site_Kit\Core\Storage\Options;
@@ -157,6 +158,9 @@ final class AdSense extends Module
 				}
 			}
 		);
+
+		// Set up the site reset hook to reset the ad blocking recovery notification.
+		add_action( 'googlesitekit_reset', array( $this, 'reset_ad_blocking_recovery_notification' ) );
 	}
 
 	/**
@@ -205,6 +209,9 @@ final class AdSense extends Module
 
 		// Reset AdSense link settings in Analytics.
 		$this->reset_analytics_adsense_linked_settings();
+
+		// Reset the ad blocking recovery notification.
+		$this->reset_ad_blocking_recovery_notification();
 	}
 
 	/**
@@ -1124,4 +1131,20 @@ final class AdSense extends Module
 			)
 		);
 	}
+
+	/**
+	 * Resets the Ad Blocking Recovery notification.
+	 *
+	 * @since n.e.x.t
+	 */
+	private function reset_ad_blocking_recovery_notification() {
+		$dismissed_prompts = ( new Dismissed_Prompts( $this->user_options ) );
+
+		$current_dismissals = $dismissed_prompts->get();
+
+		if ( isset( $current_dismissals['ad-blocking-recovery-notification'] ) && $current_dismissals['ad-blocking-recovery-notification']['count'] < 3 ) {
+			$dismissed_prompts->remove( 'ad-blocking-recovery-notification' );
+		}
+	}
+
 }

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -212,6 +212,7 @@ final class Plugin {
 				( new Core\Util\Migration_1_8_1( $this->context, $options, $user_options, $authentication ) )->register();
 				( new Core\Dashboard_Sharing\Dashboard_Sharing( $this->context, $user_options ) )->register();
 				( new Core\Key_Metrics\Key_Metrics( $this->context, $user_options, $options ) )->register();
+				( new Core\Prompts\Prompts( $this->context, $user_options ) )->register();
 
 				// If a login is happening (runs after 'init'), update current user in dependency chain.
 				add_action(

--- a/tests/phpunit/integration/Core/Prompts/Dismissed_PromptsTest.php
+++ b/tests/phpunit/integration/Core/Prompts/Dismissed_PromptsTest.php
@@ -1,0 +1,117 @@
+<?php
+/**
+ * Dismissed_PromptsTest
+ *
+ * @package   Google\Site_Kit\Tests\Core\Prompts
+ * @copyright 2024 Google LLC
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
+ * @link      https://sitekit.withgoogle.com
+ */
+
+namespace Google\Site_Kit\Tests\Core\Prompts;
+
+use Google\Site_Kit\Context;
+use Google\Site_Kit\Core\Prompts\Dismissed_Prompts;
+use Google\Site_Kit\Core\Storage\User_Options;
+use Google\Site_Kit\Tests\TestCase;
+
+class Dismissed_PromptsTest extends TestCase {
+
+	/**
+	 * @var User_Options
+	 */
+	private $user_options;
+
+	/**
+	 * @var Dismissed_Prompts
+	 */
+	private $dismissed_prompts;
+
+	public function set_up() {
+		parent::set_up();
+
+		$user_id = $this->factory()->user->create();
+		$context = new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE );
+
+		$this->user_options      = new User_Options( $context, $user_id );
+		$this->dismissed_prompts = new Dismissed_Prompts( $this->user_options );
+		$this->dismissed_prompts->register();
+	}
+
+	public function test_add() {
+		$this->assertEmpty( $this->user_options->get( Dismissed_Prompts::OPTION ) );
+
+		$this->dismissed_prompts->add( 'foo' );
+		$this->assertEquals(
+			array(
+				'foo' => array(
+					'expires' => 0,
+					'count'   => 1,
+				),
+			),
+			$this->user_options->get( Dismissed_Prompts::OPTION )
+		);
+
+		$this->dismissed_prompts->add( 'bar', 100 );
+
+		$prompt_response = $this->user_options->get( Dismissed_Prompts::OPTION );
+		// The asserts are split to use assertEqualsWithDelta for the time based assertion.
+		$this->assertArrayHasKey( 'foo', $prompt_response );
+		$this->assertArrayHasKey( 'bar', $prompt_response );
+		$this->assertEquals( 0, $prompt_response['foo']['expires'] );
+		$this->assertEquals( 1, $prompt_response['foo']['count'] );
+		$this->assertEqualsWithDelta( time() + 100, $prompt_response['bar']['expires'], 2 );
+		$this->assertEquals( 1, $prompt_response['bar']['count'] );
+	}
+
+	public function test_remove() {
+		$this->user_options->set(
+			Dismissed_Prompts::OPTION,
+			array(
+				'foo' => array(
+					'expires' => 0,
+					'count'   => 1,
+				),
+				'bar' => array(
+					'expires' => time() + 100,
+					'count'   => 1,
+				),
+			)
+		);
+
+		$prompt_response = $this->user_options->get( Dismissed_Prompts::OPTION );
+		// The asserts are split to use assertEqualsWithDelta for the time based assertion.
+		$this->assertArrayHasKey( 'foo', $prompt_response );
+		$this->assertArrayHasKey( 'bar', $prompt_response );
+		$this->assertEquals( 0, $prompt_response['foo']['expires'] );
+		$this->assertEquals( 1, $prompt_response['foo']['count'] );
+		$this->assertEqualsWithDelta( time() + 100, $prompt_response['bar']['expires'], 2 );
+		$this->assertEquals( 1, $prompt_response['bar']['count'] );
+
+		$this->dismissed_prompts->remove( 'bar' );
+
+		$this->assertEquals(
+			array(
+				'foo' => array(
+					'expires' => 0,
+					'count'   => 1,
+				),
+			),
+			$this->user_options->get( Dismissed_Prompts::OPTION )
+		);
+
+		// If the prompt is not in dismissed prompts, there should be no change.
+		$this->dismissed_prompts->remove( 'bar' );
+
+		$this->assertEquals(
+			array(
+				'foo' => array(
+					'expires' => 0,
+					'count'   => 1,
+				),
+			),
+			$this->user_options->get( Dismissed_Prompts::OPTION )
+		);
+	}
+
+}

--- a/tests/phpunit/integration/Core/Prompts/REST_Prompts_ControllerTest.php
+++ b/tests/phpunit/integration/Core/Prompts/REST_Prompts_ControllerTest.php
@@ -1,0 +1,145 @@
+<?php
+/**
+ * REST_Prompts_ControllerTest
+ *
+ * @package   Google\Site_Kit\Tests\Core\Prompts
+ * @copyright 2024 Google LLC
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
+ * @link      https://sitekit.withgoogle.com
+ */
+
+namespace Google\Site_Kit\Tests\Core\Prompts;
+
+use Google\Site_Kit\Context;
+use Google\Site_Kit\Core\Prompts\Dismissed_Prompts;
+use Google\Site_Kit\Core\Prompts\REST_Prompts_Controller;
+use Google\Site_Kit\Core\REST_API\REST_Routes;
+use Google\Site_Kit\Core\Storage\User_Options;
+use Google\Site_Kit\Tests\RestTestTrait;
+use Google\Site_Kit\Tests\TestCase;
+use WP_REST_Request;
+
+class REST_Prompts_ControllerTest extends TestCase {
+
+	use RestTestTrait;
+
+	/**
+	 * Dismissed prompts instance.
+	 *
+	 * @var Dismissed_Prompts
+	 */
+	private $dismissed_prompts;
+
+	/**
+	 * Controller instance.
+	 *
+	 * @var REST_Prompts_Controller
+	 */
+	private $controller;
+
+	public function set_up() {
+		parent::set_up();
+
+		$user_id = $this->factory()->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $user_id );
+
+		$context                 = new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE );
+		$user_options            = new User_Options( $context, $user_id );
+		$this->dismissed_prompts = new Dismissed_Prompts( $user_options );
+		$this->controller        = new REST_Prompts_Controller( $this->dismissed_prompts );
+	}
+
+	public function tear_down() {
+		parent::tear_down();
+		// This ensures the REST server is initialized fresh for each test using it.
+		unset( $GLOBALS['wp_rest_server'] );
+	}
+
+	public function test_register() {
+		remove_all_filters( 'googlesitekit_rest_routes' );
+		remove_all_filters( 'googlesitekit_apifetch_preload_paths' );
+
+		$this->controller->register();
+
+		$this->assertTrue( has_filter( 'googlesitekit_rest_routes' ) );
+		$this->assertTrue( has_filter( 'googlesitekit_apifetch_preload_paths' ) );
+	}
+
+	public function test_get_dismissed_prompts() {
+		remove_all_filters( 'googlesitekit_rest_routes' );
+		$this->controller->register();
+		$this->register_rest_routes();
+
+		$this->dismissed_prompts->add( 'foo' );
+		$this->dismissed_prompts->add( 'bar', 100 );
+
+		$request  = new WP_REST_Request( 'GET', '/' . REST_Routes::REST_ROOT . '/core/user/data/dismissed-prompts' );
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertEqualSets(
+			array(
+				'foo' => array(
+					'expires' => 0,
+					'count'   => 1,
+				),
+				'bar' => array(
+					'expires' => time() + 100,
+					'count'   => 1,
+				),
+			),
+			$response->get_data()
+		);
+	}
+
+	public function test_dismiss_new_prompt() {
+		remove_all_filters( 'googlesitekit_rest_routes' );
+		$this->controller->register();
+		$this->register_rest_routes();
+
+		$this->dismissed_prompts->add( 'foo' );
+
+		$request = new WP_REST_Request( 'POST', '/' . REST_Routes::REST_ROOT . '/core/user/data/dismiss-prompt' );
+		$request->set_body_params(
+			array(
+				'data' => array(
+					'slug'       => 'bar',
+					'expiration' => 100,
+				),
+			)
+		);
+
+		$this->assertEqualSets(
+			array( 'foo', 'bar' ),
+			array_keys( rest_get_server()->dispatch( $request )->get_data() )
+		);
+	}
+
+	public function test_dismiss_prompt_increments_count() {
+		remove_all_filters( 'googlesitekit_rest_routes' );
+		$this->controller->register();
+		$this->register_rest_routes();
+
+		$this->dismissed_prompts->add( 'foo' );
+
+		$request = new WP_REST_Request( 'POST', '/' . REST_Routes::REST_ROOT . '/core/user/data/dismiss-prompt' );
+		$request->set_body_params(
+			array(
+				'data' => array(
+					'slug'       => 'foo',
+					'expiration' => 100,
+				),
+			)
+		);
+
+		$this->assertEqualSets(
+			array(
+				'foo' => array(
+					'expires' => time() + 100,
+					'count'   => 2,
+				),
+			),
+			rest_get_server()->dispatch( $request )->get_data()
+		);
+	}
+
+}


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #7316

## Relevant technical choices

<!-- Please describe your changes. -->
I mostly followed the IB although in testing I had to make a number of other key modifications in the prompt datastore to account for the new Object datastructure.

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
