### PR TITLE
Enhancement/9132 acr datastore partial

### DIFF
--- a/assets/js/modules/analytics-4/datastore/base.js
+++ b/assets/js/modules/analytics-4/datastore/base.js
@@ -63,6 +63,7 @@ const baseModuleStore = Modules.createModuleStore( 'analytics-4', {
 		'adsLinkedLastSyncedAt',
 		'availableAudiences',
 		'availableAudiencesLastSyncedAt',
+		'detectedEvents',
 	],
 	submitChanges,
 	rollbackChanges,

--- a/assets/js/modules/analytics-4/datastore/conversion-reporting.js
+++ b/assets/js/modules/analytics-4/datastore/conversion-reporting.js
@@ -1,0 +1,60 @@
+/**
+ * `modules/analytics-4` data store: coversion reporting.
+ *
+ * Site Kit by Google, Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import { createRegistrySelector } from 'googlesitekit-data';
+import { MODULES_ANALYTICS_4 } from './constants';
+
+export const selectors = {
+	/**
+	 * Checks whether the provided conversion reporting events are available.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param {Object}               state  Data store's state.
+	 * @param {string|Array<string>} events Conversion reporting events to check.
+	 * @return {(boolean|undefined)} True if all provided custom dimensions are available, otherwise false. Undefined if available custom dimensions are not loaded yet.
+	 */
+	hasConversionReportingEvents: createRegistrySelector(
+		( select ) => ( state, events ) => {
+			// Ensure events is always an array, even if a string is passed.
+			const eventsToCheck = Array.isArray( events ) ? events : [ events ];
+
+			const conversionReportingEvents =
+				select( MODULES_ANALYTICS_4 ).getDetectedEvents();
+
+			if ( conversionReportingEvents === undefined ) {
+				return undefined;
+			}
+
+			if ( ! conversionReportingEvents?.length ) {
+				return false;
+			}
+
+			return eventsToCheck.some( ( event ) =>
+				conversionReportingEvents.includes( event )
+			);
+		}
+	),
+};
+
+export default {
+	selectors,
+};

