### PR TITLE
Fix block editor error caused by RRM

### DIFF
--- a/includes/Modules/Reader_Revenue_Manager.php
+++ b/includes/Modules/Reader_Revenue_Manager.php
@@ -539,6 +539,7 @@ final class Reader_Revenue_Manager extends Module implements Module_With_Scopes,
 				array(
 					'src'           => $base_url . 'js/blocks/reader-revenue-manager/block-editor-plugin/index.js',
 					'dependencies'  => array(
+						'googlesitekit-components',
 						'googlesitekit-data',
 						'googlesitekit-i18n',
 						'googlesitekit-modules',
@@ -563,6 +564,7 @@ final class Reader_Revenue_Manager extends Module implements Module_With_Scopes,
 				array(
 					'src'           => $base_url . 'js/blocks/reader-revenue-manager/contribute-with-google/index.js',
 					'dependencies'  => array(
+						'googlesitekit-components',
 						'googlesitekit-data',
 						'googlesitekit-i18n',
 						'googlesitekit-modules',
@@ -578,6 +580,7 @@ final class Reader_Revenue_Manager extends Module implements Module_With_Scopes,
 				array(
 					'src'           => $base_url . 'js/blocks/reader-revenue-manager/subscribe-with-google/index.js',
 					'dependencies'  => array(
+						'googlesitekit-components',
 						'googlesitekit-data',
 						'googlesitekit-i18n',
 						'googlesitekit-modules',


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #10822 

## Relevant technical choices

This PR adds `googlesitekit-components' as a dependency for RRM scripts enqueued in the block editor, thus getting rid of the reported error.

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.
- [ ] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
