### PR TITLE
Update api-cache test to be more stable when running quickly

### DIFF
--- a/assets/js/components/KeyMetrics/hooks/useDisplayCTAWidget.test.js
+++ b/assets/js/components/KeyMetrics/hooks/useDisplayCTAWidget.test.js
@@ -107,10 +107,14 @@ describe( 'useDisplayCTAWidget hook', () => {
 			)
 		);
 
-		const { result } = await renderHook( () => useDisplayCTAWidget(), {
-			registry,
-		} );
+		const { result, waitForRegistry } = await renderHook(
+			() => useDisplayCTAWidget(),
+			{
+				registry,
+			}
+		);
 
+		await waitForRegistry();
 		expect( result.current ).toBe( false );
 	} );
 
@@ -125,10 +129,14 @@ describe( 'useDisplayCTAWidget hook', () => {
 			)
 		);
 
-		const { result } = await renderHook( () => useDisplayCTAWidget(), {
-			registry,
-		} );
+		const { result, waitForRegistry } = await renderHook(
+			() => useDisplayCTAWidget(),
+			{
+				registry,
+			}
+		);
 
+		await waitForRegistry();
 		expect( result.current ).toBe( false );
 	} );
 } );

--- a/tests/e2e/mu-plugins/e2e-rest-time-endpoint.php
+++ b/tests/e2e/mu-plugins/e2e-rest-time-endpoint.php
@@ -26,7 +26,7 @@ add_action(
 				'callback'            => function () {
 					return array(
 						'time'      => time(),
-						'microtime' => microtime(),
+						'microtime' => microtime( true ),
 					);
 				},
 				'permission_callback' => '__return_true',

--- a/tests/e2e/specs/api-cache.test.js
+++ b/tests/e2e/specs/api-cache.test.js
@@ -78,7 +78,7 @@ describe( 'API cache', () => {
 
 		const initialTimeData = await googleSiteKitAPIGetTime();
 		expect( initialTimeData ).toMatchObject( {
-			time: expect.any( Number ),
+			microtime: expect.any( Number ),
 		} );
 
 		// Show that the data is cached when fetching again.
@@ -99,9 +99,12 @@ describe( 'API cache', () => {
 		// Now that we're in a new session, we expect the API cache to be clear
 		// so the request should hit the backend and produce a new (greater) value.
 		const newTimeData = await googleSiteKitAPIGetTime();
+		expect( newTimeData ).not.toEqual( initialTimeData );
 		expect( initialTimeData ).toMatchObject( {
-			time: expect.any( Number ),
+			microtime: expect.any( Number ),
 		} );
-		expect( newTimeData.time ).toBeGreaterThan( initialTimeData.time );
+		expect( newTimeData.microtime ).toBeGreaterThan(
+			initialTimeData.microtime
+		);
 	} );
 } );

--- a/tests/js/test-utils.js
+++ b/tests/js/test-utils.js
@@ -208,8 +208,11 @@ const customRenderHook = ( callback, options = {} ) => {
 		);
 	}
 
+	const waitForRegistry = createWaitForRegistry( registry );
+
 	return {
 		...renderHook( callback, { wrapper: Wrapper, ...renderHookOptions } ),
+		waitForRegistry: () => actHook( waitForRegistry ),
 		setInView,
 		registry,
 	};


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #8229 

## Relevant technical choices

This PR only addresses the one failure we are seeing in the changes to `api-cache` test where the `time` value was not greater than before. The change here ensures that even if the test runs the assertions within the same second that the latter value should always be greater than the first. If it fails again, then there may be a real issue with the cache or storage prefix.

Also modified a JS test to fix an unrelated instability. See https://github.com/google/site-kit-wp/actions/runs/12915141223/job/36016312697?pr=10103

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [ ] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.
- [ ] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
