### PR TITLE
Save audience settings when audience groups are enabled

### DIFF
--- a/assets/js/modules/analytics-4/datastore/audience-settings.js
+++ b/assets/js/modules/analytics-4/datastore/audience-settings.js
@@ -183,7 +183,7 @@ const baseActions = {
 				);
 
 			if ( error ) {
-				yield receiveError( error, 'saveUserAudienceSettings', [] );
+				yield receiveError( error, 'saveAudienceSettings', [] );
 			}
 
 			return { response, error };

--- a/assets/js/modules/analytics-4/datastore/audiences.js
+++ b/assets/js/modules/analytics-4/datastore/audiences.js
@@ -608,8 +608,13 @@ const baseActions = {
 			userID
 		);
 
+		const audienceSettings =
+			select( MODULES_ANALYTICS_4 ).getAudienceSettings();
+
 		const { saveSettingsError } = yield commonActions.await(
-			dispatch( MODULES_ANALYTICS_4 ).saveSettings()
+			dispatch( MODULES_ANALYTICS_4 ).saveAudienceSettings(
+				audienceSettings
+			)
 		);
 
 		if ( saveSettingsError ) {

--- a/assets/js/modules/analytics-4/datastore/audiences.test.js
+++ b/assets/js/modules/analytics-4/datastore/audiences.test.js
@@ -62,10 +62,12 @@ describe( 'modules/analytics-4 audiences', () => {
 	const syncAvailableAudiencesEndpoint = new RegExp(
 		'^/google-site-kit/v1/modules/analytics-4/data/sync-audiences'
 	);
-	const audienceSettingsEndpoint = new RegExp(
+	const audienceUserSettingsEndpoint = new RegExp(
 		'^/google-site-kit/v1/core/user/data/audience-settings'
 	);
-
+	const audienceSettingsEndpoint = new RegExp(
+		'^/google-site-kit/v1/modules/analytics-4/data/save-audience-settings'
+	);
 	const analyticsSettingsEndpoint = new RegExp(
 		'^/google-site-kit/v1/modules/analytics-4/data/settings'
 	);
@@ -240,7 +242,7 @@ describe( 'modules/analytics-4 audiences', () => {
 			} );
 
 			it( 'should make a network request to sync available audiences', async () => {
-				muteFetch( audienceSettingsEndpoint );
+				muteFetch( audienceUserSettingsEndpoint );
 
 				fetchMock.postOnce( syncAvailableAudiencesEndpoint, {
 					body: availableAudiences,
@@ -270,7 +272,7 @@ describe( 'modules/analytics-4 audiences', () => {
 					status: 500,
 				} );
 
-				fetchMock.getOnce( audienceSettingsEndpoint, {
+				fetchMock.getOnce( audienceUserSettingsEndpoint, {
 					body: {
 						data: {
 							configuredAudiences: [],
@@ -302,7 +304,7 @@ describe( 'modules/analytics-4 audiences', () => {
 					status: 200,
 				} );
 
-				fetchMock.get( audienceSettingsEndpoint, {
+				fetchMock.get( audienceUserSettingsEndpoint, {
 					body: {
 						data: {
 							configuredAudiences: [],
@@ -399,7 +401,7 @@ describe( 'modules/analytics-4 audiences', () => {
 					status: 200,
 				} );
 
-				fetchMock.getOnce( audienceSettingsEndpoint, {
+				fetchMock.getOnce( audienceUserSettingsEndpoint, {
 					body: {
 						data: {
 							configuredAudiences: [],
@@ -449,7 +451,7 @@ describe( 'modules/analytics-4 audiences', () => {
 					status: 200,
 				} );
 
-				fetchMock.getOnce( audienceSettingsEndpoint, {
+				fetchMock.getOnce( audienceUserSettingsEndpoint, {
 					body: {
 						data: {
 							configuredAudiences: [],
@@ -602,14 +604,11 @@ describe( 'modules/analytics-4 audiences', () => {
 			const isAudienceSegmentationWidgetHidden = false;
 
 			beforeEach( () => {
-				fetchMock.postOnce(
-					analyticsSettingsEndpoint,
-					( url, opts ) => {
-						const { data } = JSON.parse( opts.body );
-						// Return the same settings passed to the API.
-						return { body: data, status: 200 };
-					}
-				);
+				fetchMock.postOnce( audienceSettingsEndpoint, ( url, opts ) => {
+					const { data } = JSON.parse( opts.body );
+					// Return the same settings passed to the API.
+					return { body: data, status: 200 };
+				} );
 
 				provideModules( registry, [
 					{
@@ -647,7 +646,7 @@ describe( 'modules/analytics-4 audiences', () => {
 			} );
 
 			it( 'sets `isSettingUpAudiences` to true while the action is in progress', async () => {
-				fetchMock.postOnce( audienceSettingsEndpoint, {
+				fetchMock.postOnce( audienceUserSettingsEndpoint, {
 					body: {
 						configuredAudiences: [],
 						isAudienceSegmentationWidgetHidden,
@@ -753,7 +752,7 @@ describe( 'modules/analytics-4 audiences', () => {
 						.dispatch( MODULES_ANALYTICS_4 )
 						.setAvailableAudiences( availableUserAudiences );
 
-					fetchMock.postOnce( audienceSettingsEndpoint, {
+					fetchMock.postOnce( audienceUserSettingsEndpoint, {
 						body: {
 							configuredAudiences: expectedConfiguredAudiences,
 							isAudienceSegmentationWidgetHidden,
@@ -789,7 +788,7 @@ describe( 'modules/analytics-4 audiences', () => {
 
 					expect( fetchMock ).toHaveFetchedTimes(
 						1,
-						audienceSettingsEndpoint,
+						audienceUserSettingsEndpoint,
 						{
 							body: {
 								data: {
@@ -857,7 +856,7 @@ describe( 'modules/analytics-4 audiences', () => {
 							...availableUserAudiences.slice( 1 ),
 						] );
 
-					fetchMock.postOnce( audienceSettingsEndpoint, {
+					fetchMock.postOnce( audienceUserSettingsEndpoint, {
 						body: {
 							configuredAudiences: expectedConfiguredAudiences,
 							isAudienceSegmentationWidgetHidden,
@@ -893,7 +892,7 @@ describe( 'modules/analytics-4 audiences', () => {
 
 					expect( fetchMock ).toHaveFetchedTimes(
 						1,
-						audienceSettingsEndpoint,
+						audienceUserSettingsEndpoint,
 						{
 							body: {
 								data: {
@@ -953,7 +952,7 @@ describe( 'modules/analytics-4 audiences', () => {
 					createdReturningVisitorsAudienceName,
 				];
 
-				fetchMock.postOnce( audienceSettingsEndpoint, {
+				fetchMock.postOnce( audienceUserSettingsEndpoint, {
 					body: {
 						configuredAudiences: expectedConfiguredAudiences,
 						isAudienceSegmentationWidgetHidden,
@@ -1052,7 +1051,7 @@ describe( 'modules/analytics-4 audiences', () => {
 
 				expect( fetchMock ).toHaveFetchedTimes(
 					1,
-					audienceSettingsEndpoint,
+					audienceUserSettingsEndpoint,
 					{
 						body: {
 							data: {
@@ -1116,7 +1115,7 @@ describe( 'modules/analytics-4 audiences', () => {
 					( { name } ) => name
 				);
 
-				fetchMock.postOnce( audienceSettingsEndpoint, {
+				fetchMock.postOnce( audienceUserSettingsEndpoint, {
 					body: {
 						configuredAudiences: expectedConfiguredAudiences,
 						isAudienceSegmentationWidgetHidden,
@@ -1162,7 +1161,7 @@ describe( 'modules/analytics-4 audiences', () => {
 						...availableUserAudiences.slice( 1 ),
 					] );
 
-				fetchMock.postOnce( audienceSettingsEndpoint, {
+				fetchMock.postOnce( audienceUserSettingsEndpoint, {
 					body: {
 						configuredAudiences,
 						isAudienceSegmentationWidgetHidden,
@@ -1235,7 +1234,7 @@ describe( 'modules/analytics-4 audiences', () => {
 						availableReturningVisitorsAudienceFixture,
 					] );
 
-				fetchMock.postOnce( audienceSettingsEndpoint, {
+				fetchMock.postOnce( audienceUserSettingsEndpoint, {
 					body: {
 						configuredAudiences,
 						isAudienceSegmentationWidgetHidden,
@@ -1287,7 +1286,7 @@ describe( 'modules/analytics-4 audiences', () => {
 				} );
 
 				it( "creates the `googlesitekit_post_type` custom dimension if it doesn't exist", async () => {
-					fetchMock.postOnce( audienceSettingsEndpoint, {
+					fetchMock.postOnce( audienceUserSettingsEndpoint, {
 						body: {
 							configuredAudiences: [],
 							isAudienceSegmentationWidgetHidden,
@@ -1512,7 +1511,7 @@ describe( 'modules/analytics-4 audiences', () => {
 						status: 200,
 					} );
 
-					fetchMock.postOnce( audienceSettingsEndpoint, {
+					fetchMock.postOnce( audienceUserSettingsEndpoint, {
 						body: {
 							configuredAudiences: expectedConfiguredAudiences,
 							isAudienceSegmentationWidgetHidden,
@@ -1585,7 +1584,7 @@ describe( 'modules/analytics-4 audiences', () => {
 
 					expect( fetchMock ).toHaveFetchedTimes(
 						1,
-						audienceSettingsEndpoint,
+						audienceUserSettingsEndpoint,
 						{
 							body: {
 								data: {
@@ -1660,7 +1659,7 @@ describe( 'modules/analytics-4 audiences', () => {
 						createdReturningVisitorsAudienceName,
 					];
 
-					fetchMock.postOnce( audienceSettingsEndpoint, {
+					fetchMock.postOnce( audienceUserSettingsEndpoint, {
 						body: {
 							configuredAudiences: expectedConfiguredAudiences,
 							isAudienceSegmentationWidgetHidden,
@@ -1887,7 +1886,7 @@ describe( 'modules/analytics-4 audiences', () => {
 					status: 200,
 				} );
 
-				fetchMock.postOnce( audienceSettingsEndpoint, {
+				fetchMock.postOnce( audienceUserSettingsEndpoint, {
 					body: {
 						configuredAudiences: [],
 						isAudienceSegmentationWidgetHidden,
@@ -1942,7 +1941,7 @@ describe( 'modules/analytics-4 audiences', () => {
 					authenticated: false,
 				} );
 
-				fetchMock.postOnce( audienceSettingsEndpoint, {
+				fetchMock.postOnce( audienceUserSettingsEndpoint, {
 					body: {
 						configuredAudiences: [],
 						isAudienceSegmentationWidgetHidden,
@@ -1982,7 +1981,7 @@ describe( 'modules/analytics-4 audiences', () => {
 					status: 200,
 				} );
 
-				fetchMock.postOnce( audienceSettingsEndpoint, {
+				fetchMock.postOnce( audienceUserSettingsEndpoint, {
 					body: {
 						configuredAudiences: [],
 						isAudienceSegmentationWidgetHidden,
@@ -2076,7 +2075,7 @@ describe( 'modules/analytics-4 audiences', () => {
 						status: 200,
 					} );
 
-					fetchMock.postOnce( audienceSettingsEndpoint, {
+					fetchMock.postOnce( audienceUserSettingsEndpoint, {
 						body: {
 							configuredAudiences: expectedConfiguredAudiences,
 							isAudienceSegmentationWidgetHidden,
@@ -2112,7 +2111,7 @@ describe( 'modules/analytics-4 audiences', () => {
 
 					expect( fetchMock ).toHaveFetchedTimes(
 						1,
-						audienceSettingsEndpoint,
+						audienceUserSettingsEndpoint,
 						{
 							body: {
 								data: {
@@ -2175,7 +2174,7 @@ describe( 'modules/analytics-4 audiences', () => {
 						status: 200,
 					} );
 
-					fetchMock.postOnce( audienceSettingsEndpoint, {
+					fetchMock.postOnce( audienceUserSettingsEndpoint, {
 						body: {
 							configuredAudiences: expectedConfiguredAudiences,
 							isAudienceSegmentationWidgetHidden,
@@ -2211,7 +2210,7 @@ describe( 'modules/analytics-4 audiences', () => {
 
 					expect( fetchMock ).toHaveFetchedTimes(
 						1,
-						audienceSettingsEndpoint,
+						audienceUserSettingsEndpoint,
 						{
 							body: {
 								data: {
@@ -2251,7 +2250,7 @@ describe( 'modules/analytics-4 audiences', () => {
 					status: 200,
 				} );
 
-				fetchMock.postOnce( audienceSettingsEndpoint, {
+				fetchMock.postOnce( audienceUserSettingsEndpoint, {
 					body: {
 						configuredAudiences,
 						isAudienceSegmentationWidgetHidden,

--- a/assets/js/modules/analytics-4/datastore/audiences.test.js
+++ b/assets/js/modules/analytics-4/datastore/audiences.test.js
@@ -607,7 +607,7 @@ describe( 'modules/analytics-4 audiences', () => {
 				fetchMock.postOnce( audienceSettingsEndpoint, ( url, opts ) => {
 					const { data } = JSON.parse( opts.body );
 					// Return the same settings passed to the API.
-					return { body: data, status: 200 };
+					return { body: data.settings, status: 200 };
 				} );
 
 				provideModules( registry, [

--- a/assets/js/modules/analytics-4/hooks/useEnableAudienceGroup.test.js
+++ b/assets/js/modules/analytics-4/hooks/useEnableAudienceGroup.test.js
@@ -43,11 +43,11 @@ describe( 'useEnableAudienceGroup', () => {
 	let registry;
 	let enableAudienceGroupSpy;
 
-	const audienceSettingsEndpoint = new RegExp(
+	const audienceUserSettingsEndpoint = new RegExp(
 		'^/google-site-kit/v1/core/user/data/audience-settings'
 	);
-	const analyticsSettingsEndpoint = new RegExp(
-		'^/google-site-kit/v1/modules/analytics-4/data/settings'
+	const audienceSettingsEndpoint = new RegExp(
+		'^/google-site-kit/v1/modules/analytics-4/data/save-audience-settings'
 	);
 	const reportEndpoint = new RegExp(
 		'^/google-site-kit/v1/modules/analytics-4/data/report'
@@ -71,7 +71,7 @@ describe( 'useEnableAudienceGroup', () => {
 			'enableAudienceGroup'
 		);
 
-		fetchMock.postOnce( analyticsSettingsEndpoint, ( url, opts ) => {
+		fetchMock.postOnce( audienceSettingsEndpoint, ( url, opts ) => {
 			const { data } = JSON.parse( opts.body );
 			// Return the same settings passed to the API.
 			return { body: data, status: 200 };
@@ -223,7 +223,7 @@ describe( 'useEnableAudienceGroup', () => {
 			status: 200,
 		} );
 
-		fetchMock.postOnce( audienceSettingsEndpoint, {
+		fetchMock.postOnce( audienceUserSettingsEndpoint, {
 			status: 200,
 			body: {
 				configuredAudiences: [
@@ -267,7 +267,7 @@ describe( 'useEnableAudienceGroup', () => {
 			status: 200,
 		} );
 
-		fetchMock.postOnce( audienceSettingsEndpoint, {
+		fetchMock.postOnce( audienceUserSettingsEndpoint, {
 			status: 200,
 			body: {
 				configuredAudiences: [
@@ -312,7 +312,7 @@ describe( 'useEnableAudienceGroup', () => {
 			status: 200,
 		} );
 
-		fetchMock.postOnce( audienceSettingsEndpoint, {
+		fetchMock.postOnce( audienceUserSettingsEndpoint, {
 			status: 200,
 			body: {
 				configuredAudiences: [

--- a/includes/Modules/Analytics_4.php
+++ b/includes/Modules/Analytics_4.php
@@ -1544,13 +1544,20 @@ final class Analytics_4 extends Module implements Module_With_Scopes, Module_Wit
 					);
 				}
 
-				if ( isset( $data['audienceSegmentationSetupCompletedBy'] ) && ! is_int( $data['audienceSegmentationSetupCompletedBy'] ) ) {
+				$settings = $data['settings'];
+
+				if (
+					isset( $settings['audienceSegmentationSetupCompletedBy'] ) &&
+					! is_int( $settings['audienceSegmentationSetupCompletedBy'] )
+				) {
 					throw new Invalid_Param_Exception( 'audienceSegmentationSetupCompletedBy' );
 				}
 
-				return function () use ( $data ) {
-					if ( isset( $data['audienceSegmentationSetupCompletedBy'] ) ) {
-						$new_settings['audienceSegmentationSetupCompletedBy'] = $data['audienceSegmentationSetupCompletedBy'];
+				return function () use ( $settings ) {
+					$new_settings = array();
+
+					if ( isset( $settings['audienceSegmentationSetupCompletedBy'] ) ) {
+						$new_settings['audienceSegmentationSetupCompletedBy'] = $settings['audienceSegmentationSetupCompletedBy'];
 					}
 
 					$settings = $this->audience_settings->merge( $new_settings );


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- https://github.com/google/site-kit-wp/issues/10089#issuecomment-2810211122

## Relevant technical choices

This PR aims to fix the issue reported [here](https://github.com/google/site-kit-wp/issues/10089#issuecomment-2810211122).

However, the problem seems to be a regression introduced in #8888, where the audience settings were migrated to its own instance, but upon activation, the correct settings instance wasn't saved.

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [x] Run the code.
- [x] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [x] Ensure there is a QA Brief.
- [x] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [x] Ensure the PR has the correct target branch.
- [x] Double-check that the PR is okay to be merged.
- [x] Ensure the corresponding issue has a ZenHub release assigned.
- [x] Add a changelog message to the issue.
