### PR TITLE
Correctly create web data stream when creating a new property

### DIFF
--- a/assets/js/modules/analytics-4/datastore/settings.js
+++ b/assets/js/modules/analytics-4/datastore/settings.js
@@ -89,12 +89,17 @@ export async function submitChanges( { select, dispatch } ) {
 			'webDataStreamName'
 		);
 
-		const webDataStreamAlreadyExists = isValidPropertyID( propertyID )
-			? select( MODULES_ANALYTICS_4 ).doesWebDataStreamExist(
-					propertyID,
-					webDataStreamName
-			  )
-			: false;
+		let webDataStreamAlreadyExists = false;
+
+		if ( isValidPropertyID( propertyID ) ) {
+			await dispatch( MODULES_ANALYTICS_4 ).waitForWebDataStreams(
+				propertyID
+			);
+
+			webDataStreamAlreadyExists = select(
+				MODULES_ANALYTICS_4
+			).doesWebDataStreamExist( propertyID, webDataStreamName );
+		}
 
 		if (
 			isValidWebDataStreamName( webDataStreamName ) &&


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- https://github.com/google/site-kit-wp/issues/6727#issuecomment-2037608878

## Relevant technical choices

This PR fixes an issue where the web data stream isn't created when creating a new property.

This issue happened because when a new property was created, its list of web data streams (which is guaranteed to be empty anyway) wasn't available immediately. This caused one of our checks to fail, thus not creating a web data stream.

This PR makes the selector wait for the list of web data streams to be available so that we don't get into such a scenario or similar.

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
