### PR TITLE
Convert WP Data registry actions to `yield controls`.

### DIFF
--- a/assets/js/components/FeatureTours.test.js
+++ b/assets/js/components/FeatureTours.test.js
@@ -21,7 +21,6 @@
  */
 import {
 	createTestRegistry,
-	muteFetch,
 	provideModules,
 	provideSiteInfo,
 	provideUserAuthentication,
@@ -115,7 +114,12 @@ describe( 'FeatureTours', () => {
 			'^/google-site-kit/v1/core/user/data/dismiss-tour'
 		);
 
-		muteFetch( fetchDismissTourRegExp, [] );
+		fetchMock.post( fetchDismissTourRegExp, () => {
+			return {
+				status: 200,
+				body: JSON.stringify( [] ),
+			};
+		} );
 
 		const { getByRole, waitForRegistry } = render(
 			<TourTooltipsWithMockUI />,

--- a/assets/js/googlesitekit/data/create-existing-tag-store.js
+++ b/assets/js/googlesitekit/data/create-existing-tag-store.js
@@ -25,9 +25,9 @@ import invariant from 'invariant';
  * Internal dependencies
  */
 import {
-	commonActions,
 	createRegistryControl,
 	createRegistrySelector,
+	wpControls,
 } from 'googlesitekit-data';
 import { CORE_SITE } from '../datastore/site/constants';
 import { getExistingTagURLs, extractExistingTag } from '../../util/tag';
@@ -163,15 +163,20 @@ export const createExistingTagStore = ( {
 
 	const resolvers = {
 		*getExistingTag() {
-			const registry = yield commonActions.getRegistry();
+			const existingTag = yield wpControls.select(
+				STORE_NAME,
+				'getExistingTag'
+			);
 
-			if (
-				registry.select( STORE_NAME ).getExistingTag() === undefined
-			) {
-				const existingTag = yield actions.fetchGetExistingTag();
-				registry
-					.dispatch( STORE_NAME )
-					.receiveGetExistingTag( existingTag );
+			if ( existingTag === undefined ) {
+				const existingTagFromServer =
+					yield actions.fetchGetExistingTag();
+
+				yield wpControls.dispatch(
+					STORE_NAME,
+					'receiveGetExistingTag',
+					existingTagFromServer
+				);
 			}
 		},
 	};

--- a/assets/js/googlesitekit/data/index.js
+++ b/assets/js/googlesitekit/data/index.js
@@ -20,6 +20,7 @@
  * WordPress dependencies
  */
 import {
+	controls as wpControls,
 	createRegistry,
 	createRegistryControl,
 	createRegistrySelector,
@@ -80,6 +81,7 @@ Data.useDispatch = useDispatch;
 Data.useRegistry = useRegistry;
 Data.withSelect = withSelect;
 Data.withDispatch = withDispatch;
+Data.wpControls = wpControls;
 Data.RegistryProvider = RegistryProvider;
 
 export {
@@ -96,6 +98,7 @@ export {
 	useRegistry,
 	withSelect,
 	withDispatch,
+	wpControls,
 	RegistryProvider,
 };
 

--- a/assets/js/googlesitekit/datastore/site/conversion-tracking.js
+++ b/assets/js/googlesitekit/datastore/site/conversion-tracking.js
@@ -25,15 +25,13 @@ import invariant from 'invariant';
  */
 import API from 'googlesitekit-api';
 import {
-	commonActions,
 	combineStores,
 	createRegistrySelector,
+	wpControls,
 } from 'googlesitekit-data';
 import { createFetchStore } from '../../data/create-fetch-store';
 import { createReducer } from '../../data/create-reducer';
 import { CORE_SITE } from './constants';
-
-const { getRegistry } = commonActions;
 
 const SET_CONVERSION_TRACKING_ENABLED = 'SET_CONVERSION_TRACKING_ENABLED';
 const RESET_CONVERSION_TRACKING_SETTINGS = 'RESET_CONVERSION_TRACKING_SETTINGS';
@@ -86,8 +84,10 @@ const baseActions = {
 	 * @return {Object} Object with `response` and `error`.
 	 */
 	*saveConversionTrackingSettings() {
-		const { select } = yield getRegistry();
-		const settings = select( CORE_SITE ).getConversionTrackingSettings();
+		const settings = yield wpControls.select(
+			CORE_SITE,
+			'getConversionTrackingSettings'
+		);
 
 		return yield fetchSaveConversionTrackingSettingsStore.actions.fetchSaveConversionTrackingSettings(
 			settings
@@ -189,9 +189,10 @@ const baseSelectors = {
 
 const baseResolvers = {
 	*getConversionTrackingSettings() {
-		const { select } = yield getRegistry();
-		const conversionTrackingSettings =
-			select( CORE_SITE ).getConversionTrackingSettings();
+		const conversionTrackingSettings = yield wpControls.select(
+			CORE_SITE,
+			'getConversionTrackingSettings'
+		);
 
 		if ( conversionTrackingSettings ) {
 			return;

--- a/assets/js/googlesitekit/datastore/ui/ui.js
+++ b/assets/js/googlesitekit/datastore/ui/ui.js
@@ -25,7 +25,7 @@ import { isPlainObject, isBoolean } from 'lodash';
 /**
  * Internal dependencies
  */
-import { commonActions } from 'googlesitekit-data';
+import { commonActions, wpControls } from 'googlesitekit-data';
 import { CORE_UI } from './constants';
 import { CORE_USER } from '../user/constants';
 
@@ -116,14 +116,16 @@ export const actions = {
 	*dismissOverlayNotification( overlayNotification ) {
 		invariant( overlayNotification, 'overlayNotification is required.' );
 
-		const registry = yield commonActions.getRegistry();
+		const activeOverlayNotification = yield wpControls.select(
+			CORE_UI,
+			'getValue',
+			'activeOverlayNotification'
+		);
 
-		const activeOverlayNotification = registry
-			.select( CORE_UI )
-			.getValue( 'activeOverlayNotification' );
-
-		yield commonActions.await(
-			registry.dispatch( CORE_USER ).dismissItem( overlayNotification )
+		yield wpControls.dispatch(
+			CORE_USER,
+			'dismissItem',
+			overlayNotification
 		);
 
 		if (

--- a/assets/js/googlesitekit/datastore/user/audience-settings.js
+++ b/assets/js/googlesitekit/datastore/user/audience-settings.js
@@ -30,6 +30,7 @@ import {
 	createRegistrySelector,
 	commonActions,
 	combineStores,
+	wpControls,
 } from 'googlesitekit-data';
 import {
 	AUDIENCE_TYPE_SORT_ORDER,
@@ -122,19 +123,19 @@ const baseActions = {
 		function* ( settings = {} ) {
 			yield clearError( 'saveAudienceSettings', [] );
 
-			const registry = yield commonActions.getRegistry();
-			const audienceSettings = yield commonActions.await(
-				registry.resolveSelect( CORE_USER ).getAudienceSettings()
+			const audienceSettings = yield wpControls.resolveSelect(
+				CORE_USER,
+				'getAudienceSettings'
 			);
+
 			const finalSettings = {
 				...audienceSettings,
 				...settings,
 			};
 
-			const availableAudiences = yield commonActions.await(
-				registry
-					.resolveSelect( MODULES_ANALYTICS_4 )
-					.getAvailableAudiences()
+			const availableAudiences = yield wpControls.resolveSelect(
+				MODULES_ANALYTICS_4,
+				'getAvailableAudiences'
 			);
 
 			const sortedConfiguredAudiences = [

--- a/assets/js/googlesitekit/datastore/user/dismissed-items.js
+++ b/assets/js/googlesitekit/datastore/user/dismissed-items.js
@@ -26,15 +26,13 @@ import invariant from 'invariant';
  */
 import API from 'googlesitekit-api';
 import {
-	commonActions,
 	createRegistrySelector,
 	combineStores,
+	wpControls,
 } from 'googlesitekit-data';
 import { CORE_USER } from './constants';
 import { createFetchStore } from '../../data/create-fetch-store';
 import { createValidatedAction } from '../../data/utils';
-
-const { getRegistry } = commonActions;
 
 function reducerCallback( state, dismissedItems ) {
 	return {
@@ -158,8 +156,11 @@ const baseActions = {
 
 const baseResolvers = {
 	*getDismissedItems() {
-		const { select } = yield getRegistry();
-		const dismissedItems = select( CORE_USER ).getDismissedItems();
+		const dismissedItems = yield wpControls.select(
+			CORE_USER,
+			'getDismissedItems'
+		);
+
 		if ( dismissedItems === undefined ) {
 			yield fetchGetDismissedItemsStore.actions.fetchGetDismissedItems();
 		}

--- a/assets/js/googlesitekit/datastore/user/expirable-items.js
+++ b/assets/js/googlesitekit/datastore/user/expirable-items.js
@@ -26,15 +26,13 @@ import invariant from 'invariant';
  */
 import API from 'googlesitekit-api';
 import {
-	commonActions,
 	createRegistrySelector,
 	combineStores,
+	wpControls,
 } from 'googlesitekit-data';
 import { CORE_USER } from './constants';
 import { createFetchStore } from '../../data/create-fetch-store';
 import { createValidatedAction } from '../../data/utils';
-
-const { getRegistry } = commonActions;
 
 function reducerCallback( state, expirableItems ) {
 	return {
@@ -106,8 +104,11 @@ const baseActions = {
 
 const baseResolvers = {
 	*getExpirableItems() {
-		const { select } = yield getRegistry();
-		const expirableItems = select( CORE_USER ).getExpirableItems();
+		const expirableItems = yield wpControls.select(
+			CORE_USER,
+			'getExpirableItems'
+		);
+
 		if ( expirableItems === undefined ) {
 			yield fetchGetExpirableItemsStore.actions.fetchGetExpirableItems();
 		}

--- a/assets/js/googlesitekit/datastore/user/prompts.js
+++ b/assets/js/googlesitekit/datastore/user/prompts.js
@@ -27,14 +27,12 @@ import invariant from 'invariant';
 import API from 'googlesitekit-api';
 import {
 	createRegistrySelector,
-	commonActions,
 	combineStores,
+	wpControls,
 } from 'googlesitekit-data';
 import { CORE_USER } from './constants';
 import { createFetchStore } from '../../data/create-fetch-store';
 import { createValidatedAction } from '../../data/utils';
-
-const { getRegistry } = commonActions;
 
 function reducerCallback( state, dismissedPrompts ) {
 	return {
@@ -108,8 +106,10 @@ const baseActions = {
 
 const baseResolvers = {
 	*getDismissedPrompts() {
-		const { select } = yield getRegistry();
-		const dismissedPrompts = select( CORE_USER ).getDismissedPrompts();
+		const dismissedPrompts = yield wpControls.select(
+			CORE_USER,
+			'getDismissedPrompts'
+		);
 
 		if ( dismissedPrompts === undefined ) {
 			yield fetchGetDismissedPromptsStore.actions.fetchGetDismissedPrompts();

--- a/assets/js/modules/analytics-4/datastore/properties.js
+++ b/assets/js/modules/analytics-4/datastore/properties.js
@@ -35,6 +35,7 @@ import {
 	commonActions,
 	combineStores,
 	createRegistryControl,
+	wpControls,
 } from 'googlesitekit-data';
 import { CORE_USER } from '../../../googlesitekit/datastore/user/constants';
 import { CORE_SITE } from '../../../googlesitekit/datastore/site/constants';
@@ -707,13 +708,11 @@ const baseActions = {
 		const googleTagAccountID = getGoogleTagAccountID();
 		const googleTagContainerID = getGoogleTagContainerID();
 
-		const googleTagContainerDestinations = yield commonActions.await(
-			resolveSelect(
-				MODULES_ANALYTICS_4
-			).getGoogleTagContainerDestinations(
-				googleTagAccountID,
-				googleTagContainerID
-			)
+		const googleTagContainerDestinations = yield wpControls.resolveSelect(
+			MODULES_ANALYTICS_4,
+			'getGoogleTagContainerDestinations',
+			googleTagAccountID,
+			googleTagContainerID
 		) || []; // Fallback used in the event of an error.
 
 		const googleTagContainerDestinationIDs =


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #8992

## Relevant technical choices

It wasn't too much more work to convert all files, so did this all at once to allow us to immediately remove/deprecate unused/old functions.

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [ ] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
