### PR TITLE
Followup/8275 remove deprecated function call

### DIFF
--- a/includes/Modules/Analytics_4/Web_Tag.php
+++ b/includes/Modules/Analytics_4/Web_Tag.php
@@ -86,8 +86,6 @@ class Web_Tag extends Module_Web_Tag implements Tag_Interface {
 	 * Gets args to use if blocked_on_consent is deprecated.
 	 *
 	 * @since 1.122.0
-	 * @deprecated This method is deprecated and should be removed when the legacy tag blocking mechanism
-	 *             is removed (see the method `Module_Web_Tag::is_tag_blocked_on_consent`).
 	 *
 	 * @return array args to pass to apply_filters_deprecated if deprecated ($version, $replacement, $message)
 	 */
@@ -234,10 +232,9 @@ class Web_Tag extends Module_Web_Tag implements Tag_Interface {
 	/**
 	 * Adds HTML attributes to the gtag script tag to block it until user consent is granted.
 	 *
+	 * This mechanism for blocking the tag is deprecated and the Consent Mode feature should be used instead.
+	 *
 	 * @since 1.122.0
-	 * @deprecated This mechanism for blocking the tag is deprecated and the Consent Mode feature should be used instead.
-	 *             This method should be removed when the legacy tag blocking mechanism is removed (see the method
-	 *             `Module_Web_Tag::is_tag_blocked_on_consent`).
 	 *
 	 * @param string $tag     The script tag.
 	 * @param string $gtag_src The gtag script source URL.

--- a/includes/Modules/Analytics_4/Web_Tag.php
+++ b/includes/Modules/Analytics_4/Web_Tag.php
@@ -50,16 +50,6 @@ class Web_Tag extends Module_Web_Tag implements Tag_Interface {
 	private $ads_conversion_id;
 
 	/**
-	 * Boolean flag for whether Consent Mode is enabled.
-	 *
-	 * @since 1.122.0
-	 * @deprecated This property is deprecated and should be removed when the legacy tag blocking mechanism
-	 *             is removed (see the method `Module_Web_Tag::is_tag_blocked_on_consent`).
-	 * @var bool
-	 */
-	private $is_consent_mode_enabled;
-
-	/**
 	 * Sets custom dimensions data.
 	 *
 	 * @since 1.113.0
@@ -181,12 +171,10 @@ class Web_Tag extends Module_Web_Tag implements Tag_Interface {
 			$snippet_comment_begin = sprintf( "\n<!-- %s -->\n", esc_html__( 'Google Analytics snippet added by Site Kit', 'google-site-kit' ) );
 			$snippet_comment_end   = sprintf( "\n<!-- %s -->\n", esc_html__( 'End Google Analytics snippet added by Site Kit', 'google-site-kit' ) );
 
-			if ( ! $this->is_consent_mode_enabled ) {
-				$block_on_consent_attrs = $this->get_tag_blocked_on_consent_attribute();
+			$block_on_consent_attrs = $this->get_tag_blocked_on_consent_attribute();
 
-				if ( $block_on_consent_attrs ) {
-						$tag = $this->add_legacy_block_on_consent_attributes( $tag, $gtag_src, $block_on_consent_attrs );
-				}
+			if ( $block_on_consent_attrs ) {
+				$tag = $this->add_legacy_block_on_consent_attributes( $tag, $gtag_src, $block_on_consent_attrs );
 			}
 
 			return $snippet_comment_begin . $tag . $snippet_comment_end;

--- a/includes/Modules/Analytics_4/Web_Tag.php
+++ b/includes/Modules/Analytics_4/Web_Tag.php
@@ -54,7 +54,7 @@ class Web_Tag extends Module_Web_Tag implements Tag_Interface {
 	 *
 	 * @since 1.122.0
 	 * @deprecated This property is deprecated and should be removed when the legacy tag blocking mechanism
-	 *             is removed (see the `add_legacy_block_on_consent_attributes()` method below).
+	 *             is removed (see the method `Module_Web_Tag::is_tag_blocked_on_consent`).
 	 * @var bool
 	 */
 	private $is_consent_mode_enabled;
@@ -97,7 +97,7 @@ class Web_Tag extends Module_Web_Tag implements Tag_Interface {
 	 *
 	 * @since 1.122.0
 	 * @deprecated This method is deprecated and should be removed when the legacy tag blocking mechanism
-	 *             is removed (see the `add_legacy_block_on_consent_attributes()` method below).
+	 *             is removed (see the method `Module_Web_Tag::is_tag_blocked_on_consent`).
 	 *
 	 * @return array args to pass to apply_filters_deprecated if deprecated ($version, $replacement, $message)
 	 */
@@ -248,6 +248,8 @@ class Web_Tag extends Module_Web_Tag implements Tag_Interface {
 	 *
 	 * @since 1.122.0
 	 * @deprecated This mechanism for blocking the tag is deprecated and the Consent Mode feature should be used instead.
+	 *             This method should be removed when the legacy tag blocking mechanism is removed (see the method
+	 *             `Module_Web_Tag::is_tag_blocked_on_consent`).
 	 *
 	 * @param string $tag     The script tag.
 	 * @param string $gtag_src The gtag script source URL.
@@ -255,8 +257,6 @@ class Web_Tag extends Module_Web_Tag implements Tag_Interface {
 	 * @return string The script tag with the added attributes.
 	 */
 	protected function add_legacy_block_on_consent_attributes( $tag, $gtag_src, $block_on_consent_attrs ) {
-		_deprecated_function( __METHOD__, '1.122.0' );
-
 		return str_replace(
 			array(
 				"<script src='$gtag_src'", // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript

--- a/tests/phpunit/integration/Modules/Analytics_4Test.php
+++ b/tests/phpunit/integration/Modules/Analytics_4Test.php
@@ -3666,7 +3666,6 @@ class Analytics_4Test extends TestCase {
 		$this->assertStringContainsString( 'https://www.googletagmanager.com/gtag/js?id=A1B2C3D4E5', $output );
 
 		if ( $test_parameters['expected_block_on_consent'] ) {
-			$this->setExpectedDeprecated( Web_Tag::class . '::add_legacy_block_on_consent_attributes' );
 			$this->assertMatchesRegularExpression( '/\sdata-block-on-consent\b/', $output );
 		} else {
 			$this->assertDoesNotMatchRegularExpression( '/\sdata-block-on-consent\b/', $output );


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #8275

## Relevant technical choices

<!-- Please describe your changes. -->

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
