### PR TITLE
Add migration test to Sign in with Google.

### DIFF
--- a/includes/Core/Util/Migration_1_163_0.php
+++ b/includes/Core/Util/Migration_1_163_0.php
@@ -118,7 +118,13 @@ class Migration_1_163_0 {
 			return;
 		}
 
-		if ( true === $sign_in_with_google_settings['oneTapOnAllPages'] ) {
+		if (
+			array_key_exists(
+				'oneTapOnAllPages',
+				$sign_in_with_google_settings
+			) &&
+			true === $sign_in_with_google_settings['oneTapOnAllPages']
+		) {
 			$sign_in_with_google_settings['oneTapEnabled'] = true;
 		} else {
 			$sign_in_with_google_settings['oneTapEnabled'] = false;

--- a/tests/phpunit/integration/Core/Util/Migration_1_163_0Test.php
+++ b/tests/phpunit/integration/Core/Util/Migration_1_163_0Test.php
@@ -1,0 +1,177 @@
+<?php
+/**
+ * \Google\Site_Kit\Tests\Core\Util\Migration_1_163_0Test
+ *
+ * @package   Google\Site_Kit\Tests\Core\Util
+ * @copyright 2025 Google LLC
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
+ * @link      https://sitekit.withgoogle.com
+ */
+
+namespace Google\Site_Kit\Tests\Core\Util;
+
+use Google\Site_Kit\Context;
+use Google\Site_Kit\Core\Storage\Options;
+use Google\Site_Kit\Core\Util\Migration_1_163_0;
+use Google\Site_Kit\Modules\Sign_In_With_Google\Settings as Sign_In_With_Google_Settings;
+use Google\Site_Kit\Tests\TestCase;
+
+class Migration_1_163_0Test extends TestCase {
+
+	/**
+	 * @var Context
+	 */
+	protected $context;
+
+	/**
+	 * @var Options
+	 */
+	protected $options;
+
+	/**
+	 * @var Sign_In_With_Google_Settings
+	 */
+	protected $sign_in_with_google_settings;
+
+	public function set_up() {
+		parent::set_up();
+
+		$this->context                      = new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE );
+		$this->options                      = new Options( $this->context );
+		$this->sign_in_with_google_settings = new Sign_In_With_Google_Settings( $this->options );
+
+		$this->sign_in_with_google_settings->register();
+		$this->delete_db_version();
+	}
+
+	public function get_new_migration_instance() {
+		return new Migration_1_163_0(
+			$this->context,
+			$this->options
+		);
+	}
+
+	public function test_register() {
+		$migration = $this->get_new_migration_instance();
+		remove_all_actions( 'admin_init' );
+
+		$migration->register();
+
+		$this->assertTrue( has_action( 'admin_init' ), 'Migration should register admin_init action.' );
+	}
+
+	public function test_migrate_one_tap_settings() {
+		$migration = $this->get_new_migration_instance();
+
+		$pre_migration_settings = array(
+			'clientID'         => '1234567890.googleusercontent.com',
+			'text'             => Sign_In_With_Google_Settings::TEXT_CONTINUE_WITH_GOOGLE['value'],
+			'theme'            => Sign_In_With_Google_Settings::THEME_LIGHT['value'],
+			'shape'            => Sign_In_With_Google_Settings::SHAPE_RECTANGULAR['value'],
+			'oneTapEnabled'    => false,
+			'oneTapOnAllPages' => false,
+		);
+
+		$this->sign_in_with_google_settings->set( $pre_migration_settings );
+
+		$migration->migrate();
+
+		$post_migration_settings = $this->sign_in_with_google_settings->get();
+
+		$this->assertArrayNotHasKey( 'oneTapOnAllPages', $post_migration_settings, 'oneTapOnAllPages setting should be removed from Sign in with Google settings.' );
+		$this->assertArrayHasKey( 'oneTapEnabled', $post_migration_settings, 'oneTapEnabled setting should remain in Sign in with Google settings.' );
+		$this->assertArrayHasKey( 'clientID', $post_migration_settings, 'Other (unrelated) settings should remain in Sign in with Google settings.' );
+		$this->assertArrayHasKey( 'shape', $post_migration_settings, 'Other (unrelated) settings should remain in Sign in with Google settings.' );
+	}
+
+	public function test_migrate_one_tap_settings_when_all_are_false() {
+		$migration = $this->get_new_migration_instance();
+
+		$pre_migration_settings = array(
+			'clientID'         => '1234567890.googleusercontent.com',
+			'text'             => Sign_In_With_Google_Settings::TEXT_CONTINUE_WITH_GOOGLE['value'],
+			'theme'            => Sign_In_With_Google_Settings::THEME_LIGHT['value'],
+			'shape'            => Sign_In_With_Google_Settings::SHAPE_RECTANGULAR['value'],
+			'oneTapEnabled'    => false,
+			'oneTapOnAllPages' => false,
+		);
+
+		$this->sign_in_with_google_settings->set( $pre_migration_settings );
+
+		$migration->migrate();
+
+		$post_migration_settings = $this->sign_in_with_google_settings->get();
+
+		$this->assertFalse( $post_migration_settings['oneTapEnabled'], 'One-tap should not be enabled after migration if it was not enabled previously.' );
+	}
+
+	public function test_migrate_one_tap_settings_when_enabled_on_all_pages_was_false() {
+		$migration = $this->get_new_migration_instance();
+
+		$pre_migration_settings = array(
+			'clientID'         => '1234567890.googleusercontent.com',
+			'text'             => Sign_In_With_Google_Settings::TEXT_CONTINUE_WITH_GOOGLE['value'],
+			'theme'            => Sign_In_With_Google_Settings::THEME_LIGHT['value'],
+			'shape'            => Sign_In_With_Google_Settings::SHAPE_RECTANGULAR['value'],
+			'oneTapEnabled'    => true,
+			'oneTapOnAllPages' => false,
+		);
+
+		$this->sign_in_with_google_settings->set( $pre_migration_settings );
+
+		$migration->migrate();
+
+		$post_migration_settings = $this->sign_in_with_google_settings->get();
+
+		$this->assertFalse( $post_migration_settings['oneTapEnabled'], 'One-tap should not be enabled after migration even if enabled previously, because "One-tap on all pages" was not previously enabled.' );
+	}
+
+	public function test_migrate_one_tap_settings_when_enabled_on_all_pages_was_true() {
+		$migration = $this->get_new_migration_instance();
+
+		$pre_migration_settings = array(
+			'clientID'         => '1234567890.googleusercontent.com',
+			'text'             => Sign_In_With_Google_Settings::TEXT_CONTINUE_WITH_GOOGLE['value'],
+			'theme'            => Sign_In_With_Google_Settings::THEME_LIGHT['value'],
+			'shape'            => Sign_In_With_Google_Settings::SHAPE_RECTANGULAR['value'],
+			'oneTapEnabled'    => true,
+			'oneTapOnAllPages' => true,
+		);
+
+		$this->sign_in_with_google_settings->set( $pre_migration_settings );
+
+		$migration->migrate();
+
+		$post_migration_settings = $this->sign_in_with_google_settings->get();
+
+		$this->assertTrue( $post_migration_settings['oneTapEnabled'], 'One-tap should be enabled after migration because "One-tap on all pages" was previously enabled.' );
+	}
+
+	public function test_migrate_one_tap_settings_when_enabled_on_all_pages_not_present() {
+		$migration = $this->get_new_migration_instance();
+
+		$pre_migration_settings = array(
+			'clientID'      => '1234567890.googleusercontent.com',
+			'text'          => Sign_In_With_Google_Settings::TEXT_CONTINUE_WITH_GOOGLE['value'],
+			'theme'         => Sign_In_With_Google_Settings::THEME_LIGHT['value'],
+			'shape'         => Sign_In_With_Google_Settings::SHAPE_RECTANGULAR['value'],
+			'oneTapEnabled' => true,
+		);
+
+		$this->sign_in_with_google_settings->set( $pre_migration_settings );
+
+		$migration->migrate();
+
+		$post_migration_settings = $this->sign_in_with_google_settings->get();
+
+		$this->assertFalse( $post_migration_settings['oneTapEnabled'], 'One-tap should not be enabled after migration because "One-tap on all pages" was not found.' );
+	}
+
+	protected function get_db_version() {
+		return $this->options->get( Migration_1_163_0::DB_VERSION_OPTION );
+	}
+
+	protected function delete_db_version() {
+		$this->options->delete( Migration_1_163_0::DB_VERSION_OPTION );
+	}
+}


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #11596

## Relevant technical choices

Adds a migration test for `1.163.0`, and also adds a check for an (admittedly unlikely) scenario where the `oneTapOnAllPages` array key is entirely missing.

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.
- [ ] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
