### PR TITLE
Issue / 10548 Restore Focus to Trigger When Closing Various Modal Dialogs

### DIFF
--- a/assets/js/components/ModalDialog.js
+++ b/assets/js/components/ModalDialog.js
@@ -41,6 +41,7 @@ import {
 	SpinnerButton,
 } from 'googlesitekit-components';
 import ExclamationIcon from '../../svg/icons/warning.svg';
+import useDialogEscapeAndScrim from '../hooks/useDialogEscapeAndScrim';
 
 function ModalDialog( {
 	className = '',
@@ -59,10 +60,31 @@ function ModalDialog( {
 	small = false,
 	medium = false,
 	buttonLink = null,
+	refocusQuerySelector = null,
 } ) {
 	const instanceID = useInstanceId( ModalDialog );
 	const describedByID = `googlesitekit-dialog-description-${ instanceID }`;
 	const hasProvides = !! ( provides && provides.length );
+
+	const handleEscapeOrScrim = () => {
+		if ( refocusQuerySelector ) {
+			// Handle onClose as setting key action props on Dialog prevents these from being called.
+			onClose?.();
+			// Refocus the passed querySelector.
+			setTimeout( () => {
+				const element = document.querySelector( refocusQuerySelector );
+				if ( element ) {
+					element.focus();
+				}
+			} );
+		}
+	};
+
+	// Override the escape and scrim click actions if refocusQuerySelector is set.
+	useDialogEscapeAndScrim(
+		handleEscapeOrScrim,
+		dialogActive && refocusQuerySelector
+	);
 
 	return (
 		<Dialog
@@ -75,6 +97,9 @@ function ModalDialog( {
 				'googlesitekit-dialog-sm': small,
 				'googlesitekit-dialog-md': medium,
 			} ) }
+			// Prevent default modal behavior if we are capturing the escape key and scrim click.
+			escapeKeyAction={ refocusQuerySelector ? '' : 'close' }
+			scrimClickAction={ refocusQuerySelector ? '' : 'close' }
 		>
 			<DialogTitle>
 				{ danger && <ExclamationIcon width={ 28 } height={ 28 } /> }
@@ -168,6 +193,7 @@ ModalDialog.propTypes = {
 	small: PropTypes.bool,
 	medium: PropTypes.bool,
 	buttonLink: PropTypes.string,
+	refocusQuerySelector: PropTypes.string,
 };
 
 export default ModalDialog;

--- a/assets/js/components/ModalDialog.test.js
+++ b/assets/js/components/ModalDialog.test.js
@@ -29,6 +29,7 @@ import ModalDialog from './ModalDialog';
 import { Button } from 'googlesitekit-components';
 import { Fragment } from '@wordpress/element';
 import { ESCAPE } from '@wordpress/keycodes';
+import { waitFor } from '@testing-library/react';
 
 describe( 'ConfirmDisableConsentModeDialog', () => {
 	let registry;
@@ -41,7 +42,7 @@ describe( 'ConfirmDisableConsentModeDialog', () => {
 		provideModules( registry );
 	} );
 
-	it( 'should trigger onCancel callback and refocus on the correct element on close.', () => {
+	it( 'should refocus the element assigned to refocusQuerySelector on close.', async () => {
 		let dialogActive = true;
 
 		const handleDialog = jest.fn( () => {
@@ -68,12 +69,14 @@ describe( 'ConfirmDisableConsentModeDialog', () => {
 			}
 		);
 
-		fireEvent.keyDown( container, { key: ESCAPE, keyCode: 27 } );
-
-		const refocusTestButton = container.querySelector(
+		const buttonToSetFocusOn = container.querySelector(
 			'button.refocus-test-button'
 		);
 
-		expect( refocusTestButton ).toHaveFocus();
+		fireEvent.keyDown( container, { key: ESCAPE, keyCode: 27 } );
+
+		await waitFor( () => {
+			expect( buttonToSetFocusOn ).toHaveFocus();
+		} );
 	} );
 } );

--- a/assets/js/components/ModalDialog.test.js
+++ b/assets/js/components/ModalDialog.test.js
@@ -1,0 +1,79 @@
+/**
+ * ModalDialog component tests.
+ *
+ * Site Kit by Google, Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import {
+	createTestRegistry,
+	provideModules,
+	render,
+	fireEvent,
+} from '../../../tests/js/test-utils';
+import ModalDialog from './ModalDialog';
+import { Button } from 'googlesitekit-components';
+import { Fragment } from '@wordpress/element';
+import { ESCAPE } from '@wordpress/keycodes';
+
+describe( 'ConfirmDisableConsentModeDialog', () => {
+	let registry;
+	const onClose = jest.fn();
+	const onHandleConfirm = jest.fn();
+
+	beforeEach( () => {
+		registry = createTestRegistry();
+
+		provideModules( registry );
+	} );
+
+	it( 'should trigger onCancel callback and refocus on the correct element on close.', () => {
+		let dialogActive = true;
+
+		const handleDialog = jest.fn( () => {
+			dialogActive = ! dialogActive;
+		} );
+
+		const { container } = render(
+			<Fragment>
+				<Button className="refocus-test-button">
+					Refocus Test Button
+				</Button>
+
+				<ModalDialog
+					title="Test Dialog"
+					dialogActive={ dialogActive }
+					handleDialog={ handleDialog }
+					handleConfirm={ onHandleConfirm }
+					onClose={ onClose }
+					refocusQuerySelector="button.refocus-test-button"
+				/>
+			</Fragment>,
+			{
+				registry,
+			}
+		);
+
+		fireEvent.keyDown( container, { key: ESCAPE, keyCode: 27 } );
+
+		const refocusTestButton = container.querySelector(
+			'button.refocus-test-button'
+		);
+
+		expect( refocusTestButton ).toHaveFocus();
+	} );
+} );

--- a/assets/js/components/PermissionsModal/AuthenticatedPermissionsModal.js
+++ b/assets/js/components/PermissionsModal/AuthenticatedPermissionsModal.js
@@ -131,6 +131,7 @@ function AuthenticatedPermissionsModal() {
 				handleDialog={ onCancel }
 				onClose={ onCancel }
 				medium
+				refocusQuerySelector=".googlesitekit-setup-module__action > button"
 			/>
 		</Portal>
 	);

--- a/assets/js/components/consent-mode/ConfirmDisableConsentModeDialog.js
+++ b/assets/js/components/consent-mode/ConfirmDisableConsentModeDialog.js
@@ -108,6 +108,7 @@ export default function ConfirmDisableConsentModeDialog( {
 			dependentModules={ dependentModulesText }
 			confirmButton={ __( 'Disable', 'google-site-kit' ) }
 			danger
+			refocusQuerySelector=".googlesitekit-settings-consent-mode .mdc-switch__native-control"
 		/>
 	);
 }

--- a/assets/js/components/conversion-tracking/ConfirmDisableConversionTrackingDialog.js
+++ b/assets/js/components/conversion-tracking/ConfirmDisableConversionTrackingDialog.js
@@ -70,6 +70,7 @@ export default function ConfirmDisableConversionTrackingDialog( {
 			provides={ provides }
 			confirmButton={ __( 'Disable', 'google-site-kit' ) }
 			danger
+			refocusQuerySelector=".googlesitekit-conversion-tracking-toggle .mdc-switch input"
 		/>
 	);
 }

--- a/assets/js/components/conversion-tracking/ConversionTrackingToggle.js
+++ b/assets/js/components/conversion-tracking/ConversionTrackingToggle.js
@@ -49,7 +49,7 @@ export default function ConversionTrackingToggle( { children, loading } ) {
 	const { setConversionTrackingEnabled } = useDispatch( CORE_SITE );
 
 	return (
-		<div>
+		<div className="googlesitekit-conversion-tracking-toggle">
 			<LoadingWrapper loading={ loading } width="180px" height="21.3px">
 				<div className="googlesitekit-module-settings-group__switch">
 					<Switch

--- a/assets/js/components/dashboard-sharing/DashboardSharingDialog/index.js
+++ b/assets/js/components/dashboard-sharing/DashboardSharingDialog/index.js
@@ -19,7 +19,7 @@
 /**
  * External dependencies
  */
-import { useWindowScroll, useKey } from 'react-use';
+import { useWindowScroll } from 'react-use';
 import classnames from 'classnames';
 
 /**
@@ -48,7 +48,7 @@ import {
 	SETTINGS_DIALOG,
 } from '../DashboardSharingSettings/constants';
 import { BREAKPOINT_SMALL, useBreakpoint } from '../../../hooks/useBreakpoint';
-import { ESCAPE } from '@wordpress/keycodes';
+import useDialogEscapeAndScrim from '../../../hooks/useDialogEscapeAndScrim';
 import Portal from '../../Portal';
 import {
 	Dialog,
@@ -63,6 +63,7 @@ import Footer from './Footer';
 export default function DashboardSharingDialog() {
 	const [ shouldFocusResetButton, setShouldFocusResetButton ] =
 		useState( false );
+
 	const breakpoint = useBreakpoint();
 	const { y } = useWindowScroll();
 
@@ -144,29 +145,8 @@ export default function DashboardSharingDialog() {
 		closeSettingsDialog();
 	}, [ closeResetDialog, closeSettingsDialog, resetDialogOpen ] );
 
-	// Handle escape key for reset dialog
-	useKey(
-		( event ) => resetDialogOpen && ESCAPE === event.keyCode,
-		closeResetDialog
-	);
-
-	// Handle clicking on the scrim (outside the dialog)
-	useEffect( () => {
-		const handleScrimClick = ( event ) => {
-			if (
-				resetDialogOpen &&
-				event.target.classList.contains( 'mdc-dialog__scrim' )
-			) {
-				closeResetDialog();
-			}
-		};
-
-		document.addEventListener( 'click', handleScrimClick );
-
-		return () => {
-			document.removeEventListener( 'click', handleScrimClick );
-		};
-	}, [ resetDialogOpen, closeResetDialog ] );
+	// Handle escape key and scrim click for reset dialog.
+	useDialogEscapeAndScrim( closeResetDialog, resetDialogOpen );
 
 	return (
 		<Portal>

--- a/assets/js/components/settings/SettingsActiveModule/ConfirmDisconnect.js
+++ b/assets/js/components/settings/SettingsActiveModule/ConfirmDisconnect.js
@@ -156,6 +156,7 @@ export default function ConfirmDisconnect( { slug } ) {
 			dependentModules={ dependentModulesText }
 			inProgress={ isDeactivating }
 			danger
+			refocusQuerySelector=".googlesitekit-settings-module__footer .googlesitekit-settings-module__remove-button"
 		/>
 	);
 }

--- a/assets/js/hooks/useDialogEscapeAndScrim.js
+++ b/assets/js/hooks/useDialogEscapeAndScrim.js
@@ -1,0 +1,64 @@
+/**
+ * Dialog Escape and Scrim Click hook.
+ *
+ * Site Kit by Google, Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import { useKey } from 'react-use';
+import { useEffect } from '@wordpress/element';
+import { ESCAPE } from '@wordpress/keycodes';
+
+/**
+ * Hook to handle dialog escape key press and scrim click for a MD2 Dialog.
+ *
+ * NOTE: You must set escapeKeyAction and scrimClickAction to an empty string ("") to disable the
+ * default behavior of the Dialog component for these hook events to take precedence.
+ *
+ * @since n.e.x.t
+ *
+ * @param {Function} callback Callback function to execute on escape key press or scrim click.
+ * @param {boolean}  active   Optional. Condition to determine if the callback should be executed. Default true.
+ */
+export default function useDialogEscapeAndScrim( callback, active = true ) {
+	// Handle escape key press.
+	useKey(
+		( event ) => active && ESCAPE === event.keyCode,
+		() => {
+			callback();
+		}
+	);
+
+	// Handle clicking on the scrim (outside the dialog).
+	useEffect( () => {
+		if ( ! active ) {
+			return;
+		}
+
+		const handleScrimClick = ( event ) => {
+			if ( event.target.classList.contains( 'mdc-dialog__scrim' ) ) {
+				callback();
+			}
+		};
+
+		document.addEventListener( 'click', handleScrimClick );
+
+		return () => {
+			document.removeEventListener( 'click', handleScrimClick );
+		};
+	}, [ active, callback ] );
+}

--- a/assets/js/modules/analytics-4/components/audience-segmentation/dashboard/AudienceErrorModal.js
+++ b/assets/js/modules/analytics-4/components/audience-segmentation/dashboard/AudienceErrorModal.js
@@ -184,6 +184,7 @@ export default function AudienceErrorModal( {
 				onClose={ onCancel }
 				danger
 				inProgress={ inProgress }
+				refocusQuerySelector=".googlesitekit-settings-visitor-groups__setup .googlesitekit-cta-link"
 			/>
 		</Portal>
 	);


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #10548

## Relevant technical choices

<!-- Please describe your changes. -->

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [ ] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.
- [ ] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
