### PR TITLE
Remove s param from all GTG tag srcs

### DIFF
--- a/includes/Core/Tags/GTag.php
+++ b/includes/Core/Tags/GTag.php
@@ -306,19 +306,9 @@ JS;
 	 * @return string
 	 */
 	protected function get_gtg_src( $tag_id ) {
-		$query_args = array(
-			'id' => $tag_id,
-			's'  => '/gtag/js',
-		);
-
-		// Remove the `s` query arg for Tag Manager tags.
-		// See: https://github.com/google/site-kit-wp/issues/11417#issuecomment-3282223421.
-		if ( strpos( $tag_id, 'GTM-' ) === 0 ) {
-			unset( $query_args['s'] );
-		}
-
 		return add_query_arg(
-			$query_args,
+			'id',
+			$tag_id,
 			plugins_url( 'gtg/measurement.php', GOOGLESITEKIT_PLUGIN_MAIN_FILE )
 		);
 	}

--- a/tests/phpunit/integration/Core/Tags/GTagTest.php
+++ b/tests/phpunit/integration/Core/Tags/GTagTest.php
@@ -117,7 +117,7 @@ class GTagTest extends TestCase {
 						'isGTGHealthy'          => true,
 						'isScriptAccessEnabled' => true,
 					),
-					'expected_src' => plugins_url( 'gtg/measurement.php', GOOGLESITEKIT_PLUGIN_MAIN_FILE ) . '?id=' . static::TEST_TAG_ID_1 . '&#038;s=/gtag/js',
+					'expected_src' => plugins_url( 'gtg/measurement.php', GOOGLESITEKIT_PLUGIN_MAIN_FILE ) . '?id=' . static::TEST_TAG_ID_1,
 				),
 			),
 			'isEnabled false'             => array(


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #11417

## Relevant technical choices

The `s` parameter is no longer needed or preferred for tags loaded with measurement.php (not just excluded for GTM).

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [x] Run the code.
- [x] Ensure the acceptance criteria are satisfied.
- [x] Reassess the implementation with the IB.
- [x] Ensure no unrelated changes are included.
- [x] Ensure CI checks pass.
- [x] Check Storybook where applicable.
- [x] Ensure there is a QA Brief.
- [x] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [x] Ensure the PR has the correct target branch.
- [x] Double-check that the PR is okay to be merged.
- [x] Ensure the corresponding issue has a ZenHub release assigned.
- [x] Add a changelog message to the issue.
