### PR TITLE
Enhancement/10419 always prompt modal

### DIFF
--- a/assets/js/modules/ads/components/common/WooCommerceRedirectModal.js
+++ b/assets/js/modules/ads/components/common/WooCommerceRedirectModal.js
@@ -55,6 +55,7 @@ export default function WooCommerceRedirectModal( {
 	onClose,
 	onDismiss = null,
 	onContinue = null,
+	onBeforeSetupCallback = null,
 } ) {
 	const [ isSaving, setIsSaving ] = useState( '' );
 
@@ -132,8 +133,16 @@ export default function WooCommerceRedirectModal( {
 			return;
 		}
 
+		onBeforeSetupCallback?.();
 		onSetupCallback();
-	}, [ setIsSaving, onDismiss, onClose, onSetupCallback, onContinue ] );
+	}, [
+		setIsSaving,
+		onDismiss,
+		onClose,
+		onBeforeSetupCallback,
+		onSetupCallback,
+		onContinue,
+	] );
 
 	const { dismissNotification } = useDispatch( CORE_NOTIFICATIONS );
 

--- a/assets/js/modules/ads/components/common/WooCommerceRedirectModal.js
+++ b/assets/js/modules/ads/components/common/WooCommerceRedirectModal.js
@@ -261,4 +261,5 @@ WooCommerceRedirectModal.propTypes = {
 	onDismiss: PropTypes.func,
 	onClose: PropTypes.func.isRequired,
 	onContinue: PropTypes.func,
+	onBeforeSetupCallback: PropTypes.func,
 };

--- a/assets/js/modules/ads/components/notifications/AccountLinkedViaGoogleForWooCommerceSubtleNotification.js
+++ b/assets/js/modules/ads/components/notifications/AccountLinkedViaGoogleForWooCommerceSubtleNotification.js
@@ -32,13 +32,9 @@ import { useCallback, useState } from '@wordpress/element';
  */
 import { useDispatch } from 'googlesitekit-data';
 import { CORE_NOTIFICATIONS } from '../../../../googlesitekit/notifications/datastore/constants';
-import { CORE_USER } from '../../../../googlesitekit/datastore/user/constants';
 import { CORE_SITE } from '../../../../googlesitekit/datastore/site/constants';
-import {
-	ADS_WOOCOMMERCE_REDIRECT_MODAL_CACHE_KEY,
-	ADS_WOOCOMMERCE_REDIRECT_MODAL_DISMISS_KEY,
-} from '../../datastore/constants';
-import { HOUR_IN_SECONDS, MINUTE_IN_SECONDS } from '../../../../util';
+import { ADS_WOOCOMMERCE_REDIRECT_MODAL_CACHE_KEY } from '../../datastore/constants';
+import { MINUTE_IN_SECONDS } from '../../../../util';
 import SubtleNotification from '../../../../googlesitekit/notifications/components/layout/SubtleNotification';
 import Dismiss from '../../../../googlesitekit/notifications/components/common/Dismiss';
 import CTALinkSubtle from '../../../../googlesitekit/notifications/components/common/CTALinkSubtle';
