### PR TITLE
Enhancement/9312 fix focus trap

### DIFF
--- a/assets/js/components/SelectionPanel/SelectionPanel.js
+++ b/assets/js/components/SelectionPanel/SelectionPanel.js
@@ -30,6 +30,7 @@ import SideSheet from '../SideSheet';
 export default function SelectionPanel( {
 	children,
 	isOpen,
+	isLoading,
 	onOpen,
 	closePanel,
 	className,
@@ -41,11 +42,11 @@ export default function SelectionPanel( {
 				className
 			) }
 			isOpen={ isOpen }
+			isLoading={ isLoading }
 			onOpen={ onOpen }
 			closeSheet={ closePanel }
 			focusTrapOptions={ {
-				initialFocus:
-					'.googlesitekit-selection-panel-item .googlesitekit-selection-box input',
+				initialFocus: `.${ className } .googlesitekit-selection-panel-item .googlesitekit-selection-box input`,
 			} }
 		>
 			{ children }
@@ -56,7 +57,8 @@ export default function SelectionPanel( {
 SelectionPanel.propTypes = {
 	children: PropTypes.node,
 	isOpen: PropTypes.bool,
+	isLoading: PropTypes.bool,
 	onOpen: PropTypes.func,
 	closePanel: PropTypes.func,
-	className: PropTypes.string,
+	className: PropTypes.string.isRequired,
 };

--- a/assets/js/components/SelectionPanel/SelectionPanel.js
+++ b/assets/js/components/SelectionPanel/SelectionPanel.js
@@ -35,6 +35,11 @@ export default function SelectionPanel( {
 	closePanel,
 	className,
 } ) {
+	const classNameSelector = className
+		.split( /\s+/ )
+		.map( ( name ) => `.${ name }` )
+		.join( '' );
+
 	return (
 		<SideSheet
 			className={ classnames(
@@ -46,7 +51,7 @@ export default function SelectionPanel( {
 			onOpen={ onOpen }
 			closeSheet={ closePanel }
 			focusTrapOptions={ {
-				initialFocus: `.${ className } .googlesitekit-selection-panel-item .googlesitekit-selection-box input`,
+				initialFocus: `${ classNameSelector } .googlesitekit-selection-panel-item .googlesitekit-selection-box input`,
 			} }
 		>
 			{ children }

--- a/assets/js/components/SelectionPanel/SelectionPanel.js
+++ b/assets/js/components/SelectionPanel/SelectionPanel.js
@@ -36,9 +36,13 @@ export default function SelectionPanel( {
 	className,
 } ) {
 	const classNameSelector = className
-		.split( /\s+/ )
+		?.split( /\s+/ )
 		.map( ( name ) => `.${ name }` )
 		.join( '' );
+
+	const initialFocus = classNameSelector
+		? `${ classNameSelector } .googlesitekit-selection-panel-item .googlesitekit-selection-box input`
+		: '.googlesitekit-selection-panel-item .googlesitekit-selection-box input';
 
 	return (
 		<SideSheet
@@ -51,7 +55,7 @@ export default function SelectionPanel( {
 			onOpen={ onOpen }
 			closeSheet={ closePanel }
 			focusTrapOptions={ {
-				initialFocus: `${ classNameSelector } .googlesitekit-selection-panel-item .googlesitekit-selection-box input`,
+				initialFocus,
 			} }
 		>
 			{ children }
@@ -65,5 +69,5 @@ SelectionPanel.propTypes = {
 	isLoading: PropTypes.bool,
 	onOpen: PropTypes.func,
 	closePanel: PropTypes.func,
-	className: PropTypes.string.isRequired,
+	className: PropTypes.string,
 };

--- a/assets/js/components/SideSheet.js
+++ b/assets/js/components/SideSheet.js
@@ -45,6 +45,7 @@ export default function SideSheet( {
 	className,
 	children,
 	isOpen,
+	isLoading,
 	onOpen = () => {},
 	closeSheet = () => {},
 	focusTrapOptions = {},
@@ -69,31 +70,31 @@ export default function SideSheet( {
 
 	useKey( ( event ) => isOpen && ESCAPE === event.keyCode, closeSheet );
 
+	const content = (
+		<section
+			ref={ sideSheetRef }
+			className={ classnames( 'googlesitekit-side-sheet', className, {
+				'googlesitekit-side-sheet--open': isOpen,
+			} ) }
+			role="dialog"
+			aria-modal="true"
+			aria-hidden={ ! isOpen }
+			tabIndex="0"
+		>
+			{ children }
+		</section>
+	);
+
 	return (
 		<Portal>
 			<FocusTrap
-				active={ !! isOpen }
+				active={ !! isOpen && ! isLoading }
 				focusTrapOptions={ {
 					fallbackFocus: 'body',
 					...focusTrapOptions,
 				} }
 			>
-				<section
-					ref={ sideSheetRef }
-					className={ classnames(
-						'googlesitekit-side-sheet',
-						className,
-						{
-							'googlesitekit-side-sheet--open': isOpen,
-						}
-					) }
-					role="dialog"
-					aria-modal="true"
-					aria-hidden={ ! isOpen }
-					tabIndex="0"
-				>
-					{ children }
-				</section>
+				{ content }
 			</FocusTrap>
 			{ isOpen && <span className="googlesitekit-side-sheet-overlay" /> }
 		</Portal>
@@ -104,6 +105,7 @@ SideSheet.propTypes = {
 	className: PropTypes.string,
 	children: PropTypes.node,
 	isOpen: PropTypes.bool,
+	isLoading: PropTypes.bool,
 	onOpen: PropTypes.func,
 	closeSheet: PropTypes.func,
 	focusTrapOptions: PropTypes.object,

--- a/assets/js/components/SideSheet.js
+++ b/assets/js/components/SideSheet.js
@@ -70,21 +70,6 @@ export default function SideSheet( {
 
 	useKey( ( event ) => isOpen && ESCAPE === event.keyCode, closeSheet );
 
-	const content = (
-		<section
-			ref={ sideSheetRef }
-			className={ classnames( 'googlesitekit-side-sheet', className, {
-				'googlesitekit-side-sheet--open': isOpen,
-			} ) }
-			role="dialog"
-			aria-modal="true"
-			aria-hidden={ ! isOpen }
-			tabIndex="0"
-		>
-			{ children }
-		</section>
-	);
-
 	return (
 		<Portal>
 			<FocusTrap
@@ -94,7 +79,22 @@ export default function SideSheet( {
 					...focusTrapOptions,
 				} }
 			>
-				{ content }
+				<section
+					ref={ sideSheetRef }
+					className={ classnames(
+						'googlesitekit-side-sheet',
+						className,
+						{
+							'googlesitekit-side-sheet--open': isOpen,
+						}
+					) }
+					role="dialog"
+					aria-modal="true"
+					aria-hidden={ ! isOpen }
+					tabIndex="0"
+				>
+					{ children }
+				</section>
 			</FocusTrap>
 			{ isOpen && <span className="googlesitekit-side-sheet-overlay" /> }
 		</Portal>

--- a/assets/js/modules/analytics-4/components/audience-segmentation/dashboard/AudienceSelectionPanel/AudienceItems.js
+++ b/assets/js/modules/analytics-4/components/audience-segmentation/dashboard/AudienceSelectionPanel/AudienceItems.js
@@ -71,19 +71,6 @@ export default function AudienceItems( { savedItemSlugs = [] } ) {
 		syncAudiences();
 	}, [ firstView, isOpen, syncAvailableAudiences ] );
 
-	useEffect( () => {
-		// @TODO Explore more elegant option to re-establish the focus. After `syncAvailableAudiences`
-		// happens the focus is lost, even without preview block being shown.
-		if ( ! isLoading && isOpen ) {
-			const firstInput = document.querySelector(
-				'.googlesitekit-audience-selection-panel .googlesitekit-selection-panel-item input'
-			);
-			if ( firstInput ) {
-				firstInput.focus();
-			}
-		}
-	}, [ isLoading, isOpen ] );
-
 	const availableAudiences = useInViewSelect( ( select ) => {
 		const {
 			getConfigurableAudiences,

--- a/assets/js/modules/analytics-4/components/audience-segmentation/dashboard/AudienceSelectionPanel/Panel.js
+++ b/assets/js/modules/analytics-4/components/audience-segmentation/dashboard/AudienceSelectionPanel/Panel.js
@@ -57,6 +57,10 @@ export default function Panel() {
 	const isOpen = useSelect( ( select ) =>
 		select( CORE_UI ).getValue( AUDIENCE_SELECTION_PANEL_OPENED_KEY )
 	);
+	const isLoading = useSelect( ( select ) =>
+		select( MODULES_ANALYTICS_4 ).isFetchingSyncAvailableAudiences()
+	);
+
 	const savedItemSlugs = useInViewSelect( ( select ) => {
 		const { getConfigurableAudiences } = select( MODULES_ANALYTICS_4 );
 		const { getConfiguredAudiences } = select( CORE_USER );
@@ -104,6 +108,7 @@ export default function Panel() {
 			className="googlesitekit-audience-selection-panel"
 			closePanel={ closePanel }
 			isOpen={ isOpen || isCreatingAudienceFromOAuth }
+			isLoading={ isLoading }
 			onOpen={ onSideSheetOpen }
 		>
 			<Header closePanel={ closePanel } />


### PR DESCRIPTION
## Summary

Fixes the focus trap error reported here: https://github.com/google/site-kit-wp/issues/9312#issuecomment-2503310122.

Addresses issue:

- #9312 

## Relevant technical choices

- Update the `SelectionPanel` `initialFocus` selector to avoid selecting items from other panels.
- Ensure Audience Selection Panel focus trap is only active when the panel is not loading.

<!-- Please describe your changes. -->

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [x] Run the code.
- [x] Ensure the acceptance criteria are satisfied.
- [x] Reassess the implementation with the IB.
- [x] Ensure no unrelated changes are included.
- [x] Ensure CI checks pass.
- [x] Check Storybook where applicable.
- [x] Ensure there is a QA Brief.
- [x] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [x] Ensure the PR has the correct target branch.
- [x] Double-check that the PR is okay to be merged.
- [x] Ensure the corresponding issue has a ZenHub release assigned.
- [x] Add a changelog message to the issue.
