### PR TITLE
Reset product ID notification dismissals

### DIFF
--- a/includes/Modules/Reader_Revenue_Manager.php
+++ b/includes/Modules/Reader_Revenue_Manager.php
@@ -18,6 +18,7 @@ use Google\Site_Kit\Core\Assets\Script;
 use Google\Site_Kit\Core\Assets\Stylesheet;
 use Google\Site_Kit\Core\Authentication\Authentication;
 use Google\Site_Kit\Core\Authentication\Clients\Google_Site_Kit_Client;
+use Google\Site_Kit\Core\Dismissals\Dismissed_Items;
 use Google\Site_Kit\Core\Modules\Module;
 use Google\Site_Kit\Core\Modules\Module_With_Assets;
 use Google\Site_Kit\Core\Modules\Module_With_Assets_Trait;
@@ -113,6 +114,11 @@ final class Reader_Revenue_Manager extends Module implements Module_With_Scopes,
 	 */
 	private $tag_guard;
 
+	const PRODUCT_ID_NOTIFICATIONS = array(
+		'rrm-product-id-contributions-notification',
+		'rrm-product-id-subscriptions-notification',
+	);
+
 	/**
 	 * Constructor.
 	 *
@@ -192,6 +198,19 @@ final class Reader_Revenue_Manager extends Module implements Module_With_Scopes,
 
 		// Reader Revenue Manager tag placement logic.
 		add_action( 'template_redirect', array( $this, 'register_tag' ) );
+
+		// If the publication ID changes, clear the dismissed state for product ID notifications.
+		$this->get_settings()->on_change(
+			function ( $old_value, $new_value ) {
+				if ( $old_value['publicationID'] !== $new_value['publicationID'] ) {
+					$dismissed_items = new Dismissed_Items( $this->user_options );
+
+					foreach ( self::PRODUCT_ID_NOTIFICATIONS as $notification ) {
+						$dismissed_items->remove( $notification );
+					}
+				}
+			}
+		);
 	}
 
 	/**

--- a/tests/phpunit/integration/Modules/Reader_Revenue_ManagerTest.php
+++ b/tests/phpunit/integration/Modules/Reader_Revenue_ManagerTest.php
@@ -12,6 +12,7 @@ namespace Google\Site_Kit\Tests\Modules;
 
 use Google\Site_Kit\Context;
 use Google\Site_Kit\Core\Authentication\Authentication;
+use Google\Site_Kit\Core\Dismissals\Dismissed_Items;
 use Google\Site_Kit\Core\Modules\Module;
 use Google\Site_Kit\Core\Modules\Module_With_Service_Entity;
 use Google\Site_Kit\Core\Modules\Module_With_Settings;
@@ -100,6 +101,31 @@ class Reader_Revenue_ManagerTest extends TestCase {
 			$this->reader_revenue_manager->get_scopes(),
 			apply_filters( 'googlesitekit_auth_scopes', array() )
 		);
+	}
+
+	public function test_register__reset_product_id_dismissals_on_publication_change() {
+		$this->reader_revenue_manager->register();
+		$this->reader_revenue_manager->get_settings()->register();
+
+		$dismissed_items = new Dismissed_Items( $this->user_options );
+
+		// Set dismissals for product ID notifications.
+		foreach ( Reader_Revenue_Manager::PRODUCT_ID_NOTIFICATIONS as $notification ) {
+			$dismissed_items->add( $notification );
+
+			$this->assertTrue( $dismissed_items->is_dismissed( $notification ) );
+		}
+
+		$this->reader_revenue_manager->get_settings()->merge(
+			array(
+				'publicationID' => 'A1A2C4D5E6',
+			)
+		);
+
+		// Verify that the product ID notification dismissals are reset.
+		foreach ( Reader_Revenue_Manager::PRODUCT_ID_NOTIFICATIONS as $notification ) {
+			$this->assertFalse( $dismissed_items->is_dismissed( $notification ) );
+		}
 	}
 
 	public function test_magic_methods() {


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #10311 

## Relevant technical choices

This PR adds reset functionality for Reader Revenue Manager product ID notifications, so that their dismissals are cleared when the connected publication is changed.

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [x] Run the code.
- [x] Ensure the acceptance criteria are satisfied.
- [x] Reassess the implementation with the IB.
- [x] Ensure no unrelated changes are included.
- [x] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [x] Ensure there is a QA Brief.
- [x] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [x] Ensure the PR has the correct target branch.
- [x] Double-check that the PR is okay to be merged.
- [x] Ensure the corresponding issue has a ZenHub release assigned.
- [x] Add a changelog message to the issue.
