### PR TITLE
Improve OAuth abort experience when setting up RRM

### DIFF
--- a/assets/js/components/notifications/UnsatisfiedScopesAlert/utils.js
+++ b/assets/js/components/notifications/UnsatisfiedScopesAlert/utils.js
@@ -32,6 +32,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import { listFormat } from '@/js/util';
 import { MODULE_SLUG_SEARCH_CONSOLE } from '@/js/modules/search-console/constants';
 import { MODULE_SLUG_ANALYTICS_4 } from '@/js/modules/analytics-4/constants';
+import { MODULE_SLUG_READER_REVENUE_MANAGER } from '@/js/modules/reader-revenue-manager/constants';
 
 const MESSAGE_MULTIPLE = 'multiple';
 const MESSAGE_SINGULAR = 'single';
@@ -56,6 +57,7 @@ export function mapScopesToModuleNames( scopes, modules ) {
 		siteverification: 'site-verification',
 		webmasters: MODULE_SLUG_SEARCH_CONSOLE,
 		analytics: MODULE_SLUG_ANALYTICS_4,
+		subscribewithgoogle: MODULE_SLUG_READER_REVENUE_MANAGER,
 	};
 
 	return (


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #10797 

## Relevant technical choices

This PR improves the user experience when returned to Site Kit after they abort the OAuth flow when setting up RRM.

This updates the `UnsatisfiedScopesAlert` component to correctly detect if scopes were not granted for RRM, and convey the messaging accordingly.

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [x] Run the code.
- [x] Ensure the acceptance criteria are satisfied.
- [x] Reassess the implementation with the IB.
- [x] Ensure no unrelated changes are included.
- [x] Ensure CI checks pass.
- [x] Check Storybook where applicable.
- [x] Ensure there is a QA Brief.
- [x] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [x] Ensure the PR has the correct target branch.
- [x] Double-check that the PR is okay to be merged.
- [x] Ensure the corresponding issue has a ZenHub release assigned.
- [x] Add a changelog message to the issue.
