### PR TITLE
Fix edge case in class loader

### DIFF
--- a/includes/loader.php
+++ b/includes/loader.php
@@ -39,6 +39,8 @@ function autoload_classes() {
 					|| 0 === strpos( $class_instance, 'Google\\Site_Kit_Dependencies\\' )
 					|| file_exists( $class_map[ $class_instance ] )
 				)
+				// Only load files that exist.
+				&& file_exists( $class_map[ $class_instance ] )
 			) {
 				require_once $class_map[ $class_instance ];
 			}


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #10022

## Relevant technical choices

A unit test couldn't be added for this because PHPUnit uses SK's PSR-4 autoloader which seems to avoid the potential for error

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [ ] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.
- [ ] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
