### PR TITLE
Fix audience resource data availability date reset on module deactivation.

### DIFF
--- a/includes/Modules/Analytics_4.php
+++ b/includes/Modules/Analytics_4.php
@@ -412,10 +412,12 @@ final class Analytics_4 extends Module
 	 * @since 1.30.0
 	 */
 	public function on_deactivation() {
+		// We need to reset the resource data availability date before deleting the settings.
+		// This is because the audience resources are pulled from settings.
+		$this->resource_data_availability_date->reset_all_resource_dates();
 		$this->get_settings()->delete();
 		$this->reset_data_available();
 		$this->custom_dimensions_data_available->reset_data_available();
-		$this->resource_data_availability_date->reset_all_resource_dates();
 	}
 
 	/**

--- a/includes/Modules/Analytics_4.php
+++ b/includes/Modules/Analytics_4.php
@@ -412,8 +412,8 @@ final class Analytics_4 extends Module
 	 * @since 1.30.0
 	 */
 	public function on_deactivation() {
-		// We need to reset the resource data availability date before deleting the settings.
-		// This is because the audience resources are pulled from settings.
+		// We need to reset the resource data availability dates before deleting the settings.
+		// This is because the property ID and the audience resource names are pulled from settings.
 		$this->resource_data_availability_date->reset_all_resource_dates();
 		$this->get_settings()->delete();
 		$this->reset_data_available();

--- a/tests/phpunit/integration/Modules/Analytics_4Test.php
+++ b/tests/phpunit/integration/Modules/Analytics_4Test.php
@@ -313,6 +313,29 @@ class Analytics_4Test extends TestCase {
 		$this->assertNotFalse( get_transient( $test_resource_data_availability_transient_property ) );
 	}
 
+	public function test_register__reset_resource_data_availability_date__on_deactivation() {
+		$this->enable_feature( 'audienceSegmentation' );
+
+		list(
+			,
+			,
+			,
+			$test_resource_data_availability_transient_audience,
+			$test_resource_data_availability_transient_custom_dimension,
+			$test_resource_data_availability_transient_property,
+		) = $this->set_test_resource_data_availability_dates();
+
+		$this->assertNotFalse( get_transient( $test_resource_data_availability_transient_audience ) );
+		$this->assertNotFalse( get_transient( $test_resource_data_availability_transient_custom_dimension ) );
+		$this->assertNotFalse( get_transient( $test_resource_data_availability_transient_property ) );
+
+		$this->analytics->on_deactivation();
+
+		$this->assertFalse( get_transient( $test_resource_data_availability_transient_audience ) );
+		$this->assertFalse( get_transient( $test_resource_data_availability_transient_custom_dimension ) );
+		$this->assertFalse( get_transient( $test_resource_data_availability_transient_property ) );
+	}
+
 	public function test_handle_provisioning_callback() {
 		$context   = new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE, new MutableInput() );
 		$analytics = new Analytics_4( $context );


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #8141 

## Relevant technical choices

This fixes the audience resource date reset on deactivation as spotted by @hussain-t while QA-ing. Also adds some test coverage. 

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [ ] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [x] Run the code.
- [x] Ensure the acceptance criteria are satisfied.
- [x] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [x] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [x] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [x] Ensure the PR has the correct target branch.
- [x] Double-check that the PR is okay to be merged.
- [x] Ensure the corresponding issue has a ZenHub release assigned.
- [x] Add a changelog message to the issue.
