### PR TITLE
Change action used to register Sign in with Google to fix redirect action.

### DIFF
--- a/includes/Modules/Sign_In_With_Google.php
+++ b/includes/Modules/Sign_In_With_Google.php
@@ -180,7 +180,10 @@ final class Sign_In_With_Google extends Module implements Module_With_Inline_Dat
 
 		// Sign in with Google tag placement logic.
 		add_action( 'template_redirect', array( $this, 'register_tag' ) );
-		add_action( 'login_redirect', array( $this, 'register_tag' ) );
+		// Used to add the tag registration to the login footer in
+		// `/wp-login.php`, which doesn't use the `template_redirect` action
+		// like most WordPress pages.
+		add_action( 'login_init', array( $this, 'register_tag' ) );
 
 		// Check to see if the module is connected before registering the block.
 		if ( $this->is_connected() ) {


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #10027

## Relevant technical choices

Changes the action used to register the SiwG tag on the WordPress Login page so it doesn't remove the redirect value.

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.
- [ ] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
