### PR TITLE
Remove onboarding state notice when it changes

### DIFF
--- a/assets/js/modules/reader-revenue-manager/components/common/PublicationOnboardingStateNotice.js
+++ b/assets/js/modules/reader-revenue-manager/components/common/PublicationOnboardingStateNotice.js
@@ -19,12 +19,13 @@
 /**
  * WordPress dependencies
  */
+import { useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
-import { useSelect } from 'googlesitekit-data';
+import { useSelect, useDispatch } from 'googlesitekit-data';
 import {
 	MODULES_READER_REVENUE_MANAGER,
 	PUBLICATION_ONBOARDING_STATES,
@@ -32,7 +33,7 @@ import {
 import SubtleNotification from '../../../../components/notifications/SubtleNotification';
 import { trackEvent } from '../../../../util';
 import useViewContext from '../../../../hooks/useViewContext';
-import { useEffect } from 'react';
+import { useRefocus } from '../../../../hooks/useRefocus';
 
 const { PENDING_VERIFICATION, ONBOARDING_ACTION_REQUIRED } =
 	PUBLICATION_ONBOARDING_STATES;
@@ -61,6 +62,10 @@ export default function PublicationOnboardingStateNotice() {
 		} )
 	);
 
+	const { syncPublicationOnboardingState } = useDispatch(
+		MODULES_READER_REVENUE_MANAGER
+	);
+
 	const showNotice =
 		onboardingState &&
 		actionableOnboardingStates.includes( onboardingState );
@@ -76,6 +81,10 @@ export default function PublicationOnboardingStateNotice() {
 			onboardingState
 		);
 	}, [ onboardingState, showNotice, viewContext ] );
