### PR TITLE
Issue / 8735 Update PAX `termsAndConditions.notify` Response

### DIFF
--- a/assets/js/modules/ads/datastore/constants.js
+++ b/assets/js/modules/ads/datastore/constants.js
@@ -24,3 +24,6 @@ export const PAX_SETUP_STEP = {
 	LAUNCH: 1,
 	FINISHED: 2,
 };
+
+// Date range offset days for Ads report requests.
+export const DATE_RANGE_OFFSET = 1;

--- a/assets/js/modules/ads/pax/services.js
+++ b/assets/js/modules/ads/pax/services.js
@@ -127,7 +127,16 @@ export function createPaxServices( registry, options = {} ) {
 			},
 		},
 		termsAndConditionsService: {
-			notify: () => {
+			// Ignore the ESLint rule that requires `await` in the function body.
+			//
+			// We mark this function as `async` to make it clear that it returns a
+			// promise and in case, in the future, anything here wants to be async.
+			//
+			// Marking this function as `async` makes it clear that this will be
+			// allowed.
+			//
+			// eslint-disable-next-line require-await
+			notify: async () => {
 				return {};
 			},
 		},

--- a/assets/js/modules/ads/pax/services.js
+++ b/assets/js/modules/ads/pax/services.js
@@ -25,10 +25,9 @@ import apiFetch from '@wordpress/api-fetch';
  * Internal dependencies
  */
 import { CORE_SITE } from '../../../googlesitekit/datastore/site/constants';
-import { MODULES_ADS } from '../datastore/constants';
+import { DATE_RANGE_OFFSET, MODULES_ADS } from '../datastore/constants';
 import { formatPaxDate } from './utils';
 import { CORE_USER } from '../../../googlesitekit/datastore/user/constants';
-import { DATE_RANGE_OFFSET } from '../../analytics-4/datastore/constants';
 
 const restFetchWpPages = async () => {
 	try {

--- a/assets/js/modules/ads/pax/services.js
+++ b/assets/js/modules/ads/pax/services.js
@@ -127,7 +127,9 @@ export function createPaxServices( registry, options = {} ) {
 			},
 		},
 		termsAndConditionsService: {
-			notify: async () => {},
+			notify: () => {
+				return {};
+			},
 		},
 		partnerDateRangeService: {
 			// Ignore the ESLint rule that requires `await` in the function body.

--- a/assets/js/modules/ads/pax/services.test.js
+++ b/assets/js/modules/ads/pax/services.test.js
@@ -55,9 +55,9 @@ describe( 'PAX partner services', () => {
 				termsAndConditionsService: {
 					notify: expect.any( Function ),
 				},
-				partnerDateRangeService: expect.objectContaining( {
+				partnerDateRangeService: {
 					get: expect.any( Function ),
-				} ),
+				},
 			} );
 		} );
 
@@ -119,6 +119,27 @@ describe( 'PAX partner services', () => {
 						'http://something.test/homepage'
 					);
 					/* eslint-enable sitekit/acronym-case */
+				} );
+			} );
+		} );
+
+		describe( 'campaignService', () => {
+			describe( 'notifyNewCampaignCreated', () => {
+				it( 'should return a callback function', async () => {
+					const mockOnCampaignCreated = jest.fn();
+					const servicesWithCampaign = createPaxServices( registry, {
+						onCampaignCreated: mockOnCampaignCreated,
+					} );
+
+					await servicesWithCampaign.campaignService.notifyNewCampaignCreated();
+
+					expect( servicesWithCampaign ).toEqual(
+						expect.objectContaining( {
+							campaignService: expect.objectContaining( {
+								notifyNewCampaignCreated: mockOnCampaignCreated,
+							} ),
+						} )
+					);
 				} );
 			} );
 		} );
@@ -197,62 +218,6 @@ describe( 'PAX partner services', () => {
 					] );
 				} );
 			} );
