### PR TITLE
Fix condition to display the publication approved overlay notification

### DIFF
--- a/assets/js/modules/reader-revenue-manager/datastore/publications.js
+++ b/assets/js/modules/reader-revenue-manager/datastore/publications.js
@@ -99,12 +99,7 @@ const baseActions = {
 			registry
 				.resolveSelect( MODULES_READER_REVENUE_MANAGER )
 				.getPublications()
-		);
-
-		// If there are no publications, do not attempt to sync the onboarding state.
-		if ( ! publications ) {
-			return;
-		}
+		) || [];
 
 		const publication = publications.find(
 			// eslint-disable-next-line sitekit/acronym-case

--- a/assets/js/modules/reader-revenue-manager/datastore/publications.js
+++ b/assets/js/modules/reader-revenue-manager/datastore/publications.js
@@ -136,10 +136,11 @@ const baseActions = {
 		// Save the settings to the API.
 		registry.dispatch( MODULES_READER_REVENUE_MANAGER ).saveSettings();
 
-		// If the onboarding state is complete, set the key in CORE_UI to trigger the notification.
+		// If the onboarding state changes to complete, set the key in CORE_UI to trigger the notification.
 		if (
+			onboardingState !== currentOnboardingState &&
 			onboardingState ===
-			PUBLICATION_ONBOARDING_STATES.ONBOARDING_COMPLETE
+				PUBLICATION_ONBOARDING_STATES.ONBOARDING_COMPLETE
 		) {
 			registry
 				.dispatch( CORE_UI )

--- a/assets/js/modules/reader-revenue-manager/datastore/publications.js
+++ b/assets/js/modules/reader-revenue-manager/datastore/publications.js
@@ -68,6 +68,12 @@ const baseActions = {
 	 */
 	*syncPublicationOnboardingState() {
 		const registry = yield commonActions.getRegistry();
+		// Ensure settings are loaded before checking for changed state below.
+		const settings = yield commonActions.await(
+			registry
+				.resolveSelect( MODULES_READER_REVENUE_MANAGER )
+				.getSettings()
+		);
 
 		const hasPublicationIDChanged = registry
 			.select( MODULES_READER_REVENUE_MANAGER )
@@ -78,12 +84,6 @@ const baseActions = {
 		if ( hasPublicationIDChanged ) {
 			return;
 		}
-
-		const settings = yield commonActions.await(
-			registry
-				.resolveSelect( MODULES_READER_REVENUE_MANAGER )
-				.getSettings()
-		);
 
 		const {
 			publicationID,


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #9089 

## Relevant technical choices

This PR includes the following unrelated changes:
1. Improves the `syncPublicationOnboardingState` action to do the following:
	1. Only sync when the publication ID has not changed from the "saved" value.
	2. Wait for the publications to be resolved.
	3. Update module settings in a way such that the settings object in the registry is not mutated.
2. Includes typo fixes.

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
