### PR TITLE
Update E2E to update CA certs for old WP runs

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -80,12 +80,15 @@ jobs:
       matrix:
         amp_version: ['']
         wp_version: ['latest', 'nightly']
+        ca_cert_refresh: ['']
         include:
           - amp_version: '1.5.5'
             wp_version: '5.2.21'
+            ca_cert_refresh: true
     env:
       AMP_VERSION: ${{ matrix.amp_version }}
       WP_VERSION: ${{ matrix.wp_version }}
+      CA_CERT_REFRESH: ${{ matrix.ca_cert_refresh }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     if: github.event_name == 'push' || github.event.pull_request.draft == false

--- a/bin/local-env/install-wordpress.sh
+++ b/bin/local-env/install-wordpress.sh
@@ -87,6 +87,12 @@ if [ "$WP_VERSION" == "latest" ]; then
 	wp core update-db --quiet
 fi
 
+if [ -n "$CA_CERT_REFRESH" ]; then
+  status_message "Updating WordPress certificate bundle..."
+  container curl --remote-name --show-error --silent https://raw.githubusercontent.com/WordPress/wordpress-develop/refs/heads/trunk/src/wp-includes/certificates/ca-bundle.crt
+  container mv ca-bundle.crt wp-includes/certificates/ca-bundle.crt
+fi
+
 # Switch to `twentytwenty` theme for consistent results (particularly for AMP compatibility).
 # For older versions of WP, download and install it if it isn't present.
 # If `twentytwenty` is already the active theme, the script will continue


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #9810

## Relevant technical choices

It works
<img width="1118" alt="image" src="https://github.com/user-attachments/assets/974b5b3d-26cd-44a3-b950-e152983d5ea3">


## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [ ] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.
- [ ] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
