### PR TITLE
Remove `s` query parameter from GTG src URL for Tag Manager

### DIFF
--- a/includes/Core/Tags/GTag.php
+++ b/includes/Core/Tags/GTag.php
@@ -308,12 +308,13 @@ JS;
 	protected function get_gtg_src( $tag_id ) {
 		$query_args = array(
 			'id' => $tag_id,
+			's'  => '/gtag/js',
 		);
 
-		// Do not add the `s` query arg for Tag Manager tags.
+		// Remove the `s` query arg for Tag Manager tags.
 		// See: https://github.com/google/site-kit-wp/issues/11417#issuecomment-3282223421.
-		if ( ! str_starts_with( $tag_id, 'GTM-' ) ) {
-			$query_args['s'] = '/gtag/js';
+		if ( strpos( $tag_id, 'GTM-' ) === 0 ) {
+			unset( $query_args['s'] );
 		}
 
 		return add_query_arg(


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #11417 

## Relevant technical choices

See https://github.com/google/site-kit-wp/issues/11417#issuecomment-3282223421

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.
- [ ] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
