### PR TITLE
Fix AdminMenuTooltip position responsively.

### DIFF
--- a/assets/js/components/AdminMenuTooltip/AdminMenuTooltip.js
+++ b/assets/js/components/AdminMenuTooltip/AdminMenuTooltip.js
@@ -80,7 +80,7 @@ export function AdminMenuTooltip() {
 	return (
 		<JoyrideTooltip
 			target={ isMobileTablet ? 'body' : defaultTarget }
-			placement={ isMobileTablet ? 'center' : 'auto' }
+			placement={ isMobileTablet ? 'center' : 'right' }
 			className={
 				isMobileTablet
 					? 'googlesitekit-tour-tooltip__modal_step'

--- a/assets/js/components/AdminMenuTooltip/AdminMenuTooltip.js
+++ b/assets/js/components/AdminMenuTooltip/AdminMenuTooltip.js
@@ -82,7 +82,9 @@ export function AdminMenuTooltip() {
 			target={ isMobileTablet ? 'body' : defaultTarget }
 			placement={ isMobileTablet ? 'center' : 'auto' }
 			className={
-				isMobileTablet ? 'googlesitekit-tour-tooltip__modal_step' : ''
+				isMobileTablet
+					? 'googlesitekit-tour-tooltip__modal_step'
+					: 'googlesitekit-tour-tooltip__fixed-settings-tooltip'
 			}
 			disableOverlay={ ! isMobileTablet }
 			slug="ga4-activation-banner-admin-menu-tooltip"

--- a/assets/sass/components/tour-tooltip/_googlesitekit-tour-tooltip.scss
+++ b/assets/sass/components/tour-tooltip/_googlesitekit-tour-tooltip.scss
@@ -188,13 +188,21 @@
 // Fix AdminMenuTooltip jumping on scroll by using fixed positioning.
 #react-joyride-step-0:has(.googlesitekit-tour-tooltip__fixed-settings-tooltip) > div.__floater {
 
-	left: 10px !important;
+	left: 170px !important;
 	position: fixed !important;
-	top: 175px !important;
+	top: 113px !important;
 	transform: none !important;
+}
+.folded {
+	#react-joyride-step-0:has(.googlesitekit-tour-tooltip__fixed-settings-tooltip) > div.__floater {
 
-	@media (min-width: 1145px) {
-		left: 170px !important;
-		top: 65px !important;
+		left: 46px !important;
+		top: 46px !important;
 	}
+}
+
+// Fix the arrow alignment to make it consistent to allow fixed positioning to align reliably.
+#react-joyride-step-0:has(.googlesitekit-tour-tooltip__fixed-settings-tooltip) div.__floater__arrow > span {
+	margin-top: 42px !important;
+	top: 0 !important;
 }

--- a/assets/sass/components/tour-tooltip/_googlesitekit-tour-tooltip.scss
+++ b/assets/sass/components/tour-tooltip/_googlesitekit-tour-tooltip.scss
@@ -193,14 +193,16 @@
 	top: 113px !important;
 	transform: none !important;
 }
-.folded {
-	#react-joyride-step-0:has(.googlesitekit-tour-tooltip__fixed-settings-tooltip) > div.__floater {
-		left: 46px !important;
-		top: 46px !important;
-	}
+
+// !important is required to override Joyride's inline styles.
+.folded #react-joyride-step-0:has(.googlesitekit-tour-tooltip__fixed-settings-tooltip) > div.__floater {
+	left: 46px !important;
+	top: 46px !important;
 }
 
-// Fix the arrow alignment to make it consistent to allow fixed positioning to align reliably.
+// Fix the arrow alignment to make it consistent to allow fixed positioning
+// to align reliably.
+// !important is required to override Joyride's inline styles.
 #react-joyride-step-0:has(.googlesitekit-tour-tooltip__fixed-settings-tooltip) div.__floater__arrow > span {
 	margin-top: 42px !important;
 	top: 0 !important;

--- a/assets/sass/components/tour-tooltip/_googlesitekit-tour-tooltip.scss
+++ b/assets/sass/components/tour-tooltip/_googlesitekit-tour-tooltip.scss
@@ -184,3 +184,17 @@
 		padding: 0 16px;
 	}
 }
+
+// Fix AdminMenuTooltip jumping on scroll by using fixed positioning.
+#react-joyride-step-0:has(.googlesitekit-tour-tooltip__fixed-settings-tooltip) > div.__floater {
+
+	left: 10px !important;
+	position: fixed !important;
+	top: 175px !important;
+	transform: none !important;
+
+	@media (min-width: 1145px) {
+		left: 170px !important;
+		top: 65px !important;
+	}
+}

--- a/assets/sass/components/tour-tooltip/_googlesitekit-tour-tooltip.scss
+++ b/assets/sass/components/tour-tooltip/_googlesitekit-tour-tooltip.scss
@@ -186,8 +186,8 @@
 }
 
 // Fix AdminMenuTooltip jumping on scroll by using fixed positioning.
+// !important is required to override Joyride's inline styles.
 #react-joyride-step-0:has(.googlesitekit-tour-tooltip__fixed-settings-tooltip) > div.__floater {
-
 	left: 170px !important;
 	position: fixed !important;
 	top: 113px !important;
@@ -195,7 +195,6 @@
 }
 .folded {
 	#react-joyride-step-0:has(.googlesitekit-tour-tooltip__fixed-settings-tooltip) > div.__floater {
-
 		left: 46px !important;
 		top: 46px !important;
 	}


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #7321

## Relevant technical choices

<!-- Please describe your changes. -->

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [ ] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.
- [ ] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
