### PR TITLE
Use reference date for Prompts.

### DIFF
--- a/assets/js/googlesitekit/datastore/user/prompts.js
+++ b/assets/js/googlesitekit/datastore/user/prompts.js
@@ -29,6 +29,7 @@ import Data from 'googlesitekit-data';
 import { CORE_USER } from './constants';
 import { createFetchStore } from '../../data/create-fetch-store';
 import { createValidatedAction } from '../../data/utils';
+import { stringToDate } from '../../../util';
 
 const { createRegistrySelector, commonActions } = Data;
 const { getRegistry } = commonActions;
@@ -86,7 +87,7 @@ const baseActions = {
 	dismissPrompt: createValidatedAction(
 		( slug, options = {} ) => {
 			const { expiresInSeconds = 0 } = options;
-			invariant( slug, 'A tour slug is required to dismiss a tour.' );
+			invariant( slug, 'A prompt slug is required to dismiss a prompt.' );
 			invariant(
 				Number.isInteger( expiresInSeconds ),
 				'expiresInSeconds must be an integer.'
@@ -123,12 +124,16 @@ const baseSelectors = {
 	 * @param {Object} state Data store's state.
 	 * @return {(string[]|undefined)} Array of dismissed prompt keys, `undefined` if there are none.
 	 */
-	getDismissedPrompts( state ) {
+	getDismissedPrompts: createRegistrySelector( ( select ) => ( state ) => {
 		if ( state.dismissedPrompts === undefined ) {
 			return undefined;
 		}
 
-		const currentTimeInSeconds = Math.floor( Date.now() / 1000 );
+		const referenceDate = select( CORE_USER ).getReferenceDate();
+
+		const currentTimeInSeconds = Math.floor(
+			stringToDate( referenceDate ).getTime() / 1000
+		);
 		return Object.entries( state.dismissedPrompts ).reduce(
 			( acc, [ slug, { expires } ] ) => {
 				if ( expires === 0 || expires > currentTimeInSeconds ) {
@@ -138,7 +143,7 @@ const baseSelectors = {
 			},
 			[]
 		);
-	},
+	} ),
 
 	/**
 	 * Gets the count of a dismissed prompt.

--- a/assets/js/googlesitekit/datastore/user/prompts.test.js
+++ b/assets/js/googlesitekit/datastore/user/prompts.test.js
@@ -25,6 +25,7 @@ import {
 	muteFetch,
 	untilResolved,
 } from '../../../../../tests/js/utils';
+import { stringToDate } from '../../../util';
 
 describe( 'core/user dismissed-prompts', () => {
 	const fetchGetDismissedPrompts = new RegExp(
@@ -34,10 +35,14 @@ describe( 'core/user dismissed-prompts', () => {
 		'^/google-site-kit/v1/core/user/data/dismiss-prompt'
 	);
 
+	const referenceDate = '2023-06-22';
+
 	let registry;
 
 	beforeEach( () => {
 		registry = createTestRegistry();
+
+		registry.dispatch( CORE_USER ).setReferenceDate( referenceDate );
 	} );
 
 	describe( 'actions', () => {
@@ -132,13 +137,21 @@ describe( 'core/user dismissed-prompts', () => {
 			} );
 
 			it( 'should not return dismissed prompts once they have expired', async () => {
-				const currentTimeInSeconds = Math.floor( Date.now() / 1000 );
+				const referenceDateInSeconds = Math.floor(
+					stringToDate( referenceDate ).getTime() / 1000
+				);
 
 				fetchMock.getOnce( fetchGetDismissedPrompts, {
 					body: {
 						foo: { expires: 0, count: 1 },
-						bar: { expires: currentTimeInSeconds + 2000, count: 1 },
-						baz: { expires: currentTimeInSeconds - 2000, count: 1 },
+						bar: {
+							expires: referenceDateInSeconds + 2000,
+							count: 1,
+						},
+						baz: {
+							expires: referenceDateInSeconds - 2000,
+							count: 1,
+						},
 					},
 				} );
 

--- a/includes/Core/Prompts/Dismissed_Prompts.php
+++ b/includes/Core/Prompts/Dismissed_Prompts.php
@@ -41,12 +41,15 @@ class Dismissed_Prompts extends User_Setting {
 	public function add( $prompt, $expires_in_seconds = self::DISMISS_PROMPT_PERMANENTLY ) {
 		$prompts = $this->get();
 
+		$reference_date    = apply_filters( 'googlesitekit_reference_date', null );
+		$current_timestamp = $reference_date ? strtotime( $reference_date ) : time();
+
 		if ( array_key_exists( $prompt, $prompts ) ) {
-			$prompts[ $prompt ]['expires'] = $expires_in_seconds ? time() + $expires_in_seconds : 0;
+			$prompts[ $prompt ]['expires'] = $expires_in_seconds ? $current_timestamp + $expires_in_seconds : 0;
 			$prompts[ $prompt ]['count']   = $prompts[ $prompt ]['count'] + 1;
 		} else {
 			$prompts[ $prompt ] = array(
-				'expires' => $expires_in_seconds ? time() + $expires_in_seconds : 0,
+				'expires' => $expires_in_seconds ? $current_timestamp + $expires_in_seconds : 0,
 				'count'   => 1,
 			);
 		}


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #7316

This PR uses the reference date in Prompts which can be easily overriden with the Tester Plugin for testing and QA. 

## Relevant technical choices

<!-- Please describe your changes. -->

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [ ] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
