### PR TITLE
Remove default deps value in useInViewSelect

### DIFF
--- a/assets/js/hooks/useInViewSelect.js
+++ b/assets/js/hooks/useInViewSelect.js
@@ -48,7 +48,7 @@ function notInViewCallback() {
  * @param {Array}    deps      Deps passed to `useInViewSelect`'s `deps` argument.
  * @return {*} The result of the selector if in-view; `undefined` if not in-view.
  */
-export const useInViewSelect = ( mapSelect, deps = [] ) => {
+export const useInViewSelect = ( mapSelect, deps ) => {
 	const isInView = useInView( { sticky: true } );
 	const latestSelectorResult = useRef();
 


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #8789

## Relevant technical choices

<!-- Please describe your changes. -->

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [ ] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [x] Run the code.
- [x] Ensure the acceptance criteria are satisfied.
- [x] Reassess the implementation with the IB.
- [x] Ensure no unrelated changes are included.
- [x] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [x] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [x] Ensure the PR has the correct target branch.
- [x] Double-check that the PR is okay to be merged.
- [x] Ensure the corresponding issue has a ZenHub release assigned.
- [x] Add a changelog message to the issue.
