### PR TITLE
Bug/#9471 - Capture insufficient permissions error for `create-audience` request failures

### DIFF
--- a/assets/js/modules/analytics-4/datastore/audiences.js
+++ b/assets/js/modules/analytics-4/datastore/audiences.js
@@ -438,8 +438,9 @@ const baseActions = {
 				if ( result.error ) {
 					if ( isInsufficientPermissionsError( result.error ) ) {
 						insufficientPermissionsError = result.error;
+					} else {
+						failedAudiencesToRetry.push( audienceSlug );
 					}
-					failedAudiencesToRetry.push( audienceSlug );
 				} else {
 					configuredAudiences.push( result.response.name );
 				}

--- a/assets/js/modules/analytics-4/datastore/audiences.js
+++ b/assets/js/modules/analytics-4/datastore/audiences.js
@@ -36,6 +36,7 @@ import { createFetchStore } from '../../../googlesitekit/data/create-fetch-store
 import { createValidatedAction } from '../../../googlesitekit/data/utils';
 import { CORE_USER } from '../../../googlesitekit/datastore/user/constants';
 import { getPreviousDate } from '../../../util';
+import { isInsufficientPermissionsError } from '../../../util/errors';
 import { validateAudience } from '../utils/validation';
 import { RESOURCE_TYPE_AUDIENCE } from './partial-data';
 
@@ -429,15 +430,24 @@ const baseActions = {
 			);
 
 			const failedAudiencesToRetry = [];
+			let insufficientPermissionsError = null;
 
 			audienceCreationResults.forEach( ( result, index ) => {
 				const audienceSlug = audiencesToCreate[ index ];
+
 				if ( result.error ) {
+					if ( isInsufficientPermissionsError( result.error ) ) {
+						insufficientPermissionsError = result.error;
+					}
 					failedAudiencesToRetry.push( audienceSlug );
 				} else {
 					configuredAudiences.push( result.response.name );
 				}
 			} );
+
+			if ( insufficientPermissionsError ) {
+				return { error: insufficientPermissionsError };
+			}
 
 			yield commonActions.await(
 				resolveSelect( CORE_USER ).getAudienceSettings()

--- a/assets/js/modules/analytics-4/datastore/audiences.test.js
+++ b/assets/js/modules/analytics-4/datastore/audiences.test.js
@@ -1575,7 +1575,7 @@ describe( 'modules/analytics-4 audiences', () => {
 					).toEqual( expectedConfiguredAudiences );
 				} );
 
-				it( 'should return an insufficient permisions error if "create-audience" request fails', async () => {
+				it( 'should return an insufficient permisions error if the "create-audience" request fails', async () => {
 					const insufficientPermissionsError = {
 						code: 'test_error',
 						message: 'Error message.',

--- a/assets/js/modules/analytics-4/datastore/audiences.test.js
+++ b/assets/js/modules/analytics-4/datastore/audiences.test.js
@@ -40,6 +40,7 @@ import {
 	SITE_KIT_AUDIENCE_DEFINITIONS,
 } from './constants';
 import { CORE_USER } from '../../../googlesitekit/datastore/user/constants';
+import { ERROR_REASON_INSUFFICIENT_PERMISSIONS } from '../../../util/errors';
 import {
 	properties as propertiesFixture,
 	audiences as audiencesFixture,
@@ -1572,6 +1573,47 @@ describe( 'modules/analytics-4 audiences', () => {
 					expect(
 						registry.select( CORE_USER ).getConfiguredAudiences()
 					).toEqual( expectedConfiguredAudiences );
+				} );
+
+				it( 'should return an insufficient permisions error if "create-audience" request fails', async () => {
+					const insufficientPermissionsError = {
+						code: 'test_error',
+						message: 'Error message.',
+						data: {
+							reason: ERROR_REASON_INSUFFICIENT_PERMISSIONS,
+						},
+					};
+
+					fetchMock.postOnce( syncAvailableAudiencesEndpoint, {
+						body: [],
+						status: 200,
+					} );
+
+					// Mocking createAudience API call with insufficient permissions error.
+					fetchMock.post(
+						{ url: createAudienceEndpoint, repeat: 2 },
+						{
+							body: insufficientPermissionsError,
+							status: 400,
+						}
+					);
+
+					const { response, error } = await registry
+						.dispatch( MODULES_ANALYTICS_4 )
+						.enableAudienceGroup();
+
+					await waitForDefaultTimeouts();
+
+					expect( response ).toBeUndefined();
+					expect( error ).toEqual( insufficientPermissionsError );
+
+					// Ensuring no configured audiences are set when all creation attempts fail.
+					expect(
+						registry.select( CORE_USER ).getConfiguredAudiences()
+					).toBeNull();
+
+					expect( console ).toHaveErrored();
+					expect( console ).toHaveErrored();
 				} );
 			} );
 		} );


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #9471 

## Relevant technical choices

<!-- Please describe your changes. -->

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [x] Run the code.
- [x] Ensure the acceptance criteria are satisfied.
- [x] Reassess the implementation with the IB.
- [x] Ensure no unrelated changes are included.
- [x] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [x] Ensure there is a QA Brief.
- [x] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [x] Ensure the PR has the correct target branch.
- [x] Double-check that the PR is okay to be merged.
- [x] Ensure the corresponding issue has a ZenHub release assigned.
- [x] Add a changelog message to the issue.
