### PR TITLE
PoC bugfix for broken setup CTA layouts

### DIFF
--- a/assets/js/components/FeatureToursDesktop.js
+++ b/assets/js/components/FeatureToursDesktop.js
@@ -19,7 +19,8 @@
 /**
  * External dependencies
  */
-import { useWindowWidth } from '@react-hook/window-size/throttled';
+// import { useWindowWidth } from '@react-hook/window-size/throttled';
+import { useWindowWidth } from '../hooks/useWindowWidth';
 
 /**
  * Internal dependencies

--- a/assets/js/components/KeyMetrics/KeyMetricsCTAContent.js
+++ b/assets/js/components/KeyMetrics/KeyMetricsCTAContent.js
@@ -22,7 +22,8 @@
 import classnames from 'classnames';
 import PropTypes from 'prop-types';
 import { useIntersection } from 'react-use';
-import { useWindowWidth } from '@react-hook/window-size/throttled';
+// import { useWindowWidth } from '@react-hook/window-size/throttled';
+import { useWindowWidth } from '../../hooks/useWindowWidth';
 
 /**
  * WordPress dependencies
@@ -78,6 +79,17 @@ export default function KeyMetricsCTAContent( {
 			breakpoint === BREAKPOINT_TABLET && onlyWidth < 800;
 		isSmallDesktopBreakpoint = onlyWidth >= 800 && onlyWidth < 1280;
 	}
+
+	// eslint-disable-next-line no-console
+	console.log( {
+		breakpoint,
+		onlyWidth,
+		ga4Connected,
+		isMobileBreakpoint,
+		isTabletBreakpoint,
+		isSmallDesktopBreakpoint,
+		isDesktopBreakpoint,
+	} );
 
 	const intersectionEntry = useIntersection( trackingRef, {
 		threshold: 0.25,

--- a/assets/js/components/notifications/BannerNotification/index.js
+++ b/assets/js/components/notifications/BannerNotification/index.js
@@ -22,7 +22,8 @@
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { useMount, useMountedState, useIntersection } from 'react-use';
-import { useWindowWidth } from '@react-hook/window-size/throttled';
+// import { useWindowWidth } from '@react-hook/window-size/throttled';
+import { useWindowWidth } from '../../../hooks/useWindowWidth';
 
 /*
  * WordPress dependencies

--- a/assets/js/googlesitekit/widgets/components/WidgetAreaHeader.js
+++ b/assets/js/googlesitekit/widgets/components/WidgetAreaHeader.js
@@ -20,7 +20,8 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
-import { useWindowWidth } from '@react-hook/window-size/throttled';
+// import { useWindowWidth } from '@react-hook/window-size/throttled';
+import { useWindowWidth } from '../../../hooks/useWindowWidth';
 
 /**
  * WordPress dependencies

--- a/assets/js/googlesitekit/widgets/components/WidgetAreaRenderer.js
+++ b/assets/js/googlesitekit/widgets/components/WidgetAreaRenderer.js
@@ -21,7 +21,8 @@
  */
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
-import { useWindowWidth } from '@react-hook/window-size/throttled';
+// import { useWindowWidth } from '@react-hook/window-size/throttled';
+import { useWindowWidth } from '../../../hooks/useWindowWidth';
 
 /**
  * WordPress dependencies

--- a/assets/js/hooks/useBreakpoint.js
+++ b/assets/js/hooks/useBreakpoint.js
@@ -19,7 +19,8 @@
 /**
  * External dependencies
  */
-import { useWindowWidth } from '@react-hook/window-size/throttled';
+// import { useWindowWidth } from '@react-hook/window-size/throttled';
+import { useWindowWidth } from './useWindowWidth';
 
 export const BREAKPOINT_XLARGE = 'xlarge';
 export const BREAKPOINT_DESKTOP = 'desktop';

--- a/assets/js/hooks/useWindowWidth.js
+++ b/assets/js/hooks/useWindowWidth.js
@@ -1,3 +1,6 @@
+// Copied from https://github.com/jaredLunde/react-hook/blob/b8ac9515e26937e838a36a27001dc46c7f46a390/packages/window-size/throttled/src/index.tsx
+// Modified to use global.innerWidth and global.innerHeight instead of document.documentElement.clientWidth and document.documentElement.clientHeight.
+
 import { useThrottle } from '@react-hook/throttle';
 import useEvent from '@react-hook/event';
 

--- a/assets/js/hooks/useWindowWidth.js
+++ b/assets/js/hooks/useWindowWidth.js
@@ -1,0 +1,34 @@
+import { useThrottle } from '@react-hook/throttle';
+import useEvent from '@react-hook/event';
+
+const emptyObj = {};
+
+const win = typeof global === 'undefined' ? null : global;
+const getSize = () => [
+	// document.documentElement.clientWidth,
+	// document.documentElement.clientHeight,
+	global.innerWidth,
+	global.innerHeight,
+];
+
+export const useWindowSize = ( options = emptyObj ) => {
+	const { fps, leading, initialWidth = 0, initialHeight = 0 } = options;
+	const [ size, setThrottledSize ] = useThrottle(
+		/* istanbul ignore next */
+		typeof document === 'undefined'
+			? [ initialWidth, initialHeight ]
+			: getSize,
+		fps,
+		leading
+	);
+	const setSize = () => setThrottledSize( getSize );
+
+	useEvent( win, 'resize', setSize );
+	useEvent( win, 'orientationchange', setSize );
+
+	return size;
+};
+
+export const useWindowHeight = ( options ) => useWindowSize( options )[ 1 ];
+
+export const useWindowWidth = ( options ) => useWindowSize( options )[ 0 ];


### PR DESCRIPTION
## Summary

Addresses issue:

- #9911 

## Relevant technical choices

This replaces the `useWindowWidth()` utility hook provided by `@react-hook/window-size/throttled` with a version that uses `window.innerWidth` instead of `document.documentElement.clientWidth` to determine the window width.

This fixes an edge case with layouts in browsers that display a visible scrollbar.

<!-- Please describe your changes. -->

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [ ] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.
- [ ] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
