### PR TITLE
Restore Ads conversion ID labels in Site Health

### DIFF
--- a/includes/Modules/Ads.php
+++ b/includes/Modules/Ads.php
@@ -181,8 +181,8 @@ final class Ads extends Module implements Module_With_Assets, Module_With_Debug_
 		$settings = $this->get_settings()->get();
 
 		return array(
-			'conversion_tracking_id' => array(
-				'label' => __( 'Conversion Tracking ID', 'google-site-kit' ),
+			'ads_conversion_tracking_id' => array(
+				'label' => __( 'Ads Conversion Tracking ID', 'google-site-kit' ),
 				'value' => $settings['conversionID'],
 				'debug' => Debug_Data::redact_debug_value( $settings['conversionID'] ),
 			),

--- a/includes/Modules/Analytics_4.php
+++ b/includes/Modules/Analytics_4.php
@@ -395,11 +395,6 @@ final class Analytics_4 extends Module
 				'value' => $settings['accountID'],
 				'debug' => Debug_Data::redact_debug_value( $settings['accountID'] ),
 			),
-			'analytics_4_ads_conversion_id'           => array(
-				'label' => __( 'Analytics Ads conversion ID', 'google-site-kit' ),
-				'value' => $settings['adsConversionID'],
-				'debug' => Debug_Data::redact_debug_value( $settings['adsConversionID'] ),
-			),
 			'analytics_4_property_id'                 => array(
 				'label' => __( 'Analytics property ID', 'google-site-kit' ),
 				'value' => $settings['propertyID'],
@@ -419,6 +414,11 @@ final class Analytics_4 extends Module
 				'label' => __( 'Analytics snippet placed', 'google-site-kit' ),
 				'value' => $settings['useSnippet'] ? __( 'Yes', 'google-site-kit' ) : __( 'No', 'google-site-kit' ),
 				'debug' => $settings['useSnippet'] ? 'yes' : 'no',
+			),
+			'analytics_4_ads_conversion_id'           => array(
+				'label' => __( 'Analytics Ads conversion ID', 'google-site-kit' ),
+				'value' => $settings['adsConversionID'],
+				'debug' => Debug_Data::redact_debug_value( $settings['adsConversionID'] ),
 			),
 			'analytics_4_available_custom_dimensions' => array(
 				'label' => __( 'Analytics available custom dimensions', 'google-site-kit' ),

--- a/tests/phpunit/integration/Modules/AdsTest.php
+++ b/tests/phpunit/integration/Modules/AdsTest.php
@@ -58,15 +58,15 @@ class AdsTest extends TestCase {
 
 		$this->assertEqualSets(
 			array(
-				'conversion_tracking_id',
+				'ads_conversion_tracking_id',
 			),
 			array_keys( $ads->get_debug_fields() )
 		);
 
 		$this->assertEquals(
 			array(
-				'conversion_tracking_id' => array(
-					'label' => 'Conversion Tracking ID',
+				'ads_conversion_tracking_id' => array(
+					'label' => 'Ads Conversion Tracking ID',
 					'value' => 'AW-123456789',
 					'debug' => 'AW-1••••••••',
 				),


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #8473

## Relevant technical choices

<!-- Please describe your changes. -->

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [ ] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [x] Run the code.
- [x] Ensure the acceptance criteria are satisfied.
- [x] Reassess the implementation with the IB.
- [x] Ensure no unrelated changes are included.
- [x] Ensure CI checks pass.
- [x] Check Storybook where applicable.
- [x] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [x] Ensure the PR has the correct target branch.
- [x] Double-check that the PR is okay to be merged.
- [x] Ensure the corresponding issue has a ZenHub release assigned.
- [x] Add a changelog message to the issue.
