### PR TITLE
Scroll to audiences widget area

### DIFF
--- a/assets/js/modules/analytics-4/components/audience-segmentation/dashboard/AudienceSegmentationSetupSuccessSubtleNotification.js
+++ b/assets/js/modules/analytics-4/components/audience-segmentation/dashboard/AudienceSegmentationSetupSuccessSubtleNotification.js
@@ -28,15 +28,18 @@ import { useDispatch, useSelect } from 'googlesitekit-data';
 import { CORE_USER } from '../../../../../googlesitekit/datastore/user/constants';
 import { Button } from 'googlesitekit-components';
 import SubtleNotification from '../../SubtleNotification';
-import useViewOnly from '../../../../../hooks/useViewOnly';
+import { getContextScrollTop } from '../../../../../util/scroll';
+import { useBreakpoint } from '../../../../../hooks/useBreakpoint';
 import useDashboardType, {
 	DASHBOARD_TYPE_MAIN,
 } from '../../../../../hooks/useDashboardType';
+import useViewOnly from '../../../../../hooks/useViewOnly';
 
 export const AUDIENCE_SEGMENTATION_SETUP_SUCCESS_NOTIFICATION =
 	'audience_segmentation_setup_success_notification';
 
 export default function AudienceSegmentationSetupSuccessSubtleNotification() {
+	const breakpoint = useBreakpoint();
 	const dashboardType = useDashboardType();
 	const viewOnly = useViewOnly();
 
@@ -60,11 +63,21 @@ export default function AudienceSegmentationSetupSuccessSubtleNotification() {
 		dismissItem( AUDIENCE_SEGMENTATION_SETUP_SUCCESS_NOTIFICATION );
 	}
 
-	function scrollToWidgetArea() {
+	const scrollToWidgetArea = ( event ) => {
+		event.preventDefault();
+
 		dismissNotificationForUser();
 
-		// TODO: Scrolling to the widget area will be implemented in a subsequent issue.
-	}
+		setTimeout( () => {
+			const widgetClass =
+				'.googlesitekit-widget-area--mainDashboardTrafficAudienceSegmentation';
+
+			global.scrollTo( {
+				top: getContextScrollTop( widgetClass, breakpoint ),
+				behavior: 'smooth',
+			} );
+		}, 50 );
+	};
 
 	const shouldShowNotification =
 		// Only show this notification on the main dashboard, where the Setup CTA Banner is shown.


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #8874 

## Relevant technical choices

This PR adds functionality to scroll to the Audiences widget area from the feature's setup success notification.

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [x] Run the code.
- [x] Ensure the acceptance criteria are satisfied.
- [x] Reassess the implementation with the IB.
- [x] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [x] Ensure there is a QA Brief.
- [x] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [x] Ensure the PR has the correct target branch.
- [x] Double-check that the PR is okay to be merged.
- [x] Ensure the corresponding issue has a ZenHub release assigned.
- [x] Add a changelog message to the issue.
