### PR TITLE
Generate build provenance attestation during deployment

### DIFF
--- a/.github/workflows/zips.yml
+++ b/.github/workflows/zips.yml
@@ -264,7 +264,7 @@ jobs:
     environment: wordpress-plugin-svn
     if: github.event_name == 'workflow_dispatch' && ( github.ref_type == 'tag' || inputs.release_version != '' )
     needs: build-zips
-    timeout-minutes: 20
+    timeout-minutes: 60
     steps:
       - name: Install SVN ( Subversion )
         run: |

--- a/.github/workflows/zips.yml
+++ b/.github/workflows/zips.yml
@@ -278,9 +278,18 @@ jobs:
         run: |
           unzip /tmp/google-site-kit.zip
       - uses: 10up/action-wordpress-plugin-deploy@2.2.2
+        id: deploy
+        with:
+          generate-zip: true
         env:
           BUILD_DIR: ./google-site-kit
           SLUG: google-site-kit
           SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
           SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
           VERSION: ${{ inputs.release_version }}
+      - name: Generate build provenance attestation
+        uses: johnbillion/action-wordpress-plugin-attestation@0.7.0
+        with:
+          zip-path: ${{ steps.deploy.outputs.zip-path }}
+          plugin: google-site-kit
+          version: ${{ inputs.release_version }}


### PR DESCRIPTION
## Summary

This uses [the WordPress Plugin Attestation action](https://github.com/johnbillion/action-wordpress-plugin-attestation) to generate a build provenance attestation for the zip file of Site Kit. This ties the zip file on wordpress.org back to the GitHub Actions workflow that performed the deployment.

The timeout has been increased from 20 minutes to 60 to facilitate waiting for [plugin release confirmation](https://developer.wordpress.org/plugins/wordpress-org/release-confirmation-emails/).

## Testing instructions

This isn't testable in isolation because the workflow only runs when you publish a release, but [it's used by several other plugins](https://github.com/johnbillion/action-wordpress-plugin-attestation/network/dependents).

## PR Author Checklist

- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.
- [ ] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
