### PR TITLE
Issue / 8777 Prevent Conversion Tracking When Toggled Off

### DIFF
--- a/includes/Core/Conversion_Tracking/Conversion_Tracking.php
+++ b/includes/Core/Conversion_Tracking/Conversion_Tracking.php
@@ -92,7 +92,7 @@ class Conversion_Tracking {
 		$this->conversion_tracking_settings->register();
 		$this->rest_conversion_tracking_controller->register();
 
-		if ( $this->conversion_tracking_settings->is_conversion_tracking_enabled() ) {
+		if ( ! $this->conversion_tracking_settings->is_conversion_tracking_enabled() ) {
 			return;
 		}
 

--- a/includes/Core/Conversion_Tracking/Conversion_Tracking.php
+++ b/includes/Core/Conversion_Tracking/Conversion_Tracking.php
@@ -92,29 +92,33 @@ class Conversion_Tracking {
 		$this->conversion_tracking_settings->register();
 		$this->rest_conversion_tracking_controller->register();
 
-		add_action(
-			'wp_enqueue_scripts',
-			function() {
-				// Do nothing if neither Ads nor Analytics snippet has been inserted.
-				if ( ! $this->conversion_tracking_settings->is_conversion_tracking_enabled() || ( ! did_action( 'googlesitekit_ads_init_tag' ) && ! did_action( 'googlesitekit_analytics-4_init_tag' ) ) ) {
-					return;
-				}
+		add_action( 'wp_enqueue_scripts', fn () => $this->maybe_enqueue_scripts(), 30 );
+	}
 
-				$active_providers = $this->get_active_providers();
+	/**
+	 * Enqueues conversion tracking scripts if conditions are satisfied.
+	 */
+	protected function maybe_enqueue_scripts() {
+		if (
+			// Do nothing if neither Ads nor Analytics *web* snippet has been inserted.
+			! ( did_action( 'googlesitekit_ads_init_tag' ) || did_action( 'googlesitekit_analytics-4_init_tag' ) )
+			|| ! $this->conversion_tracking_settings->is_conversion_tracking_enabled()
+		) {
+			return;
+		}
 
-				array_walk(
-					$active_providers,
-					function( Conversion_Events_Provider $active_provider ) {
-						$script_asset = $active_provider->register_script();
-						$script_asset->enqueue();
-					}
-				);
+		$active_providers = $this->get_active_providers();
 
-				wp_add_inline_script( GTag::HANDLE, 'window._googlesitekit = window._googlesitekit || {};' );
-				wp_add_inline_script( GTag::HANDLE, 'window._googlesitekit.trackEvent = (name, data) => gtag("event", name, {...data, _source: "site-kit" });' );
-			},
-			30
+		array_walk(
+			$active_providers,
+			function( Conversion_Events_Provider $active_provider ) {
+				$script_asset = $active_provider->register_script();
+				$script_asset->enqueue();
+			}
 		);
+
+		wp_add_inline_script( GTag::HANDLE, 'window._googlesitekit = window._googlesitekit || {};' );
+		wp_add_inline_script( GTag::HANDLE, 'window._googlesitekit.trackEvent = (name, data) => gtag("event", name, {...data, _source: "site-kit" });' );
 	}
 
 	/**

--- a/includes/Core/Conversion_Tracking/Conversion_Tracking.php
+++ b/includes/Core/Conversion_Tracking/Conversion_Tracking.php
@@ -92,6 +92,10 @@ class Conversion_Tracking {
 		$this->conversion_tracking_settings->register();
 		$this->rest_conversion_tracking_controller->register();
 
+		if ( $this->conversion_tracking_settings->is_conversion_tracking_enabled() ) {
+			return;
+		}
+
 		add_action(
 			'wp_enqueue_scripts',
 			function() {

--- a/includes/Core/Conversion_Tracking/Conversion_Tracking.php
+++ b/includes/Core/Conversion_Tracking/Conversion_Tracking.php
@@ -92,15 +92,11 @@ class Conversion_Tracking {
 		$this->conversion_tracking_settings->register();
 		$this->rest_conversion_tracking_controller->register();
 
-		if ( ! $this->conversion_tracking_settings->is_conversion_tracking_enabled() ) {
-			return;
-		}
-
 		add_action(
 			'wp_enqueue_scripts',
 			function() {
 				// Do nothing if neither Ads nor Analytics snippet has been inserted.
-				if ( ! did_action( 'googlesitekit_ads_init_tag' ) && ! did_action( 'googlesitekit_analytics-4_init_tag' ) ) {
+				if ( ! $this->conversion_tracking_settings->is_conversion_tracking_enabled() || ( ! did_action( 'googlesitekit_ads_init_tag' ) && ! did_action( 'googlesitekit_analytics-4_init_tag' ) ) ) {
 					return;
 				}
 

--- a/tests/phpunit/integration/Core/Conversion_Tracking/Conversion_TrackingTest.php
+++ b/tests/phpunit/integration/Core/Conversion_Tracking/Conversion_TrackingTest.php
@@ -64,7 +64,6 @@ class Conversion_TrackingTest extends TestCase {
 			'enabled' => true,
 		);
 
-		$this->conversion_tracking_settings->register();
 		$this->conversion_tracking_settings->set( $original_conversion_tracking_settings );
 	}
 
@@ -82,7 +81,6 @@ class Conversion_TrackingTest extends TestCase {
 			'enabled' => false,
 		);
 
-		$this->conversion_tracking_settings->register();
 		$this->conversion_tracking_settings->set( $original_conversion_tracking_settings );
 
 		$this->conversion_tracking->register();

--- a/tests/phpunit/integration/Core/Conversion_Tracking/Conversion_TrackingTest.php
+++ b/tests/phpunit/integration/Core/Conversion_Tracking/Conversion_TrackingTest.php
@@ -43,12 +43,8 @@ class Conversion_TrackingTest extends TestCase {
 		$this->conversion_tracking          = new Conversion_Tracking( $context, $options );
 		$this->conversion_tracking_settings = new Conversion_Tracking_Settings( $options );
 
-		$original_conversion_tracking_settings = array(
-			'enabled' => true,
-		);
-
 		$this->conversion_tracking_settings->register();
-		$this->conversion_tracking_settings->set( $original_conversion_tracking_settings );
+		$this->conversion_tracking_settings->set( array( 'enabled' => true ) );
 
 		Conversion_Tracking::$providers = array(
 			FakeConversionEventProvider::CONVERSION_EVENT_PROVIDER_SLUG        => FakeConversionEventProvider::class,
@@ -60,12 +56,6 @@ class Conversion_TrackingTest extends TestCase {
 		parent::tear_down();
 
 		Conversion_Tracking::$providers = array();
-
-		$original_conversion_tracking_settings = array(
-			'enabled' => true,
-		);
-
-		$this->conversion_tracking_settings->set( $original_conversion_tracking_settings );
 	}
 
 	public function test_register__not_enqueued_when_no_snippet_inserted() {
@@ -78,11 +68,7 @@ class Conversion_TrackingTest extends TestCase {
 	}
 
 	public function test_register__not_enqueued_when_tracking_disabled() {
-		$original_conversion_tracking_settings = array(
-			'enabled' => false,
-		);
-
-		$this->conversion_tracking_settings->set( $original_conversion_tracking_settings );
+		$this->conversion_tracking_settings->set( array( 'enabled' => false ) );
 
 		$this->conversion_tracking->register();
 

--- a/tests/phpunit/integration/Core/Conversion_Tracking/Conversion_TrackingTest.php
+++ b/tests/phpunit/integration/Core/Conversion_Tracking/Conversion_TrackingTest.php
@@ -38,8 +38,9 @@ class Conversion_TrackingTest extends TestCase {
 	public function set_up() {
 		parent::set_up();
 
-		$this->conversion_tracking          = new Conversion_Tracking( new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE ), new Options( new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE ) ) );
-		$options                            = new Options( new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE ) );
+		$context                            = new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE );
+		$options                            = new Options( $context );
+		$this->conversion_tracking          = new Conversion_Tracking( $context, $options );
 		$this->conversion_tracking_settings = new Conversion_Tracking_Settings( $options );
 
 		$original_conversion_tracking_settings = array(


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #8777

## Relevant technical choices

- Added gating of event provider script enqueue if conversion tracking is not enabled.
- Updated test suite for `Conversion_TrackingTest` to add test that asserts scripts are not enqueued when conversion tracking is disabled.

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [x] Run the code.
- [x] Ensure the acceptance criteria are satisfied.
- [x] Reassess the implementation with the IB.
- [x] Ensure no unrelated changes are included.
- [x] Ensure CI checks pass.
- [x] Check Storybook where applicable.
- [x] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
