### PR TITLE
Update time based tests to use assertEqualsWithDelta to make them more stable.

### DIFF
--- a/tests/phpunit/integration/Core/Dismissals/Dismissed_ItemsTest.php
+++ b/tests/phpunit/integration/Core/Dismissals/Dismissed_ItemsTest.php
@@ -50,13 +50,11 @@ class Dismissed_ItemsTest extends TestCase {
 		);
 
 		$this->dismissed_items->add( 'bar', 100 );
-		$this->assertEquals(
-			array(
-				'foo' => 0,
-				'bar' => time() + 100,
-			),
-			$this->user_options->get( Dismissed_Items::OPTION )
-		);
+		$user_options = $this->user_options->get( Dismissed_Items::OPTION );
+		$this->assertArrayHasKey( 'foo', $user_options );
+		$this->assertEquals( 0, $user_options['foo'] );
+		$this->assertArrayHasKey( 'bar', $user_options );
+		$this->assertEqualsWithDelta( time() + 100, $user_options['bar'], 2 );
 	}
 
 	public function test_remove() {
@@ -69,14 +67,13 @@ class Dismissed_ItemsTest extends TestCase {
 			)
 		);
 
-		$this->assertEquals(
-			array(
-				'foo' => 0,
-				'bar' => time() + 100,
-				'baz' => time() + 200,
-			),
-			$this->user_options->get( Dismissed_Items::OPTION )
-		);
+		$user_options = $this->user_options->get( Dismissed_Items::OPTION );
+		$this->assertArrayHasKey( 'foo', $user_options );
+		$this->assertArrayHasKey( 'bar', $user_options );
+		$this->assertArrayHasKey( 'baz', $user_options );
+		$this->assertEquals( 0, $user_options['foo'] );
+		$this->assertEqualsWithDelta( time() + 100, $user_options['bar'], 2 );
+		$this->assertEqualsWithDelta( time() + 200, $user_options['baz'], 2 );
 
 		$this->dismissed_items->remove( 'bar' );
 

--- a/tests/phpunit/integration/Core/User_Surveys/Survey_TimeoutsTest.php
+++ b/tests/phpunit/integration/Core/User_Surveys/Survey_TimeoutsTest.php
@@ -42,12 +42,9 @@ class Survey_TimeoutsTest extends TestCase {
 		$this->assertEmpty( $this->user_options->get( Survey_Timeouts::OPTION ) );
 
 		$this->timeouts->add( 'foo', 100 );
-		$this->assertEquals(
-			array(
-				'foo' => time() + 100,
-			),
-			$this->user_options->get( Survey_Timeouts::OPTION )
-		);
+		$timeouts = $this->user_options->get( Survey_Timeouts::OPTION );
+		$this->assertArrayHasKey( 'foo', $timeouts );
+		$this->assertEqualsWithDelta( time() + 100, $timeouts['foo'], 2 );
 	}
 
 	public function test_get_survey_timeouts() {


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #6758

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
