### PR TITLE
Schedule cron task only if FPM is enabled

### DIFF
--- a/assets/js/googlesitekit/notifications/register-defaults.js
+++ b/assets/js/googlesitekit/notifications/register-defaults.js
@@ -479,15 +479,15 @@ export const DEFAULT_NOTIFICATIONS = {
 				return false;
 			}
 
-			if (
-				[ isFPMHealthy(), isScriptAccessEnabled() ].includes( null )
-			) {
-				await dispatch(
-					CORE_SITE
-				).fetchGetFPMServerRequirementStatus();
+			const isHealthy = isFPMHealthy();
+			const isAccessEnabled = isScriptAccessEnabled();
+
+			if ( [ isHealthy, isAccessEnabled ].includes( null ) ) {
+				dispatch( CORE_SITE ).fetchGetFPMServerRequirementStatus();
+				return false;
 			}
 
-			return isFPMHealthy() && isScriptAccessEnabled();
+			return isHealthy && isAccessEnabled;
 		},
 		isDismissible: true,
 	},

--- a/assets/js/googlesitekit/notifications/register-defaults.js
+++ b/assets/js/googlesitekit/notifications/register-defaults.js
@@ -451,7 +451,7 @@ export const DEFAULT_NOTIFICATIONS = {
 		areaSlug: NOTIFICATION_AREAS.BANNERS_BELOW_NAV,
 		groupID: NOTIFICATION_GROUPS.SETUP_CTAS,
 		viewContexts: [ VIEW_CONTEXT_MAIN_DASHBOARD ],
-		checkRequirements: async ( { select, resolveSelect } ) => {
+		checkRequirements: async ( { select, resolveSelect, dispatch } ) => {
 			if ( ! isFeatureEnabled( 'firstPartyMode' ) ) {
 				return false;
 			}
@@ -475,11 +475,19 @@ export const DEFAULT_NOTIFICATIONS = {
 				isScriptAccessEnabled,
 			} = select( CORE_SITE );
 
-			return (
-				! isFirstPartyModeEnabled() &&
-				isFPMHealthy() &&
-				isScriptAccessEnabled()
-			);
+			if ( isFirstPartyModeEnabled() ) {
+				return false;
+			}
+
+			if (
+				[ isFPMHealthy(), isScriptAccessEnabled() ].includes( null )
+			) {
+				await dispatch(
+					CORE_SITE
+				).fetchGetFPMServerRequirementStatus();
+			}
+
+			return isFPMHealthy() && isScriptAccessEnabled();
 		},
 		isDismissible: true,
 	},

--- a/includes/Core/Tags/First_Party_Mode/First_Party_Mode.php
+++ b/includes/Core/Tags/First_Party_Mode/First_Party_Mode.php
@@ -71,7 +71,10 @@ class First_Party_Mode implements Module_With_Debug_Fields {
 		$options                         = $options ?: new Options( $context );
 		$this->first_party_mode_settings = new First_Party_Mode_Settings( $options );
 		$this->rest_controller           = new REST_First_Party_Mode_Controller( $this, $this->first_party_mode_settings );
-		$this->cron                      = new First_Party_Mode_Cron( array( $this, 'healthcheck' ) );
+		$this->cron                      = new First_Party_Mode_Cron(
+			array( $this, 'healthcheck' ),
+			$this->first_party_mode_settings
+		);
 	}
 
 	/**

--- a/includes/Core/Tags/First_Party_Mode/First_Party_Mode.php
+++ b/includes/Core/Tags/First_Party_Mode/First_Party_Mode.php
@@ -72,8 +72,8 @@ class First_Party_Mode implements Module_With_Debug_Fields {
 		$this->first_party_mode_settings = new First_Party_Mode_Settings( $options );
 		$this->rest_controller           = new REST_First_Party_Mode_Controller( $this, $this->first_party_mode_settings );
 		$this->cron                      = new First_Party_Mode_Cron(
-			array( $this, 'healthcheck' ),
-			$this->first_party_mode_settings
+			$this->first_party_mode_settings,
+			array( $this, 'healthcheck' )
 		);
 	}
 

--- a/includes/Core/Tags/First_Party_Mode/First_Party_Mode_Cron.php
+++ b/includes/Core/Tags/First_Party_Mode/First_Party_Mode_Cron.php
@@ -29,14 +29,26 @@ class First_Party_Mode_Cron {
 	private $cron_callback;
 
 	/**
+	 * First_Party_Mode_Settings instance.
+	 *
+	 * @var First_Party_Mode_Settings
+	 */
+	private $first_party_mode_settings;
+
+	/**
 	 * Constructor.
 	 *
 	 * @since n.e.x.t
 	 *
-	 * @param callable $callback Function to call on the cron action.
+	 * @param callable                  $callback                  Function to call on the cron action.
+	 * @param First_Party_Mode_Settings $first_party_mode_settings First_Party_Mode_Settings instance.
 	 */
-	public function __construct( callable $callback ) {
-		$this->cron_callback = $callback;
+	public function __construct(
+		callable $callback,
+		First_Party_Mode_Settings $first_party_mode_settings
+	) {
+		$this->cron_callback             = $callback;
+		$this->first_party_mode_settings = $first_party_mode_settings;
 	}
 
 	/**
@@ -54,7 +66,14 @@ class First_Party_Mode_Cron {
 	 * @since n.e.x.t
 	 */
 	public function maybe_schedule_cron() {
-		if ( ! wp_next_scheduled( self::CRON_ACTION ) && ! wp_installing() ) {
+		$settings    = $this->first_party_mode_settings->get();
+		$fpm_enabled = $settings['isEnabled'];
+
+		if (
+			$fpm_enabled &&
+			! wp_next_scheduled( self::CRON_ACTION ) &&
+			! wp_installing()
+		) {
 			wp_schedule_event( time(), 'hourly', self::CRON_ACTION );
 		}
 	}

--- a/includes/Core/Tags/First_Party_Mode/First_Party_Mode_Cron.php
+++ b/includes/Core/Tags/First_Party_Mode/First_Party_Mode_Cron.php
@@ -40,15 +40,15 @@ class First_Party_Mode_Cron {
 	 *
 	 * @since n.e.x.t
 	 *
-	 * @param callable                  $callback                  Function to call on the cron action.
 	 * @param First_Party_Mode_Settings $first_party_mode_settings First_Party_Mode_Settings instance.
+	 * @param callable                  $callback                  Function to call on the cron action.
 	 */
 	public function __construct(
-		callable $callback,
-		First_Party_Mode_Settings $first_party_mode_settings
+		First_Party_Mode_Settings $first_party_mode_settings,
+		callable $callback
 	) {
-		$this->cron_callback             = $callback;
 		$this->first_party_mode_settings = $first_party_mode_settings;
+		$this->cron_callback             = $callback;
 	}
 
 	/**

--- a/tests/phpunit/integration/Core/Tags/First_Party_Mode/First_Party_Mode_CronTest.php
+++ b/tests/phpunit/integration/Core/Tags/First_Party_Mode/First_Party_Mode_CronTest.php
@@ -37,7 +37,7 @@ class First_Party_Mode_CronTest extends TestCase {
 	}
 
 	public function test_register() {
-		$cron = new First_Party_Mode_Cron( '__return_true', $this->settings );
+		$cron = new First_Party_Mode_Cron( $this->settings, '__return_true' );
 		$this->assertFalse( has_action( First_Party_Mode_Cron::CRON_ACTION ) );
 
 		$cron->register();
@@ -47,7 +47,7 @@ class First_Party_Mode_CronTest extends TestCase {
 
 	public function test_register__given_callable() {
 		$spy  = new MethodSpy();
-		$cron = new First_Party_Mode_Cron( array( $spy, 'func' ), $this->settings );
+		$cron = new First_Party_Mode_Cron( $this->settings, array( $spy, 'func' ) );
 		$cron->register();
 		$this->assertTrue( empty( $spy->invocations['func'] ) );
 
@@ -57,7 +57,7 @@ class First_Party_Mode_CronTest extends TestCase {
 	}
 
 	public function test_maybe_schedule_cron() {
-		$cron = new First_Party_Mode_Cron( '__return_true', $this->settings );
+		$cron = new First_Party_Mode_Cron( $this->settings, '__return_true' );
 
 		$this->assertFalse(
 			wp_next_scheduled( First_Party_Mode_Cron::CRON_ACTION )

--- a/tests/phpunit/integration/Core/Tags/First_Party_Mode/First_Party_Mode_CronTest.php
+++ b/tests/phpunit/integration/Core/Tags/First_Party_Mode/First_Party_Mode_CronTest.php
@@ -10,19 +10,34 @@
 
 namespace Google\Site_Kit\Tests\Core\Tags\First_Party_Mode;
 
+use Google\Site_Kit\Context;
+use Google\Site_Kit\Core\Storage\Options;
 use Google\Site_Kit\Core\Tags\First_Party_Mode\First_Party_Mode_Cron;
+use Google\Site_Kit\Core\Tags\First_Party_Mode\First_Party_Mode_Settings;
 use Google\Site_Kit\Tests\MethodSpy;
 use Google\Site_Kit\Tests\TestCase;
 
 class First_Party_Mode_CronTest extends TestCase {
 
+	/**
+	 * First_Party_Mode_Settings instance.
+	 *
+	 * @var First_Party_Mode_Settings
+	 */
+	private $settings;
+
 	public function set_up() {
 		parent::set_up();
 		remove_all_actions( First_Party_Mode_Cron::CRON_ACTION );
+
+		$context        = new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE );
+		$options        = new Options( $context );
+		$this->settings = new First_Party_Mode_Settings( $options );
+		$this->settings->register();
 	}
 
 	public function test_register() {
-		$cron = new First_Party_Mode_Cron( '__return_true' );
+		$cron = new First_Party_Mode_Cron( '__return_true', $this->settings );
 		$this->assertFalse( has_action( First_Party_Mode_Cron::CRON_ACTION ) );
 
 		$cron->register();
@@ -32,12 +47,34 @@ class First_Party_Mode_CronTest extends TestCase {
 
 	public function test_register__given_callable() {
 		$spy  = new MethodSpy();
-		$cron = new First_Party_Mode_Cron( array( $spy, 'func' ) );
+		$cron = new First_Party_Mode_Cron( array( $spy, 'func' ), $this->settings );
 		$cron->register();
 		$this->assertTrue( empty( $spy->invocations['func'] ) );
 
 		do_action( First_Party_Mode_Cron::CRON_ACTION );
 
 		$this->assertCount( 1, $spy->invocations['func'] );
+	}
+
+	public function test_maybe_schedule_cron() {
+		$cron = new First_Party_Mode_Cron( '__return_true', $this->settings );
+
+		$this->assertFalse(
+			wp_next_scheduled( First_Party_Mode_Cron::CRON_ACTION )
+		);
+
+		$cron->maybe_schedule_cron();
+
+		$this->assertFalse(
+			wp_next_scheduled( First_Party_Mode_Cron::CRON_ACTION )
+		);
+
+		$this->settings->merge( array( 'isEnabled' => true ) );
+
+		$cron->maybe_schedule_cron();
+
+		$this->assertNotEmpty(
+			wp_next_scheduled( First_Party_Mode_Cron::CRON_ACTION )
+		);
 	}
 }


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #9842 

## Relevant technical choices

This PR schedules the cron task to obtain FPM server requirement status only if FPM is enabled.

### Deviations from IB

> * Replace the `getFirstPartyModeSettings` selector call with the `fetchGetFPMServerRequirementStatus` action

This PR persists the `getFirstPartyModeSettings` selector call as it is needed to see if FPM is enabled or if server requirement status fields are not set.

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [x] Run the code.
- [x] Ensure the acceptance criteria are satisfied.
- [x] Reassess the implementation with the IB.
- [x] Ensure no unrelated changes are included.
- [x] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [x] Ensure there is a QA Brief.
- [x] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [x] Ensure the PR has the correct target branch.
- [x] Double-check that the PR is okay to be merged.
- [x] Ensure the corresponding issue has a ZenHub release assigned.
- [x] Add a changelog message to the issue.
