### PR TITLE
Enhancement/#10371 - Refactor `useRequestInterception` to receive `path:response` mappings object

### DIFF
--- a/tests/e2e/specs/modules/analytics/setup-with-account-with-tag.test.js
+++ b/tests/e2e/specs/modules/analytics/setup-with-account-with-tag.test.js
@@ -46,77 +46,102 @@ async function assertSetupSuccessful() {
 	} );
 }
 
+function getRequestResponseMappings() {
+	const measurementID = 'G-500';
+	const containerMock = fixtures.containerE2E[ measurementID ];
+
+	// Analytics 4 responses.
+	const analyticsResponses = {
+		'analytics-4/data/report': {
+			status: 200,
+			body: JSON.stringify( {} ),
+		},
+		'analytics-4/data/conversion-events': {
+			status: 200,
+			body: JSON.stringify( [] ),
+		},
+		'analytics-4/data/create-property': {
+			status: 200,
+			body: JSON.stringify( fixtures.createProperty ),
+		},
+		'analytics-4/data/create-webdatastream': {
+			status: 200,
+			body: JSON.stringify( fixtures.createWebDataStream ),
+		},
+		'analytics-4/data/enhanced-measurement-settings': {
+			status: 200,
+			body: JSON.stringify( fixtures.defaultEnhancedMeasurementSettings ),
+		},
+		'analytics-4/data/google-tag-settings': {
+			status: 200,
+			body: JSON.stringify( fixtures.googleTagSettings ),
+		},
+		'analytics-4/data/container-lookup': {
+			status: 200,
+			body: JSON.stringify( containerMock ),
+		},
+		'analytics-4/data/property': {
+			status: 200,
+			body: JSON.stringify( fixtures.properties[ 0 ] ),
+		},
+		'analytics-4/data/sync-custom-dimensions': {
+			status: 200,
+			body: '[]',
+		},
+		'analytics-4/data/properties': {
+			status: 200,
+			body: JSON.stringify( fixtures.properties ),
+		},
+	};
+
+	// Search Console responses.
+	const searchConsoleResponses = {
+		'google-site-kit/v1/modules/search-console/data/searchanalytics': {
+			status: 200,
+			body: JSON.stringify( [] ),
+		},
+	};
+
+	// PageSpeed Insights responses.
+	const pageSpeedResponses = {
+		'google-site-kit/v1/modules/pagespeed-insights/data/pagespeed': {
+			status: 200,
+			body: JSON.stringify( {} ),
+		},
+	};
+
+	// Audience settings responses.
+	const audienceSettingsResponses = {
+		'user/data/audience-settings': {
+			status: 200,
+			body: JSON.stringify( {
+				configuredAudiences: [ fixtures.availableAudiences[ 2 ].name ],
+				isAudienceSegmentationWidgetHidden: false,
+			} ),
+		},
+	};
+
+	// Legacy Analytics responses.
+	const legacyAnalyticsResponses = {
+		'google-site-kit/v1/modules/analytics/data/goals': {
+			status: 200,
+			body: JSON.stringify( {} ),
+		},
+	};
+
+	return {
+		...analyticsResponses,
+		...searchConsoleResponses,
+		...pageSpeedResponses,
+		...audienceSettingsResponses,
+		...legacyAnalyticsResponses,
+	};
+}
+
 describe( 'setting up the Analytics module with an existing account and existing tag', () => {
 	beforeAll( async () => {
 		await page.setRequestInterception( true );
-		const measurementID = 'G-500';
-		const containerMock = fixtures.containerE2E[ measurementID ];
-
-		useRequestInterception( {
-			'google-site-kit/v1/modules/search-console/data/searchanalytics': {
-				status: 200,
-				body: JSON.stringify( [] ),
-			},
-			'google-site-kit/v1/modules/pagespeed-insights/data/pagespeed': {
-				status: 200,
-				body: JSON.stringify( {} ),
-			},
-			'/wp-json/google-site-kit/v1/modules/analytics-4/data/report?': {
-				status: 200,
-				body: JSON.stringify( {} ),
-			},
-			'analytics-4/data/conversion-events': {
-				status: 200,
-				body: JSON.stringify( [] ),
-			},
-			'google-site-kit/v1/modules/analytics-4/data/create-property': {
-				status: 200,
-				body: JSON.stringify( fixtures.createProperty ),
-			},
-			'analytics-4/data/create-webdatastream': {
-				status: 200,
-				body: JSON.stringify( fixtures.createWebDataStream ),
-			},
-			'analytics-4/data/enhanced-measurement-settings': {
-				status: 200,
-				body: JSON.stringify(
-					fixtures.defaultEnhancedMeasurementSettings
-				),
-			},
-			'analytics-4/data/google-tag-settings': {
-				status: 200,
-				body: JSON.stringify( fixtures.googleTagSettings ),
-			},
-			'analytics-4/data/container-lookup': {
-				status: 200,
-				body: JSON.stringify( containerMock ),
-			},
-			'analytics-4/data/property': {
-				status: 200,
-				body: JSON.stringify( fixtures.properties[ 0 ] ),
-			},
-			'analytics-4/data/sync-custom-dimensions': {
-				status: 200,
-				body: '[]',
-			},
-			'google-site-kit/v1/modules/analytics/data/goals': {
-				status: 200,
-				body: JSON.stringify( {} ),
-			},
-			'user/data/audience-settings': {
-				status: 200,
-				body: JSON.stringify( {
-					configuredAudiences: [
-						fixtures.availableAudiences[ 2 ].name,
-					],
-					isAudienceSegmentationWidgetHidden: false,
-				} ),
-			},
-			'analytics-4/data/properties': {
-				status: 200,
-				body: JSON.stringify( fixtures.properties ),
-			},
-		} );
+		useRequestInterception( getRequestResponseMappings() );
 	} );
 
 	beforeEach( async () => {

--- a/tests/e2e/specs/modules/analytics/setup-with-account-with-tag.test.js
+++ b/tests/e2e/specs/modules/analytics/setup-with-account-with-tag.test.js
@@ -1,5 +1,3 @@
-/* eslint complexity: [ "error", 16 ] */
-
 /**
  * WordPress dependencies
  */
@@ -51,125 +49,73 @@ async function assertSetupSuccessful() {
 describe( 'setting up the Analytics module with an existing account and existing tag', () => {
 	beforeAll( async () => {
 		await page.setRequestInterception( true );
-		useRequestInterception( ( request ) => {
-			const measurementID = 'G-500';
-			const containerMock = fixtures.containerE2E[ measurementID ];
+		const measurementID = 'G-500';
+		const containerMock = fixtures.containerE2E[ measurementID ];
 
-			if (
-				request
-					.url()
-					.match(
-						'google-site-kit/v1/modules/search-console/data/searchanalytics'
-					)
-			) {
-				request.respond( { status: 200, body: JSON.stringify( [] ) } );
-			} else if (
-				request
-					.url()
-					.match(
-						'google-site-kit/v1/modules/pagespeed-insights/data/pagespeed'
-					)
-			) {
-				request.respond( { status: 200, body: JSON.stringify( {} ) } );
-			} else if (
-				request
-					.url()
-					.match(
-						'/wp-json/google-site-kit/v1/modules/analytics-4/data/report?'
-					)
-			) {
-				request.respond( {
-					status: 200,
-					body: JSON.stringify( {} ),
-				} );
-			} else if (
-				request.url().match( 'analytics-4/data/conversion-events' )
-			) {
-				request.respond( {
-					status: 200,
-					body: JSON.stringify( [] ),
-				} );
-			} else if (
-				request
-					.url()
-					.match(
-						'google-site-kit/v1/modules/analytics-4/data/create-property'
-					)
-			) {
-				request.respond( {
-					body: JSON.stringify( fixtures.createProperty ),
-					status: 200,
-				} );
-			} else if (
-				request.url().match( 'analytics-4/data/create-webdatastream' )
-			) {
-				request.respond( {
-					body: JSON.stringify( fixtures.createWebDataStream ),
-					status: 200,
-				} );
-			} else if (
-				request
-					.url()
-					.match( 'analytics-4/data/enhanced-measurement-settings' )
-			) {
-				request.respond( {
-					status: 200,
-					body: JSON.stringify(
-						fixtures.defaultEnhancedMeasurementSettings
-					),
-				} );
-			} else if (
-				request.url().match( 'analytics-4/data/google-tag-settings' )
-			) {
-				request.respond( {
-					body: JSON.stringify( fixtures.googleTagSettings ),
-					status: 200,
-				} );
-			} else if (
-				request.url().match( 'analytics-4/data/container-lookup' )
-			) {
-				request.respond( {
-					body: JSON.stringify( containerMock ),
-					status: 200,
-				} );
-			} else if ( request.url().match( 'analytics-4/data/property' ) ) {
-				request.respond( {
-					body: JSON.stringify( fixtures.properties[ 0 ] ),
-					status: 200,
-				} );
-			} else if (
-				request.url().match( 'analytics-4/data/sync-custom-dimensions' )
-			) {
-				request.respond( {
-					status: 200,
-					body: '[]',
-				} );
-			} else if (
-				request
-					.url()
-					.match( 'google-site-kit/v1/modules/analytics/data/goals' )
-			) {
-				request.respond( { status: 200, body: JSON.stringify( {} ) } );
-			} else if ( request.url().match( 'user/data/audience-settings' ) ) {
-				request.respond( {
-					status: 200,
-					body: JSON.stringify( {
-						configuredAudiences: [
-							fixtures.availableAudiences[ 2 ].name,
-						],
-						isAudienceSegmentationWidgetHidden: false,
-					} ),
-				} );
-			} else if ( request.url().match( 'analytics-4/data/properties' ) ) {
-				request.respond( {
-					status: 200,
-					body: JSON.stringify( fixtures.properties ),
-				} );
-			}
-
-			if ( ! request._interceptionHandled ) {
-				request.continue();
-			}
+		useRequestInterception( {
+			'google-site-kit/v1/modules/search-console/data/searchanalytics': {
+				status: 200,
+				body: JSON.stringify( [] ),
+			},
+			'google-site-kit/v1/modules/pagespeed-insights/data/pagespeed': {
+				status: 200,
+				body: JSON.stringify( {} ),
+			},
+			'/wp-json/google-site-kit/v1/modules/analytics-4/data/report?': {
+				status: 200,
+				body: JSON.stringify( {} ),
+			},
+			'analytics-4/data/conversion-events': {
+				status: 200,
+				body: JSON.stringify( [] ),
+			},
+			'google-site-kit/v1/modules/analytics-4/data/create-property': {
+				status: 200,
+				body: JSON.stringify( fixtures.createProperty ),
+			},
+			'analytics-4/data/create-webdatastream': {
+				status: 200,
+				body: JSON.stringify( fixtures.createWebDataStream ),
+			},
+			'analytics-4/data/enhanced-measurement-settings': {
+				status: 200,
+				body: JSON.stringify(
+					fixtures.defaultEnhancedMeasurementSettings
+				),
+			},
+			'analytics-4/data/google-tag-settings': {
+				status: 200,
+				body: JSON.stringify( fixtures.googleTagSettings ),
+			},
+			'analytics-4/data/container-lookup': {
+				status: 200,
+				body: JSON.stringify( containerMock ),
+			},
+			'analytics-4/data/property': {
+				status: 200,
+				body: JSON.stringify( fixtures.properties[ 0 ] ),
+			},
+			'analytics-4/data/sync-custom-dimensions': {
+				status: 200,
+				body: '[]',
+			},
+			'google-site-kit/v1/modules/analytics/data/goals': {
+				status: 200,
+				body: JSON.stringify( {} ),
+			},
+			'user/data/audience-settings': {
+				status: 200,
+				body: JSON.stringify( {
+					configuredAudiences: [
+						fixtures.availableAudiences[ 2 ].name,
+					],
+					isAudienceSegmentationWidgetHidden: false,
+				} ),
+			},
+			'analytics-4/data/properties': {
+				status: 200,
+				body: JSON.stringify( fixtures.properties ),
+			},
 		} );
 	} );
 

--- a/tests/e2e/utils/use-request-interception.js
+++ b/tests/e2e/utils/use-request-interception.js
@@ -1,23 +1,51 @@
 /**
  * Adds a request handler for intercepting requests.
  *
- * Used intercept HTTP requests during tests with a custom handler function.
- * Returns a function that, when called, stops further request
- * handling/interception.
+ * Used intercept HTTP requests during tests with either a callback function
+ * or a path:response mapping object.
  *
  * @since 1.0.0
+ * @since n.e.x.t Added support for path:response mapping object to simplify request handling.
  *
- * @param {Function} callback Function to handle requests.
+ * @param {Function|Object} config Either a callback function or a path:response mapping object.
  * @return {Function} Function that can be called to remove the added handler function from the page.
  */
-export function useRequestInterception( callback ) {
+export function useRequestInterception( config ) {
 	const requestHandler = ( request ) => {
 		// Prevent errors for requests that happen after interception is disabled.
 		if ( ! request._allowInterception ) {
 			return;
 		}
 
-		callback( request );
+		// If config is a function, use the original callback pattern.
+		if ( typeof config === 'function' ) {
+			config( request );
+			return;
+		}
+
+		// Find matching path pattern.
+		const matchingPath = Object.keys( config ).find( ( pattern ) =>
+			request.url().match( pattern )
+		);
+
+		if ( matchingPath ) {
+			const response = config[ matchingPath ];
+
+			// Handle different response types.
+			if ( typeof response === 'function' ) {
+				// If response is a function, call it with the request.
+				response( request );
+			} else if ( response && typeof response === 'object' ) {
+				// If response is an object, use it directly.
+				request.respond( response );
+			} else {
+				// If response is invalid, continue the request.
+				request.continue();
+			}
+		} else {
+			// No matching path, continue the request.
+			request.continue();
+		}
 	};
 
 	page.on( 'request', requestHandler );


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #10371 

## Relevant technical choices

<!-- Please describe your changes. -->

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [x] Run the code.
- [x] Ensure the acceptance criteria are satisfied.
- [x] Reassess the implementation with the IB.
- [x] Ensure no unrelated changes are included.
- [x] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [x] Ensure there is a QA Brief.
- [x] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [x] Ensure the PR has the correct target branch.
- [x] Double-check that the PR is okay to be merged.
- [x] Ensure the corresponding issue has a ZenHub release assigned.
- [x] Add a changelog message to the issue.
