### PR TITLE
Prevent duplicate consent update calls

### DIFF
--- a/assets/js/consent-mode/consent-mode.js
+++ b/assets/js/consent-mode/consent-mode.js
@@ -17,7 +17,7 @@
 /**
  * External dependencies
  */
-const { isEqual } = require( 'lodash' );
+import { isEqual } from 'lodash';
 
 ( function () {
 	function actionConsentChange( event ) {

--- a/assets/js/consent-mode/consent-mode.js
+++ b/assets/js/consent-mode/consent-mode.js
@@ -14,6 +14,11 @@
  * limitations under the License.
  */
 
+/**
+ * External dependencies
+ */
+const { isEqual } = require( 'lodash' );
+
 ( function () {
 	function actionConsentChange( event ) {
 		if ( event.detail ) {
@@ -62,8 +67,13 @@
 				}
 			}
 		);
-		if ( hasConsentParameters ) {
+		if (
+			hasConsentParameters &&
+			// Prevent duplicate calls to gtag, only updating if the consent parameters have changed.
+			! isEqual( consentParameters, global._googlesitekitConsents )
+		) {
 			global.gtag( 'consent', 'update', consentParameters );
+			global._googlesitekitConsents = consentParameters;
 		}
 	}
 	document.addEventListener(

--- a/assets/js/consent-mode/consent-mode.test.js
+++ b/assets/js/consent-mode/consent-mode.test.js
@@ -29,11 +29,18 @@ describe( 'Consent Mode', () => {
 		global._googlesitekitConsentCategoryMap = {
 			'test-category': [ 'test-parameter' ],
 		};
+		global.wp_consent_type = 'optin';
+		global.wp_has_consent = () => true;
+		global._googlesitekitConsents = {};
 	} );
 
 	afterEach( () => {
+		gtagMock.mockReset();
 		delete global.gtag;
 		delete global._googlesitekitConsentCategoryMap;
+		delete global.wp_consent_type;
+		delete global.wp_has_consent;
+		delete global._googlesitekitConsents;
 	} );
 
 	it( 'should call gtag with the correct parameters when wp_listen_for_consent_change event is triggered', () => {
@@ -68,5 +75,18 @@ describe( 'Consent Mode', () => {
 		expect( gtagMock ).toHaveBeenCalledWith( 'consent', 'update', {
 			'test-parameter': 'granted',
 		} );
+	} );
+
+	it( 'should not trigger duplicate calls to gtag if the consent parameter have not changed', () => {
+		document.dispatchEvent( new Event( 'DOMContentLoaded' ) );
+		document.dispatchEvent(
+			new CustomEvent( 'wp_consent_type_defined', {
+				detail: {
+					'test-category': 'allow',
+				},
+			} )
+		);
+
+		expect( gtagMock ).toHaveBeenCalledTimes( 1 );
 	} );
 } );

--- a/includes/Core/Consent_Mode/Consent_Mode.php
+++ b/includes/Core/Consent_Mode/Consent_Mode.php
@@ -175,6 +175,7 @@ class Consent_Mode {
 window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments);}
 gtag('consent', 'default', <?php echo wp_json_encode( $consent_defaults ); ?>);
 window._googlesitekitConsentCategoryMap = <?php	echo wp_json_encode( $consent_category_map ); ?>;
+window._googlesitekitConsents = <?php echo wp_json_encode( $consent_defaults ); ?>
 </script>
 <!-- <?php echo esc_html__( 'End Google tag (gtag.js) Consent Mode dataLayer added by Site Kit', 'google-site-kit' ); ?> -->
 			<?php


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #8387

## Relevant technical choices

I used lodash `isEqual` to compare consent objects.

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