+
+	// Sync the publication onboarding state.
+	// TODO: This should be done only on CTA click.
+	useRefocus( syncPublicationOnboardingState, 15000 );
 
 	if ( ! showNotice ) {
 		return null;

--- a/assets/js/modules/reader-revenue-manager/components/common/PublicationOnboardingStateNotice.test.js
+++ b/assets/js/modules/reader-revenue-manager/components/common/PublicationOnboardingStateNotice.test.js
@@ -26,8 +26,10 @@ import {
 	provideUserAuthentication,
 	provideUserInfo,
 	render,
+	waitFor,
 } from '../../../../../../tests/js/test-utils';
 import { VIEW_CONTEXT_MAIN_DASHBOARD } from '../../../../googlesitekit/constants';
+import * as fixtures from '../../datastore/__fixtures__';
 import * as tracking from '../../../../util/tracking';
 import {
 	MODULES_READER_REVENUE_MANAGER,
@@ -40,7 +42,13 @@ mockTrackEvent.mockImplementation( () => Promise.resolve() );
 
 describe( 'PublicationOnboardingStateNotice', () => {
 	let registry;
-	let mockSyncPublication;
+
+	const publicationsEndpoint = new RegExp(
+		'^/google-site-kit/v1/modules/reader-revenue-manager/data/publications'
+	);
+	const settingsEndpoint = new RegExp(
+		'^/google-site-kit/v1/modules/reader-revenue-manager/data/settings'
+	);
 
 	const {
 		ONBOARDING_ACTION_REQUIRED,
@@ -146,27 +154,42 @@ describe( 'PublicationOnboardingStateNotice', () => {
 		}
 	);
 
-	it( 'should sync onboarding state when the window is refocused 15 seconds after clicking the CTA', () => {
-		jest.useFakeTimers();
+	it( 'should sync onboarding state when the window is refocused 15 seconds after clicking the CTA', async () => {
+		const originalDateNow = Date.now;
 
-		mockSyncPublication = jest.spyOn(
-			registry.dispatch( MODULES_READER_REVENUE_MANAGER ),
-			'syncPublicationOnboardingState'
-		);
-		mockSyncPublication.mockImplementation( () => Promise.resolve() );
+		// Mock the date to be an arbitrary time.
+		const mockNow = new Date( '2020-01-01 12:30:00' ).getTime();
+		Date.now = jest.fn( () => mockNow );
+
+		jest.useFakeTimers();
 
 		registry
 			.dispatch( MODULES_READER_REVENUE_MANAGER )
 			.receiveGetSettings( {
-				publicationID: 'ABCDEFGH',
+				publicationID: 'QRSTUVWX',
 				publicationOnboardingState: ONBOARDING_ACTION_REQUIRED,
 				publicationOnboardingStateLastSyncedAtMs: 0,
 			} );
 
-		const { getByText } = render( <PublicationOnboardingStateNotice />, {
-			registry,
-			viewContext: VIEW_CONTEXT_MAIN_DASHBOARD,
+		fetchMock.getOnce( publicationsEndpoint, {
+			body: fixtures.publications,
+			status: 200,
 		} );
+
+		fetchMock.postOnce( settingsEndpoint, ( _url, opts ) => {
+			const { data } = JSON.parse( opts.body );
+
+			// Return the same settings passed to the API.
+			return { body: data, status: 200 };
+		} );
+
+		const { container, getByText } = render(
+			<PublicationOnboardingStateNotice />,
+			{
+				registry,
+				viewContext: VIEW_CONTEXT_MAIN_DASHBOARD,
+			}
+		);
 
 		act( () => {
 			fireEvent.click( getByText( 'Complete publication setup' ) );
@@ -176,8 +199,6 @@ describe( 'PublicationOnboardingStateNotice', () => {
 			global.window.dispatchEvent( new Event( 'blur' ) );
 		} );
 
-		expect( mockSyncPublication ).toHaveBeenCalledTimes( 0 );
-
 		act( () => {
 			jest.advanceTimersByTime( 15000 );
 		} );
@@ -186,8 +207,30 @@ describe( 'PublicationOnboardingStateNotice', () => {
 			global.window.dispatchEvent( new Event( 'focus' ) );
 		} );
 
-		expect( mockSyncPublication ).toHaveBeenCalledTimes( 1 );
+		await waitFor( () => {
+			expect( fetchMock ).toHaveFetched( publicationsEndpoint );
+			expect( fetchMock ).toHaveFetched( settingsEndpoint, {
+				body: {
+					data: {
+						publicationID: 'QRSTUVWX',
+						publicationOnboardingState: ONBOARDING_COMPLETE,
+						publicationOnboardingStateLastSyncedAtMs: Date.now(),
+					},
+				},
+			} );
+		} );
 
-		mockSyncPublication.mockReset();
+		// Verify that the onboarding state has been synced.
+		expect(
+			registry
+				.select( MODULES_READER_REVENUE_MANAGER )
+				.getPublicationOnboardingState()
+		).toBe( ONBOARDING_COMPLETE );
+
+		// Verify the the notice is removed.
+		expect( container ).toBeEmptyDOMElement();
+
+		// Restore Date.now method.
+		Date.now = originalDateNow;
 	} );
 } );

--- a/assets/js/modules/reader-revenue-manager/components/dashboard/RRMSetupSuccessSubtleNotification.js
+++ b/assets/js/modules/reader-revenue-manager/components/dashboard/RRMSetupSuccessSubtleNotification.js
@@ -19,7 +19,7 @@
 /**
  * WordPress dependencies
  */
-import { useEffect } from '@wordpress/element';
+import { useCallback, useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -116,7 +116,9 @@ function RRMSetupSuccessSubtleNotification() {
 		dismissNotice();
 	};
 
-	const onCTAClick = () => {
+	const onCTAClick = ( event ) => {
+		event.preventDefault();
+
 		// Set publication data to be reset when user re-focuses window.
 		if (
 			actionableOnboardingStates.includes( publicationOnboardingState )
@@ -133,15 +135,17 @@ function RRMSetupSuccessSubtleNotification() {
 				publicationOnboardingState
 			);
 		}
+
+		global.open( serviceURL, '_blank' );
 	};
 
-	const syncPublication = () => {
+	const syncPublication = useCallback( () => {
 		if ( ! shouldSyncPublication ) {
 			return;
 		}
 
 		syncPublicationOnboardingState();
-	};
+	}, [ shouldSyncPublication, syncPublicationOnboardingState ] );
 
 	useEffect( () => {
 		if (

--- a/assets/js/modules/reader-revenue-manager/components/dashboard/RRMSetupSuccessSubtleNotification.test.js
+++ b/assets/js/modules/reader-revenue-manager/components/dashboard/RRMSetupSuccessSubtleNotification.test.js
@@ -97,6 +97,13 @@ describe( 'RRMSetupSuccessSubtleNotification', () => {
 					return [ READER_REVENUE_MANAGER_MODULE_SLUG, setValueMock ];
 			}
 		} );
+
+		// Provide fallback for `window.open`.
+		global.open = jest.fn();
+	} );
+
+	afterEach( () => {
+		global.open.mockClear();
 	} );
 
 	it.each( invalidPublicationOnboardingStates )(

--- a/assets/js/modules/reader-revenue-manager/datastore/constants.js
+++ b/assets/js/modules/reader-revenue-manager/datastore/constants.js
@@ -38,6 +38,11 @@ export const READER_REVENUE_MANAGER_SETUP_BANNER_DISMISSED_KEY =
 export const READER_REVENUE_MANAGER_SETUP_FORM =
 	'readerRevenueManagerSetupForm';
 
+export const READER_REVENUE_MANAGER_NOTICES_FORM =
+	'readerRevenueManagerNoticesForm';
+
 export const SHOW_PUBLICATION_CREATE = 'showPublicationCreate';
 
 export const RESET_PUBLICATIONS = 'resetPublications';
+
+export const SYNC_PUBLICATION = 'syncPublication';

--- a/assets/js/modules/reader-revenue-manager/datastore/publications.js
+++ b/assets/js/modules/reader-revenue-manager/datastore/publications.js
@@ -75,16 +75,17 @@ const baseActions = {
 				.getSettings()
 		);
 
-		const {
-			publicationID,
-			publicationOnboardingState: currentOnboardingState,
-		} = settings;
+		const publicationID = registry
+			.select( MODULES_READER_REVENUE_MANAGER )
+			.getPublicationID();
 
 		// If there is no publication ID in state, do not attempt to sync
 		// the onboarding state.
 		if ( publicationID === undefined ) {
 			return;
 		}
+
+		yield baseActions.resetPublications();
 
 		const publications = yield commonActions.await(
 			registry
@@ -124,7 +125,11 @@ const baseActions = {
 			// eslint-disable-next-line sitekit/no-direct-date
 			.setPublicationOnboardingStateLastSyncedAtMs( Date.now() );
 
-		registry.dispatch( MODULES_READER_REVENUE_MANAGER ).saveSettings();
+		yield commonActions.await(
+			registry.dispatch( MODULES_READER_REVENUE_MANAGER ).saveSettings()
+		);
+
+		const { publicationOnboardingState: currentOnboardingState } = settings;
 
 		// If the onboarding state changes to complete from a non-empty state, set
 		// the key in CORE_UI to trigger the notification.

--- a/assets/js/modules/reader-revenue-manager/datastore/publications.test.js
+++ b/assets/js/modules/reader-revenue-manager/datastore/publications.test.js
@@ -106,10 +106,6 @@ describe( 'modules/reader-revenue-manager publications', () => {
 				const mockNow = new Date( '2020-01-01 12:30:00' ).getTime();
 				Date.now = jest.fn( () => mockNow );
 
-				registry
-					.dispatch( MODULES_READER_REVENUE_MANAGER )
-					.receiveGetPublications( fixtures.publications );
-
 				const publication = fixtures.publications[ 0 ];
 
 				const settings = {
@@ -118,6 +114,11 @@ describe( 'modules/reader-revenue-manager publications', () => {
 						PUBLICATION_ONBOARDING_STATES.PENDING_VERIFICATION,
 					publicationOnboardingStateLastSyncedAtMs: 0,
 				};
+
+				fetchMock.getOnce( publicationsEndpoint, {
+					body: fixtures.publications,
+					status: 200,
+				} );
 
 				fetchMock.postOnce( settingsEndpoint, {
 					body: {
@@ -139,7 +140,8 @@ describe( 'modules/reader-revenue-manager publications', () => {
 
 				// Set expectations for settings endpoint.
 				expect( fetchMock ).toHaveFetched( settingsEndpoint );
-				expect( fetchMock ).toHaveFetchedTimes( 1 );
+
+				expect( fetchMock ).toHaveFetchedTimes( 2 );
 
 				// Set expectations for publication ID.
 				expect(
@@ -168,10 +170,6 @@ describe( 'modules/reader-revenue-manager publications', () => {
 			} );
 
 			it( 'should set UI_KEY_SHOW_RRM_PUBLICATION_APPROVED_NOTIFICATION to true in CORE_UI store if onboarding state changes to complete', async () => {
-				registry
-					.dispatch( MODULES_READER_REVENUE_MANAGER )
-					.receiveGetPublications( fixtures.publications );
-
 				const publication = fixtures.publications[ 3 ];
 
 				// Set the current settings.
@@ -181,6 +179,11 @@ describe( 'modules/reader-revenue-manager publications', () => {
 						PUBLICATION_ONBOARDING_STATES.UNSPECIFIED,
 					publicationOnboardingStateLastSyncedAtMs: 0,
 				};
+
+				fetchMock.getOnce( publicationsEndpoint, {
+					body: fixtures.publications,
+					status: 200,
+				} );
 
 				fetchMock.postOnce( settingsEndpoint, {
 					body: {
@@ -219,10 +222,6 @@ describe( 'modules/reader-revenue-manager publications', () => {
 			} );
 
 			it( 'should not set UI_KEY_SHOW_RRM_PUBLICATION_APPROVED_NOTIFICATION to true in CORE_UI store if onboarding state does not change', async () => {
-				registry
-					.dispatch( MODULES_READER_REVENUE_MANAGER )
-					.receiveGetPublications( fixtures.publications );
-
 				const publication = fixtures.publications[ 3 ];
 
 				// Set the current settings.
@@ -232,6 +231,11 @@ describe( 'modules/reader-revenue-manager publications', () => {
 						PUBLICATION_ONBOARDING_STATES.ONBOARDING_COMPLETE,
 					publicationOnboardingStateLastSyncedAtMs: 0,
 				};
+
+				fetchMock.getOnce( publicationsEndpoint, {
+					body: fixtures.publications,
+					status: 200,
+				} );
 
 				fetchMock.postOnce( settingsEndpoint, {
 					body: {
@@ -270,9 +274,10 @@ describe( 'modules/reader-revenue-manager publications', () => {
 			} );
 
 			it( 'should not update the timestamp, call the saveSettings endpoint, and set UI_KEY_SHOW_RRM_PUBLICATION_APPROVED_NOTIFICATION to true in CORE_UI store if there is no saved publication', async () => {
-				registry
-					.dispatch( MODULES_READER_REVENUE_MANAGER )
-					.receiveGetPublications( fixtures.publications );
+				fetchMock.getOnce( publicationsEndpoint, {
+					body: fixtures.publications,
+					status: 200,
+				} );
 
 				// Set default settings.
 				registry
@@ -432,10 +437,6 @@ describe( 'modules/reader-revenue-manager publications', () => {
 			} );
 
 			it( 'should sync publication onboarding state when last sync was more than an hour ago', async () => {
-				registry
-					.dispatch( MODULES_READER_REVENUE_MANAGER )
-					.receiveGetPublications( fixtures.publications );
-
 				const publication = fixtures.publications[ 0 ];
 
 				const lastSyncedMS = Date.now() - 1000 * 60 * 60 - 1;
@@ -447,6 +448,11 @@ describe( 'modules/reader-revenue-manager publications', () => {
 					publicationOnboardingStateLastSyncedAtMs: lastSyncedMS,
 				};
 
+				fetchMock.getOnce( publicationsEndpoint, {
+					body: fixtures.publications,
+					status: 200,
+				} );
+
 				fetchMock.postOnce( settingsEndpoint, {
 					body: {
 						...settings,
@@ -466,7 +472,7 @@ describe( 'modules/reader-revenue-manager publications', () => {
 					.maybeSyncPublicationOnboardingState();
 
 				expect( fetchMock ).toHaveFetched( settingsEndpoint );
-				expect( fetchMock ).toHaveFetchedTimes( 1 );
+				expect( fetchMock ).toHaveFetchedTimes( 2 );
 
 				expect(
 					registry
@@ -476,10 +482,6 @@ describe( 'modules/reader-revenue-manager publications', () => {
 			} );
 
 			it( 'should sync publication onboarding state when `publicationOnboardingStateLastSyncedAtMs` is 0', async () => {
-				registry
-					.dispatch( MODULES_READER_REVENUE_MANAGER )
-					.receiveGetPublications( fixtures.publications );
-
 				const publication = fixtures.publications[ 0 ];
 
 				const settings = {
@@ -488,6 +490,11 @@ describe( 'modules/reader-revenue-manager publications', () => {
 						PUBLICATION_ONBOARDING_STATES.PENDING_VERIFICATION,
 					publicationOnboardingStateLastSyncedAtMs: 0,
 				};
+
+				fetchMock.getOnce( publicationsEndpoint, {
+					body: fixtures.publications,
+					status: 200,
+				} );
 
 				fetchMock.postOnce( settingsEndpoint, {
 					body: {
@@ -508,7 +515,7 @@ describe( 'modules/reader-revenue-manager publications', () => {
 					.maybeSyncPublicationOnboardingState();
 
 				expect( fetchMock ).toHaveFetched( settingsEndpoint );
-				expect( fetchMock ).toHaveFetchedTimes( 1 );
+				expect( fetchMock ).toHaveFetchedTimes( 2 );
 
 				expect(
 					registry


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #9262 

## Relevant technical choices

This PR removes the RRM onboarding state notice when it changes to a state where it is no longer needed.

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [x] Run the code.
- [x] Ensure the acceptance criteria are satisfied.
- [x] Reassess the implementation with the IB.
- [x] Ensure no unrelated changes are included.
- [x] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [x] Ensure there is a QA Brief.
- [x] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [x] Ensure the PR has the correct target branch.
- [x] Double-check that the PR is okay to be merged.
- [x] Ensure the corresponding issue has a ZenHub release assigned.
- [x] Add a changelog message to the issue.
