### PR TITLE
Use product IDs as returned from the API

### DIFF
--- a/assets/js/modules/reader-revenue-manager/datastore/publications.js
+++ b/assets/js/modules/reader-revenue-manager/datastore/publications.js
@@ -274,18 +274,7 @@ const baseActions = {
 								return ids;
 							}
 
-							const productIDSeparatorIndex = name.indexOf( ':' );
-
-							if ( productIDSeparatorIndex !== -1 ) {
-								return [
-									...ids,
-									name.substring(
-										productIDSeparatorIndex + 1
-									),
-								];
-							}
-
-							return ids;
+							return [ ...ids, name ];
 						},
 						[]
 					);

--- a/assets/js/modules/reader-revenue-manager/datastore/publications.test.js
+++ b/assets/js/modules/reader-revenue-manager/datastore/publications.test.js
@@ -347,7 +347,7 @@ describe( 'modules/reader-revenue-manager publications', () => {
 						registry
 							.select( MODULES_READER_REVENUE_MANAGER )
 							.getProductIDs()
-					).toEqual( [ 'product-1', 'product-2' ] );
+					).toEqual( [ 'ABC:product-1', 'DEF:product-2' ] );
 				} );
 
 				it( 'should set an empty product IDs array when products array is empty', () => {
@@ -405,28 +405,7 @@ describe( 'modules/reader-revenue-manager publications', () => {
 						registry
 							.select( MODULES_READER_REVENUE_MANAGER )
 							.getProductIDs()
-					).toEqual( [ 'product-1', 'product-2' ] );
-				} );
-
-				it( 'should handle products with invalid name format', () => {
-					const products = [
-						{ name: 'ABC:product-1' },
-						{ name: 'invalid-format' }, // No separator
-						{ name: 'DEF:product-2' },
-					];
-					registry
-						.dispatch( MODULES_READER_REVENUE_MANAGER )
-						.selectPublication( {
-							publicationId: 'publication-id',
-							onboardingState: 'onboarding-state',
-							products,
-						} );
-
-					expect(
-						registry
-							.select( MODULES_READER_REVENUE_MANAGER )
-							.getProductIDs()
-					).toEqual( [ 'product-1', 'product-2' ] );
+					).toEqual( [ 'ABC:product-1', 'DEF:product-2' ] );
 				} );
 
 				it( 'should set the payment option in state when a payment option is provided', () => {

--- a/includes/Modules/Reader_Revenue_Manager/Synchronize_Publication.php
+++ b/includes/Modules/Reader_Revenue_Manager/Synchronize_Publication.php
@@ -155,13 +155,7 @@ class Synchronize_Publication {
 
 		if ( ! empty( $products ) ) {
 			foreach ( $products as $product ) {
-				$name = $product->getName();
-
-				// Extract the product ID from the name, which is in
-				// the format of `publicationID:productID`.
-				if ( strpos( $name, ':' ) !== false ) {
-					$product_ids[] = substr( $name, strpos( $name, ':' ) + 1 );
-				}
+				$product_ids[] = $product->getName();
 			}
 		}
 

--- a/tests/phpunit/integration/Modules/Reader_Revenue_Manager/Synchronize_PublicationTest.php
+++ b/tests/phpunit/integration/Modules/Reader_Revenue_Manager/Synchronize_PublicationTest.php
@@ -220,7 +220,7 @@ class Synchronize_PublicationTest extends TestCase {
 		do_action( Synchronize_Publication::CRON_SYNCHRONIZE_PUBLICATION );
 
 		$settings = $this->reader_revenue_manager->get_settings()->get();
-		$this->assertEquals( array( 'basic', 'advanced' ), $settings['productIDs'] );
+		$this->assertEquals( array( 'testpubID:basic', 'testpubID:advanced' ), $settings['productIDs'] );
 	}
 
 	public function test_synchronize_product_ids_with_non_existent_publication() {


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #10228 

## Relevant technical choices

This PR reformats the product IDs when storing to use the original format as returned from the API.

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [x] Run the code.
- [x] Ensure the acceptance criteria are satisfied.
- [x] Reassess the implementation with the IB.
- [x] Ensure no unrelated changes are included.
- [x] Ensure CI checks pass.
- [x] Check Storybook where applicable.
- [x] Ensure there is a QA Brief.
- [x] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [x] Ensure the PR has the correct target branch.
- [x] Double-check that the PR is okay to be merged.
- [x] Ensure the corresponding issue has a ZenHub release assigned.
- [x] Add a changelog message to the issue.
