### PR TITLE
Add onClose prop to the Dialog component.

### DIFF
--- a/assets/js/components/ModalDialog.js
+++ b/assets/js/components/ModalDialog.js
@@ -64,6 +64,7 @@ function ModalDialog( {
 	return (
 		<Dialog
 			open={ dialogActive }
+			onClose={ handleDialog }
 			aria-describedby={ hasProvides ? describedByID : undefined }
 			tabIndex="-1"
 			className={ classnames( className, {

--- a/assets/js/components/ModalDialog.js
+++ b/assets/js/components/ModalDialog.js
@@ -46,6 +46,7 @@ function ModalDialog( {
 	className = '',
 	dialogActive = false,
 	handleDialog = null,
+	onClose = null,
 	title = null,
 	provides,
 	handleConfirm,
@@ -64,7 +65,7 @@ function ModalDialog( {
 	return (
 		<Dialog
 			open={ dialogActive }
-			onClose={ handleDialog }
+			onClose={ onClose }
 			aria-describedby={ hasProvides ? describedByID : undefined }
 			tabIndex="-1"
 			className={ classnames( className, {

--- a/assets/js/components/conversion-tracking/ConfirmDisableConversionTrackingDialog.js
+++ b/assets/js/components/conversion-tracking/ConfirmDisableConversionTrackingDialog.js
@@ -56,6 +56,7 @@ export default function ConfirmDisableConversionTrackingDialog( {
 			subtitle={ subtitle }
 			handleConfirm={ onConfirm }
 			handleDialog={ onCancel }
+			onClose={ onCancel }
 			provides={ provides }
 			confirmButton={ __( 'Disable', 'google-site-kit' ) }
 			danger


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #8818

## Relevant technical choices

* Diverged a bit from the IB, by adding the `onClose` prop instead, which inherits `onCancel` prop. Since not all components where using `handlePopup` just to close it, 2 tests were failing, as they have custom listeners and additional logic. But `onCancel` is always used just for closing the popup

<!-- Please describe your changes. -->

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
