### PR TITLE
Ensure GA4 + AdSense link overlay only appears on the main dashboard.

### DIFF
--- a/assets/js/components/OverlayNotification/LinkAnalyticsAndAdSenseAccountsOverlayNotification.js
+++ b/assets/js/components/OverlayNotification/LinkAnalyticsAndAdSenseAccountsOverlayNotification.js
@@ -36,6 +36,9 @@ import AnalyticsAdsenseConnectGraphic from '../../../svg/graphics/analytics-adse
 import OverlayNotification from './OverlayNotification';
 import useViewOnly from '../../hooks/useViewOnly';
 import { useFeature } from '../../hooks/useFeature';
+import useDashboardType, {
+	DASHBOARD_TYPE_MAIN,
+} from '../../hooks/useDashboardType';
 
 const { useSelect, useDispatch } = Data;
 
@@ -48,6 +51,8 @@ export default function LinkAnalyticsAndAdSenseAccountsOverlayNotification() {
 	);
 
 	const isViewOnly = useViewOnly();
+	const dashboardType = useDashboardType();
+	const isMainDashboard = dashboardType === DASHBOARD_TYPE_MAIN;
 
 	const isShowingNotification = useSelect( ( select ) =>
 		select( CORE_UI ).isShowingOverlayNotification(
@@ -77,7 +82,7 @@ export default function LinkAnalyticsAndAdSenseAccountsOverlayNotification() {
 	);
 
 	const analyticsModuleConnected = useSelect( ( select ) => {
-		if ( isViewOnly || isDismissed ) {
+		if ( isViewOnly || ! isMainDashboard || isDismissed ) {
 			return null;
 		}
 
@@ -85,7 +90,7 @@ export default function LinkAnalyticsAndAdSenseAccountsOverlayNotification() {
 	} );
 
 	const adSenseModuleConnected = useSelect( ( select ) => {
-		if ( isViewOnly || isDismissed ) {
+		if ( isViewOnly || ! isMainDashboard || isDismissed ) {
 			return null;
 		}
 
@@ -93,7 +98,7 @@ export default function LinkAnalyticsAndAdSenseAccountsOverlayNotification() {
 	} );
 
 	const isAdSenseLinked = useSelect( ( select ) => {
-		if ( isViewOnly || isDismissed ) {
+		if ( isViewOnly || ! isMainDashboard || isDismissed ) {
 			return null;
 		}
 
@@ -106,6 +111,7 @@ export default function LinkAnalyticsAndAdSenseAccountsOverlayNotification() {
 	const shouldShowNotification =
 		isGA4AdSenseIntegrationEnabled &&
 		! isViewOnly &&
+		isMainDashboard &&
 		analyticsAndAdSenseAreConnected &&
 		isAdSenseLinked === false &&
 		isDismissed === false;

--- a/assets/js/components/OverlayNotification/LinkAnalyticsAndAdSenseAccountsOverlayNotification.stories.js
+++ b/assets/js/components/OverlayNotification/LinkAnalyticsAndAdSenseAccountsOverlayNotification.stories.js
@@ -24,6 +24,7 @@ import {
 	provideModules,
 	provideUserAuthentication,
 } from '../../../../tests/js/utils';
+import { VIEW_CONTEXT_MAIN_DASHBOARD } from '../../googlesitekit/constants';
 import { MODULES_ANALYTICS_4 } from '../../modules/analytics-4/datastore/constants';
 import LinkAnalyticsAndAdSenseAccountsOverlayNotification from './LinkAnalyticsAndAdSenseAccountsOverlayNotification';
 
@@ -33,6 +34,9 @@ function Template() {
 
 export const Default = Template.bind( {} );
 Default.storyName = 'Default';
+Default.args = {
+	viewContext: VIEW_CONTEXT_MAIN_DASHBOARD,
+};
 Default.scenario = {
 	label: 'Components/LinkAnalyticsAndAdSenseAccountsOverlayNotification',
 };
@@ -40,7 +44,9 @@ Default.scenario = {
 export default {
 	title: 'Components/LinkAnalyticsAndAdSenseAccountsOverlayNotification',
 	component: LinkAnalyticsAndAdSenseAccountsOverlayNotification,
-	parameters: { features: [ 'ga4AdSenseIntegration' ] },
+	parameters: {
+		features: [ 'ga4AdSenseIntegration' ],
+	},
 	decorators: [
 		( Story ) => {
 			const setupRegistry = ( registry ) => {
@@ -65,7 +71,7 @@ export default {
 			};
 
 			return (
-				<WithRegistrySetup func={ setupRegistry }>
+				<WithRegistrySetup func={ setupRegistry } v>
 					<Story />
 				</WithRegistrySetup>
 			);

--- a/assets/js/components/OverlayNotification/LinkAnalyticsAndAdSenseAccountsOverlayNotification.stories.js
+++ b/assets/js/components/OverlayNotification/LinkAnalyticsAndAdSenseAccountsOverlayNotification.stories.js
@@ -26,6 +26,7 @@ import {
 } from '../../../../tests/js/utils';
 import { VIEW_CONTEXT_MAIN_DASHBOARD } from '../../googlesitekit/constants';
 import { MODULES_ANALYTICS_4 } from '../../modules/analytics-4/datastore/constants';
+import { Provider as ViewContextProvider } from '../Root/ViewContextContext';
 import LinkAnalyticsAndAdSenseAccountsOverlayNotification from './LinkAnalyticsAndAdSenseAccountsOverlayNotification';
 
 function Template() {
@@ -34,9 +35,6 @@ function Template() {
 
 export const Default = Template.bind( {} );
 Default.storyName = 'Default';
-Default.args = {
-	viewContext: VIEW_CONTEXT_MAIN_DASHBOARD,
-};
 Default.scenario = {
 	label: 'Components/LinkAnalyticsAndAdSenseAccountsOverlayNotification',
 };
@@ -46,9 +44,12 @@ export default {
 	component: LinkAnalyticsAndAdSenseAccountsOverlayNotification,
 	parameters: {
 		features: [ 'ga4AdSenseIntegration' ],
+		viewContext: VIEW_CONTEXT_MAIN_DASHBOARD,
 	},
 	decorators: [
-		( Story ) => {
+		( Story, { parameters } ) => {
+			const { viewContext } = parameters;
+
 			const setupRegistry = ( registry ) => {
 				provideUserAuthentication( registry );
 
@@ -71,8 +72,10 @@ export default {
 			};
 
 			return (
-				<WithRegistrySetup func={ setupRegistry } v>
-					<Story />
+				<WithRegistrySetup func={ setupRegistry }>
+					<ViewContextProvider value={ viewContext }>
+						<Story />
+					</ViewContextProvider>
 				</WithRegistrySetup>
 			);
 		},

--- a/assets/js/components/OverlayNotification/LinkAnalyticsAndAdSenseAccountsOverlayNotification.test.js
+++ b/assets/js/components/OverlayNotification/LinkAnalyticsAndAdSenseAccountsOverlayNotification.test.js
@@ -33,7 +33,10 @@ import { CORE_USER } from '../../googlesitekit/datastore/user/constants';
 import { CORE_SITE } from '../../googlesitekit/datastore/site/constants';
 import { MODULES_ANALYTICS_4 } from '../../modules/analytics-4/datastore/constants';
 import { CORE_UI } from '../../googlesitekit/datastore/ui/constants';
-import { VIEW_CONTEXT_MAIN_DASHBOARD_VIEW_ONLY } from '../../googlesitekit/constants';
+import {
+	VIEW_CONTEXT_MAIN_DASHBOARD,
+	VIEW_CONTEXT_MAIN_DASHBOARD_VIEW_ONLY,
+} from '../../googlesitekit/constants';
 
 describe( 'LinkAnalyticsAndAdSenseAccountsOverlayNotification', () => {
 	let registry;
@@ -218,6 +221,7 @@ describe( 'LinkAnalyticsAndAdSenseAccountsOverlayNotification', () => {
 			<LinkAnalyticsAndAdSenseAccountsOverlayNotification />,
 			{
 				registry,
+				viewContext: VIEW_CONTEXT_MAIN_DASHBOARD,
 			}
 		);
 		expect( container ).not.toHaveTextContent(
@@ -231,6 +235,7 @@ describe( 'LinkAnalyticsAndAdSenseAccountsOverlayNotification', () => {
 			{
 				registry,
 				features: [ 'ga4AdSenseIntegration' ],
+				viewContext: VIEW_CONTEXT_MAIN_DASHBOARD,
 			}
 		);
 
@@ -248,6 +253,7 @@ describe( 'LinkAnalyticsAndAdSenseAccountsOverlayNotification', () => {
 			<LinkAnalyticsAndAdSenseAccountsOverlayNotification />,
 			{
 				registry,
+				viewContext: VIEW_CONTEXT_MAIN_DASHBOARD,
 				features: [ 'ga4AdSenseIntegration' ],
 			}
 		);
@@ -271,6 +277,7 @@ describe( 'LinkAnalyticsAndAdSenseAccountsOverlayNotification', () => {
 			{
 				registry,
 				features: [ 'ga4AdSenseIntegration' ],
+				viewContext: VIEW_CONTEXT_MAIN_DASHBOARD,
 			}
 		);
 
@@ -302,6 +309,7 @@ describe( 'LinkAnalyticsAndAdSenseAccountsOverlayNotification', () => {
 			{
 				registry,
 				features: [ 'ga4AdSenseIntegration' ],
+				viewContext: VIEW_CONTEXT_MAIN_DASHBOARD,
 			}
 		);
 


### PR DESCRIPTION
## Summary

This is a small follow-up that ensures this overlay only appears on the main dashboard and not the entity dashboard, as discussed here: https://github.com/google/site-kit-wp/issues/8236#issuecomment-2003005509

Addresses issue:

- #8236

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
