### PR TITLE
Reset error key on settings first load.

### DIFF
--- a/assets/js/components/settings/SettingsActiveModule/Footer.js
+++ b/assets/js/components/settings/SettingsActiveModule/Footer.js
@@ -116,6 +116,7 @@ export default function Footer( props ) {
 					'update_module_settings',
 					slug
 				);
+				setValue( errorKey, undefined );
 				await clearErrors?.();
 				history.push( `/connected-services/${ slug }` );
 

--- a/assets/js/modules/analytics-4/datastore/settings.js
+++ b/assets/js/modules/analytics-4/datastore/settings.js
@@ -158,7 +158,7 @@ export async function submitChanges( { select, dispatch } ) {
 	const { error } = await saveSettings( select, dispatch );
 
 	if ( error ) {
-		return error;
+		return { error };
 	}
 
 	await API.invalidateCache( 'modules', 'analytics-4' );


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #8481

## Relevant technical choices

~The implementation in the IB didn't quite work because it wouldn't remove the red border until the user clicked the confirm button again after returning to the page. Instead I use a useEffect to reset this error key on first load which removes the border when returning from the OAuth flow.~

The implementation reverted back to the IB as discussed here: https://github.com/google/site-kit-wp/pull/9410#discussion_r1775605391

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [x] Run the code.
- [x] Ensure the acceptance criteria are satisfied.
- [x] Reassess the implementation with the IB.
- [x] Ensure no unrelated changes are included.
- [x] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [x] Ensure there is a QA Brief.
- [x] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [x] Ensure the PR has the correct target branch.
- [x] Double-check that the PR is okay to be merged.
- [x] Ensure the corresponding issue has a ZenHub release assigned.
- [x] Add a changelog message to the issue.