@@ -53,18 +49,13 @@ export default function AccountLinkedViaGoogleForWooCommerceSubtleNotification( 
 
 	const { dismissNotification } = useDispatch( CORE_NOTIFICATIONS );
 
-	const { dismissItem } = useDispatch( CORE_USER );
 	const { setCacheItem } = useDispatch( CORE_SITE );
 
 	const dismissWooCommerceRedirectModal = useCallback( async () => {
 		await setCacheItem( ADS_WOOCOMMERCE_REDIRECT_MODAL_CACHE_KEY, true, {
 			ttl: 5 * MINUTE_IN_SECONDS,
 		} );
-		// This will be removed as part of #10419.
-		await dismissItem( ADS_WOOCOMMERCE_REDIRECT_MODAL_DISMISS_KEY, {
-			expiresInSeconds: HOUR_IN_SECONDS,
-		} );
-	}, [ dismissItem, setCacheItem ] );
+	}, [ setCacheItem ] );
 
 	const onCTAClick = useCallback( async () => {
 		setIsSaving( true );

--- a/assets/js/modules/ads/components/notifications/AdsModuleSetupCTABanner.js
+++ b/assets/js/modules/ads/components/notifications/AdsModuleSetupCTABanner.js
@@ -33,9 +33,9 @@ import { __ } from '@wordpress/i18n';
 import { useDispatch, useSelect } from 'googlesitekit-data';
 import { CORE_NOTIFICATIONS } from '../../../../googlesitekit/notifications/datastore/constants';
 import { CORE_USER } from '../../../../googlesitekit/datastore/user/constants';
-import { WEEK_IN_SECONDS } from '../../../../util';
+import { MINUTE_IN_SECONDS, WEEK_IN_SECONDS } from '../../../../util';
 import {
-	ADS_WOOCOMMERCE_REDIRECT_MODAL_DISMISS_KEY,
+	ADS_WOOCOMMERCE_REDIRECT_MODAL_CACHE_KEY,
 	MODULES_ADS,
 } from '../../datastore/constants';
 import AdsSetupSVG from '../../../../../svg/graphics/ads-setup.svg';
@@ -106,9 +106,7 @@ export default function AdsModuleSetupCTABanner( { id, Notification } ) {
 	} );
 
 	const isWooCommerceRedirectModalDismissed = useSelect( ( select ) =>
-		select( CORE_USER ).isItemDismissed(
-			ADS_WOOCOMMERCE_REDIRECT_MODAL_DISMISS_KEY
-		)
+		select( MODULES_ADS ).isWooCommerceRedirectModalDismissed()
 	);
 
 	const { dismissNotification } = useDispatch( CORE_NOTIFICATIONS );
@@ -119,6 +117,13 @@ export default function AdsModuleSetupCTABanner( { id, Notification } ) {
 			expiresInSeconds: 2 * WEEK_IN_SECONDS,
 		} );
 	}, [ id, dismissNotification ] );
+
+	const { setCacheItem } = useDispatch( CORE_SITE );
+	const dismissWooCommerceRedirectModal = useCallback( () => {
+		setCacheItem( ADS_WOOCOMMERCE_REDIRECT_MODAL_CACHE_KEY, true, {
+			ttl: 5 * MINUTE_IN_SECONDS,
+		} );
+	}, [ setCacheItem ] );
 
 	const activateModule = useActivateModuleCallback( 'ads' );
 
@@ -232,6 +237,7 @@ export default function AdsModuleSetupCTABanner( { id, Notification } ) {
 				<WooCommerceRedirectModal
 					onDismiss={ onModalDismiss }
 					onClose={ onModalClose }
+					onBeforeSetupCallback={ dismissWooCommerceRedirectModal }
 					dialogActive
 				/>
 			) }

--- a/assets/js/modules/ads/components/notifications/AdsModuleSetupCTABanner.test.js
+++ b/assets/js/modules/ads/components/notifications/AdsModuleSetupCTABanner.test.js
@@ -37,11 +37,7 @@ import { CORE_USER } from '../../../../googlesitekit/datastore/user/constants';
 import { CORE_MODULES } from '../../../../googlesitekit/modules/datastore/constants';
 import { CORE_NOTIFICATIONS } from '../../../../googlesitekit/notifications/datastore/constants';
 import { ADS_NOTIFICATIONS } from '../..';
-import {
-	ADS_WOOCOMMERCE_REDIRECT_MODAL_DISMISS_KEY,
-	MODULES_ADS,
-	PLUGINS,
-} from '../../datastore/constants';
+import { MODULES_ADS, PLUGINS } from '../../datastore/constants';
 import { VIEW_CONTEXT_MAIN_DASHBOARD } from '../../../../googlesitekit/constants';
 import { withNotificationComponentProps } from '../../../../googlesitekit/notifications/util/component-props';
 import AdsModuleSetupCTABanner from './AdsModuleSetupCTABanner';
