### PR TITLE
Add `fpm-server-requirement-status` E2E test (draft).

### DIFF
--- a/bin/local-env/docker-compose.yml
+++ b/bin/local-env/docker-compose.yml
@@ -20,8 +20,21 @@ services:
       - ../../:/var/www/html/wp-content/plugins/google-site-kit
       - ../../tests/e2e/plugins:/var/www/html/wp-content/plugins/google-site-kit-test-plugins
       - ../../tests/e2e/mu-plugins:/var/www/html/wp-content/mu-plugins
+      - ./wordpress/ca-certificates:/usr/local/share/ca-certificates/
+      # - ./proxy/hosts:/etc/hosts
     depends_on:
       - mysql
+
+  proxy:
+    image: nginx:1.27.2-alpine
+    ports:
+      - 9003:80
+      - 443:443
+    volumes:
+      - ./proxy/conf/nginx.conf:/etc/nginx/nginx.conf
+      - ./proxy/certs:/etc/nginx/certs
+    depends_on:
+      - wordpress
 
   wordpress-debug-log:
     image: alpine

--- a/bin/local-env/proxy/conf/nginx.conf
+++ b/bin/local-env/proxy/conf/nginx.conf
@@ -1,0 +1,29 @@
+events {
+  worker_connections 1024;
+}
+
+http {
+  server {
+    listen 80;
+    return 301 https://$host$request_uri;
+  }
+
+  server {
+    listen 443 ssl;
+    server_name g-1234.fps.goog;
+
+    ssl_certificate /etc/nginx/certs/g-1234.fps.goog.crt;
+    ssl_certificate_key /etc/nginx/certs/g-1234.fps.goog.key;
+    ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+    ssl_ciphers HIGH:!aNULL:!MD5;
+
+    location / {
+      proxy_buffering off;
+      proxy_set_header X-Forwarded-Proto $scheme;
+      proxy_set_header X-Forwarded-Host $host;
+      proxy_set_header X-Forwarded-Port $server_port;
+
+      proxy_pass http://wordpress:80;
+    }
+  }
+}

--- a/bin/local-env/proxy/hosts
+++ b/bin/local-env/proxy/hosts
@@ -1,0 +1,12 @@
+127.0.0.1       localhost
+::1     localhost ip6-localhost ip6-loopback
+fe00::0 ip6-localnet
+ff00::0 ip6-mcastprefix
+ff02::1 ip6-allnodes
+ff02::2 ip6-allrouters
+
+# These addresses are liable to change when the containers or network are recreated,
+# so we can't actually provide a hardcoded value here. This is for illustration only.
+172.18.0.4      d9308e3a7e28
+# Point the FPFE hostname to the proxy container.
+172.18.0.6 g-1234.fps.goog

--- a/mkcert-notes.md
+++ b/mkcert-notes.md
@@ -1,0 +1,8 @@
+mkcert \
+  -cert-file g-1234.fps.goog.crt \
+  -key-file g-1234.fps.goog.key \
+  g-1234.fps.goog
+
+cp g-1234.fps.goog.* ./bin/local-env/proxy/certs/
+
+cp $(mkcert -CAROOT)/rootCA.pem ./bin/local-env/wordpress/ca-certificate/

--- a/tests/e2e/plugins/fpm-server-requirement-status.php
+++ b/tests/e2e/plugins/fpm-server-requirement-status.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Plugin Name: E2E Tests FPM Server Requirement Status Plugin
+ * Description: Setup for FPM server requirement status E2E tests.
+ *
+ * @package   Google\Site_Kit
+ * @copyright 2024 Google LLC
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
+ * @link      https://sitekit.withgoogle.com
+ */
+
+add_action(
+	'rest_api_init',
+	function () {
+		add_filter(
+			'plugins_url',
+			function ( $url ) {
+				return str_replace( ':9002', ':80', $url );
+			},
+			10,
+			1
+		);
+	},
+	0
+);

--- a/tests/e2e/specs/site/fpm-server-requirement-status.test.js
+++ b/tests/e2e/specs/site/fpm-server-requirement-status.test.js
@@ -1,0 +1,57 @@
+/**
+ * FPM server requirement status test.
+ *
+ * Site Kit by Google, Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import {
+	activatePlugins,
+	deactivateUtilityPlugins,
+	enableFeature,
+	resetSiteKit,
+	setupSiteKit,
+	wpApiFetch,
+} from '../../utils';
+
+describe( 'FPM server requirement status', () => {
+	beforeEach( async () => {
+		await activatePlugins(
+			'e2e-tests-fpm-server-requirement-status-plugin'
+		);
+		await setupSiteKit();
+		await enableFeature( 'firstPartyMode' );
+	} );
+
+	afterEach( async () => {
+		await deactivateUtilityPlugins();
+		await resetSiteKit();
+	} );
+
+	it( 'shows the correct status', async () => {
+		const response = await wpApiFetch( {
+			path: 'google-site-kit/v1/core/site/data/fpm-server-requirement-status',
+			method: 'get',
+		} );
+
+		expect( response ).toEqual( {
+			isEnabled: null,
+			isFPMHealthy: true,
+			isScriptAccessEnabled: true,
+		} );
+	} );
+} );


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #9632

## Relevant technical choices

This is an exploration of how we could provide E2E tests for the `fpm-server-requirement-status`. It's provided to capture the investigative work, however we should probably take an alternative approach, see https://github.com/google/site-kit-wp/issues/9708.

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [ ] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.
- [ ] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
