### PR TITLE
Add RRM `Web_Tag`

### DIFF
--- a/includes/Modules/Reader_Revenue_Manager/Tag_Guard.php
+++ b/includes/Modules/Reader_Revenue_Manager/Tag_Guard.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Class Google\Site_Kit\Modules\Reader_Revenue_Manager\Tag_Guard
+ *
+ * @package   Google\Site_Kit\Modules\Reader_Revenue_Manager
+ * @copyright 2024 Google LLC
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
+ * @link      https://sitekit.withgoogle.com
+ */
+
+namespace Google\Site_Kit\Modules\Reader_Revenue_Manager;
+
+use Google\Site_Kit\Core\Modules\Tags\Module_Tag_Guard;
+
+/**
+ * Class for the Reader Revenue Manager tag guard.
+ *
+ * @since n.e.x.t
+ * @access private
+ * @ignore
+ */
+class Tag_Guard extends Module_Tag_Guard {
+
+	/**
+	 * Determines whether the guarded tag can be activated or not.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @return bool|WP_Error TRUE if guarded tag can be activated, otherwise FALSE or an error.
+	 */
+	public function can_activate() {
+		$settings = $this->settings->get();
+		return ! empty( $settings['publicationID'] );
+	}
+}

--- a/includes/Modules/Reader_Revenue_Manager/Tag_Matchers.php
+++ b/includes/Modules/Reader_Revenue_Manager/Tag_Matchers.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Class Google\Site_Kit\Modules\Reader_Revenue_Manager\Tag_Matchers
+ *
+ * @package   Google\Site_Kit\Modules\Reader_Revenue_Manager
+ * @copyright 2024 Google LLC
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
+ * @link      https://sitekit.withgoogle.com
+ */
+
+namespace Google\Site_Kit\Modules\Reader_Revenue_Manager;
+
+use Google\Site_Kit\Core\Modules\Tags\Module_Tag_Matchers;
+use Google\Site_Kit\Core\Tags\Tag_Matchers_Interface;
+
+/**
+ * Class for Tag matchers.
+ *
+ * @since n.e.x.t
+ * @access private
+ * @ignore
+ */
+class Tag_Matchers extends Module_Tag_Matchers implements Tag_Matchers_Interface {
+
+	/**
+	 * Holds array of regex tag matchers.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @return array Array of regex matchers.
+	 */
+	public function regex_matchers() {
+		return array(
+			"/<script\\s+[^>]*src=['|\"]https?:\\/\\/news\\.google\\.com\\/swg\\/js\\/v1\\/swg-basic\\.js['|\"][^>]*>",
+			'/\\(self\\.SWG_BASIC=self\\.SWG_BASIC\\|\\|\\[\\]\\)\\.push/',
+		);
+	}
+}

