### PR TITLE
Add First-Party Mode site health and value helpers.

### DIFF
--- a/includes/Core/Site_Health/Debug_Data.php
+++ b/includes/Core/Site_Health/Debug_Data.php
@@ -22,6 +22,7 @@ use Google\Site_Kit\Core\Modules\Modules;
 use Google\Site_Kit\Core\Storage\Options;
 use Google\Site_Kit\Core\Storage\User_Options;
 use Google\Site_Kit\Core\Permissions\Permissions;
+use Google\Site_Kit\Core\Tags\First_Party_Mode\First_Party_Mode;
 use Google\Site_Kit\Core\Util\Feature_Flags;
 use Google\Site_Kit\Core\Util\Scopes;
 
@@ -559,7 +560,13 @@ class Debug_Data {
 			array_values( $modules_with_debug_fields )
 		);
 
-		return array_merge( array(), ...$fields_by_module );
+		if ( Feature_Flags::enabled( 'firstPartyMode' ) ) {
+			// First-Party Mode is not a module so it's debug fields must be added here.
+			$first_party_mode             = new First_Party_Mode( $this->context );
+			$fields_from_first_party_mode = $first_party_mode->get_debug_fields();
+		}
+
+		return array_merge( array(), $fields_from_first_party_mode, ...$fields_by_module );
 	}
 
 	/**

--- a/includes/Core/Site_Health/Debug_Data.php
+++ b/includes/Core/Site_Health/Debug_Data.php
@@ -22,7 +22,6 @@ use Google\Site_Kit\Core\Modules\Modules;
 use Google\Site_Kit\Core\Storage\Options;
 use Google\Site_Kit\Core\Storage\User_Options;
 use Google\Site_Kit\Core\Permissions\Permissions;
-use Google\Site_Kit\Core\Tags\First_Party_Mode\First_Party_Mode;
 use Google\Site_Kit\Core\Util\Feature_Flags;
 use Google\Site_Kit\Core\Util\Scopes;
 
@@ -560,13 +559,7 @@ class Debug_Data {
 			array_values( $modules_with_debug_fields )
 		);
 
-		if ( Feature_Flags::enabled( 'firstPartyMode' ) ) {
-			// First-Party Mode is not a module so it's debug fields must be added here.
-			$first_party_mode             = new First_Party_Mode( $this->context );
-			$fields_from_first_party_mode = $first_party_mode->get_debug_fields();
-		}
-
-		return array_merge( array(), $fields_from_first_party_mode, ...$fields_by_module );
+		return array_merge( array(), ...$fields_by_module );
 	}
 
 	/**

--- a/includes/Core/Tags/First_Party_Mode/First_Party_Mode.php
+++ b/includes/Core/Tags/First_Party_Mode/First_Party_Mode.php
@@ -11,6 +11,7 @@
 namespace Google\Site_Kit\Core\Tags\First_Party_Mode;
 
 use Google\Site_Kit\Context;
+use Google\Site_Kit\Core\Modules\Module_With_Debug_Fields;
 use Google\Site_Kit\Core\Storage\Options;
 use Google\Site_Kit\Core\Util\Method_Proxy_Trait;
 
@@ -21,7 +22,7 @@ use Google\Site_Kit\Core\Util\Method_Proxy_Trait;
  * @access private
  * @ignore
  */
