### PR TITLE
Fix GA4 AdSense linked notification dismissal logic.

### DIFF
--- a/assets/js/components/notifications/GA4AdSenseLinkedNotification.js
+++ b/assets/js/components/notifications/GA4AdSenseLinkedNotification.js
@@ -40,6 +40,9 @@ import useDashboardType from '../../hooks/useDashboardType';
 
 const { useSelect, useDispatch } = Data;
 
+export const GA4_ADSENSE_LINKED_NOTIFICATION =
+	'ga4_adsense_linked_notification';
+
 export default function GA4AdSenseLinkedNotification() {
 	const isGA4AdSenseIntegrationEnabled = useFeature(
 		'ga4AdSenseIntegration'
@@ -76,17 +79,12 @@ export default function GA4AdSenseLinkedNotification() {
 		adSenseModuleConnected && analyticsModuleConnected && isAdSenseLinked;
 
 	const isDismissed = useSelect( ( select ) => {
-		if (
-			! isGA4AdSenseIntegrationEnabled ||
-			! dashboardType ||
-			viewOnly ||
-			! analyticsAndAdsenseConnectedAndLinked
-		) {
+		if ( ! isGA4AdSenseIntegrationEnabled || ! dashboardType || viewOnly ) {
 			return null;
 		}
 
 		return select( CORE_USER ).isItemDismissed(
-			GA4_ADSENSE_LINKED_NOTIFICATION_DISMISSED_ITEM_KEY
+			GA4_ADSENSE_LINKED_NOTIFICATION
 		);
 	} );
 
@@ -97,9 +95,6 @@ export default function GA4AdSenseLinkedNotification() {
 			offsetDays: DATE_RANGE_OFFSET,
 		} )
 	);
-
-	const GA4_ADSENSE_LINKED_NOTIFICATION_DISMISSED_ITEM_KEY =
-		'ga4_adsense_linked_notification_dimissed_item';
 
 	const reportOptions = {
 		startDate,
@@ -135,8 +130,8 @@ export default function GA4AdSenseLinkedNotification() {
 		);
 	} );
 
-	const dismissNotificationForUser = useCallback( () => {
-		dismissItem( GA4_ADSENSE_LINKED_NOTIFICATION_DISMISSED_ITEM_KEY );
+	const dismissNotificationForUser = useCallback( async () => {
+		await dismissItem( GA4_ADSENSE_LINKED_NOTIFICATION );
 	}, [ dismissItem ] );
 
 	// This notification should only appear when the user has connected their

--- a/assets/js/components/notifications/GA4AdSenseLinkedNotification.test.js
+++ b/assets/js/components/notifications/GA4AdSenseLinkedNotification.test.js
@@ -19,7 +19,9 @@
 /**
  * Internal dependencies
  */
-import GA4AdSenseLinkedNotification from './GA4AdSenseLinkedNotification';
+import GA4AdSenseLinkedNotification, {
+	GA4_ADSENSE_LINKED_NOTIFICATION,
+} from './GA4AdSenseLinkedNotification';
 import {
 	render,
 	createTestRegistry,
@@ -35,9 +37,6 @@ import {
 
 describe( 'GA4AdSenseLinkedNotification', () => {
 	let registry;
-
-	const GA4_ADSENSE_LINKED_NOTIFICATION_DISMISSED_ITEM_KEY =
-		'ga4_adsense_linked_notification_dimissed_item';
 
 	const fetchDismissItem = new RegExp(
 		'^/google-site-kit/v1/core/user/data/dismiss-item'
@@ -59,9 +58,7 @@ describe( 'GA4AdSenseLinkedNotification', () => {
 		muteFetch( analyticsReport );
 
 		fetchMock.postOnce( fetchDismissItem, {
-			body: JSON.stringify( [
-				GA4_ADSENSE_LINKED_NOTIFICATION_DISMISSED_ITEM_KEY,
-			] ),
+			body: JSON.stringify( [ GA4_ADSENSE_LINKED_NOTIFICATION ] ),
 			status: 200,
 		} );
 
@@ -95,9 +92,7 @@ describe( 'GA4AdSenseLinkedNotification', () => {
 		muteFetch( analyticsReport );
 
 		fetchMock.postOnce( fetchDismissItem, {
-			body: JSON.stringify( [
-				GA4_ADSENSE_LINKED_NOTIFICATION_DISMISSED_ITEM_KEY,
-			] ),
+			body: JSON.stringify( [ GA4_ADSENSE_LINKED_NOTIFICATION ] ),
 			status: 200,
 		} );
 
@@ -134,9 +129,7 @@ describe( 'GA4AdSenseLinkedNotification', () => {
 		muteFetch( analyticsReport );
 
 		fetchMock.postOnce( fetchDismissItem, {
-			body: JSON.stringify( [
-				GA4_ADSENSE_LINKED_NOTIFICATION_DISMISSED_ITEM_KEY,
-			] ),
+			body: JSON.stringify( [ GA4_ADSENSE_LINKED_NOTIFICATION ] ),
 			status: 200,
 		} );
 
@@ -158,9 +151,7 @@ describe( 'GA4AdSenseLinkedNotification', () => {
 	it( 'does not render if already dismissed', async () => {
 		registry
 			.dispatch( CORE_USER )
-			.receiveGetDismissedItems( [
-				GA4_ADSENSE_LINKED_NOTIFICATION_DISMISSED_ITEM_KEY,
-			] );
+			.receiveGetDismissedItems( [ GA4_ADSENSE_LINKED_NOTIFICATION ] );
 
 		const { container, waitForRegistry } = render(
 			<GA4AdSenseLinkedNotification />,


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #8238

## Relevant technical choices

Fixed the logic for checking whether the notification should be dismissed or not. Also tidied up the dismissal key name.

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
