### PR TITLE
Fix / 10534 typo in setIsPromptDismissing method across multiple files

### DIFF
--- a/assets/js/components/consent-mode/ConsentModeSetupCTAWidget.test.js
+++ b/assets/js/components/consent-mode/ConsentModeSetupCTAWidget.test.js
@@ -81,7 +81,7 @@ describe( 'ConsentModeSetupCTAWidget', () => {
 	it( 'should not render the widget when it is being dismissed', async () => {
 		registry
 			.dispatch( CORE_USER )
-			.setIsPromptDimissing( CONSENT_MODE_SETUP_CTA_WIDGET_SLUG, true );
+			.setIsPromptDismissing( CONSENT_MODE_SETUP_CTA_WIDGET_SLUG, true );
 
 		const { container, waitForRegistry } = render(
 			<ConsentModeSetupCTAWidgetComponent />,

--- a/assets/js/googlesitekit/datastore/user/prompts.js
+++ b/assets/js/googlesitekit/datastore/user/prompts.js
@@ -101,7 +101,7 @@ const baseActions = {
 
 			const registry = yield commonActions.getRegistry();
 
-			registry.dispatch( CORE_USER ).setIsPromptDimissing( slug, true );
+			registry.dispatch( CORE_USER ).setIsPromptDismissing( slug, true );
 
 			const { response, error } =
 				yield fetchDismissPromptStore.actions.fetchDismissPrompt(
@@ -109,12 +109,12 @@ const baseActions = {
 					expiresInSeconds
 				);
 
-			registry.dispatch( CORE_USER ).setIsPromptDimissing( slug, false );
+			registry.dispatch( CORE_USER ).setIsPromptDismissing( slug, false );
 
 			return { response, error };
 		}
 	),
-	setIsPromptDimissing( slug, isDismissing ) {
+	setIsPromptDismissing( slug, isDismissing ) {
 		return {
 			payload: { slug, isDismissing },
 			type: 'SET_IS_PROMPT_DISMISSING',

--- a/assets/js/googlesitekit/datastore/user/prompts.test.js
+++ b/assets/js/googlesitekit/datastore/user/prompts.test.js
@@ -94,13 +94,13 @@ describe( 'core/user dismissed-prompts', () => {
 			} );
 		} );
 
-		describe( 'setIsPromptDimissing', () => {
+		describe( 'setIsPromptDismissing', () => {
 			it( 'should set the dismissing state for a prompt', () => {
 				const slug = 'foo-bar';
 
 				registry
 					.dispatch( CORE_USER )
-					.setIsPromptDimissing( slug, true );
+					.setIsPromptDismissing( slug, true );
 
 				expect(
 					registry.select( CORE_USER ).isDismissingPrompt( slug )
@@ -108,7 +108,7 @@ describe( 'core/user dismissed-prompts', () => {
 
 				registry
 					.dispatch( CORE_USER )
-					.setIsPromptDimissing( slug, false );
+					.setIsPromptDismissing( slug, false );
 
 				expect(
 					registry.select( CORE_USER ).isDismissingPrompt( slug )
@@ -118,13 +118,13 @@ describe( 'core/user dismissed-prompts', () => {
 			it( 'should always set the boolean value', () => {
 				const slug = 'foo-bar';
 
-				registry.dispatch( CORE_USER ).setIsPromptDimissing( slug, 1 );
+				registry.dispatch( CORE_USER ).setIsPromptDismissing( slug, 1 );
 
 				expect(
 					registry.select( CORE_USER ).isDismissingPrompt( slug )
 				).toBe( true );
 
-				registry.dispatch( CORE_USER ).setIsPromptDimissing( slug, 0 );
+				registry.dispatch( CORE_USER ).setIsPromptDismissing( slug, 0 );
 
 				expect(
 					registry.select( CORE_USER ).isDismissingPrompt( slug )
@@ -157,7 +157,7 @@ describe( 'core/user dismissed-prompts', () => {
 			} );
 
 			// Explicitly set dismissing state to true.
-			registry.dispatch( CORE_USER ).setIsPromptDimissing( slug, true );
+			registry.dispatch( CORE_USER ).setIsPromptDismissing( slug, true );
 
 			await registry.dispatch( CORE_USER ).dismissPrompt( slug );
 

--- a/assets/js/modules/adsense/components/dashboard/AdBlockingRecoverySetupCTAWidget.test.js
+++ b/assets/js/modules/adsense/components/dashboard/AdBlockingRecoverySetupCTAWidget.test.js
@@ -361,7 +361,7 @@ describe( 'AdBlockingRecoverySetupCTAWidget', () => {
 
 			registry
 				.dispatch( CORE_USER )
-				.setIsPromptDimissing(
+				.setIsPromptDismissing(
 					AD_BLOCKING_RECOVERY_MAIN_NOTIFICATION_KEY,
 					true
 				);


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #10534 

## Relevant technical choices

<!-- Please describe your changes. -->

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [ ] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.
- [ ] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
