### PR TITLE
Follow Up: Fix error states being hidden by notification dismissal and console log warnings.

### DIFF
--- a/assets/js/googlesitekit/notifications/register-defaults.js
+++ b/assets/js/googlesitekit/notifications/register-defaults.js
@@ -575,7 +575,7 @@ export const DEFAULT_NOTIFICATIONS = {
 		priority: 145,
 		areaSlug: NOTIFICATION_AREAS.BANNERS_ABOVE_NAV,
 		viewContexts: [ VIEW_CONTEXT_MAIN_DASHBOARD ],
-		isDismissible: true,
+		isDismissible: false,
 		checkRequirements: async ( { resolveSelect } ) => {
 			const recoverableModules = await resolveSelect(
 				CORE_MODULES


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #9299

## Relevant technical choices

This follow up fixes:
 1. Only dismisses notification if all modules have been recovered.
 2. Fixes propType warning on Checkbox for missing value
 3. Fixes warning of attempted state update in `RecoverableActions` component after unmount caused by all modules from being recovered. 

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.
- [ ] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
