### PR TITLE
Revert "Add googleTagGatewayPhase2 feature flag."

### DIFF
--- a/feature-flags.json
+++ b/feature-flags.json
@@ -1,7 +1,6 @@
 [
 	"adsPax",
 	"googleTagGateway",
-	"googleTagGatewayPhase2",
 	"gtagUserData",
 	"privacySandboxModule",
 	"proactiveUserEngagement",


### PR DESCRIPTION
This reverts commit 2e00a3305343a6929d145eba5c8f1f1fbe2b62d3.

## Summary

We've determined that we don't need this new flag, as we can bump the Site Kit version associated with the `googleTagGateway` flag instead.

Addresses issue:

- #11400 

## Relevant technical choices

<!-- Please describe your changes. -->

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.
- [ ] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
