### PR TITLE
Issue / 8563 Extends Ads Settings View PAX

### DIFF
--- a/assets/js/modules/ads/components/settings/SettingsView.js
+++ b/assets/js/modules/ads/components/settings/SettingsView.js
@@ -52,65 +52,43 @@ export default function SettingsView() {
 		select( CORE_USER ).isAdBlockerActive()
 	);
 
+	const conversionIDValue =
+		paxEnabled && paxConversionID ? paxConversionID : conversionID;
+
+	const isPaxView = paxEnabled && ( paxConversionID || extCustomerID );
+
 	return (
 		<Fragment>
 			<AdBlockerWarning />
-			{ ! isAdBlockerActive &&
-				( ( ! paxConversionID && ! extCustomerID ) ||
-					! paxEnabled ) && (
-					<div className="googlesitekit-settings-module__meta-item">
-						<h5 className="googlesitekit-settings-module__meta-item-type">
-							{ __(
-								'Conversion Tracking ID',
-								'google-site-kit'
-							) }
-						</h5>
-						<p className="googlesitekit-settings-module__meta-item-data">
-							{ conversionID ? (
-								<DisplaySetting value={ conversionID } />
-							) : (
-								__( 'None', 'google-site-kit' )
-							) }
-						</p>
-					</div>
-				) }
+			{ ! isAdBlockerActive && (
+				<div className="googlesitekit-settings-module__meta-item">
+					<h5 className="googlesitekit-settings-module__meta-item-type">
+						{ __( 'Conversion Tracking ID', 'google-site-kit' ) }
+					</h5>
+					<p className="googlesitekit-settings-module__meta-item-data">
+						{ conversionIDValue ? (
+							<DisplaySetting value={ conversionIDValue } />
+						) : (
+							__( 'None', 'google-site-kit' )
+						) }
+					</p>
+				</div>
+			) }
 
-			{ ! isAdBlockerActive &&
-				paxEnabled &&
-				( paxConversionID || extCustomerID ) && (
-					<div className="googlesitekit-settings-module__meta-item">
-						<h5 className="googlesitekit-settings-module__meta-item-type">
-							{ __(
-								'Conversion Tracking ID',
-								'google-site-kit'
-							) }
-						</h5>
-						<p className="googlesitekit-settings-module__meta-item-data">
-							{ paxConversionID ? (
-								<DisplaySetting value={ paxConversionID } />
-							) : (
-								__( 'None', 'google-site-kit' )
-							) }
-						</p>
-					</div>
-				) }
-
-			{ ! isAdBlockerActive &&
-				paxEnabled &&
-				( paxConversionID || extCustomerID ) && (
-					<div className="googlesitekit-settings-module__meta-item">
-						<h5 className="googlesitekit-settings-module__meta-item-type">
-							{ __( 'Customer ID', 'google-site-kit' ) }
-						</h5>
-						<p className="googlesitekit-settings-module__meta-item-data">
-							{ extCustomerID ? (
-								<DisplaySetting value={ extCustomerID } />
-							) : (
-								__( 'None', 'google-site-kit' )
-							) }
-						</p>
-					</div>
-				) }
+			{ ! isAdBlockerActive && isPaxView && (
+				<div className="googlesitekit-settings-module__meta-item">
+					<h5 className="googlesitekit-settings-module__meta-item-type">
+						{ __( 'Customer ID', 'google-site-kit' ) }
+					</h5>
+					<p className="googlesitekit-settings-module__meta-item-data">
+						{ extCustomerID ? (
+							<DisplaySetting value={ extCustomerID } />
+						) : (
+							__( 'None', 'google-site-kit' )
+						) }
+					</p>
+				</div>
+			) }
 		</Fragment>
 	);
 }

--- a/assets/js/modules/ads/components/settings/SettingsView.js
+++ b/assets/js/modules/ads/components/settings/SettingsView.js
@@ -30,9 +30,12 @@ import { MODULES_ADS } from '../../datastore/constants';
 import { CORE_USER } from '../../../../googlesitekit/datastore/user/constants';
 import DisplaySetting from '../../../../components/DisplaySetting';
 import AdBlockerWarning from '../common/AdBlockerWarning';