--- a/includes/Modules/Reader_Revenue_Manager/Web_Tag.php
+++ b/includes/Modules/Reader_Revenue_Manager/Web_Tag.php
@@ -1,0 +1,118 @@
+<?php
+/**
+ * Class Google\Site_Kit\Modules\Reader_Revenue_Manager\Web_Tag
+ *
+ * @package   Google\Site_Kit\Modules\Reader_Revenue_Manager
+ * @copyright 2024 Google LLC
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
+ * @link      https://sitekit.withgoogle.com
+ */
+
+namespace Google\Site_Kit\Modules\Reader_Revenue_Manager;
+
+use Google\Site_Kit\Core\Modules\Tags\Module_Web_Tag;
+use Google\Site_Kit\Core\Tags\Tag_With_DNS_Prefetch_Trait;
+use Google\Site_Kit\Core\Util\Method_Proxy_Trait;
+
+/**
+ * Class for Web tag.
+ *
+ * @since n.e.x.t
+ * @access private
+ * @ignore
+ */
+class Web_Tag extends Module_Web_Tag {
+
+	use Method_Proxy_Trait;
+	use Tag_With_DNS_Prefetch_Trait;
+
+	/**
+	 * Registers tag hooks.
+	 *
+	 * @since n.e.x.t
+	 */
+	public function register() {
+		add_action( 'wp_enqueue_scripts', $this->get_method_proxy( 'enqueue_swg_script' ) );
+
+		add_filter(
+			'script_loader_tag',
+			$this->get_method_proxy( 'add_snippet_comments' ),
+			10,
+			2
+		);
+
+		add_filter(
+			'wp_resource_hints',
+			$this->get_dns_prefetch_hints_callback( '//news.google.com' ),
+			10,
+			2
+		);
+
+		$this->do_init_tag_action();
+	}
+
+	/**
+	 * Enqueues the Reader Revenue Manager (SWG) script.
+	 *
+	 * @since n.e.x.t
+	 */
+	protected function enqueue_swg_script() {
+		$locale = str_replace( '_', '-', get_locale() );
+
+		$subscription = array(
+			'type'              => 'NewsArticle',
+			'isPartOfType'      => array( 'Product' ),
+			'isPartOfProductId' => $this->tag_id . ':openaccess',
+			'clientOptions'     => array(
+				'theme' => 'light',
+				'lang'  => $locale,
+			),
+		);
+
+		$json_encoded_subscription = wp_json_encode( $subscription );
+
+		if ( ! $json_encoded_subscription ) {
+			$json_encoded_subscription = 'null';
+		}
+
+		$swg_inline_script = sprintf(
+			'(self.SWG_BASIC=self.SWG_BASIC||[]).push(basicSubscriptions=>{basicSubscriptions.init(%s);});',
+			$json_encoded_subscription
+		);
+
+		// phpcs:ignore WordPress.WP.EnqueuedResourceParameters.MissingVersion
+		wp_register_script( 'google_swgjs', 'https://news.google.com/swg/js/v1/swg-basic.js', array(), null, true );
+		wp_add_inline_script( 'google_swgjs', $swg_inline_script );
+
+		wp_enqueue_script( 'google_swgjs' );
+	}
+
+	/**
+	 * Add snippet comments around the tag.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param string $tag    The tag.
+	 * @param string $handle The script handle.
+	 *
+	 * @return string The tag with snippet comments.
+	 */
+	protected function add_snippet_comments( $tag, $handle ) {
+		if ( 'google_swgjs' !== $handle ) {
+			return $tag;
+		}
+
+		$before = sprintf( "\n<!-- %s -->\n", esc_html__( 'Google Reader Revenue Manager snippet added by Site Kit', 'google-site-kit' ) );
+		$after  = sprintf( "\n<!-- %s -->\n", esc_html__( 'End Google Reader Revenue Manager snippet added by Site Kit', 'google-site-kit' ) );
+		return $before . $tag . $after;
+	}
+
+	/**
+	 * Outputs snippet.
+	 *
+	 * @since n.e.x.t
+	 */
+	protected function render() {
+		// Do nothing, script is enqueued.
+	}
+}

--- a/tests/phpunit/integration/Modules/Reader_Revenue_Manager/Tag_GuardTest.php
+++ b/tests/phpunit/integration/Modules/Reader_Revenue_Manager/Tag_GuardTest.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Class Google\Site_Kit\Tests\Modules\Reader_Revenue_Manager\Tag_GuardTest
+ *
+ * @package   Google\Site_Kit\Tests\Modules\Reader_Revenue_Manager
+ * @copyright 2024 Google LLC
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
+ * @link      https://sitekit.withgoogle.com
+ */
+
+namespace Google\Site_Kit\Tests\Modules\Reader_Revenue_Manager;
+
+use Google\Site_Kit\Context;
+use Google\Site_Kit\Core\Storage\Options;
+use Google\Site_Kit\Modules\Reader_Revenue_Manager\Settings;
+use Google\Site_Kit\Modules\Reader_Revenue_Manager\Tag_Guard;
+use Google\Site_Kit\Tests\TestCase;
+
+/**
+ * @group Modules
+ * @group Reader_Revenue_Manager
+ */
+class Tag_GuardTest extends TestCase {
+
+	/**
+	 * Settings object.
+	 *
+	 * @var Settings
+	 */
+	private $settings;
+
+	/**
+	 * Tag_Guard object.
+	 *
+	 * @var Tag_Guard
+	 */
+	private $guard;
+
+	public function set_up() {
+		parent::set_up();
+
+		update_option(
+			Settings::OPTION,
+			array(
+				'publicationID' => '12345',
+			)
+		);
+
+		$this->settings = new Settings( new Options( new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE ) ) );
+		$this->guard    = new Tag_Guard( $this->settings );
+	}
+
+	public function test_can_activate() {
+		$this->assertTrue( $this->guard->can_activate() );
+	}
+
+	public function test_cant_activate_when_usesnippet_is_falsy() {
+		$this->settings->merge( array( 'publicationID' => '' ) );
+
+		$this->assertFalse( $this->guard->can_activate(), 'Should return FALSE when publicationID is not set.' );
+	}
+}

