### PR TITLE
Allow settings submission with zero post types

### DIFF
--- a/assets/js/googlesitekit/data/create-settings-store.js
+++ b/assets/js/googlesitekit/data/create-settings-store.js
@@ -54,6 +54,7 @@ export const INVARIANT_SETTINGS_NOT_CHANGED =
 // Actions
 const SET_SETTINGS = 'SET_SETTINGS';
 const ROLLBACK_SETTINGS = 'ROLLBACK_SETTINGS';
+const ROLLBACK_SETTING = 'ROLLBACK_SETTING';
 
 /**
  * Creates a store object that includes actions and selectors for managing settings.
@@ -194,6 +195,25 @@ export const createSettingsStore = (
 		},
 
 		/**
+		 * Returns a specific setting back to the current saved value.
+		 *
+		 * @since n.e.x.t
+		 *
+		 * @param {string} setting The setting to rollback.
+		 * @return {Object} Redux-style action.
+		 */
+		rollbackSetting( setting ) {
+			invariant( setting, 'setting is required.' );
+
+			return {
+				payload: {
+					setting,
+				},
+				type: ROLLBACK_SETTING,
+			};
+		},
+
+		/**
 		 * Saves all current settings to the server.
 		 *
 		 * @since 1.6.0
@@ -240,6 +260,24 @@ export const createSettingsStore = (
 				return {
 					...state,
 					settings: state.savedSettings,
+				};
+			}
+
+			case ROLLBACK_SETTING: {
+				const { setting } = payload;
+
+				if ( ! state.savedSettings[ setting ] ) {
+					return {
+						...state,
+					};
+				}
+
+				return {
+					...state,
+					settings: {
+						...( state.settings || {} ),
+						[ setting ]: state.savedSettings[ setting ],
+					},
 				};
 			}
 

--- a/assets/js/googlesitekit/data/create-settings-store.test.js
+++ b/assets/js/googlesitekit/data/create-settings-store.test.js
@@ -50,7 +50,7 @@ describe( 'createSettingsStore store', () => {
 		registry = createRegistry();
 
 		storeDefinition = createSettingsStore( ...STORE_ARGS, {
-			settingSlugs: [ 'isSkyBlue' ],
+			settingSlugs: [ 'isSkyBlue', 'isGroundGreen' ],
 			registry,
 		} );
 		registry.registerStore( storeDefinition.STORE_NAME, storeDefinition );
@@ -289,6 +289,37 @@ describe( 'createSettingsStore store', () => {
 				dispatch.rollbackSettings();
 
 				expect( select.getIsSkyBlue() ).toBe( 'yes' );
+			} );
+		} );
+
+		describe( 'rollbackSetting', () => {
+			it( 'requires the setting param', () => {
+				expect( () => {
+					dispatch.rollbackSetting();
+				} ).toThrow( 'setting is required.' );
+			} );
+
+			it( 'returns a specific setting back to its saved value', () => {
+				const savedSettings = {
+					isSkyBlue: 'yes',
+					isGroundGreen: 'yes',
+				};
+
+				dispatch.receiveSaveSettings( savedSettings, { values: {} } );
+
+				expect( select.getIsSkyBlue() ).toBe( 'yes' );
+				expect( select.getIsGroundGreen() ).toBe( 'yes' );
+
+				dispatch.setIsSkyBlue( 'no' );
+				dispatch.setIsGroundGreen( 'maybe' );
+
+				expect( select.getIsSkyBlue() ).toBe( 'no' );
+				expect( select.getIsGroundGreen() ).toBe( 'maybe' );
+
+				dispatch.rollbackSetting( 'isGroundGreen' );
+
+				expect( select.getIsSkyBlue() ).toBe( 'no' );
+				expect( select.getIsGroundGreen() ).toBe( 'yes' );
 			} );
 		} );
 	} );

--- a/assets/js/modules/reader-revenue-manager/datastore/base.js
+++ b/assets/js/modules/reader-revenue-manager/datastore/base.js
@@ -21,10 +21,11 @@
  */
 import Modules from 'googlesitekit-modules';
 import { MODULES_READER_REVENUE_MANAGER } from './constants';
