### PR TITLE
Remove unused WAIT_FOR_HTML_FOR_URL control.

### DIFF
--- a/assets/js/googlesitekit/datastore/site/html.js
+++ b/assets/js/googlesitekit/datastore/site/html.js
@@ -89,7 +89,6 @@ const fetchHTMLForURLStore = createFetchStore( {
 
 // Actions
 const RESET_HTML_FOR_URL = 'RESET_HTML_FOR_URL';
-const WAIT_FOR_HTML_FOR_URL = 'WAIT_FOR_HTML_FOR_URL';
 const CHECK_FOR_SETUP_TAG = 'CHECK_FOR_SETUP_TAG';
 
 // Errors
@@ -132,11 +131,6 @@ const baseActions = {
 };
 
 const baseControls = {
-	[ WAIT_FOR_HTML_FOR_URL ]: createRegistryControl(
-		( registry ) =>
-			( { payload: { url } } ) =>
-				registry.resolveSelect( CORE_SITE ).getHTMLForURL( url )
-	),
 	[ CHECK_FOR_SETUP_TAG ]: createRegistryControl(
 		( registry ) => async () => {
 			let error;


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #9008 

## Relevant technical choices

Removes the unused `WAIT_FOR_HTML_FOR_URL` control which was missed in the first PR for the issue.

Please note, the QA aspect of this can be verified by the code reviewer at CR time as per the update to the QA Brief on the issue.

<!-- Please describe your changes. -->

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.
- [ ] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
