### PR TITLE
Group errors based on reconnectURL.

### DIFF
--- a/assets/js/components/ReportError.js
+++ b/assets/js/components/ReportError.js
@@ -94,9 +94,10 @@ export default function ReportError( { moduleSlug, error } ) {
 			...err,
 			message: getMessage( err ),
 			// The `code` parameter contains a session ID which can vary
-			// between requests, so we ignore it when comparing.
+			// between requests, so we ignore it for comparison below.
+			// To use the original `reconnectURL` elsewhere, use `err.data.reconnectURL`.
 			reconnectURL: err.data?.reconnectURL
-				? removeQueryArgs( err.data?.reconnectURL, 'code' )
+				? removeQueryArgs( err.data.reconnectURL, 'code' )
 				: undefined,
 		} ) ),
 		( errorA, errorB ) =>

--- a/assets/js/components/ReportError.test.js
+++ b/assets/js/components/ReportError.test.js
@@ -571,8 +571,8 @@ describe( 'ReportError', () => {
 		expect( invalidateResolutionSpy ).toHaveBeenCalledTimes( 4 );
 	} );
 
-	it( 'it should not list error descriptions with the same `reconnectURL`s', async () => {
-		const { container } = render(
+	it( 'should not list error descriptions with the same `reconnectURL`s', async () => {
+		const { container, waitForRegistry } = render(
 			<ReportError
 				moduleSlug={ moduleName }
 				error={ [
@@ -610,9 +610,18 @@ describe( 'ReportError', () => {
 			}
 		);
 
-		expect( container.querySelectorAll( 'p' ).length ).toBe( 2 );
+		await waitForRegistry();
 
-		await act( waitForDefaultTimeouts );
+		const errorDescriptionElement = container.querySelectorAll(
+			'.googlesitekit-cta__description'
+		);
+
+		// Verify the child element count for the error description element is two.
+		// However, the passed error array has three repetitive error objects.
+		// The second error is not listed because it has the same `message` and `reconnectURL`
+		// as the first one. Note that the `code` query parameter in the `reconnectURL` is
+		// ignored for comparison, as it is expected to be different for each URL.
+		expect( errorDescriptionElement[ 0 ].childElementCount ).toBe( 2 );
 	} );
 
 	it( 'should render `Get help` link without prefix text on non-retryable error', async () => {


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #8970

## Relevant technical choices

<!-- Please describe your changes. -->

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [x] Run the code.
- [x] Ensure the acceptance criteria are satisfied.
- [x] Reassess the implementation with the IB.
- [x] Ensure no unrelated changes are included.
- [x] Ensure CI checks pass.
- [x] Check Storybook where applicable.
- [x] Ensure there is a QA Brief.
- [x] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [x] Ensure the PR has the correct target branch.
- [x] Double-check that the PR is okay to be merged.
- [x] Ensure the corresponding issue has a ZenHub release assigned.
- [x] Add a changelog message to the issue.
