### PR TITLE
Enhance/#8524 - Update WordPress Footer Color (follow-up)

### DIFF
--- a/assets/sass/authorize-application/_googlesitekit-authorize-application.scss
+++ b/assets/sass/authorize-application/_googlesitekit-authorize-application.scss
@@ -21,5 +21,5 @@
 }
 
 #footer-thankyou a {
-	color: $c-deep-blue;
+	color: $c-vivid-blue;
 }

--- a/assets/sass/config/_variables.scss
+++ b/assets/sass/config/_variables.scss
@@ -81,6 +81,7 @@ $c-boulder: #757575;
 $c-mariner: #3367d6;
 $c-woodsmoke: #131418;
 $c-deep-blue: #0b57d0;
+$c-vivid-blue: #1a73e8;
 
 // WordPress core pallete
 // see https://make.wordpress.org/core/2021/02/23/standardization-of-wp-admin-colors-in-wordpress-5-7/


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #8524 

## Relevant technical choices

* This follow-up PR applies the correct color `#1a73e8` to the Authorize Application screen footer. Please refer to this QA [comment](https://github.com/google/site-kit-wp/issues/8524#issuecomment-2071663283).

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
