### PR TITLE
Ensure hooks for conversion tracking classes can be registered.

### DIFF
--- a/includes/Core/Conversion_Tracking/Conversion_Event_Providers/WooCommerce.php
+++ b/includes/Core/Conversion_Tracking/Conversion_Event_Providers/WooCommerce.php
@@ -72,7 +72,7 @@ class WooCommerce extends Conversion_Events_Provider {
 	/**
 	 * Adds a hook for a purchase event.
 	 *
-	 * @since n.e.x.t
+	 * @since 1.129.0
 	 */
 	public function register_hooks() {
 		$is_active = $this->is_active();

--- a/includes/Core/Conversion_Tracking/Conversion_Event_Providers/WooCommerce.php
+++ b/includes/Core/Conversion_Tracking/Conversion_Event_Providers/WooCommerce.php
@@ -66,21 +66,24 @@ class WooCommerce extends Conversion_Events_Provider {
 
 		$script->register( $this->context );
 
-		$this->add_purchase_event_hook();
-
 		return $script;
 	}
 
 	/**
 	 * Adds a hook for a purchase event.
+	 *
+	 * @since n.e.x.t
 	 */
-	public function add_purchase_event_hook() {
+	public function register_hooks() {
+		$is_active = $this->is_active();
+		$input     = $this->context->input();
+
 		add_action(
 			'woocommerce_thankyou',
-			function ( $order_id ) {
+			function ( $order_id ) use ( $input, $is_active ) {
 				// Don't output this script tag if conversion tracking is
 				// disabled.
-				if ( ! $this->is_active() ) {
+				if ( ! $is_active ) {
 					return;
 				}
 
@@ -95,7 +98,6 @@ class WooCommerce extends Conversion_Events_Provider {
 
 				// Ensure the order key in the query param is valid for this
 				// order.
-				$input     = $this->context->input();
 				$order_key = $input->filter( INPUT_GET, 'key' );
 
 				// Don't output the script tag if the order key is invalid.
@@ -115,5 +117,4 @@ class WooCommerce extends Conversion_Events_Provider {
 			1
 		);
 	}
-
 }

--- a/includes/Core/Conversion_Tracking/Conversion_Event_Providers/WooCommerce.php
+++ b/includes/Core/Conversion_Tracking/Conversion_Event_Providers/WooCommerce.php
@@ -75,18 +75,11 @@ class WooCommerce extends Conversion_Events_Provider {
 	 * @since 1.129.0
 	 */
 	public function register_hooks() {
-		$is_active = $this->is_active();
-		$input     = $this->context->input();
+		$input = $this->context->input();
 
 		add_action(
 			'woocommerce_thankyou',
-			function ( $order_id ) use ( $input, $is_active ) {
-				// Don't output this script tag if conversion tracking is
-				// disabled.
-				if ( ! $is_active ) {
-					return;
-				}
-
+			function ( $order_id ) use ( $input ) {
 				$order = wc_get_order( $order_id );
 
 				// If there isn't a valid order for this ID, or if this order

--- a/includes/Core/Conversion_Tracking/Conversion_Events_Provider.php
+++ b/includes/Core/Conversion_Tracking/Conversion_Events_Provider.php
@@ -63,6 +63,16 @@ abstract class Conversion_Events_Provider {
 	abstract public function get_event_names();
 
 	/**
+	 * Registers any actions/hooks for this provider.
+	 *
+	 * @since n.e.x.t
+	 */
+	public function register_hooks() {
+		// No-op by default, but left here so subclasses can implement
+		// their own `add_action`/hook calls.
+	}
+
+	/**
 	 * Registers the script for the provider.
 	 *
 	 * @since 1.125.0

--- a/includes/Core/Conversion_Tracking/Conversion_Events_Provider.php
+++ b/includes/Core/Conversion_Tracking/Conversion_Events_Provider.php
@@ -65,7 +65,7 @@ abstract class Conversion_Events_Provider {
 	/**
 	 * Registers any actions/hooks for this provider.
 	 *
-	 * @since n.e.x.t
+	 * @since 1.129.0
 	 */
 	public function register_hooks() {
 		// No-op by default, but left here so subclasses can implement

--- a/includes/Core/Conversion_Tracking/Conversion_Tracking.php
+++ b/includes/Core/Conversion_Tracking/Conversion_Tracking.php
@@ -93,6 +93,15 @@ class Conversion_Tracking {
 		$this->rest_conversion_tracking_controller->register();
 
 		add_action( 'wp_enqueue_scripts', fn () => $this->maybe_enqueue_scripts(), 30 );
+
+		$active_providers = $this->get_active_providers();
+
+		array_walk(
+			$active_providers,
+			function( Conversion_Events_Provider $active_provider ) {
+				$active_provider->register_hooks();
+			}
+		);
 	}
 
 	/**

--- a/tests/phpunit/includes/Core/Conversion_Tracking/Conversion_Event_Providers/FakeConversionEventProvider.php
+++ b/tests/phpunit/includes/Core/Conversion_Tracking/Conversion_Event_Providers/FakeConversionEventProvider.php
@@ -50,4 +50,14 @@ class FakeConversionEventProvider extends Conversion_Events_Provider {
 		return $script_asset;
 	}
 
+	/**
+	 * Registers any actions/hooks for this provider.
+	 *
+	 * @since 1.129.0
+	 */
+	public function register_hooks() {
+		// Register a fake action.
+		add_action( 'fake_provider_action', '__return_true' );
+	}
+
 }

--- a/tests/phpunit/integration/Core/Conversion_Tracking/Conversion_Event_Providers/WooCommerceTest.php
+++ b/tests/phpunit/integration/Core/Conversion_Tracking/Conversion_Event_Providers/WooCommerceTest.php
@@ -49,4 +49,10 @@ class WooCommerceTest extends TestCase {
 		$this->assertTrue( wp_script_is( $handle, 'registered' ) );
 	}
 
+	public function test_register_hooks() {
+		$this->assertFalse( has_action( 'woocommerce_thankyou' ) );
+		$this->woocommerce->register_hooks();
+		$this->assertTrue( has_action( 'woocommerce_thankyou' ) );
+	}
+
 }

--- a/tests/phpunit/integration/Core/Conversion_Tracking/Conversion_TrackingTest.php
+++ b/tests/phpunit/integration/Core/Conversion_Tracking/Conversion_TrackingTest.php
@@ -82,6 +82,8 @@ class Conversion_TrackingTest extends TestCase {
 	 * @dataProvider data_modules
 	 */
 	public function test_register__enqueued_when_snippet_inserted( $module_slug ) {
+		$this->assertFalse( has_action( 'fake_provider_action' ) );
+
 		$this->conversion_tracking->register();
 
 		do_action( "googlesitekit_{$module_slug}_init_tag" );
@@ -89,6 +91,8 @@ class Conversion_TrackingTest extends TestCase {
 
 		$this->assertTrue( wp_script_is( 'gsk-cep-' . FakeConversionEventProvider_Active::CONVERSION_EVENT_PROVIDER_SLUG ) );
 		$this->assertFalse( wp_script_is( 'gsk-cep-' . FakeConversionEventProvider::CONVERSION_EVENT_PROVIDER_SLUG ) );
+
+		$this->assertTrue( has_action( 'fake_provider_action' ) );
 	}
 
 	public function data_modules() {


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #8814

## Relevant technical choices

Needed to add a new method to `Conversion_Events_Provider` classes that allows us to register hooks outside of `register_script`, which is already [called inside an action](https://github.com/google/site-kit-wp/blob/259adc5302288b3c944cf6228d33aa97fd3f11b5/includes/Core/Conversion_Tracking/Conversion_Tracking.php#L95) so would register too late and not run.

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
