### PR TITLE
Remove redundant keyup lisetner in UserMenu.

### DIFF
--- a/assets/js/components/UserMenu/index.js
+++ b/assets/js/components/UserMenu/index.js
@@ -19,7 +19,7 @@
 /**
  * External dependencies
  */
-import { useClickAway, useEvent } from 'react-use';
+import { useClickAway } from 'react-use';
 
 /**
  * WordPress dependencies
@@ -101,18 +101,6 @@ export default function UserMenu() {
 		toggleDialog( false );
 		setMenuOpen( false );
 	}, [ toggleDialog, setMenuOpen ] );
-
-	const handleEscapeKeyPress = useCallback(
-		( e ) => {
-			// Close if Escape key is pressed.
-			if ( ESCAPE === e.keyCode ) {
-				handleClose();
-			}
-		},
-		[ handleClose ]
-	);
-
-	useEvent( 'keyup', handleEscapeKeyPress );
 
 	const { setValue } = useDispatch( CORE_UI );
 	const handleMenu = useCallback( () => {

--- a/assets/js/components/UserMenu/index.test.js
+++ b/assets/js/components/UserMenu/index.test.js
@@ -100,7 +100,7 @@ describe( 'UserMenu', () => {
 		} );
 
 		it( 'should close the menu when escape is pressed', () => {
-			fireEvent.keyUp( document, { keyCode: ESCAPE } );
+			fireEvent.keyDown( menu, { keyCode: ESCAPE } );
 			expect( menu ).toHaveAttribute( 'aria-hidden', 'true' );
 		} );
 


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #11608

## Relevant technical choices

<!-- Please describe your changes. -->

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.
- [ ] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