-			describe( 'campaignService', () => {
-				describe( 'notifyNewCampaignCreated', () => {
-					it( 'should return a callback function', async () => {
-						const mockOnCampaignCreated = jest.fn();
-						const servicesWithCampaign = createPaxServices(
-							registry,
-							{ onCampaignCreated: mockOnCampaignCreated }
-						);
-
-						await servicesWithCampaign.campaignService.notifyNewCampaignCreated();
-
-						expect( servicesWithCampaign ).toEqual(
-							expect.objectContaining( {
-								campaignService: expect.objectContaining( {
-									notifyNewCampaignCreated:
-										mockOnCampaignCreated,
-								} ),
-							} )
-						);
-					} );
-				} );
-			} );
-
-			describe( 'partnerDateRangeService', () => {
-				describe( 'get', () => {
-					it( 'should contain startDate and endDate properties', async () => {
-						const partnerDateRange =
-							await services.partnerDateRangeService.get();
-
-						expect( partnerDateRange ).toHaveProperty(
-							'startDate'
-						);
-						expect( partnerDateRange ).toHaveProperty( 'endDate' );
-					} );
-
-					it( 'should contain correct accessToken', async () => {
-						registry
-							.dispatch( CORE_USER )
-							.setReferenceDate( '2020-09-08' );
-
-						const partnerDateRange =
-							await services.partnerDateRangeService.get();
-
-						expect( partnerDateRange.startDate ).toEqual( {
-							day: 11,
-							month: 8,
-							year: 2020,
-						} );
-						expect( partnerDateRange.endDate ).toEqual( {
-							day: 7,
-							month: 9,
-							year: 2020,
-						} );
-					} );
-				} );
-			} );
 
 			describe( 'getSupportedConversionTrackingTypes', () => {
 				it( 'should return the expected supported types', async () => {
@@ -263,6 +228,43 @@ describe( 'PAX partner services', () => {
 
 					expect( supportedTypes ).toMatchObject( {
 						conversionTrackingTypes: [ 'TYPE_PAGE_VIEW' ],
+					} );
+				} );
+			} );
+		} );
+
+		describe( 'partnerDateRangeService', () => {
+			describe( 'get', () => {
+				it( 'should contain startDate and endDate properties', async () => {
+					const partnerDateRange =
+						await services.partnerDateRangeService.get();
+
+					expect( partnerDateRange ).toHaveProperty( 'startDate' );
+					expect( partnerDateRange ).toHaveProperty( 'endDate' );
+				} );
+
+				it( 'should contain correct Date values', async () => {
+					registry
+						.dispatch( CORE_USER )
+						.setReferenceDate( '2020-09-08' );
+					// Set the date range so that it selects the range we should expect:
+					// Sept 1 - Sept 7
+					registry
+						.dispatch( CORE_USER )
+						.setDateRange( 'last-7-days' );
+
+					const partnerDateRange =
+						await services.partnerDateRangeService.get();
+
+					expect( partnerDateRange.startDate ).toEqual( {
+						month: 9,
+						day: 1,
+						year: 2020,
+					} );
+					expect( partnerDateRange.endDate ).toEqual( {
+						month: 9,
+						day: 7,
+						year: 2020,
 					} );
 				} );
 			} );

--- a/assets/js/modules/ads/pax/services.test.js
+++ b/assets/js/modules/ads/pax/services.test.js
@@ -269,13 +269,15 @@ describe( 'PAX partner services', () => {
 		} );
 
 		describe( 'termsAndConditionsService', () => {
-			it( 'notify callback should return an empty object', async () => {
-				const termsAndConditionsServiceNotifyResponse =
-					await services.termsAndConditionsService.notify();
+			describe( 'notify', () => {
+				it( 'notify callback should return an empty object', async () => {
+					const termsAndConditionsServiceNotifyResponse =
+						await services.termsAndConditionsService.notify();
 
-				expect( termsAndConditionsServiceNotifyResponse ).toEqual(
-					{}
-				);
+					expect( termsAndConditionsServiceNotifyResponse ).toEqual(
+						{}
+					);
+				} );
 			} );
 		} );
 	} );

--- a/assets/js/modules/ads/pax/services.test.js
+++ b/assets/js/modules/ads/pax/services.test.js
@@ -267,5 +267,16 @@ describe( 'PAX partner services', () => {
 				} );
 			} );
 		} );
+
+		describe( 'termsAndConditionsService', () => {
+			it( 'notify callback should return an empty object', async () => {
+				const termsAndConditionsServiceNotifyResponse =
+					await services.termsAndConditionsService.notify();
+
+				expect( termsAndConditionsServiceNotifyResponse ).toMatchObject(
+					{}
+				);
+			} );
+		} );
 	} );
 } );

--- a/assets/js/modules/ads/pax/services.test.js
+++ b/assets/js/modules/ads/pax/services.test.js
@@ -253,17 +253,17 @@ describe( 'PAX partner services', () => {
 					} );
 				} );
 			} );
-		} );
 
-		describe( 'getSupportedConversionTrackingTypes', () => {
-			it( 'should return the expected supported types', async () => {
-				const supportedTypes =
-					await services.conversionTrackingService.getSupportedConversionTrackingTypes(
-						{}
-					);
+			describe( 'getSupportedConversionTrackingTypes', () => {
+				it( 'should return the expected supported types', async () => {
+					const supportedTypes =
+						await services.conversionTrackingService.getSupportedConversionTrackingTypes(
+							{}
+						);
 
-				expect( supportedTypes ).toMatchObject( {
-					conversionTrackingTypes: [ 'TYPE_PAGE_VIEW' ],
+					expect( supportedTypes ).toMatchObject( {
+						conversionTrackingTypes: [ 'TYPE_PAGE_VIEW' ],
+					} );
 				} );
 			} );
 		} );


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #8735

## Relevant technical choices

- Updated `assets/js/modules/ads/pax/services.js`
    - Updated `termsAndConditions.notify` function body to return empty object, `return {};`
- Update test suite at `assets/js/modules/ads/pax/services.test.js`
    - Added new test in `termsAndConditionsService`to assert that `termsAndConditions.notify` returns an empty object

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
