### PR TITLE
Keep existing params in admin url

### DIFF
--- a/assets/js/googlesitekit/datastore/site/info.js
+++ b/assets/js/googlesitekit/datastore/site/info.js
@@ -402,10 +402,13 @@ export const selectors = {
 					return adminURL;
 				}
 
-				const baseURL =
-					adminURL[ adminURL.length - 1 ] === '/'
-						? adminURL
-						: `${ adminURL }/`;
+				const url = new URL( adminURL );
+
+				// If the URL does not end with a trailing slash, add one.
+				if ( url.pathname[url.pathname.length] !== '/' ) {
+					url.pathname += '/';
+				}
+
 				let pageArg = page;
 				let phpFile = 'admin.php';
 
@@ -421,10 +424,14 @@ export const selectors = {
 					phpFile = splitPage.shift();
 				}
 
+				// Add file pathname
+				url.pathname += phpFile;
+
 				// Since page should be first query arg, create queryArgs without 'page' to prevent a 'page' in args from overriding it.
 				const { page: extraPage, ...queryArgs } = args; // eslint-disable-line no-unused-vars
 
-				return addQueryArgs( `${ baseURL }${ phpFile }`, {
+				url.searchParams.set
+				return addQueryArgs( url.href, {
 					page: pageArg,
 					...queryArgs,
 				} );

--- a/includes/Core/Assets/Assets.php
+++ b/includes/Core/Assets/Assets.php
@@ -748,7 +748,7 @@ final class Assets {
 		$inline_data = array(
 			'homeURL'           => trailingslashit( $this->context->get_canonical_home_url() ),
 			'referenceSiteURL'  => esc_url_raw( trailingslashit( $site_url ) ),
-			'adminURL'          => esc_url_raw( trailingslashit( admin_url() ) ),
+			'adminURL'          => esc_url_raw( admin_url() ),
 			'assetsURL'         => esc_url_raw( $this->context->url( 'dist/assets/' ) ),
 			'widgetsAdminURL'   => esc_url_raw( $this->get_widgets_admin_url() ),
 			'blogPrefix'        => $wpdb->get_blog_prefix(),


### PR DESCRIPTION
## Summary

Build the admin URL without expecting the base data to be a clean queryless URL. The URL is parsed and the pathname is manipulated to add the `phpFile` that is requested, or the default `admin.php`.

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue: 11115

- #

## Relevant technical choices

<!-- Please describe your changes. -->

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [ ] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.
- [ ] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