@@ -183,68 +179,6 @@ describe( 'AdsModuleSetupCTABanner', () => {
 
 		it( 'should start Ads module activation when WooCommerce is not active', async () => {
 			provideModuleRegistrations( registry );
-
-			fetchMock.getOnce(
-				RegExp( '^/google-site-kit/v1/core/user/data/authentication' ),
-				{
-					body: { needsReauthentication: false },
-				}
-			);
-			fetchMock.postOnce(
-				RegExp( 'google-site-kit/v1/core/modules/data/activation' ),
-				{
-					body: { success: true },
-				}
-			);
-			fetchMock.postOnce( fetchDismissPrompt, {
-				body: {
-					[ NOTIFICATION_ID ]: { expires: 0, count: 1 },
-				},
-			} );
-
-			const { getByText, waitForRegistry } = render(
-				<AdsModuleSetupCTABannerComponent />,
-				{ registry, viewContext: VIEW_CONTEXT_MAIN_DASHBOARD }
-			);
-
-			const primaryCTA = getByText( 'Set up Ads' );
-			fireEvent.click( primaryCTA );
-
-			await waitForRegistry();
-
-			expect(
-				document.querySelector( '.mdc-dialog' )
-			).not.toBeInTheDocument();
-
-			expect(
-				registry
-					.select( CORE_MODULES )
-					.isDoingSetModuleActivation( 'ads' )
-			).toBe( true );
-
-			// Dismissal should be triggered when the CTA is clicked.
-			expect( fetchMock ).toHaveFetched( fetchDismissPrompt );
-		} );
-
-		it( 'should start Ads module activation if WooCommerce redirect modal was previously dismissed', async () => {
-			provideModuleRegistrations( registry );
-			registry.dispatch( MODULES_ADS ).receiveModuleData( {
-				plugins: {
-					[ PLUGINS.WOOCOMMERCE ]: {
-						active: true,
-					},
-					[ PLUGINS.GOOGLE_FOR_WOOCOMMERCE ]: {
-						active: true,
-						adsConnected: false,
-					},
-				},
-			} );
-
-			registry
-				.dispatch( CORE_USER )
-				.receiveGetDismissedItems( [
-					ADS_WOOCOMMERCE_REDIRECT_MODAL_DISMISS_KEY,
-				] );
 
 			fetchMock.getOnce(
 				RegExp( '^/google-site-kit/v1/core/user/data/authentication' ),

--- a/assets/js/modules/ads/components/setup/SetupMainPAX.js
+++ b/assets/js/modules/ads/components/setup/SetupMainPAX.js
@@ -48,7 +48,6 @@ import AdBlockerWarning from '../../../../components/notifications/AdBlockerWarn
 import { CORE_USER } from '../../../../googlesitekit/datastore/user/constants';
 import { CORE_LOCATION } from '../../../../googlesitekit/datastore/location/constants';
 import {
-	ADS_WOOCOMMERCE_REDIRECT_MODAL_DISMISS_KEY,
 	ADWORDS_SCOPE,
 	MODULES_ADS,
 	SUPPORT_CONTENT_SCOPE,
@@ -182,9 +181,7 @@ export default function SetupMainPAX( { finishSetup } ) {
 	}, [ registry, finishSetup ] );
 
 	const isWooCommerceRedirectModalDismissed = useSelect( ( select ) =>
-		select( CORE_USER ).isItemDismissed(
-			ADS_WOOCOMMERCE_REDIRECT_MODAL_DISMISS_KEY
-		)
+		select( MODULES_ADS ).isWooCommerceRedirectModalDismissed()
 	);
 	const isWooCommerceActivated = useSelect( ( select ) =>
 		select( MODULES_ADS ).isWooCommerceActivated()

--- a/assets/js/modules/ads/datastore/constants.js
+++ b/assets/js/modules/ads/datastore/constants.js
@@ -29,8 +29,6 @@ export const ADS_MODULE_SETUP_BANNER_PROMPT_DISMISSED_KEY =
 	'ads_module_setup_banner_prompt_dismissed_key';
 
 export const ADS_WOOCOMMERCE_REDIRECT_MODAL_CACHE_KEY = 'wc-redirect-modal';
-// This will be removed as part of #10414.
-export const ADS_WOOCOMMERCE_REDIRECT_MODAL_DISMISS_KEY = 'wc-redirect-modal';
 
 export const PLUGINS = {
 	WOOCOMMERCE: 'woocommerce',


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #10419 

## Relevant technical choices

Small diverging from IB, the cache item is set as optional callback passed to the modal, instead of adding it in `useEffect` when modal is opened, so it can be invoked in more reliable way only when actual CTA is clicked. Also the tests are updated to verify the callback is invoked which verifies modal will be "dismissed" in cache 

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.
- [ ] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
