### PR TITLE
Enhance/#8504 - Conditionally Enqueue Admin Scripts and Styles for Authorize Application Screen

### DIFF
--- a/includes/Core/Admin/Authorize_Application.php
+++ b/includes/Core/Admin/Authorize_Application.php
@@ -1,0 +1,116 @@
+<?php
+/**
+ * Class Google\Site_Kit\Core\Admin\Authorize_Application
+ *
+ * @package   Google\Site_Kit
+ * @copyright 2024 Google LLC
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
+ * @link      https://sitekit.withgoogle.com
+ */
+
+namespace Google\Site_Kit\Core\Admin;
+
+use Google\Site_Kit\Context;
+use Google\Site_Kit\Core\Assets\Assets;
+
+/**
+ * Class to handle all wp-admin Authorize Application related functionality.
+ *
+ * @since n.e.x.t
+ * @access private
+ * @ignore
+ */
+
+final class Authorize_Application {
+
+    /**
+	 * Plugin context.
+	 *
+	 * @since n.e.x.t
+	 * @var Context
+	 */
+	private $context;
+
+	/**
+	 * Assets Instance.
+	 *
+	 * @since n.e.x.t
+	 * @var Assets
+	 */
+	private $assets;
+
+    /**
+	 * Constructor.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param Context $context Plugin context.
+	 * @param Assets  $assets  Optional. Assets API instance. Default is a new instance.
+	 */
+	public function __construct(
+		Context $context,
+		Assets $assets = null
+	) {
+		$this->context = $context;
+		$this->assets  = $assets ?: new Assets( $this->context );
+	}
+
+    /**
+	 * Registers functionality through WordPress hooks.
+	 *
+	 * @since n.e.x.t
+	 */
+    public function register() {
+        add_action(
+			'admin_enqueue_scripts',
+			array( $this, 'enqueue_assets' )
+		);
+    }
+
+    /**
+     * Checks if the current screen is the Authorize Application screen.
+     * 
+     * @since n.e.x.t
+     * 
+     * @return bool True if the current screen is the Authorize Application screen, false otherwise.
+     */
+    protected function is_Authorize_Application_screen() {
+        if ( function_exists( 'get_current_screen' ) && get_current_screen()->id === 'authorize-application' ) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Checks if the current service is Google.
+     * 
+     * @since n.e.x.t
+     * 
+     * @return bool True if the current service is Google, false otherwise.
+     */
+    protected function is_google_service() {
+        $success_url = isset( $_GET['success_url'] ) ? $_GET['success_url'] : '';
+
+        $parsed_url = parse_url( $success_url );
+
+        if (empty($parsed_url['host'])) {
+            return false;
+        }
+
+        // Check if the domain is a '*.google.com' domain
+        return preg_match('/\.google\.com$/', $parsed_url['host']) === 1;
+    }
+
+    /**
+     * Enqueues assets for the Authorize Application screen.
+     *
+     * @since n.e.x.t
+     */
+    public function enqueue_assets() {
+        if ( $this->is_Authorize_Application_screen() && $this->is_google_service() ) {
+            $this->assets->enqueue_asset( 'googlesitekit-authorize-application' );
+        }
+    }
+
+}

--- a/includes/Core/Admin/Authorize_Application.php
+++ b/includes/Core/Admin/Authorize_Application.php
@@ -78,7 +78,7 @@ final class Authorize_Application {
 	protected function is_authorize_application_screen() {
 		$current_screen = function_exists( 'get_current_screen' ) ? get_current_screen() : null;
 
-		if ( $current_screen instanceof \WP_Screen && $current_screen->id === 'authorize-application' ) {
+		if ( $current_screen instanceof \WP_Screen && 'authorize-application' === $current_screen->id ) {
 			return true;
 		}
 

--- a/includes/Core/Admin/Authorize_Application.php
+++ b/includes/Core/Admin/Authorize_Application.php
@@ -23,7 +23,7 @@ use Google\Site_Kit\Core\Assets\Assets;
 
 final class Authorize_Application {
 
-    /**
+	/**
 	 * Plugin context.
 	 *
 	 * @since n.e.x.t
@@ -39,7 +39,7 @@ final class Authorize_Application {
 	 */
 	private $assets;
 
-    /**
+	/**
 	 * Constructor.
 	 *
 	 * @since n.e.x.t
@@ -55,62 +55,62 @@ final class Authorize_Application {
 		$this->assets  = $assets ?: new Assets( $this->context );
 	}
 
-    /**
+	/**
 	 * Registers functionality through WordPress hooks.
 	 *
 	 * @since n.e.x.t
 	 */
-    public function register() {
-        add_action(
+	public function register() {
+		add_action(
 			'admin_enqueue_scripts',
 			array( $this, 'enqueue_assets' )
 		);
-    }
+	}
 
-    /**
-     * Checks if the current screen is the Authorize Application screen.
-     * 
-     * @since n.e.x.t
-     * 
-     * @return bool True if the current screen is the Authorize Application screen, false otherwise.
-     */
-    protected function is_Authorize_Application_screen() {
-        if ( function_exists( 'get_current_screen' ) && get_current_screen()->id === 'authorize-application' ) {
-            return true;
-        }
+	/**
+	 * Checks if the current screen is the Authorize Application screen.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @return bool True if the current screen is the Authorize Application screen, false otherwise.
+	 */
+	protected function is_Authorize_Application_screen() {
+		if ( function_exists( 'get_current_screen' ) && get_current_screen()->id === 'authorize-application' ) {
+			return true;
+		}
 
-        return false;
-    }
+		return false;
+	}
 
-    /**
-     * Checks if the current service is Google.
-     * 
-     * @since n.e.x.t
-     * 
-     * @return bool True if the current service is Google, false otherwise.
-     */
-    protected function is_google_service() {
-        $success_url = isset( $_GET['success_url'] ) ? $_GET['success_url'] : '';
+	/**
+	 * Checks if the current service is Google.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @return bool True if the current service is Google, false otherwise.
+	 */
+	protected function is_google_service() {
+		$success_url = isset( $_GET['success_url'] ) ? $_GET['success_url'] : '';
 
-        $parsed_url = parse_url( $success_url );
+		$parsed_url = parse_url( $success_url );
 
-        if (empty($parsed_url['host'])) {
-            return false;
-        }
+		if ( empty( $parsed_url['host'] ) ) {
+			return false;
+		}
 
-        // Check if the domain is a '*.google.com' domain
-        return preg_match('/\.google\.com$/', $parsed_url['host']) === 1;
-    }
+		// Check if the domain is a '*.google.com' domain
+		return preg_match( '/\.google\.com$/', $parsed_url['host'] ) === 1;
+	}
 
-    /**
-     * Enqueues assets for the Authorize Application screen.
-     *
-     * @since n.e.x.t
-     */
-    public function enqueue_assets() {
-        if ( $this->is_Authorize_Application_screen() && $this->is_google_service() ) {
-            $this->assets->enqueue_asset( 'googlesitekit-authorize-application' );
-        }
-    }
+	/**
+	 * Enqueues assets for the Authorize Application screen.
+	 *
+	 * @since n.e.x.t
+	 */
+	public function enqueue_assets() {
+		if ( $this->is_Authorize_Application_screen() && $this->is_google_service() ) {
+			$this->assets->enqueue_asset( 'googlesitekit-authorize-application' );
+		}
+	}
 
 }

--- a/includes/Core/Admin/Authorize_Application.php
+++ b/includes/Core/Admin/Authorize_Application.php
@@ -20,7 +20,6 @@ use Google\Site_Kit\Core\Assets\Assets;
  * @access private
  * @ignore
  */
-
 final class Authorize_Application {
 
 	/**
@@ -74,7 +73,7 @@ final class Authorize_Application {
 	 *
 	 * @return bool True if the current screen is the Authorize Application screen, false otherwise.
 	 */
-	protected function is_Authorize_Application_screen() {
+	protected function is_authorize_application_screen() {
 		if ( function_exists( 'get_current_screen' ) && get_current_screen()->id === 'authorize-application' ) {
 			return true;
 		}
@@ -90,15 +89,16 @@ final class Authorize_Application {
 	 * @return bool True if the current service is Google, false otherwise.
 	 */
 	protected function is_google_service() {
-		$success_url = isset( $_GET['success_url'] ) ? $_GET['success_url'] : '';
+		$success_url = isset( $_GET['success_url'] ) ? esc_url_raw( wp_unslash( $_GET['success_url'] ) ) : '';
+		$success_url = sanitize_text_field( $success_url );
 
-		$parsed_url = parse_url( $success_url );
+		$parsed_url = wp_parse_url( $success_url );
 
 		if ( empty( $parsed_url['host'] ) ) {
 			return false;
 		}
 
-		// Check if the domain is a '*.google.com' domain
+		// Check if the domain is a '*.google.com' domain.
 		return preg_match( '/\.google\.com$/', $parsed_url['host'] ) === 1;
 	}
 
@@ -108,7 +108,7 @@ final class Authorize_Application {
 	 * @since n.e.x.t
 	 */
 	public function enqueue_assets() {
-		if ( $this->is_Authorize_Application_screen() && $this->is_google_service() ) {
+		if ( $this->is_authorize_application_screen() && $this->is_google_service() ) {
 			$this->assets->enqueue_asset( 'googlesitekit-authorize-application' );
 		}
 	}

--- a/includes/Core/Admin/Authorize_Application.php
+++ b/includes/Core/Admin/Authorize_Application.php
@@ -12,6 +12,7 @@ namespace Google\Site_Kit\Core\Admin;
 
 use Google\Site_Kit\Context;
 use Google\Site_Kit\Core\Assets\Assets;
+use Google\Site_Kit\Core\Util\Method_Proxy_Trait;
 
 /**
  * Class to handle all wp-admin Authorize Application related functionality.
@@ -22,6 +23,8 @@ use Google\Site_Kit\Core\Assets\Assets;
  */
 final class Authorize_Application {
 
+	use Method_Proxy_Trait;
+
 	/**
 	 * Plugin context.
 	 *
@@ -31,7 +34,7 @@ final class Authorize_Application {
 	private $context;
 
 	/**
-	 * Assets Instance.
+	 * Assets instance.
 	 *
 	 * @since n.e.x.t
 	 * @var Assets
@@ -60,12 +63,7 @@ final class Authorize_Application {
 	 * @since n.e.x.t
 	 */
 	public function register() {
-		add_action(
-			'admin_enqueue_scripts',
-			function() {
-				$this->enqueue_assets();
-			}
-		);
+		add_action( 'admin_enqueue_scripts', $this->get_method_proxy( 'enqueue_assets' ) );
 	}
 
 	/**
@@ -86,11 +84,11 @@ final class Authorize_Application {
 	}
 
 	/**
-	 * Checks if the current service is Google.
+	 * Checks if the current service is a Google service.
 	 *
 	 * @since n.e.x.t
 	 *
-	 * @return bool True if the current service is Google, false otherwise.
+	 * @return bool True if the current service is a Google service, false otherwise.
 	 */
 	protected function is_google_service() {
 		$success_url = isset( $_GET['success_url'] ) ? esc_url_raw( wp_unslash( $_GET['success_url'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification

--- a/includes/Core/Admin/Authorize_Application.php
+++ b/includes/Core/Admin/Authorize_Application.php
@@ -89,7 +89,7 @@ final class Authorize_Application {
 	 * @return bool True if the current service is Google, false otherwise.
 	 */
 	protected function is_google_service() {
-		$success_url = isset( $_GET['success_url'] ) ? esc_url_raw( wp_unslash( $_GET['success_url'] ) ) : '';
+		$success_url = isset( $_GET['success_url'] ) ? esc_url_raw( wp_unslash( $_GET['success_url'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification
 		$success_url = sanitize_text_field( $success_url );
 
 		$parsed_url = wp_parse_url( $success_url );

--- a/includes/Core/Admin/Authorize_Application.php
+++ b/includes/Core/Admin/Authorize_Application.php
@@ -113,7 +113,7 @@ final class Authorize_Application {
 	 */
 	private function enqueue_assets() {
 		if ( $this->is_authorize_application_screen() && $this->is_google_service() ) {
-			$this->assets->enqueue_asset( 'googlesitekit-authorize-application' );
+			$this->assets->enqueue_asset( 'googlesitekit-authorize-application-css' );
 		}
 	}
 }

--- a/includes/Core/Admin/Authorize_Application.php
+++ b/includes/Core/Admin/Authorize_Application.php
@@ -62,7 +62,9 @@ final class Authorize_Application {
 	public function register() {
 		add_action(
 			'admin_enqueue_scripts',
-			array( $this, 'enqueue_assets' )
+			function() {
+				$this->enqueue_assets();
+			}
 		);
 	}
 
@@ -74,7 +76,9 @@ final class Authorize_Application {
 	 * @return bool True if the current screen is the Authorize Application screen, false otherwise.
 	 */
 	protected function is_authorize_application_screen() {
-		if ( function_exists( 'get_current_screen' ) && get_current_screen()->id === 'authorize-application' ) {
+		$current_screen = function_exists( 'get_current_screen' ) ? get_current_screen() : null;
+
+		if ( $current_screen instanceof \WP_Screen && $current_screen->id === 'authorize-application' ) {
 			return true;
 		}
 
@@ -107,10 +111,9 @@ final class Authorize_Application {
 	 *
 	 * @since n.e.x.t
 	 */
-	public function enqueue_assets() {
+	private function enqueue_assets() {
 		if ( $this->is_authorize_application_screen() && $this->is_google_service() ) {
 			$this->assets->enqueue_asset( 'googlesitekit-authorize-application' );
 		}
 	}
-
 }

--- a/includes/Core/Assets/Assets.php
+++ b/includes/Core/Assets/Assets.php
@@ -650,7 +650,7 @@ final class Assets {
 				)
 			),
 			new Stylesheet(
-				'googlesitekit-authorize-application',
+				'googlesitekit-authorize-application-css',
 				array(
 					'src'          => $base_url . 'css/googlesitekit-authorize-application-css.css',
 					'dependencies' => array(

--- a/includes/Core/Assets/Assets.php
+++ b/includes/Core/Assets/Assets.php
@@ -649,6 +649,15 @@ final class Assets {
 					),
 				)
 			),
+			new Stylesheet(
+				'googlesitekit-authorize-application',
+				array(
+					'src'          => $base_url . 'css/googlesitekit-authorize-application-css.css',
+					'dependencies' => array(
+						'googlesitekit-fonts',
+					),
+				)
+			),
 			// Admin bar assets.
 			new Script(
 				'googlesitekit-adminbar',

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -202,6 +202,7 @@ final class Plugin {
 				( new Core\Admin\Notices() )->register();
 				( new Core\Admin\Pointers() )->register();
 				( new Core\Admin\Dashboard( $this->context, $assets, $modules ) )->register();
+				( new Core\Admin\Authorize_Application( $this->context, $assets ) )->register();
 				( new Core\Notifications\Notifications( $this->context, $options, $authentication ) )->register();
 				( new Core\Site_Health\Site_Health( $this->context, $options, $user_options, $authentication, $modules, $permissions ) )->register();
 				( new Core\Util\Health_Checks( $authentication ) )->register();

--- a/tests/phpunit/integration/Core/Admin/Authorize_ApplicationTest.php
+++ b/tests/phpunit/integration/Core/Admin/Authorize_ApplicationTest.php
@@ -28,10 +28,10 @@ class Authorize_ApplicationTest extends TestCase {
 
 		// Set the success URL with the `google.com` domain.
 		$this->set_global_get_params( 'https://example.google.com/settings/authorization/wordpress' );
-        
+
 		// Verify that the expected assets aren't enqueued yet.
 		$this->assertFalse( wp_style_is( 'googlesitekit-authorize-application', 'enqueued' ) );
-        
+
 		$authorize_application = new Authorize_Application( new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE ) );
 		$authorize_application->register();
 
@@ -53,7 +53,7 @@ class Authorize_ApplicationTest extends TestCase {
 
 		// Verify that the expected assets aren't enqueued yet.
 		$this->assertFalse( wp_style_is( 'googlesitekit-authorize-application', 'enqueued' ) );
-        
+
 		$authorize_application = new Authorize_Application( new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE ) );
 		$authorize_application->register();
 
@@ -70,10 +70,10 @@ class Authorize_ApplicationTest extends TestCase {
 		// Set the current screen to dashboard.
 		$current_screen = convert_to_screen( 'dashboard' );
 
-        // Set the success URL with the `google.com` domain.
+		// Set the success URL with the `google.com` domain.
 		$this->set_global_get_params( 'https://example.google.com/settings/authorization/wordpress' );
 
-        // Verify that the expected assets aren't enqueued yet.
+		// Verify that the expected assets aren't enqueued yet.
 		$this->assertFalse( wp_style_is( 'googlesitekit-authorize-application', 'enqueued' ) );
 
 		$authorize_application = new Authorize_Application( new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE ) );
@@ -101,7 +101,7 @@ class Authorize_ApplicationTest extends TestCase {
 		unset( $_GET['sitekit'] );
 	}
 
-    public function tear_down() {
+	public function tear_down() {
 		parent::tear_down();
 		$this->unset_global_get_params();
 		wp_dequeue_style( 'googlesitekit-authorize-application' );

--- a/tests/phpunit/integration/Core/Admin/Authorize_ApplicationTest.php
+++ b/tests/phpunit/integration/Core/Admin/Authorize_ApplicationTest.php
@@ -1,0 +1,109 @@
+<?php
+/**
+ * Class Google\Site_Kit\Tests\Core\Admin\Authorize_ApplicationTest
+ *
+ * @package   Google\Site_Kit\Tests\Core\Admin
+ * @copyright 2024 Google LLC
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
+ * @link      https://sitekit.withgoogle.com
+ */
+
+namespace Google\Site_Kit\Tests\Core\Admin;
+
+use Google\Site_Kit\Core\Admin\Authorize_Application;
+use Google\Site_Kit\Context;
+use Google\Site_Kit\Tests\TestCase;
+
+/**
+ * @group Admin
+ */
+class Authorize_ApplicationTest extends TestCase {
+
+	public function test_register() {
+		global $current_screen;
+		remove_all_actions( 'admin_enqueue_scripts' );
+
+		// Set the current screen to authorize-application.
+		$current_screen = convert_to_screen( 'authorize-application' );
+
+		// Set the success URL with the `google.com` domain.
+		$this->set_global_get_params( 'https://example.google.com/settings/authorization/wordpress' );
+        
+		// Verify that the expected assets aren't enqueued yet.
+		$this->assertFalse( wp_style_is( 'googlesitekit-authorize-application', 'enqueued' ) );
+        
+		$authorize_application = new Authorize_Application( new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE ) );
+		$authorize_application->register();
+
+		do_action( 'admin_enqueue_scripts' );
+
+		// Check that the expected assets are enqueued.
+		$this->assertTrue( wp_style_is( 'googlesitekit-authorize-application', 'enqueued' ) );
+	}
+
+	public function test_register_with_incorrect_success_url() {
+		global $current_screen;
+		remove_all_actions( 'admin_enqueue_scripts' );
+
+		// Set the current screen to authorize-application.
+		$current_screen = convert_to_screen( 'authorize-application' );
+
+		// Set the success URL to an incorrect value with a different domain.
+		$this->set_global_get_params( 'https://example.com/settings/authorization/wordpress' );
+
+		// Verify that the expected assets aren't enqueued yet.
+		$this->assertFalse( wp_style_is( 'googlesitekit-authorize-application', 'enqueued' ) );
+        
+		$authorize_application = new Authorize_Application( new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE ) );
+		$authorize_application->register();
+
+		do_action( 'admin_enqueue_scripts' );
+
+		// Check that the assets aren't enqueued due to incorrect success URL.
+		$this->assertFalse( wp_style_is( 'googlesitekit-authorize-application', 'enqueued' ) );
+	}
+
+	public function test_register_with_incorrect_screen() {
+		global $current_screen;
+		remove_all_actions( 'admin_enqueue_scripts' );
+
+		// Set the current screen to dashboard.
+		$current_screen = convert_to_screen( 'dashboard' );
+
+        // Set the success URL with the `google.com` domain.
+		$this->set_global_get_params( 'https://example.google.com/settings/authorization/wordpress' );
+
+        // Verify that the expected assets aren't enqueued yet.
+		$this->assertFalse( wp_style_is( 'googlesitekit-authorize-application', 'enqueued' ) );
+
+		$authorize_application = new Authorize_Application( new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE ) );
+		$authorize_application->register();
+
+		do_action( 'admin_enqueue_scripts' );
+
+		// Check that expected assets aren't enqueued due to incorrect screen.
+		$this->assertFalse( wp_style_is( 'googlesitekit-authorize-application', 'enqueued' ) );
+	}
+
+	public function set_global_get_params( $success_url ) {
+		// Set $_GET parameters
+		$_GET['app_name']    = 'GoogleServiceIntegration';
+		$_GET['app_id']      = wp_generate_uuid4();
+		$_GET['success_url'] = $success_url;
+		$_GET['sitekit']     = 'true';
+	}
+
+	public function tear_down() {
+		parent::tear_down();
+		$this->unset_get_params();
+		wp_dequeue_style( 'googlesitekit-authorize-application' );
+	}
+
+	public function unset_get_params() {
+		// Unset $_GET parameters
+		unset( $_GET['app_name'] );
+		unset( $_GET['app_id'] );
+		unset( $_GET['success_url'] );
+		unset( $_GET['sitekit'] );
+	}
+}

--- a/tests/phpunit/integration/Core/Admin/Authorize_ApplicationTest.php
+++ b/tests/phpunit/integration/Core/Admin/Authorize_ApplicationTest.php
@@ -30,7 +30,7 @@ class Authorize_ApplicationTest extends TestCase {
 		$this->set_global_get_params( 'https://example.google.com/settings/authorization/wordpress' );
 
 		// Verify that the expected assets aren't enqueued yet.
-		$this->assertFalse( wp_style_is( 'googlesitekit-authorize-application', 'enqueued' ) );
+		$this->assertFalse( wp_style_is( 'googlesitekit-authorize-application-css', 'enqueued' ) );
 
 		$authorize_application = new Authorize_Application( new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE ) );
 		$authorize_application->register();
@@ -38,7 +38,7 @@ class Authorize_ApplicationTest extends TestCase {
 		do_action( 'admin_enqueue_scripts' );
 
 		// Check that the expected assets are enqueued.
-		$this->assertTrue( wp_style_is( 'googlesitekit-authorize-application', 'enqueued' ) );
+		$this->assertTrue( wp_style_is( 'googlesitekit-authorize-application-css', 'enqueued' ) );
 	}
 
 	public function test_register_with_incorrect_success_url() {
@@ -52,7 +52,7 @@ class Authorize_ApplicationTest extends TestCase {
 		$this->set_global_get_params( 'https://example.com/settings/authorization/wordpress' );
 
 		// Verify that the expected assets aren't enqueued yet.
-		$this->assertFalse( wp_style_is( 'googlesitekit-authorize-application', 'enqueued' ) );
+		$this->assertFalse( wp_style_is( 'googlesitekit-authorize-application-css', 'enqueued' ) );
 
 		$authorize_application = new Authorize_Application( new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE ) );
 		$authorize_application->register();
@@ -60,7 +60,7 @@ class Authorize_ApplicationTest extends TestCase {
 		do_action( 'admin_enqueue_scripts' );
 
 		// Check that the assets aren't enqueued due to incorrect success URL.
-		$this->assertFalse( wp_style_is( 'googlesitekit-authorize-application', 'enqueued' ) );
+		$this->assertFalse( wp_style_is( 'googlesitekit-authorize-application-css', 'enqueued' ) );
 	}
 
 	public function test_register_with_incorrect_screen() {
@@ -74,7 +74,7 @@ class Authorize_ApplicationTest extends TestCase {
 		$this->set_global_get_params( 'https://example.google.com/settings/authorization/wordpress' );
 
 		// Verify that the expected assets aren't enqueued yet.
-		$this->assertFalse( wp_style_is( 'googlesitekit-authorize-application', 'enqueued' ) );
+		$this->assertFalse( wp_style_is( 'googlesitekit-authorize-application-css', 'enqueued' ) );
 
 		$authorize_application = new Authorize_Application( new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE ) );
 		$authorize_application->register();
@@ -82,7 +82,7 @@ class Authorize_ApplicationTest extends TestCase {
 		do_action( 'admin_enqueue_scripts' );
 
 		// Check that expected assets aren't enqueued due to incorrect screen.
-		$this->assertFalse( wp_style_is( 'googlesitekit-authorize-application', 'enqueued' ) );
+		$this->assertFalse( wp_style_is( 'googlesitekit-authorize-application-css', 'enqueued' ) );
 	}
 
 	public function set_global_get_params( $success_url ) {
@@ -104,6 +104,6 @@ class Authorize_ApplicationTest extends TestCase {
 	public function tear_down() {
 		parent::tear_down();
 		$this->unset_global_get_params();
-		wp_dequeue_style( 'googlesitekit-authorize-application' );
+		wp_dequeue_style( 'googlesitekit-authorize-application-css' );
 	}
 }

--- a/tests/phpunit/integration/Core/Admin/Authorize_ApplicationTest.php
+++ b/tests/phpunit/integration/Core/Admin/Authorize_ApplicationTest.php
@@ -93,17 +93,17 @@ class Authorize_ApplicationTest extends TestCase {
 		$_GET['sitekit']     = 'true';
 	}
 
-	public function tear_down() {
-		parent::tear_down();
-		$this->unset_get_params();
-		wp_dequeue_style( 'googlesitekit-authorize-application' );
-	}
-
-	public function unset_get_params() {
+	public function unset_global_get_params() {
 		// Unset $_GET parameters
 		unset( $_GET['app_name'] );
 		unset( $_GET['app_id'] );
 		unset( $_GET['success_url'] );
 		unset( $_GET['sitekit'] );
+	}
+
+    public function tear_down() {
+		parent::tear_down();
+		$this->unset_global_get_params();
+		wp_dequeue_style( 'googlesitekit-authorize-application' );
 	}
 }


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #8504 

## Relevant technical choices

* Initially, the IB proposed validating the specific static path `/settings/authorization/wordpress` within the `success_url`. However, after further discussion and review, the decision was made to validate instead that the `success_url` contains a `.google.com` domain.

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [x] Run the code.
- [x] Ensure the acceptance criteria are satisfied.
- [x] Reassess the implementation with the IB.
- [x] Ensure no unrelated changes are included.
- [x] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [x] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [x] Ensure the PR has the correct target branch.
- [x] Double-check that the PR is okay to be merged.
- [x] Ensure the corresponding issue has a ZenHub release assigned.
- [x] Add a changelog message to the issue.
