### PR TITLE
Add Storybook story for `EditorButton`

### DIFF
--- a/assets/blocks/reader-revenue-manager/common/EditorButton.stories.js
+++ b/assets/blocks/reader-revenue-manager/common/EditorButton.stories.js
@@ -1,0 +1,48 @@
+/**
+ * EditorButton component Stories.
+ *
+ * Site Kit by Google, Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import EditorButton from './EditorButton';
+
+function Template() {
+	return (
+		<div>
+			<p>
+				<span>Default</span>
+				<EditorButton disabled={ false }>
+					Subscribe with Google
+				</EditorButton>
+			</p>
+
+			<p>
+				<span>Disabled</span>
+				<EditorButton disabled>Subscribe with Google</EditorButton>
+			</p>
+		</div>
+	);
+}
+
+export const Default = Template.bind( {} );
+Default.storyName = 'EditorButton';
+Default.scenario = {};
+
+export default {
+	title: 'Blocks/Reader Revenue Manager/EditorButton',
+};

--- a/storybook/assets/sass/blocks.scss
+++ b/storybook/assets/sass/blocks.scss
@@ -1,0 +1,21 @@
+/**
+ * Import block styles.
+ *
+ * Site Kit by Google, Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@import "../../../assets/blocks/reader-revenue-manager/block-editor-plugin/editor-styles";
+@import "../../../assets/blocks/reader-revenue-manager/common/editor-styles";
+@import "../../../assets/blocks/sign-in-with-google/editor-styles";

--- a/storybook/main.js
+++ b/storybook/main.js
@@ -32,7 +32,10 @@ function vrtHead() {
 }
 
 module.exports = {
-	stories: [ '../assets/js/**/*.stories.js' ],
+	stories: [
+		'../assets/js/**/*.stories.js',
+		'../assets/blocks/**/*.stories.js',
+	],
 	addons: [ '@storybook/addon-viewport', '@storybook/addon-postcss' ],
 	previewHead: ( head ) => {
 		if ( process.env.VRT === '1' ) {

--- a/storybook/preview.js
+++ b/storybook/preview.js
@@ -28,6 +28,7 @@ import '../assets/sass/wpdashboard.scss';
 import '../assets/sass/adminbar.scss';
 import '../assets/sass/admin.scss';
 import './assets/sass/wp-admin.scss';
+import './assets/sass/blocks.scss';
 import './assets/sass/stories/tokens.scss';
 import './assets/sass/stories/type-scale.scss';
 // Ensure all globals are set up before any other imports are run.
@@ -46,12 +47,21 @@ bootstrapFetchMocks();
 
 // Decorators run from last added to first. (Eg. In reverse order as listed.)
 export const decorators = [
-	( Story, { parameters } ) => {
+	( Story, { parameters, kind } ) => {
 		const styles = {};
 
 		const { padding } = parameters || {};
 		if ( padding !== undefined ) {
 			styles.padding = padding;
+		}
+
+		// Render block stories in non-Site Kit context.
+		if ( kind.startsWith( 'Blocks/' ) ) {
+			return (
+				<Grid style={ styles }>
+					<Story />
+				</Grid>
+			);
 		}
 
 		return (


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #10751 

## Relevant technical choices

This PR configures Storybook for the block editor, and adds a story for the `EditorButton` component.

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.
- [ ] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
