### PR TITLE
Sync publication onboarding state on dashboard load based on last sync timestamp

### DIFF
--- a/assets/js/modules/reader-revenue-manager/components/DashboardMainEffectComponent.js
+++ b/assets/js/modules/reader-revenue-manager/components/DashboardMainEffectComponent.js
@@ -1,0 +1,40 @@
+/**
+ * Reader Revenue Manager - DashboardMainEffectComponent component.
+ *
+ * Site Kit by Google, Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import { useMount } from 'react-use';
+
+/**
+ * Internal dependencies
+ */
+import { useDispatch } from 'googlesitekit-data';
+import { MODULES_READER_REVENUE_MANAGER } from '../datastore/constants';
+
+export default function DashboardMainEffectComponent() {
+	const { maybeSyncPublicationOnboardingState } = useDispatch(
+		MODULES_READER_REVENUE_MANAGER
+	);
+
+	useMount( () => {
+		maybeSyncPublicationOnboardingState();
+	} );
+
+	return null;
+}

--- a/assets/js/modules/reader-revenue-manager/components/DashboardMainEffectComponent.js
+++ b/assets/js/modules/reader-revenue-manager/components/DashboardMainEffectComponent.js
@@ -26,14 +26,19 @@ import { useMount } from 'react-use';
  */
 import { useDispatch } from 'googlesitekit-data';
 import { MODULES_READER_REVENUE_MANAGER } from '../datastore/constants';
+import useViewOnly from '../../../hooks/useViewOnly';
 
 export default function DashboardMainEffectComponent() {
+	const viewOnlyDashboard = useViewOnly();
+
 	const { maybeSyncPublicationOnboardingState } = useDispatch(
 		MODULES_READER_REVENUE_MANAGER
 	);
 
 	useMount( () => {
-		maybeSyncPublicationOnboardingState();
+		if ( ! viewOnlyDashboard ) {
+			maybeSyncPublicationOnboardingState();
+		}
 	} );
 
 	return null;

--- a/assets/js/modules/reader-revenue-manager/index.js
+++ b/assets/js/modules/reader-revenue-manager/index.js
@@ -29,6 +29,7 @@ import {
 	MODULES_READER_REVENUE_MANAGER,
 	ERROR_CODE_NON_HTTPS_SITE,
 } from './datastore/constants';
+import DashboardMainEffectComponent from './components/DashboardMainEffectComponent';
 import { SetupMain } from './components/setup';
 import { SettingsEdit, SettingsView } from './components/settings';
 import ReaderRevenueManagerIcon from '../../../svg/graphics/reader-revenue-manager.svg';
@@ -51,6 +52,7 @@ export const registerModule = isRrmModuleEnabled( ( modules ) => {
 		SettingsEditComponent: SettingsEdit,
 		SettingsViewComponent: SettingsView,
 		SetupComponent: SetupMain,
+		DashboardMainEffectComponent,
 		Icon: ReaderRevenueManagerIcon,
 		features: [
 			__(


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #8797 

## Relevant technical choices

Mostly follows the IB. With a couple of exception. 

1. Uses the new Dashboard effects pattern introduced on #8211. 
2. Only syncs on Main dashboard (this is consistent with the `syncGoogleTagSettings` which is referenced in the ACs). 
3. Only syncs on authenticated dashboard. 

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [ ] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [x] Run the code.
- [x] Ensure the acceptance criteria are satisfied.
- [x] Reassess the implementation with the IB.
- [x] Ensure no unrelated changes are included.
- [x] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [x] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [x] Ensure the PR has the correct target branch.
- [x] Double-check that the PR is okay to be merged.
- [x] Ensure the corresponding issue has a ZenHub release assigned.
- [x] Add a changelog message to the issue.
