### PR TITLE
Retain choice to display visitor groups on reset

### DIFF
--- a/includes/Core/User/Audience_Settings.php
+++ b/includes/Core/User/Audience_Settings.php
@@ -77,6 +77,7 @@ class Audience_Settings extends User_Setting {
 		$allowed_settings = array(
 			'configuredAudiences'                => true,
 			'isAudienceSegmentationWidgetHidden' => true,
+			'didSetAudiences'                    => true,
 		);
 
 		$updated = array_intersect_key( $partial, $allowed_settings );
@@ -108,11 +109,11 @@ class Audience_Settings extends User_Setting {
 
 			$sanitized_settings = array();
 
-			if ( isset( $settings['configuredAudiences'] ) ) {
-				$sanitized_settings['configuredAudiences'] = Sanitize::sanitize_string_list( $settings['configuredAudiences'] );
-			} elseif ( is_null( $settings['configuredAudiences'] ) ) {
-				// Allow setting `null` for `configuredAudiences`.
-				$sanitized_settings['configuredAudiences'] = null;
+			// Allow setting `null` for `configuredAudiences`.
+			if ( array_key_exists( 'configuredAudiences', $settings ) ) {
+				$sanitized_settings['configuredAudiences'] = is_null( $settings['configuredAudiences'] )
+					? null
+					: Sanitize::sanitize_string_list( $settings['configuredAudiences'] );
 			}
 
 			if ( isset( $settings['isAudienceSegmentationWidgetHidden'] ) ) {

--- a/includes/Core/User/Audience_Settings.php
+++ b/includes/Core/User/Audience_Settings.php
@@ -58,6 +58,7 @@ class Audience_Settings extends User_Setting {
 	 * Merges an array of settings to update.
 	 *
 	 * @since 1.124.0
+	 * @since n.e.x.t Allow setting `null` for `configuredAudiences`.
 	 *
 	 * @param array $partial Partial settings array to save.
 	 * @return bool True on success, false on failure.
@@ -66,9 +67,11 @@ class Audience_Settings extends User_Setting {
 		$settings = $this->get();
 		$partial  = array_filter(
 			$partial,
-			function ( $value ) {
-				return null !== $value;
-			}
+			function ( $value, $key ) {
+				// Allow setting `null` for `configuredAudiences`.
+				return 'configuredAudiences' === $key ? true : null !== $value;
+			},
+			ARRAY_FILTER_USE_BOTH
 		);
 
 		$allowed_settings = array(
@@ -93,6 +96,7 @@ class Audience_Settings extends User_Setting {
 	 * Gets the callback for sanitizing the setting's value before saving.
 	 *
 	 * @since 1.124.0
+	 * @since n.e.x.t Allow setting `null` for `configuredAudiences`.
 	 *
 	 * @return callable Sanitize callback.
 	 */
@@ -106,6 +110,9 @@ class Audience_Settings extends User_Setting {
 
 			if ( isset( $settings['configuredAudiences'] ) ) {
 				$sanitized_settings['configuredAudiences'] = Sanitize::sanitize_string_list( $settings['configuredAudiences'] );
+			} elseif ( is_null( $settings['configuredAudiences'] ) ) {
+				// Allow setting `null` for `configuredAudiences`.
+				$sanitized_settings['configuredAudiences'] = null;
 			}
 
 			if ( isset( $settings['isAudienceSegmentationWidgetHidden'] ) ) {

--- a/includes/Modules/Analytics_4/Reset_Audiences.php
+++ b/includes/Modules/Analytics_4/Reset_Audiences.php
@@ -129,8 +129,15 @@ class Reset_Audiences {
 					}
 				}
 
-				// Reset the users audience settings, such as configured audiences.
-				$this->audience_settings->delete();
+				// Reset the user's audience settings.
+				if ( $this->audience_settings->has() ) {
+					$this->audience_settings->merge(
+						array(
+							'configuredAudiences' => null,
+							'didSetAudiences'     => false,
+						),
+					);
+				}
 			}
 
 			// Restore original user.

--- a/tests/phpunit/integration/Core/User/Audience_SettingsTest.php
+++ b/tests/phpunit/integration/Core/User/Audience_SettingsTest.php
@@ -259,13 +259,12 @@ class Audience_SettingsTest extends TestCase {
 			$this->audience_settings->get()
 		);
 
-		// Make sure that we can't set wrong format for the isAudienceSegmentationWidgetHidden property
+		// Make sure that we can't set wrong format (or `null`) for the isAudienceSegmentationWidgetHidden property
 		$this->audience_settings->set( $original_settings );
 		$this->audience_settings->merge( array( 'isAudienceSegmentationWidgetHidden' => null ) );
 		$this->assertEqualSetsWithIndex( $original_settings, $this->audience_settings->get() );
 
-		// Make sure that we can't set wrong format (or `null`) for the
-		// configuredAudiences property.
+		// Make sure that we can't set wrong format for the configuredAudiences property.
 		$this->audience_settings->set( $original_settings );
 		$this->audience_settings->merge( array( 'configuredAudiences' => false ) );
 		$this->assertEqualSetsWithIndex(

--- a/tests/phpunit/integration/Core/User/Audience_SettingsTest.php
+++ b/tests/phpunit/integration/Core/User/Audience_SettingsTest.php
@@ -73,6 +73,14 @@ class Audience_SettingsTest extends TestCase {
 				array( 'configuredAudiences' => array( 'validAudienceResourceName1', 'validAudienceResourceName2', 'validAudienceResourceName3' ) ),
 				array( 'configuredAudiences' => array( 'validAudienceResourceName1', 'validAudienceResourceName2', 'validAudienceResourceName3' ) ),
 			),
+			'null configuredAudiences setting'             => array(
+				array(
+					'configuredAudiences' => null,
+				),
+				array(
+					'configuredAudiences' => null,
+				),
+			),
 			'null isAudienceSegmentationWidgetHidden flag' => array(
 				array(
 					'isAudienceSegmentationWidgetHidden' => null,
@@ -256,10 +264,32 @@ class Audience_SettingsTest extends TestCase {
 		$this->audience_settings->merge( array( 'isAudienceSegmentationWidgetHidden' => null ) );
 		$this->assertEqualSetsWithIndex( $original_settings, $this->audience_settings->get() );
 
-		// Make sure that we can't set wrong format for the configuredAudiences property
+		// Make sure that we can't set wrong format (or `null`) for the
+		// configuredAudiences property.
+		$this->audience_settings->set( $original_settings );
+		$this->audience_settings->merge( array( 'configuredAudiences' => false ) );
+		$this->assertEqualSetsWithIndex(
+			array_merge(
+				$original_settings,
+				array(
+					'configuredAudiences' => array(),
+				)
+			),
+			$this->audience_settings->get()
+		);
+
+		// Make sure we can set `null` for the configuredAudiences property.
 		$this->audience_settings->set( $original_settings );
 		$this->audience_settings->merge( array( 'configuredAudiences' => null ) );
-		$this->assertEqualSetsWithIndex( $original_settings, $this->audience_settings->get() );
+		$this->assertEqualSetsWithIndex(
+			array_merge(
+				$original_settings,
+				array(
+					'configuredAudiences' => null,
+				)
+			),
+			$this->audience_settings->get()
+		);
 	}
 
 	public function test_merge__did_set_audiences() {
@@ -287,6 +317,18 @@ class Audience_SettingsTest extends TestCase {
 
 		// Verify that `didSetAudiences` retains its value when `configuredAudiences` is updated to an empty array.
 		$this->audience_settings->merge( array( 'configuredAudiences' => array() ) );
+		$this->assertEqualSetsWithIndex(
+			array(
+				'configuredAudiences'                => array(),
+				'isAudienceSegmentationWidgetHidden' => false,
+				'didSetAudiences'                    => true,
+			),
+			$this->audience_settings->get()
+		);
+
+		// Make sure that we can't set wrong format (or `null`) for the
+		// `didSetAudiences` property.
+		$this->audience_settings->merge( array( 'didSetAudiences' => null ) );
 		$this->assertEqualSetsWithIndex(
 			array(
 				'configuredAudiences'                => array(),

--- a/tests/phpunit/integration/Modules/Analytics_4/Reset_AudiencesTest.php
+++ b/tests/phpunit/integration/Modules/Analytics_4/Reset_AudiencesTest.php
@@ -209,10 +209,15 @@ class Reset_AudiencesTest extends TestCase {
 				$this->assertFalse( array_key_exists( $dismissed_item, $user_dismissed_items ) );
 			}
 
-			// Confirm the user's audience settings have been reset.
+			// Confirm the user's applicable audience settings have been reset.
 			$audience_settings = $this->audience_settings->get();
 			foreach ( array_keys( $default_user_audience_settings ) as $key ) {
+				// `isAudienceSegmentationWidgetHidden` should not be reset.
+				if ( 'isAudienceSegmentationWidgetHidden' === $key ) {
+					$this->assertEquals( $activated_user_audience_settings[ $key ], $audience_settings[ $key ] );
+				} else {
 					$this->assertEquals( $default_user_audience_settings[ $key ], $audience_settings[ $key ] );
+				}
 			}
 		}
 


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #9432

## Relevant technical choices

This PR improves the reset behaviour of Audience Segmentation settings so that the value for `isAudienceSegmentationWidgetHidden` is retained while the others are reset.

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.
- [ ] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [x] Ensure the PR has the correct target branch.
- [x] Double-check that the PR is okay to be merged.
- [x] Ensure the corresponding issue has a ZenHub release assigned.
- [x] Add a changelog message to the issue.
