### PR TITLE
(Follow-up) Fix event tracking label when saving audience selection

### DIFF
--- a/assets/js/modules/analytics-4/components/audience-segmentation/dashboard/AudienceSelectionPanel/Footer.js
+++ b/assets/js/modules/analytics-4/components/audience-segmentation/dashboard/AudienceSelectionPanel/Footer.js
@@ -77,12 +77,11 @@ export default function Footer( { isOpen, closePanel, savedItemSlugs } ) {
 	const availableAudiences = useSelect( ( select ) =>
 		select( MODULES_ANALYTICS_4 ).getAvailableAudiences()
 	);
-	const configuredAudiences = useSelect( ( select ) =>
-		select( CORE_USER ).getConfiguredAudiences()
-	);
 
 	const { saveAudienceSettings, removeDismissedItems } =
 		useDispatch( CORE_USER );
+
+	const { getConfiguredAudiences } = useSelect( CORE_USER );
 
 	const selectedItemsCount = selectedItems?.length || 0;
 	let itemLimitError;
@@ -167,6 +166,10 @@ export default function Footer( { isOpen, closePanel, savedItemSlugs } ) {
 			DEFAULT_AUDIENCE: 'default',
 		};
 
+		// Call to the selector within the callback ensures that the latest
+		// value is used.
+		const configuredAudiences = getConfiguredAudiences();
+
 		const eventLabel = Object.keys( audienceTypeLabels )
 			.map( ( type ) => {
 				const audiencesOfType = configuredAudiences.filter(
@@ -188,7 +191,7 @@ export default function Footer( { isOpen, closePanel, savedItemSlugs } ) {
 			'audiences_sidebar_save',
 			eventLabel
 		);
-	}, [ availableAudiences, configuredAudiences, viewContext ] );
+	}, [ availableAudiences, getConfiguredAudiences, viewContext ] );
 
 	const onCancel = useCallback( () => {
 		trackEvent(

--- a/assets/js/modules/analytics-4/components/audience-segmentation/dashboard/AudienceSelectionPanel/index.test.js
+++ b/assets/js/modules/analytics-4/components/audience-segmentation/dashboard/AudienceSelectionPanel/index.test.js
@@ -808,7 +808,7 @@ describe( 'AudienceSelectionPanel', () => {
 			fetchMock.postOnce( audienceSettingsEndpoint, ( url, opts ) => {
 				const { data } = JSON.parse( opts.body );
 				// Return the same settings passed to the API.
-				return { body: data, status: 200 };
+				return { body: data.settings, status: 200 };
 			} );
 
 			fetchMock.postOnce(
@@ -1869,7 +1869,11 @@ describe( 'AudienceSelectionPanel', () => {
 				didSetAudiences: true,
 			} );
 
-			muteFetch( audienceSettingsEndpoint );
+			fetchMock.postOnce( audienceSettingsEndpoint, ( url, opts ) => {
+				const { data } = JSON.parse( opts.body );
+				// Return the same settings passed to the API.
+				return { body: data.settings, status: 200 };
+			} );
 
 			registry
 				.dispatch( CORE_UI )


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- https://github.com/google/site-kit-wp/issues/9497#issuecomment-2462922926 (ITEM 1)

## Relevant technical choices

This PR fixes the event tracking level as indicated in the comment above by ensuring that the count of saved audiences is correct by getting the latest value of `configuredAudiences`.

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.
- [ ] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
