### PR TITLE
Restore the Audience Segmentation Connect Analytics CTA and Settings section when Analytics is disconnected.

### DIFF
--- a/includes/Modules/Analytics_4.php
+++ b/includes/Modules/Analytics_4.php
@@ -495,6 +495,8 @@ final class Analytics_4 extends Module implements Module_With_Scopes, Module_Wit
 		// This is because the property ID and the audience resource names are pulled from settings.
 		$this->resource_data_availability_date->reset_all_resource_dates();
 
+		// Unregister property change handlers to avoid the on-change logic from running when settings are
+		// updated in $settings->clear_non_persistent_settings().
 		( $this->unregister_property_change_handlers )();
 
 		/**

--- a/includes/Modules/Analytics_4/Settings.php
+++ b/includes/Modules/Analytics_4/Settings.php
@@ -77,6 +77,35 @@ class Settings extends Module_Settings implements Setting_With_Owned_Keys_Interf
 	}
 
 	/**
+	 * Gets the keys for settings that will persist when deactivating the module.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @return array List of keys.
+	 */
+	public function get_persistent_keys() {
+		return array(
+			'availableAudiences',
+			'audienceSegmentationSetupCompletedBy',
+			'availableAudiencesLastSyncedAt',
+			'previousPropertyID',
+		);
+	}
+
+	/**
+	 * Clears non-persistent settings.
+	 *
+	 * @since n.e.x.t
+	 */
+	public function clear_non_persistent_settings() {
+		$current_settings = $this->get();
+
+		$persistent_settings = array_intersect_key( $current_settings, array_flip( $this->get_persistent_keys() ) );
+
+		$this->set( $persistent_settings );
+	}
+
+	/**
 	 * Gets the default value.
 	 *
 	 * @since 1.30.0
@@ -89,6 +118,7 @@ class Settings extends Module_Settings implements Setting_With_Owned_Keys_Interf
 			'accountID'                            => '',
 			'adsConversionID'                      => '',
 			'propertyID'                           => '',
+			'previousPropertyID'                   => null,
 			'webDataStreamID'                      => '',
 			'measurementID'                        => '',
 			'trackingDisabled'                     => array( 'loggedinUsers' ),
@@ -211,6 +241,11 @@ class Settings extends Module_Settings implements Setting_With_Owned_Keys_Interf
 					if ( ! is_int( $option['audienceSegmentationSetupCompletedBy'] ) ) {
 						$option['audienceSegmentationSetupCompletedBy'] = null;
 					}
+				}
+
+				// Populate previousPropertyID if it's not set.
+				if ( ! isset( $option['previousPropertyID'] ) ) {
+					$option['previousPropertyID'] = $option['propertyID'];
 				}
 			}
 


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #9442 

## Relevant technical choices

<!-- Please describe your changes. -->

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.
- [ ] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
