### PR TITLE
Add GHA workflow to test credentials

### DIFF
--- a/.github/workflows/test-credentials.yml
+++ b/.github/workflows/test-credentials.yml
@@ -20,14 +20,16 @@ jobs:
         with:
           credentials_json: ${{ secrets.TEST_GCP_CREDENTIALS }}
       - uses: google-github-actions/setup-gcloud@v2
-      - run: gcloud config get-value project > /dev/null
+      - run: gcloud config get-value project > /dev/null && echo "GCP credentials test succeeded"
 
   test-gh-bot-token:
     name: Test GitHub bot token
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - run: gh api user --jq '.login' --token "${{ secrets.TEST_GH_BOT_TOKEN }}"
+      - run: gh api user --jq '.login'
+        env:
+          GITHUB_TOKEN: ${{ secrets.TEST_GH_BOT_TOKEN }}
 
   test-zenhub-gql-api-token:
     name: Test Zenhub GraphQL API token
@@ -36,8 +38,10 @@ jobs:
     steps:
       - run: |
           curl -X POST https://api.zenhub.com/public/graphql \
-            -H "Authorization: Bearer ${{ secrets.TEST_ZENHUB_GQL_API_TOKEN }}" \
+            -H "Authorization: Bearer $ZENHUB_GQL_API_TOKEN" \
             -H "Content-Type: application/json" \
             -d '{"query": "{ viewer { githubUser { login } } }"}' \
             --fail --silent --show-error
+        env:
+          ZENHUB_GQL_API_TOKEN: ${{ secrets.TEST_ZENHUB_GQL_API_TOKEN }}
 


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #11418 

## Relevant technical choices

This PR adds a GitHub actions workflow to test GCP, GitHub bot token, and ZenHub API credentials on demand.

The following secrets should be added to the repository for this action to work:
- `TEST_GCP_CREDENTIALS`
- `TEST_GH_BOT_TOKEN`
- `TEST_ZENHUB_GQL_API_TOKEN`

Unfortunately, I couldn't test this prior as it uses a `workflow_dispatch` trigger, which can only be triggered once the action is present in the base branch.

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [x] Run the code.
- [x] Ensure the acceptance criteria are satisfied.
- [x] Reassess the implementation with the IB.
- [x] Ensure no unrelated changes are included.
- [x] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [x] Ensure there is a QA Brief.
- [x] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [x] Ensure the PR has the correct target branch.
- [x] Double-check that the PR is okay to be merged.
- [x] Ensure the corresponding issue has a ZenHub release assigned.
- [x] Add a changelog message to the issue.
