### PR TITLE
Add the ability to pin notifications

### DIFF
--- a/assets/js/googlesitekit/notifications/datastore/notifications.js
+++ b/assets/js/googlesitekit/notifications/datastore/notifications.js
@@ -922,6 +922,19 @@ export const selectors = {
 			return false;
 		}
 	),
+
+	/**
+	 * Gets the ID of the pinned notification for a specific group, if any.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param {Object} state   Data store's state.
+	 * @param {string} groupID The group ID to get the pinned notification ID for.
+	 * @return {(string|undefined)} The ID of the pinned notification, or undefined if none is pinned.
+	 */
+	getPinnedNotificationID: ( state, groupID ) => {
+		return state.pinnedNotification[ groupID ];
+	},
 };
 
 export default {

--- a/assets/js/googlesitekit/notifications/datastore/notifications.js
+++ b/assets/js/googlesitekit/notifications/datastore/notifications.js
@@ -419,6 +419,15 @@ export const actions = {
 				.select( CORE_NOTIFICATIONS )
 				.getNotification( id );
 
+			// Check if the notification is pinned; if so, unpin it.
+			const pinnedNotificationID = registry
+				.select( CORE_NOTIFICATIONS )
+				.getPinnedNotificationID( notification?.groupID );
+
+			if ( pinnedNotificationID === id ) {
+				yield actions.unpinNotification( id, notification.groupID );
+			}
+
 			// Skip persisting notification dismissal in database if the notification is not dismissible.
 			if ( notification.isDismissible !== true ) {
 				return;

--- a/assets/js/googlesitekit/notifications/datastore/notifications.js
+++ b/assets/js/googlesitekit/notifications/datastore/notifications.js
@@ -49,6 +49,7 @@ const DISMISS_NOTIFICATION = 'DISMISS_NOTIFICATION';
 const QUEUE_NOTIFICATION = 'QUEUE_NOTIFICATION';
 const RESET_QUEUE = 'RESET_QUEUE';
 const MARK_NOTIFICATION_SEEN = 'MARK_NOTIFICATION_SEEN';
+const PIN_NOTIFICATION = 'PIN_NOTIFICATION';
 // Controls.
 const POPULATE_QUEUE = 'POPULATE_QUEUE';
 const PERSIST_SEEN_NOTIFICATIONS = 'PERSIST_SEEN_NOTIFICATIONS';
@@ -67,6 +68,7 @@ export const initialState = {
 	seenNotifications: JSON.parse(
 		storage.getItem( NOTIFICATION_SEEN_STORAGE_KEY ) || '{}'
 	),
+	pinnedNotification: {},
 };
 
 export const actions = {
@@ -447,6 +449,35 @@ export const actions = {
 			);
 		}
 	),
+
+	/**
+	 * Pins a notification to the top of its respective queue.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param {string} id      Notification ID to pin.
+	 * @param {string} groupID Group ID the notification belongs to.
+	 * @return {Object} Redux-style action.
+	 */
+	pinNotification: createValidatedAction(
+		( id, groupID ) => {
+			invariant(
+				id,
+				'A notification id is required to pin a notification.'
+			);
+
+			invariant(
+				groupID,
+				'A groupID is required to pin a notification to a specific group.'
+			);
+		},
+		( id, groupID ) => {
+			return {
+				type: PIN_NOTIFICATION,
+				payload: { id, groupID },
+			};
+		}
+	),
 };
 
 export const controls = {
@@ -685,6 +716,14 @@ export const reducer = createReducer( ( state, { type, payload } ) => {
 					1
 				);
 			}
+			break;
+		}
+
+		case PIN_NOTIFICATION: {
+			const { id, groupID } = payload;
+
+			state.pinnedNotification[ groupID ] = id;
+
 			break;
 		}
 

--- a/assets/js/googlesitekit/notifications/datastore/notifications.js
+++ b/assets/js/googlesitekit/notifications/datastore/notifications.js
@@ -50,6 +50,7 @@ const QUEUE_NOTIFICATION = 'QUEUE_NOTIFICATION';
 const RESET_QUEUE = 'RESET_QUEUE';
 const MARK_NOTIFICATION_SEEN = 'MARK_NOTIFICATION_SEEN';
 const PIN_NOTIFICATION = 'PIN_NOTIFICATION';
+const UNPIN_NOTIFICATION = 'UNPIN_NOTIFICATION';
 // Controls.
 const POPULATE_QUEUE = 'POPULATE_QUEUE';
 const PERSIST_SEEN_NOTIFICATIONS = 'PERSIST_SEEN_NOTIFICATIONS';
@@ -478,6 +479,35 @@ export const actions = {
 			};
 		}
 	),
+
+	/**
+	 * Unpins a notification from the top of its respective queue.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param {string} id      Notification ID to unpin.
+	 * @param {string} groupID Group ID the notification belongs to.
+	 * @return {Object} Redux-style action.
+	 */
+	unpinNotification: createValidatedAction(
+		( id, groupID ) => {
+			invariant(
+				id,
+				'A notification id is required to unpin a notification.'
+			);
+
+			invariant(
+				groupID,
+				'A groupID is required to unpin notification from a specific group.'
+			);
+		},
+		( id, groupID ) => {
+			return {
+				type: UNPIN_NOTIFICATION,
+				payload: { id, groupID },
+			};
+		}
+	),
 };
 
 export const controls = {
@@ -723,6 +753,16 @@ export const reducer = createReducer( ( state, { type, payload } ) => {
 			const { id, groupID } = payload;
 
 			state.pinnedNotification[ groupID ] = id;
+
+			break;
+		}
+
+		case UNPIN_NOTIFICATION: {
+			const { id, groupID } = payload;
+
+			if ( state.pinnedNotification[ groupID ] === id ) {
+				delete state.pinnedNotification[ groupID ];
+			}
 
 			break;
 		}


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #10890 

## Relevant technical choices

This PR adds the ability to pin notifications in case they need to appear after a subsequent page load, such as an OAuth flow for continuity.

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.
- [ ] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
