### PR TITLE
Issue / 10704 Debug Link New Tab And Self Issue

### DIFF
--- a/assets/js/modules/ads/components/common/WooCommerceRedirectModal.js
+++ b/assets/js/modules/ads/components/common/WooCommerceRedirectModal.js
@@ -146,21 +146,25 @@ export default function WooCommerceRedirectModal( {
 			trackEventLabel
 		);
 
-		setIsSaving( 'primary' );
-		onDismiss?.();
-		if ( ! isGoogleForWooCommerceAdsConnected ) {
+		if ( isGoogleForWooCommerceAdsConnected ) {
+			setIsSaving( 'primary' );
 			navigateTo( googleForWooCommerceRedirectURI );
+			onDismiss?.();
+		} else {
+			onDismiss?.();
+			onClose?.();
 		}
 	}, [
 		isAccountLinkedViaGoogleForWoocommerceNoticeDismissed,
 		dismissNotification,
 		setIsSaving,
 		onDismiss,
+		onClose,
 		navigateTo,
 		googleForWooCommerceRedirectURI,
 		viewContext,
 		trackEventLabel,
-		googleForWooCommerceRedirectURI,
+		isGoogleForWooCommerceAdsConnected,
 	] );
 
 	const onSetupCallback = useActivateModuleCallback( 'ads' );

--- a/assets/js/modules/ads/components/common/WooCommerceRedirectModal.js
+++ b/assets/js/modules/ads/components/common/WooCommerceRedirectModal.js
@@ -148,8 +148,9 @@ export default function WooCommerceRedirectModal( {
 
 		setIsSaving( 'primary' );
 		onDismiss?.();
-
-		navigateTo( googleForWooCommerceRedirectURI );
+		if ( ! isGoogleForWooCommerceAdsConnected ) {
+			navigateTo( googleForWooCommerceRedirectURI );
+		}
 	}, [
 		isAccountLinkedViaGoogleForWoocommerceNoticeDismissed,
 		dismissNotification,
@@ -159,6 +160,7 @@ export default function WooCommerceRedirectModal( {
 		googleForWooCommerceRedirectURI,
 		viewContext,
 		trackEventLabel,
+		googleForWooCommerceRedirectURI,
 	] );
 
 	const onSetupCallback = useActivateModuleCallback( 'ads' );

--- a/assets/js/modules/ads/components/common/WooCommerceRedirectModal.js
+++ b/assets/js/modules/ads/components/common/WooCommerceRedirectModal.js
@@ -149,11 +149,9 @@ export default function WooCommerceRedirectModal( {
 		if ( isGoogleForWooCommerceAdsConnected ) {
 			setIsSaving( 'primary' );
 			navigateTo( googleForWooCommerceRedirectURI );
-			onDismiss?.();
-		} else {
-			onDismiss?.();
-			onClose?.();
 		}
+		onDismiss?.();
+		onClose?.();
 	}, [
 		isAccountLinkedViaGoogleForWoocommerceNoticeDismissed,
 		dismissNotification,


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #10704

## Relevant technical choices

- Added some conditional checks within the `handleGoogleForWooCommerceRedirect` callback function so that `navigateTo` is not called when `href` values are applied to the CTA

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.
- [ ] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
