### PR TITLE
Enhancement/#9828 - Update Default Value of `isEnabled` Setting to `false` for First-Party Mode

### DIFF
--- a/assets/js/components/first-party-mode/FirstPartyModeToggle.stories.js
+++ b/assets/js/components/first-party-mode/FirstPartyModeToggle.stories.js
@@ -50,7 +50,7 @@ ServerRequirementsFail.args = {
 	setupRegistry: () => {
 		fetchMock.getOnce( serverRequirementStatusEndpoint, {
 			body: {
-				isEnabled: null,
+				isEnabled: false,
 				isFPMHealthy: false,
 				isScriptAccessEnabled: false,
 			},

--- a/assets/js/components/first-party-mode/FirstPartyModeToggle.test.js
+++ b/assets/js/components/first-party-mode/FirstPartyModeToggle.test.js
@@ -39,7 +39,7 @@ describe( 'FirstPartyModeToggle', () => {
 		registry = createTestRegistry();
 
 		registry.dispatch( CORE_SITE ).receiveGetFirstPartyModeSettings( {
-			isEnabled: null,
+			isEnabled: false,
 			isFPMHealthy: null,
 			isScriptAccessEnabled: null,
 		} );
@@ -77,7 +77,7 @@ describe( 'FirstPartyModeToggle', () => {
 	it( 'should render in default state', async () => {
 		fetchMock.getOnce( serverRequirementStatusEndpoint, {
 			body: {
-				isEnabled: null,
+				isEnabled: false,
 				isFPMHealthy: true,
 				isScriptAccessEnabled: true,
 			},
@@ -101,7 +101,7 @@ describe( 'FirstPartyModeToggle', () => {
 	it( 'should render in disabled state if server requirements are not met', async () => {
 		fetchMock.getOnce( serverRequirementStatusEndpoint, {
 			body: {
-				isEnabled: null,
+				isEnabled: false,
 				isFPMHealthy: false,
 				isScriptAccessEnabled: false,
 			},
@@ -130,7 +130,7 @@ describe( 'FirstPartyModeToggle', () => {
 		'should not render in disabled state unless %s is explicitly false',
 		async ( requirement ) => {
 			const response = {
-				isEnabled: null,
+				isEnabled: false,
 				isFPMHealthy: true,
 				isScriptAccessEnabled: true,
 			};
@@ -159,7 +159,7 @@ describe( 'FirstPartyModeToggle', () => {
 		'should render in disabled state if %s is false',
 		async ( requirement ) => {
 			const response = {
-				isEnabled: null,
+				isEnabled: false,
 				isFPMHealthy: true,
 				isScriptAccessEnabled: true,
 			};
@@ -187,7 +187,7 @@ describe( 'FirstPartyModeToggle', () => {
 	it( 'should toggle first party mode on click', async () => {
 		fetchMock.getOnce( serverRequirementStatusEndpoint, {
 			body: {
-				isEnabled: null,
+				isEnabled: false,
 				isFPMHealthy: true,
 				isScriptAccessEnabled: true,
 			},
@@ -207,9 +207,9 @@ describe( 'FirstPartyModeToggle', () => {
 
 		expect( switchControl ).not.toBeChecked();
 
-		expect(
-			registry.select( CORE_SITE ).isFirstPartyModeEnabled()
-		).toBeNull();
+		expect( registry.select( CORE_SITE ).isFirstPartyModeEnabled() ).toBe(
+			false
+		);
 
 		switchControl.click();
 
@@ -232,7 +232,7 @@ describe( 'FirstPartyModeToggle', () => {
 	it( 'should render a "Beta" badge', async () => {
 		fetchMock.getOnce( serverRequirementStatusEndpoint, {
 			body: {
-				isEnabled: null,
+				isEnabled: false,
 				isFPMHealthy: true,
 				isScriptAccessEnabled: true,
 			},

--- a/assets/js/googlesitekit/datastore/site/first-party-mode.js
+++ b/assets/js/googlesitekit/datastore/site/first-party-mode.js
@@ -194,7 +194,7 @@ const baseSelectors = {
 	 * @since 1.141.0
 	 *
 	 * @param {Object} state Data store's state.
-	 * @return {boolean|null|undefined} True if first-party mode is enabled, otherwise false. Returns undefined if the state is not loaded.
+	 * @return {boolean|undefined} True if first-party mode is enabled, otherwise false. Returns undefined if the state is not loaded.
 	 */
 	isFirstPartyModeEnabled: createRegistrySelector( ( select ) => () => {
 		const { isEnabled } =

--- a/includes/Core/Tags/First_Party_Mode/First_Party_Mode_Settings.php
+++ b/includes/Core/Tags/First_Party_Mode/First_Party_Mode_Settings.php
@@ -46,7 +46,7 @@ class First_Party_Mode_Settings extends Setting {
 	 */
 	protected function get_default() {
 		return array(
-			'isEnabled'             => null,
+			'isEnabled'             => false,
 			'isFPMHealthy'          => null,
 			'isScriptAccessEnabled' => null,
 		);

--- a/tests/phpunit/integration/Core/Tags/First_Party_Mode/First_Party_Mode_SettingsTest.php
+++ b/tests/phpunit/integration/Core/Tags/First_Party_Mode/First_Party_Mode_SettingsTest.php
@@ -48,7 +48,7 @@ class First_Party_Mode_SettingsTest extends SettingsTestCase {
 		$default_settings = get_option( $this->get_option_name() );
 		$this->assertEqualSetsWithIndex(
 			array(
-				'isEnabled'             => null,
+				'isEnabled'             => false,
 				'isFPMHealthy'          => null,
 				'isScriptAccessEnabled' => null,
 			),
@@ -73,7 +73,7 @@ class First_Party_Mode_SettingsTest extends SettingsTestCase {
 			'empty settings'        => array(
 				array(),
 				array(
-					'isEnabled'             => null,
+					'isEnabled'             => false,
 					'isFPMHealthy'          => null,
 					'isScriptAccessEnabled' => null,
 				),

--- a/tests/phpunit/integration/Core/Tags/First_Party_Mode/REST_First_Party_Mode_ControllerTest.php
+++ b/tests/phpunit/integration/Core/Tags/First_Party_Mode/REST_First_Party_Mode_ControllerTest.php
@@ -86,7 +86,7 @@ class REST_First_Party_Mode_ControllerTest extends TestCase {
 		$this->grant_manage_options_permission();
 
 		$original_settings = array(
-			'isEnabled'             => null,
+			'isEnabled'             => false,
 			'isFPMHealthy'          => null,
 			'isScriptAccessEnabled' => null,
 		);
@@ -106,7 +106,7 @@ class REST_First_Party_Mode_ControllerTest extends TestCase {
 		$this->register_rest_routes();
 
 		$original_settings = array(
-			'isEnabled'             => null,
+			'isEnabled'             => false,
 			'isFPMHealthy'          => null,
 			'isScriptAccessEnabled' => null,
 		);
@@ -130,7 +130,7 @@ class REST_First_Party_Mode_ControllerTest extends TestCase {
 		$this->grant_manage_options_permission();
 
 		$original_settings = array(
-			'isEnabled'             => null,
+			'isEnabled'             => false,
 			'isFPMHealthy'          => null,
 			'isScriptAccessEnabled' => null,
 		);
@@ -165,7 +165,7 @@ class REST_First_Party_Mode_ControllerTest extends TestCase {
 		$this->register_rest_routes();
 
 		$original_settings = array(
-			'isEnabled'             => null,
+			'isEnabled'             => false,
 			'isFPMHealthy'          => null,
 			'isScriptAccessEnabled' => null,
 		);
@@ -282,7 +282,7 @@ class REST_First_Party_Mode_ControllerTest extends TestCase {
 
 		$this->assertEqualSetsWithIndex(
 			array(
-				'isEnabled'             => null,
+				'isEnabled'             => false,
 				'isFPMHealthy'          => $expected_settings['isFPMHealthy'],
 				'isScriptAccessEnabled' => $expected_settings['isScriptAccessEnabled'],
 			),


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #9828 

## Relevant technical choices

<!-- Please describe your changes. -->

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.
- [ ] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
