### PR TITLE
Fix Sign in with Google comments tests on multisite.

### DIFF
--- a/includes/Modules/Sign_In_With_Google/Authenticator.php
+++ b/includes/Modules/Sign_In_With_Google/Authenticator.php
@@ -296,8 +296,8 @@ class Authenticator implements Authenticator_Interface {
 	 * @return bool True if registration is open, false otherwise.
 	 */
 	protected function is_registration_open() {
-		// No need to check the multisite settings because it is already incorporated in the following
-		// users_can_register check.
+		// No need to check the multisite settings because it is already
+		// incorporated in the following users_can_register check.
 		// See: https://github.com/WordPress/WordPress/blob/505b7c55f5363d51e7e28d512ce7dcb2d5f45894/wp-includes/ms-default-filters.php#L20.
 		return get_option( 'users_can_register' );
 	}

--- a/tests/phpunit/integration/Modules/Sign_In_With_GoogleTest.php
+++ b/tests/phpunit/integration/Modules/Sign_In_With_GoogleTest.php
@@ -174,13 +174,15 @@ class Sign_In_With_GoogleTest extends TestCase {
 			)
 		);
 		update_site_option( 'users_can_register', true );
+		// Ensure multisite option is also set.
+		add_filter( 'option_users_can_register', '__return_true' );
 
 		// Render the button.
 		ob_start();
 		comment_form( array(), $post_id );
 		$output = ob_get_clean();
 
-		$this->assertStringContainsString( "<div class=\"googlesitekit-sign-in-with-google__frontend-output-button googlesitekit-sign-in-with-google__comments-form-button googlesitekit-sign-in-with-google__comments-form-button-postid-$post_id", $output, 'Button should render when when both open user registration and the Shownext to comments setting are enabled.' );
+		$this->assertStringContainsString( "<div class=\"googlesitekit-sign-in-with-google__frontend-output-button googlesitekit-sign-in-with-google__comments-form-button googlesitekit-sign-in-with-google__comments-form-button-postid-$post_id", $output, 'Button should render when when both open user registration and the Show next to comments setting are enabled.' );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #11478

## Relevant technical choices

Updated tests to use filter for Multisite testing.

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.
- [ ] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
