### PR TITLE
Update monetization widget graph colors.

### DIFF
--- a/assets/js/modules/adsense/components/module/ModuleOverviewWidget/Stats.js
+++ b/assets/js/modules/adsense/components/module/ModuleOverviewWidget/Stats.js
@@ -41,7 +41,7 @@ export default function Stats( props ) {
 		currentRangeData.headers[ selectedStats + 1 ]
 	);
 
-	const colors = [ '#6380b8', '#bed4ff', '#5c9271', '#6e48ab' ];
+	const colors = [ '#6380b8', '#4bbbbb', '#3c7251', '#8e68cb' ];
 
 	function getFormat( { type, currencyCode } = {} ) {
 		if ( type === 'METRIC_CURRENCY' ) {


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #8247 

## Relevant technical choices

* Matched the graph colors of the `Search traffic over the last 28 days` widget to match the one for search widget

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
