### PR TITLE
Add Sign in with Google Gutenberg block.

### DIFF
--- a/assets/js/modules/sign-in-with-google/blocks/SignInWithGoogleBlock/Edit.js
+++ b/assets/js/modules/sign-in-with-google/blocks/SignInWithGoogleBlock/Edit.js
@@ -1,0 +1,39 @@
+/**
+ * Site Kit by Google, Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * WordPress dependencies
+ */
+// eslint-disable-next-line import/no-unresolved
+import { useBlockProps } from '@wordpress-core/block-editor';
+// import { useState, useEffect } from '@wordpress-core/element';
+
+// import './editor.scss';
+
+/**
+ * Sign in with Google Block Edit component.
+ *
+ * @since n.e.x.t
+ *
+ * @return {Element} Element to render.
+ */
+export default function Edit() {
+	const blockProps = useBlockProps();
+
+	return (
+		<div { ...blockProps }>Sign in with Google block edit component.</div>
+	);
+}

--- a/assets/js/modules/sign-in-with-google/blocks/SignInWithGoogleBlock/block.json
+++ b/assets/js/modules/sign-in-with-google/blocks/SignInWithGoogleBlock/block.json
@@ -1,0 +1,16 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "google-site-kit/sign-in-with-google",
+	"version": "0.1.0",
+	"title": "Sign in with Google",
+	"category": "widgets",
+	"icon": "google",
+	"description": "Allow users to sign in to your site using their Google Account.",
+	"example": {},
+	"supports": {},
+	"textdomain": "sign-in-with-google",
+	"editorScript": "file:./index.js",
+	"editorStyle": "file:./index.css",
+	"style": "file:./style-index.css"
+}

--- a/assets/js/modules/sign-in-with-google/blocks/SignInWithGoogleBlock/index.js
+++ b/assets/js/modules/sign-in-with-google/blocks/SignInWithGoogleBlock/index.js
@@ -1,0 +1,32 @@
+/**
+ * Site Kit by Google, Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// eslint-disable-next-line import/no-unresolved
+import { registerBlockType } from '@wordpress-core/blocks';
+// import './style.scss';
+
+/**
+ * Internal dependencies
+ */
+import Edit from './Edit';
+import metadata from './block.json';
+
+/**
+ * Register the Memorable Quotes Block.
+ */
+registerBlockType( metadata.name, {
+	edit: Edit,
+} );

--- a/includes/Modules/Sign_In_With_Google/Sign_In_With_Google_Block.php
+++ b/includes/Modules/Sign_In_With_Google/Sign_In_With_Google_Block.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * Class Google\Site_Kit\Modules\Sign_In_With_Google\Sign_In_With_Google_Block
+ *
+ * @package   Google\Site_Kit\Modules\Sign_In_With_Google
+ * @copyright 2025 Google LLC
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
+ * @link      https://sitekit.withgoogle.com
+ */
+
+namespace Google\Site_Kit\Modules\Sign_In_With_Google;
+
+use Google\Site_Kit\Context;
+use Google\Site_Kit\Core\Util\Feature_Flags;
+use Google\Site_Kit\Modules\Sign_In_With_Google;
+
+/**
+ * Sign in with Google Gutenberg Block.
+ *
+ * @since n.e.x.t
+ */
+class Sign_In_With_Google_Block {
+	/**
+	 * Context instance.
+	 *
+	 * @since n.e.x.t
+	 * @var Context
+	 */
+	protected $context;
+
+	/**
+	 * Constructor.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param Context $context Plugin context.
+	 */
+	public function __construct( Context $context ) {
+		$this->context = $context;
+	}
+
+	/**
+	 * Initializes the block for displaying a Sign in with Google
+	 * button.
+	 *
+	 * @since n.e.x.t
+	 */
+	public function block_init() {
+		register_block_type(
+			__DIR__ . '/../../../dist/assets/js/sign-in-with-google-block/block.json',
+			array(
+				'render_callback' => array( $this, 'render_callback' ),
+			)
+		);
+	}
+
+	/**
+	 * Render callback for the Sign in with Google block.
+	 *
+	 * @since n.e.x.t
+	 * @return string Rendered block.
+	 */
+	public function render_callback() {
+		$sign_in_with_google_connected = apply_filters( 'googlesitekit_is_module_connected', false, Sign_In_With_Google::MODULE_SLUG );
+
+		if ( empty( $sign_in_with_google_connected ) ) {
+			return '';
+		}
+
+		// Start buffer output.
+		ob_start();
+		?>
+<div class="googlesitekit-sign-in-with-google__frontend-output-button"></div>
+		<?php
+		// Get the buffer output.
+		$output = ob_get_clean();
+
+		return $output;
+	}
+}

--- a/webpack/blockEditor.config.js
+++ b/webpack/blockEditor.config.js
@@ -20,6 +20,7 @@
  * External dependencies
  */
 const CircularDependencyPlugin = require( 'circular-dependency-plugin' );
+const CopyWebpackPlugin = require( 'copy-webpack-plugin' );
 const ESLintPlugin = require( 'eslint-webpack-plugin' );
 const ManifestPlugin = require( 'webpack-manifest-plugin' );
 const WebpackBar = require( 'webpackbar' );
@@ -40,6 +41,8 @@ module.exports = ( mode ) => ( {
 	entry: {
 		'googlesitekit-reader-revenue-manager-block-editor':
 			'./assets/js/googlesitekit-reader-revenue-manager-block-editor.js',
+		'sign-in-with-google-block/index':
+			'./assets/js/modules/sign-in-with-google/blocks/SignInWithGoogleBlock/index.js',
 	},
 	externals: gutenbergExternals,
 	output: {
@@ -72,6 +75,14 @@ module.exports = ( mode ) => ( {
 			emitError: true,
 			emitWarning: true,
 			failOnError: true,
+		} ),
+		new CopyWebpackPlugin( {
+			patterns: [
+				{
+					from: 'assets/js/modules/sign-in-with-google/blocks/SignInWithGoogleBlock/block.json',
+					to: 'sign-in-with-google-block',
+				},
+			],
 		} ),
 	],
 	optimization: {

--- a/webpack/common.js
+++ b/webpack/common.js
@@ -275,6 +275,8 @@ exports.GOOGLESITEKIT_VERSION = googleSiteKitVersion
 
 const corePackages = [
 	'api-fetch',
+	'block-editor',
+	'blocks',
 	'compose',
 	'data',
 	'dom-ready',


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #10046.

## Relevant technical choices

* Always output the Sign in with Google render JS, so that any page can output a button.
* Still conditionally renders the WordPress login and WooCommerce login code.

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [ ] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.
- [ ] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
