### PR TITLE
Fix WC class references in event provider

### DIFF
--- a/includes/Core/Conversion_Tracking/Conversion_Event_Providers/WooCommerce.php
+++ b/includes/Core/Conversion_Tracking/Conversion_Event_Providers/WooCommerce.php
@@ -31,9 +31,9 @@ class WooCommerce extends Conversion_Events_Provider {
 	const CONVERSION_EVENT_PROVIDER_SLUG = 'woocommerce';
 
 	/**
-	 * Avaialble products on the page.
+	 * Available products on the page.
 	 *
-	 * @var Array
+	 * @var array
 	 *
 	 * @since 1.153.0
 	 */
@@ -97,7 +97,7 @@ class WooCommerce extends Conversion_Events_Provider {
 
 		$settings = get_option( 'woocommerce_google_analytics_settings' );
 
-		// If only product identifier is availabe in the saved settings, it means default options are used.
+		// If only product identifier is available in the saved settings, it means default options are used.
 		// And by default all events are tracked.
 		if ( isset( $settings['ga_product_identifier'] ) && count( $settings ) === 1 ) {
 			return array(


### PR DESCRIPTION
## Summary

Don't force `WC_Product` because this might also be called with `WC_Product_Simple` and will cause errors.

Addresses issue:

- #11049

## Relevant technical choices

<!-- Please describe your changes. -->

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [ ] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.
- [ ] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
