### PR TITLE
This is a PoC for using `enqueue_block_assets` to enqueue block styles.

### DIFF
--- a/includes/Core/Assets/Asset.php
+++ b/includes/Core/Assets/Asset.php
@@ -22,10 +22,11 @@ use Google\Site_Kit\Context;
 abstract class Asset {
 
 	// Various page contexts for Site Kit in the WordPress Admin.
-	const CONTEXT_ADMIN_GLOBAL      = 'admin-global';
-	const CONTEXT_ADMIN_POST_EDITOR = 'admin-post-editor';
-	const CONTEXT_ADMIN_POSTS       = 'admin-posts';
-	const CONTEXT_ADMIN_SITEKIT     = 'admin-sitekit';
+	const CONTEXT_ADMIN_GLOBAL       = 'admin-global';
+	const CONTEXT_ADMIN_POST_EDITOR  = 'admin-post-editor';
+	const CONTEXT_ADMIN_BLOCK_EDITOR = 'admin-block-editor';
+	const CONTEXT_ADMIN_POSTS        = 'admin-posts';
+	const CONTEXT_ADMIN_SITEKIT      = 'admin-sitekit';
 
 	/**
 	 * Unique asset handle.

--- a/includes/Core/Assets/Assets.php
+++ b/includes/Core/Assets/Assets.php
@@ -134,6 +134,24 @@ final class Assets {
 			}
 		);
 
+		if ( is_admin() ) {
+			add_action(
+				'enqueue_block_assets',
+				function () {
+					$assets = $this->get_assets();
+
+					array_walk(
+						$assets,
+						function ( $asset ) {
+							if ( $asset->has_context( Asset::CONTEXT_ADMIN_BLOCK_EDITOR ) ) {
+								$this->enqueue_asset( $asset->get_handle() );
+							}
+						}
+					);
+				}
+			);
+		}
+
 		add_action(
 			'enqueue_block_editor_assets',
 			function () {

--- a/includes/Modules/Reader_Revenue_Manager.php
+++ b/includes/Modules/Reader_Revenue_Manager.php
@@ -171,6 +171,14 @@ final class Reader_Revenue_Manager extends Module implements Module_With_Scopes,
 				$this->subscribe_with_google_block->register();
 
 				add_action(
+					'enqueue_block_assets',
+					$this->get_method_proxy(
+						'enqueue_block_assets_for_non_sitekit_user'
+					),
+					40
+				);
+
+				add_action(
 					'enqueue_block_editor_assets',
 					$this->get_method_proxy(
 						'enqueue_block_editor_assets_for_non_sitekit_user'
@@ -591,7 +599,7 @@ final class Reader_Revenue_Manager extends Module implements Module_With_Scopes,
 				array(
 					'src'           => $base_url . 'js/blocks/reader-revenue-manager/common/editor-styles.css',
 					'dependencies'  => array(),
-					'load_contexts' => array( Asset::CONTEXT_ADMIN_POST_EDITOR ),
+					'load_contexts' => array( Asset::CONTEXT_ADMIN_BLOCK_EDITOR ),
 				)
 			);
 		}
@@ -674,6 +682,23 @@ final class Reader_Revenue_Manager extends Module implements Module_With_Scopes,
 	}
 
 	/**
+	 * Enqueues block assets for non-Site Kit users.
+	 *
+	 * This is used for enqueueing styles to ensure they are loaded in all block editor contexts including iframes.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @return void
+	 */
+	private function enqueue_block_assets_for_non_sitekit_user() {
+		// Include a check for is_admin() to ensure the styles are only enqueued on admin screens.
+		if ( is_admin() && $this->is_non_sitekit_user() ) {
+			// Enqueue styles.
+			$this->assets->enqueue_asset( 'blocks-reader-revenue-manager-common-editor-styles' );
+		}
+	}
+
+	/**
 	 * Enqueues block editor assets for non-Site Kit users.
 	 *
 	 * @since n.e.x.t
@@ -682,9 +707,6 @@ final class Reader_Revenue_Manager extends Module implements Module_With_Scopes,
 	 */
 	private function enqueue_block_editor_assets_for_non_sitekit_user() {
 		if ( $this->is_non_sitekit_user() ) {
-			// Enqueue styles.
-			$this->assets->enqueue_asset( 'blocks-reader-revenue-manager-common-editor-styles' );
-
 			// Enqueue scripts.
 			$this->assets->enqueue_asset( 'blocks-contribute-with-google-non-sitekit-user' );
 			$this->assets->enqueue_asset( 'blocks-subscribe-with-google-non-sitekit-user' );

--- a/tests/phpunit/integration/Core/Assets/AssetsTest.php
+++ b/tests/phpunit/integration/Core/Assets/AssetsTest.php
@@ -41,6 +41,7 @@ class AssetsTest extends TestCase {
 		'wp_print_scripts',
 		'admin_print_styles',
 		'wp_print_styles',
+		'enqueue_block_editor_assets',
 	);
 
 	private $authorized_filters = array(
@@ -111,6 +112,25 @@ class AssetsTest extends TestCase {
 		foreach ( $this->authorized_filters as $hook ) {
 			$this->assertTrue( has_filter( $hook ), "Failed asserting that filter was added to {$hook}." );
 		}
+	}
+
+	public function test_register_enqueue_block_assets() {
+		remove_all_actions( 'enqueue_block_assets' );
+
+		// Ensure the current user can authenticate.
+		$admin_id = $this->factory()->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $admin_id );
+
+		// First, ensure that the action is not added when not in admin context.
+		$this->assertFalse( is_admin() );
+		$this->assets->register();
+		$this->assertFalse( has_action( 'enqueue_block_assets' ), 'Failed asserting that action was not added to enqueue_block_assets.' );
+
+		// Now, set admin context and ensure the action is added.
+		set_current_screen( 'dashboard' );
+		$this->assertTrue( is_admin() );
+		$this->assets->register();
+		$this->assertTrue( has_action( 'enqueue_block_assets' ), 'Failed asserting that action was added to enqueue_block_assets.' );
 	}
 
 	public function test_register_dashboard_sharing() {

--- a/tests/phpunit/integration/Modules/Reader_Revenue_ManagerTest.php
+++ b/tests/phpunit/integration/Modules/Reader_Revenue_ManagerTest.php
@@ -895,6 +895,9 @@ class Reader_Revenue_ManagerTest extends TestCase {
 		remove_all_actions( 'googlesitekit_assets' );
 		remove_all_actions( 'enqueue_block_assets' );
 
+		// Set admin context.
+		set_current_screen( 'dashboard' );
+
 		$modules = new Modules( $this->context, $this->options, $this->user_options );
 		$modules->register();
 

--- a/tests/phpunit/integration/Modules/Reader_Revenue_ManagerTest.php
+++ b/tests/phpunit/integration/Modules/Reader_Revenue_ManagerTest.php
@@ -11,6 +11,7 @@
 namespace Google\Site_Kit\Tests\Modules;
 
 use Google\Site_Kit\Context;
+use Google\Site_Kit\Core\Assets\Assets;
 use Google\Site_Kit\Core\Authentication\Authentication;
 use Google\Site_Kit\Core\Modules\Module;
 use Google\Site_Kit\Core\Modules\Module_With_Service_Entity;
@@ -744,7 +745,7 @@ class Reader_Revenue_ManagerTest extends TestCase {
 		$this->assertFalse( $registered );
 	}
 
-	public function test_block_editor_script_enqueued() {
+	public function test_block_editor_assets_set_up() {
 		if ( version_compare( get_bloginfo( 'version' ), '5.8', '<' ) ) {
 			$this->markTestSkipped( 'This test only runs on WordPress 5.8 and above.' );
 		}
@@ -775,9 +776,9 @@ class Reader_Revenue_ManagerTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider data_block_editor_script_not_enqueued
+	 * @dataProvider data_block_editor_assets_not_set_up
 	 */
-	public function test_block_editor_script_not_enqueued( $data ) {
+	public function test_block_editor_assets_not_set_up( $data ) {
 		$wp_version_condition = $data['wpVersionCondition'];
 
 		if ( $wp_version_condition && version_compare( get_bloginfo( 'version' ), $wp_version_condition['version'], $wp_version_condition['operator'] ) === false ) {
@@ -881,7 +882,7 @@ class Reader_Revenue_ManagerTest extends TestCase {
 		);
 	}
 
-	public function data_block_editor_script_not_enqueued() {
+	public function data_block_editor_assets_not_set_up() {
 		return array(
 			'feature flag disabled'                  => array(
 				array(

--- a/tests/phpunit/integration/Modules/Reader_Revenue_ManagerTest.php
+++ b/tests/phpunit/integration/Modules/Reader_Revenue_ManagerTest.php
@@ -831,26 +831,28 @@ class Reader_Revenue_ManagerTest extends TestCase {
 			)
 		);
 
+		$this->enable_feature( 'rrmModule' );
+		$this->enable_feature( 'rrmModuleV2' );
+
+		remove_all_actions( 'googlesitekit_assets' );
+		remove_all_actions( 'enqueue_block_editor_assets' );
+
+		$modules = new Modules( $this->context, $this->options, $this->user_options );
+		$modules->register();
+
+		// Ensure the module is connected.
+		$this->reader_revenue_manager->get_settings()->set(
+			array(
+				'publicationID' => 'ABCDEFGH',
+			)
+		);
+
+		$this->reader_revenue_manager->register();
+
 		do_action( 'enqueue_block_editor_assets' );
 
-		$registerable_asset_handles = array_map(
-			function ( $asset ) {
-				return $asset->get_handle();
-			},
-			$this->reader_revenue_manager->get_assets()
-		);
-
-		$non_sk_users_block_editor_scripts = array(
-			'blocks-contribute-with-google-non-sitekit-user',
-			'blocks-subscribe-with-google-non-sitekit-user',
-		);
-
-		$present_handles = array_intersect( $non_sk_users_block_editor_scripts, $registerable_asset_handles );
-
-		$this->assertEmpty(
-			$present_handles,
-			'The following block editor handles should not be present: ' . implode( ', ', $present_handles )
-		);
+		$this->assertFalse( wp_script_is( 'blocks-contribute-with-google-non-sitekit-user', 'enqueued' ), 'blocks-contribute-with-google-non-sitekit-user should not be enqueued' );
+		$this->assertFalse( wp_script_is( 'blocks-subscribe-with-google-non-sitekit-user', 'enqueued' ), 'blocks-subscribe-with-google-non-sitekit-user should not be enqueued' );
 	}
 
 	public function test_non_sk_user_scripts_enqueued() {
@@ -858,28 +860,55 @@ class Reader_Revenue_ManagerTest extends TestCase {
 			$this->markTestSkipped( 'This test only runs on WordPress 5.8 and above.' );
 		}
 
+		$this->enable_feature( 'rrmModule' );
 		$this->enable_feature( 'rrmModuleV2' );
+
+		remove_all_actions( 'googlesitekit_assets' );
+		remove_all_actions( 'enqueue_block_editor_assets' );
+		$modules = new Modules( $this->context, $this->options, $this->user_options );
+		$modules->register();
+
+		// Ensure the module is connected.
+		$this->reader_revenue_manager->get_settings()->set(
+			array(
+				'publicationID' => 'ABCDEFGH',
+			)
+		);
+
+		$this->reader_revenue_manager->register();
 
 		do_action( 'enqueue_block_editor_assets' );
 
-		$registerable_asset_handles = array_map(
-			function ( $asset ) {
-				return $asset->get_handle();
-			},
-			$this->reader_revenue_manager->get_assets()
+		$this->assertTrue( wp_script_is( 'blocks-contribute-with-google-non-sitekit-user', 'enqueued' ), 'blocks-contribute-with-google-non-sitekit-user should be enqueued' );
+		$this->assertTrue( wp_script_is( 'blocks-subscribe-with-google-non-sitekit-user', 'enqueued' ), 'blocks-subscribe-with-google-non-sitekit-user should be enqueued' );
+	}
+
+	public function test_non_sk_user_has_styles_enqueued() {
+		if ( version_compare( get_bloginfo( 'version' ), '5.8', '<' ) ) {
+			$this->markTestSkipped( 'This test only runs on WordPress 5.8 and above.' );
+		}
+
+		$this->enable_feature( 'rrmModule' );
+		$this->enable_feature( 'rrmModuleV2' );
+
+		remove_all_actions( 'googlesitekit_assets' );
+		remove_all_actions( 'enqueue_block_assets' );
+
+		$modules = new Modules( $this->context, $this->options, $this->user_options );
+		$modules->register();
+
+		// Ensure the module is connected.
+		$this->reader_revenue_manager->get_settings()->set(
+			array(
+				'publicationID' => 'ABCDEFGH',
+			)
 		);
 
-		$non_sk_users_block_editor_scripts = array(
-			'blocks-contribute-with-google-non-sitekit-user',
-			'blocks-subscribe-with-google-non-sitekit-user',
-		);
+		$this->reader_revenue_manager->register();
 
-		$present_handles = array_intersect( $non_sk_users_block_editor_scripts, $registerable_asset_handles );
+		do_action( 'enqueue_block_assets' );
 
-		$this->assertEquals(
-			$non_sk_users_block_editor_scripts,
-			$present_handles
-		);
+		$this->assertTrue( wp_style_is( 'blocks-reader-revenue-manager-common-editor-styles', 'enqueued' ), 'blocks-reader-revenue-manager-common-editor-styles should be enqueued' );
 	}
 
 	public function data_block_editor_assets_not_set_up() {

--- a/tests/phpunit/integration/Modules/Reader_Revenue_ManagerTest.php
+++ b/tests/phpunit/integration/Modules/Reader_Revenue_ManagerTest.php
@@ -11,7 +11,6 @@
 namespace Google\Site_Kit\Tests\Modules;
 
 use Google\Site_Kit\Context;
-use Google\Site_Kit\Core\Assets\Assets;
 use Google\Site_Kit\Core\Authentication\Authentication;
 use Google\Site_Kit\Core\Modules\Module;
 use Google\Site_Kit\Core\Modules\Module_With_Service_Entity;

--- a/tests/phpunit/integration/Modules/Reader_Revenue_ManagerTest.php
+++ b/tests/phpunit/integration/Modules/Reader_Revenue_ManagerTest.php
@@ -16,6 +16,7 @@ use Google\Site_Kit\Core\Authentication\Authentication;
 use Google\Site_Kit\Core\Modules\Module;
 use Google\Site_Kit\Core\Modules\Module_With_Service_Entity;
 use Google\Site_Kit\Core\Modules\Module_With_Settings;
+use Google\Site_Kit\Core\Modules\Modules;
 use Google\Site_Kit\Core\Storage\Options;
 use Google\Site_Kit\Core\Storage\User_Options;
 use Google\Site_Kit\Core\Util\URL;


### PR DESCRIPTION
It ensures the styles are available in all block editor contexts including iframes.

## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #10479

## Relevant technical choices

<!-- Please describe your changes. -->

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [x] Run the code.
- [x] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [x] Ensure there is a QA Brief.
- [x] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [x] Ensure the PR has the correct target branch.
- [x] Double-check that the PR is okay to be merged.
- [x] Ensure the corresponding issue has a ZenHub release assigned.
- [x] Add a changelog message to the issue.
