### PR TITLE
Remove the `_deprecated_function()` call from `set_consent_mode_enabled()`.

### DIFF
--- a/includes/Modules/Analytics_4/Web_Tag.php
+++ b/includes/Modules/Analytics_4/Web_Tag.php
@@ -103,8 +103,6 @@ class Web_Tag extends Module_Web_Tag implements Tag_Interface {
 	 * @param bool $is_consent_mode_enabled Whether consent mode is enabled.
 	 */
 	public function set_consent_mode_enabled( $is_consent_mode_enabled ) {
-		_deprecated_function( __METHOD__, 'n.e.x.t' );
-
 		$this->is_consent_mode_enabled = $is_consent_mode_enabled;
 	}
 

--- a/tests/e2e/config/wordpress-debug-log/log-ignore-list.js
+++ b/tests/e2e/config/wordpress-debug-log/log-ignore-list.js
@@ -16,16 +16,14 @@ export const logIgnoreList = {
 		'PHP Notice:  Trying to access array offset on value of type null in /var/www/html/wp-includes/rest-api/class-wp-rest-request.php',
 		'PHP Notice:  Trying to access array offset on value of type bool in /var/www/html/wp-includes/theme.php',
 
-		// These Site Kit deprecation errors should be updated as deprecated code is removed.
-		'PHP Notice:  Google\\Site_Kit\\Modules\\Analytics_4\\Web_Tag::set_consent_mode_enabled is <strong>deprecated</strong> since version',
+		// This Site Kit deprecation error should be removed when the deprecated code is removed.
 		'PHP Notice:  Google\\Site_Kit\\Modules\\Analytics_4\\Web_Tag::add_legacy_block_on_consent_attributes is <strong>deprecated</strong> since version',
 	],
 	latest: [
 		// TODO: See if we can avoid this error in a follow-up. It occurs when running the E2E tests in `specs/modules/analytics/admin-bar.test.js`.
 		'tail: /var/www/html/wp-content/debug.log has appeared; following end of new file',
 
-		// These Site Kit deprecation errors should be updated as deprecated code is removed.
-		'PHP Deprecated:  Function Google\\Site_Kit\\Modules\\Analytics_4\\Web_Tag::set_consent_mode_enabled is deprecated since version',
+		// This Site Kit deprecation error should be removed when the deprecated code is removed.
 		'PHP Deprecated:  Function Google\\Site_Kit\\Modules\\Analytics_4\\Web_Tag::add_legacy_block_on_consent_attributes is deprecated since version',
 	],
 	nightly: [
@@ -36,8 +34,7 @@ export const logIgnoreList = {
 		// TODO: See if we can avoid this error in a follow-up. It occurs when running the E2E tests in `specs/modules/analytics/admin-bar.test.js`.
 		'tail: /var/www/html/wp-content/debug.log has appeared; following end of new file',
 
-		// These Site Kit deprecation errors should be updated as deprecated code is removed.
-		'PHP Deprecated:  Function Google\\Site_Kit\\Modules\\Analytics_4\\Web_Tag::set_consent_mode_enabled is deprecated since version',
+		// This Site Kit deprecation error should be removed when the deprecated code is removed.
 		'PHP Deprecated:  Function Google\\Site_Kit\\Modules\\Analytics_4\\Web_Tag::add_legacy_block_on_consent_attributes is deprecated since version',
 	],
 };

--- a/tests/phpunit/integration/Modules/Analytics_4Test.php
+++ b/tests/phpunit/integration/Modules/Analytics_4Test.php
@@ -2878,7 +2878,6 @@ class Analytics_4Test extends TestCase {
 	 */
 	public function test_tracking_opt_out_snippet( $settings, $logged_in, $is_tracking_active, $is_content_creator = false ) {
 		if ( $settings['useSnippet'] && $settings['measurementID'] ) {
-			$this->setExpectedDeprecated( Web_Tag::class . '::set_consent_mode_enabled' );
 			$this->setExpectedDeprecated( Web_Tag::class . '::add_legacy_block_on_consent_attributes' );
 		}
 
@@ -3597,8 +3596,6 @@ class Analytics_4Test extends TestCase {
 	}
 
 	public function test_register_template_redirect_non_amp() {
-		$this->setExpectedDeprecated( Web_Tag::class . '::set_consent_mode_enabled' );
-
 		$context   = new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE );
 		$analytics = new Analytics_4( $context );
 
@@ -3656,8 +3653,6 @@ class Analytics_4Test extends TestCase {
 		} else {
 			$this->setExpectedDeprecated( Web_Tag::class . '::add_legacy_block_on_consent_attributes' );
 		}
-
-		$this->setExpectedDeprecated( Web_Tag::class . '::set_consent_mode_enabled' );
 
 		$analytics = new Analytics_4( new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE ) );
 		$analytics->get_settings()->merge(


### PR DESCRIPTION
This is to cut down on the number of deprecated warnings being emitted. We are keeping the warning in `add_legacy_block_on_consent_attributes()` so it will still be emitted if the user has the legacy tag blocking enabled.

## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #8275 

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
