### PR TITLE
Hide the Ads Conversion ID None state from the Analytics Settings view after module reset.

### DIFF
--- a/assets/js/modules/analytics-4/components/settings/OptionalSettingsView.js
+++ b/assets/js/modules/analytics-4/components/settings/OptionalSettingsView.js
@@ -77,22 +77,26 @@ export default function OptionalSettingsView() {
 				</div>
 			</div>
 
-			{ useSnippet && ! adsConversionIDMigratedAtMs && (
-				<div className="googlesitekit-settings-module__meta-items">
-					<div className="googlesitekit-settings-module__meta-item">
-						<h5 className="googlesitekit-settings-module__meta-item-type">
-							{ __( 'Ads Conversion ID', 'google-site-kit' ) }
-						</h5>
-						<p className="googlesitekit-settings-module__meta-item-data">
-							{ !! adsConversionID && (
-								<DisplaySetting value={ adsConversionID } />
-							) }
-							{ ! adsConversionID &&
-								__( 'None', 'google-site-kit' ) }
-						</p>
+			{ /* Prevent the Ads Conversion ID setting displaying after this field has been
+				 migrated to the Ads module, even after resetting the Analytics module. */ }
+			{ useSnippet &&
+				! adsConversionIDMigratedAtMs &&
+				!! adsConversionID && (
+					<div className="googlesitekit-settings-module__meta-items">
+						<div className="googlesitekit-settings-module__meta-item">
+							<h5 className="googlesitekit-settings-module__meta-item-type">
+								{ __( 'Ads Conversion ID', 'google-site-kit' ) }
+							</h5>
+							<p className="googlesitekit-settings-module__meta-item-data">
+								{ !! adsConversionID && (
+									<DisplaySetting value={ adsConversionID } />
+								) }
+								{ ! adsConversionID &&
+									__( 'None', 'google-site-kit' ) }
+							</p>
+						</div>
 					</div>
-				</div>
-			) }
+				) }
 
 			<AdsConversionIDSettingsNotice />
 		</Fragment>


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #8541

## Relevant technical choices

I further updated the logic to hide the Ads Conversion ID on the Analytics Settings View even if the user resets the Analytics module.

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
