### PR TITLE
Enhancement/11012 use global is url using https util function

### DIFF
--- a/assets/js/modules/reader-revenue-manager/index.js
+++ b/assets/js/modules/reader-revenue-manager/index.js
@@ -35,7 +35,7 @@ import {
 import { SetupMain } from './components/setup';
 import { SettingsEdit, SettingsView } from './components/settings';
 import ReaderRevenueManagerIcon from '../../../svg/graphics/reader-revenue-manager.svg';
-import { isURLUsingHTTPS } from './utils/validation';
+import { isURLUsingHTTPS } from '../../util/is-url-using-https';
 import {
 	ReaderRevenueManagerSetupCTABanner,
 	RRMSetupSuccessSubtleNotification,

--- a/assets/js/modules/reader-revenue-manager/utils/validation.js
+++ b/assets/js/modules/reader-revenue-manager/utils/validation.js
@@ -56,28 +56,6 @@ export function isValidOnboardingState( onboardingState ) {
 }
 
 /**
- * Checks if a given URL uses HTTPS.
- *
- * @since 1.131.0
- *
- * @param {string} url The URL to check.
- * @return {boolean} True if the URL uses HTTPS, false otherwise.
- */
-export const isURLUsingHTTPS = ( url ) => {
-	try {
-		if ( typeof url !== 'string' || ! url ) {
-			throw new TypeError( `Invalid URL: ${ url }` );
-		}
-
-		const parsedURL = new URL( url );
-		return parsedURL.protocol === 'https:';
-	} catch ( error ) {
-		global.console.warn( 'Invalid URL:', error );
-		return false;
-	}
-};
-
-/**
  * Validates if a value is one of the allowed snippet modes.
  *
  * @since 1.145.0

--- a/assets/js/modules/reader-revenue-manager/utils/validation.test.js
+++ b/assets/js/modules/reader-revenue-manager/utils/validation.test.js
@@ -22,8 +22,8 @@
 import {
 	isValidPublicationID,
 	isValidSnippetMode,
-	isURLUsingHTTPS,
 } from './validation';
+import { isURLUsingHTTPS } from '../../../util/is-url-using-https';
 
 describe( 'utility functions', () => {
 	describe( 'isValidPublicationID', () => {


### PR DESCRIPTION
## Summary


Addresses issue: #11012 


## Relevant technical choices

This PR updates the Reader Revenue Manager (RRM) module to use the global isURLUsingHTTPS utility from assets/js/util/is-url-using-https.js instead of the local definition.

Changes:
- Updated index.js and validation.test.js to import the global util.
- Removed the local implementation of isURLUsingHTTPS from validation.js.
- No functional changes; this is a refactor to improve code reuse and avoid duplication.

No additional test changes were needed since existing test coverage remains valid.

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.
- [ ] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
