### PR TITLE
Enhance/#8134 - Fix issue where closing the modal does not re-trigger it (follow-up)

### DIFF
--- a/assets/js/modules/analytics-4/components/audience-segmentation/dashboard/AudienceErrorModal.js
+++ b/assets/js/modules/analytics-4/components/audience-segmentation/dashboard/AudienceErrorModal.js
@@ -129,6 +129,7 @@ export default function AudienceErrorModal( {
 				handleConfirm={ onRetry }
 				confirmButton={ confirmButton }
 				handleDialog={ onCancel }
+				onClose={ onCancel }
 				danger
 				inProgress={ inProgress }
 			/>


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #8134 

## Relevant technical choices

* Fix the modal behavior to ensure that clicking outside of the modal does not affect the state of the "Enable groups" button.
* Updated the event handling to ensure the error modal reappears correctly upon subsequent actions as reported in the following QA [observation](https://github.com/google/site-kit-wp/issues/8134#issuecomment-2220331392):

>ITEM 5:
Generic Error Variant
Clicking outside of modal makes enable disabled. Video is attached for reference.

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