-class First_Party_Mode {
+class First_Party_Mode implements Module_With_Debug_Fields {
 	use Method_Proxy_Trait;
 
 	/**
@@ -71,5 +72,24 @@ class First_Party_Mode {
 	public function register() {
 		$this->first_party_mode_settings->register();
 		$this->rest_controller->register();
+	}
+
+	/**
+	 * Gets an array of debug field definitions.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @return array
+	 */
+	public function get_debug_fields() {
+		$settings = $this->first_party_mode_settings->get();
+
+		return array(
+			'first_party_mode_is_enabled' => array(
+				'label' => __( 'First Party Mode: Enabled', 'google-site-kit' ),
+				'value' => $settings['isEnabled'] ? __( 'Yes', 'google-site-kit' ) : __( 'No', 'google-site-kit' ),
+				'debug' => $settings['isEnabled'] ? 'yes' : 'no',
+			),
+		);
 	}
 }

--- a/includes/Core/Tags/First_Party_Mode/First_Party_Mode.php
+++ b/includes/Core/Tags/First_Party_Mode/First_Party_Mode.php
@@ -86,7 +86,7 @@ class First_Party_Mode implements Module_With_Debug_Fields {
 
 		return array(
 			'first_party_mode_is_enabled' => array(
-				'label' => __( 'First Party Mode: Enabled', 'google-site-kit' ),
+				'label' => __( 'First-Party Mode: Enabled', 'google-site-kit' ),
 				'value' => $settings['isEnabled'] ? __( 'Yes', 'google-site-kit' ) : __( 'No', 'google-site-kit' ),
 				'debug' => $settings['isEnabled'] ? 'yes' : 'no',
 			),

--- a/includes/Modules/Ads.php
+++ b/includes/Modules/Ads.php
@@ -28,6 +28,7 @@ use Google\Site_Kit\Core\Modules\Module_With_Tag_Trait;
 use Google\Site_Kit\Core\Modules\Tags\Module_Tag_Matchers;
 use Google\Site_Kit\Core\Permissions\Permissions;
 use Google\Site_Kit\Core\Site_Health\Debug_Data;
+use Google\Site_Kit\Core\Tags\First_Party_Mode\First_Party_Mode;
 use Google\Site_Kit\Modules\Ads\PAX_Config;
 use Google\Site_Kit\Modules\Ads\Settings;
 use Google\Site_Kit\Modules\Ads\Has_Tag_Guard;
@@ -307,13 +308,24 @@ final class Ads extends Module implements Module_With_Assets, Module_With_Debug_
 	public function get_debug_fields() {
 		$settings = $this->get_settings()->get();
 
-		return array(
+		$debug_fields = array(
 			'ads_conversion_tracking_id' => array(
 				'label' => __( 'Ads: Conversion Tracking ID', 'google-site-kit' ),
 				'value' => $settings['conversionID'],
 				'debug' => Debug_Data::redact_debug_value( $settings['conversionID'] ),
 			),
 		);
+
+		// Add fields from First-Party Mode.
+		// Note: fields are added in both Analytics and Ads so that the debug fields will show if either module is enabled.
+		if ( Feature_Flags::enabled( 'firstPartyMode' ) ) {
+			$first_party_mode             = new First_Party_Mode( $this->context );
+			$fields_from_first_party_mode = $first_party_mode->get_debug_fields();
+
+			$debug_fields = array_merge( $debug_fields, $fields_from_first_party_mode );
+		}
+
+		return $debug_fields;
 	}
 
 	/**

--- a/includes/Modules/Analytics_4.php
+++ b/includes/Modules/Analytics_4.php
@@ -89,6 +89,7 @@ use Google\Site_Kit_Dependencies\Google\Service\TagManager as Google_Service_Tag
 use Google\Site_Kit_Dependencies\Google_Service_TagManager_Container;
 use Google\Site_Kit_Dependencies\Psr\Http\Message\RequestInterface;
 use Google\Site_Kit\Core\REST_API\REST_Routes;
+use Google\Site_Kit\Core\Tags\First_Party_Mode\First_Party_Mode;
 use Google\Site_Kit\Modules\Analytics_4\Conversion_Reporting\Conversion_Reporting_Cron;
 use Google\Site_Kit\Modules\Analytics_4\Conversion_Reporting\Conversion_Reporting_Events_Sync;
 use Google\Site_Kit\Modules\Analytics_4\Conversion_Reporting\Conversion_Reporting_Provider;
@@ -591,6 +592,15 @@ final class Analytics_4 extends Module implements Module_With_Scopes, Module_Wit
 					? 'none'
 					: join( ', ', $site_kit_audiences ),
 			);
+		}
+
+		// Add fields from First-Party Mode.
+		// Note: fields are added in both Analytics and Ads so that the debug fields will show if either module is enabled.
+		if ( Feature_Flags::enabled( 'firstPartyMode' ) ) {
+			$first_party_mode             = new First_Party_Mode( $this->context );
+			$fields_from_first_party_mode = $first_party_mode->get_debug_fields();
+
+			$debug_fields = array_merge( $debug_fields, $fields_from_first_party_mode );
 		}
 
 		return $debug_fields;


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #9667

## Relevant technical choices

During execution I realised that because First-Party Mode is not a module it's debug fields won't show up. First I updated DebugData before settling on adding the fields in the Analytics and Ads module. The code is in both so that the debug field appears if either module is connected. As they have the same key, only one field shows even if both modules are connected.

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [x] Run the code.
- [x] Ensure the acceptance criteria are satisfied.
- [x] Reassess the implementation with the IB.
- [x] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [x] Ensure there is a QA Brief.
- [x] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [x] Ensure the PR has the correct target branch.
- [x] Double-check that the PR is okay to be merged.
- [x] Ensure the corresponding issue has a ZenHub release assigned.
- [x] Add a changelog message to the issue.