-import { validateCanSubmitChanges } from './settings';
+import { submitChanges, validateCanSubmitChanges } from './settings';
 
 export default Modules.createModuleStore( 'reader-revenue-manager', {
 	storeName: MODULES_READER_REVENUE_MANAGER,
+	submitChanges,
 	validateCanSubmitChanges,
 	ownedSettingsSlugs: [ 'publicationID' ],
 	settingSlugs: [

--- a/assets/js/modules/reader-revenue-manager/datastore/settings.js
+++ b/assets/js/modules/reader-revenue-manager/datastore/settings.js
@@ -104,9 +104,10 @@ export function validateCanSubmitChanges( select ) {
 		);
 
 		invariant(
-			Array.isArray( postTypes ) &&
-				postTypes.every( ( item ) => typeof item === 'string' ) &&
-				postTypes.length > 0,
+			snippetMode !== 'post_types' ||
+				( Array.isArray( postTypes ) &&
+					postTypes.every( ( item ) => typeof item === 'string' ) &&
+					postTypes.length > 0 ),
 			INVARIANT_INVALID_POST_TYPES
 		);
 

--- a/assets/js/modules/reader-revenue-manager/datastore/settings.js
+++ b/assets/js/modules/reader-revenue-manager/datastore/settings.js
@@ -24,6 +24,7 @@ import invariant from 'invariant';
 /**
  * Internal dependencies
  */
+import API from 'googlesitekit-api';
 import { MODULES_READER_REVENUE_MANAGER } from './constants';
 import {
 	INVARIANT_DOING_SUBMIT_CHANGES,
@@ -127,4 +128,34 @@ export function validateCanSubmitChanges( select ) {
 			INVARIANT_INVALID_PAYMENT_OPTION
 		);
 	}
+}
+
+export async function submitChanges( { dispatch, select } ) {
+	const { getSnippetMode, hasSettingChanged, haveSettingsChanged } = select(
+		MODULES_READER_REVENUE_MANAGER
+	);
+
+	if ( haveSettingsChanged() ) {
+		if (
+			isFeatureEnabled( 'rrmModuleV2' ) &&
+			hasSettingChanged( 'postTypes' ) &&
+			'post_types' !== getSnippetMode()
+		) {
+			await dispatch( MODULES_READER_REVENUE_MANAGER ).rollbackSetting(
+				'postTypes'
+			);
+		}
+
+		const { error } = await dispatch(
+			MODULES_READER_REVENUE_MANAGER
+		).saveSettings();
+
+		if ( error ) {
+			return { error };
+		}
+	}
+
+	await API.invalidateCache( 'modules', 'reader-revenue-manager' );
+
+	return {};
 }

--- a/assets/js/modules/reader-revenue-manager/datastore/settings.test.js
+++ b/assets/js/modules/reader-revenue-manager/datastore/settings.test.js
@@ -174,6 +174,24 @@ describe( 'modules/reader-revenue-manager settings', () => {
 			);
 		} );
 
+		it( 'should not throw invariant error if no post types are selected and the snippet mode is different', () => {
+			enabledFeatures.add( 'rrmModuleV2' );
+
+			const settings = {
+				...validSettings,
+				postTypes: [],
+				snippetMode: 'per_post',
+			};
+
+			registry
+				.dispatch( MODULES_READER_REVENUE_MANAGER )
+				.setSettings( settings );
+
+			expect( () =>
+				validateCanSubmitChanges( registry.select )
+			).not.toThrow( INVARIANT_INVALID_POST_TYPES );
+		} );
+
 		it( 'should throw invariant error for invalid product ID', () => {
 			enabledFeatures.add( 'rrmModuleV2' );
 

--- a/assets/js/modules/reader-revenue-manager/datastore/settings.test.js
+++ b/assets/js/modules/reader-revenue-manager/datastore/settings.test.js
@@ -37,6 +37,21 @@ import {
 describe( 'modules/reader-revenue-manager settings', () => {
 	let registry;
 
+	const settingsEndpoint = new RegExp(
+		'^/google-site-kit/v1/modules/reader-revenue-manager/data/settings'
+	);
+
+	const validSettings = {
+		publicationID: 'ABCDEFGH',
+		publicationOnboardingState: 'ONBOARDING_ACTION_REQUIRED',
+		publicationOnboardingStateChanged: false,
+		snippetMode: 'post_types',
+		postTypes: [ 'post' ],
+		productID: 'valid-id',
+		productIDs: [ 'valid' ],
+		paymentOption: 'valid-option',
+	};
+
 	beforeAll( () => {
 		API.setUsingCache( false );
 	} );
@@ -50,17 +65,6 @@ describe( 'modules/reader-revenue-manager settings', () => {
 	} );
 
 	describe( 'validateCanSubmitChanges', () => {
-		const validSettings = {
-			publicationID: 'ABCDEFGH',
-			publicationOnboardingState: 'ONBOARDING_ACTION_REQUIRED',
-			publicationOnboardingStateChanged: false,
-			snippetMode: 'post_types',
-			postTypes: [ 'post' ],
-			productID: 'valid-id',
-			productIDs: [ 'valid' ],
-			paymentOption: 'valid-option',
-		};
-
 		it( 'should throw invariant error for invalid publication ID of type number', () => {
 			const settings = {
 				...validSettings,
@@ -258,6 +262,102 @@ describe( 'modules/reader-revenue-manager settings', () => {
 			expect( () => validateCanSubmitChanges( registry.select ) ).toThrow(
 				INVARIANT_INVALID_PAYMENT_OPTION
 			);
+		} );
+	} );
+
+	describe( 'submitChanges', () => {
+		it( 'should dispatch saveSettings', async () => {
+			registry
+				.dispatch( MODULES_READER_REVENUE_MANAGER )
+				.setSettings( validSettings );
+
+			fetchMock.postOnce( settingsEndpoint, {
+				body: validSettings,
+				status: 200,
+			} );
+
+			await registry
+				.dispatch( MODULES_READER_REVENUE_MANAGER )
+				.submitChanges();
+
+			expect( fetchMock ).toHaveFetched( settingsEndpoint, {
+				body: { data: validSettings },
+			} );
+
+			expect(
+				registry
+					.select( MODULES_READER_REVENUE_MANAGER )
+					.haveSettingsChanged()
+			).toBe( false );
+		} );
+
+		describe( 'with "rrmModuleV2" feature flag enabled', () => {
+			beforeEach( () => {
+				enabledFeatures.add( 'rrmModuleV2' );
+			} );
+
+			it( 'should save selected post types', async () => {
+				fetchMock.post( settingsEndpoint, {
+					body: {
+						...validSettings,
+						snippetMode: 'post_types',
+						postTypes: [ 'post', 'page' ],
+					},
+					status: 200,
+				} );
+
+				registry
+					.dispatch( MODULES_READER_REVENUE_MANAGER )
+					.setSettings( {
+						...validSettings,
+						snippetMode: 'post_types',
+						postTypes: [ 'post', 'page' ],
+					} );
+
+				await registry
+					.dispatch( MODULES_READER_REVENUE_MANAGER )
+					.submitChanges();
+
+				expect(
+					registry
+						.select( MODULES_READER_REVENUE_MANAGER )
+						.getPostTypes()
+				).toEqual( [ 'post', 'page' ] );
+			} );
+
+			it( 'should not save selected post types for a different snippet mode', async () => {
+				registry
+					.dispatch( MODULES_READER_REVENUE_MANAGER )
+					.receiveGetSettings( {
+						...validSettings,
+						snippetMode: 'post_types',
+						postTypes: [ 'post', 'page' ],
+					} );
+
+				fetchMock.post( settingsEndpoint, ( url, { body } ) => {
+					const { data } = JSON.parse( body );
+
+					return { body: data };
+				} );
+
+				registry
+					.dispatch( MODULES_READER_REVENUE_MANAGER )
+					.setSettings( {
+						...validSettings,
+						snippetMode: 'per_post',
+						postTypes: [ 'page' ],
+					} );
+
+				await registry
+					.dispatch( MODULES_READER_REVENUE_MANAGER )
+					.submitChanges();
+
+				expect(
+					registry
+						.select( MODULES_READER_REVENUE_MANAGER )
+						.getPostTypes()
+				).toEqual( [ 'post', 'page' ] );
+			} );
 		} );
 	} );
 } );

--- a/assets/js/modules/reader-revenue-manager/datastore/settings.test.js
+++ b/assets/js/modules/reader-revenue-manager/datastore/settings.test.js
@@ -343,7 +343,6 @@ describe( 'modules/reader-revenue-manager settings', () => {
 				registry
 					.dispatch( MODULES_READER_REVENUE_MANAGER )
 					.setSettings( {
-						...validSettings,
 						snippetMode: 'per_post',
 						postTypes: [ 'page' ],
 					} );
@@ -357,6 +356,13 @@ describe( 'modules/reader-revenue-manager settings', () => {
 						.select( MODULES_READER_REVENUE_MANAGER )
 						.getPostTypes()
 				).toEqual( [ 'post', 'page' ] );
+
+				// Verify that the snippet mode is saved as expected.
+				expect(
+					registry
+						.select( MODULES_READER_REVENUE_MANAGER )
+						.getSnippetMode()
+				).toEqual( 'per_post' );
 			} );
 		} );
 	} );


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- https://github.com/google/site-kit-wp/issues/10066#issuecomment-2662994533

## Relevant technical choices

This PR makes the RRM `SettingsEdit` allow submission with no post types selected if the snippet mode is set to anything else.

Under the hood, it rolls back the post types to previous saved value on submission in this case.

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [x] Run the code.
- [x] Ensure the acceptance criteria are satisfied.
- [x] Reassess the implementation with the IB.
- [x] Ensure no unrelated changes are included.
- [x] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [x] Ensure there is a QA Brief.
- [x] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [x] Ensure the PR has the correct target branch.
- [x] Double-check that the PR is okay to be merged.
- [x] Ensure the corresponding issue has a ZenHub release assigned.
- [x] Add a changelog message to the issue.
