### PR TITLE
Add a `min-width` to the Sign in with Google block.

### DIFF
--- a/blocks/sign-in-with-google/editor-styles.scss
+++ b/blocks/sign-in-with-google/editor-styles.scss
@@ -18,4 +18,5 @@
 
 .googlesitekit-blocks-sign-in-with-google {
     max-width: 180px;
+    min-width: 120px;
 }


### PR DESCRIPTION
## Summary

Adds a `min-width` to the block style for template parts that require blocks to have a min-width.

Fixes the issue mentioned by @mohitwp here: https://github.com/google/site-kit-wp/issues/10046#issuecomment-2674701805

Addresses issue:

- #10046

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.
- [ ] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
