### PR TITLE
Disable flakey Google Charts VRT tests.

### DIFF
--- a/assets/js/modules/analytics-4/components/dashboard/DashboardAllTrafficWidgetGA4/indexEntityDashboard.stories.js
+++ b/assets/js/modules/analytics-4/components/dashboard/DashboardAllTrafficWidgetGA4/indexEntityDashboard.stories.js
@@ -165,7 +165,11 @@ EntityDashboardLoaded.args = {
 		} );
 	},
 };
-EntityDashboardLoaded.scenario = {};
+// TODO: Restore this test
+// (see: https://github.com/google/site-kit-wp/issues/11619) once the
+// underlying issue with Google Charts in VRT tests is diagnosed + resolved.
+//
+// EntityDashboardLoaded.scenario = {};
 
 export const EntityDashboardLoading = Template.bind( {} );
 EntityDashboardLoading.storyName = 'Loading';
@@ -305,7 +309,11 @@ EntityDashboardOneRowOfData.args = {
 		} );
 	},
 };
-EntityDashboardOneRowOfData.scenario = {};
+// TODO: Restore this test
+// (see: https://github.com/google/site-kit-wp/issues/11619) once the
+// underlying issue with Google Charts in VRT tests is diagnosed + resolved.
+//
+// EntityDashboardOneRowOfData.scenario = {};
 
 export const NoDataInComparisonDateRange = Template.bind( {} );
 NoDataInComparisonDateRange.storyName = 'NoDataInComparisonDateRange';
@@ -318,7 +326,11 @@ NoDataInComparisonDateRange.args = {
 		} );
 	},
 };
-NoDataInComparisonDateRange.scenario = {};
+// TODO: Restore this test
+// (see: https://github.com/google/site-kit-wp/issues/11619) once the
+// underlying issue with Google Charts in VRT tests is diagnosed + resolved.
+//
+// NoDataInComparisonDateRange.scenario = {};
 
 export default {
 	title: 'Modules/Analytics4/Widgets/All Traffic Widget GA4/Entity Dashboard',


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #11620

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.
- [ ] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
