### PR TITLE
Replace Finite Timeouts in E2E Tests with Page.waitForNetworkIdle.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-	"name": "google-site-kit",
+	"name": "site-kit-wp",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-	"name": "site-kit-wp",
+	"name": "google-site-kit",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {

--- a/tests/e2e/specs/modules/analytics/setup-proxy-no-account-no-tag.test.js
+++ b/tests/e2e/specs/modules/analytics/setup-proxy-no-account-no-tag.test.js
@@ -33,7 +33,6 @@ import {
 	resetSiteKit,
 	useRequestInterception,
 	setSearchConsoleProperty,
-	pageWait,
 } from '../../../utils';
 
 describe( 'setting up the Analytics module with no existing account and no existing tag via proxy', () => {
@@ -100,7 +99,7 @@ describe( 'setting up the Analytics module with no existing account and no exist
 	} );
 
 	it( 'displays account creation form when user has no Analytics account', async () => {
-		await pageWait( 3000 );
+		await page.waitForNetworkIdle();
 		await expect( page ).toMatchElement( '.googlesitekit-heading-4', {
 			text: /Create your Analytics account/i,
 		} );

--- a/tests/e2e/specs/modules/analytics/setup-with-account-no-tag.test.js
+++ b/tests/e2e/specs/modules/analytics/setup-with-account-no-tag.test.js
@@ -34,7 +34,6 @@ import {
 	setSearchConsoleProperty,
 	wpApiFetch,
 	useRequestInterception,
-	pageWait,
 	step,
 } from '../../../utils';
 import * as fixtures from '../../../../../assets/js/modules/analytics-4/datastore/__fixtures__';
@@ -325,7 +324,7 @@ describe( 'setting up the Analytics module with an existing account and no exist
 			} );
 
 			await step( 'wait and click configure button', async () => {
-				await pageWait( 500 );
+				await page.waitForNetworkIdle();
 				await expect( page ).toClick( 'button', {
 					text: /complete setup/i,
 				} );

--- a/tests/e2e/specs/modules/analytics/write-scope-requests.test.js
+++ b/tests/e2e/specs/modules/analytics/write-scope-requests.test.js
@@ -435,6 +435,8 @@ describe( 'Analytics write scope requests', () => {
 
 		// They should end up on the dashboard.
 		await page.waitForNavigation();
+		await page.waitForNetworkIdle();
+
 		await expect( page ).toMatchElement( '.googlesitekit-notice__title', {
 			text: /Congrats on completing the setup for Analytics!/i,
 		} );

--- a/tests/e2e/specs/modules/analytics/write-scope-requests.test.js
+++ b/tests/e2e/specs/modules/analytics/write-scope-requests.test.js
@@ -435,7 +435,7 @@ describe( 'Analytics write scope requests', () => {
 
 		// They should end up on the dashboard.
 		await page.waitForNavigation();
-		await page.waitForNetworkIdle();
+		await page.waitForTimeout( 5000 );
 		await expect( page ).toMatchElement( '.googlesitekit-notice__title', {
 			text: /Congrats on completing the setup for Analytics!/i,
 		} );

--- a/tests/e2e/specs/modules/analytics/write-scope-requests.test.js
+++ b/tests/e2e/specs/modules/analytics/write-scope-requests.test.js
@@ -435,7 +435,7 @@ describe( 'Analytics write scope requests', () => {
 
 		// They should end up on the dashboard.
 		await page.waitForNavigation();
-		await page.waitForTimeout( 5000 );
+		await page.waitForNetworkIdle();
 		await expect( page ).toMatchElement( '.googlesitekit-notice__title', {
 			text: /Congrats on completing the setup for Analytics!/i,
 		} );

--- a/tests/e2e/specs/modules/analytics/write-scope-requests.test.js
+++ b/tests/e2e/specs/modules/analytics/write-scope-requests.test.js
@@ -435,7 +435,9 @@ describe( 'Analytics write scope requests', () => {
 
 		// They should end up on the dashboard.
 		await page.waitForNavigation();
-		await page.waitForNetworkIdle();
+		await page.waitForSelector( '.googlesitekit-notice__title', {
+			timeout: 5000,
+		} );
 
 		await expect( page ).toMatchElement( '.googlesitekit-notice__title', {
 			text: /Congrats on completing the setup for Analytics!/i,

--- a/tests/e2e/specs/modules/analytics/write-scope-requests.test.js
+++ b/tests/e2e/specs/modules/analytics/write-scope-requests.test.js
@@ -35,7 +35,6 @@ import {
 	resetSiteKit,
 	useRequestInterception,
 	setupSiteKit,
-	pageWait,
 	ignorePermissionScopeErrors,
 } from '../../../utils';
 import * as fixtures from '../../../../../assets/js/modules/analytics-4/datastore/__fixtures__';
@@ -317,7 +316,7 @@ describe( 'Analytics write scope requests', () => {
 		await expect( page ).toClick( '.googlesitekit-cta-link', {
 			text: /set up analytics/i,
 		} );
-		await pageWait();
+		await page.waitForNetworkIdle();
 		await page.waitForSelector( '.googlesitekit-setup-module--analytics' );
 		await page.waitForSelector( '.googlesitekit-setup-module__inputs' );
 
@@ -329,7 +328,7 @@ describe( 'Analytics write scope requests', () => {
 			text: /set up a new property/i,
 		} );
 		// Add a brief delay to allow the submit button to become enabled.
-		await pageWait();
+		await page.waitForNetworkIdle();
 
 		// Click on confirm changes button and wait for permissions modal dialog.
 		await expect( page ).toClick( '.mdc-button--raised', {
@@ -436,7 +435,7 @@ describe( 'Analytics write scope requests', () => {
 
 		// They should end up on the dashboard.
 		await page.waitForNavigation();
-		await page.waitForTimeout( 5000 );
+		await page.waitForNetworkIdle();
 		await expect( page ).toMatchElement( '.googlesitekit-notice__title', {
 			text: /Congrats on completing the setup for Analytics!/i,
 		} );

--- a/tests/e2e/specs/modules/analytics/write-scope-requests.test.js
+++ b/tests/e2e/specs/modules/analytics/write-scope-requests.test.js
@@ -435,7 +435,6 @@ describe( 'Analytics write scope requests', () => {
 
 		// They should end up on the dashboard.
 		await page.waitForNavigation();
-		await page.waitForNetworkIdle();
 		await expect( page ).toMatchElement( '.googlesitekit-notice__title', {
 			text: /Congrats on completing the setup for Analytics!/i,
 		} );

--- a/tests/e2e/specs/modules/search-console/dashboard-date-range.test.js
+++ b/tests/e2e/specs/modules/search-console/dashboard-date-range.test.js
@@ -103,7 +103,7 @@ describe( 'date range filtering on dashboard views', () => {
 			switchDateRange( 'last 28 days', 'last 14 days' ),
 		] );
 
-		await pageWait();
+		await page.waitForNetworkIdle();
 		const TOTAL_IMPRESSIONS_14_DAYS = await getTotalImpressions();
 
 		expect( TOTAL_IMPRESSIONS_14_DAYS ).not.toBe(

--- a/tests/e2e/specs/modules/tagmanager/setup.test.js
+++ b/tests/e2e/specs/modules/tagmanager/setup.test.js
@@ -31,7 +31,6 @@ import {
  */
 import {
 	deactivateUtilityPlugins,
-	pageWait,
 	resetSiteKit,
 	setAMPMode,
 	setupSiteKit,
@@ -193,7 +192,7 @@ describe( 'Tag Manager module setup', () => {
 				}
 			);
 
-			await pageWait( 1000 );
+			await page.waitForNetworkIdle();
 			await expect( page ).toClick( 'button', {
 				text: new RegExp( 'complete setup', 'i' ),
 			} );
@@ -287,7 +286,7 @@ describe( 'Tag Manager module setup', () => {
 				}
 			);
 
-			await pageWait( 1000 );
+			await page.waitForNetworkIdle();
 			await expect( page ).toClick( 'button', {
 				text: new RegExp( 'complete setup', 'i' ),
 			} );

--- a/tests/e2e/specs/user-input-questions.test.js
+++ b/tests/e2e/specs/user-input-questions.test.js
@@ -83,10 +83,9 @@ describe( 'User Input Settings', () => {
 					{ text: /complete setup/i }
 				),
 				page.waitForNavigation(),
+				page.waitForNetworkIdle(),
 			] )
 		);
-
-		await pageWait( 600 );
 
 		await step(
 			'wait for a Key Metric tile to successfully appear',

--- a/tests/e2e/specs/user-input-questions.test.js
+++ b/tests/e2e/specs/user-input-questions.test.js
@@ -86,7 +86,7 @@ describe( 'User Input Settings', () => {
 			] )
 		);
 
-		await page.waitForNetworkIdle();
+		await pageWait( 600 );
 
 		await step(
 			'wait for a Key Metric tile to successfully appear',

--- a/tests/e2e/specs/user-input-questions.test.js
+++ b/tests/e2e/specs/user-input-questions.test.js
@@ -86,7 +86,7 @@ describe( 'User Input Settings', () => {
 			] )
 		);
 
-		await pageWait( 600 );
+		await page.waitForNetworkIdle();
 
 		await step(
 			'wait for a Key Metric tile to successfully appear',
@@ -263,8 +263,10 @@ describe( 'User Input Settings', () => {
 		await setSearchConsoleProperty();
 
 		await step( 'visit admin settings', async () => {
-			await visitAdminPage( 'admin.php', 'page=googlesitekit-settings' );
-			await pageWait();
+			await Promise.all( [
+				visitAdminPage( 'admin.php', 'page=googlesitekit-settings' ),
+				page.waitForNetworkIdle(),
+			] );
 			await page.waitForSelector( '.mdc-tab-bar a.mdc-tab' );
 			await expect( page ).toClick( 'a.mdc-tab', {
 				text: /admin settings/i,
@@ -281,7 +283,7 @@ describe( 'User Input Settings', () => {
 			] );
 		} );
 
-		await pageWait();
+		await page.waitForNetworkIdle();
 
 		await fillInInputSettings();
 	} );

--- a/tests/e2e/specs/user-input-questions.test.js
+++ b/tests/e2e/specs/user-input-questions.test.js
@@ -263,10 +263,8 @@ describe( 'User Input Settings', () => {
 		await setSearchConsoleProperty();
 
 		await step( 'visit admin settings', async () => {
-			await Promise.all( [
-				visitAdminPage( 'admin.php', 'page=googlesitekit-settings' ),
-				page.waitForNetworkIdle(),
-			] );
+			await visitAdminPage( 'admin.php', 'page=googlesitekit-settings' );
+			await pageWait();
 			await page.waitForSelector( '.mdc-tab-bar a.mdc-tab' );
 			await expect( page ).toClick( 'a.mdc-tab', {
 				text: /admin settings/i,

--- a/tests/e2e/specs/user-input-questions.test.js
+++ b/tests/e2e/specs/user-input-questions.test.js
@@ -262,8 +262,10 @@ describe( 'User Input Settings', () => {
 		await setSearchConsoleProperty();
 
 		await step( 'visit admin settings', async () => {
-			await visitAdminPage( 'admin.php', 'page=googlesitekit-settings' );
-			await pageWait();
+			await Promise.all( [
+				visitAdminPage( 'admin.php', 'page=googlesitekit-settings' ),
+				page.waitForNetworkIdle(),
+			] );
 			await page.waitForSelector( '.mdc-tab-bar a.mdc-tab' );
 			await expect( page ).toClick( 'a.mdc-tab', {
 				text: /admin settings/i,

--- a/tests/e2e/specs/user-input-questions.test.js
+++ b/tests/e2e/specs/user-input-questions.test.js
@@ -281,7 +281,7 @@ describe( 'User Input Settings', () => {
 			] );
 		} );
 
-		await page.waitForNetworkIdle();
+		await pageWait();
 
 		await fillInInputSettings();
 	} );

--- a/tests/e2e/specs/user-input-questions.test.js
+++ b/tests/e2e/specs/user-input-questions.test.js
@@ -282,7 +282,7 @@ describe( 'User Input Settings', () => {
 			] );
 		} );
 
-		await pageWait();
+		await page.waitForNetworkIdle();
 
 		await fillInInputSettings();
 	} );


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #10639 

## Relevant technical choices

<!-- Please describe your changes. -->

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [x] Run the code.
- [x] Ensure the acceptance criteria are satisfied.
- [x] Reassess the implementation with the IB.
- [x] Ensure no unrelated changes are included.
- [x] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [x] Ensure there is a QA Brief.
- [x] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [x] Ensure the PR has the correct target branch.
- [x] Double-check that the PR is okay to be merged.
- [x] Ensure the corresponding issue has a ZenHub release assigned.
- [x] Add a changelog message to the issue.
