### PR TITLE
Improve RRM entity access check

### DIFF
--- a/includes/Modules/Reader_Revenue_Manager.php
+++ b/includes/Modules/Reader_Revenue_Manager.php
@@ -158,6 +158,9 @@ final class Reader_Revenue_Manager extends Module implements Module_With_Scopes,
 		try {
 			$response = $subscribewithgoogle->publications->listPublications();
 		} catch ( Exception $e ) {
+			if ( $e->getCode() === 403 ) {
+				return false;
+			}
 			return $this->exception_to_error( $e );
 		}
 

--- a/includes/Modules/Reader_Revenue_Manager.php
+++ b/includes/Modules/Reader_Revenue_Manager.php
@@ -149,13 +149,16 @@ final class Reader_Revenue_Manager extends Module implements Module_With_Scopes,
 	 * @return boolean|WP_Error
 	 */
 	public function check_service_entity_access() {
-		try {
-			$response = $this->get_publications_list();
-		} catch ( Exception $e ) {
-			if ( $e->getCode() === 403 ) {
-				return false;
-			}
+		/**
+		 * Get the SubscribewithGoogle service instance.
+		 *
+		 * @var Google_Service_SubscribewithGoogle
+		 */
+		$subscribewithgoogle = $this->get_service( 'subscribewithgoogle' );
 
+		try {
+			$response = $subscribewithgoogle->publications->listPublications();
+		} catch ( Exception $e ) {
 			return $this->exception_to_error( $e );
 		}
 
@@ -203,7 +206,13 @@ final class Reader_Revenue_Manager extends Module implements Module_With_Scopes,
 	protected function create_data_request( Data_Request $data ) {
 		switch ( "{$data->method}:{$data->datapoint}" ) {
 			case 'GET:publications':
-				return $this->get_publications_list();
+				/**
+				 * Get the SubscribewithGoogle service instance.
+				 *
+				 * @var Google_Service_SubscribewithGoogle
+				 */
+				$subscribewithgoogle = $this->get_service( 'subscribewithgoogle' );
+				return $subscribewithgoogle->publications->listPublications( array( 'filter' => $this->get_publication_filter() ) );
 		}
 
 		return parent::create_data_request( $data );
@@ -380,23 +389,5 @@ final class Reader_Revenue_Manager extends Module implements Module_With_Scopes,
 				'debug' => $settings['publicationOnboardingStateLastSyncedAtMs'],
 			),
 		);
-	}
-
-	/**
-	 * Makes a request to fetch publications list.
-	 *
-	 * @since n.e.x.t
-	 *
-	 * @return ListPublicationsResponse Publications list response instance.
-	 */
-	protected function get_publications_list() {
-		/**
-		 * Get the SubscribewithGoogle service instance.
-		 *
-		 * @var Google_Service_SubscribewithGoogle
-		 */
-		$subscribewithgoogle = $this->get_service( 'subscribewithgoogle' );
-
-		return $subscribewithgoogle->publications->listPublications( array( 'filter' => $this->get_publication_filter() ) );
 	}
 }

--- a/includes/Modules/Reader_Revenue_Manager.php
+++ b/includes/Modules/Reader_Revenue_Manager.php
@@ -38,7 +38,6 @@ use Google\Site_Kit\Modules\Reader_Revenue_Manager\Tag_Matchers;
 use Google\Site_Kit\Modules\Reader_Revenue_Manager\Web_Tag;
 use Google\Site_Kit\Modules\Search_Console\Settings as Search_Console_Settings;
 use Google\Site_Kit_Dependencies\Google\Service\SubscribewithGoogle as Google_Service_SubscribewithGoogle;
-use Google\Site_Kit_Dependencies\Google\Service\SubscribewithGoogle\ListPublicationsResponse;
 use WP_Error;
 
 /**

--- a/tests/phpunit/integration/Modules/Reader_Revenue_ManagerTest.php
+++ b/tests/phpunit/integration/Modules/Reader_Revenue_ManagerTest.php
@@ -19,6 +19,8 @@ use Google\Site_Kit\Core\Storage\Options;
 use Google\Site_Kit\Core\Storage\User_Options;
 use Google\Site_Kit\Modules\Reader_Revenue_Manager;
 use Google\Site_Kit\Modules\Reader_Revenue_Manager\Settings;
+use Google\Site_Kit\Tests\Core\Modules\Module_With_Owner_ContractTests;
+use Google\Site_Kit\Tests\Core\Modules\Module_With_Scopes_ContractTests;
 use Google\Site_Kit\Tests\Core\Modules\Module_With_Service_Entity_ContractTests;
 use Google\Site_Kit\Tests\Core\Modules\Module_With_Settings_ContractTests;
 use Google\Site_Kit\Tests\FakeHttp;
@@ -34,8 +36,10 @@ use Google\Site_Kit_Dependencies\GuzzleHttp\Psr7\Response;
  */
 class Reader_Revenue_ManagerTest extends TestCase {
 
-	use Module_With_Settings_ContractTests;
+	use Module_With_Owner_ContractTests;
+	use Module_With_Scopes_ContractTests;
 	use Module_With_Service_Entity_ContractTests;
+	use Module_With_Settings_ContractTests;
 
 	/**
 	 * Context object.
@@ -232,6 +236,23 @@ class Reader_Revenue_ManagerTest extends TestCase {
 		$this->assertEquals( false, $access );
 	}
 
+	/**
+	 * @return Module_With_Scopes
+	 */
+	protected function get_module_with_scopes() {
+		return $this->reader_revenue_manager;
+	}
+
+	/**
+	 * @return Module_With_Owner
+	 */
+	protected function get_module_with_owner() {
+		return $this->reader_revenue_manager;
+	}
+
+	/**
+	 * @return Module_With_Settings
+	 */
 	public function get_module_with_settings() {
 		return $this->reader_revenue_manager;
 	}


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #9150 

## Relevant technical choices

This PR improves the RRM entity access checks by ensuring that the saved publication exists in the current user's publisher center.

### Unrelated changes

- While working on this issue, I noticed that the test suite for `Reader_Revenue_Manager` was missing test coverage for `Module_With_Owner` and `Module_With_Scopes` traits. I've added them.

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [x] Run the code.
- [x] Ensure the acceptance criteria are satisfied.
- [x] Reassess the implementation with the IB.
- [x] Ensure no unrelated changes are included.
- [x] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [x] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [x] Ensure the PR has the correct target branch.
- [x] Double-check that the PR is okay to be merged.
- [x] Ensure the corresponding issue has a ZenHub release assigned.
- [x] Add a changelog message to the issue.
