### PR TITLE
Update Key Metrics questions dividers to content width.

### DIFF
--- a/assets/sass/components/user-input/googlesitekit-user-input-controls.scss
+++ b/assets/sass/components/user-input/googlesitekit-user-input-controls.scss
@@ -20,6 +20,8 @@
 
 	.googlesitekit-user-input__select-options {
 		margin: 0 0 20px;
+		max-width: 100%;
+		width: max-content;
 	}
 
 	.googlesitekit-user-input__select-option {

--- a/assets/sass/components/user-input/googlesitekit-user-input-preview.scss
+++ b/assets/sass/components/user-input/googlesitekit-user-input-preview.scss
@@ -95,16 +95,8 @@
 	}
 
 	.googlesitekit-user-input__preview-group {
-
 		.googlesitekit-user-input__author {
 			margin: 24px 0 28px;
-		}
-
-		.googlesitekit-user-input__select-option {
-
-			&:not(:last-child) {
-				border-bottom: none;
-			}
 		}
 	}
 


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #10157

## Relevant technical choices

Added one additional `max-width` to prevent overflow of parent on tablet viewports in the User Input Questionnaire.

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.
- [ ] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
