### PR TITLE
Follow up: Allow the Anyone can register notice to take full width of setup screen.

### DIFF
--- a/assets/js/modules/sign-in-with-google/components/settings/SettingsView.js
+++ b/assets/js/modules/sign-in-with-google/components/settings/SettingsView.js
@@ -182,36 +182,32 @@ export default function SettingsView() {
 							/>
 						</p>
 					) }
-
-					{ anyoneCanRegisterNoticeDismissed === false &&
-						anyoneCanRegister === false && (
-							<SettingsNotice
-								type={ TYPE_WARNING }
-								dismiss
-								dismissCallback={ () => {
-									dismissItem(
-										'sign-in-with-google-anyone-can-register-notice'
-									);
-								} }
-								dismissLabel={ __(
-									'Got it',
-									'google-site-kit'
-								) }
-								Icon={ WarningIcon }
-								notice={ createInterpolateElement(
-									__(
-										'Enable the “Anyone can register” setting to allow your visitors to create an account using the Sign in with Google button. <br/>Visit <a>WordPress Settings</a> to manage this setting.',
-										'google-site-kit'
-									),
-									{
-										a: <Link href={ generalSettingsURL } />,
-										br: <br />,
-									}
-								) }
-							/>
-						) }
 				</div>
 			</div>
+
+			{ anyoneCanRegisterNoticeDismissed === false &&
+				anyoneCanRegister === false && (
+					<SettingsNotice
+						type={ TYPE_WARNING }
+						dismiss
+						dismissCallback={ () => {
+							dismissItem(
+								'sign-in-with-google-anyone-can-register-notice'
+							);
+						} }
+						dismissLabel={ __( 'Got it', 'google-site-kit' ) }
+						Icon={ WarningIcon }
+						notice={ createInterpolateElement(
+							__(
+								'Enable the “Anyone can register” setting to allow your visitors to create an account using the Sign in with Google button. Visit <a>WordPress Settings</a> to manage this setting.',
+								'google-site-kit'
+							),
+							{
+								a: <Link href={ generalSettingsURL } />,
+							}
+						) }
+					/>
+				) }
 		</div>
 	);
 }

--- a/assets/sass/components/sign-in-with-google/_googlesitekit-sign-in-with-google-setup-module.scss
+++ b/assets/sass/components/sign-in-with-google/_googlesitekit-sign-in-with-google-setup-module.scss
@@ -116,6 +116,12 @@
 				}
 			}
 		}
+
+		.googlesitekit-settings-notice__button {
+			align-items: center;
+			display: flex;
+			text-wrap: nowrap;
+		}
 	}
 
 	.googlesitekit-setup__footer--sign-in-with-google {


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #9477

## Relevant technical choices

I also removed the br because it lead to strange line breaks on common screen sizes:
<img width="778" alt="Screenshot 2024-11-25 at 19 54 57" src="https://github.com/user-attachments/assets/d6883c71-757c-4299-91f6-708b0d2202ff">


## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.
- [ ] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
