### PR TITLE
Rename the height prop on the ProgressBar component.

### DIFF
--- a/assets/js/components/google-tag-gateway/__snapshots__/GoogleTagGatewayToggle.test.js.snap
+++ b/assets/js/components/google-tag-gateway/__snapshots__/GoogleTagGatewayToggle.test.js.snap
@@ -204,6 +204,7 @@ exports[`GoogleTagGatewayToggle should render in loading state if the server req
     <div
       class="mdc-linear-progress googlesitekit-google-tag-gateway-toggle__progress mdc-linear-progress--indeterminate mdc-linear-progress--small"
       role="progressbar"
+      style="height: 4px;"
     >
       <div
         class="mdc-linear-progress__buffering-dots"

--- a/assets/js/googlesitekit/components-gm2/ProgressBar.js
+++ b/assets/js/googlesitekit/components-gm2/ProgressBar.js
@@ -28,7 +28,6 @@ import {
 	BREAKPOINT_XLARGE,
 	useBreakpoint,
 } from '../../hooks/useBreakpoint';
-import invariant from 'invariant';
 
 export default function ProgressBar( {
 	className,
@@ -36,36 +35,41 @@ export default function ProgressBar( {
 	compress,
 	indeterminate,
 	height,
-	smallHeight,
-	tabletHeight,
-	desktopHeight,
+	verticalSpacing,
+	mobileVerticalSpacing,
+	tabletVerticalSpacing,
+	desktopVerticalSpacing,
 	progress,
 } ) {
 	const breakpoint = useBreakpoint();
 
-	let progressBarHeight = height;
+	let progressBarVerticalSpacing = verticalSpacing;
 
-	if ( BREAKPOINT_SMALL === breakpoint && smallHeight !== undefined ) {
-		progressBarHeight = smallHeight;
+	if (
+		BREAKPOINT_SMALL === breakpoint &&
+		mobileVerticalSpacing !== undefined
+	) {
+		progressBarVerticalSpacing = mobileVerticalSpacing;
 	} else if (
 		BREAKPOINT_TABLET === breakpoint &&
-		tabletHeight !== undefined
+		tabletVerticalSpacing !== undefined
 	) {
-		progressBarHeight = tabletHeight;
+		progressBarVerticalSpacing = tabletVerticalSpacing;
 	} else if (
 		( BREAKPOINT_XLARGE === breakpoint ||
 			BREAKPOINT_DESKTOP === breakpoint ) &&
-		desktopHeight !== undefined
+		desktopVerticalSpacing !== undefined
 	) {
-		progressBarHeight = desktopHeight;
+		progressBarVerticalSpacing = desktopVerticalSpacing;
 	}
 
 	let margin;
 
-	if ( progressBarHeight !== undefined ) {
-		// 4px is the height of the progress bar. Therefore the height must be at least 4px.
-		invariant( progressBarHeight >= 4, 'height must be >= 4.' );
-		margin = Math.round( ( progressBarHeight - 4 ) / 2 );
+	if ( progressBarVerticalSpacing !== undefined ) {
+		margin =
+			progressBarVerticalSpacing === 0
+				? 0
+				: Math.round( progressBarVerticalSpacing / 2 );
 	}
 
 	const transform = progress ? `scaleX(${ progress })` : undefined;
@@ -73,7 +77,11 @@ export default function ProgressBar( {
 	return (
 		<div
 			role="progressbar"
-			style={ { marginTop: margin, marginBottom: margin } }
+			style={ {
+				marginTop: margin,
+				marginBottom: margin,
+				...( height && { height: `${ height }px` } ),
+			} }
 			className={ classnames( 'mdc-linear-progress', className, {
 				'mdc-linear-progress--indeterminate': indeterminate,
 				'mdc-linear-progress--small': small,
@@ -102,9 +110,10 @@ ProgressBar.propTypes = {
 	indeterminate: PropTypes.bool,
 	progress: PropTypes.number,
 	height: PropTypes.number,
-	smallHeight: PropTypes.number,
-	tabletHeight: PropTypes.number,
-	desktopHeight: PropTypes.number,
+	verticalSpacing: PropTypes.number,
+	mobileVerticalSpacing: PropTypes.number,
+	tabletVerticalSpacing: PropTypes.number,
+	desktopVerticalSpacing: PropTypes.number,
 };
 
 ProgressBar.defaultProps = {
@@ -113,4 +122,5 @@ ProgressBar.defaultProps = {
 	compress: false,
 	indeterminate: true,
 	progress: 0,
+	height: 4,
 };

--- a/assets/js/modules/adsense/components/settings/SettingsView.js
+++ b/assets/js/modules/adsense/components/settings/SettingsView.js
@@ -203,7 +203,7 @@ export default function SettingsView() {
 
 			{ adBlockingRecoverySetupStatus?.length > 0 && (
 				<div className="googlesitekit-settings-module__meta-items">
-					{ loading && <ProgressBar height={ 90 } small /> }
+					{ loading && <ProgressBar verticalSpacing={ 86 } small /> }
 					{ ! loading && (
 						<div className="googlesitekit-settings-module__meta-item">
 							<h5 className="googlesitekit-settings-module__meta-item-type">
@@ -260,7 +260,7 @@ export default function SettingsView() {
 
 			{ ! adBlockingRecoverySetupStatus?.length && (
 				<Fragment>
-					{ loading && <ProgressBar height={ 135 } small /> }
+					{ loading && <ProgressBar verticalSpacing={ 131 } small /> }
 					{ ! loading && <AdBlockingRecoverySetupCTANotice /> }
 				</Fragment>
 			) }

--- a/assets/js/modules/analytics-4/components/common/AccountCreate/__snapshots__/index.test.js.snap
+++ b/assets/js/modules/analytics-4/components/common/AccountCreate/__snapshots__/index.test.js.snap
@@ -5,6 +5,7 @@ exports[`AccountCreate renders correctly in a loading state 1`] = `
   <div
     class="mdc-linear-progress mdc-linear-progress--indeterminate"
     role="progressbar"
+    style="height: 4px;"
   >
     <div
       class="mdc-linear-progress__buffering-dots"

--- a/assets/js/modules/analytics-4/components/common/PropertySelect.js
+++ b/assets/js/modules/analytics-4/components/common/PropertySelect.js
@@ -106,7 +106,13 @@ export default function PropertySelect( props ) {
 	if ( ! isValidAccountID( accountID ) ) {
 		return null;
 	} else if ( isLoading ) {
-		return <ProgressBar smallHeight={ 80 } desktopHeight={ 88 } small />;
+		return (
+			<ProgressBar
+				mobileVerticalSpacing={ 76 }
+				desktopVerticalSpacing={ 84 }
+				small
+			/>
+		);
 	}
 
 	const isValidSelection =

--- a/assets/js/modules/analytics-4/components/common/WebDataStreamSelect.js
+++ b/assets/js/modules/analytics-4/components/common/WebDataStreamSelect.js
@@ -111,7 +111,13 @@ export default function WebDataStreamSelect( props ) {
 	if ( ! isValidAccountID( accountID ) ) {
 		return null;
 	} else if ( isLoading ) {
-		return <ProgressBar smallHeight={ 80 } desktopHeight={ 88 } small />;
+		return (
+			<ProgressBar
+				mobileVerticalSpacing={ 76 }
+				desktopVerticalSpacing={ 84 }
+				small
+			/>
+		);
 	}
 
 	const isValidSelection =

--- a/assets/js/modules/analytics-4/components/common/__snapshots__/EnhancedMeasurementSwitch.test.js.snap
+++ b/assets/js/modules/analytics-4/components/common/__snapshots__/EnhancedMeasurementSwitch.test.js.snap
@@ -179,6 +179,7 @@ exports[`EnhancedMeasurementSwitch should render correctly in the loading state 
     <div
       class="mdc-linear-progress googlesitekit-analytics-enable-enhanced-measurement__progress--settings-edit mdc-linear-progress--indeterminate mdc-linear-progress--small"
       role="progressbar"
+      style="height: 4px;"
     >
       <div
         class="mdc-linear-progress__buffering-dots"

--- a/assets/js/modules/analytics-4/components/dashboard/EnhancedMeasurementActivationBanner/ProcessingBanner.js
+++ b/assets/js/modules/analytics-4/components/dashboard/EnhancedMeasurementActivationBanner/ProcessingBanner.js
@@ -79,7 +79,8 @@ export default function ProcessingBanner( { id, Notification, onDismiss } ) {
 					onClick: onDismiss,
 				} }
 				waitingProgress={ {
-					height: 4, // The progress bar height is set to 7px via CSS. This value removes margins within the ProgressBar component.
+					verticalSpacing: 0, // Remove vertical spacing to show the banner flush to the header.
+					height: 7,
 					indeterminate: true,
 				} }
 				helpText={ __(

--- a/assets/js/modules/analytics-4/components/dashboard/EnhancedMeasurementActivationBanner/__snapshots__/index.test.js.snap
+++ b/assets/js/modules/analytics-4/components/dashboard/EnhancedMeasurementActivationBanner/__snapshots__/index.test.js.snap
@@ -8,7 +8,7 @@ exports[`EnhancedMeasurementActivationBanner should render the in progress step 
     <div
       class="mdc-linear-progress googlesitekit-banner__progress-bar mdc-linear-progress--indeterminate"
       role="progressbar"
-      style="margin-top: 0px; margin-bottom: 0px;"
+      style="margin-top: 0px; margin-bottom: 0px; height: 7px;"
     >
       <div
         class="mdc-linear-progress__buffering-dots"

--- a/assets/js/modules/analytics-4/components/settings/__snapshots__/SettingsEnhancedMeasurementSwitch.test.js.snap
+++ b/assets/js/modules/analytics-4/components/settings/__snapshots__/SettingsEnhancedMeasurementSwitch.test.js.snap
@@ -118,6 +118,7 @@ exports[`SettingsEnhancedMeasurementSwitch should render correctly, with the swi
     <div
       class="mdc-linear-progress googlesitekit-analytics-enable-enhanced-measurement__progress--settings-edit mdc-linear-progress--indeterminate mdc-linear-progress--small"
       role="progressbar"
+      style="height: 4px;"
     >
       <div
         class="mdc-linear-progress__buffering-dots"
@@ -176,6 +177,7 @@ exports[`SettingsEnhancedMeasurementSwitch should render correctly, with the swi
     <div
       class="mdc-linear-progress googlesitekit-analytics-enable-enhanced-measurement__progress--settings-edit mdc-linear-progress--indeterminate mdc-linear-progress--small"
       role="progressbar"
+      style="height: 4px;"
     >
       <div
         class="mdc-linear-progress__buffering-dots"
@@ -234,6 +236,7 @@ exports[`SettingsEnhancedMeasurementSwitch should render correctly, with the swi
     <div
       class="mdc-linear-progress googlesitekit-analytics-enable-enhanced-measurement__progress--settings-edit mdc-linear-progress--indeterminate mdc-linear-progress--small"
       role="progressbar"
+      style="height: 4px;"
     >
       <div
         class="mdc-linear-progress__buffering-dots"

--- a/assets/js/modules/reader-revenue-manager/components/common/PublicationSelect.js
+++ b/assets/js/modules/reader-revenue-manager/components/common/PublicationSelect.js
@@ -82,7 +82,13 @@ export default function PublicationSelect( props ) {
 
 	if ( ! publicationsLoaded ) {
 		// Display progress bar while publications are loading.
-		return <ProgressBar smallHeight={ 80 } desktopHeight={ 88 } small />;
+		return (
+			<ProgressBar
+				mobileVerticalSpacing={ 76 }
+				desktopVerticalSpacing={ 84 }
+				small
+			/>
+		);
 	}
 
 	const isValidSelection =

--- a/assets/sass/components/banner/_googlesitekit-banner.scss
+++ b/assets/sass/components/banner/_googlesitekit-banner.scss
@@ -168,8 +168,6 @@
 }
 
 .googlesitekit-banner__progress-bar {
-	height: 7px;
-
 	// Prevent page shift between variants as the progress bar removes 10px padding from the widget context.
 	margin-bottom: 3px;
 


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #10894

## Relevant technical choices

As I simplified the calculation of the vertical spacing to not deduct the progress bar height I adjusted the component props to account for this and keep spacing identical in existing components.

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [ ] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.
- [ ] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
