### PR TITLE
Require at least one RRM CTA post type

### DIFF
--- a/assets/js/modules/reader-revenue-manager/datastore/settings.js
+++ b/assets/js/modules/reader-revenue-manager/datastore/settings.js
@@ -105,7 +105,8 @@ export function validateCanSubmitChanges( select ) {
 
 		invariant(
 			Array.isArray( postTypes ) &&
-				postTypes.every( ( item ) => typeof item === 'string' ),
+				postTypes.every( ( item ) => typeof item === 'string' ) &&
+				postTypes.length > 0,
 			INVARIANT_INVALID_POST_TYPES
 		);
 

--- a/assets/js/modules/reader-revenue-manager/datastore/settings.test.js
+++ b/assets/js/modules/reader-revenue-manager/datastore/settings.test.js
@@ -157,6 +157,23 @@ describe( 'modules/reader-revenue-manager settings', () => {
 			);
 		} );
 
+		it( 'should throw invariant error if at least 1 post type is not selected', () => {
+			enabledFeatures.add( 'rrmModuleV2' );
+
+			const settings = {
+				...validSettings,
+				postTypes: [],
+			};
+
+			registry
+				.dispatch( MODULES_READER_REVENUE_MANAGER )
+				.setSettings( settings );
+
+			expect( () => validateCanSubmitChanges( registry.select ) ).toThrow(
+				INVARIANT_INVALID_POST_TYPES
+			);
+		} );
+
 		it( 'should throw invariant error for invalid product ID', () => {
 			enabledFeatures.add( 'rrmModuleV2' );
 


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- https://github.com/google/site-kit-wp/issues/10066#issuecomment-2647779475

## Relevant technical choices

This PR updates the Reader Revenue Manager settings validation to require at least one post type to be selected to display RRM CTAs in.

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.
- [ ] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
