### PR TITLE
Prevent deprecation notice in Ads

### DIFF
--- a/includes/Modules/Ads/Web_Tag.php
+++ b/includes/Modules/Ads/Web_Tag.php
@@ -13,6 +13,7 @@ namespace Google\Site_Kit\Modules\Ads;
 use Google\Site_Kit\Core\Modules\Tags\Module_Web_Tag;
 use Google\Site_Kit\Core\Tags\GTag;
 use Google\Site_Kit\Core\Tags\Tag_With_Linker_Interface;
+use Google\Site_Kit\Core\Tags\Tag_With_Linker_Trait;
 use Google\Site_Kit\Core\Util\Method_Proxy_Trait;
 
 /**
@@ -25,17 +26,7 @@ use Google\Site_Kit\Core\Util\Method_Proxy_Trait;
 class Web_Tag extends Module_Web_Tag implements Tag_With_Linker_Interface {
 
 	use Method_Proxy_Trait;
-
-	/**
-	 * Sets the current home domain.
-	 *
-	 * @since 1.125.0
-	 *
-	 * @param string $domain Domain name.
-	 */
-	public function set_home_domain( $domain ) {
-		$this->home_domain = $domain;
-	}
+	use Tag_With_Linker_Trait;
 
 	/**
 	 * Registers tag hooks.


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #9531 

## Relevant technical choices

This PR does address the AC of the issue, but does not address the additionally proposed solution to embed a linker command, because that doesn't account for the fact that when both Analytics and Ads modules are connected, two duplicate linker commands are output. [#9947](https://github.com/google/site-kit-wp/issues/9947) has been created to address that separately as that isn't a part of the original AC.

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [x] Run the code.
- [x] Ensure the acceptance criteria are satisfied.
- [x] Reassess the implementation with the IB.
- [x] Ensure no unrelated changes are included.
- [x] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [x] Ensure there is a QA Brief.
- [ ] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [x] Ensure the PR has the correct target branch.
- [x] Double-check that the PR is okay to be merged.
- [x] Ensure the corresponding issue has a ZenHub release assigned.
- [x] Add a changelog message to the issue.
