### PR TITLE
Fix publications filtering

### DIFF
--- a/includes/Modules/Reader_Revenue_Manager.php
+++ b/includes/Modules/Reader_Revenue_Manager.php
@@ -267,30 +267,26 @@ final class Reader_Revenue_Manager extends Module implements Module_With_Scopes,
 	private function get_publication_filter() {
 		$sc_settings    = $this->options->get( Search_Console_Settings::OPTION );
 		$sc_property_id = $sc_settings['propertyID'];
-		$raw_url        = str_replace(
-			array( 'sc-domain:', 'https://', 'http://', 'www.' ),
-			'',
-			$sc_property_id
-		);
 
 		if ( 0 === strpos( $sc_property_id, 'sc-domain:' ) ) { // Domain property.
+			$host   = str_replace( 'sc-domain:', '', $sc_property_id );
 			$filter = join(
 				' OR ',
 				array_map(
-					function ( $host ) {
-						return sprintf( 'domain = "%s"', $host );
+					function ( $domain ) {
+						return sprintf( 'domain = "%s"', $domain );
 					},
-					URL::permute_site_hosts( $raw_url )
+					URL::permute_site_hosts( $host )
 				)
 			);
 		} else { // URL property.
 			$filter = join(
 				' OR ',
 				array_map(
-					function ( $host ) {
-						return sprintf( 'site_url = "%s"', $host );
+					function ( $url ) {
+						return sprintf( 'site_url = "%s"', $url );
 					},
-					URL::permute_site_url( $raw_url )
+					URL::permute_site_url( $sc_property_id )
 				)
 			);
 		}

--- a/tests/phpunit/integration/Modules/Reader_Revenue_ManagerTest.php
+++ b/tests/phpunit/integration/Modules/Reader_Revenue_ManagerTest.php
@@ -17,8 +17,10 @@ use Google\Site_Kit\Core\Modules\Module_With_Service_Entity;
 use Google\Site_Kit\Core\Modules\Module_With_Settings;
 use Google\Site_Kit\Core\Storage\Options;
 use Google\Site_Kit\Core\Storage\User_Options;
+use Google\Site_Kit\Core\Util\URL;
 use Google\Site_Kit\Modules\Reader_Revenue_Manager;
 use Google\Site_Kit\Modules\Reader_Revenue_Manager\Settings;
+use Google\Site_Kit\Modules\Search_Console\Settings as Search_Console_Settings;
 use Google\Site_Kit\Tests\Core\Modules\Module_With_Owner_ContractTests;
 use Google\Site_Kit\Tests\Core\Modules\Module_With_Scopes_ContractTests;
 use Google\Site_Kit\Tests\Core\Modules\Module_With_Service_Entity_ContractTests;
@@ -29,8 +31,6 @@ use Google\Site_Kit_Dependencies\Google\Service\SubscribewithGoogle\ListPublicat
 use Google\Site_Kit_Dependencies\Google\Service\SubscribewithGoogle\Publication;
 use Google\Site_Kit_Dependencies\GuzzleHttp\Psr7\Request;
 use Google\Site_Kit_Dependencies\GuzzleHttp\Psr7\Response;
-use Google\Site_Kit\Modules\Search_Console\Settings as Search_Console_Settings;
-use Google\Site_Kit\Core\Util\URL;
 
 /**
  * @group Modules
@@ -125,40 +125,7 @@ class Reader_Revenue_ManagerTest extends TestCase {
 		);
 	}
 
-	public function test_get_publications_based() {
-		FakeHttp::fake_google_http_handler(
-			$this->reader_revenue_manager->get_client(),
-			function ( Request $request ) {
-				$url = parse_url( $request->getUri() );
-
-				switch ( $url['path'] ) {
-					case '/v1/publications':
-						return new Response(
-							200,
-							array(),
-							json_encode( $this->get_publications_list_response() )
-						);
-				}
-			}
-		);
-
-		$this->reader_revenue_manager->register();
-
-		$this->authentication->get_oauth_client()->set_granted_scopes(
-			$this->authentication->get_oauth_client()->get_required_scopes()
-		);
-
-		$result = $this->reader_revenue_manager->get_data( 'publications' );
-		$this->assertNotWPError( $result );
-		$this->assertContainsOnlyInstancesOf( Publication::class, $result );
-
-		$publication = $result[0];
-
-		$this->assertEquals( 'Test Property', $publication->getDisplayName() );
-		$this->assertEquals( 'ABCDEFGH', $publication->getPublicationId() );
-	}
-
-	public function test_get_publications_filter_url() {
+	public function test_get_publications__url() {
 		$filter = '';
 		// Set the Search console option.
 		$this->options->set( Search_Console_Settings::OPTION, array( 'propertyID' => 'http://test.com' ) );
@@ -187,7 +154,16 @@ class Reader_Revenue_ManagerTest extends TestCase {
 			$this->authentication->get_oauth_client()->get_required_scopes()
 		);
 
-		$this->reader_revenue_manager->get_data( 'publications' );
+		$result = $this->reader_revenue_manager->get_data( 'publications' );
+
+		$this->assertNotWPError( $result );
+		$this->assertContainsOnlyInstancesOf( Publication::class, $result );
+
+		$publication = $result[0];
+
+		$this->assertEquals( 'Test Property', $publication->getDisplayName() );
+		$this->assertEquals( 'ABCDEFGH', $publication->getPublicationId() );
+
 		$expected_filter = 'filter=' . join(
 			' OR ',
 			array_map(
@@ -201,7 +177,7 @@ class Reader_Revenue_ManagerTest extends TestCase {
 		$this->assertEquals( $expected_filter, urldecode( $filter ) );
 	}
 
-	public function test_get_publications_filter_host() {
+	public function test_get_publications__domain() {
 		$filter = '';
 		// Set the Search console option.
 		$this->options->set( Search_Console_Settings::OPTION, array( 'propertyID' => 'sc-domain:example.com' ) );
@@ -230,7 +206,16 @@ class Reader_Revenue_ManagerTest extends TestCase {
 			$this->authentication->get_oauth_client()->get_required_scopes()
 		);
 
-		$this->reader_revenue_manager->get_data( 'publications' );
+		$result = $this->reader_revenue_manager->get_data( 'publications' );
+
+		$this->assertNotWPError( $result );
+		$this->assertContainsOnlyInstancesOf( Publication::class, $result );
+
+		$publication = $result[0];
+
+		$this->assertEquals( 'Test Property', $publication->getDisplayName() );
+		$this->assertEquals( 'ABCDEFGH', $publication->getPublicationId() );
+
 		$expected_filter = 'filter=' . join(
 			' OR ',
 			array_map(

--- a/tests/phpunit/integration/Modules/Reader_Revenue_ManagerTest.php
+++ b/tests/phpunit/integration/Modules/Reader_Revenue_ManagerTest.php
@@ -127,7 +127,8 @@ class Reader_Revenue_ManagerTest extends TestCase {
 
 	public function test_get_publications__url() {
 		$filter = '';
-		// Set the Search console option.
+
+		// Set the Search Console option.
 		$this->options->set( Search_Console_Settings::OPTION, array( 'propertyID' => 'http://test.com' ) );
 
 		FakeHttp::fake_google_http_handler(
@@ -179,7 +180,8 @@ class Reader_Revenue_ManagerTest extends TestCase {
 
 	public function test_get_publications__domain() {
 		$filter = '';
-		// Set the Search console option.
+
+		// Set the Search Console option.
 		$this->options->set( Search_Console_Settings::OPTION, array( 'propertyID' => 'sc-domain:example.com' ) );
 
 		FakeHttp::fake_google_http_handler(


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #9247 

## Relevant technical choices

This PR fixes the publications filtering for the RRM `GET:publications` endpoint.

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [x] Run the code.
- [x] Ensure the acceptance criteria are satisfied.
- [x] Reassess the implementation with the IB.
- [x] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [x] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
