### PR TITLE
Bug/5354 dashboard sharing blocked no owner

### DIFF
--- a/assets/js/components/dashboard-sharing/DashboardSharingSettings/Module.js
+++ b/assets/js/components/dashboard-sharing/DashboardSharingSettings/Module.js
@@ -202,17 +202,9 @@ export default function Module( {
 				{ recoverable && (
 					<WarningNotice>
 						{ createInterpolateElement(
-							sprintf(
-								/* translators: 1: The warning message. 2: "Learn more" link. */
-								__(
-									'%1$s. <Link>%2$s</Link>',
-									'google-site-kit'
-								),
-								__(
-									'Managing user required to manage view access',
-									'google-site-kit'
-								),
-								__( 'Learn more', 'google-site-kit' )
+							__(
+								'Managing user required to manage view access. <Link>Learn more</Link>',
+								'google-site-kit'
 							),
 							{
 								Link: (

--- a/assets/js/components/dashboard-sharing/DashboardSharingSettings/Module.js
+++ b/assets/js/components/dashboard-sharing/DashboardSharingSettings/Module.js
@@ -227,7 +227,7 @@ export default function Module( {
 					</WarningNotice>
 				) }
 
-				{ ! recoverable && ! hasSharingCapability && (
+				{ ! hasSharingCapability && ! recoverable && (
 					<p className="googlesitekit-dashboard-sharing-settings__note">
 						{ __(
 							'Contact managing user to manage view access',

--- a/assets/js/components/dashboard-sharing/DashboardSharingSettings/Module.js
+++ b/assets/js/components/dashboard-sharing/DashboardSharingSettings/Module.js
@@ -78,8 +78,8 @@ export default function Module( {
 
 	const [ manageViewAccess, setManageViewAccess ] = useState( undefined );
 
-	const hasRecoverableModules = useSelect(
-		( select ) => !! select( CORE_MODULES ).getRecoverableModules()
+	const hasRecoverableModules = useSelect( ( select ) =>
+		select( CORE_MODULES ).hasRecoverableModules()
 	);
 	const hasMultipleAdmins = useSelect( ( select ) =>
 		select( CORE_SITE ).hasMultipleAdmins()

--- a/assets/js/components/dashboard-sharing/DashboardSharingSettings/index.js
+++ b/assets/js/components/dashboard-sharing/DashboardSharingSettings/index.js
@@ -39,8 +39,8 @@ import {
 } from '../../../googlesitekit/datastore/user/constants';
 
 export default function DashboardSharingSettings() {
-	const hasRecoverableModules = useSelect(
-		( select ) => !! select( CORE_MODULES ).getRecoverableModules()
+	const hasRecoverableModules = useSelect( ( select ) =>
+		select( CORE_MODULES ).hasRecoverableModules()
 	);
 
 	const hasMultipleAdmins = useSelect( ( select ) =>

--- a/assets/js/components/dashboard-sharing/DashboardSharingSettings/index.js
+++ b/assets/js/components/dashboard-sharing/DashboardSharingSettings/index.js
@@ -39,9 +39,15 @@ import {
 } from '../../../googlesitekit/datastore/user/constants';
 
 export default function DashboardSharingSettings() {
+	const hasRecoverableModules = useSelect(
+		( select ) => !! select( CORE_MODULES ).getRecoverableModules()
+	);
+
 	const hasMultipleAdmins = useSelect( ( select ) =>
 		select( CORE_SITE ).hasMultipleAdmins()
 	);
+
+	const showManageColumn = hasRecoverableModules || hasMultipleAdmins;
 
 	const sortedShareableModules = useSelect( ( select ) => {
 		const userID = select( CORE_USER ).getID();
@@ -79,7 +85,7 @@ export default function DashboardSharingSettings() {
 				'googlesitekit-dashboard-sharing-settings',
 				{
 					'googlesitekit-dashboard-sharing-settings--has-multiple-admins':
-						hasMultipleAdmins,
+						showManageColumn,
 				}
 			) }
 		>
@@ -91,7 +97,7 @@ export default function DashboardSharingSettings() {
 					{ __( 'Who can view', 'google-site-kit' ) }
 				</div>
 
-				{ hasMultipleAdmins && (
+				{ showManageColumn && (
 					<div className="googlesitekit-dashboard-sharing-settings__column--manage">
 						{ __(
 							'Who can manage view access',
@@ -102,14 +108,17 @@ export default function DashboardSharingSettings() {
 			</header>
 
 			<div className="googlesitekit-dashboard-sharing-settings__main">
-				{ sortedShareableModules.map( ( { slug, name, owner } ) => (
-					<Module
-						key={ slug }
-						moduleSlug={ slug }
-						moduleName={ name }
-						ownerUsername={ owner?.login }
-					/>
-				) ) }
+				{ sortedShareableModules.map(
+					( { slug, name, owner, recoverable } ) => (
+						<Module
+							key={ slug }
+							moduleSlug={ slug }
+							moduleName={ name }
+							ownerUsername={ owner?.login }
+							recoverable={ recoverable }
+						/>
+					)
+				) }
 			</div>
 		</div>
 	);

--- a/assets/js/components/dashboard-sharing/DashboardSharingSettings/index.test.js
+++ b/assets/js/components/dashboard-sharing/DashboardSharingSettings/index.test.js
@@ -81,7 +81,7 @@ describe( 'DashboardSharingSettings', () => {
 			expect( container ).toHaveTextContent( 'Search Console' );
 		} );
 
-		it( 'should render the modules with user role select when the admin owns the modules', () => {
+		it( 'should render the modules with user role select when the admin owns the modules', async () => {
 			act( () => {
 				provideModules( registry, modules );
 				provideModuleRegistrations( registry );
@@ -107,9 +107,15 @@ describe( 'DashboardSharingSettings', () => {
 					.dispatch( MODULES_SEARCH_CONSOLE )
 					.receiveGetSettings( { ownerID: 1 } );
 			} );
-			const { container } = render( <DashboardSharingSettings />, {
-				registry,
-			} );
+
+			const { container, waitForRegistry } = render(
+				<DashboardSharingSettings />,
+				{
+					registry,
+				}
+			);
+
+			await waitForRegistry();
 
 			expect(
 				container.querySelector(
@@ -118,7 +124,7 @@ describe( 'DashboardSharingSettings', () => {
 			).toBeInTheDocument();
 		} );
 
-		it( 'should not render sharing management for a single admin environment', () => {
+		it( 'should not render sharing management for a single admin environment', async () => {
 			act( () => {
 				provideModules( registry, modules );
 				provideModuleRegistrations( registry );
@@ -144,9 +150,14 @@ describe( 'DashboardSharingSettings', () => {
 					.dispatch( MODULES_SEARCH_CONSOLE )
 					.receiveGetSettings( { ownerID: 1 } );
 			} );
-			const { container } = render( <DashboardSharingSettings />, {
-				registry,
-			} );
+			const { container, waitForRegistry } = render(
+				<DashboardSharingSettings />,
+				{
+					registry,
+				}
+			);
+
+			await waitForRegistry();
 
 			expect( container ).not.toHaveTextContent(
 				'Who can manage view access'

--- a/assets/js/googlesitekit/modules/datastore/modules.js
+++ b/assets/js/googlesitekit/modules/datastore/modules.js
@@ -1320,6 +1320,25 @@ const baseSelectors = {
 	} ),
 
 	/**
+	 * Checks if there are any recoverable modules for dashboard sharing.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param {Object} state Data store's state.
+	 * @return {(boolean|undefined)} `true` if there are recoverable modules.
+	 * 								 `false` if there are none.
+	 * 								 `undefined` if not loaded.
+	 */
+	hasRecoverableModules: ( state ) => {
+		// Return `undefined` if recoverableModules haven't been loaded yet.
+		if ( state.recoverableModules === undefined ) {
+			return undefined;
+		}
+
+		return Object.keys( state.recoverableModules ).length > 0;
+	},
+
+	/**
 	 * Gets the list of shared ownership modules for dashboard sharing.
 	 *
 	 * Returns an Object/map of objects, keyed by slug as same as `getModules`.

--- a/assets/sass/components/global/_googlesitekit-sharing-settings.scss
+++ b/assets/sass/components/global/_googlesitekit-sharing-settings.scss
@@ -164,6 +164,16 @@
 			display: flex;
 			flex: 1 1 45%;
 		}
+
+		.googlesitekit-warning-notice {
+			margin-right: $grid-gap-desktop;
+			padding: $grid-gap-phone / 2 $grid-gap-phone;
+
+			.googlesitekit-cta-link {
+				font-weight: $fw-normal;
+				text-decoration: underline;
+			}
+		}
 	}
 
 	.googlesitekit-dashboard-sharing-settings__row {


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #5354 

## Relevant technical choices

- Added an additional selector instead of computing recoverable module count within the react components.

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
