### PR TITLE
Improve RRM publication synchronization efficiency

### DIFF
--- a/assets/js/modules/reader-revenue-manager/utils/settings.js
+++ b/assets/js/modules/reader-revenue-manager/utils/settings.js
@@ -73,3 +73,43 @@ export function getProductIDLabel( productID ) {
 
 	return productID.substring( separatorIndex + 1 );
 }
+
+/**
+ * Gets an array of product ID names from the products array.
+ *
+ * @since n.e.x.t
+ *
+ * @param {Array} products Array of products.
+ * @return {Array} Array of product ID names.
+ */
+export function getProductIDs( products ) {
+	if ( ! Array.isArray( products ) || products.length === 0 ) {
+		return [];
+	}
+
+	return products.reduce( ( ids, { name } ) => {
+		if ( ! name ) {
+			return ids;
+		}
+
+		return [ ...ids, name ];
+	}, [] );
+}
+
+/**
+ * Gets the payment option from the payment options object.
+ *
+ * @since n.e.x.t
+ *
+ * @param {Object} paymentOptions The payment options object.
+ * @return {string} The payment option.
+ */
+export function getPaymentOption( paymentOptions ) {
+	if ( ! paymentOptions ) {
+		return '';
+	}
+
+	return Object.keys( paymentOptions ).find(
+		( key ) => !! paymentOptions[ key ]
+	);
+}


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #10482 

## Relevant technical choices

This is a PoC PR which aims to solve the bug reported at #10482 by improving the efficiency of RRM publication synchronization, by updating the module settings every time the `GET:publications` endpoint is fetched.

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.
- [ ] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
