### PR TITLE
Bug/7908 ad blocking recovery ux

### DIFF
--- a/assets/js/components/notifications/BannerNotification/BannerActions.js
+++ b/assets/js/components/notifications/BannerNotification/BannerActions.js
@@ -42,6 +42,7 @@ export default function BannerActions( props ) {
 		showSpinner,
 		dismissLabel,
 		dismissCallback,
+		dismissIsTertiary,
 	} = props;
 
 	const [ isAwaitingCTAResponse, setIsAwaitingCTAResponse ] =
@@ -92,7 +93,7 @@ export default function BannerActions( props ) {
 
 			{ dismissLabel && (
 				<Button
-					tertiary={ ctaLink || ctaComponent }
+					tertiary={ ctaLink || ctaComponent || dismissIsTertiary }
 					onClick={ dismissCallback }
 					disabled={ isAwaitingCTAResponse || isNavigatingToCTALink }
 				>
@@ -109,6 +110,8 @@ BannerActions.propTypes = {
 	ctaComponent: PropTypes.element,
 	ctaTarget: PropTypes.string,
 	ctaCallback: PropTypes.func,
+	showSpinner: PropTypes.bool,
 	dismissLabel: PropTypes.string,
 	dismissCallback: PropTypes.func,
+	dismissIsTertiary: PropTypes.bool,
 };

--- a/assets/js/components/notifications/BannerNotification/BannerActions.js
+++ b/assets/js/components/notifications/BannerNotification/BannerActions.js
@@ -39,7 +39,6 @@ export default function BannerActions( props ) {
 		ctaComponent,
 		ctaTarget,
 		ctaCallback,
-		showSpinner,
 		dismissLabel,
 		dismissCallback,
 		dismissIsTertiary,
@@ -76,16 +75,8 @@ export default function BannerActions( props ) {
 					href={ ctaLink }
 					target={ ctaTarget }
 					onClick={ handleCTAClick }
-					disabled={
-						isAwaitingCTAResponse ||
-						isNavigatingToCTALink ||
-						showSpinner
-					}
-					isSaving={
-						isAwaitingCTAResponse ||
-						isNavigatingToCTALink ||
-						showSpinner
-					}
+					disabled={ isAwaitingCTAResponse || isNavigatingToCTALink }
+					isSaving={ isAwaitingCTAResponse || isNavigatingToCTALink }
 				>
 					{ ctaLabel }
 				</SpinnerButton>
@@ -110,7 +101,6 @@ BannerActions.propTypes = {
 	ctaComponent: PropTypes.element,
 	ctaTarget: PropTypes.string,
 	ctaCallback: PropTypes.func,
-	showSpinner: PropTypes.bool,
 	dismissLabel: PropTypes.string,
 	dismissCallback: PropTypes.func,
 	dismissIsTertiary: PropTypes.bool,

--- a/assets/js/components/notifications/BannerNotification/BannerActions.js
+++ b/assets/js/components/notifications/BannerNotification/BannerActions.js
@@ -39,6 +39,7 @@ export default function BannerActions( props ) {
 		ctaComponent,
 		ctaTarget,
 		ctaCallback,
+		showSpinner,
 		dismissLabel,
 		dismissCallback,
 	} = props;
@@ -74,8 +75,16 @@ export default function BannerActions( props ) {
 					href={ ctaLink }
 					target={ ctaTarget }
 					onClick={ handleCTAClick }
-					disabled={ isAwaitingCTAResponse || isNavigatingToCTALink }
-					isSaving={ isAwaitingCTAResponse || isNavigatingToCTALink }
+					disabled={
+						isAwaitingCTAResponse ||
+						isNavigatingToCTALink ||
+						showSpinner
+					}
+					isSaving={
+						isAwaitingCTAResponse ||
+						isNavigatingToCTALink ||
+						showSpinner
+					}
 				>
 					{ ctaLabel }
 				</SpinnerButton>

--- a/assets/js/modules/adsense/components/dashboard/AdBlockingRecoverySetupCTAWidget.js
+++ b/assets/js/modules/adsense/components/dashboard/AdBlockingRecoverySetupCTAWidget.js
@@ -133,13 +133,6 @@ function AdBlockingRecoverySetupCTAWidget( { Widget, WidgetNull } ) {
 	const referenceDate = useSelect( ( select ) =>
 		select( CORE_USER ).getReferenceDate()
 	);
-	const isNavigatingToRecoveryPageURL = useSelect( ( select ) => {
-		if ( ! recoveryPageURL ) {
-			return false;
-		}
-
-		return select( CORE_LOCATION ).isNavigatingTo( recoveryPageURL );
-	} );
 
 	const { dismissPrompt } = useDispatch( CORE_USER );
 	const { navigateTo } = useDispatch( CORE_LOCATION );
@@ -259,7 +252,6 @@ function AdBlockingRecoverySetupCTAWidget( { Widget, WidgetNull } ) {
 						ctaLabel={ __( 'Set up now', 'google-site-kit' ) }
 						ctaCallback={ handleCTAClick }
 						dismissCallback={ handleDismissClick }
-						showSpinner={ isNavigatingToRecoveryPageURL }
 						dismissIsTertiary
 						dismissLabel={
 							dismissCount < 2

--- a/assets/js/modules/adsense/components/dashboard/AdBlockingRecoverySetupCTAWidget.js
+++ b/assets/js/modules/adsense/components/dashboard/AdBlockingRecoverySetupCTAWidget.js
@@ -133,6 +133,9 @@ function AdBlockingRecoverySetupCTAWidget( { Widget, WidgetNull } ) {
 	const referenceDate = useSelect( ( select ) =>
 		select( CORE_USER ).getReferenceDate()
 	);
+	const isNavigatingToRecoveryPageURL = useSelect( ( select ) =>
+		select( CORE_LOCATION ).isNavigatingTo( recoveryPageURL )
+	);
 
 	const { dismissPrompt } = useDispatch( CORE_USER );
 	const { navigateTo } = useDispatch( CORE_LOCATION );
@@ -247,10 +250,10 @@ function AdBlockingRecoverySetupCTAWidget( { Widget, WidgetNull } ) {
 					</div>
 
 					<BannerActions
-						ctaLink="#"
 						ctaLabel={ __( 'Set up now', 'google-site-kit' ) }
 						ctaCallback={ handleCTAClick }
 						dismissCallback={ handleDismissClick }
+						showSpinner={ isNavigatingToRecoveryPageURL }
 						dismissLabel={
 							dismissCount < 2
 								? __( 'Maybe later', 'google-site-kit' )

--- a/assets/js/modules/adsense/components/dashboard/AdBlockingRecoverySetupCTAWidget.js
+++ b/assets/js/modules/adsense/components/dashboard/AdBlockingRecoverySetupCTAWidget.js
@@ -176,7 +176,9 @@ function AdBlockingRecoverySetupCTAWidget( { Widget, WidgetNull } ) {
 			`${ viewContext }_adsense-abr-cta-widget`,
 			'confirm_notification'
 		);
-		return navigateTo( recoveryPageURL );
+		navigateTo( recoveryPageURL );
+
+		return new Promise();
 	};
 
 	const handleDismissClick = async () => {

--- a/assets/js/modules/adsense/components/dashboard/AdBlockingRecoverySetupCTAWidget.js
+++ b/assets/js/modules/adsense/components/dashboard/AdBlockingRecoverySetupCTAWidget.js
@@ -171,7 +171,9 @@ function AdBlockingRecoverySetupCTAWidget( { Widget, WidgetNull } ) {
 		);
 		navigateTo( recoveryPageURL );
 
-		return new Promise();
+		return new Promise( () => {
+			// We are intentionally letting this promise unresolved.
+		} );
 	};
 
 	const handleDismissClick = async () => {

--- a/assets/js/modules/adsense/components/dashboard/AdBlockingRecoverySetupCTAWidget.js
+++ b/assets/js/modules/adsense/components/dashboard/AdBlockingRecoverySetupCTAWidget.js
@@ -133,9 +133,13 @@ function AdBlockingRecoverySetupCTAWidget( { Widget, WidgetNull } ) {
 	const referenceDate = useSelect( ( select ) =>
 		select( CORE_USER ).getReferenceDate()
 	);
-	const isNavigatingToRecoveryPageURL = useSelect( ( select ) =>
-		select( CORE_LOCATION ).isNavigatingTo( recoveryPageURL )
-	);
+	const isNavigatingToRecoveryPageURL = useSelect( ( select ) => {
+		if ( ! recoveryPageURL ) {
+			return false;
+		}
+
+		return select( CORE_LOCATION ).isNavigatingTo( recoveryPageURL );
+	} );
 
 	const { dismissPrompt } = useDispatch( CORE_USER );
 	const { navigateTo } = useDispatch( CORE_LOCATION );
@@ -254,6 +258,7 @@ function AdBlockingRecoverySetupCTAWidget( { Widget, WidgetNull } ) {
 						ctaCallback={ handleCTAClick }
 						dismissCallback={ handleDismissClick }
 						showSpinner={ isNavigatingToRecoveryPageURL }
+						dismissIsTertiary
 						dismissLabel={
 							dismissCount < 2
 								? __( 'Maybe later', 'google-site-kit' )

--- a/assets/js/modules/adsense/components/settings/AdBlockingRecoverySetupCTANotice.js
+++ b/assets/js/modules/adsense/components/settings/AdBlockingRecoverySetupCTANotice.js
@@ -29,7 +29,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { Button } from 'googlesitekit-components';
+import { SpinnerButton } from 'googlesitekit-components';
 import { useSelect, useDispatch } from 'googlesitekit-data';
 import Badge from '../../../../components/Badge';
 import SettingsNotice from '../../../../components/SettingsNotice/SettingsNotice';
@@ -61,6 +61,9 @@ export default function AdBlockingRecoverySetupCTANotice() {
 	);
 	const recoveryPageURL = useSelect( ( select ) =>
 		select( CORE_SITE ).getAdminURL( 'googlesitekit-ad-blocking-recovery' )
+	);
+	const isNavigatingToRecoveryPageURL = useSelect( ( select ) =>
+		select( CORE_LOCATION ).isNavigatingTo( recoveryPageURL )
 	);
 
 	const { navigateTo } = useDispatch( CORE_LOCATION );
@@ -113,9 +116,13 @@ export default function AdBlockingRecoverySetupCTANotice() {
 			}
 			className="googlesitekit-settings-notice-ad-blocking-recovery-cta"
 			OuterCTA={ () => (
-				<Button onClick={ handleCTAClick }>
+				<SpinnerButton
+					onClick={ handleCTAClick }
+					isSaving={ isNavigatingToRecoveryPageURL }
+					disabled={ isNavigatingToRecoveryPageURL }
+				>
 					{ __( 'Set up now', 'google-site-kit' ) }
-				</Button>
+				</SpinnerButton>
 			) }
 		>
 			{ createInterpolateElement(


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #7908 

## Relevant technical choices

I had to diverge from IB in part, as proposed solution didn't fix the spinner, current implementation ensures spinner is showing. And the final approach ended up being slightly simpler.

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.
- [ ] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
