### PR TITLE
Fix platform name for proxy.

### DIFF
--- a/includes/Core/Authentication/Google_Proxy.php
+++ b/includes/Core/Authentication/Google_Proxy.php
@@ -583,7 +583,7 @@ class Google_Proxy {
 		if ( is_multisite() ) {
 			return 'wordpress-multisite';
 		}
-		return 'WordPress'; // phpcs:ignore WordPress.WP.CapitalPDangit.Misspelled
+		return 'wordpress'; // phpcs:ignore WordPress.WP.CapitalPDangit.MisspelledInText
 	}
 
 	/**

--- a/tests/phpunit/integration/Core/Authentication/Google_ProxyTest.php
+++ b/tests/phpunit/integration/Core/Authentication/Google_ProxyTest.php
@@ -452,7 +452,7 @@ class Google_ProxyTest extends TestCase {
 			array(
 				'site_id'                => $site_id,
 				'site_secret'            => $site_secret,
-				'platform'               => is_multisite() ? 'wordpress-multisite/google-site-kit' : 'WordPress/google-site-kit',
+				'platform'               => is_multisite() ? 'wordpress-multisite/google-site-kit' : 'wordpress/google-site-kit',
 				'version'                => GOOGLESITEKIT_VERSION,
 				'platform_version'       => $wp_version,
 				'user_count'             => 5, // 1 default admin + 1 admin + 2 editors + 1 subscriber.
@@ -492,7 +492,7 @@ class Google_ProxyTest extends TestCase {
 	 * @group ms-excluded
 	 */
 	public function test_get_platform() {
-		$this->assertEquals( 'WordPress', Google_Proxy::get_platform() ); // phpcs:ignore WordPress.WP.CapitalPDangit.Misspelled
+		$this->assertEquals( 'wordpress', Google_Proxy::get_platform() ); // phpcs:ignore WordPress.WP.CapitalPDangit.MisspelledInText
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Prevents this error from being returned by the SKS when setting up Site Kit:

![image](https://github.com/google/site-kit-wp/assets/18395600/b8256f4b-7c24-4c3d-8331-fe4652488edd)

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #8724 

## Relevant technical choices

<!-- Please describe your changes. -->

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
