### PR TITLE
Fix minus figure appearing in AdSense chart when no earnings made.

### DIFF
--- a/assets/js/modules/adsense/components/module/ModuleOverviewWidget/Stats.js
+++ b/assets/js/modules/adsense/components/module/ModuleOverviewWidget/Stats.js
@@ -134,8 +134,8 @@ export default function Stats( props ) {
 	};
 
 	if (
-		isZeroReport( currentRangeData ) &&
-		isZeroReport( previousRangeData )
+		isZeroReport( currentRangeData, selectedStats + 1 ) &&
+		isZeroReport( previousRangeData, selectedStats + 1 )
 	) {
 		options.vAxis.viewWindow.max = 100;
 	} else {

--- a/assets/js/modules/adsense/util/is-zero-report.js
+++ b/assets/js/modules/adsense/util/is-zero-report.js
@@ -21,10 +21,11 @@
  *
  * @since 1.21.0
  *
- * @param {Object} report Report data.
+ * @param {Object} report             Report data.
+ * @param {number} selectedStatsIndex The index of the selected stats tab.
  * @return {boolean|undefined} TRUE if the report has no data, otherwise FALSE. `undefined` if the `report` passed is undefined.
  */
-export function isZeroReport( report ) {
+export function isZeroReport( report, selectedStatsIndex ) {
 	if ( report === undefined ) {
 		return undefined;
 	}
@@ -39,7 +40,8 @@ export function isZeroReport( report ) {
 		return true;
 	}
 
-	if ( ! totals.cells.some( ( cell ) => cell?.value > 0 ) ) {
+	// Take into account the value of the selected tab.
+	if ( +totals.cells[ selectedStatsIndex ]?.value === 0 ) {
 		return true;
 	}
 

--- a/assets/js/modules/adsense/util/is-zero-report.test.js
+++ b/assets/js/modules/adsense/util/is-zero-report.test.js
@@ -107,14 +107,14 @@ describe( 'isZeroReport', () => {
 		[ 'an object without rows', { totals: [ 1 ] } ],
 		[ 'an object with invalid rows', { rows: 12, totals: [ 1 ] } ],
 	] )( 'should return TRUE when %s is passed', ( _, report ) => {
-		expect( isZeroReport( report ) ).toBe( true );
+		expect( isZeroReport( report, 1 ) ).toBe( true );
 	} );
 
 	it( 'should return FALSE when a valid object is passed', () => {
-		expect( isZeroReport( validReport ) ).toBe( false );
+		expect( isZeroReport( validReport, 1 ) ).toBe( false );
 	} );
 
 	it( 'should return undefined when an undefined value is passed', () => {
-		expect( isZeroReport( undefined ) ).toBeUndefined();
+		expect( isZeroReport( undefined, 1 ) ).toBeUndefined();
 	} );
 } );


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #6479

## Relevant technical choices

 - Addressed as in IB.

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [ ] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
