### PR TITLE
Resize wrapper of GoogleChart using ResizeObserver.

### DIFF
--- a/assets/js/components/GoogleChart/index.js
+++ b/assets/js/components/GoogleChart/index.js
@@ -28,6 +28,7 @@ import invariant from 'invariant';
 import PropTypes from 'prop-types';
 import { Chart } from 'react-google-charts';
 import { useMount } from 'react-use';
+import { debounce } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -339,6 +340,27 @@ export default function GoogleChart( props ) {
 		}
 	};
 
+	const [ resizeChartWidth, setResizeChartWidth ] = useState( '100%' );
+	const debounceSetResizeChartWidth = debounce( setResizeChartWidth, 100 );
+
+	useEffect( () => {
+		if ( global.ResizeObserver ) {
+			const targetElement = global.document.querySelector(
+				'.googlesitekit-unique-visitors-chart-widget'
+			);
+			const resizeObserver = new ResizeObserver( () => {
+				debounceSetResizeChartWidth(
+					`${ targetElement.offsetWidth }px`
+				);
+			} );
+			resizeObserver.observe( targetElement );
+
+			return () => {
+				resizeObserver.disconnect();
+			};
+		}
+	}, [] );
+
 	if ( googleChartsCollisionError ) {
 		return null;
 	}
@@ -394,6 +416,7 @@ export default function GoogleChart( props ) {
 				) }
 				id={ `googlesitekit-chart-${ instanceID }` }
 				tabIndex={ -1 }
+				style={ { width: resizeChartWidth } }
 			>
 				<Chart
 					className="googlesitekit-chart__inner"


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #9756 

## Relevant technical choices

POC confirming Google Charts can resize responsively.

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [ ] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.
- [ ] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
