### PR TITLE
Add Ads model settings class.

### DIFF
--- a/includes/Modules/Ads.php
+++ b/includes/Modules/Ads.php
@@ -11,6 +11,12 @@
 namespace Google\Site_Kit\Modules;
 
 use Google\Site_Kit\Core\Modules\Module;
+use Google\Site_Kit\Core\Modules\Module_Settings;
+use Google\Site_Kit\Core\Modules\Module_With_Data_Available_State;
+use Google\Site_Kit\Core\Modules\Module_With_Data_Available_State_Trait;
+use Google\Site_Kit\Core\Modules\Module_With_Settings;
+use Google\Site_Kit\Core\Modules\Module_With_Settings_Trait;
+use Google\Site_Kit\Modules\Ads\Settings;
 
 /**
  * Class representing the Ads module.
@@ -19,7 +25,9 @@ use Google\Site_Kit\Core\Modules\Module;
  * @access private
  * @ignore
  */
-final class Ads extends Module {
+final class Ads extends Module implements Module_With_Settings, Module_With_Data_Available_State {
+	use Module_With_Settings_Trait;
+	use Module_With_Data_Available_State_Trait;
 
 	/**
 	 * Module slug name.
@@ -48,6 +56,42 @@ final class Ads extends Module {
 			'order'       => 1,
 			'homepage'    => __( 'https://google.com/ads', 'google-site-kit' ),
 		);
+	}
+
+	/**
+	 * Sets up the module's settings instance.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @return Module_Settings
+	 */
+	protected function setup_settings() {
+		return new Settings( $this->options );
+	}
+
+	/**
+	 * Checks whether the module is connected.
+	 *
+	 * A module being connected means that all steps required as part of its activation are completed.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @return bool True if module is connected, false otherwise.
+	 */
+	public function is_connected() {
+		$options = $this->get_settings()->get();
+
+		return parent::is_connected() && ! empty( $options['adsConversionID'] );
+	}
+
+	/**
+	 * Cleans up when the module is deactivated.
+	 *
+	 * @since n.e.x.t
+	 */
+	public function on_deactivation() {
+		$this->get_settings()->delete();
+		$this->reset_data_available();
 	}
 
 }

--- a/includes/Modules/Ads/Settings.php
+++ b/includes/Modules/Ads/Settings.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Class Google\Site_Kit\Modules\Ads\Settings
+ *
+ * @package   Google\Site_Kit\Modules\Ads
+ * @copyright 2024 Google LLC
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
+ * @link      https://sitekit.withgoogle.com
+ */
+
+namespace Google\Site_Kit\Modules\Ads;
+
+use Google\Site_Kit\Core\Modules\Module_Settings;
+use Google\Site_Kit\Core\Storage\Setting_With_Owned_Keys_Interface;
+use Google\Site_Kit\Core\Storage\Setting_With_Owned_Keys_Trait;
+
+/**
+ * Class for Ads settings.
+ *
+ * @since n.e.x.t
+ * @access private
+ * @ignore
+ */
+class Settings extends Module_Settings implements Setting_With_Owned_Keys_Interface {
+	use Setting_With_Owned_Keys_Trait;
+
+	const OPTION = 'googlesitekit_ads_settings';
+
+	/**
+	 * Registers the setting in WordPress.
+	 *
+	 * @since n.e.x.t
+	 */
+	public function register() {
+		parent::register();
+
+		$this->register_owned_keys();
+	}
+
+	/**
+	 * Gets the default value.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @return array An array of default settings values.
+	 */
+	protected function get_default() {
+		return array(
+			'adsConversionID' => '',
+		);
+	}
+
+	/**
+	 * Returns keys for owned settings.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @return array An array of keys for owned settings.
+	 */
+	public function get_owned_keys() {
+		return array( 'adsConversionID' );
+	}
+}

--- a/tests/phpunit/integration/Modules/Ads/SettingsTest.php
+++ b/tests/phpunit/integration/Modules/Ads/SettingsTest.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Class Google\Site_Kit\Tests\Modules\Ads\SettingsTest
+ *
+ * @package   Google\Site_Kit\Tests\Modules\Ads
+ * @copyright 2024 Google LLC
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
+ * @link      https://sitekit.withgoogle.com
+ */
+
+namespace Google\Site_Kit\Tests\Modules\Ads;
+
+use Google\Site_Kit\Context;
+use Google\Site_Kit\Core\Storage\Options;
+use Google\Site_Kit\Modules\Ads\Settings;
+use Google\Site_Kit\Tests\Modules\SettingsTestCase;
+
+/**
+ * @group Modules
+ * @group Ads
+ */
+class SettingsTest extends SettingsTestCase {
+
+	public function test_get_default() {
+		$settings = new Settings( new Options( new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE ) ) );
+		$settings->register();
+
+		$this->assertEqualSetsWithIndex(
+			array(
+				'adsConversionID' => '',
+			),
+			get_option( Settings::OPTION )
+		);
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	protected function get_option_name() {
+		return Settings::OPTION;
+	}
+}

--- a/tests/phpunit/integration/Modules/AdsTest.php
+++ b/tests/phpunit/integration/Modules/AdsTest.php
@@ -26,4 +26,27 @@ class AdsTest extends TestCase {
 		$this->assertEquals( 'Ads', $ads->name );
 		$this->assertEquals( 'https://google.com/ads', $ads->homepage );
 	}
+
+	public function test_is_connected_when_ads_conversion_id_is_set() {
+		$ads = new Ads( new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE ) );
+
+		$this->assertFalse( $ads->is_connected() );
+
+		$ads->get_settings()->set( array( 'adsConversionID' => 'AW-123456789' ) );
+
+		$this->assertTrue( $ads->is_connected() );
+	}
+
+	public function test_settings_reset_on_deactivation() {
+		$ads = new Ads( new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE ) );
+
+		$ads->get_settings()->set( array( 'adsConversionID' => 'AW-123456789' ) );
+
+		$ads->on_deactivation();
+
+		$ads_settings = $ads->get_settings()->get();
+
+		$this->assertFalse( $ads_settings );
+	}
+
 }


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #8223 

## Relevant technical choices

 * Implemented as in the IB.
 * I had to inherit and use the `Module_With_Data_Available_State` and `Module_With_Data_Available_State_Trait` in order to access the `reset_data_available` method.
 * I added tests across all new key methods.

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [ ] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
