### PR TITLE
Output consent mode JS via `wp_print_inline_script_tag()`

### DIFF
--- a/includes/Core/Consent_Mode/Consent_Mode.php
+++ b/includes/Core/Consent_Mode/Consent_Mode.php
@@ -239,7 +239,7 @@ class Consent_Mode {
 					'window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments);}',
 					sprintf( "gtag('consent', 'default', %s);", wp_json_encode( $consent_defaults ) ),
 					sprintf( 'window._googlesitekitConsentCategoryMap = %s;', wp_json_encode( $consent_category_map ) ),
-					sprintf( "window._googlesitekitConsents = %s;", wp_json_encode( $consent_defaults ) ),
+					sprintf( 'window._googlesitekitConsents = %s;', wp_json_encode( $consent_defaults ) ),
 				)
 			),
 			array( 'id' => 'google_gtagjs-js-consent-mode-data-layer' )

--- a/includes/Core/Consent_Mode/Consent_Mode.php
+++ b/includes/Core/Consent_Mode/Consent_Mode.php
@@ -13,6 +13,7 @@ namespace Google\Site_Kit\Core\Consent_Mode;
 use Google\Site_Kit\Context;
 use Google\Site_Kit\Core\Assets\Script;
 use Google\Site_Kit\Core\Storage\Options;
+use Google\Site_Kit\Core\Util\BC_Functions;
 use Google\Site_Kit\Core\Util\Method_Proxy_Trait;
 use Plugin_Upgrader;
 use Plugin_Installer_Skin;
@@ -232,7 +233,7 @@ class Consent_Mode {
 		// The core Consent Mode code is in assets/js/consent-mode/consent-mode.js.
 		// Only code that passes data from PHP to JS should be in this file.
 		printf( "<!-- %s -->\n", esc_html__( 'Google tag (gtag.js) Consent Mode dataLayer added by Site Kit', 'google-site-kit' ) );
-		wp_print_inline_script_tag(
+		BC_Functions::wp_print_inline_script_tag(
 			join(
 				"\n",
 				array(

--- a/includes/Core/Consent_Mode/Consent_Mode.php
+++ b/includes/Core/Consent_Mode/Consent_Mode.php
@@ -231,16 +231,20 @@ class Consent_Mode {
 
 		// The core Consent Mode code is in assets/js/consent-mode/consent-mode.js.
 		// Only code that passes data from PHP to JS should be in this file.
-		?>
-<!-- <?php echo esc_html__( 'Google tag (gtag.js) Consent Mode dataLayer added by Site Kit', 'google-site-kit' ); ?> -->
-<script id='google_gtagjs-js-consent-mode-data-layer'>
-window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments);}
-gtag('consent', 'default', <?php echo wp_json_encode( $consent_defaults ); ?>);
-window._googlesitekitConsentCategoryMap = <?php	echo wp_json_encode( $consent_category_map ); ?>;
-window._googlesitekitConsents = <?php echo wp_json_encode( $consent_defaults ); ?>
-</script>
-<!-- <?php echo esc_html__( 'End Google tag (gtag.js) Consent Mode dataLayer added by Site Kit', 'google-site-kit' ); ?> -->
-			<?php
+		printf( "<!-- %s -->\n", esc_html__( 'Google tag (gtag.js) Consent Mode dataLayer added by Site Kit', 'google-site-kit' ) );
+		wp_print_inline_script_tag(
+			join(
+				"\n",
+				array(
+					'window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments);}',
+					sprintf( "gtag('consent', 'default', %s);", wp_json_encode( $consent_defaults ) ),
+					sprintf( 'window._googlesitekitConsentCategoryMap = %s;', wp_json_encode( $consent_category_map ) ),
+					sprintf( "window._googlesitekitConsents = %s;", wp_json_encode( $consent_defaults ) ),
+				)
+			),
+			array( 'id' => 'google_gtagjs-js-consent-mode-data-layer' )
+		);
+		printf( "<!-- %s -->\n", esc_html__( 'End Google tag (gtag.js) Consent Mode dataLayer added by Site Kit', 'google-site-kit' ) );
 	}
 
 	/**

--- a/includes/Modules/Sign_In_With_Google.php
+++ b/includes/Modules/Sign_In_With_Google.php
@@ -27,6 +27,7 @@ use Google\Site_Kit\Core\Permissions\Permissions;
 use Google\Site_Kit\Core\Site_Health\Debug_Data;
 use Google\Site_Kit\Core\Storage\Options;
 use Google\Site_Kit\Core\Storage\User_Options;
+use Google\Site_Kit\Core\Util\BC_Functions;
 use Google\Site_Kit\Core\Util\Method_Proxy_Trait;
 use Google\Site_Kit\Modules\Sign_In_With_Google\Authenticator;
 use Google\Site_Kit\Modules\Sign_In_With_Google\Authenticator_Interface;
@@ -262,10 +263,9 @@ final class Sign_In_With_Google extends Module implements Module_With_Assets, Mo
 
 		// Render the Sign in with Google button and related inline styles.
 		printf( "\n<!-- %s -->\n", esc_html__( 'Sign in with Google button added by Site Kit', 'google-site-kit' ) );
+		BC_Functions::wp_print_script_tag( array( 'src' => 'https://accounts.google.com/gsi/client' ) );
+		ob_start();
 		?>
-<?php /* phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript */ ?>
-<script src="https://accounts.google.com/gsi/client"></script>
-<script>
 ( () => {
 	const parent = document.createElement( 'div' );
 <?php if ( $is_woo_commerce_login ) : // phpcs:ignore Generic.WhiteSpace.ScopeIndent.Incorrect ?>
@@ -306,8 +306,8 @@ final class Sign_In_With_Google extends Module implements Module_With_Assets, Mo
 	document.cookie = "<?php echo esc_js( Authenticator::COOKIE_REDIRECT_TO ); ?>=<?php echo esc_js( $redirect_to ); ?>;expires="  + expires.toUTCString() + ";path=<?php echo esc_js( Authenticator::get_cookie_path() ); ?>";
 		<?php endif; // phpcs:ignore Generic.WhiteSpace.ScopeIndent.Incorrect ?>
 } )();
-</script>
 		<?php
+		BC_Functions::wp_print_inline_script_tag( ob_get_clean() );
 		printf( "\n<!-- %s -->\n", esc_html__( 'End Sign in with Google button added by Site Kit', 'google-site-kit' ) );
 	}
 


### PR DESCRIPTION
## Summary

Addresses issue:

- #9725

## Relevant technical choices

Use `wp_print_inline_script_tag()` and `wp_print_script_tag()` rather than manually print script tags.

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [ ] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [x] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.
- [ ] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
