### PR TITLE
Update module name to analytics-4 in the settings footer isLoading function.

### DIFF
--- a/assets/js/components/settings/SettingsActiveModule/Footer.js
+++ b/assets/js/components/settings/SettingsActiveModule/Footer.js
@@ -154,7 +154,7 @@ export default function Footer( props ) {
 	// premature interactions by the user.
 	const isLoading = useSelect( ( select ) => {
 		const resolutionMapping = {
-			analytics: 'getAccountSummaries',
+			'analytics-4': 'getAccountSummaries',
 			tagmanager: 'getAccounts',
 			'search-console': 'getMatchedProperties',
 		};


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #8508

## Relevant technical choices

@kelvinballoo found a bug caused by the SAM migration where this module slug was not updated causing the Save button to become prematurely active on the Analytics settings screen.

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [x] Run the code.
- [x] Ensure the acceptance criteria are satisfied.
- [x] Reassess the implementation with the IB.
- [x] Ensure no unrelated changes are included.
- [x] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [x] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
