### PR TITLE
Add site health fields for Consent Mode

### DIFF
--- a/includes/Core/Consent_Mode/Consent_Mode.php
+++ b/includes/Core/Consent_Mode/Consent_Mode.php
@@ -67,7 +67,9 @@ class Consent_Mode {
 		$plugin = GOOGLESITEKIT_PLUGIN_BASENAME;
 		add_filter( "wp_consent_api_registered_{$plugin}", '__return_true' );
 
-		if ( $this->consent_mode_settings->is_consent_mode_enabled() ) {
+		$consent_mode_enabled = $this->consent_mode_settings->is_consent_mode_enabled();
+
+		if ( $consent_mode_enabled ) {
 			// The `wp_head` action is used to ensure the snippets are printed in the head on the front-end only, not admin pages.
 			add_action(
 				'wp_head',
@@ -75,6 +77,13 @@ class Consent_Mode {
 				1 // Set priority to 1 to ensure the snippet is printed with top priority in the head.
 			);
 		}
+
+		add_filter(
+			'googlesitekit_consent_mode_status',
+			function () use ( $consent_mode_enabled ) {
+				return $consent_mode_enabled ? 'enabled' : 'disabled';
+			}
+		);
 	}
 
 	/**

--- a/includes/Core/Site_Health/Debug_Data.php
+++ b/includes/Core/Site_Health/Debug_Data.php
@@ -191,6 +191,8 @@ class Debug_Data {
 			'enabled_features'     => $this->get_feature_fields(),
 		);
 
+		$fields = array_merge( $fields, $this->get_consent_mode_fields() );
+
 		$fields = array_merge( $fields, $this->get_module_sharing_settings_fields() );
 
 		$fields = array_filter(
@@ -576,6 +578,39 @@ class Debug_Data {
 		return array(
 			'label' => __( 'Features', 'google-site-kit' ),
 			'value' => $value,
+		);
+	}
+
+	/**
+	 * Gets the consent mode fields.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @return array
+	 */
+	private function get_consent_mode_fields() {
+		/**
+		 * Filters the status of consent mode in Site Kit.
+		 *
+		 * @since n.e.x.t
+		 *
+		 * @param string $status The consent mode status. Default: 'disabled'.
+		 */
+		$consent_mode_status = apply_filters( 'googlesitekit_consent_mode_status', 'disabled' );
+
+		$consent_api_active = function_exists( 'wp_set_consent' );
+
+		return array(
+			'consent_mode' => array(
+				'label' => __( 'Consent Mode', 'google-site-kit' ),
+				'value' => 'enabled' === $consent_mode_status ? __( 'Enabled', 'google-site-kit' ) : __( 'Disabled', 'google-site-kit' ),
+				'debug' => $consent_mode_status,
+			),
+			'consent_api'  => array(
+				'label' => __( 'WP Consent API', 'google-site-kit' ),
+				'value' => $consent_api_active ? __( 'Detected', 'google-site-kit' ) : __( 'Not detected', 'google-site-kit' ),
+				'debug' => $consent_api_active ? 'detected' : 'not-detected',
+			),
 		);
 	}
 }

--- a/tests/phpunit/integration/Core/Consent_Mode/Consent_ModeTest.php
+++ b/tests/phpunit/integration/Core/Consent_Mode/Consent_ModeTest.php
@@ -62,4 +62,13 @@ class Consent_ModeTest extends TestCase {
 
 		$this->assertStringNotContainsString( 'Google tag (gtag.js) Consent Mode snippet added by Site Kit', $output );
 	}
+
+	public function test_register__googlesitekit_consent_mode_status() {
+		remove_all_filters( 'googlesitekit_consent_mode_status' );
+
+		$consent_mode = new Consent_Mode( $this->context, $this->options );
+		$consent_mode->register();
+
+		$this->assertTrue( has_filter( 'googlesitekit_consent_mode_status' ) );
+	}
 }

--- a/tests/phpunit/integration/Core/Site_Health/Debug_DataTest.php
+++ b/tests/phpunit/integration/Core/Site_Health/Debug_DataTest.php
@@ -61,6 +61,9 @@ class Debug_DataTest extends TestCase {
 		$this->assertNonConditionalFields( $info );
 		$this->assertArrayHasKey( 'recoverable_modules', $info['google-site-kit']['fields'] );
 		$this->assertHasDashboardSharingModuleFields( 'fake-module', $info );
+
+		$this->assertArrayHasKey( 'consent_mode', $info['google-site-kit']['fields'] );
+		$this->assertArrayHasKey( 'consent_api', $info['google-site-kit']['fields'] );
 	}
 
 	/**
@@ -113,6 +116,8 @@ class Debug_DataTest extends TestCase {
 			'required_scopes',
 			'capabilities',
 			'enabled_features',
+			'consent_mode',
+			'consent_api',
 		);
 		$actual_keys          = array_keys( $debug_information['google-site-kit']['fields'] );
 


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #8356 

## Relevant technical choices

This PR adds site health fields for Consent Mode.

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [x] Run the code.
- [x] Ensure the acceptance criteria are satisfied.
- [x] Reassess the implementation with the IB.
- [x] Ensure no unrelated changes are included.
- [x] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [x] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [x] Ensure the PR has the correct target branch.
- [x] Double-check that the PR is okay to be merged.
- [x] Ensure the corresponding issue has a ZenHub release assigned.
- [x] Add a changelog message to the issue.
