### PR TITLE
Switch true/punycode for symfony/polyfill-intl-idn and update usage.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "google/apiclient-services": "0.277.*",
     "google/apiclient-services-adsenselinks": "^0.1.0",
     "guzzlehttp/guzzle": "^6.5.8",
-    "true/punycode": "^2.0 <2.1.1"
+		"symfony/polyfill-intl-idn": "<=1.19.0"
   },
   "replace": {
     "paragonie/random_compat": ">=2",

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "google/apiclient-services": "0.277.*",
     "google/apiclient-services-adsenselinks": "^0.1.0",
     "guzzlehttp/guzzle": "^6.5.8",
-		"symfony/polyfill-intl-idn": "<=1.19.0"
+		"symfony/polyfill-intl-idn": "^1"
   },
   "replace": {
     "paragonie/random_compat": ">=2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7b536d79eb4d7b13c2b9b6689ebd8ac6",
+    "content-hash": "13d9c947aa204760608fe0599f8f8d80",
     "packages": [
         {
             "name": "firebase/php-jwt",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fc2d426d126ea7321fcde8c5d2172f6f",
+    "content-hash": "7b536d79eb4d7b13c2b9b6689ebd8ac6",
     "packages": [
         {
             "name": "firebase/php-jwt",
@@ -1166,56 +1166,6 @@
                 }
             ],
             "time": "2020-10-23T09:01:57+00:00"
-        },
-        {
-            "name": "true/punycode",
-            "version": "v2.1.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/true/php-punycode.git",
-                "reference": "74033cbe9fdd3eba597f8af501947a125b3b8087"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/true/php-punycode/zipball/74033cbe9fdd3eba597f8af501947a125b3b8087",
-                "reference": "74033cbe9fdd3eba597f8af501947a125b3b8087",
-                "shasum": ""
-            },
-            "require": {
-                "ext-mbstring": "*",
-                "php": ">=5.3.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "~4.7",
-                "squizlabs/php_codesniffer": "~2.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "TrueBV\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Renan Gonçalves",
-                    "email": "renan.saddam@gmail.com"
-                }
-            ],
-            "description": "A Bootstring encoding of Unicode for Internationalized Domain Names in Applications (IDNA)",
-            "homepage": "https://github.com/true/php-punycode",
-            "keywords": [
-                "idna",
-                "punycode"
-            ],
-            "support": {
-                "issues": "https://github.com/true/php-punycode/issues",
-                "source": "https://github.com/true/php-punycode/tree/master"
-            },
-            "time": "2016-08-09T14:50:44+00:00"
         }
     ],
     "packages-dev": [

--- a/includes/Core/Util/URL.php
+++ b/includes/Core/Util/URL.php
@@ -10,8 +10,6 @@
 
 namespace Google\Site_Kit\Core\Util;
 
-use Google\Site_Kit_Dependencies\TrueBV\Punycode;
-
 /**
  * Class for custom URL parsing methods.
  *
@@ -20,6 +18,11 @@ use Google\Site_Kit_Dependencies\TrueBV\Punycode;
  * @ignore
  */
 class URL {
+
+	/**
+	 * Prefix for Punycode-encoded hostnames.
+	 */
+	const PUNYCODE_PREFIX = 'xn--';
 
 	/**
 	 * Parses URLs with UTF-8 multi-byte characters,
@@ -135,7 +138,6 @@ class URL {
 	 * @return string[] Hostname variations.
 	 */
 	public static function permute_site_hosts( $hostname ) {
-		$punycode = new Punycode();
 		// See \Requests_IDNAEncoder::is_ascii.
 		$is_ascii = preg_match( '/(?:[^\x00-\x7F])/', $hostname ) !== 1;
 		$is_www   = 0 === strpos( $hostname, 'www.' );
@@ -147,13 +149,13 @@ class URL {
 			// An ASCII hostname can only be non-IDN or punycode-encoded.
 			if ( $is_ascii ) {
 				// If the hostname is in punycode encoding, add the decoded version to the list of hosts.
-				if ( 0 === strpos( $hostname, Punycode::PREFIX ) || false !== strpos( $hostname, '.' . Punycode::PREFIX ) ) {
-					$host_decoded = $punycode->decode( $hostname );
+				if ( 0 === strpos( $hostname, self::PUNYCODE_PREFIX ) || false !== strpos( $hostname, '.' . self::PUNYCODE_PREFIX ) ) {
+					$host_decoded = idn_to_utf8( $hostname, IDNA_DEFAULT, INTL_IDNA_VARIANT_UTS46 );
 					array_push( $hosts, $host_decoded, "www.$host_decoded" );
 				}
 			} else {
 				// If it's not ASCII, then add the punycode encoded version.
-				$host_encoded = $punycode->encode( $hostname );
+				$host_encoded = idn_to_ascii( $hostname, IDNA_DEFAULT, INTL_IDNA_VARIANT_UTS46 );
 				array_push( $hosts, $host_encoded, "www.$host_encoded" );
 			}
 		} catch ( Exception $exception ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch

--- a/includes/Core/Util/URL.php
+++ b/includes/Core/Util/URL.php
@@ -150,12 +150,14 @@ class URL {
 			if ( $is_ascii ) {
 				// If the hostname is in punycode encoding, add the decoded version to the list of hosts.
 				if ( 0 === strpos( $hostname, self::PUNYCODE_PREFIX ) || false !== strpos( $hostname, '.' . self::PUNYCODE_PREFIX ) ) {
-					$host_decoded = idn_to_utf8( $hostname, IDNA_DEFAULT, INTL_IDNA_VARIANT_UTS46 );
+					// phpcs:ignore PHPCompatibility.ParameterValues.NewIDNVariantDefault.NotSet
+					$host_decoded = idn_to_utf8( $hostname );
 					array_push( $hosts, $host_decoded, "www.$host_decoded" );
 				}
 			} else {
 				// If it's not ASCII, then add the punycode encoded version.
-				$host_encoded = idn_to_ascii( $hostname, IDNA_DEFAULT, INTL_IDNA_VARIANT_UTS46 );
+				// phpcs:ignore PHPCompatibility.ParameterValues.NewIDNVariantDefault.NotSet
+				$host_encoded = idn_to_ascii( $hostname );
 				array_push( $hosts, $host_encoded, "www.$host_encoded" );
 			}
 		} catch ( Exception $exception ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch

--- a/includes/Core/Util/URL.php
+++ b/includes/Core/Util/URL.php
@@ -150,14 +150,16 @@ class URL {
 			if ( $is_ascii ) {
 				// If the hostname is in punycode encoding, add the decoded version to the list of hosts.
 				if ( 0 === strpos( $hostname, self::PUNYCODE_PREFIX ) || false !== strpos( $hostname, '.' . self::PUNYCODE_PREFIX ) ) {
-					// Ignoring phpcs here, and not passing the variant so that the correct default can be selected by PHP based on the version. INTL_IDNA_VARIANT_UTS46 for php>=7.4, INTL_IDNA_VARIANT_2003 for php<7.4.
+					// Ignoring phpcs here, and not passing the variant so that the correct default can be selected by PHP based on the
+					// version. INTL_IDNA_VARIANT_UTS46 for PHP>=7.4, INTL_IDNA_VARIANT_2003 for PHP<7.4.
 					// phpcs:ignore PHPCompatibility.ParameterValues.NewIDNVariantDefault.NotSet
 					$host_decoded = idn_to_utf8( $hostname );
 					array_push( $hosts, $host_decoded, "www.$host_decoded" );
 				}
 			} else {
 				// If it's not ASCII, then add the punycode encoded version.
-				// Ignoring phpcs here, and not passing the variant so that the correct default can be selected by PHP based on the version. INTL_IDNA_VARIANT_UTS46 for php>=7.4, INTL_IDNA_VARIANT_2003 for php<7.4.
+				// Ignoring phpcs here, and not passing the variant so that the correct default can be selected by PHP based on the
+				// version. INTL_IDNA_VARIANT_UTS46 for PHP>=7.4, INTL_IDNA_VARIANT_2003 for PHP<7.4.
 				// phpcs:ignore PHPCompatibility.ParameterValues.NewIDNVariantDefault.NotSet
 				$host_encoded = idn_to_ascii( $hostname );
 				array_push( $hosts, $host_encoded, "www.$host_encoded" );

--- a/includes/Core/Util/URL.php
+++ b/includes/Core/Util/URL.php
@@ -150,12 +150,14 @@ class URL {
 			if ( $is_ascii ) {
 				// If the hostname is in punycode encoding, add the decoded version to the list of hosts.
 				if ( 0 === strpos( $hostname, self::PUNYCODE_PREFIX ) || false !== strpos( $hostname, '.' . self::PUNYCODE_PREFIX ) ) {
+					// Ignoring phpcs here, and not passing the variant so that the correct default can be selected by PHP based on the version. INTL_IDNA_VARIANT_UTS46 for php>=7.4, INTL_IDNA_VARIANT_2003 for php<7.4.
 					// phpcs:ignore PHPCompatibility.ParameterValues.NewIDNVariantDefault.NotSet
 					$host_decoded = idn_to_utf8( $hostname );
 					array_push( $hosts, $host_decoded, "www.$host_decoded" );
 				}
 			} else {
 				// If it's not ASCII, then add the punycode encoded version.
+				// Ignoring phpcs here, and not passing the variant so that the correct default can be selected by PHP based on the version. INTL_IDNA_VARIANT_UTS46 for php>=7.4, INTL_IDNA_VARIANT_2003 for php<7.4.
 				// phpcs:ignore PHPCompatibility.ParameterValues.NewIDNVariantDefault.NotSet
 				$host_encoded = idn_to_ascii( $hostname );
 				array_push( $hosts, $host_encoded, "www.$host_encoded" );


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #8094

## Relevant technical choices

<!-- Please describe your changes. -->
Implemented in the IB with fully uppercase `const PUNYCODE_PREFIX = 'xn--';` and set defaults for idn functions: `, IDNA_DEFAULT, INTL_IDNA_VARIANT_UTS46` in order to pass php lint.

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
