### PR TITLE
Improve `resetPublications` action

### DIFF
--- a/assets/js/modules/reader-revenue-manager/components/setup/SetupMain.js
+++ b/assets/js/modules/reader-revenue-manager/components/setup/SetupMain.js
@@ -45,9 +45,8 @@ import ReaderRevenueManagerIcon from '../../../../../svg/graphics/reader-revenue
 import SetupForm from './SetupForm';
 
 export default function SetupMain( { finishSetup = () => {} } ) {
-	const publications = useSelect(
-		( select ) =>
-			select( MODULES_READER_REVENUE_MANAGER ).getPublications() || []
+	const publications = useSelect( ( select ) =>
+		select( MODULES_READER_REVENUE_MANAGER ).getPublications()
 	);
 	const hasResolvedPublications = useSelect( ( select ) =>
 		select( MODULES_READER_REVENUE_MANAGER ).hasFinishedResolution(
@@ -92,6 +91,7 @@ export default function SetupMain( { finishSetup = () => {} } ) {
 		if (
 			! publicationCreateShown &&
 			hasResolvedPublications &&
+			undefined !== publications &&
 			! publications.length
 		) {
 			setValues( READER_REVENUE_MANAGER_SETUP_FORM, {
@@ -101,7 +101,7 @@ export default function SetupMain( { finishSetup = () => {} } ) {
 	}, [
 		hasResolvedPublications,
 		publicationCreateShown,
-		publications.length,
+		publications,
 		setValues,
 	] );
 

--- a/assets/js/modules/reader-revenue-manager/datastore/publications.js
+++ b/assets/js/modules/reader-revenue-manager/datastore/publications.js
@@ -225,21 +225,21 @@ const baseActions = {
 	 * Resets the publications data in the store.
 	 *
 	 * @since 1.133.0
+	 *
+	 * @return {Object} The dispatched action results.
 	 */
 	*resetPublications() {
 		const registry = yield commonActions.getRegistry();
 
-		yield errorStoreActions.clearErrors( 'getPublications' );
-
-		yield commonActions.await(
-			registry
-				.dispatch( MODULES_READER_REVENUE_MANAGER )
-				.invalidateResolutionForStoreSelector( 'getPublications' )
-		);
-
 		yield {
 			type: 'RESET_PUBLICATIONS',
 		};
+
+		yield errorStoreActions.clearErrors( 'getPublications' );
+
+		return registry
+			.dispatch( MODULES_READER_REVENUE_MANAGER )
+			.invalidateResolutionForStoreSelector( 'getPublications' );
 	},
 
 	/**


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #9176

## Relevant technical choices

This PR improves the RRM `resetPublications` action by invalidating the `getPublications` resolver **after** the existing publications have been cleared from the store.

### Unrelated change:

1. I found a relevant bug which this PR fixes. Explained [here](https://github.com/google/site-kit-wp/pull/9186#discussion_r1716067405).

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [x] Run the code.
- [x] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [x] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [x] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [x] Ensure the PR has the correct target branch.
- [x] Double-check that the PR is okay to be merged.
- [x] Ensure the corresponding issue has a ZenHub release assigned.
- [x] Add a changelog message to the issue.
