### PR TITLE
Update Dockerfile

### DIFF
--- a/docker/backstopjs/Dockerfile
+++ b/docker/backstopjs/Dockerfile
@@ -1,16 +1,27 @@
-FROM alpine:3.17
+# Stage 1: Build
+FROM alpine:3.17 AS builder
 
 ARG BACKSTOPJS_VERSION=6.1.1
-
 ENV BACKSTOPJS_VERSION=$BACKSTOPJS_VERSION
 
 RUN apk upgrade --no-cache --available && \
     apk add --no-cache openrc dbus chromium nodejs npm && \
-    PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true npm i -g backstopjs@${BACKSTOPJS_VERSION} && \
+    PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true npm install -g backstopjs@${BACKSTOPJS_VERSION} && \
     npm cache clean -f && \
     rm -rf /root/.cache && \
     rc-update add dbus
 
+# Stage 2: Runtime
+FROM alpine:3.17
+
+# Install only the necessary runtime dependencies
+RUN apk add --no-cache openrc dbus chromium nodejs
+
+# Copy BackstopJS from the builder stage
+COPY --from=builder /usr/local/lib/node_modules/backstopjs /usr/local/lib/node_modules/backstopjs
+COPY --from=builder /usr/local/bin/backstop /usr/local/bin/backstop
+
+# Create working directory
 WORKDIR /src
 
 ENTRYPOINT ["backstop"]


### PR DESCRIPTION
Explanation:
Builder Stage:

Install all necessary packages, including backstopjs. Clean up the npm cache to reduce image size.
Runtime Stage:

Install only the runtime dependencies required for running backstopjs. Copy the backstopjs installation from the builder stage to avoid reinstalling it. Benefits:
Smaller Image Size: By separating build and runtime, you only include what's necessary in the final image. Clean Environment: The final image does not contain build tools, making it more secure and efficient.

## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #

## Relevant technical choices

<!-- Please describe your changes. -->

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [ ] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.
- [ ] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
