### PR TITLE
Bug/8596 Fix GTM secondary admin settings infinite loading

### DIFF
--- a/includes/Modules/Tag_Manager.php
+++ b/includes/Modules/Tag_Manager.php
@@ -594,7 +594,7 @@ final class Tag_Manager extends Module
 		try {
 			$containers = $this->get_tagmanager_service()->accounts_containers->listAccountsContainers( "accounts/{$account_id}" );
 		} catch ( Exception $e ) {
-			if ( $e->getCode() === 403 ) {
+			if ( $e->getCode() === 404 ) {
 				return false;
 			}
 			return $this->exception_to_error( $e );

--- a/tests/phpunit/includes/Core/Modules/Module_With_Service_Entity_ContractTests.php
+++ b/tests/phpunit/includes/Core/Modules/Module_With_Service_Entity_ContractTests.php
@@ -26,6 +26,14 @@ trait Module_With_Service_Entity_ContractTests {
 	abstract protected function get_module_with_service_entity();
 
 	/**
+	 * All service entities return 403 for the permission denied error,
+	 * except for Tag Manager which returns a 404.
+	 */
+	protected function get_service_entity_no_access_error_code() {
+		return 403;
+	}
+
+	/**
 	 * @group Module_With_Service_Entity
 	 */
 	public function test_check_service_entity_access_success() {
@@ -48,7 +56,8 @@ trait Module_With_Service_Entity_ContractTests {
 		$testcase = $this->get_testcase();
 		$module   = $this->get_module_with_service_entity();
 
-		$this->mock_service_entity_access( $module, 403 );
+		$no_access_error_code = $this->get_service_entity_no_access_error_code();
+		$this->mock_service_entity_access( $module, $no_access_error_code );
 		$this->set_up_check_service_entity_access( $module );
 
 		$access = $module->check_service_entity_access();

--- a/tests/phpunit/integration/Modules/Tag_ManagerTest.php
+++ b/tests/phpunit/integration/Modules/Tag_ManagerTest.php
@@ -488,6 +488,14 @@ class Tag_ManagerTest extends TestCase {
 		return new Tag_Manager( new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE ) );
 	}
 
+	/**
+	 * @return int The error code returned by the listAccountsContainers( "accounts/{account_id}" )
+	 * endpoint when permission is denied.
+	 */
+	protected function get_service_entity_no_access_error_code() {
+		return 404;
+	}
+
 	protected function set_up_check_service_entity_access( Module $module ) {
 		$module->get_settings()->merge(
 			array(


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #8596

## Relevant technical choices

<!-- Please describe your changes. -->

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
