### PR TITLE
Ensure RRM block notice appears for non-admin users

### DIFF
--- a/assets/blocks/reader-revenue-manager/common/ButtonEdit.js
+++ b/assets/blocks/reader-revenue-manager/common/ButtonEdit.js
@@ -76,9 +76,7 @@ export default function ButtonEdit( {
 				).hasModuleAccess( 'reader-revenue-manager' );
 			}
 
-			// Note: `hasModuleOwnershipOrAccess` can be expected to be undefined if
-			// - `ownerID` is not set for view-only or non-SK users.
-			// - the `check-access` endpoint returns a 403 error for non-SK users.
+			// Note: `hasModuleOwnershipOrAccess` can be expected to be `undefined` if `ownerID` is not set for a view-only user.
 			setHasModuleAccess( !! hasModuleOwnershipOrAccess );
 		}
 

--- a/assets/blocks/reader-revenue-manager/common/ButtonEdit.js
+++ b/assets/blocks/reader-revenue-manager/common/ButtonEdit.js
@@ -76,7 +76,7 @@ export default function ButtonEdit( {
 				).hasModuleAccess( 'reader-revenue-manager' );
 			}
 
-			setHasModuleAccess( hasModuleOwnershipOrAccess );
+			setHasModuleAccess( !! hasModuleOwnershipOrAccess );
 		}
 
 		getModuleAccess();

--- a/assets/blocks/reader-revenue-manager/common/ButtonEdit.js
+++ b/assets/blocks/reader-revenue-manager/common/ButtonEdit.js
@@ -76,6 +76,9 @@ export default function ButtonEdit( {
 				).hasModuleAccess( 'reader-revenue-manager' );
 			}
 
+			// Note: `hasModuleOwnershipOrAccess` can be expected to be undefined if
+			// - `ownerID` is not set for view-only or non-SK users.
+			// - the `check-access` endpoint returns a 403 error for non-SK users.
 			setHasModuleAccess( !! hasModuleOwnershipOrAccess );
 		}
 


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #10394 

## Relevant technical choices

The reported problem occurred as non-admin WordPress users cannot have module access in Site Kit.

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [x] Run the code.
- [x] Ensure the acceptance criteria are satisfied.
- [x] Reassess the implementation with the IB.
- [x] Ensure no unrelated changes are included.
- [x] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [x] Ensure there is a QA Brief.
- [x] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [x] Ensure the PR has the correct target branch.
- [x] Double-check that the PR is okay to be merged.
- [x] Ensure the corresponding issue has a ZenHub release assigned.
- [x] Add a changelog message to the issue.
