### PR TITLE
Refactor `getNoticeWithModuleAccess` to meet coding standards

### DIFF
--- a/assets/blocks/reader-revenue-manager/common/button-edit-utils.js
+++ b/assets/blocks/reader-revenue-manager/common/button-edit-utils.js
@@ -14,23 +14,22 @@
  * limitations under the License.
  */
 
-/* eslint-disable sitekit/jsdoc-no-unnamed-boolean-params */
-
 /**
  * Gets the notice with module access.
  *
  * @since 1.148.0
  *
- * @param {boolean} hasModuleAccess           Whether the user has module access.
- * @param {string}  withModuleAccessNotice    Notice when the user has module access.
- * @param {string}  withoutModuleAccessNotice Notice when the user does not have module access.
+ * @param {Object}  options                           Options object.
+ * @param {boolean} options.hasModuleAccess           Whether the user has module access.
+ * @param {string}  options.withModuleAccessNotice    Notice when the user has module access.
+ * @param {string}  options.withoutModuleAccessNotice Notice when the user does not have module access.
  * @return {string|null} Notice text. Returns `null` if `hasModuleAccess` is `undefined`.
  */
-function getNoticeWithModuleAccess(
+function getNoticeWithModuleAccess( {
 	hasModuleAccess,
 	withModuleAccessNotice,
-	withoutModuleAccessNotice
-) {
+	withoutModuleAccessNotice,
+} ) {
 	if ( hasModuleAccess === undefined ) {
 		return null;
 	}
@@ -77,11 +76,13 @@ export function getNoticeAndDisabled( {
 	if ( paymentOption !== requiredPaymentOption ) {
 		return {
 			disabled: true,
-			notice: getNoticeWithModuleAccess(
+			notice: getNoticeWithModuleAccess( {
 				hasModuleAccess,
-				invalidPaymentOptionWithModuleAccessNotice,
-				invalidPaymentOptionWithoutModuleAccessNotice
-			),
+				withModuleAccessNotice:
+					invalidPaymentOptionWithModuleAccessNotice,
+				withoutModuleAccessNotice:
+					invalidPaymentOptionWithoutModuleAccessNotice,
+			} ),
 		};
 	}
 
@@ -94,11 +95,11 @@ export function getNoticeAndDisabled( {
 	) {
 		return {
 			disabled: true,
-			notice: getNoticeWithModuleAccess(
+			notice: getNoticeWithModuleAccess( {
 				hasModuleAccess,
-				noSnippetWithModuleAccessNotice,
-				noSnippetWithoutModuleAccessNotice
-			),
+				withModuleAccessNotice: noSnippetWithModuleAccessNotice,
+				withoutModuleAccessNotice: noSnippetWithoutModuleAccessNotice,
+			} ),
 		};
 	}
 


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #10984 

## Relevant technical choices

This PR refactors the `getNoticeWithModuleAccess` function to meet coding standards and remove ESLint suppression.

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [x] Run the code.
- [x] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [x] Ensure there is a QA Brief.
- [x] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [x] Ensure the PR has the correct target branch.
- [x] Double-check that the PR is okay to be merged.
- [x] Ensure the corresponding issue has a ZenHub release assigned.
- [x] Add a changelog message to the issue.
