### PR TITLE
Enhancement/9798 persist badges

### DIFF
--- a/assets/js/components/KeyMetrics/ChipTabGroup/index.js
+++ b/assets/js/components/KeyMetrics/ChipTabGroup/index.js
@@ -50,6 +50,7 @@ import CheckMark from '../../../../svg/icons/check-2.svg';
 import { MODULES_ANALYTICS_4 } from '../../../modules/analytics-4/datastore/constants';
 import { CORE_UI } from '../../../googlesitekit/datastore/ui/constants';
 import { CORE_MODULES } from '../../../googlesitekit/modules/datastore/constants';
+import { CORE_USER } from '../../../googlesitekit/datastore/user/constants';
 
 const currentSelectionGroup = {
 	SLUG: KEY_METRICS_CURRENT_SELECTION_GROUP_SLUG,
@@ -89,6 +90,30 @@ export default function ChipTabGroup( { allMetricItems, savedItemSlugs } ) {
 			) || []
 	);
 
+	const currentlyActiveEvents = useSelect( ( select ) => {
+		const userPickedMetrics = select( CORE_USER ).getUserPickedMetrics();
+		// It is safe to access the selector without checking if GA4 is connected,
+		// since this selector does not make request to the module endpoint.
+
+		if ( userPickedMetrics?.length ) {
+			const keyMetricsConversionEventWidgets =
+				select(
+					MODULES_ANALYTICS_4
+				).getKeyMetricsConversionEventWidgets();
+
+			return Object.keys( keyMetricsConversionEventWidgets ).filter(
+				( event ) =>
+					userPickedMetrics.some( ( metric ) =>
+						keyMetricsConversionEventWidgets[ event ].includes(
+							metric
+						)
+					)
+			);
+		}
+
+		const userInputSettings = select( CORE_USER ).getUserInputSettings();
+		return userInputSettings?.includeConversionEvents?.values;
+	} );
 	const isGA4Connected = useSelect( ( select ) =>
 		select( CORE_MODULES ).isModuleConnected( 'analytics-4' )
 	);