--- a/tests/phpunit/integration/Modules/Reader_Revenue_Manager/Web_TagTest.php
+++ b/tests/phpunit/integration/Modules/Reader_Revenue_Manager/Web_TagTest.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Class Google\Site_Kit\Tests\Modules\Reader_Revenue_Manager\Web_TagTest
+ *
+ * @package   Google\Site_Kit\Tests\Modules\Reader_Revenue_Manager
+ * @copyright 2024 Google LLC
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
+ * @link      https://sitekit.withgoogle.com
+ */
+
+namespace Google\Site_Kit\Tests\Modules\Reader_Revenue_Manager;
+
+use Google\Site_Kit\Modules\Reader_Revenue_Manager;
+use Google\Site_Kit\Modules\Reader_Revenue_Manager\Web_Tag;
+use Google\Site_Kit\Tests\TestCase;
+
+/**
+ * @group Modules
+ * @group Reader_Revenue_Manager
+ */
+class Web_TagTest extends TestCase {
+	const PUBLICATION_ID = '12345';
+
+	public function test_register() {
+		$web_tag = new Web_Tag( self::PUBLICATION_ID, Reader_Revenue_Manager::MODULE_SLUG );
+		$web_tag->register();
+
+		do_action( 'wp_enqueue_scripts' );
+
+		$footer_html = $this->capture_action( 'wp_footer' );
+
+		$this->assertStringContainsString( 'Google Reader Revenue Manager snippet added by Site Kit', $footer_html );
+		$this->assertStringContainsString( 'script type="text/javascript" src="https://news.google.com/swg/js/v1/swg-basic.js" id="google_swgjs-js"></script>', $footer_html );
+		$this->assertStringContainsString( '(self.SWG_BASIC=self.SWG_BASIC||[]).push(basicSubscriptions=>{basicSubscriptions.init({"type":"NewsArticle","isPartOfType":["Product"],"isPartOfProductId":"' . self::PUBLICATION_ID . ':openaccess","clientOptions":{"theme":"light","lang":"en-US"}});});', $footer_html );
+	}
+}

--- a/tests/phpunit/integration/Modules/Reader_Revenue_ManagerTest.php
+++ b/tests/phpunit/integration/Modules/Reader_Revenue_ManagerTest.php
@@ -193,6 +193,28 @@ class Reader_Revenue_ManagerTest extends TestCase {
 		$this->assertFalse( $reader_revenue_manager->is_data_available() );
 	}
 
+	public function test_template_redirect() {
+		$publication_id = 'ABCDEFGH';
+
+		remove_all_actions( 'template_redirect' );
+
+		$this->reader_revenue_manager->register();
+		$this->reader_revenue_manager->get_settings()->set(
+			array(
+				'publicationID' => $publication_id,
+			)
+		);
+
+		do_action( 'template_redirect' );
+		do_action( 'wp_enqueue_scripts' );
+
+		$footer_html = $this->capture_action( 'wp_footer' );
+
+		$this->assertStringContainsString( 'Google Reader Revenue Manager snippet added by Site Kit', $footer_html );
+		$this->assertStringContainsString( 'script type="text/javascript" src="https://news.google.com/swg/js/v1/swg-basic.js" id="google_swgjs-js"></script>', $footer_html );
+		$this->assertStringContainsString( '(self.SWG_BASIC=self.SWG_BASIC||[]).push(basicSubscriptions=>{basicSubscriptions.init({"type":"NewsArticle","isPartOfType":["Product"],"isPartOfProductId":"' . $publication_id . ':openaccess","clientOptions":{"theme":"light","lang":"en-US"}});});', $footer_html );
+	}
+
 	public function get_module_with_settings() {
 		return $this->reader_revenue_manager;
 	}


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #8844

## Relevant technical choices

This PR adds the `Web_Tag` class for the Reader Revenue Manager module.

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
