### PR TITLE
Update unstable time based tests in Prompts test.

### DIFF
--- a/tests/phpunit/integration/Core/Prompts/REST_Prompts_ControllerTest.php
+++ b/tests/phpunit/integration/Core/Prompts/REST_Prompts_ControllerTest.php
@@ -76,19 +76,14 @@ class REST_Prompts_ControllerTest extends TestCase {
 		$request  = new WP_REST_Request( 'GET', '/' . REST_Routes::REST_ROOT . '/core/user/data/dismissed-prompts' );
 		$response = rest_get_server()->dispatch( $request );
 
-		$this->assertEqualSets(
-			array(
-				'foo' => array(
-					'expires' => 0,
-					'count'   => 1,
-				),
-				'bar' => array(
-					'expires' => time() + 100,
-					'count'   => 1,
-				),
-			),
-			$response->get_data()
-		);
+		$response_data = $response->get_data();
+		// The asserts are split to use assertEqualsWithDelta for the time based assertion.
+		$this->assertArrayHasKey( 'foo', $response_data );
+		$this->assertArrayHasKey( 'bar', $response_data );
+		$this->assertEquals( 0, $response_data['foo']['expires'] );
+		$this->assertEquals( 1, $response_data['foo']['count'] );
+		$this->assertEqualsWithDelta( time() + 100, $response_data['bar']['expires'], 2 );
+		$this->assertEquals( 1, $response_data['bar']['count'] );
 	}
 
 	public function test_dismiss_new_prompt() {
@@ -131,15 +126,11 @@ class REST_Prompts_ControllerTest extends TestCase {
 			)
 		);
 
-		$this->assertEqualSets(
-			array(
-				'foo' => array(
-					'expires' => time() + 100,
-					'count'   => 2,
-				),
-			),
-			rest_get_server()->dispatch( $request )->get_data()
-		);
+		$response_data = rest_get_server()->dispatch( $request )->get_data();
+		// The asserts are split to use assertEqualsWithDelta for the time based assertion.
+		$this->assertArrayHasKey( 'foo', $response_data );
+		$this->assertEqualsWithDelta( time() + 100, $response_data['foo']['expires'], 2 );
+		$this->assertEquals( 2, $response_data['foo']['count'] );
 	}
 
 }


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #8488

## Relevant technical choices

Switch to `assertEqualsWithDelta` for tests I missed previously.

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [ ] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
