### PR TITLE
Fix webdatastream input showing while switching selected properties

### DIFF
--- a/assets/js/modules/analytics-4/datastore/accounts.js
+++ b/assets/js/modules/analytics-4/datastore/accounts.js
@@ -183,6 +183,8 @@ const baseActions = {
 
 			registry.dispatch( MODULES_ANALYTICS_4 ).setSettings( {
 				accountID,
+				propertyID: '',
+				webDataStreamID: '',
 			} );
 
 			if ( ACCOUNT_CREATE === accountID ) {

--- a/assets/js/modules/analytics-4/datastore/properties.js
+++ b/assets/js/modules/analytics-4/datastore/properties.js
@@ -230,23 +230,26 @@ const baseActions = {
 		},
 		function* ( propertyID ) {
 			const registry = yield Data.commonActions.getRegistry();
+			const {
+				setPropertyCreateTime,
+				setSettings,
+				setWebDataStreamID,
+				updateSettingsForMeasurementID,
+			} = registry.dispatch( MODULES_ANALYTICS_4 );
 
-			registry
-				.dispatch( MODULES_ANALYTICS_4 )
-				.setPropertyID( propertyID );
-			registry
-				.dispatch( MODULES_ANALYTICS_4 )
-				.updateSettingsForMeasurementID( '' );
-			registry.dispatch( MODULES_ANALYTICS_4 ).setPropertyCreateTime( 0 );
+			setSettings( {
+				propertyID,
+				propertyCreateTime: 0,
+			} );
+
+			updateSettingsForMeasurementID( '' );
 
 			if ( PROPERTY_CREATE === propertyID ) {
-				registry
-					.dispatch( MODULES_ANALYTICS_4 )
-					.setWebDataStreamID( WEBDATASTREAM_CREATE );
+				setWebDataStreamID( WEBDATASTREAM_CREATE );
 				return;
 			}
 
-			registry.dispatch( MODULES_ANALYTICS_4 ).setWebDataStreamID( '' );
+			setWebDataStreamID( '' );
 
 			if ( propertyID ) {
 				const property = yield Data.commonActions.await(
@@ -256,9 +259,7 @@ const baseActions = {
 				);
 
 				if ( property?.createTime ) {
-					registry
-						.dispatch( MODULES_ANALYTICS_4 )
-						.setPropertyCreateTime( property.createTime );
+					setPropertyCreateTime( property.createTime );
 				}
 			}
 
@@ -279,21 +280,15 @@ const baseActions = {
 			}
 
 			if ( webdatastream ) {
-				registry
-					.dispatch( MODULES_ANALYTICS_4 )
-					.setWebDataStreamID( webdatastream._id );
-				registry
-					.dispatch( MODULES_ANALYTICS_4 )
-					.updateSettingsForMeasurementID(
-						// eslint-disable-next-line sitekit/acronym-case
-						webdatastream.webStreamData.measurementId
-					);
+				setWebDataStreamID( webdatastream._id );
+				updateSettingsForMeasurementID(
+					// eslint-disable-next-line sitekit/acronym-case
+					webdatastream.webStreamData.measurementId
+				);
 				return;
 			}
 			// At this point there is no web data stream to set.
-			registry
-				.dispatch( MODULES_ANALYTICS_4 )
-				.setWebDataStreamID( WEBDATASTREAM_CREATE );
+			setWebDataStreamID( WEBDATASTREAM_CREATE );
 		}
 	),
 

--- a/assets/js/modules/analytics-4/datastore/properties.test.js
+++ b/assets/js/modules/analytics-4/datastore/properties.test.js
@@ -373,7 +373,7 @@ describe( 'modules/analytics-4 properties', () => {
 
 				expect( store.getState().settings ).toMatchObject( {
 					propertyID,
-					webDataStreamID: WEBDATASTREAM_CREATE,
+					webDataStreamID: '',
 					measurementID: '',
 					propertyCreateTime: 0,
 				} );
@@ -602,6 +602,7 @@ describe( 'modules/analytics-4 properties', () => {
 				expect( matchedProperty ).toBeNull();
 			} );
 		} );
+
 		describe( 'updateSettingsForMeasurementID', () => {
 			it( 'should update the settings with the measurement ID.', async () => {
 				const measurementID = 'G-1A2BCD346E';


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #6727

## Relevant technical choices

- The problem was due to how we were setting the webdatastream ID to create as soon as we were selecting a new property as a way of setting the fallback first, so the solution was to adjust this to set it more intentionally.
- The relevant changes are in https://github.com/google/site-kit-wp/pull/8490/commits/47560bc187ee99d240dfb8b3a146542566875dca
- This also includes some cleanup to avoid repetitive calls to `dispatch` on the same store which also resulted in long lines breaking into many, something we should clean up throughout 

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 5.6.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [ ] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [x] Run the code.
- [x] Ensure the acceptance criteria are satisfied.
- [x] Reassess the implementation with the IB.
- [x] Ensure no unrelated changes are included.
- [x] Ensure CI checks pass.
- [x] Check Storybook where applicable.
- [x] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [x] Ensure the PR has the correct target branch.
- [x] Double-check that the PR is okay to be merged.
- [x] Ensure the corresponding issue has a ZenHub release assigned.
- [x] Add a changelog message to the issue.
