### PR TITLE
Reset publications when creating new publication

### DIFF
--- a/assets/js/modules/reader-revenue-manager/components/common/PublicationCreate.js
+++ b/assets/js/modules/reader-revenue-manager/components/common/PublicationCreate.js
@@ -32,7 +32,12 @@ import { __ } from '@wordpress/i18n';
  */
 import { useDispatch, useSelect } from 'googlesitekit-data';
 import { Button, SpinnerButton } from 'googlesitekit-components';
-import { MODULES_READER_REVENUE_MANAGER } from '../../datastore/constants';
+import { CORE_FORMS } from '../../../../googlesitekit/datastore/forms/constants';
+import {
+	MODULES_READER_REVENUE_MANAGER,
+	READER_REVENUE_MANAGER_SETUP_FORM,
+	RESET_PUBLICATIONS,
+} from '../../datastore/constants';
 import ExternalIcon from '../../../../../svg/icons/external.svg';
 
 export default function PublicationCreate( { onCompleteSetup } ) {
@@ -43,9 +48,16 @@ export default function PublicationCreate( { onCompleteSetup } ) {
 		select( MODULES_READER_REVENUE_MANAGER ).getServiceURL()
 	);
 
+	const { setValues } = useDispatch( CORE_FORMS );
 	const { selectPublication } = useDispatch( MODULES_READER_REVENUE_MANAGER );
 
 	const hasPublication = publications && publications.length > 0;
+
+	const resetPublications = useCallback( () => {
+		setValues( READER_REVENUE_MANAGER_SETUP_FORM, {
+			[ RESET_PUBLICATIONS ]: true,
+		} );
+	}, [ setValues ] );
 
 	const handleCompleteSetupClick = useCallback( async () => {
 		if ( ! hasPublication ) {
@@ -84,6 +96,7 @@ export default function PublicationCreate( { onCompleteSetup } ) {
 							trailingIcon={
 								<ExternalIcon width={ 14 } height={ 14 } />
 							}
+							onClick={ resetPublications }
 						>
 							{ __( 'Create publication', 'google-site-kit' ) }
 						</Button>

--- a/assets/js/modules/reader-revenue-manager/components/common/PublicationCreate.js
+++ b/assets/js/modules/reader-revenue-manager/components/common/PublicationCreate.js
@@ -53,7 +53,7 @@ export default function PublicationCreate( { onCompleteSetup } ) {
 
 	const hasPublication = publications && publications.length > 0;
 
-	const resetPublications = useCallback( () => {
+	const handleLinkClick = useCallback( () => {
 		setValues( READER_REVENUE_MANAGER_SETUP_FORM, {
 			[ RESET_PUBLICATIONS ]: true,
 		} );
@@ -96,7 +96,7 @@ export default function PublicationCreate( { onCompleteSetup } ) {
 							trailingIcon={
 								<ExternalIcon width={ 14 } height={ 14 } />
 							}
-							onClick={ resetPublications }
+							onClick={ handleLinkClick }
 						>
 							{ __( 'Create publication', 'google-site-kit' ) }
 						</Button>

--- a/assets/js/modules/reader-revenue-manager/components/setup/SetupForm.js
+++ b/assets/js/modules/reader-revenue-manager/components/setup/SetupForm.js
@@ -65,7 +65,7 @@ export default function SetupForm( { onCompleteSetup } ) {
 		MODULES_READER_REVENUE_MANAGER
 	);
 
-	const resetPublications = useCallback( () => {
+	const handleLinkClick = useCallback( () => {
 		setValues( READER_REVENUE_MANAGER_SETUP_FORM, {
 			[ RESET_PUBLICATIONS ]: true,
 		} );
@@ -119,7 +119,7 @@ export default function SetupForm( { onCompleteSetup } ) {
 				<PublicationSelect />
 			</div>
 			<PublicationOnboardingStateNotice />
-			<Link external href={ serviceURL } onClick={ resetPublications }>
+			<Link external href={ serviceURL } onClick={ handleLinkClick }>
 				{ __( 'Create new publication', 'google-site-kit' ) }
 			</Link>
 			<div className="googlesitekit-setup-module__action">

--- a/assets/js/modules/reader-revenue-manager/components/setup/SetupForm.js
+++ b/assets/js/modules/reader-revenue-manager/components/setup/SetupForm.js
@@ -34,9 +34,12 @@ import { SpinnerButton } from 'googlesitekit-components';
 import { useDispatch, useSelect } from 'googlesitekit-data';
 import Link from '../../../../components/Link';
 import StoreErrorNotices from '../../../../components/StoreErrorNotices';
+import { CORE_FORMS } from '../../../../googlesitekit/datastore/forms/constants';
 import {
 	MODULE_SLUG,
 	MODULES_READER_REVENUE_MANAGER,
+	READER_REVENUE_MANAGER_SETUP_FORM,
+	RESET_PUBLICATIONS,
 } from '../../datastore/constants';
 import { PublicationOnboardingStateNotice, PublicationSelect } from '../common';
 
@@ -57,9 +60,16 @@ export default function SetupForm( { onCompleteSetup } ) {
 		select( MODULES_READER_REVENUE_MANAGER ).getServiceURL()
 	);
 
+	const { setValues } = useDispatch( CORE_FORMS );
 	const { findMatchedPublication, selectPublication } = useDispatch(
 		MODULES_READER_REVENUE_MANAGER
 	);
+
+	const resetPublications = useCallback( () => {
+		setValues( READER_REVENUE_MANAGER_SETUP_FORM, {
+			[ RESET_PUBLICATIONS ]: true,
+		} );
+	}, [ setValues ] );
 
 	const submitForm = useCallback(
 		( event ) => {
@@ -84,6 +94,10 @@ export default function SetupForm( { onCompleteSetup } ) {
 		}
 	}, [ findMatchedPublication, publicationID, selectPublication ] );
 
+	if ( ! publications ) {
+		return null;
+	}
+
 	return (
 		<form onSubmit={ submitForm }>
 			<StoreErrorNotices
@@ -105,7 +119,7 @@ export default function SetupForm( { onCompleteSetup } ) {
 				<PublicationSelect />
 			</div>
 			<PublicationOnboardingStateNotice />
-			<Link external href={ serviceURL }>
+			<Link external href={ serviceURL } onClick={ resetPublications }>
 				{ __( 'Create new publication', 'google-site-kit' ) }
 			</Link>
 			<div className="googlesitekit-setup-module__action">

--- a/assets/js/modules/reader-revenue-manager/components/setup/SetupForm.test.js
+++ b/assets/js/modules/reader-revenue-manager/components/setup/SetupForm.test.js
@@ -64,7 +64,7 @@ describe( 'SetupForm', () => {
 
 		expect( getByText( 'Publication' ) ).toBeInTheDocument();
 		expect(
-			getByRole( 'link', { name: /create new publication/i } )
+			getByRole( 'button', { name: /create new publication/i } )
 		).toBeInTheDocument();
 	} );
 

--- a/assets/js/modules/reader-revenue-manager/components/setup/SetupMain.js
+++ b/assets/js/modules/reader-revenue-manager/components/setup/SetupMain.js
@@ -34,6 +34,7 @@ import { CORE_FORMS } from '../../../../googlesitekit/datastore/forms/constants'
 import {
 	MODULES_READER_REVENUE_MANAGER,
 	READER_REVENUE_MANAGER_SETUP_FORM,
+	RESET_PUBLICATIONS,
 	SHOW_PUBLICATION_CREATE,
 } from '../../datastore/constants';
 import { useDispatch, useSelect } from 'googlesitekit-data';
@@ -59,8 +60,11 @@ export default function SetupMain( { finishSetup = () => {} } ) {
 			SHOW_PUBLICATION_CREATE
 		)
 	);
-	const publicationID = useSelect( ( select ) =>
-		select( MODULES_READER_REVENUE_MANAGER ).getPublicationID()
+	const shouldResetPublications = useSelect( ( select ) =>
+		select( CORE_FORMS ).getValue(
+			READER_REVENUE_MANAGER_SETUP_FORM,
+			RESET_PUBLICATIONS
+		)
 	);
 
 	const { setValues } = useDispatch( CORE_FORMS );
@@ -68,14 +72,17 @@ export default function SetupMain( { finishSetup = () => {} } ) {
 		MODULES_READER_REVENUE_MANAGER
 	);
 
-	const reset = useCallback( () => {
-		// Do not reset if the publication ID is already set.
-		if ( publicationID !== '' ) {
+	const reset = useCallback( async () => {
+		if ( ! shouldResetPublications ) {
 			return;
 		}
 
+		await setValues( READER_REVENUE_MANAGER_SETUP_FORM, {
+			[ RESET_PUBLICATIONS ]: false,
+		} );
+
 		resetPublications();
-	}, [ publicationID, resetPublications ] );
+	}, [ resetPublications, setValues, shouldResetPublications ] );
 
 	// Reset publication data when user re-focuses window.
 	useRefocus( reset, 15000 );

--- a/assets/js/modules/reader-revenue-manager/components/setup/__snapshots__/SetupForm.test.js.snap
+++ b/assets/js/modules/reader-revenue-manager/components/setup/__snapshots__/SetupForm.test.js.snap
@@ -52,12 +52,8 @@ exports[`SetupForm should render the form correctly 1`] = `
         </div>
       </div>
     </div>
-    <a
-      aria-label="Create new publication (opens in a new tab)"
+    <button
       class="googlesitekit-cta-link"
-      href=""
-      rel="noopener noreferrer"
-      target="_blank"
     >
       <span
         class="googlesitekit-cta-link__contents"
@@ -70,7 +66,7 @@ exports[`SetupForm should render the form correctly 1`] = `
       >
         <svg />
       </span>
-    </a>
+    </button>
     <div
       class="googlesitekit-setup-module__action"
     >

--- a/assets/js/modules/reader-revenue-manager/datastore/constants.js
+++ b/assets/js/modules/reader-revenue-manager/datastore/constants.js
@@ -36,3 +36,5 @@ export const READER_REVENUE_MANAGER_SETUP_FORM =
 	'readerRevenueManagerSetupForm';
 
 export const SHOW_PUBLICATION_CREATE = 'showPublicationCreate';
+
+export const RESET_PUBLICATIONS = 'resetPublications';

--- a/assets/js/modules/reader-revenue-manager/datastore/publications.js
+++ b/assets/js/modules/reader-revenue-manager/datastore/publications.js
@@ -214,21 +214,21 @@ const baseActions = {
 	 * Resets the publications data in the store.
 	 *
 	 * @since n.e.x.t
-	 *
-	 * @return {Object} The dispatched action results.
 	 */
 	*resetPublications() {
 		const registry = yield commonActions.getRegistry();
 
+		yield errorStoreActions.clearErrors( 'getPublications' );
+
+		yield commonActions.await(
+			registry
+				.dispatch( MODULES_READER_REVENUE_MANAGER )
+				.invalidateResolutionForStoreSelector( 'getPublications' )
+		);
+
 		yield {
 			type: 'RESET_PUBLICATIONS',
 		};
-
-		yield errorStoreActions.clearErrors( 'getPublications' );
-
-		return registry
-			.dispatch( MODULES_READER_REVENUE_MANAGER )
-			.invalidateResolutionForStoreSelector( 'getPublications' );
 	},
 
 	/**


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- https://github.com/google/site-kit-wp/issues/8800#issuecomment-2272925959

## Relevant technical choices

This PR addresses the above QA report where it enforces the publications to be reset when the "Create new publication" link is clicked under the publication select component.

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