@@ -103,9 +128,15 @@ export default function ChipTabGroup( { allMetricItems, savedItemSlugs } ) {
 		'submit_lead_form',
 		'contact',
 		'generate_lead',
-	].filter( ( item ) => detectedEvents?.includes( item ) );
+	].filter(
+		( item ) =>
+			detectedEvents?.includes( item ) ||
+			currentlyActiveEvents?.includes( item )
+	);
 	const hasSellingProductsGroup = [ 'add_to_cart', 'purchase' ].filter(
-		( item ) => detectedEvents?.includes( item )
+		( item ) =>
+			detectedEvents?.includes( item ) ||
+			currentlyActiveEvents?.includes( item )
 	);
 
 	const keyMetricsGroups = useMemo(
@@ -128,14 +159,12 @@ export default function ChipTabGroup( { allMetricItems, savedItemSlugs } ) {
 		[ keyMetricsGroups ]
 	);
 
-	const conversionReportingEventsChange = useSelect( ( select ) => {
+	const newBadgeEvents = useSelect( ( select ) => {
 		if ( ! isGA4Connected ) {
-			return null;
+			return [];
 		}
 
-		return select(
-			MODULES_ANALYTICS_4
-		).getConversionReportingEventsChange();
+		return select( MODULES_ANALYTICS_4 ).getNewBadgeEvents();
 	} );
 	const conversionReportingEventWidgets = useSelect( ( select ) => {
 		if ( ! isGA4Connected ) {
@@ -183,14 +212,13 @@ export default function ChipTabGroup( { allMetricItems, savedItemSlugs } ) {
 		}
 
 		// Check if metric is conversion event related and if new badge should be included.
-		if ( conversionReportingEventsChange?.newEvents ) {
-			const isNewlyDetectedKeyMetrics =
-				conversionReportingEventsChange.newEvents.some(
-					( conversionEvent ) =>
-						conversionReportingEventWidgets[
-							conversionEvent
-						].includes( metricItemSlug )
-				);
+		if ( newBadgeEvents?.length ) {
+			const isNewlyDetectedKeyMetrics = newBadgeEvents.some(
+				( conversionEvent ) =>
+					conversionReportingEventWidgets[ conversionEvent ].includes(
+						metricItemSlug
+					)
+			);
 
 			if ( isNewlyDetectedKeyMetrics ) {
 				newlyDetectedMetrics[ metricGroup ] = [

--- a/assets/js/components/KeyMetrics/ChipTabGroup/index.stories.js
+++ b/assets/js/components/KeyMetrics/ChipTabGroup/index.stories.js
@@ -138,6 +138,7 @@ WithError.args = {
 			.receiveConversionReportingInlineData( {
 				newEvents: [],
 				lostEvents: [],
+				newBadgeEvents: [],
 			} );
 	},
 	features: [ 'conversionReporting' ],
@@ -202,6 +203,7 @@ export default {
 					.receiveConversionReportingInlineData( {
 						newEvents: [ 'contact' ],
 						lostEvents: [],
+						newBadgeEvents: [ 'contact' ],
 					} );
 
 				// Call story-specific setup.

--- a/assets/js/components/KeyMetrics/ConfirmSitePurposeChangeModal.js
+++ b/assets/js/components/KeyMetrics/ConfirmSitePurposeChangeModal.js
@@ -135,26 +135,19 @@ function ConfirmSitePurposeChangeModal( {
 		).getUserInputPurposeConversionEvents();
 	} );
 
-	const {
-		saveUserInputSettings,
-		setKeyMetricsSetting,
-		saveKeyMetricsSettings,
-	} = useDispatch( CORE_USER );
+	const { setUserInputSetting, saveUserInputSettings } =
+		useDispatch( CORE_USER );
 
 	const saveChanges = useCallback( async () => {
 		setIsSaving( true );
-		await saveUserInputSettings();
-
-		// Update 'includeConversionTailoredMetrics' key metrics setting with included
-		// conversion events, to mark that their respective metrics should be included in the
+		// Update 'includeConversionEvents' setting with included conversion events,
+		// to mark that their respective metrics should be included in the
 		// list of tailored metrics and persist on the dashboard in case events are lost.
-		setKeyMetricsSetting(
-			'includeConversionTailoredMetrics',
+		setUserInputSetting(
+			'includeConversionEvents',
 			userInputPurposeConversionEvents
 		);
-		saveKeyMetricsSettings( {
-			widgetSlugs: undefined,
-		} );
+		await saveUserInputSettings();
 
 		setIsSaving( false );
 		onClose();
@@ -162,8 +155,7 @@ function ConfirmSitePurposeChangeModal( {
 		saveUserInputSettings,
 		onClose,
 		setIsSaving,
-		setKeyMetricsSetting,
-		saveKeyMetricsSettings,
+		setUserInputSetting,
 		userInputPurposeConversionEvents,
 	] );
 

--- a/assets/js/components/KeyMetrics/ConversionReportingNotificationCTAWidget.js
+++ b/assets/js/components/KeyMetrics/ConversionReportingNotificationCTAWidget.js
@@ -65,7 +65,7 @@ function ConversionReportingNotificationCTAWidget( { Widget, WidgetNull } ) {
 	// Initial callout is surfaced to the users with tailored metrics, if detectedEvents setting
 	// has a conversion event associated with the ACR key metrics matching the current site purpose answer.
 	// If new ACR key metrics that can be added are found using haveConversionReportingEventsForTailoredMetrics,
-	// and have not been already included, which is determined by includeConversionTailoredMetrics setting, callout banner should be displayed.
+	// and have not been already included, which is determined by includeConversionEvents user input setting, callout banner should be displayed.
 	const shouldShowInitialCalloutForTailoredMetrics =
 		! hasUserPickedMetrics?.length &&
 		isUserInputCompleted &&
@@ -102,7 +102,7 @@ function ConversionReportingNotificationCTAWidget( { Widget, WidgetNull } ) {
 		select( MODULES_ANALYTICS_4 ).getUserInputPurposeConversionEvents()
 	);
 
-	const { setKeyMetricsSetting, saveKeyMetricsSettings } =
+	const { setUserInputSetting, saveUserInputSettings } =
 		useDispatch( CORE_USER );
 	const {
 		dismissNewConversionReportingEvents,
@@ -112,20 +112,18 @@ function ConversionReportingNotificationCTAWidget( { Widget, WidgetNull } ) {
 	const handleAddMetricsClick = useCallback( () => {
 		if ( shouldShowInitialCalloutForTailoredMetrics ) {
 			setIsSaving( true );
-			setKeyMetricsSetting(
-				'includeConversionTailoredMetrics',
+			setUserInputSetting(
+				'includeConversionEvents',
 				userInputPurposeConversionEvents
 			);
-			saveKeyMetricsSettings( {
-				widgetSlugs: undefined,
-			} );
+			saveUserInputSettings();
 			setIsSaving( false );
 		}
 
 		dismissNewConversionReportingEvents();
 	}, [
-		setKeyMetricsSetting,
-		saveKeyMetricsSettings,
+		setUserInputSetting,
+		saveUserInputSettings,
 		dismissNewConversionReportingEvents,
 		userInputPurposeConversionEvents,
 		shouldShowInitialCalloutForTailoredMetrics,

--- a/assets/js/components/KeyMetrics/ConversionReportingNotificationCTAWidget.stories.js
+++ b/assets/js/components/KeyMetrics/ConversionReportingNotificationCTAWidget.stories.js
@@ -72,6 +72,7 @@ export default {
 				const data = {
 					newEvents: [ 'contact' ],
 					lostEvents: [],
+					newBadgeEvents: [],
 				};
 
 				await registry

--- a/assets/js/components/KeyMetrics/ConversionReportingNotificationCTAWidget.test.js
+++ b/assets/js/components/KeyMetrics/ConversionReportingNotificationCTAWidget.test.js
@@ -67,8 +67,8 @@ describe( 'ConversionReportingNotificationCTAWidget', () => {
 	const fetchDismissNotification = new RegExp(
 		'^/google-site-kit/v1/modules/analytics-4/data/clear-conversion-reporting-new-events'
 	);
-	const coreKeyMetricsEndpointRegExp = new RegExp(
-		'^/google-site-kit/v1/core/user/data/key-metrics'
+	const userInputSettingsEndpointRegExp = new RegExp(
+		'^/google-site-kit/v1/core/user/data/user-input-settings'
 	);
 
 	beforeEach( () => {
@@ -107,13 +107,16 @@ describe( 'ConversionReportingNotificationCTAWidget', () => {
 		beforeEach( () => {
 			registry.dispatch( CORE_USER ).receiveGetKeyMetricsSettings( {
 				widgetSlugs: [],
-				includeConversionTailoredMetrics: [],
 				isWidgetHidden: false,
 			} );
 
 			registry.dispatch( CORE_USER ).receiveGetUserInputSettings( {
 				purpose: {
 					values: [ 'publish_blog' ],
+					scope: 'site',
+				},
+				includeConversionEvents: {
+					values: [],
 					scope: 'site',
 				},
 			} );
@@ -159,13 +162,18 @@ describe( 'ConversionReportingNotificationCTAWidget', () => {
 			expect( container ).toBeEmptyDOMElement();
 		} );
 
-		it( 'does not render when includeConversionTailoredMetrics contains existing events', async () => {
+		it( 'does not render when includeConversionEvents contains existing events', async () => {
 			registry.dispatch( CORE_USER ).receiveIsUserInputCompleted( true );
 
-			registry.dispatch( CORE_USER ).receiveGetKeyMetricsSettings( {
-				widgetSlugs: [],
-				includeConversionTailoredMetrics: [ 'contact' ],
-				isWidgetHidden: false,
+			registry.dispatch( CORE_USER ).receiveGetUserInputSettings( {
+				purpose: {
+					values: [ 'publish_blog' ],
+					scope: 'site',
+				},
+				includeConversionEvents: {
+					values: [ 'contact' ],
+					scope: 'site',
+				},
 			} );
 
 			const { container, waitForRegistry } = render(
@@ -214,7 +222,7 @@ describe( 'ConversionReportingNotificationCTAWidget', () => {
 			expect( container ).toBeEmptyDOMElement();
 		} );
 
-		it( 'does render when includeConversionTailoredMetrics is not set and there are new events connected to the ACR KMW matching the currently saved site purpose', async () => {
+		it( 'does render when includeConversionEvents is not set and there are new events connected to the ACR KMW matching the currently saved site purpose', async () => {
 			registry.dispatch( CORE_USER ).receiveIsUserInputCompleted( true );
 
 			const { waitForRegistry } = render(
@@ -269,11 +277,16 @@ describe( 'ConversionReportingNotificationCTAWidget', () => {
 			fetchMock.postOnce( fetchDismissNotification, {
 				body: true,
 			} );
-			fetchMock.postOnce( coreKeyMetricsEndpointRegExp, {
+			fetchMock.postOnce( userInputSettingsEndpointRegExp, {
 				body: {
-					widgetSlugs: undefined,
-					includeConversionTailoredMetrics: [ 'contact' ],
-					isWidgetHidden: false,
+					purpose: {
+						values: [ 'publish_blog' ],
+						scope: 'site',
+					},
+					includeConversionEvents: {
+						values: [ 'contact' ],
+						scope: 'site',
+					},
 				},
 				status: 200,
 			} );
@@ -325,9 +338,9 @@ describe( 'ConversionReportingNotificationCTAWidget', () => {
 				);
 			} );
 
-			const keyMetricSettings = registry
+			const userInputSettings = registry
 				.select( CORE_USER )
-				.getKeyMetricsSettings();
+				.getUserInputSettings();
 
 			const newMetrics = registry
 				.select( CORE_USER )
@@ -335,7 +348,7 @@ describe( 'ConversionReportingNotificationCTAWidget', () => {
 
 			expect( fetchMock ).toHaveFetchedTimes( 2 );
 			expect(
-				keyMetricSettings?.includeConversionTailoredMetrics
+				userInputSettings?.includeConversionEvents?.values
 			).toEqual( [ 'contact' ] );
 
 			expect( newMetrics ).toEqual( [
@@ -648,13 +661,16 @@ describe( 'ConversionReportingNotificationCTAWidget', () => {
 
 				registry.dispatch( CORE_USER ).receiveGetKeyMetricsSettings( {
 					widgetSlugs: [],
-					includeConversionTailoredMetrics: [ 'contact' ],
 					isWidgetHidden: false,
 				} );
 
 				registry.dispatch( CORE_USER ).receiveGetUserInputSettings( {
 					purpose: {
 						values: [ 'publish_blog' ],
+						scope: 'site',
+					},
+					includeConversionEvents: {
+						values: [ 'contact' ],
 						scope: 'site',
 					},
 				} );
@@ -719,13 +735,16 @@ describe( 'ConversionReportingNotificationCTAWidget', () => {
 
 				registry.dispatch( CORE_USER ).receiveGetKeyMetricsSettings( {
 					widgetSlugs: [],
-					includeConversionTailoredMetrics: [ 'contact' ],
 					isWidgetHidden: false,
 				} );
 
 				registry.dispatch( CORE_USER ).receiveGetUserInputSettings( {
 					purpose: {
 						values: [ 'sell_products' ],
+						scope: 'site',
+					},
+					includeConversionEvents: {
+						values: [ 'contact' ],
 						scope: 'site',
 					},
 				} );
@@ -769,13 +788,16 @@ describe( 'ConversionReportingNotificationCTAWidget', () => {
 
 				registry.dispatch( CORE_USER ).receiveGetKeyMetricsSettings( {
 					widgetSlugs: [],
-					includeConversionTailoredMetrics: [ 'purchase' ],
 					isWidgetHidden: false,
 				} );
 
 				registry.dispatch( CORE_USER ).receiveGetUserInputSettings( {
 					purpose: {
 						values: [ 'sell_products' ],
+						scope: 'site',
+					},
+					includeConversionEvents: {
+						values: [ 'purchase' ],
 						scope: 'site',
 					},
 				} );
@@ -851,13 +873,16 @@ describe( 'ConversionReportingNotificationCTAWidget', () => {
 
 				registry.dispatch( CORE_USER ).receiveGetKeyMetricsSettings( {
 					widgetSlugs: [],
-					includeConversionTailoredMetrics: [ 'contact' ],
 					isWidgetHidden: false,
 				} );
 
 				registry.dispatch( CORE_USER ).receiveGetUserInputSettings( {
 					purpose: {
 						values: [ 'publish_blog' ],
+						scope: 'site',
+					},
+					includeConversionEvents: {
+						values: [ 'contact' ],
 						scope: 'site',
 					},
 				} );

--- a/assets/js/components/KeyMetrics/MetricsSelectionPanel/index.test.js
+++ b/assets/js/components/KeyMetrics/MetricsSelectionPanel/index.test.js
@@ -528,10 +528,6 @@ describe( 'MetricsSelectionPanel', () => {
 			await registry
 				.dispatch( CORE_USER )
 				.receiveIsUserInputCompleted( false );
-			await registry.dispatch( CORE_USER ).receiveGetKeyMetricsSettings( {
-				widgetSlugs: [],
-				includeConversionTailoredMetrics: [],
-			} );
 
 			provideKeyMetrics( registry );
 

--- a/assets/js/components/settings/SettingsCardKeyMetrics.test.js
+++ b/assets/js/components/settings/SettingsCardKeyMetrics.test.js
@@ -129,11 +129,6 @@ describe( 'SettingsCardKeyMetrics', () => {
 			.dispatch( CORE_USER )
 			.receiveIsUserInputCompleted( true );
 
-		registry.dispatch( CORE_USER ).receiveGetKeyMetricsSettings( {
-			widgetSlugs: [],
-			includeConversionTailoredMetrics: [ 'contact' ],
-		} );
-
 		const { container, waitForRegistry } = render(
 			<SettingsCardKeyMetrics />,
 			{

--- a/assets/js/components/user-input/UserInputQuestionnaire.js
+++ b/assets/js/components/user-input/UserInputQuestionnaire.js
@@ -174,27 +174,23 @@ export default function UserInputQuestionnaire() {
 		).getUserInputPurposeConversionEvents();
 	} );
 
-	const { setKeyMetricsSetting, saveKeyMetricsSettings } =
-		useDispatch( CORE_USER );
+	const { setUserInputSetting } = useDispatch( CORE_USER );
 
 	const submitChanges = useCallback( async () => {
 		trackEvent( gaEventCategory, 'summary_submit' );
 
+		if ( isConversionReportingEnabled ) {
+			// Update 'includeConversionEvents' setting with included conversion events,
+			// to mark that their respective metrics should be included in the
+			// list of tailored metrics and persist on the dashboard in case events are lost.
+			setUserInputSetting(
+				'includeConversionEvents',
+				userInputPurposeConversionEvents
+			);
+		}
+
 		const response = await saveUserInputSettings();
 		if ( ! response.error ) {
-			if ( isConversionReportingEnabled ) {
-				// Update 'includeConversionTailoredMetrics' key metrics setting with included
-				//conversion events, to mark that their respective metrics should be included in the
-				// list of tailored metrics and persist on the dashboard in case events are lost.
-				await setKeyMetricsSetting(
-					'includeConversionTailoredMetrics',
-					userInputPurposeConversionEvents
-				);
-				await saveKeyMetricsSettings( {
-					widgetSlugs: undefined,
-				} );
-			}
-
 			if ( !! userPickedMetrics ) {
 				await resetKeyMetricsSelection();
 			}
@@ -206,8 +202,7 @@ export default function UserInputQuestionnaire() {
 		saveUserInputSettings,
 		userInputPurposeConversionEvents,
 		dashboardURL,
-		setKeyMetricsSetting,
-		saveKeyMetricsSettings,
+		setUserInputSetting,
 		navigateTo,
 		isConversionReportingEnabled,
 		userPickedMetrics,

--- a/assets/js/googlesitekit/datastore/user/key-metrics.js
+++ b/assets/js/googlesitekit/datastore/user/key-metrics.js
@@ -363,18 +363,15 @@ const baseSelectors = {
 			const hasProductPostType = postTypes.some(
 				( { slug } ) => slug === 'product'
 			);
-			const keyMetricSettings =
-				select( CORE_USER ).getKeyMetricsSettings();
+			const userInputSettings =
+				select( CORE_USER ).getUserInputSettings();
 
 			const showConversionTailoredMetrics = ( events ) => {
 				return events.some(
 					( event ) =>
-						( Array.isArray(
-							keyMetricSettings?.includeConversionTailoredMetrics
-						) &&
-							keyMetricSettings?.includeConversionTailoredMetrics?.includes(
-								event
-							) ) ||
+						userInputSettings?.includeConversionEvents?.values?.includes(
+							event
+						) ||
 						( Array.isArray( includeConversionTailoredMetrics ) &&
 							includeConversionTailoredMetrics?.includes(
 								event

--- a/assets/js/googlesitekit/datastore/user/key-metrics.test.js
+++ b/assets/js/googlesitekit/datastore/user/key-metrics.test.js
@@ -276,12 +276,6 @@ describe( 'core/user key metrics', () => {
 				await registry
 					.dispatch( CORE_USER )
 					.receiveIsUserInputCompleted( false );
-				await registry
-					.dispatch( CORE_USER )
-					.receiveGetKeyMetricsSettings( {
-						widgetSlugs: [],
-						includeConversionTailoredMetrics: [],
-					} );
 			} );
 
 			it( 'should return undefined if user input settings are not resolved', async () => {
@@ -514,7 +508,7 @@ describe( 'core/user key metrics', () => {
 				],
 			] )(
 				'should return the correct metrics for the %s purpose when conversionReporting is enabled',
-				async (
+				(
 					purpose,
 					expectedMetricsIncludingConversionTailored,
 					conversionEvents
@@ -533,6 +527,10 @@ describe( 'core/user key metrics', () => {
 						.dispatch( CORE_USER )
 						.receiveGetUserInputSettings( {
 							purpose: { values: [ purpose ] },
+							includeConversionEvents: {
+								values: [ 'contact' ],
+								scope: 'site',
+							},
 						} );
 
 					registry
@@ -551,20 +549,21 @@ describe( 'core/user key metrics', () => {
 					}
 
 					// Conversion Tailored Metrics should be included in the list if the
-					// includeConversionTailoredMetrics contains their respective conversion reporting events.
-					await registry
+					// includeConversionEvents contains their respective conversion reporting events.
+					registry
 						.dispatch( CORE_USER )
-						.receiveGetKeyMetricsSettings( {
-							widgetSlugs: [],
-							includeConversionTailoredMetrics: conversionEvents,
+						.receiveGetUserInputSettings( {
+							purpose: { values: [ purpose ] },
+							includeConversionEvents: {
+								values: conversionEvents,
+								scope: 'site',
+							},
 						} );
 
 					expect(
-						registry.select( CORE_USER ).getKeyMetricsSettings()
-					).toEqual( {
-						widgetSlugs: [],
-						includeConversionTailoredMetrics: conversionEvents,
-					} );
+						registry.select( CORE_USER ).getUserInputSettings()
+							?.includeConversionEvents?.values
+					).toEqual( conversionEvents );
 
 					expect(
 						registry.select( CORE_USER ).getAnswerBasedMetrics()

--- a/assets/js/modules/analytics-4/datastore/conversion-reporting.js
+++ b/assets/js/modules/analytics-4/datastore/conversion-reporting.js
@@ -135,12 +135,13 @@ export const resolvers = {
 			return;
 		}
 
-		const { newEvents, lostEvents } =
+		const { newEvents, lostEvents, newBadgeEvents } =
 			global._googlesitekitModulesData[ 'analytics-4' ];
 
 		yield actions.receiveConversionReportingInlineData( {
 			newEvents,
 			lostEvents,
+			newBadgeEvents,
 		} );
 	},
 };
@@ -190,9 +191,13 @@ export const actions = {
 export const reducer = createReducer( ( state, { payload, type } ) => {
 	switch ( type ) {
 		case RECEIVE_CONVERSION_REPORTING_INLINE_DATA: {
-			const { newEvents, lostEvents } = payload.data;
+			const { newEvents, lostEvents, newBadgeEvents } = payload.data;
 
-			state.detectedEventsChange = { newEvents, lostEvents };
+			state.detectedEventsChange = {
+				newEvents,
+				lostEvents,
+				newBadgeEvents,
+			};
 			break;
 		}
 
@@ -269,11 +274,24 @@ export const selectors = {
 		hasConversionReportingEventsOfType( 'lostEvents' ),
 
 	/**
+	 * Returns newBadgeEvents if present.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @return {Array|undefined} `newBadgeEvents` array if events are present, `undefined` otherwise.
+	 */
+	getNewBadgeEvents: createRegistrySelector( ( select ) => () => {
+		const inlineData =
+			select( MODULES_ANALYTICS_4 ).getConversionReportingEventsChange();
+
+		return inlineData?.newBadgeEvents;
+	} ),
+
+	/**
 	 * Checks if there are key metrics widgets connected with the detected events for the supplied purpose answer.
 	 *
 	 * @since 1.141.0
 	 *
-	 * @param {string}  purpose      Value of saved site purpose from user input settings.
 	 * @param {boolean} useNewEvents Flag inclusion of detected new events, otherwise initial detected events will be used.
 	 * @return {boolean|undefined} TRUE if current site purpose will have any ACR key metrics widgets assigned to it, FALSE otherwise, and undefined if metrics are not loaded.
 	 */

--- a/assets/js/modules/analytics-4/datastore/conversion-reporting.test.js
+++ b/assets/js/modules/analytics-4/datastore/conversion-reporting.test.js
@@ -69,6 +69,7 @@ describe( 'modules/analytics-4 conversion-reporting', () => {
 				const data = {
 					newEvents: [ 'purchase' ],
 					lostEvents: [],
+					newBadgeEvents: [ 'purchase' ],
 				};
 
 				await registry
@@ -177,6 +178,7 @@ describe( 'modules/analytics-4 conversion-reporting', () => {
 				const inlineData = {
 					newEvents: [ 'contact' ],
 					lostEvents: [],
+					newBadgeEvents: [ 'contact' ],
 				};
 
 				global._googlesitekitModulesData = {
@@ -302,6 +304,7 @@ describe( 'modules/analytics-4 conversion-reporting', () => {
 					.receiveConversionReportingInlineData( {
 						newEvents: [ 'contact' ],
 						lostEvents: [],
+						newBadgeEvents: [],
 					} );
 
 				const haveConversionEventsForTailoredMetrics = registry
@@ -336,6 +339,7 @@ describe( 'modules/analytics-4 conversion-reporting', () => {
 					.receiveConversionReportingInlineData( {
 						newEvents: [ 'add_to_cart' ],
 						lostEvents: [],
+						newBadgeEvents: [],
 					} );
 
 				const haveConversionEventsForTailoredMetrics = registry
@@ -394,7 +398,6 @@ describe( 'modules/analytics-4 conversion-reporting', () => {
 				registry.dispatch( CORE_USER ).receiveGetKeyMetricsSettings( {
 					widgetSlugs: [],
 					isWidgetHidden: false,
-					includeConversionTailoredMetrics: [ 'contact' ],
 				} );
 			} );
 
@@ -409,6 +412,10 @@ describe( 'modules/analytics-4 conversion-reporting', () => {
 
 				registry.dispatch( CORE_USER ).receiveGetUserInputSettings( {
 					purpose: { values: [ 'publish_blog' ] },
+					includeConversionEvents: {
+						values: [ 'contact' ],
+						scope: 'site',
+					},
 				} );
 
 				registry
@@ -420,6 +427,7 @@ describe( 'modules/analytics-4 conversion-reporting', () => {
 					.receiveConversionReportingInlineData( {
 						newEvents: [ 'contact' ],
 						lostEvents: [ 'purchase' ],
+						newBadgeEvents: [],
 					} );
 
 				const haveLostEventsForCurrentMetrics = registry
@@ -433,12 +441,12 @@ describe( 'modules/analytics-4 conversion-reporting', () => {
 				registry
 					.dispatch( CORE_USER )
 					.receiveIsUserInputCompleted( true );
-				registry.dispatch( CORE_USER ).receiveGetKeyMetricsSettings( {
-					widgetSlugs: [],
-					includeConversionTailoredMetrics: [ 'contact' ],
-				} );
 				registry.dispatch( CORE_USER ).receiveGetUserInputSettings( {
 					purpose: { values: [ 'publish_blog' ] },
+					includeConversionEvents: {
+						values: [ 'contact' ],
+						scope: 'site',
+					},
 				} );
 
 				registry
@@ -450,6 +458,7 @@ describe( 'modules/analytics-4 conversion-reporting', () => {
 					.receiveConversionReportingInlineData( {
 						newEvents: [],
 						lostEvents: [ 'contact' ],
+						newBadgeEvents: [],
 					} );
 
 				const haveLostEventsForCurrentMetrics = registry
@@ -477,6 +486,7 @@ describe( 'modules/analytics-4 conversion-reporting', () => {
 					.receiveConversionReportingInlineData( {
 						newEvents: [ 'contact' ],
 						lostEvents: [ 'purchase' ],
+						newBadgeEvents: [],
 					} );
 
 				const haveLostEventsForCurrentMetrics = registry
@@ -505,6 +515,7 @@ describe( 'modules/analytics-4 conversion-reporting', () => {
 					.receiveConversionReportingInlineData( {
 						newEvents: [ 'contact' ],
 						lostEvents: [ 'purchase' ],
+						newBadgeEvents: [],
 					} );
 
 				const haveLostEventsForCurrentMetrics = registry
@@ -533,6 +544,7 @@ describe( 'modules/analytics-4 conversion-reporting', () => {
 					.receiveConversionReportingInlineData( {
 						newEvents: [ 'purchase' ],
 						lostEvents: [ 'contact' ],
+						newBadgeEvents: [],
 					} );
 
 				const haveLostEventsForCurrentMetrics = registry

--- a/includes/Core/Key_Metrics/Key_Metrics_Settings.php
+++ b/includes/Core/Key_Metrics/Key_Metrics_Settings.php
@@ -47,9 +47,8 @@ class Key_Metrics_Settings extends User_Setting {
 	 */
 	protected function get_default() {
 		return array(
-			'widgetSlugs'                      => array(),
-			'isWidgetHidden'                   => false,
-			'includeConversionTailoredMetrics' => array(),
+			'widgetSlugs'    => array(),
+			'isWidgetHidden' => false,
 		);
 	}
 
@@ -71,9 +70,8 @@ class Key_Metrics_Settings extends User_Setting {
 		);
 
 		$allowed_settings = array(
-			'widgetSlugs'                      => true,
-			'isWidgetHidden'                   => true,
-			'includeConversionTailoredMetrics' => true,
+			'widgetSlugs'    => true,
+			'isWidgetHidden' => true,
 		);
 
 		$updated = array_intersect_key( $partial, $allowed_settings );
@@ -102,10 +100,6 @@ class Key_Metrics_Settings extends User_Setting {
 
 			if ( isset( $settings['isWidgetHidden'] ) ) {
 				$sanitized_settings['isWidgetHidden'] = false !== $settings['isWidgetHidden'];
-			}
-
-			if ( isset( $settings['includeConversionTailoredMetrics'] ) ) {
-				$sanitized_settings['includeConversionTailoredMetrics'] = Sanitize::sanitize_string_list( $settings['includeConversionTailoredMetrics'] );
 			}
 
 			return $sanitized_settings;

--- a/includes/Core/User_Input/User_Input.php
+++ b/includes/Core/User_Input/User_Input.php
@@ -67,14 +67,17 @@ class User_Input {
 	 * @var array|ArrayAccess
 	 */
 	private static $questions = array(
-		'purpose'       => array(
+		'purpose'                 => array(
 			'scope' => 'site',
 		),
-		'postFrequency' => array(
+		'postFrequency'           => array(
 			'scope' => 'user',
 		),
-		'goals'         => array(
+		'goals'                   => array(
 			'scope' => 'user',
+		),
+		'includeConversionEvents' => array(
+			'scope' => 'site',
 		),
 	);
 

--- a/includes/Modules/Analytics_4.php
+++ b/includes/Modules/Analytics_4.php
@@ -92,6 +92,7 @@ use Google\Site_Kit\Core\REST_API\REST_Routes;
 use Google\Site_Kit\Core\Tags\First_Party_Mode\First_Party_Mode;
 use Google\Site_Kit\Modules\Analytics_4\Conversion_Reporting\Conversion_Reporting_Cron;
 use Google\Site_Kit\Modules\Analytics_4\Conversion_Reporting\Conversion_Reporting_Events_Sync;
+use Google\Site_Kit\Modules\Analytics_4\Conversion_Reporting\Conversion_Reporting_New_Badge_Events_Sync;
 use Google\Site_Kit\Modules\Analytics_4\Conversion_Reporting\Conversion_Reporting_Provider;
 use Google\Site_Kit\Modules\Analytics_4\Reset_Audiences;
 use stdClass;
@@ -2624,10 +2625,13 @@ final class Analytics_4 extends Module implements Module_With_Scopes, Module_Wit
 			return $modules_data;
 		}
 
-		$detected_events                           = $this->transients->get( Conversion_Reporting_Events_Sync::DETECTED_EVENTS_TRANSIENT );
-		$lost_events                               = $this->transients->get( Conversion_Reporting_Events_Sync::LOST_EVENTS_TRANSIENT );
-		$modules_data['analytics-4']['newEvents']  = is_array( $detected_events ) ? $detected_events : array();
-		$modules_data['analytics-4']['lostEvents'] = is_array( $lost_events ) ? $lost_events : array();
+		$detected_events  = $this->transients->get( Conversion_Reporting_Events_Sync::DETECTED_EVENTS_TRANSIENT );
+		$lost_events      = $this->transients->get( Conversion_Reporting_Events_Sync::LOST_EVENTS_TRANSIENT );
+		$new_events_badge = $this->transients->get( Conversion_Reporting_New_Badge_Events_Sync::NEW_EVENTS_BADGE_TRANSIENT );
+
+		$modules_data['analytics-4']['newEvents']      = is_array( $detected_events ) ? $detected_events : array();
+		$modules_data['analytics-4']['lostEvents']     = is_array( $lost_events ) ? $lost_events : array();
+		$modules_data['analytics-4']['newBadgeEvents'] = is_array( $new_events_badge ) ? $new_events_badge['events'] : array();
 
 		return $modules_data;
 	}

--- a/includes/Modules/Analytics_4/Conversion_Reporting/Conversion_Reporting_Events_Sync.php
+++ b/includes/Modules/Analytics_4/Conversion_Reporting/Conversion_Reporting_Events_Sync.php
@@ -13,7 +13,6 @@ namespace Google\Site_Kit\Modules\Analytics_4\Conversion_Reporting;
 use Google\Site_Kit\Modules\Analytics_4;
 use Google\Site_Kit\Modules\Analytics_4\Settings;
 use Google\Site_Kit\Core\Storage\Transients;
-use Google\Site_Kit\Context;
 
 /**
  * Class providing report implementation for available events for conversion reporting.
@@ -57,6 +56,13 @@ class Conversion_Reporting_Events_Sync {
 	private $analytics;
 
 	/**
+	 * Conversion_Reporting_New_Badge_Events_Sync instance.
+	 *
+	 * @var Conversion_Reporting_New_Badge_Events_Sync
+	 */
+	private $new_badge_events_sync;
+
+	/**
 	 * Transients instance.
 	 *
 	 * @since 1.139.0
@@ -69,19 +75,23 @@ class Conversion_Reporting_Events_Sync {
 	 *
 	 * @since 1.135.0
 	 * @since 1.139.0 Added $context param to constructor.
+	 * @since n.e.x.t Added $transients and $new_badge_events_sync params to constructor, and removed $context.
 	 *
-	 * @param Context     $context   Plugin context.
-	 * @param Settings    $settings  Settings module settings instance.
-	 * @param Analytics_4 $analytics Analytics 4 module instance.
+	 * @param Settings                                   $settings              Settings module settings instance.
+	 * @param Transients                                 $transients            Transients instance.
+	 * @param Analytics_4                                $analytics             Analytics 4 module instance.
+	 * @param Conversion_Reporting_New_Badge_Events_Sync $new_badge_events_sync Conversion_Reporting_New_Badge_Events_Sync instance.
 	 */
 	public function __construct(
-		Context $context,
 		Settings $settings,
-		Analytics_4 $analytics
+		Transients $transients,
+		Analytics_4 $analytics,
+		Conversion_Reporting_New_Badge_Events_Sync $new_badge_events_sync
 	) {
-		$this->settings   = $settings;
-		$this->analytics  = $analytics;
-		$this->transients = new Transients( $context );
+		$this->settings              = $settings;
+		$this->transients            = $transients;
+		$this->analytics             = $analytics;
+		$this->new_badge_events_sync = $new_badge_events_sync;
 	}
 
 	/**
@@ -118,11 +128,26 @@ class Conversion_Reporting_Events_Sync {
 			$detected_events[] = $row['dimensionValues'][0]['value'];
 		}
 
+		$this->maybe_update_new_and_lost_events( $detected_events, $saved_detected_events );
+
+		$this->settings->merge( array( 'detectedEvents' => $detected_events ) );
+	}
+
+	/**
+	 * Saves new and lost events transients.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param array $detected_events       Currently detected events array.
+	 * @param array $saved_detected_events Previously saved detected events array.
+	 */
+	protected function maybe_update_new_and_lost_events( $detected_events, $saved_detected_events ) {
 		$new_events  = array_diff( $detected_events, $saved_detected_events );
 		$lost_events = array_diff( $saved_detected_events, $detected_events );
 
 		if ( ! empty( $new_events ) ) {
 			$this->transients->set( self::DETECTED_EVENTS_TRANSIENT, array_values( $new_events ) );
+			$this->new_badge_events_sync->sync_new_events_badge( $new_events );
 		}
 
 		if ( ! empty( $lost_events ) ) {
@@ -132,8 +157,6 @@ class Conversion_Reporting_Events_Sync {
 		if ( empty( $saved_detected_events ) ) {
 			$this->transients->set( self::DETECTED_EVENTS_TRANSIENT, $detected_events );
 		}
-
-		$this->settings->merge( array( 'detectedEvents' => $detected_events ) );
 	}
 
 	/**

--- a/includes/Modules/Analytics_4/Conversion_Reporting/Conversion_Reporting_New_Badge_Events_Sync.php
+++ b/includes/Modules/Analytics_4/Conversion_Reporting/Conversion_Reporting_New_Badge_Events_Sync.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * Class Google\Site_Kit\Modules\Analytics_4\Conversion_Reporting\Conversion_Reporting_New_Badge_Events_Sync
+ *
+ * @package   Google\Site_Kit
+ * @copyright 2024 Google LLC
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
+ * @link      https://sitekit.withgoogle.com
+ */
+
+namespace Google\Site_Kit\Modules\Analytics_4\Conversion_Reporting;
+
+use Google\Site_Kit\Core\Storage\Transients;
+
+/**
+ * Class providing implementation of "new" badge for detected conversion reporting events.
+ *
+ * @since n.e.x.t
+ * @access private
+ * @ignore
+ */
+class Conversion_Reporting_New_Badge_Events_Sync {
+
+	/**
+	 * The detected events transient name.
+	 */
+	public const NEW_EVENTS_BADGE_TRANSIENT = 'googlesitekit_conversion_reporting_new_badge_events';
+
+	/**
+	 * Transients instance.
+	 *
+	 * @since n.e.x.t
+	 * @var Transients
+	 */
+	protected $transients;
+
+	/**
+	 * Constructor.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param Transients $transients  Transients instance.
+	 */
+	public function __construct(
+		Transients $transients
+	) {
+		$this->transients = $transients;
+	}
+
+	/**
+	 * Saves new events badge to the expirable items.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param array $new_events New events array.
+	 */
+	public function sync_new_events_badge( $new_events ) {
+		$new_events_badge         = $this->transients->get( self::NEW_EVENTS_BADGE_TRANSIENT );
+		$save_new_badge_transient = fn( $events ) => $this->transients->set(
+			self::NEW_EVENTS_BADGE_TRANSIENT,
+			array(
+				'created_at' => time(),
+				'events'     => $events,
+			),
+			7 * DAY_IN_SECONDS
+		);
+
+		if ( $new_events_badge ) {
+			$new_events_badge_time_existed = time() - $new_events_badge['created_at'];
+			// If the transient existed for 3 days or less, prevent scenarios where
+			// a new event is detected shortly after (within 1-3 days) the previous events.
+			// This avoids shortening the "new badge" time for previous events.
+			// Instead, we merge the new events with the previous ones to ensure the user sees all of them.
+			if ( $new_events_badge_time_existed <= ( 3 * DAY_IN_SECONDS ) ) {
+				$events = array_merge( $new_events_badge['events'], $new_events );
+
+				$save_new_badge_transient( $events );
+			}
+		} else {
+			$save_new_badge_transient( $new_events );
+		}
+	}
+}

--- a/includes/Modules/Analytics_4/Conversion_Reporting/Conversion_Reporting_Provider.php
+++ b/includes/Modules/Analytics_4/Conversion_Reporting/Conversion_Reporting_Provider.php
@@ -11,6 +11,7 @@
 namespace Google\Site_Kit\Modules\Analytics_4\Conversion_Reporting;
 
 use Google\Site_Kit\Context;
+use Google\Site_Kit\Core\Storage\Transients;
 use Google\Site_Kit\Core\Storage\User_Options;
 use Google\Site_Kit\Modules\Analytics_4;
 use Google\Site_Kit\Modules\Analytics_4\Settings;
@@ -72,8 +73,15 @@ class Conversion_Reporting_Provider {
 		$this->user_options = $user_options;
 		$this->analytics    = $analytics;
 
-		$this->events_sync = new Conversion_Reporting_Events_Sync( $context, $settings, $this->analytics );
-		$this->cron        = new Conversion_Reporting_Cron( fn() => $this->cron_callback() );
+		$transients            = new Transients( $context );
+		$new_badge_events_sync = new Conversion_Reporting_New_Badge_Events_Sync( $transients );
+		$this->events_sync     = new Conversion_Reporting_Events_Sync(
+			$settings,
+			$transients,
+			$this->analytics,
+			$new_badge_events_sync
+		);
+		$this->cron            = new Conversion_Reporting_Cron( fn() => $this->cron_callback() );
 	}
 
 	/**

--- a/tests/js/utils.js
+++ b/tests/js/utils.js
@@ -427,7 +427,6 @@ export const provideKeyMetrics = ( registry, extraData = {} ) => {
 			KM_ANALYTICS_NEW_VISITORS,
 			KM_ANALYTICS_RETURNING_VISITORS,
 		],
-		includeConversionTailoredMetrics: [],
 		isWidgetHidden: false,
 	};
 	registry.dispatch( CORE_USER ).receiveGetKeyMetricsSettings( {
@@ -451,6 +450,10 @@ export const provideKeyMetricsUserInputSettings = (
 	const defaults = {
 		purpose: {
 			values: [ 'publish_news' ],
+			scope: 'site',
+		},
+		includeConversionEvents: {
+			values: [],
 			scope: 'site',
 		},
 	};

--- a/tests/phpunit/integration/Core/Key_Metrics/Key_Metrics_SettingsTest.php
+++ b/tests/phpunit/integration/Core/Key_Metrics/Key_Metrics_SettingsTest.php
@@ -154,15 +154,13 @@ class Key_Metrics_SettingsTest extends TestCase {
 
 	public function test_merge() {
 		$original_settings = array(
-			'widgetSlugs'                      => array( 'widgetA' ),
-			'isWidgetHidden'                   => false,
-			'includeConversionTailoredMetrics' => array(),
+			'widgetSlugs'    => array( 'widgetA' ),
+			'isWidgetHidden' => false,
 		);
 
 		$changed_settings = array(
-			'widgetSlugs'                      => array( 'widgetB' ),
-			'isWidgetHidden'                   => true,
-			'includeConversionTailoredMetrics' => array( 'contact' ),
+			'widgetSlugs'    => array( 'widgetB' ),
+			'isWidgetHidden' => true,
 		);
 
 		// Make sure settings can be updated even without having them set initially
@@ -178,9 +176,8 @@ class Key_Metrics_SettingsTest extends TestCase {
 		$this->key_metrics_settings->merge( array( 'isWidgetHidden' => true ) );
 		$this->assertEqualSetsWithIndex(
 			array(
-				'widgetSlugs'                      => $original_settings['widgetSlugs'],
-				'isWidgetHidden'                   => true,
-				'includeConversionTailoredMetrics' => array(),
+				'widgetSlugs'    => $original_settings['widgetSlugs'],
+				'isWidgetHidden' => true,
 			),
 			$this->key_metrics_settings->get()
 		);
@@ -198,11 +195,6 @@ class Key_Metrics_SettingsTest extends TestCase {
 		// Make sure that we can't set wrong format for the widgetSlugs property
 		$this->key_metrics_settings->set( $original_settings );
 		$this->key_metrics_settings->merge( array( 'widgetSlugs' => null ) );
-		$this->assertEqualSetsWithIndex( $original_settings, $this->key_metrics_settings->get() );
-
-		// Make sure that we can't set wrong format for the includeConversionTailoredMetrics property
-		$this->key_metrics_settings->set( $original_settings );
-		$this->key_metrics_settings->merge( array( 'includeConversionTailoredMetrics' => null ) );
 		$this->assertEqualSetsWithIndex( $original_settings, $this->key_metrics_settings->get() );
 	}
 

--- a/tests/phpunit/integration/Core/User_Input/REST_User_Input_ControllerTest.php
+++ b/tests/phpunit/integration/Core/User_Input/REST_User_Input_ControllerTest.php
@@ -108,18 +108,22 @@ class REST_User_Input_ControllerTest extends TestCase {
 
 		$this->assertEqualSets(
 			array(
-				'purpose'       => array(
+				'purpose'                 => array(
 					'scope'      => 'site',
 					'values'     => array( 'purpose1' ),
 					'answeredBy' => get_current_user_id(),
 				),
-				'postFrequency' => array(
+				'postFrequency'           => array(
 					'scope'  => 'user',
 					'values' => array( 'daily' ),
 				),
-				'goals'         => array(
+				'goals'                   => array(
 					'scope'  => 'user',
 					'values' => array( 'goal1', 'goal2' ),
+				),
+				'includeConversionEvents' => array(
+					'scope'  => 'site',
+					'values' => array(),
 				),
 			),
 			$response->get_data()
@@ -154,9 +158,10 @@ class REST_User_Input_ControllerTest extends TestCase {
 			array(
 				'data' => array(
 					'settings' => array(
-						'purpose'       => array( 'purpose1' ),
-						'postFrequency' => array( 'daily' ),
-						'goals'         => array( 'goal1', 'goal2' ),
+						'purpose'                 => array( 'purpose1' ),
+						'postFrequency'           => array( 'daily' ),
+						'goals'                   => array( 'goal1', 'goal2' ),
+						'includeConversionEvents' => array( 'contact' ),
 					),
 				),
 			)
@@ -167,18 +172,23 @@ class REST_User_Input_ControllerTest extends TestCase {
 
 		$this->assertEqualSets(
 			array(
-				'purpose'       => array(
+				'purpose'                 => array(
 					'scope'      => 'site',
 					'values'     => array( 'purpose1' ),
 					'answeredBy' => get_current_user_id(),
 				),
-				'postFrequency' => array(
+				'postFrequency'           => array(
 					'scope'  => 'user',
 					'values' => array( 'daily' ),
 				),
-				'goals'         => array(
+				'goals'                   => array(
 					'scope'  => 'user',
 					'values' => array( 'goal1', 'goal2' ),
+				),
+				'includeConversionEvents' => array(
+					'scope'      => 'site',
+					'values'     => array( 'contact' ),
+					'answeredBy' => get_current_user_id(),
 				),
 			),
 			rest_get_server()->dispatch( $request )->get_data()

--- a/tests/phpunit/integration/Core/User_Input/User_InputTest.php
+++ b/tests/phpunit/integration/Core/User_Input/User_InputTest.php
@@ -82,16 +82,20 @@ class User_InputTest extends TestCase {
 		// If settings are not set, it returns empty default values.
 		$this->assertEquals(
 			array(
-				'purpose'       => array(
+				'purpose'                 => array(
 					'scope'  => 'site',
 					'values' => array(),
 				),
-				'postFrequency' => array(
+				'postFrequency'           => array(
 					'scope'  => 'user',
 					'values' => array(),
 				),
-				'goals'         => array(
+				'goals'                   => array(
 					'scope'  => 'user',
+					'values' => array(),
+				),
+				'includeConversionEvents' => array(
+					'scope'  => 'site',
 					'values' => array(),
 				),
 			),
@@ -113,19 +117,24 @@ class User_InputTest extends TestCase {
 				),
 			)
 		);
+
 		$this->assertEquals(
 			array(
-				'purpose'       => array(
+				'purpose'                 => array(
 					'values' => array(),
 					'scope'  => 'site',
 				),
-				'postFrequency' => array(
+				'postFrequency'           => array(
 					'values' => array( 'daily' ),
 					'scope'  => 'user',
 				),
-				'goals'         => array(
+				'goals'                   => array(
 					'values' => array( 'goal1', 'goal2' ),
 					'scope'  => 'user',
+				),
+				'includeConversionEvents' => array(
+					'scope'  => 'site',
+					'values' => array(),
 				),
 			),
 			$this->user_input->get_answers()
@@ -135,9 +144,14 @@ class User_InputTest extends TestCase {
 		update_option(
 			Site_Specific_Answers::OPTION,
 			array(
-				'purpose' => array(
+				'purpose'                 => array(
 					'values'     => array( 'purpose1' ),
 					'scope'      => 'site',
+					'answeredBy' => $this->user_id,
+				),
+				'includeConversionEvents' => array(
+					'scope'      => 'site',
+					'values'     => array( 'contact' ),
 					'answeredBy' => $this->user_id,
 				),
 			)
@@ -158,18 +172,23 @@ class User_InputTest extends TestCase {
 		);
 		$this->assertEquals(
 			array(
-				'purpose'       => array(
+				'postFrequency'           => array(
+					'scope'  => 'user',
+					'values' => array( 'daily' ),
+				),
+				'goals'                   => array(
+					'scope'  => 'user',
+					'values' => array( 'goal1', 'goal2' ),
+				),
+				'purpose'                 => array(
 					'scope'      => 'site',
 					'values'     => array( 'purpose1' ),
 					'answeredBy' => $this->user_id,
 				),
-				'postFrequency' => array(
-					'scope'  => 'user',
-					'values' => array( 'daily' ),
-				),
-				'goals'         => array(
-					'scope'  => 'user',
-					'values' => array( 'goal1', 'goal2' ),
+				'includeConversionEvents' => array(
+					'scope'      => 'site',
+					'values'     => array( 'contact' ),
+					'answeredBy' => $this->user_id,
 				),
 			),
 			$this->user_input->get_answers()
@@ -188,18 +207,22 @@ class User_InputTest extends TestCase {
 
 		$this->assertEquals(
 			array(
-				'purpose'       => array(
+				'purpose'                 => array(
 					'scope'      => 'site',
 					'values'     => array( 'purpose1' ),
 					'answeredBy' => $this->user_id,
 				),
-				'postFrequency' => array(
+				'postFrequency'           => array(
 					'scope'  => 'user',
 					'values' => array( 'daily' ),
 				),
-				'goals'         => array(
+				'goals'                   => array(
 					'scope'  => 'user',
 					'values' => array( 'goal1', 'goal2' ),
+				),
+				'includeConversionEvents' => array(
+					'scope'  => 'site',
+					'values' => array(),
 				),
 			),
 			$response

--- a/tests/phpunit/integration/Modules/Analytics_4/Conversion_Reporting/Conversion_Reporting_Events_SyncTest.php
+++ b/tests/phpunit/integration/Modules/Analytics_4/Conversion_Reporting/Conversion_Reporting_Events_SyncTest.php
@@ -17,6 +17,7 @@ use Google\Site_Kit\Core\Storage\Transients;
 use Google\Site_Kit\Core\Storage\User_Options;
 use Google\Site_Kit\Modules\Analytics_4;
 use Google\Site_Kit\Modules\Analytics_4\Conversion_Reporting\Conversion_Reporting_Events_Sync;
+use Google\Site_Kit\Modules\Analytics_4\Conversion_Reporting\Conversion_Reporting_New_Badge_Events_Sync;
 use Google\Site_Kit\Modules\Analytics_4\Settings;
 use Google\Site_Kit\Tests\Fake_Site_Connection_Trait;
 use Google\Site_Kit\Tests\FakeHttp;
@@ -34,6 +35,7 @@ class Conversion_Reporting_Events_SyncTest extends TestCase {
 	private $user;
 	private $settings;
 	private $analytics;
+	private $new_badge_events_sync;
 	private $authentication;
 	private $request_handler_calls;
 
@@ -61,6 +63,8 @@ class Conversion_Reporting_Events_SyncTest extends TestCase {
 		$this->authentication = new Authentication( $context, $options, $user_options );
 
 		$this->analytics = new Analytics_4( $context, $options, $user_options, $this->authentication );
+
+		$this->new_badge_events_sync = new Conversion_Reporting_New_Badge_Events_Sync( $this->transients );
 
 		wp_set_current_user( $this->user->ID );
 	}
@@ -117,9 +121,10 @@ class Conversion_Reporting_Events_SyncTest extends TestCase {
 
 	public function get_instance() {
 		return new Conversion_Reporting_Events_Sync(
-			$this->context,
 			$this->settings,
-			$this->analytics
+			$this->transients,
+			$this->analytics,
+			$this->new_badge_events_sync
 		);
 	}
 

--- a/tests/phpunit/integration/Modules/Analytics_4/Conversion_Reporting/Conversion_Reporting_New_Badge_Events_SyncTest.php
+++ b/tests/phpunit/integration/Modules/Analytics_4/Conversion_Reporting/Conversion_Reporting_New_Badge_Events_SyncTest.php
@@ -1,0 +1,118 @@
+<?php
+/**
+ * Conversion_Reporting_New_Badge_Events_SyncTest
+ *
+ * @package   Google\Site_Kit\Tests\Modules\Analytics_4\Conversion_Reporting
+ * @copyright 2024 Google LLC
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
+ * @link      https://sitekit.withgoogle.com
+ */
+
+namespace Google\Site_Kit\Tests\Modules\Analytics_4\Conversion_Reporting;
+
+use Google\Site_Kit\Context;
+use Google\Site_Kit\Core\Authentication\Authentication;
+use Google\Site_Kit\Core\Storage\Options;
+use Google\Site_Kit\Core\Storage\Transients;
+use Google\Site_Kit\Core\Storage\User_Options;
+use Google\Site_Kit\Modules\Analytics_4;
+use Google\Site_Kit\Modules\Analytics_4\Conversion_Reporting\Conversion_Reporting_Events_Sync;
+use Google\Site_Kit\Modules\Analytics_4\Conversion_Reporting\Conversion_Reporting_New_Badge_Events_Sync;
+use Google\Site_Kit\Modules\Analytics_4\Settings;
+use Google\Site_Kit\Tests\Fake_Site_Connection_Trait;
+use Google\Site_Kit\Tests\FakeHttp;
+use Google\Site_Kit\Tests\TestCase;
+use Google\Site_Kit_Dependencies\GuzzleHttp\Psr7\Request;
+use Google\Site_Kit_Dependencies\GuzzleHttp\Psr7\Response;
+
+/**
+ * @group Conversion_Reporting
+ */
+class Conversion_Reporting_New_Badge_Events_SyncTest extends TestCase {
+	use Fake_Site_Connection_Trait;
+
+	/**
+	 * @var Context $context Context instance.
+	 */
+	private $context;
+
+	/**
+	 * @var Conversion_Reporting_New_Badge_Events_Sync $new_badge_events_sync Conversion_Reporting_New_Badge_Events_Sync instance.
+	 */
+	private $new_badge_events_sync;
+
+	/**
+	 * @var Transients $transients Transients instance.
+	 */
+	private $transients;
+
+	public function set_up() {
+		parent::set_up();
+
+		$context          = new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE );
+		$this->transients = new Transients( $context );
+
+		$this->new_badge_events_sync = new Conversion_Reporting_New_Badge_Events_Sync( $this->transients );
+	}
+
+	public function sync_new_events_badge__no_transient_exists() {
+		$this->transients->delete( Conversion_Reporting_New_Badge_Events_Sync::NEW_EVENTS_BADGE_TRANSIENT );
+		$new_events = array( 'event1', 'event2' );
+
+		$this->new_badge_events_sync->sync_new_events_badge( $new_events );
+
+		$result = $this->transients->get( Conversion_Reporting_New_Badge_Events_Sync::NEW_EVENTS_BADGE_TRANSIENT );
+
+		$this->assertNotEmpty( $result );
+		$this->assertArrayHasKey( 'created_at', $result );
+		$this->assertArrayHasKey( 'events', $result );
+		$this->assertEquals( $new_events, $result['events'] );
+	}
+
+	public function sync_new_events_badge__transient_younger_than_3_days() {
+		$existing_events = array( 'event1' );
+		$new_events      = array( 'event2' );
+
+		// Set transient as existing for 2 days.
+		$this->transients->set(
+			Conversion_Reporting_New_Badge_Events_Sync::NEW_EVENTS_BADGE_TRANSIENT,
+			array(
+				'created_at' => time() - ( 2 * DAY_IN_SECONDS ),
+				'events'     => $existing_events,
+			),
+			7 * DAY_IN_SECONDS
+		);
+
+		$this->new_badge_events_sync->sync_new_events_badge( $new_events );
+
+		$result = $this->transients->get( Conversion_Reporting_New_Badge_Events_Sync::NEW_EVENTS_BADGE_TRANSIENT );
+
+		$this->assertNotEmpty( $result );
+		$this->assertEquals(
+			array_merge( $existing_events, $new_events ),
+			$result['events']
+		);
+	}
+
+	public function sync_new_events_badge__transient_older_than_3_days() {
+		$existing_events = array( 'event1' );
+		$new_events      = array( 'event2' );
+
+		// Set transient as existing for 4 days.
+		$this->transients->set(
+			Conversion_Reporting_New_Badge_Events_Sync::NEW_EVENTS_BADGE_TRANSIENT,
+			array(
+				'created_at' => time() - ( 4 * DAY_IN_SECONDS ),
+				'events'     => $existing_events,
+			),
+			7 * DAY_IN_SECONDS
+		);
+
+		$this->new_badge_events_sync->sync_new_events_badge( $new_events );
+
+		$result = $this->transients->get( Conversion_Reporting_New_Badge_Events_Sync::NEW_EVENTS_BADGE_TRANSIENT );
+
+		$this->assertNotEmpty( $result );
+		$this->assertEquals( $new_events, $result['events'] );
+	}
+}

--- a/tests/phpunit/integration/Modules/Analytics_4/Conversion_Reporting/Conversion_Reporting_New_Badge_Events_SyncTest.php
+++ b/tests/phpunit/integration/Modules/Analytics_4/Conversion_Reporting/Conversion_Reporting_New_Badge_Events_SyncTest.php
@@ -11,30 +11,14 @@
 namespace Google\Site_Kit\Tests\Modules\Analytics_4\Conversion_Reporting;
 
 use Google\Site_Kit\Context;
-use Google\Site_Kit\Core\Authentication\Authentication;
-use Google\Site_Kit\Core\Storage\Options;
 use Google\Site_Kit\Core\Storage\Transients;
-use Google\Site_Kit\Core\Storage\User_Options;
-use Google\Site_Kit\Modules\Analytics_4;
-use Google\Site_Kit\Modules\Analytics_4\Conversion_Reporting\Conversion_Reporting_Events_Sync;
 use Google\Site_Kit\Modules\Analytics_4\Conversion_Reporting\Conversion_Reporting_New_Badge_Events_Sync;
-use Google\Site_Kit\Modules\Analytics_4\Settings;
-use Google\Site_Kit\Tests\Fake_Site_Connection_Trait;
-use Google\Site_Kit\Tests\FakeHttp;
 use Google\Site_Kit\Tests\TestCase;
-use Google\Site_Kit_Dependencies\GuzzleHttp\Psr7\Request;
-use Google\Site_Kit_Dependencies\GuzzleHttp\Psr7\Response;
 
 /**
  * @group Conversion_Reporting
  */
 class Conversion_Reporting_New_Badge_Events_SyncTest extends TestCase {
-	use Fake_Site_Connection_Trait;
-
-	/**
-	 * @var Context $context Context instance.
-	 */
-	private $context;
 
 	/**
 	 * @var Conversion_Reporting_New_Badge_Events_Sync $new_badge_events_sync Conversion_Reporting_New_Badge_Events_Sync instance.


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #9798 

## Relevant technical choices

Besides persisting the badges, the switch from `includeConversionTailoredMetrics` key metrics settings to the user input settings under site scope is handled here instead of a different issue due to the timeline for ACR epic, and since change is not too big, just includes several files for small change of setting location switch and tests update

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.
- [ ] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
