### PR TITLE
Use inline styles for Sign in with Google Gutenberg block

### DIFF
--- a/blocks/sign-in-with-google/Edit.js
+++ b/blocks/sign-in-with-google/Edit.js
@@ -36,7 +36,10 @@ export default function Edit() {
 
 	return (
 		<div { ...blockProps }>
-			<div className="googlesitekit-blocks-sign-in-with-google">
+			<div
+				className="googlesitekit-blocks-sign-in-with-google"
+				style={ { maxWidth: '180px', minWidth: '120px' } }
+			>
 				<SignInWithGoogleIcon />
 			</div>
 		</div>

--- a/blocks/sign-in-with-google/block.json
+++ b/blocks/sign-in-with-google/block.json
@@ -1,11 +1,11 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 3,
+	"apiVersion": 2,
 	"name": "google-site-kit/sign-in-with-google",
 	"version": "1.147.0",
 	"title": "Sign in with Google",
 	"category": "widgets",
 	"icon": "google",
 	"description": "Allow users to sign in to your site using their Google Account.",
-	"textdomain": "google-site-kit/sign-in-with-google"
+	"textdomain": "google-site-kit"
 }

--- a/includes/Modules/Sign_In_With_Google.php
+++ b/includes/Modules/Sign_In_With_Google.php
@@ -303,23 +303,26 @@ final class Sign_In_With_Google extends Module implements Module_With_Assets, Mo
 					),
 				)
 			),
-			new Script(
+		);
+
+		if ( Sign_In_With_Google_Block::can_register() ) {
+			$assets[] = new Script(
 				'blocks-sign-in-with-google',
 				array(
 					'src'           => $this->context->url( 'dist/assets/js/blocks/sign-in-with-google/index.js' ),
 					'dependencies'  => array(),
 					'load_contexts' => array( Asset::CONTEXT_ADMIN_POST_EDITOR ),
 				)
-			),
-			new Stylesheet(
+			);
+			$assets[] = new Stylesheet(
 				'blocks-sign-in-with-google-editor-styles',
 				array(
 					'src'           => $this->context->url( 'dist/assets/js/blocks/sign-in-with-google/editor-styles.css' ),
 					'dependencies'  => array(),
 					'load_contexts' => array( Asset::CONTEXT_ADMIN_POST_EDITOR ),
 				)
-			),
-		);
+			);
+		}
 
 		return $assets;
 	}

--- a/includes/Modules/Sign_In_With_Google/Sign_In_With_Google_Block.php
+++ b/includes/Modules/Sign_In_With_Google/Sign_In_With_Google_Block.php
@@ -38,11 +38,28 @@ class Sign_In_With_Google_Block {
 	}
 
 	/**
+	 * Checks whether the block can be registered.
+	 *
+	 * @since 1.147.0
+	 *
+	 * @return bool
+	 */
+	public static function can_register() {
+		$wp_version = get_bloginfo( 'version' );
+		// The block currently requires version WP 5.8 or higher.
+		return (bool) version_compare( '5.8', $wp_version, '<=' );
+	}
+
+	/**
 	 * Register this block.
 	 *
 	 * @since 1.147.0
 	 */
 	public function register() {
+		if ( ! self::can_register() ) {
+			return;
+		}
+
 		add_action(
 			'init',
 			function () {


### PR DESCRIPTION
## Summary

Addresses issue:

- #10046

## Relevant technical choices

Uses inline styles as a stop-gap, because trying to load editor styles (or any styles) for this block when it's inside an `iFrame` using full-site editing does not work.

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.
- [ ] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
