### PR TITLE
issue / 9375. -full-screen-kmw-selection-panel

### DIFF
--- a/assets/js/components/KeyMetrics/KeyMetricsSetupCTAWidget.js
+++ b/assets/js/components/KeyMetrics/KeyMetricsSetupCTAWidget.js
@@ -37,7 +37,10 @@ import KeyMetricsCTAContent from './KeyMetricsCTAContent';
 import KeyMetricsCTAFooter from './KeyMetricsCTAFooter';
 import { CORE_USER } from '../../googlesitekit/datastore/user/constants';
 import { CORE_SITE } from '../../googlesitekit/datastore/site/constants';
-import { KEY_METRICS_SETUP_CTA_WIDGET_SLUG } from './constants';
+import {
+	KEY_METRICS_SETUP_CTA_WIDGET_SLUG,
+	KEY_METRICS_SELECTION_PANEL_OPENED_KEY,
+} from './constants';
 import whenActive from '../../util/when-active';
 import {
 	AdminMenuTooltip,
@@ -49,8 +52,11 @@ import useViewContext from '../../hooks/useViewContext';
 import useDisplayCTAWidget from './hooks/useDisplayCTAWidget';
 import KeyMetricsSetupCTARenderedEffect from './KeyMetricsSetupCTARenderedEffect';
 import { CORE_LOCATION } from '../../googlesitekit/datastore/location/constants';
+import { CORE_UI } from '../../googlesitekit/datastore/ui/constants';
+import { useFeature } from '../../hooks/useFeature';
 
 function KeyMetricsSetupCTAWidget( { Widget, WidgetNull } ) {
+	const isConversionReportingEnabled = useFeature( 'conversionReporting' );
 	const viewContext = useViewContext();
 	const displayCTAWidget = useDisplayCTAWidget();
 	const ctaLink = useSelect( ( select ) =>
@@ -65,6 +71,7 @@ function KeyMetricsSetupCTAWidget( { Widget, WidgetNull } ) {
 		KEY_METRICS_SETUP_CTA_WIDGET_SLUG
 	);
 
+	const { setValue } = useDispatch( CORE_UI );
 	const { dismissItem } = useDispatch( CORE_USER );
 
 	const dismissCallback = async () => {
@@ -82,12 +89,23 @@ function KeyMetricsSetupCTAWidget( { Widget, WidgetNull } ) {
 
 	const { navigateTo } = useDispatch( CORE_LOCATION );
 	const openMetricsSelectionPanel = useCallback( () => {
-		navigateTo( fullScreenSelectionLink );
+		if ( isConversionReportingEnabled ) {
+			navigateTo( fullScreenSelectionLink );
+		} else {
+			setValue( KEY_METRICS_SELECTION_PANEL_OPENED_KEY, true );
+		}
+
 		trackEvent(
 			`${ viewContext }_kmw-cta-notification`,
 			'confirm_pick_own_metrics'
 		);
-	}, [ navigateTo, fullScreenSelectionLink, viewContext ] );
+	}, [
+		navigateTo,
+		fullScreenSelectionLink,
+		viewContext,
+		isConversionReportingEnabled,
+		setValue,
+	] );
 
 	const onGetTailoredMetricsClick = useCallback( () => {
 		trackEvent(


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #9375

## Relevant technical choices

- Fix bug where manual selection link in KMW setup CTA banner was navigating to new full screen selection app as opposed to opening the panel.

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [x] Run the code.
- [x] Ensure the acceptance criteria are satisfied.
- [x] Reassess the implementation with the IB.
- [x] Ensure no unrelated changes are included.
- [x] Ensure CI checks pass.
- [x] Check Storybook where applicable.
- [x] Ensure there is a QA Brief.
- [x] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
