### PR TITLE
Rotate notifications based on distinct date view count.

### DIFF
--- a/assets/js/googlesitekit/notifications/components/Notification/ViewedStateObserver.js
+++ b/assets/js/googlesitekit/notifications/components/Notification/ViewedStateObserver.js
@@ -27,7 +27,6 @@ import { useEffect, useRef } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import { COUNT_VIEW_TIMEOUT } from '../../constants';
 import { useDispatch } from 'googlesitekit-data';
 import { CORE_UI } from '../../../datastore/ui/constants';
 import { CORE_NOTIFICATIONS } from '../../datastore/constants';
@@ -60,7 +59,7 @@ export default function ViewedStateObserver( { id, observeRef, threshold } ) {
 					setValue( useHasBeenViewed.getKey( id ), true );
 					markNotificationSeen( id );
 				}
-			}, COUNT_VIEW_TIMEOUT );
+			}, 3000 );
 		} else if ( ! isInView && timeoutRef.current ) {
 			// If notification is no longer in view, clear the timeout
 			clearTimeout( timeoutRef.current );

--- a/assets/js/googlesitekit/notifications/components/Notification/ViewedStateObserver.js
+++ b/assets/js/googlesitekit/notifications/components/Notification/ViewedStateObserver.js
@@ -44,13 +44,16 @@ export default function ViewedStateObserver( { id, observeRef, threshold } ) {
 	const viewed = useHasBeenViewed( id );
 	const timeoutRef = useRef();
 
+	const clearExistingTimeout = () => {
+		if ( timeoutRef.current ) {
+			clearTimeout( timeoutRef.current );
+		}
+	};
+
 	useEffect( () => {
 		// If notification is not viewed yet and is in view, start the timer
 		if ( ! viewed && isInView ) {
-			// Clear any existing timeout.
-			if ( timeoutRef.current ) {
-				clearTimeout( timeoutRef.current );
-			}
+			clearExistingTimeout();
 
 			// Set a new timeout for 3 seconds.
 			timeoutRef.current = setTimeout( () => {
@@ -61,15 +64,12 @@ export default function ViewedStateObserver( { id, observeRef, threshold } ) {
 				}
 			}, 3000 );
 		} else if ( ! isInView && timeoutRef.current ) {
-			// If notification is no longer in view, clear the timeout
-			clearTimeout( timeoutRef.current );
+			clearExistingTimeout();
 		}
 
 		// Cleanup function to clear timeout on unmount or when dependencies change.
 		return () => {
-			if ( timeoutRef.current ) {
-				clearTimeout( timeoutRef.current );
-			}
+			clearExistingTimeout();
 		};
 	}, [
 		viewed,

--- a/assets/js/googlesitekit/notifications/components/Notification/ViewedStateObserver.js
+++ b/assets/js/googlesitekit/notifications/components/Notification/ViewedStateObserver.js
@@ -51,7 +51,7 @@ export default function ViewedStateObserver( { id, observeRef, threshold } ) {
 	};
 
 	useEffect( () => {
-		// If notification is not viewed yet and is in view, start the timer
+		// If notification is not viewed yet and is in view, start the timer.
 		if ( ! viewed && isInView ) {
 			clearExistingTimeout();
 

--- a/assets/js/googlesitekit/notifications/components/Notification/ViewedStateObserver.js
+++ b/assets/js/googlesitekit/notifications/components/Notification/ViewedStateObserver.js
@@ -22,13 +22,15 @@ import PropTypes from 'prop-types';
 /**
  * WordPress dependencies
  */
-import { useEffect } from '@wordpress/element';
+import { useEffect, useRef } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
+import { COUNT_VIEW_TIMEOUT } from '../../constants';
 import { useDispatch } from 'googlesitekit-data';
 import { CORE_UI } from '../../../datastore/ui/constants';
+import { CORE_NOTIFICATIONS } from '../../datastore/constants';
 import useLatestIntersection from '../../../../hooks/useLatestIntersection';
 import { useHasBeenViewed } from '../../hooks/useHasBeenViewed';
 
@@ -38,14 +40,46 @@ export default function ViewedStateObserver( { id, observeRef, threshold } ) {
 	} );
 
 	const { setValue } = useDispatch( CORE_UI );
+	const { markNotificationSeen } = useDispatch( CORE_NOTIFICATIONS );
 	const isInView = !! intersectionEntry?.isIntersecting;
 	const viewed = useHasBeenViewed( id );
+	const timeoutRef = useRef();
 
 	useEffect( () => {
+		// If notification is not viewed yet and is in view, start the timer
 		if ( ! viewed && isInView ) {
-			setValue( useHasBeenViewed.getKey( id ), true );
+			// Clear any existing timeout.
+			if ( timeoutRef.current ) {
+				clearTimeout( timeoutRef.current );
+			}
+
+			// Set a new timeout for 3 seconds.
+			timeoutRef.current = setTimeout( () => {
+				// Only mark as viewed if still in view after 3 seconds.
+				if ( intersectionEntry?.isIntersecting ) {
+					setValue( useHasBeenViewed.getKey( id ), true );
+					markNotificationSeen( id );
+				}
+			}, COUNT_VIEW_TIMEOUT );
+		} else if ( ! isInView && timeoutRef.current ) {
+			// If notification is no longer in view, clear the timeout
+			clearTimeout( timeoutRef.current );
 		}
-	}, [ viewed, isInView, setValue, id ] );
+
+		// Cleanup function to clear timeout on unmount or when dependencies change.
+		return () => {
+			if ( timeoutRef.current ) {
+				clearTimeout( timeoutRef.current );
+			}
+		};
+	}, [
+		viewed,
+		isInView,
+		setValue,
+		markNotificationSeen,
+		id,
+		intersectionEntry,
+	] );
 
 	return null;
 }

--- a/assets/js/googlesitekit/notifications/components/Notification/index.test.js
+++ b/assets/js/googlesitekit/notifications/components/Notification/index.test.js
@@ -28,7 +28,6 @@ import { CORE_NOTIFICATIONS } from '../../datastore/constants';
 import { CORE_UI } from '../../../datastore/ui/constants';
 import Notification from '.';
 
-// Create a reusable NotificationWrapper component for tests
 function NotificationWrapper() {
 	return (
 		<Notification id="test-notification">
@@ -56,7 +55,7 @@ jest.mock( '../../hooks/useHasBeenViewed', () => {
 	};
 } );
 
-// Export the mock for direct access in tests
+// Export the mock for direct access in tests.
 export const mockUseHasBeenViewed = jest.requireMock(
 	'../../hooks/useHasBeenViewed'
 ).useHasBeenViewed;

--- a/assets/js/googlesitekit/notifications/components/Notification/index.test.js
+++ b/assets/js/googlesitekit/notifications/components/Notification/index.test.js
@@ -1,0 +1,189 @@
+/**
+ * Notification component tests.
+ *
+ * Site Kit by Google, Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import {
+	render,
+	createTestRegistry,
+	act,
+} from '../../../../../../tests/js/test-utils';
+import { CORE_NOTIFICATIONS } from '../../datastore/constants';
+import { CORE_UI } from '../../../datastore/ui/constants';
+import Notification from '.';
+
+// Mock the useLatestIntersection hook to control intersection state.
+jest.mock( '../../../../hooks/useLatestIntersection', () => {
+	return jest.fn().mockImplementation( () => ( {
+		isIntersecting: true,
+	} ) );
+} );
+
+// Mock the useHasBeenViewed hook to control viewed state.
+jest.mock( '../../hooks/useHasBeenViewed', () => {
+	const originalModule = jest.requireActual( '../../hooks/useHasBeenViewed' );
+	const mockUseHasBeenViewed = jest.fn().mockReturnValue( false );
+	mockUseHasBeenViewed.getKey = originalModule.useHasBeenViewed.getKey;
+
+	return {
+		...originalModule,
+		useHasBeenViewed: mockUseHasBeenViewed,
+	};
+} );
+
+describe( 'Notification', () => {
+	let registry;
+	let mockMarkNotificationSeen;
+	let mockSetValue;
+	let mockDismissNotification;
+
+	beforeEach( () => {
+		jest.useFakeTimers();
+
+		registry = createTestRegistry();
+
+		// Mock the actions.
+		mockMarkNotificationSeen = jest.fn();
+		mockSetValue = jest.fn();
+		mockDismissNotification = jest.fn();
+
+		registry.dispatch( CORE_NOTIFICATIONS ).markNotificationSeen =
+			mockMarkNotificationSeen;
+		registry.dispatch( CORE_UI ).setValue = mockSetValue;
+		registry.dispatch( CORE_NOTIFICATIONS ).dismissNotification =
+			mockDismissNotification;
+
+		// Mock the getNotificationSeenDates selector.
+		registry.select( CORE_NOTIFICATIONS ).getNotificationSeenDates = jest
+			.fn()
+			.mockReturnValue( [] );
+	} );
+
+	afterEach( () => {
+		jest.useRealTimers();
+		jest.clearAllMocks();
+	} );
+
+	it( 'renders the notification content', () => {
+		const { getByText } = render(
+			<Notification id="test-notification">
+				Test Notification Content
+			</Notification>,
+			{ registry }
+		);
+
+		expect( getByText( 'Test Notification Content' ) ).toBeInTheDocument();
+	} );
+
+	it( 'dismisses the notification when it has been viewed on 3 distinct days', () => {
+		registry.select( CORE_NOTIFICATIONS ).getNotificationSeenDates = jest
+			.fn()
+			.mockReturnValue( [ '2025-04-27', '2025-04-28', '2025-04-29' ] );
+
+		render(
+			<Notification id="test-notification">
+				Test Notification Content
+			</Notification>,
+			{ registry }
+		);
+
+		expect( mockDismissNotification ).toHaveBeenCalledWith(
+			'test-notification',
+			{ skipHidingFromQueue: true }
+		);
+	} );
+
+	it( 'does not dismiss the notification when it has been viewed on fewer than 3 distinct days', () => {
+		registry.select( CORE_NOTIFICATIONS ).getNotificationSeenDates = jest
+			.fn()
+			.mockReturnValue( [ '2025-04-28', '2025-04-29' ] );
+
+		render(
+			<Notification id="test-notification">
+				Test Notification Content
+			</Notification>,
+			{ registry }
+		);
+
+		expect( mockDismissNotification ).not.toHaveBeenCalled();
+	} );
+
+	it( 'marks notification as seen only after being in view for 3 seconds', () => {
+		render(
+			<Notification id="test-notification">
+				Test Notification Content
+			</Notification>,
+			{ registry }
+		);
+
+		// Verify markNotificationSeen is not called immediately.
+		expect( mockMarkNotificationSeen ).not.toHaveBeenCalled();
+
+		act( () => {
+			jest.advanceTimersByTime( 2000 );
+		} );
+
+		// Verify markNotificationSeen is still not called.
+		expect( mockMarkNotificationSeen ).not.toHaveBeenCalled();
+
+		// Advance time to complete the timeout.
+		act( () => {
+			jest.advanceTimersByTime( 1000 );
+		} );
+
+		expect( mockMarkNotificationSeen ).toHaveBeenCalledWith(
+			'test-notification'
+		);
+	} );
+
+	it( 'does not mark notification as seen if view ends before 3 seconds', () => {
+		const useLatestIntersection = require( '../../../../hooks/useLatestIntersection' );
+
+		// Initially in view.
+		useLatestIntersection.mockReturnValue( { isIntersecting: true } );
+
+		const { rerender } = render(
+			<Notification id="test-notification">
+				Test Notification Content
+			</Notification>,
+			{ registry }
+		);
+
+		act( () => {
+			jest.advanceTimersByTime( 2000 );
+		} );
+
+		// Change to not in view.
+		useLatestIntersection.mockReturnValue( { isIntersecting: false } );
+
+		rerender(
+			<Notification id="test-notification">
+				Test Notification Content
+			</Notification>
+		);
+
+		// Advance time to complete the timeout.
+		act( () => {
+			jest.advanceTimersByTime( 1000 );
+		} );
+
+		// Verify markNotificationSeen was not called.
+		expect( mockMarkNotificationSeen ).not.toHaveBeenCalled();
+	} );
+} );

--- a/assets/js/googlesitekit/notifications/constants.js
+++ b/assets/js/googlesitekit/notifications/constants.js
@@ -29,5 +29,3 @@ export const PRIORITY = {
 	SETUP_CTA_HIGH: 150,
 	SETUP_CTA_LOW: 200,
 };
-
-export const COUNT_VIEW_TIMEOUT = 3000;

--- a/assets/js/googlesitekit/notifications/constants.js
+++ b/assets/js/googlesitekit/notifications/constants.js
@@ -29,3 +29,5 @@ export const PRIORITY = {
 	SETUP_CTA_HIGH: 150,
 	SETUP_CTA_LOW: 200,
 };
+
+export const COUNT_VIEW_TIMEOUT = 3000;

--- a/assets/js/googlesitekit/notifications/datastore/notifications.js
+++ b/assets/js/googlesitekit/notifications/datastore/notifications.js
@@ -441,12 +441,12 @@ export const reducer = createReducer( ( state, { type, payload } ) => {
 			const { notificationID, currentDate } = payload;
 			const seenNotifications = { ...state.seenNotifications };
 
-			// Initialize array if it doesn't exist
+			// Initialize array if it doesn't exist.
 			if ( ! seenNotifications[ notificationID ] ) {
 				seenNotifications[ notificationID ] = [];
 			}
 
-			// Only add the date if it's not already in the array
+			// Only add the date if it's not already in the array.
 			if (
 				! seenNotifications[ notificationID ].includes( currentDate )
 			) {
@@ -496,12 +496,12 @@ export const resolvers = {
 
 export const selectors = {
 	/**
-	 * Gets all seen notifications view date arrays.
+	 * Gets all view dates for each notification, keyed by notification ID.
 	 *
 	 * @since n.e.x.t
 	 *
 	 * @param {Object} state Data store's state.
-	 * @return {Object} Object with notification IDs as keys and view count as values.
+	 * @return {Object} Object with notification IDs as keys and array of dates viewed as the value.
 	 */
 	getSeenNotifications( state ) {
 		return state.seenNotifications;

--- a/assets/js/googlesitekit/notifications/datastore/notifications.js
+++ b/assets/js/googlesitekit/notifications/datastore/notifications.js
@@ -353,8 +353,7 @@ export const controls = {
 
 						return {
 							...notification,
-							// Rotate viewed notifications within their priority groups by adding the view count to the priority.
-							priority: notification.priority + viewCount,
+							viewCount,
 							checkRequirements,
 							async check() {
 								if ( checkRequirements ) {
@@ -363,7 +362,8 @@ export const controls = {
 								return true;
 							},
 						};
-					} );
+					} )
+					.sort( ( a, b ) => a.viewCount - b.viewCount );
 
 				const { queueNotification } =
 					registry.dispatch( CORE_NOTIFICATIONS );

--- a/assets/js/googlesitekit/notifications/datastore/notifications.js
+++ b/assets/js/googlesitekit/notifications/datastore/notifications.js
@@ -225,12 +225,12 @@ export const actions = {
 				.getNotification( notificationID );
 
 			if ( notification?.isDismissible ) {
-				const currentDate = registry
+				const dateSeen = registry
 					.select( CORE_USER )
 					.getReferenceDate();
 
 				yield {
-					payload: { notificationID, currentDate },
+					payload: { dateSeen, notificationID },
 					type: MARK_NOTIFICATION_SEEN,
 				};
 
@@ -438,7 +438,7 @@ export const reducer = createReducer( ( state, { type, payload } ) => {
 		}
 
 		case MARK_NOTIFICATION_SEEN: {
-			const { notificationID, currentDate } = payload;
+			const { dateSeen, notificationID } = payload;
 			const seenNotifications = { ...state.seenNotifications };
 
 			// Initialize array if it doesn't exist.
@@ -447,13 +447,8 @@ export const reducer = createReducer( ( state, { type, payload } ) => {
 			}
 
 			// Only add the date if it's not already in the array.
-			if (
-				! seenNotifications[ notificationID ].includes( currentDate )
-			) {
-				seenNotifications[ notificationID ] = [
-					...seenNotifications[ notificationID ],
-					currentDate,
-				];
+			if ( ! seenNotifications[ notificationID ].includes( dateSeen ) ) {
+				seenNotifications[ notificationID ].push( dateSeen );
 			}
 
 			state.seenNotifications = seenNotifications;
@@ -518,7 +513,7 @@ export const selectors = {
 	 */
 	getNotificationSeenDates( state, notificationID ) {
 		const { seenNotifications } = state;
-		return seenNotifications[ notificationID ] || [];
+		return seenNotifications[ notificationID ] ?? [];
 	},
 
 	/**

--- a/assets/js/googlesitekit/notifications/datastore/notifications.test.js
+++ b/assets/js/googlesitekit/notifications/datastore/notifications.test.js
@@ -421,7 +421,7 @@ describe( 'core/notifications Notifications', () => {
 				expect( seenNotifications ).toEqual( {} );
 			} );
 
-			it( 'should return seen notifications with their view counts', async () => {
+			it( 'should return seen notifications with their dates viewed as an array', async () => {
 				registry.dispatch( CORE_USER ).setReferenceDate( '2025-04-29' );
 				registerNotification( 'notification-1', {
 					Component: TestNotificationComponent,


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #10106

## Relevant technical choices

I followed the IB mainly, one small change was the following:

> Ensure the getDismissedItems and getSeenNotifications() selectors are resolved before continuing at this point:

Was not needed as this selector does not need to fetch data.

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.
- [ ] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
