### PR TITLE
Fix font size in admin toolbar.

### DIFF
--- a/assets/sass/components/adminbar/_googlesitekit-adminbar.scss
+++ b/assets/sass/components/adminbar/_googlesitekit-adminbar.scss
@@ -84,6 +84,10 @@
 		.googlesitekit-adminbar__link {
 			display: none;
 		}
+
+		.googlesitekit-data-block__datapoint--resize {
+			font-size: inherit;
+		}
 	}
 
 	// Handle links on mobile.

--- a/assets/sass/components/global/_googlesitekit-data-block.scss
+++ b/assets/sass/components/global/_googlesitekit-data-block.scss
@@ -100,6 +100,10 @@
 		.googlesitekit-wp-dashboard & {
 			font-size: $fs-headline-lg;
 		}
+
+		.googlesitekit-data-block__datapoint--resize {
+			font-size: inherit;
+		}
 	}
 
 	.googlesitekit-data-block__change {

--- a/assets/sass/components/global/_googlesitekit-data-block.scss
+++ b/assets/sass/components/global/_googlesitekit-data-block.scss
@@ -100,10 +100,6 @@
 		.googlesitekit-wp-dashboard & {
 			font-size: $fs-headline-lg;
 		}
-
-		.googlesitekit-data-block__datapoint--resize {
-			font-size: inherit;
-		}
 	}
 
 	.googlesitekit-data-block__change {


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #11041

## Relevant technical choices

The file and classes mentioned in the IB don't seem to target the affected spans, instead they target the label above. In this PR I applied the same CSS but to a different target.

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [x] Run the code.
- [x] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [x] Ensure there is a QA Brief.
- [ ] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [x] Ensure the PR has the correct target branch.
- [x] Double-check that the PR is okay to be merged.
- [x] Ensure the corresponding issue has a ZenHub release assigned.
- [x] Add a changelog message to the issue.
