### PR TITLE
Direct user to RRM product page from success notification

### DIFF
--- a/assets/js/modules/reader-revenue-manager/components/common/PublicationOnboardingStateNotice.js
+++ b/assets/js/modules/reader-revenue-manager/components/common/PublicationOnboardingStateNotice.js
@@ -54,7 +54,7 @@ export default function PublicationOnboardingStateNotice() {
 
 	const serviceURL = useSelect( ( select ) =>
 		select( MODULES_READER_REVENUE_MANAGER ).getServiceURL( {
-			path: '/reader-revenue-manager',
+			path: 'reader-revenue-manager',
 			query: {
 				publication: publicationID,
 			},

--- a/assets/js/modules/reader-revenue-manager/components/common/PublicationOnboardingStateNotice.js
+++ b/assets/js/modules/reader-revenue-manager/components/common/PublicationOnboardingStateNotice.js
@@ -55,7 +55,9 @@ export default function PublicationOnboardingStateNotice() {
 	const serviceURL = useSelect( ( select ) =>
 		select( MODULES_READER_REVENUE_MANAGER ).getServiceURL( {
 			path: '/reader-revenue-manager',
-			publicationID,
+			query: {
+				publication: publicationID,
+			},
 		} )
 	);
 

--- a/assets/js/modules/reader-revenue-manager/components/common/PublicationOnboardingStateNotice.test.js
+++ b/assets/js/modules/reader-revenue-manager/components/common/PublicationOnboardingStateNotice.test.js
@@ -114,8 +114,10 @@ describe( 'PublicationOnboardingStateNotice', () => {
 			const expectedServiceURL = registry
 				.select( MODULES_READER_REVENUE_MANAGER )
 				.getServiceURL( {
-					path: '/reader-revenue-manager',
-					publicationID: 'ABCDEFGH',
+					path: 'reader-revenue-manager',
+					query: {
+						publication: 'ABCDEFGH',
+					},
 				} );
 
 			// Ensure that CTA is present and class name is correct.

--- a/assets/js/modules/reader-revenue-manager/components/dashboard/RRMSetupSuccessSubtleNotification.js
+++ b/assets/js/modules/reader-revenue-manager/components/dashboard/RRMSetupSuccessSubtleNotification.js
@@ -66,7 +66,9 @@ function RRMSetupSuccessSubtleNotification() {
 	const serviceURL = useSelect( ( select ) =>
 		select( MODULES_READER_REVENUE_MANAGER ).getServiceURL( {
 			path: '/reader-revenue-manager',
-			publicationID,
+			query: {
+				publication: publicationID,
+			},
 		} )
 	);
 

--- a/assets/js/modules/reader-revenue-manager/components/dashboard/RRMSetupSuccessSubtleNotification.js
+++ b/assets/js/modules/reader-revenue-manager/components/dashboard/RRMSetupSuccessSubtleNotification.js
@@ -65,6 +65,7 @@ function RRMSetupSuccessSubtleNotification() {
 
 	const serviceURL = useSelect( ( select ) =>
 		select( MODULES_READER_REVENUE_MANAGER ).getServiceURL( {
+			path: '/reader-revenue-manager',
 			publicationID,
 		} )
 	);

--- a/assets/js/modules/reader-revenue-manager/components/dashboard/RRMSetupSuccessSubtleNotification.js
+++ b/assets/js/modules/reader-revenue-manager/components/dashboard/RRMSetupSuccessSubtleNotification.js
@@ -65,7 +65,7 @@ function RRMSetupSuccessSubtleNotification() {
 
 	const serviceURL = useSelect( ( select ) =>
 		select( MODULES_READER_REVENUE_MANAGER ).getServiceURL( {
-			path: '/reader-revenue-manager',
+			path: 'reader-revenue-manager',
 			query: {
 				publication: publicationID,
 			},

--- a/assets/js/modules/reader-revenue-manager/components/settings/SettingsView.js
+++ b/assets/js/modules/reader-revenue-manager/components/settings/SettingsView.js
@@ -44,7 +44,9 @@ export default function SettingsView() {
 	const serviceURL = useSelect( ( select ) =>
 		select( MODULES_READER_REVENUE_MANAGER ).getServiceURL( {
 			path: '/reader-revenue-manager',
-			publicationID,
+			query: {
+				publication: publicationID,
+			},
 		} )
 	);
 

--- a/assets/js/modules/reader-revenue-manager/components/settings/SettingsView.js
+++ b/assets/js/modules/reader-revenue-manager/components/settings/SettingsView.js
@@ -43,7 +43,7 @@ export default function SettingsView() {
 
 	const serviceURL = useSelect( ( select ) =>
 		select( MODULES_READER_REVENUE_MANAGER ).getServiceURL( {
-			path: '/reader-revenue-manager',
+			path: 'reader-revenue-manager',
 			query: {
 				publication: publicationID,
 			},

--- a/assets/js/modules/reader-revenue-manager/datastore/service.js
+++ b/assets/js/modules/reader-revenue-manager/datastore/service.js
@@ -32,6 +32,7 @@ const selectors = {
 	 * Returns a link to the Reader Revenue Manager platform.
 	 *
 	 * @since 1.132.0
+	 * @since n.e.x.t Removed `publicationID` arg.
 	 *
 	 * @param {Object} state                Data store's state.
 	 * @param {Object} [args]               Object containing optional publication ID, path and query args.
@@ -42,25 +43,18 @@ const selectors = {
 	 */
 	getServiceURL: createRegistrySelector(
 		( select ) =>
-			( state, { path, query, publicationID } = {} ) => {
+			( state, { path, query } = {} ) => {
 				let serviceURL = 'https://publishercenter.google.com';
-
-				// Always add the utm_source.
-				query = {
-					...query,
-					utm_source: 'sitekit',
-				};
-
-				if ( publicationID ) {
-					query.publication = publicationID;
-				}
 
 				if ( path ) {
 					const sanitizedPath = `/${ path.replace( /^\//, '' ) }`;
 					serviceURL = `${ serviceURL }${ sanitizedPath }`;
 				}
 
-				serviceURL = addQueryArgs( serviceURL, query );
+				serviceURL = addQueryArgs( serviceURL, {
+					...query,
+					utm_source: 'sitekit', // Always add the utm_source.
+				} );
 
 				const accountChooserBaseURI =
 					select( CORE_USER ).getAccountChooserURL( serviceURL );

--- a/assets/js/modules/reader-revenue-manager/datastore/service.test.js
+++ b/assets/js/modules/reader-revenue-manager/datastore/service.test.js
@@ -69,25 +69,6 @@ describe( 'modules/reader-revenue-manager service store', () => {
 				);
 			} );
 
-			it( 'should append a publication ID to the URL', () => {
-				const publicationID = 'ABCDEFG';
-
-				const serviceURL = registry
-					.select( MODULES_READER_REVENUE_MANAGER )
-					.getServiceURL( {
-						publicationID,
-					} );
-
-				const query = {
-					publication: publicationID,
-					utm_source: 'sitekit',
-				};
-
-				expect( decodeServiceURL( serviceURL ) ).toMatchQueryParameters(
-					query
-				);
-			} );
-
 			it( 'should add the path parameter', () => {
 				const serviceURL = registry
 					.select( MODULES_READER_REVENUE_MANAGER )
@@ -104,6 +85,7 @@ describe( 'modules/reader-revenue-manager service store', () => {
 				const query = {
 					param1: '1',
 					param2: '2',
+					publicationID: 'ABCDEFG',
 				};
 
 				const serviceURL = registry


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #9313

## Relevant technical choices

This PR improves the navigation of a user from Site Kit to the Publisher Center by landing them to the RRM product page of a specific publication.

### Deviation from IB

This PR also removes redundant slash (`/`) in the `path` argument of the `getServiceURL` selector as the selector already adds that automatically.

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [x] Run the code.
- [x] Ensure the acceptance criteria are satisfied.
- [x] Reassess the implementation with the IB.
- [x] Ensure no unrelated changes are included.
- [x] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [x] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [x] Ensure the PR has the correct target branch.
- [x] Double-check that the PR is okay to be merged.
- [x] Ensure the corresponding issue has a ZenHub release assigned.
- [x] Add a changelog message to the issue.
