### PR TITLE
Ensure key metrics setup appears.

### DIFF
--- a/assets/js/components/KeyMetrics/FullScreenMetricSelectionApp.js
+++ b/assets/js/components/KeyMetrics/FullScreenMetricSelectionApp.js
@@ -78,7 +78,7 @@ export default function FullScreenMetricSelectionApp() {
 	);
 
 	const showSelectionPanel =
-		( hasFinishedGettingInputSettings && isKeyMetricsSetupCompleted ) ||
+		( hasFinishedGettingInputSettings && ! isKeyMetricsSetupCompleted ) ||
 		( ! previousIsKeyMetricsCompleted && isKeyMetricsSetupCompleted );
 
 	useEffect( () => {

--- a/assets/js/components/KeyMetrics/FullScreenMetricSelectionApp.stories.js
+++ b/assets/js/components/KeyMetrics/FullScreenMetricSelectionApp.stories.js
@@ -53,7 +53,7 @@ export default {
 
 			registry.dispatch( CORE_USER ).receiveIsUserInputCompleted( false );
 
-			provideSiteInfo( registry, { keyMetricsSetupCompletedBy: 1 } );
+			provideSiteInfo( registry );
 
 			return (
 				<WithTestRegistry

--- a/assets/js/components/KeyMetrics/FullScreenMetricSelectionApp.test.js
+++ b/assets/js/components/KeyMetrics/FullScreenMetricSelectionApp.test.js
@@ -82,7 +82,7 @@ describe( 'FullScreenMetricSelectionApp', () => {
 	beforeEach( () => {
 		registry = createTestRegistry();
 
-		provideSiteInfo( registry, { keyMetricsSetupCompletedBy: 1 } );
+		provideSiteInfo( registry );
 		provideUserAuthentication( registry );
 		provideUserInfo( registry, { id: 1 } );
 		provideModules( registry, withConnected( MODULE_SLUG_ANALYTICS_4 ) );


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #10721

## Relevant technical choices

Not sure how this happened but this condition should have been checking for `isKeyMetricsSetupCompleted` being false-y, not truthy. 😅

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [x] Run the code.
- [x] Ensure the acceptance criteria are satisfied.
- [x] Reassess the implementation with the IB.
- [x] Ensure no unrelated changes are included.
- [x] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [x] Ensure there is a QA Brief.
- [x] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [x] Ensure the PR has the correct target branch.
- [x] Double-check that the PR is okay to be merged.
- [x] Ensure the corresponding issue has a ZenHub release assigned.
- [x] Add a changelog message to the issue.
