### PR TITLE
KM Selection Panel: Do not render link to settings for a view-only user

### DIFF
--- a/assets/js/components/KeyMetrics/MetricsSelectionPanel/Header.js
+++ b/assets/js/components/KeyMetrics/MetricsSelectionPanel/Header.js
@@ -33,9 +33,12 @@ import { CORE_USER } from '../../../googlesitekit/datastore/user/constants';
 import { KEY_METRICS_SELECTION_PANEL_OPENED_KEY } from '../constants';
 import Link from '../../Link';
 import CloseIcon from '../../../../svg/icons/close.svg';
+import useViewOnly from '../../../hooks/useViewOnly';
 const { useSelect, useDispatch } = Data;
 
 export default function Header() {
+	const isViewOnly = useViewOnly();
+
 	const settingsURL = useSelect( ( select ) =>
 		select( CORE_SITE ).getAdminURL( 'googlesitekit-settings' )
 	);
@@ -67,24 +70,26 @@ export default function Header() {
 					<CloseIcon width="15" height="15" />
 				</Link>
 			</div>
-			<p>
-				{ createInterpolateElement(
-					__(
-						'Edit your personalized goals or deactivate this widget in <link><strong>Settings</strong></link>',
-						'google-site-kit'
-					),
-					{
-						link: (
-							<Link
-								secondary
-								onClick={ onSettingsClick }
-								disabled={ isSavingSettings }
-							/>
+			{ ! isViewOnly && (
+				<p>
+					{ createInterpolateElement(
+						__(
+							'Edit your personalized goals or deactivate this widget in <link><strong>Settings</strong></link>',
+							'google-site-kit'
 						),
-						strong: <strong />,
-					}
-				) }
-			</p>
+						{
+							link: (
+								<Link
+									secondary
+									onClick={ onSettingsClick }
+									disabled={ isSavingSettings }
+								/>
+							),
+							strong: <strong />,
+						}
+					) }
+				</p>
+			) }
 		</header>
 	);
 }

--- a/assets/js/components/KeyMetrics/MetricsSelectionPanel/index.stories.js
+++ b/assets/js/components/KeyMetrics/MetricsSelectionPanel/index.stories.js
@@ -25,20 +25,37 @@ import {
 	provideModules,
 	provideUserAuthentication,
 } from '../../../../../tests/js/utils';
+import {
+	VIEW_CONTEXT_MAIN_DASHBOARD,
+	VIEW_CONTEXT_MAIN_DASHBOARD_VIEW_ONLY,
+} from '../../../googlesitekit/constants';
 import { CORE_UI } from '../../../googlesitekit/datastore/ui/constants';
 import { KEY_METRICS_SELECTION_PANEL_OPENED_KEY } from '../constants';
 import { KEY_METRICS_WIDGETS } from '../key-metrics-widgets';
 import { provideKeyMetricsWidgetRegistrations } from '../test-utils';
+import { Provider as ViewContextProvider } from '../../Root/ViewContextContext';
 import MetricsSelectionPanel from './';
 
-function Template() {
-	return <MetricsSelectionPanel />;
+function Template( { viewContext } ) {
+	return (
+		<ViewContextProvider
+			value={ viewContext || VIEW_CONTEXT_MAIN_DASHBOARD }
+		>
+			<MetricsSelectionPanel />
+		</ViewContextProvider>
+	);
 }
 
 export const Default = Template.bind( {} );
-Default.storyName = 'MetricsSelectionPanel';
+Default.storyName = 'Default';
 Default.scenario = {
 	label: 'KeyMetrics/MetricsSelectionPanel',
+};
+
+export const ViewOnly = Template.bind( {} );
+ViewOnly.storyName = 'View-only user';
+ViewOnly.args = {
+	viewContext: VIEW_CONTEXT_MAIN_DASHBOARD_VIEW_ONLY,
 };
 
 export default {

--- a/assets/js/components/KeyMetrics/MetricsSelectionPanel/index.test.js
+++ b/assets/js/components/KeyMetrics/MetricsSelectionPanel/index.test.js
@@ -89,8 +89,76 @@ describe( 'MetricsSelectionPanel', () => {
 		Element.prototype.scrollIntoView = jest.fn();
 	} );
 
+	describe( 'Header', () => {
+		beforeEach( () => {
+			provideModules( registry, [
+				{
+					slug: 'analytics-4',
+					active: true,
+					connected: true,
+				},
+			] );
+
+			provideKeyMetricsWidgetRegistrations( registry, {
+				[ KM_SEARCH_CONSOLE_POPULAR_KEYWORDS ]: {
+					modules: [ 'search-console' ],
+				},
+				[ KM_ANALYTICS_RETURNING_VISITORS ]: {
+					modules: [ 'analytics-4' ],
+				},
+				[ KM_ANALYTICS_TOP_RECENT_TRENDING_PAGES ]: {
+					modules: [ 'analytics-4' ],
+				},
+			} );
+
+			provideKeyMetrics( registry, {
+				widgetSlugs: [
+					KM_SEARCH_CONSOLE_POPULAR_KEYWORDS,
+					KM_ANALYTICS_RETURNING_VISITORS,
+				],
+			} );
+
+			registry.dispatch( MODULES_ANALYTICS_4 ).receiveGetSettings( {
+				availableCustomDimensions: [],
+			} );
+		} );
+
+		it( 'should display a settings link to edit personalized goals', async () => {
+			const { getByText, waitForRegistry } = render(
+				<MetricsSelectionPanel />,
+				{
+					registry,
+				}
+			);
+
+			await waitForRegistry();
+
+			expect(
+				getByText(
+					/Edit your personalized goals or deactivate this widget in/i
+				)
+			).toBeInTheDocument();
+		} );
+
+		it( 'should not display a settings link to edit personalized goals for a view-only user', async () => {
+			const { container, waitForRegistry } = render(
+				<MetricsSelectionPanel />,
+				{
+					registry,
+					viewContext: VIEW_CONTEXT_MAIN_DASHBOARD_VIEW_ONLY,
+				}
+			);
+
+			await waitForRegistry();
+
+			expect( container ).not.toHaveTextContent(
+				'Edit your personalized goals or deactivate this widget in'
+			);
+		} );
+	} );
+
 	describe( 'Metrics', () => {
-		it( 'should list metrics regardless of modules being connected or not', () => {
+		it( 'should list metrics regardless of modules being connected or not', async () => {
 			provideKeyMetrics( registry );
 
 			provideModules( registry, [
@@ -110,7 +178,11 @@ describe( 'MetricsSelectionPanel', () => {
 				},
 			} );
 
-			render( <MetricsSelectionPanel />, { registry } );
+			const { waitForRegistry } = render( <MetricsSelectionPanel />, {
+				registry,
+			} );
+
+			await waitForRegistry();
 
 			expect(
 				document.querySelector(


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #8202

## Relevant technical choices

This PR removes the link to settings in the Key Metrics selection panel for a view-only user.

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
