### PR TITLE
Replace __experimentalResolveSelect with resolveSelect.

### DIFF
--- a/assets/js/modules/analytics-4/components/audience-segmentation/dashboard/AudienceSelectionPanel/ErrorNotice.js
+++ b/assets/js/modules/analytics-4/components/audience-segmentation/dashboard/AudienceSelectionPanel/ErrorNotice.js
@@ -25,7 +25,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import Data from 'googlesitekit-data';
+import { useSelect, useDispatch } from 'googlesitekit-data';
 import { CORE_SITE } from '../../../../../../googlesitekit/datastore/site/constants';
 import { MODULES_ANALYTICS_4 } from '../../../../datastore/constants';
 import { isInsufficientPermissionsError } from '../../../../../../util/errors';
@@ -33,8 +33,6 @@ import Link from '../../../../../../components/Link';
 import ReportErrorActions from '../../../../../../components/ReportErrorActions';
 import RequestAccessButton from './RequestAccessButton';
 import RetryButton from './RetryButton';
-
-const { useSelect, useDispatch } = Data;
 
 export default function ErrorNotice() {
 	const syncAvailableAudiencesError = useSelect( ( select ) =>

--- a/assets/js/modules/analytics-4/datastore/audiences.js
+++ b/assets/js/modules/analytics-4/datastore/audiences.js
@@ -304,9 +304,7 @@ const baseActions = {
 			} );
 
 			yield commonActions.await(
-				__experimentalResolveSelect(
-					MODULES_ANALYTICS_4
-				).getAudienceSettings()
+				resolveSelect( MODULES_ANALYTICS_4 ).getAudienceSettings()
 			);
 
 			if ( failedAudiencesToRetry.length > 0 ) {

--- a/assets/js/modules/reader-revenue-manager/index.js
+++ b/assets/js/modules/reader-revenue-manager/index.js
@@ -57,9 +57,7 @@ export const registerModule = isRrmModuleEnabled( ( modules ) => {
 		],
 		checkRequirements: async ( registry ) => {
 			// Ensure the site info is resolved to get the home URL.
-			await registry
-				.__experimentalResolveSelect( CORE_SITE )
-				.getSiteInfo();
+			await registry.resolveSelect( CORE_SITE ).getSiteInfo();
 			const homeURL = registry.select( CORE_SITE ).getHomeURL();
 
 			if ( isURLUsingHTTPS( homeURL ) ) {


### PR DESCRIPTION
## Summary

This is a followup to https://github.com/google/site-kit-wp/pull/8891, replacing calls to `__experimentalResolveSelect()` which were added after `develop` was last merged into that PR's branch.

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #8826 

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
