### PR TITLE
Remove legacy Ads Conversion ID debug field.

### DIFF
--- a/includes/Modules/Analytics_4.php
+++ b/includes/Modules/Analytics_4.php
@@ -585,11 +585,6 @@ final class Analytics_4 extends Module implements Module_With_Inline_Data, Modul
 				'value' => $settings['useSnippet'] ? __( 'Yes', 'google-site-kit' ) : __( 'No', 'google-site-kit' ),
 				'debug' => $settings['useSnippet'] ? 'yes' : 'no',
 			),
-			'analytics_4_ads_conversion_id'           => array(
-				'label' => __( 'Analytics: Ads Conversion ID', 'google-site-kit' ),
-				'value' => $settings['adsConversionID'],
-				'debug' => Debug_Data::redact_debug_value( $settings['adsConversionID'] ),
-			),
 			'analytics_4_available_custom_dimensions' => array(
 				'label' => __( 'Analytics: Available Custom Dimensions', 'google-site-kit' ),
 				'value' => empty( $settings['availableCustomDimensions'] )
@@ -2100,10 +2095,6 @@ final class Analytics_4 extends Module implements Module_With_Inline_Data, Modul
 		if ( ! empty( $custom_dimensions_data ) && $tag instanceof Tag_Interface ) {
 			$tag->set_custom_dimensions( $custom_dimensions_data );
 		}
-
-		$tag->set_ads_conversion_id(
-			$this->get_settings()->get()['adsConversionID']
-		);
 
 		$tag->register();
 	}

--- a/includes/Modules/Analytics_4/AMP_Tag.php
+++ b/includes/Modules/Analytics_4/AMP_Tag.php
@@ -36,14 +36,6 @@ class AMP_Tag extends Module_AMP_Tag implements Tag_Interface, Tag_With_Linker_I
 	private $custom_dimensions;
 
 	/**
-	 * Ads conversion ID.
-	 *
-	 * @since 1.118.0
-	 * @var string
-	 */
-	private $ads_conversion_id;
-
-	/**
 	 * Sets the current home domain.
 	 *
 	 * @since 1.118.0
@@ -54,16 +46,6 @@ class AMP_Tag extends Module_AMP_Tag implements Tag_Interface, Tag_With_Linker_I
 		$this->home_domain = $domain;
 	}
 
-	/**
-	 * Sets the ads conversion ID.
-	 *
-	 * @since 1.32.0
-	 *
-	 * @param string $ads_conversion_id Ads ID.
-	 */
-	public function set_ads_conversion_id( $ads_conversion_id ) {
-		$this->ads_conversion_id = $ads_conversion_id;
-	}
 
 	/**
 	 * Sets custom dimensions data.
@@ -109,12 +91,6 @@ class AMP_Tag extends Module_AMP_Tag implements Tag_Interface, Tag_With_Linker_I
 	 */
 	protected function render() {
 		$config = $this->get_tag_config();
-
-		if ( ! empty( $this->ads_conversion_id ) ) {
-			$config[ $this->ads_conversion_id ] = array(
-				'groups' => 'default',
-			);
-		}
 
 		$gtag_amp_opt = array(
 			'optoutElementId' => '__gaOptOutExtension',

--- a/includes/Modules/Analytics_4/Tag_Interface.php
+++ b/includes/Modules/Analytics_4/Tag_Interface.php
@@ -19,15 +19,6 @@ namespace Google\Site_Kit\Modules\Analytics_4;
  */
 interface Tag_Interface {
 	/**
-	 * Sets the ads conversion ID.
-	 *
-	 * @since 1.118.0
-	 *
-	 * @param string $ads_conversion_id Ads ID.
-	 */
-	public function set_ads_conversion_id( $ads_conversion_id );
-
-	/**
 	 * Sets custom dimensions data.
 	 *
 	 * @since 1.113.0

--- a/includes/Modules/Analytics_4/Web_Tag.php
+++ b/includes/Modules/Analytics_4/Web_Tag.php
@@ -37,14 +37,6 @@ class Web_Tag extends Module_Web_Tag implements Tag_Interface, Tag_With_Linker_I
 	private $custom_dimensions;
 
 	/**
-	 * Ads conversion ID.
-	 *
-	 * @since 1.32.0
-	 * @var string
-	 */
-	private $ads_conversion_id;
-
-	/**
 	 * Sets custom dimensions data.
 	 *
 	 * @since 1.113.0
@@ -64,17 +56,6 @@ class Web_Tag extends Module_Web_Tag implements Tag_Interface, Tag_With_Linker_I
 	 */
 	public function set_home_domain( $domain ) {
 		$this->home_domain = $domain;
-	}
-
-	/**
-	 * Sets the ads conversion ID.
-	 *
-	 * @since 1.32.0
-	 *
-	 * @param string $ads_conversion_id Ads ID.
-	 */
-	public function set_ads_conversion_id( $ads_conversion_id ) {
-		$this->ads_conversion_id = $ads_conversion_id;
 	}
 
 	/**
@@ -144,11 +125,6 @@ class Web_Tag extends Module_Web_Tag implements Tag_Interface, Tag_With_Linker_I
 		}
 
 		$gtag->add_tag( $this->tag_id, $gtag_opt );
-
-		// TODO: Lift this out to the Ads module when it's ready.
-		if ( $this->ads_conversion_id ) {
-			$gtag->add_tag( $this->ads_conversion_id );
-		}
 	}
 
 	/**

--- a/tests/phpunit/integration/Modules/Analytics_4Test.php
+++ b/tests/phpunit/integration/Modules/Analytics_4Test.php
@@ -1322,7 +1322,6 @@ class Analytics_4Test extends TestCase {
 				'analytics_4_measurement_id',
 				'analytics_4_use_snippet',
 				'analytics_4_available_custom_dimensions',
-				'analytics_4_ads_conversion_id',
 				'analytics_4_ads_linked',
 				'analytics_4_ads_linked_last_synced_at',
 				'analytics_4_site_kit_audiences',
@@ -1337,7 +1336,6 @@ class Analytics_4Test extends TestCase {
 		$this->assertEqualSets(
 			array(
 				'analytics_4_account_id',
-				'analytics_4_ads_conversion_id',
 				'analytics_4_available_custom_dimensions',
 				'analytics_4_measurement_id',
 				'analytics_4_property_id',
@@ -1365,7 +1363,6 @@ class Analytics_4Test extends TestCase {
 		$this->assertEqualSets(
 			array(
 				'analytics_4_account_id',
-				'analytics_4_ads_conversion_id',
 				'analytics_4_available_custom_dimensions',
 				'analytics_4_measurement_id',
 				'analytics_4_property_id',


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #

## Relevant technical choices

<!-- Please describe your changes. -->

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [ ] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.
- [ ] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
