### PR TITLE
Remove ads module access check in SettingsEdit

### DIFF
--- a/assets/js/modules/ads/components/settings/SettingsEdit.js
+++ b/assets/js/modules/ads/components/settings/SettingsEdit.js
@@ -22,7 +22,6 @@
 import Data from 'googlesitekit-data';
 import { ProgressBar } from 'googlesitekit-components';
 import { MODULES_ADS } from '../../datastore/constants';
-import { CORE_MODULES } from '../../../../googlesitekit/modules/datastore/constants';
 import { CORE_USER } from '../../../../googlesitekit/datastore/user/constants';
 import SettingsForm from './SettingsForm';
 import AdBlockerWarning from '../common/AdBlockerWarning';
@@ -33,10 +32,6 @@ export default function SettingsEdit() {
 		select( MODULES_ADS ).isDoingSubmitChanges()
 	);
 
-	const hasAdsAccess = useSelect( ( select ) =>
-		select( CORE_MODULES ).hasModuleOwnershipOrAccess( 'ads' )
-	);
-
 	const isAdBlockerActive = useSelect( ( select ) =>
 		select( CORE_USER ).isAdBlockerActive()
 	);
@@ -44,10 +39,10 @@ export default function SettingsEdit() {
 	let viewComponent;
 	if ( isAdBlockerActive ) {
 		viewComponent = <AdBlockerWarning />;
-	} else if ( isDoingSubmitChanges || hasAdsAccess === undefined ) {
+	} else if ( isDoingSubmitChanges ) {
 		viewComponent = <ProgressBar />;
 	} else {
-		viewComponent = <SettingsForm hasModuleAccess={ hasAdsAccess } />;
+		viewComponent = <SettingsForm />;
 	}
 
 	return (

--- a/assets/js/modules/ads/components/settings/SettingsForm.js
+++ b/assets/js/modules/ads/components/settings/SettingsForm.js
@@ -19,32 +19,16 @@
 /**
  * WordPress dependencies
  */
-import { createInterpolateElement } from '@wordpress/element';
-import { __, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
-import Data from 'googlesitekit-data';
 import { MODULES_ADS } from '../../datastore/constants';
-import { CORE_MODULES } from '../../../../googlesitekit/modules/datastore/constants';
 import StoreErrorNotices from '../../../../components/StoreErrorNotices';
-import EntityOwnershipChangeNotice from '../../../../components/settings/EntityOwnershipChangeNotice';
-import SettingsNotice from '../../../../components/SettingsNotice/SettingsNotice';
-import { TYPE_INFO } from '../../../../components/SettingsNotice';
-import WarningIcon from '../../../../../../assets/svg/icons/warning-icon.svg';
 import { ConversionIDTextField } from '../common';
-const { useSelect } = Data;
 
-export default function SettingsForm( { hasModuleAccess } ) {
-	const module = useSelect( ( select ) =>
-		select( CORE_MODULES ).getModule( 'ads' )
-	);
-
-	const formattedOwnerName = module?.owner?.login
-		? `<strong>${ module.owner.login }</strong>`
-		: __( 'Another admin', 'google-site-kit' );
-
+export default function SettingsForm() {
 	return (
 		<div className="googlesitekit-ads-settings-fields">
 			<StoreErrorNotices moduleSlug="ads" storeName={ MODULES_ADS } />
@@ -57,29 +41,6 @@ export default function SettingsForm( { hasModuleAccess } ) {
 					) }
 				/>
 			</div>
-
-			{ hasModuleAccess === false && (
-				<SettingsNotice
-					type={ TYPE_INFO }
-					Icon={ WarningIcon }
-					notice={ createInterpolateElement(
-						sprintf(
-							/* translators: 1: module owner's name, 2: module name */
-							__(
-								'%1$s configured %2$s and you don’t have access to it. Contact them to share access.',
-								'google-site-kit'
-							),
-							formattedOwnerName,
-							module?.name
-						),
-						{
-							strong: <strong />,
-						}
-					) }
-				/>
-			) }
-
-			{ hasModuleAccess && <EntityOwnershipChangeNotice slug="ads" /> }
 		</div>
 	);
 }


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #8598

## Relevant technical choices

<!-- Please describe your changes. -->

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [ ] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [x] Run the code.
- [x] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
