### PR TITLE
Remove hash from block editor files.

### DIFF
--- a/webpack/gutenbergBlocks.config.js
+++ b/webpack/gutenbergBlocks.config.js
@@ -50,8 +50,7 @@ module.exports = ( mode ) => ( {
 	},
 	externals: gutenbergExternals,
 	output: {
-		filename:
-			mode === 'production' ? '[name]-[contenthash].js' : '[name].js',
+		filename: '[name].js',
 		path: rootDir + '/dist/assets/js/blocks',
 		publicPath: '',
 	},
@@ -108,10 +107,7 @@ module.exports = ( mode ) => ( {
 			},
 		} ),
 		new MiniCssExtractPlugin( {
-			filename:
-				'production' === mode
-					? '[name]-[contenthash].min.css'
-					: '[name].css',
+			filename: '[name].css',
 		} ),
 		new ESLintPlugin( {
 			emitError: true,


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #10046

## Relevant technical choices

Block editor assets are enqueued with a version number query string instead of the content hash we usually use, so these files were 404ing in production only. See: https://fueled10up.slack.com/archives/C0788NZMLF2/p1739963216282619 / https://github.com/google/site-kit-wp/issues/10046#issuecomment-2668281869

This ensures the files are named/loaded properly in production builds.

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.
- [ ] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
