### PR TITLE
Enhance/#8134 - Fix re-creating audiences when available (follow-up)

### DIFF
--- a/assets/js/modules/analytics-4/datastore/audiences.js
+++ b/assets/js/modules/analytics-4/datastore/audiences.js
@@ -205,7 +205,7 @@ const baseActions = {
 
 		const configuredAudiences = [];
 
-		if ( ! failedSiteKitAudienceSlugs ) {
+		if ( ! failedSiteKitAudienceSlugs?.length ) {
 			if ( userAudiences.length > 0 ) {
 				// If there are user audiences, filter and sort them by total users over the last 90 days,
 				// and add the top two (MAX_INITIAL_AUDIENCES) which have users to the configured audiences.


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #8134 

## Relevant technical choices

* This PR fixes the logic that tries to recreate `new-visitors` and `returning-visitors` audiences when they are already available.

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