--- a/assets/js/modules/analytics-4/datastore/conversion-reporting.js
+++ b/assets/js/modules/analytics-4/datastore/conversion-reporting.js
@@ -1,5 +1,5 @@
 /**
- * `modules/analytics-4` data store: coversion reporting.
+ * `modules/analytics-4` data store: conversion reporting.
  *
  * Site Kit by Google, Copyright 2024 Google LLC
  *

--- a/assets/js/modules/analytics-4/datastore/conversion-reporting.js
+++ b/assets/js/modules/analytics-4/datastore/conversion-reporting.js
@@ -37,19 +37,15 @@ export const selectors = {
 			// Ensure events is always an array, even if a string is passed.
 			const eventsToCheck = Array.isArray( events ) ? events : [ events ];
 
-			const conversionReportingEvents =
+			const detectedEvents =
 				select( MODULES_ANALYTICS_4 ).getDetectedEvents();
 
-			if ( conversionReportingEvents === undefined ) {
-				return undefined;
-			}
-
-			if ( ! conversionReportingEvents?.length ) {
+			if ( ! detectedEvents?.length ) {
 				return false;
 			}
 
 			return eventsToCheck.some( ( event ) =>
-				conversionReportingEvents.includes( event )
+				detectedEvents.includes( event )
 			);
 		}
 	),

--- a/assets/js/modules/analytics-4/datastore/conversion-reporting.test.js
+++ b/assets/js/modules/analytics-4/datastore/conversion-reporting.test.js
@@ -1,0 +1,85 @@
+/**
+ * `modules/analytics-4` data store: conversion-reporting tests.
+ *
+ * Site Kit by Google, Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import { MODULES_ANALYTICS_4 } from './constants';
+import {
+	createTestRegistry,
+	provideModules,
+	provideUserAuthentication,
+} from '../../../../../tests/js/utils';
+
+describe( 'modules/analytics-4 conversion-reporting', () => {
+	let registry;
+
+	beforeEach( () => {
+		registry = createTestRegistry();
+
+		provideUserAuthentication( registry );
+		provideModules( registry );
+	} );
+
+	describe( 'selectors', () => {
+		describe( 'hasConversionReportingEvents', () => {
+			it( 'returns false when no conversion reporting events are available', () => {
+				registry
+					.dispatch( MODULES_ANALYTICS_4 )
+					.setSettings( { detectedEvents: [] } );
+
+				const hasConversionReportingEvents = registry
+					.select( MODULES_ANALYTICS_4 )
+					.hasConversionReportingEvents( [ 'test-event' ] );
+
+				expect( hasConversionReportingEvents ).toBe( false );
+			} );
+
+			it( 'returns true when provided conversion reporting event is available', () => {
+				registry.dispatch( MODULES_ANALYTICS_4 ).setSettings( {
+					detectedEvents: [ 'test-event', 'test-event-2' ],
+				} );
+
+				const hasConversionReportingEvents = registry
+					.select( MODULES_ANALYTICS_4 )
+					.hasConversionReportingEvents( [ 'test-event' ] );
+
+				expect( hasConversionReportingEvents ).toBe( true );
+			} );
+
+			it( 'returns true when some of provided conversion reporting events are available', () => {
+				registry.dispatch( MODULES_ANALYTICS_4 ).setSettings( {
+					detectedEvents: [
+						'test-event',
+						'test-event-2',
+						'test-event-3',
+					],
+				} );
+
+				const hasConversionReportingEvents = registry
+					.select( MODULES_ANALYTICS_4 )
+					.hasConversionReportingEvents( [
+						'no-event',
+						'test-event',
+					] );
+
+				expect( hasConversionReportingEvents ).toBe( true );
+			} );
+		} );
+	} );
+} );

--- a/assets/js/modules/analytics-4/datastore/index.js
+++ b/assets/js/modules/analytics-4/datastore/index.js
@@ -26,6 +26,7 @@ import audiences from './audiences';
 import baseModuleStore from './base';
 import containers from './containers';
 import conversionEvents from './conversion-events';
+import conversionReporting from './conversion-reporting';
 import customDimensions from './custom-dimensions';
 import customDimensionsGatheringData from './custom-dimensions-gathering-data';
 import enhancedMeasurement from './enhanced-measurement';
@@ -44,6 +45,7 @@ const store = combineStores(
 	baseModuleStore,
 	containers,
 	conversionEvents,
+	conversionReporting,
 	createSnapshotStore( MODULES_ANALYTICS_4 ),
 	customDimensions,
 	customDimensionsGatheringData,

--- a/includes/Modules/Analytics_4.php
+++ b/includes/Modules/Analytics_4.php
@@ -297,7 +297,7 @@ final class Analytics_4 extends Module implements Module_With_Scopes, Module_Wit
 							'adSenseLinkedLastSyncedAt' => 0,
 							'adsLinked'                 => false,
 							'adsLinkedLastSyncedAt'     => 0,
-							'recentEvents'              => array(),
+							'detectedEvents'            => array(),
 							'availableAudiencesLastSyncedAt' => 0,
 						)
 					);

--- a/includes/Modules/Analytics_4/Conversion_Reporting/Conversion_Reporting_Events_Sync.php
+++ b/includes/Modules/Analytics_4/Conversion_Reporting/Conversion_Reporting_Events_Sync.php
@@ -75,7 +75,7 @@ class Conversion_Reporting_Events_Sync {
 
 		// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 		if ( empty( $report->rowCount ) ) {
-			$this->settings->merge( array( 'recentEvents' => array() ) );
+			$this->settings->merge( array( 'detectedEvents' => array() ) );
 
 			return;
 		}
@@ -84,7 +84,7 @@ class Conversion_Reporting_Events_Sync {
 			$detected_events[] = $row['dimensionValues'][0]['value'];
 		}
 
-		$this->settings->merge( array( 'recentEvents' => $detected_events ) );
+		$this->settings->merge( array( 'detectedEvents' => $detected_events ) );
 	}
 
 	/**

--- a/includes/Modules/Analytics_4/Settings.php
+++ b/includes/Modules/Analytics_4/Settings.php
@@ -102,7 +102,7 @@ class Settings extends Module_Settings implements Setting_With_Owned_Keys_Interf
 			'adsLinkedLastSyncedAt'            => 0,
 			'availableAudiences'               => null,
 			'availableAudiencesLastSyncedAt'   => 0,
-			'recentEvents'                     => array(),
+			'detectedEvents'                   => array(),
 		);
 	}
 

--- a/tests/phpunit/integration/Modules/Analytics_4/Conversion_Reporting/Conversion_Reporting_Events_SyncTest.php
+++ b/tests/phpunit/integration/Modules/Analytics_4/Conversion_Reporting/Conversion_Reporting_Events_SyncTest.php
@@ -64,7 +64,7 @@ class Conversion_Reporting_Events_SyncTest extends TestCase {
 		$event_check = $this->get_instance();
 		$event_check->check_for_events();
 
-		$this->assertEquals( $detected_events, $this->settings->get()['recentEvents'] );
+		$this->assertEquals( $detected_events, $this->settings->get()['detectedEvents'] );
 	}
 
 	public function get_instance() {

--- a/tests/phpunit/integration/Modules/Analytics_4/SettingsTest.php
+++ b/tests/phpunit/integration/Modules/Analytics_4/SettingsTest.php
@@ -86,7 +86,7 @@ class SettingsTest extends SettingsTestCase {
 				'adsLinkedLastSyncedAt'            => 0,
 				'availableAudiences'               => null,
 				'availableAudiencesLastSyncedAt'   => 0,
-				'recentEvents'                     => array(),
+				'detectedEvents'                   => array(),
 			),
 			get_option( Settings::OPTION )
 		);

--- a/tests/phpunit/integration/Modules/Analytics_4Test.php
+++ b/tests/phpunit/integration/Modules/Analytics_4Test.php
@@ -549,7 +549,7 @@ class Analytics_4Test extends TestCase {
 				'adsLinkedLastSyncedAt'            => 0,
 				'availableAudiences'               => null,
 				'availableAudiencesLastSyncedAt'   => 0,
-				'recentEvents'                     => array(),
+				'detectedEvents'                   => array(),
 			),
 			$options->get( Settings::OPTION )
 		);
@@ -582,7 +582,7 @@ class Analytics_4Test extends TestCase {
 				'adsLinkedLastSyncedAt'            => 0,
 				'availableAudiences'               => null,
 				'availableAudiencesLastSyncedAt'   => 0,
-				'recentEvents'                     => array(),
+				'detectedEvents'                   => array(),
 			),
 			$options->get( Settings::OPTION )
 		);
@@ -708,7 +708,7 @@ class Analytics_4Test extends TestCase {
 				'adsLinkedLastSyncedAt'            => 0,
 				'availableAudiences'               => null,
 				'availableAudiencesLastSyncedAt'   => 0,
-				'recentEvents'                     => array(),
+				'detectedEvents'                   => array(),
 			),
 			$options->get( Settings::OPTION )
 		);
@@ -835,7 +835,7 @@ class Analytics_4Test extends TestCase {
 				'adsLinkedLastSyncedAt'            => 0,
 				'availableAudiences'               => null,
 				'availableAudiencesLastSyncedAt'   => 0,
-				'recentEvents'                     => array(),
+				'detectedEvents'                   => array(),
 			),
 			$options->get( Settings::OPTION )
 		);
@@ -871,7 +871,7 @@ class Analytics_4Test extends TestCase {
 				'adsLinkedLastSyncedAt'            => 0,
 				'availableAudiences'               => null,
 				'availableAudiencesLastSyncedAt'   => 0,
-				'recentEvents'                     => array(),
+				'detectedEvents'                   => array(),
 			),
 			$options->get( Settings::OPTION )
 		);


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #9132

## Relevant technical choices

* Only `hasConversionReportingEvents` selector is implemented, others are not needed since events are sourced from setting instead of inline data
* `recentEvents` setting is renamed to `detectedEvents` as part of this issue

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
