### PR TITLE
Ensure the "Top content" metric does not appear in the partial data state when the property is in the partial data state.

### DIFF
--- a/assets/js/modules/analytics-4/components/audience-segmentation/dashboard/AudienceTilesWidget/AudienceTile/index.js
+++ b/assets/js/modules/analytics-4/components/audience-segmentation/dashboard/AudienceTilesWidget/AudienceTile/index.js
@@ -118,6 +118,7 @@ export default function AudienceTile( {
 			}
 
 			return (
+				! isPropertyPartialData &&
 				! isAudiencePartialData &&
 				select( MODULES_ANALYTICS_4 ).isCustomDimensionPartialData(
 					'googlesitekit_post_type'

--- a/assets/js/modules/analytics-4/components/audience-segmentation/dashboard/AudienceTilesWidget/__snapshots__/index.test.js.snap
+++ b/assets/js/modules/analytics-4/components/audience-segmentation/dashboard/AudienceTilesWidget/__snapshots__/index.test.js.snap
@@ -347,11 +347,6 @@ exports[`AudienceTilesWidget should not render audiences that are not available 
                           42
                         </div>
                       </div>
-                      <span
-                        class="googlesitekit-audience-segmentation-partial-data-notice"
-                      >
-                        Still collecting full data for this timeframe, partial data is displayed for this metric
-                      </span>
                     </div>
                   </div>
                 </div>
@@ -740,11 +735,6 @@ exports[`AudienceTilesWidget should render correctly when there is partial data 
                           6
                         </div>
                       </div>
-                      <span
-                        class="googlesitekit-audience-segmentation-partial-data-notice"
-                      >
-                        Still collecting full data for this timeframe, partial data is displayed for this metric
-                      </span>
                     </div>
                   </div>
                 </div>
@@ -1286,11 +1276,6 @@ exports[`AudienceTilesWidget should render when all configured audiences are mat
                           42
                         </div>
                       </div>
-                      <span
-                        class="googlesitekit-audience-segmentation-partial-data-notice"
-                      >
-                        Still collecting full data for this timeframe, partial data is displayed for this metric
-                      </span>
                     </div>
                   </div>
                 </div>
@@ -1651,11 +1636,6 @@ exports[`AudienceTilesWidget should render when configured audience is matching 
                           42
                         </div>
                       </div>
-                      <span
-                        class="googlesitekit-audience-segmentation-partial-data-notice"
-                      >
-                        Still collecting full data for this timeframe, partial data is displayed for this metric
-                      </span>
                     </div>
                   </div>
                 </div>

--- a/assets/js/modules/analytics-4/components/audience-segmentation/dashboard/AudienceTilesWidget/index.test.js
+++ b/assets/js/modules/analytics-4/components/audience-segmentation/dashboard/AudienceTilesWidget/index.test.js
@@ -426,7 +426,9 @@ describe( 'AudienceTilesWidget', () => {
 					'properties/12345/audiences/4': dataAvailabilityDate,
 				},
 				customDimension: {},
-				property: {},
+				property: {
+					12345: 20201218,
+				},
 			} );
 
 		registry


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #9474

## Relevant technical choices

Addresses the defect raised here by @kelvinballoo: https://github.com/google/site-kit-wp/issues/9474#issuecomment-2432742583

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [x] Run the code.
- [x] Ensure the acceptance criteria are satisfied.
- [x] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [x] Ensure there is a QA Brief.
- [x] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [x] Ensure the PR has the correct target branch.
- [x] Double-check that the PR is okay to be merged.
- [x] Ensure the corresponding issue has a ZenHub release assigned.
- [x] Add a changelog message to the issue.
