### PR TITLE
Install Chromium via Puppeteer during build.

### DIFF
--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -6,7 +6,7 @@ on:
       - main
       - develop
       - 'feature/**'
-    # Only run if CSS/JS/MD-related files changed.
+    # Only run if CSS/JS related files changed.
     paths:
       - '.github/workflows/visual-regression.yml'
       - 'assets/**'

--- a/docker/backstopjs/Dockerfile
+++ b/docker/backstopjs/Dockerfile
@@ -5,12 +5,14 @@ ARG BACKSTOPJS_VERSION=6.1.1
 ENV BACKSTOPJS_VERSION=$BACKSTOPJS_VERSION
 
 RUN apk upgrade --no-cache --available && \
-    apk add --no-cache openrc dbus chromium nodejs npm && \
-    PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true npm i -g backstopjs@${BACKSTOPJS_VERSION} && \
+    apk add --no-cache openrc dbus nodejs npm && \
+    npm i -g backstopjs@${BACKSTOPJS_VERSION} && \
     npm cache clean -f && \
     rm -rf /root/.cache && \
     rc-update add dbus
 
 WORKDIR /src
+
+ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
 
 ENTRYPOINT ["backstop"]


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #

## Relevant technical choices

- Change Backstop Docker image build to install Chromium via Puppeteer instead of via apk

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [ ] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
