### PR TITLE
Fix AccountLinkedViaGoogleForWooCommerceSubtleNotification

### DIFF
--- a/assets/js/modules/ads/components/notifications/AccountLinkedViaGoogleForWooCommerceSubtleNotification.test.js
+++ b/assets/js/modules/ads/components/notifications/AccountLinkedViaGoogleForWooCommerceSubtleNotification.test.js
@@ -167,5 +167,33 @@ describe( 'AccountLinkedViaGoogleForWooCommerceSubtleNotification.test', () => {
 
 			expect( isActive ).toBe( true );
 		} );
+
+		it( 'should return false if the Ads module is connected', async () => {
+			provideModules( registry, [
+				{
+					slug: 'ads',
+					active: true,
+					connected: true,
+				},
+			] );
+			registry.dispatch( MODULES_ADS ).receiveModuleData( {
+				plugins: {
+					[ PLUGINS.WOOCOMMERCE ]: {
+						active: true,
+					},
+					[ PLUGINS.GOOGLE_FOR_WOOCOMMERCE ]: {
+						active: true,
+						adsConnected: true,
+					},
+				},
+			} );
+
+			const isActive = await notification.checkRequirements(
+				registry,
+				VIEW_CONTEXT_MAIN_DASHBOARD
+			);
+
+			expect( isActive ).toBe( false );
+		} );
 	} );
 } );

--- a/assets/js/modules/ads/index.js
+++ b/assets/js/modules/ads/index.js
@@ -141,6 +141,7 @@ export const ADS_NOTIFICATIONS = {
 			// isWooCommerceActivated, isGoogleForWooCommerceActivated and isGoogleForWooCommerceLinked are all relying
 			// on the data being resolved in getModuleData() selector.
 			await resolveSelect( MODULES_ADS ).getModuleData();
+			await resolveSelect( CORE_MODULES ).isModuleConnected( 'ads' );
 
 			const {
 				isWooCommerceActivated,
@@ -148,7 +149,11 @@ export const ADS_NOTIFICATIONS = {
 				hasGoogleForWooCommerceAdsAccount,
 			} = select( MODULES_ADS );
 
+			const isModuleConnected =
+				select( CORE_MODULES ).isModuleConnected( 'ads' );
+
 			return (
+				! isModuleConnected &&
 				isWooCommerceActivated() &&
 				isGoogleForWooCommerceActivated() &&
 				hasGoogleForWooCommerceAdsAccount()


### PR DESCRIPTION
Fix AccountLinkedViaGoogleForWooCommerceSubtleNotification showing when Ads setup is complete.

## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #10463

## Relevant technical choices

<!-- Please describe your changes. -->

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [ ] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.
- [ ] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
