### PR TITLE
Fix dependencies for useInViewSelect calls.

### DIFF
--- a/assets/js/modules/analytics-4/hooks/useAudienceTilesReports.js
+++ b/assets/js/modules/analytics-4/hooks/useAudienceTilesReports.js
@@ -183,7 +183,7 @@ export default function useAudienceTilesReports( {
 
 			return select( MODULES_ANALYTICS_4 ).getReport( reportOptions );
 		},
-		[ shouldFetchReport ]
+		[ shouldFetchReport, reportOptions ]
 	);
 
 	const reportLoaded = useSelect( ( select ) => {
@@ -233,7 +233,7 @@ export default function useAudienceTilesReports( {
 				newVsReturningReportOptions
 			);
 		},
-		[ shouldFetchSiteKitAudiencesReport ]
+		[ shouldFetchSiteKitAudiencesReport, newVsReturningReportOptions ]
 	);
 	const siteKitAudiencesReportLoaded = useSelect( ( select ) => {
 		if ( shouldFetchSiteKitAudiencesReport === undefined ) {


### PR DESCRIPTION
## Summary

This fixes a bug where the audience tiles get stuck in a loading state when changing the selection.

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #8144

## Relevant technical choices

<!-- Please describe your changes. -->

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
