### PR TITLE
consent mode: standardize user-facing casing to sentence case

### DIFF
--- a/assets/js/components/consent-mode/ConsentModeSetupCTABanner.js
+++ b/assets/js/components/consent-mode/ConsentModeSetupCTABanner.js
@@ -106,10 +106,10 @@ export default function ConsentModeSetupCTABanner( { id, Notification } ) {
 		<Notification gaTrackingEventArgs={ gaTrackingEventArgs }>
 			<SetupCTA
 				notificationID={ id }
-				title={ __(
-					'Enable Consent Mode to preserve tracking for your Ads campaigns',
-					'google-site-kit'
-				) }
+                    title={ __(
+                        'Enable consent mode to preserve tracking for your Ads campaigns',
+                        'google-site-kit'
+                    ) }
 				description={ __(
 					'Consent mode interacts with your Consent Management Platform (CMP) or custom implementation for obtaining visitor consent, such as a cookie consent banner.',
 					'google-site-kit'

--- a/assets/js/components/consent-mode/ConsentModeSwitch.js
+++ b/assets/js/components/consent-mode/ConsentModeSwitch.js
@@ -134,10 +134,10 @@ export default function ConsentModeSwitch( { loading } ) {
 				{ saveError && <ErrorNotice message={ saveError.message } /> }
 				{ ! loading && isConsentModeEnabled && (
 					<p className="googlesitekit-settings-consent-mode-switch__enabled-notice">
-						{ __(
-							'Site Kit added the necessary code to your tag to comply with Consent Mode.',
-							'google-site-kit'
-						) }
+                        { __(
+                            'Site Kit added the necessary code to your tag to comply with consent mode.',
+                            'google-site-kit'
+                        ) }
 					</p>
 				) }
 				{

--- a/assets/js/components/consent-mode/__snapshots__/ConsentModeSetupCTABanner.test.js.snap
+++ b/assets/js/components/consent-mode/__snapshots__/ConsentModeSetupCTABanner.test.js.snap
@@ -26,7 +26,7 @@ exports[`ConsentModeSetupCTABanner should render the banner 1`] = `
                 <p
                   class="googlesitekit-banner__title"
                 >
-                  Enable Consent Mode to preserve tracking for your Ads campaigns
+                  Enable consent mode to preserve tracking for your Ads campaigns
                 </p>
                 <div
                   class="googlesitekit-banner__description"

--- a/assets/js/components/settings/SettingsCardConsentMode.js
+++ b/assets/js/components/settings/SettingsCardConsentMode.js
@@ -98,7 +98,7 @@ export default function SettingsCardConsentMode() {
 
 	return (
 		<Layout
-			title={ __( 'Consent Mode', 'google-site-kit' ) }
+            title={ __( 'Consent mode', 'google-site-kit' ) }
 			badge={
 				isAdsConnected ? (
 					<Badge

--- a/includes/Core/Consent_Mode/Consent_Mode.php
+++ b/includes/Core/Consent_Mode/Consent_Mode.php
@@ -243,7 +243,7 @@ class Consent_Mode {
 
 		// The core Consent Mode code is in assets/js/consent-mode/consent-mode.js.
 		// Only code that passes data from PHP to JS should be in this file.
-		printf( "<!-- %s -->\n", esc_html__( 'Google tag (gtag.js) Consent Mode dataLayer added by Site Kit', 'google-site-kit' ) );
+        printf( "<!-- %s -->\n", esc_html__( 'Google tag (gtag.js) consent mode dataLayer added by Site Kit', 'google-site-kit' ) );
 		BC_Functions::wp_print_inline_script_tag(
 			join(
 				"\n",
@@ -256,7 +256,7 @@ class Consent_Mode {
 			),
 			array( 'id' => 'google_gtagjs-js-consent-mode-data-layer' )
 		);
-		printf( "<!-- %s -->\n", esc_html__( 'End Google tag (gtag.js) Consent Mode dataLayer added by Site Kit', 'google-site-kit' ) );
+        printf( "<!-- %s -->\n", esc_html__( 'End Google tag (gtag.js) consent mode dataLayer added by Site Kit', 'google-site-kit' ) );
 	}
 
 	/**

--- a/includes/Core/Site_Health/Debug_Data.php
+++ b/includes/Core/Site_Health/Debug_Data.php
@@ -606,7 +606,7 @@ class Debug_Data {
 
 		return array(
 			'consent_mode' => array(
-				'label' => __( 'Consent Mode', 'google-site-kit' ),
+                'label' => __( 'Consent mode', 'google-site-kit' ),
 				'value' => 'enabled' === $consent_mode_status ? __( 'Enabled', 'google-site-kit' ) : __( 'Disabled', 'google-site-kit' ),
 				'debug' => $consent_mode_status,
 			),


### PR DESCRIPTION
This standardizes the casing of “consent mode” in user‑facing strings to sentence case/lowercase to align with the style requested.

Changes
- PHP: lower‑case “consent mode” in the injected dataLayer HTML comments (Consent_Mode.php).
- Site Health: change the label to “Consent mode”.
- UI text: update banner title, settings card title, and enabled notice to use “consent mode”.
- Update the corresponding snapshot expectation.

Non‑user‑facing code comments and Storybook titles are left as‑is.

Ref: #11076.
