### PR TITLE
Update date ESLint rule to flag usage of `new Date()` with arguments.

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -169,6 +169,17 @@
           "off"
         ]
       }
+    },
+    {
+      "files": [
+        "webpack/*",
+        "**/__factories__/*",
+        "*.stories.js",
+        "*.test.js"
+      ],
+      "rules": {
+        "sitekit/no-direct-date": "off"
+      }
     }
   ],
   "plugins": [

--- a/assets/js/components/GoogleChart/index.js
+++ b/assets/js/components/GoogleChart/index.js
@@ -234,6 +234,8 @@ export default function GoogleChart( props ) {
 
 	// Only use markers if the date is within the current date range.
 	const dateMarkersInRange = dateMarkers.filter( ( dateMarker ) => {
+		// Valid use of `new Date()` with an argument.
+		// eslint-disable-next-line sitekit/no-direct-date
 		return isDateWithinRange( new Date( dateMarker.date ) );
 	} );
 
@@ -260,6 +262,8 @@ export default function GoogleChart( props ) {
 
 		// Add the dotted line and tooltip for each date marker.
 		dateMarkersInRange.forEach( ( dateMarker, index ) => {
+			// Valid use of `new Date()` with an argument.
+			// eslint-disable-next-line sitekit/no-direct-date
 			const dateFromMarker = new Date( dateMarker.date );
 
 			const chartLine = document.getElementById(

--- a/assets/js/components/notifications/BannerNotification/index.js
+++ b/assets/js/components/notifications/BannerNotification/index.js
@@ -218,6 +218,8 @@ export default function BannerNotification( props ) {
 		const { value: dismissed } = await getItem( cacheKeyDismissed );
 
 		if ( dismissed ) {
+			// Valid use of `new Date()` with an argument.
+			// eslint-disable-next-line sitekit/no-direct-date
 			const expiration = new Date( dismissed );
 
 			expiration.setSeconds(

--- a/assets/js/modules/adsense/util/data-mock.js
+++ b/assets/js/modules/adsense/util/data-mock.js
@@ -257,9 +257,14 @@ export function getAdSenseMockResponse( args ) {
 	const ops = [
 		// Converts range number to a date string.
 		map( ( item ) => {
+			// Valid use of `new Date()` with an argument.
+			// eslint-disable-next-line sitekit/no-direct-date
 			const updatedMilliseconds = new Date( startDate ).setDate(
 				startDate.getDate() + item
 			);
+
+			// Valid use of `new Date()` with an argument.
+			// eslint-disable-next-line sitekit/no-direct-date
 			return getDateString( new Date( updatedMilliseconds ) );
 		} ),
 		// Add dimension and metric values.

--- a/assets/js/modules/adsense/util/site-stats-data.js
+++ b/assets/js/modules/adsense/util/site-stats-data.js
@@ -71,6 +71,8 @@ export function getSiteStatsDataForGoogleChart(
 	];
 
 	const nextDate = ( date ) => {
+		// Valid use of `new Date()` with an argument.
+		// eslint-disable-next-line sitekit/no-direct-date
 		const next = new Date( date );
 		next.setDate( date.getDate() + 1 );
 		return next;

--- a/assets/js/modules/analytics-4/components/dashboard/DashboardAllTrafficWidgetGA4/UserCountGraph.js
+++ b/assets/js/modules/analytics-4/components/dashboard/DashboardAllTrafficWidgetGA4/UserCountGraph.js
@@ -145,6 +145,8 @@ export default function UserCountGraph( props ) {
 						? [
 								{
 									date: getDateString(
+										// Valid use of `new Date()` with an argument.
+										// eslint-disable-next-line sitekit/no-direct-date
 										new Date( propertyCreateTime )
 									),
 									text: __(

--- a/assets/js/modules/analytics-4/datastore/custom-dimensions-gathering-data.js
+++ b/assets/js/modules/analytics-4/datastore/custom-dimensions-gathering-data.js
@@ -326,6 +326,8 @@ const baseSelectors = {
 			const endDate = select( CORE_USER ).getReferenceDate();
 
 			return {
+				// Valid use of `new Date()` with an argument.
+				// eslint-disable-next-line sitekit/no-direct-date
 				startDate: getDateString( new Date( propertyCreateTime ) ),
 				endDate,
 				dimensions: [ `customEvent:${ customDimension }` ],

--- a/assets/js/modules/analytics-4/datastore/partial-data.js
+++ b/assets/js/modules/analytics-4/datastore/partial-data.js
@@ -506,6 +506,8 @@ const baseSelectors = {
 				return undefined;
 			}
 
+			// Valid use of `new Date()` with an argument.
+			// eslint-disable-next-line sitekit/no-direct-date
 			const startDate = getDateString( new Date( propertyCreateTime ) );
 			const endDate = select( CORE_USER ).getReferenceDate();
 

--- a/assets/js/modules/search-console/components/common/AnalyticsStats.js
+++ b/assets/js/modules/search-console/components/common/AnalyticsStats.js
@@ -77,6 +77,8 @@ export default function AnalyticsStats( props ) {
 	if ( propertyCreateTime ) {
 		dateMarkers = [
 			{
+				// Valid use of `new Date()` with an argument.
+				// eslint-disable-next-line sitekit/no-direct-date
 				date: getDateString( new Date( propertyCreateTime ) ),
 				text: __(
 					'Google Analytics property created',

--- a/assets/js/modules/search-console/util/data-mock.js
+++ b/assets/js/modules/search-console/util/data-mock.js
@@ -78,9 +78,14 @@ export function getSearchConsoleMockResponse( args ) {
 	const ops = [
 		// Converts range number to a date string.
 		map( ( item ) => {
+			// Valid use of `new Date()` with an argument.
+			// eslint-disable-next-line sitekit/no-direct-date
 			const updatedMilliseconds = new Date( startDate ).setDate(
 				startDate.getDate() + item
 			);
+
+			// Valid use of `new Date()` with an argument.
+			// eslint-disable-next-line sitekit/no-direct-date
 			return getDateString( new Date( updatedMilliseconds ) );
 		} ),
 		// Add dimension and metric values.

--- a/assets/js/util/convert-time.js
+++ b/assets/js/util/convert-time.js
@@ -58,7 +58,10 @@ export const convertSecondsToArray = ( seconds ) => {
 export const convertDateStringToUNIXTimestamp = ( dateStringValue ) => {
 	const unixTimestamp =
 		dateStringValue && ! Number.isInteger( dateStringValue )
-			? // Valid use of `new Date()` with an argument.
+			? // Valid use of `new Date()` with an argument, because this should only
+			  // be passed full time strings, not `YYYY-MM-DD` style dates.
+			  //
+			  // See: https://github.com/google/site-kit-wp/pull/9459#discussion_r1790660073
 			  // eslint-disable-next-line sitekit/no-direct-date
 			  new Date( dateStringValue ).getTime()
 			: dateStringValue;

--- a/assets/js/util/convert-time.js
+++ b/assets/js/util/convert-time.js
@@ -58,7 +58,9 @@ export const convertSecondsToArray = ( seconds ) => {
 export const convertDateStringToUNIXTimestamp = ( dateStringValue ) => {
 	const unixTimestamp =
 		dateStringValue && ! Number.isInteger( dateStringValue )
-			? new Date( dateStringValue ).getTime()
+			? // Valid use of `new Date()` with an argument.
+			  // eslint-disable-next-line sitekit/no-direct-date
+			  new Date( dateStringValue ).getTime()
 			: dateStringValue;
 
 	if ( isNaN( unixTimestamp ) || ! unixTimestamp ) {

--- a/assets/js/util/dates.js
+++ b/assets/js/util/dates.js
@@ -114,7 +114,10 @@ export function isValidDateString( dateString = '' ) {
 		return false;
 	}
 
+	// Valid use of `new Date()`, constructing a new date from the string.
+	// eslint-disable-next-line sitekit/no-direct-date
 	const date = new Date( dateString );
+
 	return isDate( date ) && ! isNaN( date );
 }
 
@@ -217,5 +220,8 @@ export function dateSub( relativeDate, duration ) {
 	const timestamp = isValidDateString( relativeDate )
 		? Date.parse( relativeDate )
 		: relativeDate.getTime();
+
+	// Valid use of `new Date()` using calculations.
+	// eslint-disable-next-line sitekit/no-direct-date
 	return new Date( timestamp - duration * 1000 );
 }

--- a/packages/eslint-plugin/configs/main.js
+++ b/packages/eslint-plugin/configs/main.js
@@ -27,16 +27,6 @@ module.exports = {
 		'sitekit/jsdoc-tag-grouping': [ 'error' ],
 		'sitekit/jsdoc-tag-order': [ 'error' ],
 		'sitekit/no-yield-dispatch': [ 'error' ],
-		'sitekit/no-direct-date': [
-			'error',
-			{
-				ignoreFiles: [
-					'*/webpack/*',
-					'*/__factories__/*',
-					'*.stories.js',
-					'*.test.js',
-				],
-			},
-		],
+		'sitekit/no-direct-date': [ 'error' ],
 	},
 };

--- a/packages/eslint-plugin/rules/no-direct-date.js
+++ b/packages/eslint-plugin/rules/no-direct-date.js
@@ -53,7 +53,8 @@ module.exports = {
 			NewExpression( node ) {
 				if (
 					node.callee.name === 'Date' &&
-					node.arguments.length === 0
+					node.arguments.length >= 0 &&
+					node.arguments.length <= 2
 				) {
 					report( node );
 				}
@@ -62,7 +63,9 @@ module.exports = {
 				if (
 					node.callee.object &&
 					node.callee.object.name === 'Date' &&
-					node.callee.property.name === 'now'
+					node.callee.property.name === 'now' &&
+					node.arguments.length >= 0 &&
+					node.arguments.length <= 2
 				) {
 					// Don't show an error if Date.now() is used within another Date expression.
 					if (

--- a/packages/eslint-plugin/rules/no-direct-date.js
+++ b/packages/eslint-plugin/rules/no-direct-date.js
@@ -62,8 +62,7 @@ module.exports = {
 				if (
 					node.callee.object &&
 					node.callee.object.name === 'Date' &&
-					node.callee.property.name === 'now' &&
-					node.arguments.length <= 2
+					node.callee.property.name === 'now'
 				) {
 					// Don't show an error if Date.now() is used within another Date expression.
 					if (

--- a/packages/eslint-plugin/rules/no-direct-date.js
+++ b/packages/eslint-plugin/rules/no-direct-date.js
@@ -53,7 +53,6 @@ module.exports = {
 			NewExpression( node ) {
 				if (
 					node.callee.name === 'Date' &&
-					node.arguments.length >= 0 &&
 					node.arguments.length <= 2
 				) {
 					report( node );
@@ -64,7 +63,6 @@ module.exports = {
 					node.callee.object &&
 					node.callee.object.name === 'Date' &&
 					node.callee.property.name === 'now' &&
-					node.arguments.length >= 0 &&
 					node.arguments.length <= 2
 				) {
 					// Don't show an error if Date.now() is used within another Date expression.

--- a/packages/eslint-plugin/rules/no-direct-date.test.js
+++ b/packages/eslint-plugin/rules/no-direct-date.test.js
@@ -36,7 +36,7 @@ const ruleTester = new RuleTester( {
 ruleTester.run( 'no-direct-date', rule, {
 	valid: [
 		'const date = select( CORE_USER ).getReferenceDate();',
-		'const createTime = new Date( Date.now() - DAY_IN_SECONDS * 1.5 * 1000 ).toISOString();',
+		'const createTime = new Date( DAY_IN_SECONDS * 1.5 * 1000, 20, 3 ).toISOString();',
 	],
 	invalid: [
 		{
@@ -50,6 +50,42 @@ ruleTester.run( 'no-direct-date', rule, {
 		},
 		{
 			code: 'const timestamp = Date.now();',
+			errors: [
+				{
+					message:
+						"Avoid using 'Date.now()'. Use select( CORE_USER ).getReferenceDate() or add a comment explaining why the reference date should not be used here.",
+				},
+			],
+		},
+		{
+			code: 'const date = new Date( 12345 );',
+			errors: [
+				{
+					message:
+						"Avoid using 'new Date()'. Use select( CORE_USER ).getReferenceDate() or add a comment explaining why the reference date should not be used here.",
+				},
+			],
+		},
+		{
+			code: 'const timestamp = Date.now( 12345 );',
+			errors: [
+				{
+					message:
+						"Avoid using 'Date.now()'. Use select( CORE_USER ).getReferenceDate() or add a comment explaining why the reference date should not be used here.",
+				},
+			],
+		},
+		{
+			code: 'const date = new Date( 12345, 2 );',
+			errors: [
+				{
+					message:
+						"Avoid using 'new Date()'. Use select( CORE_USER ).getReferenceDate() or add a comment explaining why the reference date should not be used here.",
+				},
+			],
+		},
+		{
+			code: 'const timestamp = Date.now( 12345, 2 );',
 			errors: [
 				{
 					message:

--- a/packages/eslint-plugin/rules/no-direct-date.test.js
+++ b/packages/eslint-plugin/rules/no-direct-date.test.js
@@ -36,7 +36,7 @@ const ruleTester = new RuleTester( {
 ruleTester.run( 'no-direct-date', rule, {
 	valid: [
 		'const date = select( CORE_USER ).getReferenceDate();',
-		'const createTime = new Date( DAY_IN_SECONDS * 1.5 * 1000, 20, 3 ).toISOString();',
+		'const createTime = new Date( 2024, 5, 9 ).toISOString();',
 	],
 	invalid: [
 		{


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #9032

## Relevant technical choices

A difference between the IB is that it requests errors with `> 0 && < 3`, but I think this was actually meant to just be `< 3`, because we still want errors when no arguments are used, so I made that change.

It seems like all existing instances of `new Date()` with arguments are valid, so I just added comments.

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.
- [ ] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
