### PR TITLE
Enqueue RRM snippet only on WP singular posts

### DIFF
--- a/includes/Modules/Reader_Revenue_Manager/Web_Tag.php
+++ b/includes/Modules/Reader_Revenue_Manager/Web_Tag.php
@@ -55,6 +55,7 @@ class Web_Tag extends Module_Web_Tag {
 	 * Enqueues the Reader Revenue Manager (SWG) script.
 	 *
 	 * @since 1.132.0
+	 * @since n.e.x.t Updated to enqueue the script only on singular posts.
 	 */
 	protected function enqueue_swg_script() {
 		$locale = str_replace( '_', '-', get_locale() );

--- a/includes/Modules/Reader_Revenue_Manager/Web_Tag.php
+++ b/includes/Modules/Reader_Revenue_Manager/Web_Tag.php
@@ -85,7 +85,9 @@ class Web_Tag extends Module_Web_Tag {
 		wp_script_add_data( 'google_swgjs', 'strategy', 'async' );
 		wp_add_inline_script( 'google_swgjs', $swg_inline_script, 'before' );
 
-		wp_enqueue_script( 'google_swgjs' );
+		if ( is_singular( 'post' ) ) {
+			wp_enqueue_script( 'google_swgjs' );
+		}
 	}
 
 	/**

--- a/includes/Modules/Reader_Revenue_Manager/Web_Tag.php
+++ b/includes/Modules/Reader_Revenue_Manager/Web_Tag.php
@@ -86,7 +86,19 @@ class Web_Tag extends Module_Web_Tag {
 		wp_script_add_data( 'google_swgjs', 'strategy', 'async' );
 		wp_add_inline_script( 'google_swgjs', $swg_inline_script, 'before' );
 
-		if ( is_singular( 'post' ) ) {
+		/**
+		 * Filters the post types where Reader Revenue Manager CTAs should appear.
+		 *
+		 * @since n.e.x.t
+		 *
+		 * @param array $cta_post_types The array of post types.
+		 */
+		$cta_post_types = apply_filters(
+			'googlesitekit_reader_revenue_manager_cta_post_types',
+			array( 'post' )
+		);
+
+		if ( is_singular( $cta_post_types ) ) {
 			wp_enqueue_script( 'google_swgjs' );
 		}
 	}

--- a/tests/phpunit/integration/Modules/Reader_Revenue_Manager/Web_TagTest.php
+++ b/tests/phpunit/integration/Modules/Reader_Revenue_Manager/Web_TagTest.php
@@ -21,6 +21,12 @@ use Google\Site_Kit\Tests\TestCase;
 class Web_TagTest extends TestCase {
 	const PUBLICATION_ID = '12345';
 
+	const EXPECTED_SNIPPET_STRINGS = array(
+		'Google Reader Revenue Manager snippet added by Site Kit',
+		'<script type="text/javascript" src="https://news.google.com/swg/js/v1/swg-basic.js" id="google_swgjs-js" async="async" data-wp-strategy="async"></script>', // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
+		'(self.SWG_BASIC=self.SWG_BASIC||[]).push(basicSubscriptions=>{basicSubscriptions.init({"type":"NewsArticle","isPartOfType":["Product"],"isPartOfProductId":"' . self::PUBLICATION_ID . ':openaccess","clientOptions":{"theme":"light","lang":"en-US"}});});',
+	);
+
 	public function set_up() {
 		parent::set_up();
 
@@ -33,9 +39,9 @@ class Web_TagTest extends TestCase {
 
 		$footer_html = $this->capture_action( 'wp_footer' );
 
-		$this->assertStringNotContainsString( 'Google Reader Revenue Manager snippet added by Site Kit', $footer_html );
-		$this->assertStringNotContainsString( '<script type="text/javascript" src="https://news.google.com/swg/js/v1/swg-basic.js" id="google_swgjs-js" async="async" data-wp-strategy="async"></script>', $footer_html ); // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
-		$this->assertStringNotContainsString( '(self.SWG_BASIC=self.SWG_BASIC||[]).push(basicSubscriptions=>{basicSubscriptions.init({"type":"NewsArticle","isPartOfType":["Product"],"isPartOfProductId":"' . self::PUBLICATION_ID . ':openaccess","clientOptions":{"theme":"light","lang":"en-US"}});});', $footer_html );
+		foreach ( self::EXPECTED_SNIPPET_STRINGS as $snippet_string ) {
+			$this->assertStringNotContainsString( $snippet_string, $footer_html );
+		}
 	}
 
 	public function test_snippet_inserted_on_singular_posts() {
@@ -46,8 +52,8 @@ class Web_TagTest extends TestCase {
 
 		$footer_html = $this->capture_action( 'wp_footer' );
 
-		$this->assertStringContainsString( 'Google Reader Revenue Manager snippet added by Site Kit', $footer_html );
-		$this->assertStringContainsString( '<script type="text/javascript" src="https://news.google.com/swg/js/v1/swg-basic.js" id="google_swgjs-js" async="async" data-wp-strategy="async"></script>', $footer_html ); // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
-		$this->assertStringContainsString( '(self.SWG_BASIC=self.SWG_BASIC||[]).push(basicSubscriptions=>{basicSubscriptions.init({"type":"NewsArticle","isPartOfType":["Product"],"isPartOfProductId":"' . self::PUBLICATION_ID . ':openaccess","clientOptions":{"theme":"light","lang":"en-US"}});});', $footer_html );
+		foreach ( self::EXPECTED_SNIPPET_STRINGS as $snippet_string ) {
+			$this->assertStringContainsString( $snippet_string, $footer_html );
+		}
 	}
 }

--- a/tests/phpunit/integration/Modules/Reader_Revenue_Manager/Web_TagTest.php
+++ b/tests/phpunit/integration/Modules/Reader_Revenue_Manager/Web_TagTest.php
@@ -21,9 +21,26 @@ use Google\Site_Kit\Tests\TestCase;
 class Web_TagTest extends TestCase {
 	const PUBLICATION_ID = '12345';
 
-	public function test_register() {
+	public function set_up() {
+		parent::set_up();
+
 		$web_tag = new Web_Tag( self::PUBLICATION_ID, Reader_Revenue_Manager::MODULE_SLUG );
 		$web_tag->register();
+	}
+
+	public function test_snippet_not_inserted_on_non_singular_posts() {
+		do_action( 'wp_enqueue_scripts' );
+
+		$footer_html = $this->capture_action( 'wp_footer' );
+
+		$this->assertStringNotContainsString( 'Google Reader Revenue Manager snippet added by Site Kit', $footer_html );
+		$this->assertStringNotContainsString( '<script type="text/javascript" src="https://news.google.com/swg/js/v1/swg-basic.js" id="google_swgjs-js" async="async" data-wp-strategy="async"></script>', $footer_html ); // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
+		$this->assertStringNotContainsString( '(self.SWG_BASIC=self.SWG_BASIC||[]).push(basicSubscriptions=>{basicSubscriptions.init({"type":"NewsArticle","isPartOfType":["Product"],"isPartOfProductId":"' . self::PUBLICATION_ID . ':openaccess","clientOptions":{"theme":"light","lang":"en-US"}});});', $footer_html );
+	}
+
+	public function test_snippet_inserted_on_singular_posts() {
+		$post_ID = $this->factory()->post->create();
+		$this->go_to( get_permalink( $post_ID ) );
 
 		do_action( 'wp_enqueue_scripts' );
 

--- a/tests/phpunit/integration/Modules/Reader_Revenue_ManagerTest.php
+++ b/tests/phpunit/integration/Modules/Reader_Revenue_ManagerTest.php
@@ -276,6 +276,10 @@ class Reader_Revenue_ManagerTest extends TestCase {
 			)
 		);
 
+		// Navigate to a singular post.
+		$post_ID = $this->factory()->post->create();
+		$this->go_to( get_permalink( $post_ID ) );
+
 		do_action( 'template_redirect' );
 		do_action( 'wp_enqueue_scripts' );
 


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #9670 

## Relevant technical choices

This PR changes the RRM snippet placement logic so that it is only placed on WordPress singular posts.

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [x] Run the code.
- [x] Ensure the acceptance criteria are satisfied.
- [x] Reassess the implementation with the IB.
- [x] Ensure no unrelated changes are included.
- [x] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [x] Ensure there is a QA Brief.
- [x] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [x] Ensure the PR has the correct target branch.
- [x] Double-check that the PR is okay to be merged.
- [x] Ensure the corresponding issue has a ZenHub release assigned.
- [x] Add a changelog message to the issue.
