### PR TITLE
Add GA tracking for RRM CTA placement settings

### DIFF
--- a/assets/js/modules/reader-revenue-manager/components/settings/SettingsEdit.js
+++ b/assets/js/modules/reader-revenue-manager/components/settings/SettingsEdit.js
@@ -19,43 +19,38 @@
 /* eslint complexity: [ "error", 17 ] */
 
 /**
+ * External dependencies
+ */
+import { useUnmount } from 'react-use';
+
+/**
  * WordPress dependencies
  */
-import { createInterpolateElement } from '@wordpress/element';
-import { __, sprintf } from '@wordpress/i18n';
+import { useEffect, useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import { ProgressBar } from 'googlesitekit-components';
 import { useSelect } from 'googlesitekit-data';
-import { useFeature } from '../../../../hooks/useFeature';
+import useViewContext from '../../../../hooks/useViewContext';
+import { getPostTypesString } from '../../utils/settings';
+import { trackEvent } from '../../../../util';
 import { CORE_MODULES } from '../../../../googlesitekit/modules/datastore/constants';
+import { CORE_SITE } from '../../../../googlesitekit/datastore/site/constants';
 import {
 	MODULES_READER_REVENUE_MANAGER,
 	READER_REVENUE_MANAGER_MODULE_SLUG,
 } from '../../datastore/constants';
-import ErrorText from '../../../../components/ErrorText';
-import {
-	PostTypesSelect,
-	PublicationOnboardingStateNotice,
-	PublicationSelect,
-	SnippetModeSelect,
-} from '../common';
-import SettingsNotice, {
-	TYPE_INFO,
-} from '../../../../components/SettingsNotice';
-import WarningIcon from '../../../../../../assets/svg/icons/warning-icon.svg';
-import StoreErrorNotices from '../../../../components/StoreErrorNotices';
-import ProductIDSettings from './ProductIDSettings';
+import { SNIPPET_MODES } from '../../constants';
+import SettingsForm from './SettingsForm';
 
 export default function SettingsEdit() {
-	const isRRMv2Enabled = useFeature( 'rrmModuleV2' );
+	const viewContext = useViewContext();
 
 	const isDoingSubmitChanges = useSelect( ( select ) =>
 		select( MODULES_READER_REVENUE_MANAGER ).isDoingSubmitChanges()
 	);
-
 	const hasModuleAccess = useSelect( ( select ) => {
 		const { hasModuleOwnershipOrAccess, getErrorForAction } =
 			select( CORE_MODULES );
@@ -88,79 +83,53 @@ export default function SettingsEdit() {
 
 		return false;
 	} );
-
-	const publicationID = useSelect( ( select ) =>
-		select( MODULES_READER_REVENUE_MANAGER ).getPublicationID()
+	const haveSettingsChanged = useSelect( ( select ) =>
+		select( MODULES_READER_REVENUE_MANAGER ).haveSettingsChanged()
+	);
+	const allPostTypes = useSelect( ( select ) =>
+		select( CORE_SITE ).getPostTypes()
+	);
+	const settings = useSelect( ( select ) =>
+		select( MODULES_READER_REVENUE_MANAGER ).getSettings()
 	);
 
-	const missingProductID = useSelect( ( select ) => {
-		const productID = select(
-			MODULES_READER_REVENUE_MANAGER
-		).getProductID();
+	const { snippetMode, postTypes } = settings || {};
 
-		if ( productID === undefined ) {
-			return undefined;
+	const [ oldSettings, setOldSettings ] = useState( settings );
+
+	// Set old settings if they were not available on mount.
+	useEffect( () => {
+		if ( ! oldSettings && !! settings ) {
+			setOldSettings( settings );
+		}
+	}, [ oldSettings, settings ] );
+
+	// Track GA event when snippet mode or post types change.
+	useUnmount( () => {
+		// Do not run if settings have not been saved.
+		if ( haveSettingsChanged ) {
+			return;
 		}
 
-		if ( 'openaccess' === productID ) {
-			return null;
+		if ( snippetMode !== oldSettings.snippetMode ) {
+			trackEvent(
+				`${ viewContext }_rrm-settings`,
+				'change_snippet_mode',
+				SNIPPET_MODES[ snippetMode ]
+			);
 		}
 
-		const productIDs = select(
-			MODULES_READER_REVENUE_MANAGER
-		).getProductIDs();
-
-		if ( productIDs === undefined ) {
-			return undefined;
+		if (
+			getPostTypesString( postTypes ) !==
+			getPostTypesString( oldSettings.postTypes )
+		) {
+			trackEvent(
+				`${ viewContext }_rrm-settings`,
+				'change_post_types',
+				getPostTypesString( postTypes, allPostTypes )
+			);
 		}
-
-		return productIDs.includes( productID ) ? null : productID;
 	} );
-
-	const publicationAvailable = useSelect( ( select ) => {
-		if ( hasModuleAccess === undefined ) {
-			return undefined;
-		}
-
-		if ( hasModuleAccess === false ) {
-			return false;
-		}
-
-		const publications = select(
-			MODULES_READER_REVENUE_MANAGER
-		).getPublications();
-
-		if ( ! Array.isArray( publications ) ) {
-			return undefined;
-		}
-
-		return publications.some(
-			// eslint-disable-next-line sitekit/acronym-case
-			( { publicationId: id } ) => id === publicationID
-		);
-	} );
-	const formattedOwnerName = useSelect( ( select ) => {
-		const module = select( CORE_MODULES ).getModule(
-			READER_REVENUE_MANAGER_MODULE_SLUG
-		);
-
-		return module?.owner?.login
-			? `<strong>${ module.owner.login }</strong>`
-			: __( 'Another admin', 'google-site-kit' );
-	} );
-	const snippetMode = useSelect( ( select ) =>
-		select( MODULES_READER_REVENUE_MANAGER ).getSnippetMode()
-	);
-	const productIDs = useSelect( ( select ) =>
-		select( MODULES_READER_REVENUE_MANAGER ).getProductIDs()
-	);
-	const publicationsLoaded = useSelect(
-		( select ) =>
-			hasModuleAccess === false ||
-			select( MODULES_READER_REVENUE_MANAGER ).hasFinishedResolution(
-				'getPublications'
-			)
-	);
 
 	if ( isDoingSubmitChanges || undefined === hasModuleAccess ) {
 		return <ProgressBar />;
@@ -168,99 +137,7 @@ export default function SettingsEdit() {
 
 	return (
 		<div className="googlesitekit-setup-module googlesitekit-setup-module--reader-revenue-manager googlesitekit-rrm-settings-edit">
-			<div className="googlesitekit-settings-module__fields-group">
-				<StoreErrorNotices
-					moduleSlug={ READER_REVENUE_MANAGER_MODULE_SLUG }
-					storeName={ MODULES_READER_REVENUE_MANAGER }
-				/>
-
-				{ hasModuleAccess && false === publicationAvailable && (
-					<ErrorText
-						message={ sprintf(
-							/* translators: 1: Publication ID. */
-							__(
-								'The previously selected publication with ID %s was not found. Please select a new publication.',
-								'google-site-kit'
-							),
-							publicationID
-						) }
-					/>
-				) }
-
-				{ isRRMv2Enabled &&
-					hasModuleAccess &&
-					publicationAvailable &&
-					missingProductID && (
-						<ErrorText
-							message={ sprintf(
-								/* translators: 1: Product ID. */
-								__(
-									'The previously selected product ID %s was not found. Please select a new product ID.',
-									'google-site-kit'
-								),
-								missingProductID
-							) }
-						/>
-					) }
-
-				<div className="googlesitekit-setup-module__inputs">
-					<PublicationSelect hasModuleAccess={ hasModuleAccess } />
-				</div>
-				{ hasModuleAccess && publicationAvailable && (
-					<PublicationOnboardingStateNotice />
-				) }
-				{ ! hasModuleAccess && (
-					<SettingsNotice
-						type={ TYPE_INFO }
-						Icon={ WarningIcon }
-						notice={ createInterpolateElement(
-							sprintf(
-								/* translators: %s: module owner's name */
-								__(
-									'%s configured Reader Revenue Manager and you don’t have access to its configured publication. Contact them to share access or change the configured publication.',
-									'google-site-kit'
-								),
-								formattedOwnerName
-							),
-							{
-								strong: <strong />,
-							}
-						) }
-					/>
-				) }
-				{ isRRMv2Enabled &&
-					publicationsLoaded &&
-					productIDs?.length > 0 && (
-						<ProductIDSettings
-							hasModuleAccess={ hasModuleAccess }
-						/>
-					) }
-			</div>
-			{ isRRMv2Enabled && (
-				<div className="googlesitekit-settings-module__fields-group">
-					<h4 className="googlesitekit-settings-module__fields-group-title">
-						{ __( 'CTA Placement', 'google-site-kit' ) }
-					</h4>
-					<div className="googlesitekit-rrm-settings-edit__snippet-mode">
-						<SnippetModeSelect
-							hasModuleAccess={ hasModuleAccess }
-						/>
-					</div>
-					{ snippetMode === 'post_types' && (
-						<div className="googlesitekit-rrm-settings-edit__post-types">
-							<h5>
-								{ __(
-									'Select the content types where you want your CTAs to appear:',
-									'google-site-kit'
-								) }
-							</h5>
-							<PostTypesSelect
-								hasModuleAccess={ hasModuleAccess }
-							/>
-						</div>
-					) }
-				</div>
-			) }
+			<SettingsForm hasModuleAccess={ hasModuleAccess } />
 		</div>
 	);
 }

--- a/assets/js/modules/reader-revenue-manager/components/settings/SettingsEdit.js
+++ b/assets/js/modules/reader-revenue-manager/components/settings/SettingsEdit.js
@@ -51,6 +51,7 @@ export default function SettingsEdit() {
 	const isDoingSubmitChanges = useSelect( ( select ) =>
 		select( MODULES_READER_REVENUE_MANAGER ).isDoingSubmitChanges()
 	);
+
 	const hasModuleAccess = useSelect( ( select ) => {
 		const { hasModuleOwnershipOrAccess, getErrorForAction } =
 			select( CORE_MODULES );
@@ -83,12 +84,15 @@ export default function SettingsEdit() {
 
 		return false;
 	} );
+
 	const haveSettingsChanged = useSelect( ( select ) =>
 		select( MODULES_READER_REVENUE_MANAGER ).haveSettingsChanged()
 	);
+
 	const allPostTypes = useSelect( ( select ) =>
 		select( CORE_SITE ).getPostTypes()
 	);
+
 	const settings = useSelect( ( select ) =>
 		select( MODULES_READER_REVENUE_MANAGER ).getSettings()
 	);

--- a/assets/js/modules/reader-revenue-manager/components/settings/SettingsEdit.test.js
+++ b/assets/js/modules/reader-revenue-manager/components/settings/SettingsEdit.test.js
@@ -94,6 +94,10 @@ describe( 'SettingsEdit', () => {
 		registry.dispatch( CORE_USER ).receiveGetDismissedItems( [] );
 	} );
 
+	afterEach( () => {
+		mockTrackEvent.mockClear();
+	} );
+
 	it( 'should render the "SettingsEdit" component', async () => {
 		const { getByRole, getByText, waitForRegistry } = render(
 			<SettingsEdit />,
@@ -404,81 +408,75 @@ describe( 'SettingsEdit', () => {
 		} );
 	} );
 
-	describe( 'GA event tracking', () => {
-		afterEach( () => {
-			mockTrackEvent.mockClear();
+	it( 'should track an event if snippet mode was changed', async () => {
+		fetchMock.postOnce( settingsEndpoint, {
+			body: {
+				...settings,
+				snippetMode: 'per_post',
+			},
+			status: 200,
 		} );
 
-		it( 'should track an event if snippet mode was changed', async () => {
-			fetchMock.postOnce( settingsEndpoint, () => ( {
-				body: {
-					...settings,
-					snippetMode: 'per_post',
-				},
-				status: 200,
-			} ) );
-
-			const { unmount, waitForRegistry } = render( <SettingsEdit />, {
-				registry,
-				viewContext: VIEW_CONTEXT_SETTINGS,
-				features: [ 'rrmModuleV2' ],
-			} );
-
-			await waitForRegistry();
-
-			await act( async () => {
-				registry
-					.dispatch( MODULES_READER_REVENUE_MANAGER )
-					.setSnippetMode( 'per_post' );
-
-				await registry
-					.dispatch( MODULES_READER_REVENUE_MANAGER )
-					.submitChanges();
-			} );
-
-			unmount();
-
-			expect( mockTrackEvent ).toHaveBeenCalledWith(
-				'settings_rrm-settings',
-				'change_snippet_mode',
-				'Specified pages'
-			);
+		const { unmount, waitForRegistry } = render( <SettingsEdit />, {
+			registry,
+			viewContext: VIEW_CONTEXT_SETTINGS,
+			features: [ 'rrmModuleV2' ],
 		} );
 
-		it( 'should track an event if post types were changed', async () => {
-			fetchMock.postOnce( settingsEndpoint, () => ( {
-				body: {
-					...settings,
-					postTypes: [ 'post', 'page' ],
-				},
-				status: 200,
-			} ) );
+		await waitForRegistry();
 
-			const { unmount, waitForRegistry } = render( <SettingsEdit />, {
-				registry,
-				viewContext: VIEW_CONTEXT_SETTINGS,
-				features: [ 'rrmModuleV2' ],
-			} );
+		await act( async () => {
+			registry
+				.dispatch( MODULES_READER_REVENUE_MANAGER )
+				.setSnippetMode( 'per_post' );
 
-			await waitForRegistry();
-
-			await act( async () => {
-				registry
-					.dispatch( MODULES_READER_REVENUE_MANAGER )
-					.setPostTypes( [ 'post', 'page' ] );
-
-				await registry
-					.dispatch( MODULES_READER_REVENUE_MANAGER )
-					.submitChanges();
-			} );
-
-			unmount();
-
-			expect( mockTrackEvent ).toHaveBeenCalledWith(
-				'settings_rrm-settings',
-				'change_post_types',
-				'Posts, Pages'
-			);
+			await registry
+				.dispatch( MODULES_READER_REVENUE_MANAGER )
+				.submitChanges();
 		} );
+
+		unmount();
+
+		expect( mockTrackEvent ).toHaveBeenCalledWith(
+			'settings_rrm-settings',
+			'change_snippet_mode',
+			'Specified pages'
+		);
+	} );
+
+	it( 'should track an event if post types were changed', async () => {
+		fetchMock.postOnce( settingsEndpoint, {
+			body: {
+				...settings,
+				postTypes: [ 'post', 'page' ],
+			},
+			status: 200,
+		} );
+
+		const { unmount, waitForRegistry } = render( <SettingsEdit />, {
+			registry,
+			viewContext: VIEW_CONTEXT_SETTINGS,
+			features: [ 'rrmModuleV2' ],
+		} );
+
+		await waitForRegistry();
+
+		await act( async () => {
+			registry
+				.dispatch( MODULES_READER_REVENUE_MANAGER )
+				.setPostTypes( [ 'post', 'page' ] );
+
+			await registry
+				.dispatch( MODULES_READER_REVENUE_MANAGER )
+				.submitChanges();
+		} );
+
+		unmount();
+
+		expect( mockTrackEvent ).toHaveBeenCalledWith(
+			'settings_rrm-settings',
+			'change_post_types',
+			'Posts, Pages'
+		);
 	} );
 } );

--- a/assets/js/modules/reader-revenue-manager/components/settings/SettingsEdit.test.js
+++ b/assets/js/modules/reader-revenue-manager/components/settings/SettingsEdit.test.js
@@ -20,6 +20,7 @@
  * Internal dependencies
  */
 import {
+	act,
 	createTestRegistry,
 	provideModuleRegistrations,
 	provideModules,
@@ -27,6 +28,7 @@ import {
 	provideUserInfo,
 	render,
 } from '../../../../../../tests/js/test-utils';
+import * as tracking from '../../../../util/tracking';
 import {
 	RRM_PRODUCT_ID_INFO_NOTICE_SLUG,
 	RRM_PRODUCT_ID_OPEN_ACCESS_NOTICE_SLUG,
@@ -39,9 +41,17 @@ import {
 	READER_REVENUE_MANAGER_MODULE_SLUG,
 } from '../../datastore/constants';
 import { CORE_USER } from '../../../../googlesitekit/datastore/user/constants';
+import { VIEW_CONTEXT_SETTINGS } from '../../../../googlesitekit/constants';
+
+const mockTrackEvent = jest.spyOn( tracking, 'trackEvent' );
+mockTrackEvent.mockImplementation( () => Promise.resolve() );
 
 describe( 'SettingsEdit', () => {
 	let registry;
+
+	const settingsEndpoint = new RegExp(
+		'^/google-site-kit/v1/modules/reader-revenue-manager/data/settings'
+	);
 
 	const publication = publications[ 2 ];
 	const {
@@ -391,6 +401,84 @@ describe( 'SettingsEdit', () => {
 					'Select the content types where you want your CTAs to appear:'
 				)
 			).not.toBeInTheDocument();
+		} );
+	} );
+
+	describe( 'GA event tracking', () => {
+		afterEach( () => {
+			mockTrackEvent.mockClear();
+		} );
+
+		it( 'should track an event if snippet mode was changed', async () => {
+			fetchMock.postOnce( settingsEndpoint, () => ( {
+				body: {
+					...settings,
+					snippetMode: 'per_post',
+				},
+				status: 200,
+			} ) );
+
+			const { unmount, waitForRegistry } = render( <SettingsEdit />, {
+				registry,
+				viewContext: VIEW_CONTEXT_SETTINGS,
+				features: [ 'rrmModuleV2' ],
+			} );
+
+			await waitForRegistry();
+
+			await act( async () => {
+				registry
+					.dispatch( MODULES_READER_REVENUE_MANAGER )
+					.setSnippetMode( 'per_post' );
+
+				await registry
+					.dispatch( MODULES_READER_REVENUE_MANAGER )
+					.submitChanges();
+			} );
+
+			unmount();
+
+			expect( mockTrackEvent ).toHaveBeenCalledWith(
+				'settings_rrm-settings',
+				'change_snippet_mode',
+				'Specified pages'
+			);
+		} );
+
+		it( 'should track an event if post types were changed', async () => {
+			fetchMock.postOnce( settingsEndpoint, () => ( {
+				body: {
+					...settings,
+					postTypes: [ 'post', 'page' ],
+				},
+				status: 200,
+			} ) );
+
+			const { unmount, waitForRegistry } = render( <SettingsEdit />, {
+				registry,
+				viewContext: VIEW_CONTEXT_SETTINGS,
+				features: [ 'rrmModuleV2' ],
+			} );
+
+			await waitForRegistry();
+
+			await act( async () => {
+				registry
+					.dispatch( MODULES_READER_REVENUE_MANAGER )
+					.setPostTypes( [ 'post', 'page' ] );
+
+				await registry
+					.dispatch( MODULES_READER_REVENUE_MANAGER )
+					.submitChanges();
+			} );
+
+			unmount();
+
+			expect( mockTrackEvent ).toHaveBeenCalledWith(
+				'settings_rrm-settings',
+				'change_post_types',
+				'Posts, Pages'
+			);
 		} );
 	} );
 } );

--- a/assets/js/modules/reader-revenue-manager/components/settings/SettingsForm.js
+++ b/assets/js/modules/reader-revenue-manager/components/settings/SettingsForm.js
@@ -52,12 +52,15 @@ export default function SettingsForm( { hasModuleAccess } ) {
 	const publicationID = useSelect( ( select ) =>
 		select( MODULES_READER_REVENUE_MANAGER ).getPublicationID()
 	);
+
 	const productIDs = useSelect( ( select ) =>
 		select( MODULES_READER_REVENUE_MANAGER ).getProductIDs()
 	);
+
 	const snippetMode = useSelect( ( select ) =>
 		select( MODULES_READER_REVENUE_MANAGER ).getSnippetMode()
 	);
+
 	const missingProductID = useSelect( ( select ) => {
 		const productID = select(
 			MODULES_READER_REVENUE_MANAGER
@@ -77,6 +80,7 @@ export default function SettingsForm( { hasModuleAccess } ) {
 
 		return productIDs.includes( productID ) ? null : productID;
 	} );
+
 	const publicationAvailable = useSelect( ( select ) => {
 		if ( hasModuleAccess === undefined ) {
 			return undefined;
@@ -99,6 +103,7 @@ export default function SettingsForm( { hasModuleAccess } ) {
 			( { publicationId: id } ) => id === publicationID
 		);
 	} );
+
 	const formattedOwnerName = useSelect( ( select ) => {
 		const module = select( CORE_MODULES ).getModule(
 			READER_REVENUE_MANAGER_MODULE_SLUG
@@ -108,6 +113,7 @@ export default function SettingsForm( { hasModuleAccess } ) {
 			? `<strong>${ module.owner.login }</strong>`
 			: __( 'Another admin', 'google-site-kit' );
 	} );
+
 	const publicationsLoaded = useSelect(
 		( select ) =>
 			hasModuleAccess === false ||

--- a/assets/js/modules/reader-revenue-manager/components/settings/SettingsForm.js
+++ b/assets/js/modules/reader-revenue-manager/components/settings/SettingsForm.js
@@ -1,0 +1,216 @@
+/**
+ * Reader Revenue Manager SettingsEdit component.
+ *
+ * Site Kit by Google, Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { createInterpolateElement, Fragment } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { useSelect } from 'googlesitekit-data';
+import { useFeature } from '../../../../hooks/useFeature';
+import { CORE_MODULES } from '../../../../googlesitekit/modules/datastore/constants';
+import {
+	MODULES_READER_REVENUE_MANAGER,
+	READER_REVENUE_MANAGER_MODULE_SLUG,
+} from '../../datastore/constants';
+import ErrorText from '../../../../components/ErrorText';
+import {
+	PostTypesSelect,
+	PublicationOnboardingStateNotice,
+	PublicationSelect,
+	SnippetModeSelect,
+} from '../common';
+import SettingsNotice, {
+	TYPE_INFO,
+} from '../../../../components/SettingsNotice';
+import WarningIcon from '../../../../../../assets/svg/icons/warning-icon.svg';
+import StoreErrorNotices from '../../../../components/StoreErrorNotices';
+import ProductIDSettings from './ProductIDSettings';
+
+export default function SettingsForm( { hasModuleAccess } ) {
+	const isRRMv2Enabled = useFeature( 'rrmModuleV2' );
+
+	const publicationID = useSelect( ( select ) =>
+		select( MODULES_READER_REVENUE_MANAGER ).getPublicationID()
+	);
+	const productIDs = useSelect( ( select ) =>
+		select( MODULES_READER_REVENUE_MANAGER ).getProductIDs()
+	);
+	const snippetMode = useSelect( ( select ) =>
+		select( MODULES_READER_REVENUE_MANAGER ).getSnippetMode()
+	);
+	const missingProductID = useSelect( ( select ) => {
+		const productID = select(
+			MODULES_READER_REVENUE_MANAGER
+		).getProductID();
+
+		if ( productID === undefined ) {
+			return undefined;
+		}
+
+		if ( 'openaccess' === productID ) {
+			return null;
+		}
+
+		if ( productIDs === undefined ) {
+			return undefined;
+		}
+
+		return productIDs.includes( productID ) ? null : productID;
+	} );
+	const publicationAvailable = useSelect( ( select ) => {
+		if ( hasModuleAccess === undefined ) {
+			return undefined;
+		}
+
+		if ( hasModuleAccess === false ) {
+			return false;
+		}
+
+		const publications = select(
+			MODULES_READER_REVENUE_MANAGER
+		).getPublications();
+
+		if ( ! Array.isArray( publications ) ) {
+			return undefined;
+		}
+
+		return publications.some(
+			// eslint-disable-next-line sitekit/acronym-case
+			( { publicationId: id } ) => id === publicationID
+		);
+	} );
+	const formattedOwnerName = useSelect( ( select ) => {
+		const module = select( CORE_MODULES ).getModule(
+			READER_REVENUE_MANAGER_MODULE_SLUG
+		);
+
+		return module?.owner?.login
+			? `<strong>${ module.owner.login }</strong>`
+			: __( 'Another admin', 'google-site-kit' );
+	} );
+	const publicationsLoaded = useSelect(
+		( select ) =>
+			hasModuleAccess === false ||
+			select( MODULES_READER_REVENUE_MANAGER ).hasFinishedResolution(
+				'getPublications'
+			)
+	);
+
+	return (
+		<Fragment>
+			<div className="googlesitekit-settings-module__fields-group">
+				<StoreErrorNotices
+					moduleSlug={ READER_REVENUE_MANAGER_MODULE_SLUG }
+					storeName={ MODULES_READER_REVENUE_MANAGER }
+				/>
+
+				{ hasModuleAccess && false === publicationAvailable && (
+					<ErrorText
+						message={ sprintf(
+							/* translators: 1: Publication ID. */
+							__(
+								'The previously selected publication with ID %s was not found. Please select a new publication.',
+								'google-site-kit'
+							),
+							publicationID
+						) }
+					/>
+				) }
+
+				{ isRRMv2Enabled &&
+					hasModuleAccess &&
+					publicationAvailable &&
+					missingProductID && (
+						<ErrorText
+							message={ sprintf(
+								/* translators: 1: Product ID. */
+								__(
+									'The previously selected product ID %s was not found. Please select a new product ID.',
+									'google-site-kit'
+								),
+								missingProductID
+							) }
+						/>
+					) }
+
+				<div className="googlesitekit-setup-module__inputs">
+					<PublicationSelect hasModuleAccess={ hasModuleAccess } />
+				</div>
+				{ hasModuleAccess && publicationAvailable && (
+					<PublicationOnboardingStateNotice />
+				) }
+				{ ! hasModuleAccess && (
+					<SettingsNotice
+						type={ TYPE_INFO }
+						Icon={ WarningIcon }
+						notice={ createInterpolateElement(
+							sprintf(
+								/* translators: %s: module owner's name */
+								__(
+									'%s configured Reader Revenue Manager and you don’t have access to its configured publication. Contact them to share access or change the configured publication.',
+									'google-site-kit'
+								),
+								formattedOwnerName
+							),
+							{
+								strong: <strong />,
+							}
+						) }
+					/>
+				) }
+				{ isRRMv2Enabled &&
+					publicationsLoaded &&
+					productIDs?.length > 0 && (
+						<ProductIDSettings
+							hasModuleAccess={ hasModuleAccess }
+						/>
+					) }
+			</div>
+			{ isRRMv2Enabled && (
+				<div className="googlesitekit-settings-module__fields-group">
+					<h4 className="googlesitekit-settings-module__fields-group-title">
+						{ __( 'CTA Placement', 'google-site-kit' ) }
+					</h4>
+					<div className="googlesitekit-rrm-settings-edit__snippet-mode">
+						<SnippetModeSelect
+							hasModuleAccess={ hasModuleAccess }
+						/>
+					</div>
+					{ snippetMode === 'post_types' && (
+						<div className="googlesitekit-rrm-settings-edit__post-types">
+							<h5>
+								{ __(
+									'Select the content types where you want your CTAs to appear:',
+									'google-site-kit'
+								) }
+							</h5>
+							<PostTypesSelect
+								hasModuleAccess={ hasModuleAccess }
+							/>
+						</div>
+					) }
+				</div>
+			) }
+		</Fragment>
+	);
+}

--- a/assets/js/modules/reader-revenue-manager/components/settings/SettingsForm.js
+++ b/assets/js/modules/reader-revenue-manager/components/settings/SettingsForm.js
@@ -1,7 +1,7 @@
 /**
- * Reader Revenue Manager SettingsEdit component.
+ * Reader Revenue Manager SettingsForm component.
  *
- * Site Kit by Google, Copyright 2024 Google LLC
+ * Site Kit by Google, Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,12 +39,12 @@ import {
 	PublicationSelect,
 	SnippetModeSelect,
 } from '../common';
+import ProductIDSettings from './ProductIDSettings';
 import SettingsNotice, {
 	TYPE_INFO,
 } from '../../../../components/SettingsNotice';
-import WarningIcon from '../../../../../../assets/svg/icons/warning-icon.svg';
 import StoreErrorNotices from '../../../../components/StoreErrorNotices';
-import ProductIDSettings from './ProductIDSettings';
+import WarningIcon from '../../../../../../assets/svg/icons/warning-icon.svg';
 
 export default function SettingsForm( { hasModuleAccess } ) {
 	const isRRMv2Enabled = useFeature( 'rrmModuleV2' );

--- a/assets/js/modules/reader-revenue-manager/components/settings/index.js
+++ b/assets/js/modules/reader-revenue-manager/components/settings/index.js
@@ -18,4 +18,5 @@
 
 export { default as ProductIDSettings } from './ProductIDSettings';
 export { default as SettingsEdit } from './SettingsEdit';
+export { default as SettingsForm } from './SettingsForm';
 export { default as SettingsView } from './SettingsView';


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #10332 

## Relevant technical choices

This PR adds opt-in GA event tracking for the new Reader Revenue Manager CTA placement settings.

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [x] Run the code.
- [x] Ensure the acceptance criteria are satisfied.
- [x] Reassess the implementation with the IB.
- [x] Ensure no unrelated changes are included.
- [x] Ensure CI checks pass.
- [x] Check Storybook where applicable.
- [x] Ensure there is a QA Brief.
- [x] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [x] Ensure the PR has the correct target branch.
- [x] Double-check that the PR is okay to be merged.
- [x] Ensure the corresponding issue has a ZenHub release assigned.
- [x] Add a changelog message to the issue.
