### PR TITLE
Fix locale in backstop to `en-US`

### DIFF
--- a/tests/backstop/config.js
+++ b/tests/backstop/config.js
@@ -32,7 +32,7 @@ module.exports = {
 			'--disable-gpu',
 			'--disable-setuid-sandbox',
 			'--no-zygote',
-			'--accept-lang=en_US',
+			'--accept-lang=en-US',
 		],
 		executablePath: '/usr/bin/chromium',
 	},

--- a/tests/backstop/config.js
+++ b/tests/backstop/config.js
@@ -32,6 +32,7 @@ module.exports = {
 			'--disable-gpu',
 			'--disable-setuid-sandbox',
 			'--no-zygote',
+			'--accept-lang=en_US',
 		],
 		executablePath: '/usr/bin/chromium',
 	},


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #10550

## Relevant technical choices

<!-- Please describe your changes. -->

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.
- [ ] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
