### PR TITLE
Hide the Ads Conversion ID None state from the Analytics Settings view once migration is complete and the banner is dismissed.

### DIFF
--- a/assets/js/modules/analytics-4/components/settings/OptionalSettingsView.js
+++ b/assets/js/modules/analytics-4/components/settings/OptionalSettingsView.js
@@ -37,6 +37,9 @@ export default function OptionalSettingsView() {
 	const useSnippet = useSelect( ( select ) =>
 		select( MODULES_ANALYTICS_4 ).getUseSnippet()
 	);
+	const adsConversionIDMigratedAtMs = useSelect( ( select ) =>
+		select( MODULES_ANALYTICS_4 ).getAdsConversionIDMigratedAtMs()
+	);
 	const trackingDisabled = useSelect(
 		( select ) => select( MODULES_ANALYTICS_4 ).getTrackingDisabled() || []
 	);
@@ -74,7 +77,7 @@ export default function OptionalSettingsView() {
 				</div>
 			</div>
 
-			{ useSnippet && (
+			{ useSnippet && ! adsConversionIDMigratedAtMs && (
 				<div className="googlesitekit-settings-module__meta-items">
 					<div className="googlesitekit-settings-module__meta-item">
 						<h5 className="googlesitekit-settings-module__meta-item-type">


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #8541

## Relevant technical choices

This follow up PR addresses [a UX issue](https://github.com/google/site-kit-wp/issues/8541#issuecomment-2112012997) where, once you have completed the full flow of migration to the Ads module and have dismissed the migration banner, you will still see the "None" state of the Ads Conversion ID in the Analytics module settings view.

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
