### PR TITLE
Fix the migration notice banner not showing and the banner position on settings edit.

### DIFF
--- a/assets/js/modules/analytics-4/components/settings/SettingsForm.js
+++ b/assets/js/modules/analytics-4/components/settings/SettingsForm.js
@@ -52,12 +52,7 @@ export default function SettingsForm( { hasModuleAccess } ) {
 		<Fragment>
 			<SettingsControls hasModuleAccess={ hasModuleAccess } />
 
-			{ isValidAccountID( accountID ) && (
-				<Fragment>
-					<TrackingExclusionSwitches />
-					<AdsConversionIDSettingsNotice />
-				</Fragment>
-			) }
+			{ isValidAccountID( accountID ) && <TrackingExclusionSwitches /> }
 
 			{ hasModuleAccess && (
 				<EntityOwnershipChangeNotice slug={ [ 'analytics-4' ] } />
@@ -70,6 +65,10 @@ export default function SettingsForm( { hasModuleAccess } ) {
 						'google-site-kit'
 					) }
 				</ConversionTrackingToggle>
+			) }
+
+			{ isValidAccountID( accountID ) && (
+				<AdsConversionIDSettingsNotice />
 			) }
 		</Fragment>
 	);

--- a/includes/Core/Util/Migration_Conversion_ID.php
+++ b/includes/Core/Util/Migration_Conversion_ID.php
@@ -140,7 +140,7 @@ class Migration_Conversion_ID {
 		$this->ads_settings->set( $ads_settings );
 
 		unset( $analytics_settings['adsConversionID'] );
-		$analytics_settings['adsConversionIDMigratedAtMs'] = time();
+		$analytics_settings['adsConversionIDMigratedAtMs'] = time() * 1000;
 
 		$this->analytics_settings->set( $analytics_settings );
 	}


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #8455 

## Relevant technical choices

@mohitwp noticed the banner didn't show correctly after a successful migration. This was due to the timestamp being a PHP timestamp which meant that the 28 days check would never pass, I also noticed when fixing this that the banner on the edit page looked odd as it was in between checkboxes so I fixed that also.

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
