### PR TITLE
Specify core-js@3.28.0 and update webdatastreams.js to use toSorted with polyfill imported.

### DIFF
--- a/assets/js/modules/analytics-4/datastore/webdatastreams.js
+++ b/assets/js/modules/analytics-4/datastore/webdatastreams.js
@@ -21,6 +21,8 @@
  */
 import invariant from 'invariant';
 import { pick, difference } from 'lodash';
+// Polyfill for `Array.prototype.toSorted` method for tests. This can be removed once the project uses > node.js 20.
+import 'core-js/actual/array/to-sorted';
 
 /**
  * Internal dependencies
@@ -444,7 +446,8 @@ const baseSelectors = {
 				? measurements
 				: [ measurements ];
 
-			let summaries = select( MODULES_ANALYTICS_4 ).getAccountSummaries();
+			const summaries =
+				select( MODULES_ANALYTICS_4 ).getAccountSummaries();
 			if ( ! Array.isArray( summaries ) ) {
 				return undefined;
 			}
@@ -454,22 +457,25 @@ const baseSelectors = {
 			// account will contain a measurement ID that we are looking for.
 			const currentAccountID = select( MODULES_ANALYTICS ).getAccountID();
 			// Clone summaries to avoid mutating the original array.
-			summaries = [ ...summaries ].sort( ( { _id: accountID } ) =>
-				accountID === currentAccountID ? -1 : 0
+			const sortedSummaries = summaries.toSorted(
+				( { _id: accountID } ) =>
+					accountID === currentAccountID ? -1 : 0
 			);
 
 			const info = {};
 			const propertyIDs = [];
 
-			summaries.forEach( ( { _id: accountID, propertySummaries } ) => {
-				propertySummaries.forEach( ( { _id: propertyID } ) => {
-					propertyIDs.push( propertyID );
-					info[ propertyID ] = {
-						accountID,
-						propertyID,
-					};
-				} );
-			} );
+			sortedSummaries.forEach(
+				( { _id: accountID, propertySummaries } ) => {
+					propertySummaries.forEach( ( { _id: propertyID } ) => {
+						propertyIDs.push( propertyID );
+						info[ propertyID ] = {
+							accountID,
+							propertyID,
+						};
+					} );
+				}
+			);
 
 			if ( propertyIDs.length === 0 ) {
 				return null;

--- a/package-lock.json
+++ b/package-lock.json
@@ -27622,9 +27622,9 @@
       }
     },
     "core-js": {
-      "version": "3.6.5",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
-      "integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA==",
+      "version": "3.28.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.28.0.tgz",
+      "integrity": "sha512-GiZn9D4Z/rSYvTeg1ljAIsEqFm0LaN9gVtwDCrKL80zHtS31p9BAjmTxVqTQDMpwlMolJZOFntUG2uwyj7DAqw==",
       "dev": true
     },
     "core-js-compat": {

--- a/package.json
+++ b/package.json
@@ -196,6 +196,7 @@
 		"babel-jest": "^26.6.3",
 		"babel-loader": "^8.1.0",
 		"circular-dependency-plugin": "^5.2.0",
+		"core-js": "^3.28.0",
 		"create-file-webpack": "^1.0.2",
 		"cross-env": "^7.0.3",
 		"css-loader": "^3.6.0",


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #7571

## Relevant technical choices

<!-- Please describe your changes. -->
As suggested by @techanvil using core-js by specifying version `3.28.0` allows us to use toSorted in the tests.

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [ ] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
