### PR TITLE
Refactor ResetButton to remove key event listeners.

### DIFF
--- a/assets/js/components/ResetButton.js
+++ b/assets/js/components/ResetButton.js
@@ -27,7 +27,6 @@ import {
 	useEffect,
 	useState,
 } from '@wordpress/element';
-import { ESCAPE } from '@wordpress/keycodes';
 import { useDebounce } from '@/js/hooks/useDebounce';
 
 /**
@@ -72,28 +71,6 @@ function ResetButton( { children } ) {
 			debouncedSetInProgress( false );
 		}
 	}, [ isDoingReset, isNavigatingToPostResetURL, debouncedSetInProgress ] );
-
-	useEffect( () => {
-		function handleCloseModal( event ) {
-			if ( ESCAPE === event.keyCode ) {
-				// Only close the modal if the "Escape" key is pressed.
-				setDialogActive( false );
-			}
-		}
-
-		if ( dialogActive ) {
-			// When the dialogActive changes and it is set to true(has opened), add the event listener.
-			global.addEventListener( 'keyup', handleCloseModal, false );
-		}
-		// Remove the event listener when the dialog is removed; there's no need
-		// to have it attached when it won't be used.
-		return () => {
-			if ( dialogActive ) {
-				// When the dialogActive is true(is open) and its value changes, remove the event listener.
-				global.removeEventListener( 'keyup', handleCloseModal );
-			}
-		};
-	}, [ dialogActive ] );
 
 	const { reset } = useDispatch( CORE_SITE );
 	const { navigateTo } = useDispatch( CORE_LOCATION );


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #11319

## Relevant technical choices

While the original IB outlines a refactor from a `useEffect` + `addEventListener` to using the `useKey` hook, I noticed that the `ModalDialog` component (or rather, the underlying `Dialog` component from `@material/react-dialog`) already handles the Escape key behavior, so there is no need for any special handling in the `ResetButton` component.

Also, it looks like targeting the `keyUp` seems to have no effect as the `ModalDialog` closes on `keyDown`, before our `keyUp` event is triggered.

`UserMenu` also seems to have redundant event listeners that already taken care of by the `ModalDialog` component, so we should create an issue to refactor that once we confirm this is indeed redundant.


## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [x] Run the code.
- [x] Ensure the acceptance criteria are satisfied.
- [x] Reassess the implementation with the IB.
- [x] Ensure no unrelated changes are included.
- [x] Ensure CI checks pass.
- [x] Check Storybook where applicable.
- [x] Ensure there is a QA Brief.
- [x] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [x] Ensure the PR has the correct target branch.
- [x] Double-check that the PR is okay to be merged.
- [x] Ensure the corresponding issue has a ZenHub release assigned.
- [x] Add a changelog message to the issue.
