### PR TITLE
Update Analytics to use `GTag` infrastructure

### DIFF
--- a/includes/Core/Tags/GTag.php
+++ b/includes/Core/Tags/GTag.php
@@ -124,15 +124,16 @@ class GTag {
 
 		// Note that `gtag()` may already be defined via the `Consent_Mode` output, but this is safe to call multiple times.
 		wp_add_inline_script( self::HANDLE, 'window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments);}' );
+
+		foreach ( $this->commands as $command ) {
+			wp_add_inline_script( self::HANDLE, $this->get_gtag_call_for_command( $command ), $command['position'] );
+		}
+
 		wp_add_inline_script( self::HANDLE, 'gtag("js", new Date());' );
 		wp_add_inline_script( self::HANDLE, 'gtag("set", "developer_id.dZTNiMT", true);' ); // Site Kit developer ID.
 
 		foreach ( $this->tags as $tag ) {
 			wp_add_inline_script( self::HANDLE, $this->get_gtag_call_for_tag( $tag ) );
-		}
-
-		foreach ( $this->commands as $command ) {
-			wp_add_inline_script( self::HANDLE, $this->get_gtag_call_for_command( $command ), $command['position'] );
 		}
 
 		$filter_google_gtagjs = function ( $tag, $handle ) {
@@ -192,9 +193,13 @@ class GTag {
 	 *
 	 * @since n.e.x.t
 	 *
-	 * @return string The gtag source URL.
+	 * @return string|false The gtag source URL. False if no tags are added.
 	 */
 	public function get_gtag_src() {
+		if ( empty( $this->tags ) ) {
+			return false;
+		}
+
 		// Load the GTag scripts using the first tag ID - it doesn't matter which is used,
 		// all registered tags will be set up with a config command regardless
 		// of which is used to load the source.

--- a/includes/Core/Tags/GTag.php
+++ b/includes/Core/Tags/GTag.php
@@ -116,9 +116,7 @@ class GTag {
 			return;
 		}
 
-		// Load the GTag scripts using the first tag ID - it doesn't matter which is used, all registered tags will be set up with a
-		// config command regardless of which is used to load the source.
-		$gtag_src = 'https://www.googletagmanager.com/gtag/js?id=' . rawurlencode( $this->tags[0]['tag_id'] );
+		$gtag_src = $this->get_gtag_src();
 
 		// phpcs:ignore WordPress.WP.EnqueuedResourceParameters.MissingVersion
 		wp_enqueue_script( self::HANDLE, $gtag_src, false, null, false );
@@ -187,5 +185,19 @@ class GTag {
 		);
 
 		return sprintf( 'gtag(%s);', implode( ',', $gtag_args ) );
+	}
+
+	/**
+	 * Returns the gtag source URL.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @return string The gtag source URL.
+	 */
+	public function get_gtag_src() {
+		// Load the GTag scripts using the first tag ID - it doesn't matter which is used,
+		// all registered tags will be set up with a config command regardless
+		// of which is used to load the source.
+		return 'https://www.googletagmanager.com/gtag/js?id=' . rawurlencode( $this->tags[0]['tag_id'] );
 	}
 }

--- a/includes/Modules/Analytics_4/Web_Tag.php
+++ b/includes/Modules/Analytics_4/Web_Tag.php
@@ -11,6 +11,7 @@
 namespace Google\Site_Kit\Modules\Analytics_4;
 
 use Google\Site_Kit\Core\Modules\Tags\Module_Web_Tag;
+use Google\Site_Kit\Core\Tags\GTag;
 use Google\Site_Kit\Core\Tags\Tag_With_DNS_Prefetch_Trait;
 use Google\Site_Kit\Core\Util\Method_Proxy_Trait;
 
@@ -101,13 +102,8 @@ class Web_Tag extends Module_Web_Tag implements Tag_Interface {
 	 * @since 1.31.0
 	 */
 	public function register() {
-		add_action( 'wp_enqueue_scripts', $this->get_method_proxy( 'enqueue_gtag_script' ), 20 );
-		add_filter(
-			'wp_resource_hints',
-			$this->get_dns_prefetch_hints_callback( '//www.googletagmanager.com' ),
-			10,
-			2
-		);
+		add_action( 'googlesitekit_setup_gtag', $this->get_method_proxy( 'setup_gtag' ) );
+
 		$this->do_init_tag_action();
 	}
 
@@ -121,18 +117,15 @@ class Web_Tag extends Module_Web_Tag implements Tag_Interface {
 	}
 
 	/**
-	 * Enqueues gtag script.
+	 * Configures gtag script.
 	 *
 	 * @since 1.24.0
+	 * @since n.e.x.t Renamed and refactored to use new GTag infrastructure.
+	 *
+	 * @param GTag $gtag GTag instance.
 	 */
-	protected function enqueue_gtag_script() {
+	protected function setup_gtag( $gtag ) {
 		$gtag_opt = $this->get_tag_config();
-		$gtag_src = 'https://www.googletagmanager.com/gtag/js?id=' . rawurlencode( $this->tag_id );
-
-		// phpcs:ignore WordPress.WP.EnqueuedResourceParameters.MissingVersion
-		wp_enqueue_script( 'google_gtagjs', $gtag_src, false, null, false );
-		wp_script_add_data( 'google_gtagjs', 'script_execution', 'async' );
-		wp_add_inline_script( 'google_gtagjs', 'window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments);}' );
 
 		/**
 		 * Filters the gtag configuration options for the Analytics snippet.
@@ -148,64 +141,30 @@ class Web_Tag extends Module_Web_Tag implements Tag_Interface {
 		$gtag_opt = apply_filters( 'googlesitekit_gtag_opt', $gtag_opt );
 
 		if ( ! empty( $gtag_opt['linker'] ) ) {
-			$linker = wp_json_encode( $gtag_opt['linker'] );
-			$linker = sprintf( "gtag('set', 'linker', %s );", $linker );
-			wp_add_inline_script( 'google_gtagjs', $linker );
+			$gtag->add_command( 'set', array( 'linker', $gtag_opt['linker'] ) );
 		}
 
 		unset( $gtag_opt['linker'] );
 
-		wp_add_inline_script( 'google_gtagjs', 'gtag("js", new Date());' );
-		wp_add_inline_script( 'google_gtagjs', 'gtag("set", "developer_id.dZTNiMT", true);' ); // Site Kit developer ID.
+		$gtag->add_tag( $this->tag_id, $gtag_opt );
 
-		$this->add_inline_config( $this->tag_id, $gtag_opt );
-		$this->add_inline_ads_conversion_id_config();
+		// TODO: Lift this out to the Ads module when it's ready.
+		if ( $this->ads_conversion_id ) {
+			$gtag->add_tag( $this->ads_conversion_id );
+		}
 
-		$filter_google_gtagjs = function ( $tag, $handle ) use ( $gtag_src ) {
-			if ( 'google_gtagjs' !== $handle ) {
+		$filter_google_gtagjs = function ( $tag, $handle ) {
+			if ( GTag::HANDLE !== $handle ) {
 				return $tag;
 			}
 
-			$snippet_comment_begin = sprintf( "\n<!-- %s -->\n", esc_html__( 'Google Analytics snippet added by Site Kit', 'google-site-kit' ) );
-			$snippet_comment_end   = sprintf( "\n<!-- %s -->\n", esc_html__( 'End Google Analytics snippet added by Site Kit', 'google-site-kit' ) );
+			// Retain this comment for detection of Site Kit placed tag.
+			$snippet_comment = sprintf( "\n<!-- %s -->\n", esc_html__( 'Google Analytics snippet added by Site Kit', 'google-site-kit' ) );
 
-			$block_on_consent_attrs = $this->get_tag_blocked_on_consent_attribute();
-
-			if ( $block_on_consent_attrs ) {
-				$tag = $this->add_legacy_block_on_consent_attributes( $tag, $gtag_src, $block_on_consent_attrs );
-			}
-
-			return $snippet_comment_begin . $tag . $snippet_comment_end;
+			return $snippet_comment . $tag;
 		};
 
 		add_filter( 'script_loader_tag', $filter_google_gtagjs, 10, 2 );
-	}
-
-	/**
-	 * Adds an inline script to configure ads conversion tracking.
-	 *
-	 * @since 1.32.0
-	 */
-	protected function add_inline_ads_conversion_id_config() {
-		if ( $this->ads_conversion_id ) {
-			$this->add_inline_config( $this->ads_conversion_id, array() );
-		}
-	}
-
-	/**
-	 * Adds an inline script to configure provided tag including configuration options.
-	 *
-	 * @since 1.113.0
-	 *
-	 * @param string $tag_id The tag ID to add config for.
-	 * @param array  $gtag_opt The gtag configuration.
-	 */
-	protected function add_inline_config( $tag_id, $gtag_opt ) {
-		$config = ! empty( $gtag_opt )
-			? sprintf( 'gtag("config", "%s", %s);', esc_js( $tag_id ), wp_json_encode( $gtag_opt ) )
-			: sprintf( 'gtag("config", "%s");', esc_js( $tag_id ) );
-
-		wp_add_inline_script( 'google_gtagjs', $config );
 	}
 
 	/**
@@ -227,35 +186,5 @@ class Web_Tag extends Module_Web_Tag implements Tag_Interface {
 		}
 
 		return $config;
-	}
-
-	/**
-	 * Adds HTML attributes to the gtag script tag to block it until user consent is granted.
-	 *
-	 * This mechanism for blocking the tag is deprecated and the Consent Mode feature should be used instead.
-	 *
-	 * @since 1.122.0
-	 *
-	 * @param string $tag     The script tag.
-	 * @param string $gtag_src The gtag script source URL.
-	 * @param string $block_on_consent_attrs The attributes to add to the script tag to block it until user consent is granted.
-	 * @return string The script tag with the added attributes.
-	 */
-	protected function add_legacy_block_on_consent_attributes( $tag, $gtag_src, $block_on_consent_attrs ) {
-		return str_replace(
-			array(
-				"<script src='$gtag_src'", // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
-					"<script src=\"$gtag_src\"", // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
-					"<script type='text/javascript' src='$gtag_src'", // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
-					"<script type=\"text/javascript\" src=\"$gtag_src\"", // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
-			),
-			array( // `type` attribute intentionally excluded in replacements.
-				"<script{$block_on_consent_attrs} src='$gtag_src'", // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
-					"<script{$block_on_consent_attrs} src=\"$gtag_src\"", // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
-					"<script{$block_on_consent_attrs} src='$gtag_src'", // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
-					"<script{$block_on_consent_attrs} src=\"$gtag_src\"", // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
-			),
-			$tag
-		);
 	}
 }

--- a/includes/Modules/Analytics_4/Web_Tag.php
+++ b/includes/Modules/Analytics_4/Web_Tag.php
@@ -124,7 +124,7 @@ class Web_Tag extends Module_Web_Tag implements Tag_Interface {
 	 *
 	 * @param GTag $gtag GTag instance.
 	 */
-	protected function setup_gtag( $gtag ) {
+	protected function setup_gtag( GTag $gtag ) {
 		$gtag_opt = $this->get_tag_config();
 
 		/**

--- a/tests/phpunit/integration/Core/Tags/GTagTest.php
+++ b/tests/phpunit/integration/Core/Tags/GTagTest.php
@@ -103,4 +103,21 @@ class GTagTest extends TestCase {
 		$this->assertEquals( 'gtag("config", "' . static::TEST_TAG_ID_2 . '", ' . json_encode( self::TEST_TAG_ID_2_CONFIG ) . ');', $script->extra['after'][6] );
 	}
 
+	public function test_get_gtag_src() {
+		$this->assertEquals( 'https://www.googletagmanager.com/gtag/js?id=' . static::TEST_TAG_ID_1, $this->gtag->get_gtag_src() );
+
+		// Reset the GTag instance.
+		$this->gtag = new GTag();
+		$this->gtag->register();
+
+		// Verify that this returns `false` when no tags are added.
+		$this->assertFalse( $this->gtag->get_gtag_src() );
+
+		// Add a different tag ID.
+		$this->gtag->add_tag( static::TEST_TAG_ID_2 );
+
+		// Verify that this returns the correct URL for the different tag ID.
+		$this->assertEquals( 'https://www.googletagmanager.com/gtag/js?id=' . static::TEST_TAG_ID_2, $this->gtag->get_gtag_src() );
+	}
+
 }

--- a/tests/phpunit/integration/Core/Tags/GTagTest.php
+++ b/tests/phpunit/integration/Core/Tags/GTagTest.php
@@ -71,8 +71,8 @@ class GTagTest extends TestCase {
 		$script  = $scripts->registered[ GTag::HANDLE ];
 
 		// Assert the array of inline script data contains the necessary gtag config line.
-		// Should be in index 4, the first registered gtag.
-		$this->assertEquals( 'gtag("config", "' . static::TEST_TAG_ID_1 . '");', $script->extra['after'][4] );
+		// Should be in index 5, the first registered gtag.
+		$this->assertEquals( 'gtag("config", "' . static::TEST_TAG_ID_1 . '");', $script->extra['after'][5] );
 	}
 
 	public function test_gtag_script_commands() {
@@ -83,7 +83,7 @@ class GTagTest extends TestCase {
 		$this->assertEquals( sprintf( 'gtag(%s");', '"' . static::TEST_COMMAND_1 . '","' . implode( '","', static::TEST_COMMAND_1_PARAMS ) ), $script->extra['before'][1] );
 
 		// Test commands in the after position.
-		$this->assertEquals( sprintf( 'gtag(%s);', '"' . static::TEST_COMMAND_2 . '",' . json_encode( static::TEST_COMMAND_2_PARAMS[0] ) ), $script->extra['after'][5] );
+		$this->assertEquals( sprintf( 'gtag(%s);', '"' . static::TEST_COMMAND_2 . '",' . json_encode( static::TEST_COMMAND_2_PARAMS[0] ) ), $script->extra['after'][2] );
 	}
 
 	public function test_gtag_with_tag_config() {
@@ -99,8 +99,8 @@ class GTagTest extends TestCase {
 		$script  = $scripts->registered[ GTag::HANDLE ];
 
 		// Assert the array of inline script data contains the necessary gtag entry for the second script.
-		// Should be in index 5, immediately after the first registered gtag.
-		$this->assertEquals( 'gtag("config", "' . static::TEST_TAG_ID_2 . '", ' . json_encode( self::TEST_TAG_ID_2_CONFIG ) . ');', $script->extra['after'][5] );
+		// Should be in index 6, immediately after the first registered gtag.
+		$this->assertEquals( 'gtag("config", "' . static::TEST_TAG_ID_2 . '", ' . json_encode( self::TEST_TAG_ID_2_CONFIG ) . ');', $script->extra['after'][6] );
 	}
 
 }

--- a/tests/phpunit/integration/Modules/Analytics_4Test.php
+++ b/tests/phpunit/integration/Modules/Analytics_4Test.php
@@ -2809,7 +2809,6 @@ class Analytics_4Test extends TestCase {
 		remove_all_actions( 'googlesitekit_setup_gtag' );
 		$analytics->register();
 		do_action( 'template_redirect' );
-		do_action( 'wp_enqueue_scripts' );
 
 		$head_html = $this->capture_action( 'wp_head' );
 		// Confidence check.

--- a/tests/phpunit/integration/Modules/Analytics_4Test.php
+++ b/tests/phpunit/integration/Modules/Analytics_4Test.php
@@ -2803,6 +2803,7 @@ class Analytics_4Test extends TestCase {
 		$analytics->get_settings()->set( $settings );
 
 		remove_all_actions( 'template_redirect' );
+		remove_all_actions( 'googlesitekit_setup_gtag' );
 		$analytics->register();
 		do_action( 'template_redirect' );
 

--- a/tests/phpunit/integration/Modules/Analytics_4Test.php
+++ b/tests/phpunit/integration/Modules/Analytics_4Test.php
@@ -3556,7 +3556,6 @@ class Analytics_4Test extends TestCase {
 		wp_scripts()->queue      = array();
 		wp_scripts()->done       = array();
 		remove_all_actions( 'template_redirect' );
-		remove_all_actions( 'googlesitekit_setup_gtag' );
 		$analytics->register();
 
 		// Hook `wp_print_head_scripts` on placeholder action for capturing.

--- a/tests/phpunit/integration/Modules/Analytics_4Test.php
+++ b/tests/phpunit/integration/Modules/Analytics_4Test.php
@@ -3501,10 +3501,10 @@ class Analytics_4Test extends TestCase {
 		remove_all_actions( 'template_redirect' );
 		$analytics->register();
 
-		remove_all_actions( 'wp_enqueue_scripts' );
+		remove_all_actions( 'googlesitekit_setup_gtag' );
 
 		do_action( 'template_redirect' );
-		$this->assertFalse( has_action( 'wp_enqueue_scripts' ) );
+		$this->assertFalse( has_action( 'googlesitekit_setup_gtag' ) );
 
 		$analytics->get_settings()->merge(
 			array(
@@ -3516,19 +3516,19 @@ class Analytics_4Test extends TestCase {
 		);
 
 		do_action( 'template_redirect' );
-		$this->assertTrue( has_action( 'wp_enqueue_scripts' ) );
+		$this->assertTrue( has_action( 'googlesitekit_setup_gtag' ) );
 
 		// Tag not hooked when blocked.
-		remove_all_actions( 'wp_enqueue_scripts' );
+		remove_all_actions( 'googlesitekit_setup_gtag' );
 		add_filter( 'googlesitekit_analytics-4_tag_blocked', '__return_true' );
 		do_action( 'template_redirect' );
-		$this->assertFalse( has_action( 'wp_enqueue_scripts' ) );
+		$this->assertFalse( has_action( 'googlesitekit_setup_gtag' ) );
 
 		// Tag hooked when only AMP blocked.
 		add_filter( 'googlesitekit_analytics-4_tag_blocked', '__return_false' );
 		add_filter( 'googlesitekit_analytics-4_tag_amp_blocked', '__return_true' );
 		do_action( 'template_redirect' );
-		$this->assertTrue( has_action( 'wp_enqueue_scripts' ) );
+		$this->assertTrue( has_action( 'googlesitekit_setup_gtag' ) );
 	}
 
 	/**
@@ -3555,7 +3555,7 @@ class Analytics_4Test extends TestCase {
 		wp_scripts()->queue      = array();
 		wp_scripts()->done       = array();
 		remove_all_actions( 'template_redirect' );
-		remove_all_actions( 'wp_enqueue_scripts' );
+		remove_all_actions( 'googlesitekit_setup_gtag' );
 		$analytics->register();
 
 		// Hook `wp_print_head_scripts` on placeholder action for capturing.
@@ -3567,7 +3567,6 @@ class Analytics_4Test extends TestCase {
 		}
 
 		do_action( 'template_redirect' );
-		do_action( 'wp_enqueue_scripts' );
 
 		$output = $this->capture_action( '__test_print_scripts' );
 

--- a/tests/phpunit/integration/Modules/Analytics_4Test.php
+++ b/tests/phpunit/integration/Modules/Analytics_4Test.php
@@ -2792,6 +2792,9 @@ class Analytics_4Test extends TestCase {
 		wp_scripts()->done       = array();
 		wp_styles(); // Prevent potential ->queue of non-object error.
 
+		// Remove irrelevant script from throwing errors in CI from readfile().
+		remove_action( 'wp_head', 'print_emoji_detection_script', 7 );
+
 		// Set the current user (can be 0 for no user)
 		$role = $is_content_creator ? 'administrator' : 'subscriber';
 		$user = $logged_in ?
@@ -2806,6 +2809,7 @@ class Analytics_4Test extends TestCase {
 		remove_all_actions( 'googlesitekit_setup_gtag' );
 		$analytics->register();
 		do_action( 'template_redirect' );
+		do_action( 'wp_enqueue_scripts' );
 
 		$head_html = $this->capture_action( 'wp_head' );
 		// Confidence check.

--- a/tests/phpunit/integration/Modules/Analytics_4Test.php
+++ b/tests/phpunit/integration/Modules/Analytics_4Test.php
@@ -2795,6 +2795,12 @@ class Analytics_4Test extends TestCase {
 		// Remove irrelevant script from throwing errors in CI from readfile().
 		remove_action( 'wp_head', 'print_emoji_detection_script', 7 );
 
+		// Prevent test from failing in CI with deprecation notice.
+		$has_emoji_styles = has_action( 'wp_print_styles', 'print_emoji_styles' );
+		if ( $has_emoji_styles ) {
+			remove_action( 'wp_print_styles', 'print_emoji_styles' );
+		}
+
 		// Set the current user (can be 0 for no user)
 		$role = $is_content_creator ? 'administrator' : 'subscriber';
 		$user = $logged_in ?

--- a/tests/phpunit/integration/Modules/Analytics_4Test.php
+++ b/tests/phpunit/integration/Modules/Analytics_4Test.php
@@ -26,6 +26,7 @@ use Google\Site_Kit\Core\Permissions\Permissions;
 use Google\Site_Kit\Core\Storage\Options;
 use Google\Site_Kit\Core\Storage\Transients;
 use Google\Site_Kit\Core\Storage\User_Options;
+use Google\Site_Kit\Core\Tags\GTag;
 use Google\Site_Kit\Modules\AdSense\Settings as AdSense_Settings;
 use Google\Site_Kit\Modules\Analytics_4;
 use Google\Site_Kit\Modules\Analytics_4\Custom_Dimensions_Data_Available;
@@ -136,6 +137,8 @@ class Analytics_4Test extends TestCase {
 		$this->authentication = new Authentication( $this->context, $this->options, $this->user_options );
 		$this->analytics      = new Analytics_4( $this->context, $this->options, $this->user_options, $this->authentication );
 		wp_set_current_user( $this->user->ID );
+		remove_all_actions( 'wp_enqueue_scripts' );
+		( new GTag() )->register();
 	}
 
 	public function test_register() {

--- a/tests/phpunit/integration/Modules/Analytics_4Test.php
+++ b/tests/phpunit/integration/Modules/Analytics_4Test.php
@@ -3568,6 +3568,7 @@ class Analytics_4Test extends TestCase {
 		}
 
 		do_action( 'template_redirect' );
+		do_action( 'wp_enqueue_scripts' );
 
 		$output = $this->capture_action( '__test_print_scripts' );
 

--- a/tests/phpunit/integration/Modules/Analytics_4Test.php
+++ b/tests/phpunit/integration/Modules/Analytics_4Test.php
@@ -2792,9 +2792,6 @@ class Analytics_4Test extends TestCase {
 		wp_scripts()->done       = array();
 		wp_styles(); // Prevent potential ->queue of non-object error.
 
-		// Remove irrelevant script from throwing errors in CI from readfile().
-		remove_action( 'wp_head', 'print_emoji_detection_script', 7 );
-
 		// Set the current user (can be 0 for no user)
 		$role = $is_content_creator ? 'administrator' : 'subscriber';
 		$user = $logged_in ?

--- a/tests/phpunit/integration/Modules/Analytics_4Test.php
+++ b/tests/phpunit/integration/Modules/Analytics_4Test.php
@@ -2796,10 +2796,7 @@ class Analytics_4Test extends TestCase {
 		remove_action( 'wp_head', 'print_emoji_detection_script', 7 );
 
 		// Prevent test from failing in CI with deprecation notice.
-		$has_emoji_styles = has_action( 'wp_print_styles', 'print_emoji_styles' );
-		if ( $has_emoji_styles ) {
-			remove_action( 'wp_print_styles', 'print_emoji_styles' );
-		}
+		remove_action( 'wp_print_styles', 'print_emoji_styles' );
 
 		// Set the current user (can be 0 for no user)
 		$role = $is_content_creator ? 'administrator' : 'subscriber';


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #8273 

## Relevant technical choices

- This PR updates the Analytics module to use the new `GTag` infrastructure.

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
