### PR TITLE
Remove the gap between the widget error and body.

### DIFF
--- a/assets/js/components/notifications/CTA.js
+++ b/assets/js/components/notifications/CTA.js
@@ -58,39 +58,43 @@ function CTA( {
 					{ headerContent }
 				</div>
 			) }
-			{ title && <h3 className="googlesitekit-cta__title">{ title }</h3> }
-			{ description && typeof description === 'string' && (
-				<p className="googlesitekit-cta__description">
-					{ description }
-				</p>
-			) }
-			{ description && typeof description !== 'string' && (
-				<div className="googlesitekit-cta__description">
-					{ description }
-				</div>
-			) }
-			{ ctaLabel && ctaType === 'button' && (
-				<Button
-					aria-label={ ariaLabel }
-					href={ ctaLink }
-					onClick={ onClick }
-				>
-					{ ctaLabel }
-				</Button>
-			) }
-			{ ctaLabel && ctaType === 'link' && (
-				<Link
-					href={ ctaLink }
-					onClick={ onClick }
-					aria-label={ ariaLabel }
-					external={ ctaLinkExternal }
-					hideExternalIndicator={ ctaLinkExternal }
-					arrow
-				>
-					{ ctaLabel }
-				</Link>
-			) }
-			{ children }
+			<div className="googlesitekit-cta__body">
+				{ title && (
+					<h3 className="googlesitekit-cta__title">{ title }</h3>
+				) }
+				{ description && typeof description === 'string' && (
+					<p className="googlesitekit-cta__description">
+						{ description }
+					</p>
+				) }
+				{ description && typeof description !== 'string' && (
+					<div className="googlesitekit-cta__description">
+						{ description }
+					</div>
+				) }
+				{ ctaLabel && ctaType === 'button' && (
+					<Button
+						aria-label={ ariaLabel }
+						href={ ctaLink }
+						onClick={ onClick }
+					>
+						{ ctaLabel }
+					</Button>
+				) }
+				{ ctaLabel && ctaType === 'link' && (
+					<Link
+						href={ ctaLink }
+						onClick={ onClick }
+						aria-label={ ariaLabel }
+						external={ ctaLinkExternal }
+						hideExternalIndicator={ ctaLinkExternal }
+						arrow
+					>
+						{ ctaLabel }
+					</Link>
+				) }
+				{ children }
+			</div>
 		</div>
 	);
 }