+import { useFeature } from './../../../../hooks/useFeature';
 const { useSelect } = Data;
 
 export default function SettingsView() {
+	const paxEnabled = useFeature( 'adsPax' );
+
 	const conversionID = useSelect( ( select ) =>
 		select( MODULES_ADS ).getConversionID()
 	);
@@ -52,50 +55,62 @@ export default function SettingsView() {
 	return (
 		<Fragment>
 			<AdBlockerWarning />
-			{ ! isAdBlockerActive && ! paxConversionID && ! extCustomerID && (
-				<div className="googlesitekit-settings-module__meta-item">
-					<h5 className="googlesitekit-settings-module__meta-item-type">
-						{ __( 'Conversion Tracking ID', 'google-site-kit' ) }
-					</h5>
-					<p className="googlesitekit-settings-module__meta-item-data">
-						{ conversionID ? (
-							<DisplaySetting value={ conversionID } />
-						) : (
-							__( 'None', 'google-site-kit' )
-						) }
-					</p>
-				</div>
-			) }
+			{ ! isAdBlockerActive &&
+				( ( ! paxConversionID && ! extCustomerID ) ||
+					! paxEnabled ) && (
+					<div className="googlesitekit-settings-module__meta-item">
+						<h5 className="googlesitekit-settings-module__meta-item-type">
+							{ __(
+								'Conversion Tracking ID',
+								'google-site-kit'
+							) }
+						</h5>
+						<p className="googlesitekit-settings-module__meta-item-data">
+							{ conversionID ? (
+								<DisplaySetting value={ conversionID } />
+							) : (
+								__( 'None', 'google-site-kit' )
+							) }
+						</p>
+					</div>
+				) }
 
-			{ ! isAdBlockerActive && paxConversionID && extCustomerID && (
-				<div className="googlesitekit-settings-module__meta-item">
-					<h5 className="googlesitekit-settings-module__meta-item-type">
-						{ __( 'Conversion Tracking ID', 'google-site-kit' ) }
-					</h5>
-					<p className="googlesitekit-settings-module__meta-item-data">
-						{ paxConversionID ? (
-							<DisplaySetting value={ paxConversionID } />
-						) : (
-							__( 'None', 'google-site-kit' )
-						) }
-					</p>
-				</div>
-			) }
+			{ ! isAdBlockerActive &&
+				paxEnabled &&
+				( paxConversionID || extCustomerID ) && (
+					<div className="googlesitekit-settings-module__meta-item">
+						<h5 className="googlesitekit-settings-module__meta-item-type">
+							{ __(
+								'Conversion Tracking ID',
+								'google-site-kit'
+							) }
+						</h5>
+						<p className="googlesitekit-settings-module__meta-item-data">
+							{ paxConversionID ? (
+								<DisplaySetting value={ paxConversionID } />
+							) : (
+								__( 'None', 'google-site-kit' )
+							) }
+						</p>
+					</div>
+				) }
 
-			{ ! isAdBlockerActive && paxConversionID && extCustomerID && (
-				<div className="googlesitekit-settings-module__meta-item">
-					<h5 className="googlesitekit-settings-module__meta-item-type">
-						{ __( 'Customer ID', 'google-site-kit' ) }
-					</h5>
-					<p className="googlesitekit-settings-module__meta-item-data">
-						{ extCustomerID ? (
-							<DisplaySetting value={ extCustomerID } />
-						) : (
-							__( 'None', 'google-site-kit' )
-						) }
-					</p>
-				</div>
-			) }
+			{ ! isAdBlockerActive &&
+				paxEnabled &&
+				( paxConversionID || extCustomerID ) && (
+					<div className="googlesitekit-settings-module__meta-item">
+						<h5 className="googlesitekit-settings-module__meta-item-type">
+							{ __( 'Customer ID', 'google-site-kit' ) }
+						</h5>
+						<p className="googlesitekit-settings-module__meta-item-data">
+							{ extCustomerID ? (
+								<DisplaySetting value={ extCustomerID } />
+							) : (
+								__( 'None', 'google-site-kit' )
+							) }
+						</p>
+					</div>
+				) }
 		</Fragment>
 	);
 }

--- a/assets/js/modules/ads/components/settings/SettingsView.stories.js
+++ b/assets/js/modules/ads/components/settings/SettingsView.stories.js
@@ -83,8 +83,11 @@ PaxConnected.scenario = {
 	label: 'Modules/Ads/Settings/SettingsView/PAX',
 	delay: 250,
 };
+PaxConnected.parameters = {
+	features: [ 'adsPax' ],
+};
 PaxConnected.decorators = [
-	( Story ) => {
+	( Story, { parameters } ) => {
 		const setupRegistry = ( registry ) => {
 			// Unset the value set in the prrevious scenario.
 			registry.dispatch( MODULES_ADS ).setConversionID( null );
@@ -96,7 +99,10 @@ PaxConnected.decorators = [
 		};
 
 		return (
-			<WithRegistrySetup func={ setupRegistry }>
+			<WithRegistrySetup
+				func={ setupRegistry }
+				features={ parameters.features || [] }
+			>
 				<Story />
 			</WithRegistrySetup>
 		);


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #8563

## Relevant technical choices

- Updated logic so that PAX view settings show if only one PAX setting has a value
- Added logic for gating PAX ads settings view behind feature flag
- Updated PAX ads settings story to use feature flag

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [x] Run the code.
- [x] Ensure the acceptance criteria are satisfied.
- [x] Reassess the implementation with the IB.
- [x] Ensure no unrelated changes are included.
- [x] Ensure CI checks pass.
- [x] Check Storybook where applicable.
- [x] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
