### PR TITLE
Scroll to visitor groups with title visible.

### DIFF
--- a/assets/js/components/layout/Layout.js
+++ b/assets/js/components/layout/Layout.js
@@ -51,6 +51,7 @@ class Layout extends Component {
 			relative,
 			rounded = false,
 			transparent = false,
+			...otherProps
 		} = this.props;
 
 		return (
@@ -61,6 +62,7 @@ class Layout extends Component {
 					'googlesitekit-layout--rounded': rounded,
 					'googlesitekit-layout--transparent': transparent,
 				} ) }
+				{ ...otherProps }
 			>
 				{ header && (
 					<LayoutHeader

--- a/assets/js/modules/analytics-4/components/audience-segmentation/settings/SettingsCardVisitorGroups/index.js
+++ b/assets/js/modules/analytics-4/components/audience-segmentation/settings/SettingsCardVisitorGroups/index.js
@@ -95,7 +95,9 @@ export default function SettingsCardVisitorGroups() {
 
 		setTimeout( () => {
 			global.scrollTo( {
-				top: getNavigationalScrollTop( '#visitor-groups', breakpoint ),
+				top:
+					getNavigationalScrollTop( '#visitor-groups', breakpoint ) -
+					20,
 				behavior: 'smooth',
 			} );
 		}, 50 );
@@ -113,16 +115,14 @@ export default function SettingsCardVisitorGroups() {
 
 	return (
 		<Layout
+			id="visitor-groups"
 			className="googlesitekit-settings-meta"
 			title={ __( 'Visitor groups', 'google-site-kit' ) }
 			header
 			fill
 			rounded
 		>
-			<div
-				id="visitor-groups"
-				className="googlesitekit-settings-module googlesitekit-settings-module--active"
-			>
+			<div className="googlesitekit-settings-module googlesitekit-settings-module--active">
 				<Grid>
 					<Row>
 						<Cell size={ 12 }>


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #8875

## Relevant technical choices

After QA, it turned out adding the "visitor-groups" to the wrapping `Layout` component was a better option because it helps scroll to the start of the section and have the section's title visible.

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [x] Run the code.
- [x] Ensure the acceptance criteria are satisfied.
- [x] Reassess the implementation with the IB.
- [x] Ensure no unrelated changes are included.
- [x] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [x] Ensure there is a QA Brief.
- [x] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [x] Ensure the PR has the correct target branch.
- [x] Double-check that the PR is okay to be merged.
- [x] Ensure the corresponding issue has a ZenHub release assigned.
- [x] Add a changelog message to the issue.