--- a/assets/js/googlesitekit/widgets/components/__snapshots__/WPDashboardReportError.test.js.snap
+++ b/assets/js/googlesitekit/widgets/components/__snapshots__/WPDashboardReportError.test.js.snap
@@ -7,41 +7,45 @@ exports[`WPDashboardReportError should only render one error per module when the
       class="googlesitekit-cta googlesitekit-cta--error"
     >
       
-      <h3
-        class="googlesitekit-cta__title"
-      >
-        Data error in Search Console
-      </h3>
       <div
-        class="googlesitekit-cta__description"
+        class="googlesitekit-cta__body"
       >
-        <div
-          class="googlesitekit-error-text"
+        <h3
+          class="googlesitekit-cta__title"
         >
-          <p>
-            Error: Test error message
-          </p>
-        </div>
-      </div>
-      
-      
-      <div
-        class="googlesitekit-report-error-actions"
-      >
-        <div>
-          <a
-            aria-label="Get help (opens in a new tab)"
-            class="googlesitekit-cta-link"
-            href="undefined?error_id=test_error"
-            rel="noopener noreferrer"
-            target="_blank"
+          Data error in Search Console
+        </h3>
+        <div
+          class="googlesitekit-cta__description"
+        >
+          <div
+            class="googlesitekit-error-text"
           >
-            <span
-              class="googlesitekit-cta-link__contents"
+            <p>
+              Error: Test error message
+            </p>
+          </div>
+        </div>
+        
+        
+        <div
+          class="googlesitekit-report-error-actions"
+        >
+          <div>
+            <a
+              aria-label="Get help (opens in a new tab)"
+              class="googlesitekit-cta-link"
+              href="undefined?error_id=test_error"
+              rel="noopener noreferrer"
+              target="_blank"
             >
-              Get help
-            </span>
-          </a>
+              <span
+                class="googlesitekit-cta-link__contents"
+              >
+                Get help
+              </span>
+            </a>
+          </div>
         </div>
       </div>
     </div>
@@ -49,41 +53,45 @@ exports[`WPDashboardReportError should only render one error per module when the
       class="googlesitekit-cta googlesitekit-cta--error"
     >
       
-      <h3
-        class="googlesitekit-cta__title"
-      >
-        Data error in Analytics 4
-      </h3>
       <div
-        class="googlesitekit-cta__description"
+        class="googlesitekit-cta__body"
       >
-        <div
-          class="googlesitekit-error-text"
+        <h3
+          class="googlesitekit-cta__title"
         >
-          <p>
-            Error: Test error message
-          </p>
-        </div>
-      </div>
-      
-      
-      <div
-        class="googlesitekit-report-error-actions"
-      >
-        <div>
-          <a
-            aria-label="Get help (opens in a new tab)"
-            class="googlesitekit-cta-link"
-            href="undefined?error_id=test_error"
-            rel="noopener noreferrer"
-            target="_blank"
+          Data error in Analytics 4
+        </h3>
+        <div
+          class="googlesitekit-cta__description"
+        >
+          <div
+            class="googlesitekit-error-text"
           >
-            <span
-              class="googlesitekit-cta-link__contents"
+            <p>
+              Error: Test error message
+            </p>
+          </div>
+        </div>
+        
+        
+        <div
+          class="googlesitekit-report-error-actions"
+        >
+          <div>
+            <a
+              aria-label="Get help (opens in a new tab)"
+              class="googlesitekit-cta-link"
+              href="undefined?error_id=test_error"
+              rel="noopener noreferrer"
+              target="_blank"
             >
-              Get help
-            </span>
-          </a>
+              <span
+                class="googlesitekit-cta-link__contents"
+              >
+                Get help
+              </span>
+            </a>
+          </div>
         </div>
       </div>
     </div>

--- a/assets/js/googlesitekit/widgets/components/__snapshots__/WidgetAreaRenderer.test.js.snap
+++ b/assets/js/googlesitekit/widgets/components/__snapshots__/WidgetAreaRenderer.test.js.snap
@@ -20,6 +20,35 @@ exports[`WidgetAreaRenderer should combine multiple widgets in RecoverableModule
             class="googlesitekit-cta"
           >
             
+            <div
+              class="googlesitekit-cta__body"
+            >
+              <h3
+                class="googlesitekit-cta__title"
+              >
+                Data Unavailable
+              </h3>
+              <p
+                class="googlesitekit-cta__description"
+              >
+                Search Console data was previously shared by an admin who no longer has access. Please contact another admin to restore it.
+              </p>
+              
+              
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="googlesitekit-hidden"
+      >
+        <div
+          class="googlesitekit-cta"
+        >
+          
+          <div
+            class="googlesitekit-cta__body"
+          >
             <h3
               class="googlesitekit-cta__title"
             >
@@ -33,27 +62,6 @@ exports[`WidgetAreaRenderer should combine multiple widgets in RecoverableModule
             
             
           </div>
-        </div>
-      </div>
-      <div
-        class="googlesitekit-hidden"
-      >
-        <div
-          class="googlesitekit-cta"
-        >
-          
-          <h3
-            class="googlesitekit-cta__title"
-          >
-            Data Unavailable
-          </h3>
-          <p
-            class="googlesitekit-cta__description"
-          >
-            Search Console data was previously shared by an admin who no longer has access. Please contact another admin to restore it.
-          </p>
-          
-          
         </div>
       </div>
     </div>
@@ -70,18 +78,22 @@ exports[`WidgetAreaRenderer should combine multiple widgets in RecoverableModule
             class="googlesitekit-cta"
           >
             
-            <h3
-              class="googlesitekit-cta__title"
+            <div
+              class="googlesitekit-cta__body"
             >
-              Data Unavailable
-            </h3>
-            <p
-              class="googlesitekit-cta__description"
-            >
-              Search Console data was previously shared by an admin who no longer has access. Please contact another admin to restore it.
-            </p>
-            
-            
+              <h3
+                class="googlesitekit-cta__title"
+              >
+                Data Unavailable
+              </h3>
+              <p
+                class="googlesitekit-cta__description"
+              >
+                Search Console data was previously shared by an admin who no longer has access. Please contact another admin to restore it.
+              </p>
+              
+              
+            </div>
           </div>
         </div>
       </div>

--- a/assets/js/modules/analytics-4/components/widgets/__snapshots__/TopTrafficSourceWidget.test.js.snap
+++ b/assets/js/modules/analytics-4/components/widgets/__snapshots__/TopTrafficSourceWidget.test.js.snap
@@ -82,46 +82,50 @@ exports[`TopTrafficSourceWidget retries both reports when an error is encountere
           <svg />
         </span>
       </div>
-      <h3
-        class="googlesitekit-cta__title"
-      >
-        Data loading failed
-      </h3>
-      
-      
-      
-      
       <div
-        class="googlesitekit-report-error-actions"
+        class="googlesitekit-cta__body"
       >
-        <button
-          class="mdc-button mdc-button--raised"
-          target="_self"
+        <h3
+          class="googlesitekit-cta__title"
         >
-          <span
-            class="mdc-button__label"
-          >
-            Retry
-          </span>
-        </button>
-        <span
-          class="googlesitekit-error-retry-text"
+          Data loading failed
+        </h3>
+        
+        
+        
+        
+        <div
+          class="googlesitekit-report-error-actions"
         >
-          Retry didn’t work? 
-          <a
-            aria-label="Get help (opens in a new tab)"
-            class="googlesitekit-cta-link"
-            href="undefined?error_id=invalid_json"
-            rel="noopener noreferrer"
-            target="_blank"
+          <button
+            class="mdc-button mdc-button--raised"
+            target="_self"
           >
             <span
-              class="googlesitekit-cta-link__contents"
+              class="mdc-button__label"
             >
-              Get help
+              Retry
             </span>
-          </a>
-        </span>
+          </button>
+          <span
+            class="googlesitekit-error-retry-text"
+          >
+            Retry didn’t work? 
+            <a
+              aria-label="Get help (opens in a new tab)"
+              class="googlesitekit-cta-link"
+              href="undefined?error_id=invalid_json"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              <span
+                class="googlesitekit-cta-link__contents"
+              >
+                Get help
+              </span>
+            </a>
+          </span>
+        </div>
       </div>
     </div>
   </div>

--- a/assets/sass/components/key-metrics/_googlesitekit-km-widget-tile.scss
+++ b/assets/sass/components/key-metrics/_googlesitekit-km-widget-tile.scss
@@ -272,11 +272,11 @@
 		.mdc-layout-grid__inner {
 
 			@media (min-width: $bp-tablet) {
-				grid-template-rows: auto 1fr auto auto 1fr auto;
+				grid-template-rows: auto 1fr auto 1fr;
 			}
 
 			@media (min-width: $bp-desktop) {
-				grid-template-rows: auto 1fr auto;
+				grid-template-rows: auto 1fr;
 			}
 		}
 


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #7761

## Relevant technical choices

I addressed the [QA feedback here](https://github.com/google/site-kit-wp/issues/7761#issuecomment-1975320050) with a simple update, wrapping the CTA body in a div to allow the subgrid to group the title and CTA description. In my testing this did not effect the styles of the CTA component in other uses.

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
