### PR TITLE
Remove `rrmPolicyViolations` feature flag

### DIFF
--- a/assets/js/components/settings/SettingsActiveModules.stories.js
+++ b/assets/js/components/settings/SettingsActiveModules.stories.js
@@ -160,9 +160,6 @@ WithRRMActionNeeded.args = {
 			} );
 	},
 };
-WithRRMActionNeeded.parameters = {
-	features: [ 'rrmPolicyViolations' ],
-};
 WithRRMActionNeeded.scenario = {};
 
 export default {

--- a/assets/js/modules/reader-revenue-manager/components/settings/SettingsEdit.stories.js
+++ b/assets/js/modules/reader-revenue-manager/components/settings/SettingsEdit.stories.js
@@ -218,9 +218,6 @@ MissingProductID.args = {
 export const WithPolicyViolationPending = Template.bind( {} );
 WithPolicyViolationPending.storyName = 'With Policy Violation (Pending)';
 WithPolicyViolationPending.scenario = {};
-WithPolicyViolationPending.parameters = {
-	features: [ 'rrmPolicyViolations' ],
-};
 WithPolicyViolationPending.args = {
 	setupRegistry: ( registry ) => {
 		setupPublicationsWithProduct( registry, 0, 'product-b' );
@@ -239,9 +236,6 @@ WithPolicyViolationPending.args = {
 export const WithPolicyViolationActive = Template.bind( {} );
 WithPolicyViolationActive.storyName = 'With Policy Violation (Active)';
 WithPolicyViolationActive.scenario = {};
-WithPolicyViolationActive.parameters = {
-	features: [ 'rrmPolicyViolations' ],
-};
 WithPolicyViolationActive.args = {
 	setupRegistry: ( registry ) => {
 		setupPublicationsWithProduct( registry, 0, 'product-b' );
@@ -259,9 +253,6 @@ WithPolicyViolationActive.args = {
 export const WithPolicyViolationExtreme = Template.bind( {} );
 WithPolicyViolationExtreme.storyName = 'With Policy Violation (Extreme)';
 WithPolicyViolationExtreme.scenario = {};
-WithPolicyViolationExtreme.parameters = {
-	features: [ 'rrmPolicyViolations' ],
-};
 WithPolicyViolationExtreme.args = {
 	setupRegistry: ( registry ) => {
 		setupPublicationsWithProduct( registry, 0, 'product-b' );

--- a/assets/js/modules/reader-revenue-manager/components/settings/SettingsForm.js
+++ b/assets/js/modules/reader-revenue-manager/components/settings/SettingsForm.js
@@ -36,7 +36,6 @@ import {
 	PublicationSelect,
 	SnippetModeSelect,
 } from '@/js/modules/reader-revenue-manager/components/common';
-import { useFeature } from '@/js/hooks/useFeature';
 import ProductIDSettings from './ProductIDSettings';
 import StoreErrorNotices from '@/js/components/StoreErrorNotices';
 import { getProductIDLabel } from '@/js/modules/reader-revenue-manager/utils/settings';
@@ -45,8 +44,6 @@ import ErrorNotice from '@/js/components/ErrorNotice';
 import Typography from '@/js/components/Typography';
 
 export default function SettingsForm( { hasModuleAccess } ) {
-	const rrmPolicyViolationsEnabled = useFeature( 'rrmPolicyViolations' );
-
 	const publicationID = useSelect( ( select ) =>
 		select( MODULES_READER_REVENUE_MANAGER ).getPublicationID()
 	);
@@ -162,11 +159,9 @@ export default function SettingsForm( { hasModuleAccess } ) {
 				{ hasModuleAccess && publicationAvailable && (
 					<PublicationOnboardingStateNotice />
 				) }
-				{ hasModuleAccess &&
-					publicationAvailable &&
-					rrmPolicyViolationsEnabled && (
-						<PolicyViolationSettingsNotice />
-					) }
+				{ hasModuleAccess && publicationAvailable && (
+					<PolicyViolationSettingsNotice />
+				) }
 				{ ! hasModuleAccess && (
 					<Notice
 						className="googlesitekit-moduleaccess-warning-notice"

--- a/assets/js/modules/reader-revenue-manager/components/settings/SettingsView.js
+++ b/assets/js/modules/reader-revenue-manager/components/settings/SettingsView.js
@@ -41,12 +41,9 @@ import {
 	PolicyViolationSettingsNotice,
 	PublicationOnboardingStateNotice,
 } from '@/js/modules/reader-revenue-manager/components/common';
-import { useFeature } from '@/js/hooks/useFeature';
 import Typography from '@/js/components/Typography';
 
 export default function SettingsView() {
-	const rrmPolicyViolationsEnabled = useFeature( 'rrmPolicyViolations' );
-
 	const publicationID = useSelect( ( select ) =>
 		select( MODULES_READER_REVENUE_MANAGER ).getPublicationID()
 	);
@@ -138,9 +135,7 @@ export default function SettingsView() {
 			</div>
 
 			{ hasModuleAccess && <PublicationOnboardingStateNotice /> }
-			{ hasModuleAccess && rrmPolicyViolationsEnabled && (
-				<PolicyViolationSettingsNotice />
-			) }
+			{ hasModuleAccess && <PolicyViolationSettingsNotice /> }
 
 			<div className="googlesitekit-settings-module__meta-items">
 				<div className="googlesitekit-settings-module__meta-item">

--- a/assets/js/modules/reader-revenue-manager/components/settings/SettingsView.stories.js
+++ b/assets/js/modules/reader-revenue-manager/components/settings/SettingsView.stories.js
@@ -113,9 +113,6 @@ WithoutModuleAccess.scenario = {};
 
 export const WithPolicyViolationPending = Template.bind( {} );
 WithPolicyViolationPending.storyName = 'With Policy Violation (Pending)';
-WithPolicyViolationPending.parameters = {
-	features: [ 'rrmPolicyViolations' ],
-};
 WithPolicyViolationPending.args = {
 	contentPolicyState:
 		CONTENT_POLICY_STATES.CONTENT_POLICY_VIOLATION_GRACE_PERIOD,
@@ -124,9 +121,6 @@ WithPolicyViolationPending.scenario = {};
 
 export const WithPolicyViolationActive = Template.bind( {} );
 WithPolicyViolationActive.storyName = 'With Policy Violation (Active)';
-WithPolicyViolationActive.parameters = {
-	features: [ 'rrmPolicyViolations' ],
-};
 WithPolicyViolationActive.args = {
 	contentPolicyState: CONTENT_POLICY_STATES.CONTENT_POLICY_VIOLATION_ACTIVE,
 };
@@ -134,9 +128,6 @@ WithPolicyViolationActive.scenario = {};
 
 export const WithPolicyViolationExtreme = Template.bind( {} );
 WithPolicyViolationExtreme.storyName = 'With Policy Violation (Extreme)';
-WithPolicyViolationExtreme.parameters = {
-	features: [ 'rrmPolicyViolations' ],
-};
 WithPolicyViolationExtreme.args = {
 	contentPolicyState:
 		CONTENT_POLICY_STATES.CONTENT_POLICY_ORGANIZATION_VIOLATION_ACTIVE_IMMEDIATE,

--- a/assets/js/modules/reader-revenue-manager/datastore/base.js
+++ b/assets/js/modules/reader-revenue-manager/datastore/base.js
@@ -23,7 +23,6 @@ import Modules from 'googlesitekit-modules';
 import { MODULES_READER_REVENUE_MANAGER } from './constants';
 import { MODULE_SLUG_READER_REVENUE_MANAGER } from '@/js/modules/reader-revenue-manager/constants';
 import { submitChanges, validateCanSubmitChanges } from './settings';
-import { isFeatureEnabled } from '@/js/features';
 
 export default Modules.createModuleStore( MODULE_SLUG_READER_REVENUE_MANAGER, {
 	storeName: MODULES_READER_REVENUE_MANAGER,
@@ -40,8 +39,6 @@ export default Modules.createModuleStore( MODULE_SLUG_READER_REVENUE_MANAGER, {
 		'productID',
 		'productIDs',
 		'paymentOption',
-		...( isFeatureEnabled( 'rrmPolicyViolations' )
-			? [ 'contentPolicyStatus' ]
-			: [] ),
+		'contentPolicyStatus',
 	],
 } );

--- a/assets/js/modules/reader-revenue-manager/datastore/publications.js
+++ b/assets/js/modules/reader-revenue-manager/datastore/publications.js
@@ -41,7 +41,6 @@ import {
 } from './constants';
 import { MODULE_SLUG_READER_REVENUE_MANAGER } from '@/js/modules/reader-revenue-manager/constants';
 import { actions as errorStoreActions } from '@/js/googlesitekit/data/create-error-store';
-import { isFeatureEnabled } from '@/js/features';
 
 const fetchGetPublicationsStore = createFetchStore( {
 	baseName: 'getPublications',
@@ -281,10 +280,7 @@ const baseActions = {
 
 			settings.productID = 'openaccess';
 
-			if (
-				isFeatureEnabled( 'rrmPolicyViolations' ) &&
-				contentPolicyStatus
-			) {
+			if ( contentPolicyStatus ) {
 				settings.contentPolicyStatus = contentPolicyStatus;
 			}
 

--- a/assets/js/modules/reader-revenue-manager/datastore/publications.test.js
+++ b/assets/js/modules/reader-revenue-manager/datastore/publications.test.js
@@ -34,7 +34,6 @@ import {
 	provideModuleRegistrations,
 	muteFetch,
 } from '../../../../../tests/js/utils';
-import { setEnabledFeatures } from '../../../../../tests/js/test-utils';
 import * as fixtures from './__fixtures__';
 import {
 	MODULES_READER_REVENUE_MANAGER,
@@ -493,8 +492,6 @@ describe( 'modules/reader-revenue-manager publications', () => {
 			} );
 
 			it( 'should set `contentPolicyStatus` in state when provided', () => {
-				setEnabledFeatures( [ 'rrmPolicyViolations' ] );
-
 				const contentPolicyStatus = {
 					contentPolicyState: 'CONTENT_POLICY_VIOLATION_ACTIVE',
 					policyInfoLink: 'https://example.com/policy-info',
@@ -518,8 +515,6 @@ describe( 'modules/reader-revenue-manager publications', () => {
 			} );
 
 			it( 'should not set `contentPolicyStatus` when not provided', () => {
-				setEnabledFeatures( [ 'rrmPolicyViolations' ] );
-
 				registry
 					.dispatch( MODULES_READER_REVENUE_MANAGER )
 					.selectPublication( {

--- a/assets/js/modules/reader-revenue-manager/datastore/settings.js
+++ b/assets/js/modules/reader-revenue-manager/datastore/settings.js
@@ -38,7 +38,6 @@ import {
 	isValidOnboardingState,
 	isValidSnippetMode,
 } from '@/js/modules/reader-revenue-manager/utils/validation';
-import { isFeatureEnabled } from '@/js/features';
 
 // Invariant error messages.
 export const INVARIANT_INVALID_PUBLICATION_ID =
@@ -128,16 +127,14 @@ export function validateCanSubmitChanges( select ) {
 		INVARIANT_INVALID_PAYMENT_OPTION
 	);
 
-	if ( isFeatureEnabled( 'rrmPolicyViolations' ) ) {
-		const contentPolicyStatus = strictSelect(
-			MODULES_READER_REVENUE_MANAGER
-		).getContentPolicyStatus();
+	const contentPolicyStatus = strictSelect(
+		MODULES_READER_REVENUE_MANAGER
+	).getContentPolicyStatus();
 
-		invariant(
-			isPlainObject( contentPolicyStatus ),
-			INVARIANT_INVALID_CONTENT_POLICY_STATUS
-		);
-	}
+	invariant(
+		isPlainObject( contentPolicyStatus ),
+		INVARIANT_INVALID_CONTENT_POLICY_STATUS
+	);
 }
 
 export async function submitChanges( { dispatch, select } ) {

--- a/assets/js/modules/reader-revenue-manager/datastore/settings.test.js
+++ b/assets/js/modules/reader-revenue-manager/datastore/settings.test.js
@@ -20,7 +20,6 @@
  * Internal dependencies
  */
 import { setUsingCache } from 'googlesitekit-api';
-import { enabledFeatures } from '@/js/features';
 import { MODULES_READER_REVENUE_MANAGER } from './constants';
 import {
 	INVARIANT_INVALID_CONTENT_POLICY_STATUS,
@@ -51,6 +50,7 @@ describe( 'modules/reader-revenue-manager settings', () => {
 		productID: 'valid-id',
 		productIDs: [ 'valid' ],
 		paymentOption: 'valid-option',
+		contentPolicyStatus: {},
 	};
 
 	beforeAll( () => {
@@ -61,219 +61,210 @@ describe( 'modules/reader-revenue-manager settings', () => {
 		setUsingCache( true );
 	} );
 
-	describe.each( [ true, false ] )(
-		'validateCanSubmitChanges with rrmPolicyViolations feature flag enabled: %s',
-		( withRRMPolicyViolations ) => {
-			beforeEach( () => {
-				if ( withRRMPolicyViolations ) {
-					enabledFeatures.add( 'rrmPolicyViolations' );
-				}
+	describe( 'validateCanSubmitChanges', () => {
+		beforeEach( () => {
+			createTestRegistry =
+				require( '../../../../../tests/js/utils' ).createTestRegistry;
 
-				createTestRegistry =
-					require( '../../../../../tests/js/utils' ).createTestRegistry;
+			registry = createTestRegistry();
+		} );
 
-				registry = createTestRegistry();
-			} );
+		it( 'should throw invariant error for invalid publication ID of type number', () => {
+			const settings = {
+				...validSettings,
+				publicationID: 12345,
+			};
 
-			it( 'should throw invariant error for invalid publication ID of type number', () => {
-				const settings = {
-					...validSettings,
-					publicationID: 12345,
-				};
+			registry
+				.dispatch( MODULES_READER_REVENUE_MANAGER )
+				.setSettings( settings );
 
-				registry
-					.dispatch( MODULES_READER_REVENUE_MANAGER )
-					.setSettings( settings );
+			expect( () => validateCanSubmitChanges( registry.select ) ).toThrow(
+				INVARIANT_INVALID_PUBLICATION_ID
+			);
+		} );
 
-				expect( () =>
-					validateCanSubmitChanges( registry.select )
-				).toThrow( INVARIANT_INVALID_PUBLICATION_ID );
-			} );
+		it( 'should throw invariant error for invalid publication ID with special chars', () => {
+			const settings = {
+				...validSettings,
+				publicationID: 'ABCD&*12345',
+			};
 
-			it( 'should throw invariant error for invalid publication ID with special chars', () => {
-				const settings = {
-					...validSettings,
-					publicationID: 'ABCD&*12345',
-				};
+			registry
+				.dispatch( MODULES_READER_REVENUE_MANAGER )
+				.setSettings( settings );
 
-				registry
-					.dispatch( MODULES_READER_REVENUE_MANAGER )
-					.setSettings( settings );
+			expect( () => validateCanSubmitChanges( registry.select ) ).toThrow(
+				INVARIANT_INVALID_PUBLICATION_ID
+			);
+		} );
 
-				expect( () =>
-					validateCanSubmitChanges( registry.select )
-				).toThrow( INVARIANT_INVALID_PUBLICATION_ID );
-			} );
+		it( 'should throw invariant error for invalid publication onboarding state', () => {
+			const settings = {
+				...validSettings,
+				publicationOnboardingState: 'invalid_state',
+			};
 
-			it( 'should throw invariant error for invalid publication onboarding state', () => {
-				const settings = {
-					...validSettings,
-					publicationOnboardingState: 'invalid_state',
-				};
+			registry
+				.dispatch( MODULES_READER_REVENUE_MANAGER )
+				.setSettings( settings );
 
-				registry
-					.dispatch( MODULES_READER_REVENUE_MANAGER )
-					.setSettings( settings );
+			expect( () => validateCanSubmitChanges( registry.select ) ).toThrow(
+				INVARIANT_INVALID_PUBLICATION_ONBOARDING_STATE
+			);
+		} );
 
-				expect( () =>
-					validateCanSubmitChanges( registry.select )
-				).toThrow( INVARIANT_INVALID_PUBLICATION_ONBOARDING_STATE );
-			} );
+		it( 'should throw invariant error for invalid snippet mode', () => {
+			const settings = {
+				...validSettings,
+				snippetMode: 'invalid-mode',
+			};
 
-			it( 'should throw invariant error for invalid snippet mode', () => {
-				const settings = {
-					...validSettings,
-					snippetMode: 'invalid-mode',
-				};
+			registry
+				.dispatch( MODULES_READER_REVENUE_MANAGER )
+				.setSettings( settings );
 
-				registry
-					.dispatch( MODULES_READER_REVENUE_MANAGER )
-					.setSettings( settings );
+			expect( () => validateCanSubmitChanges( registry.select ) ).toThrow(
+				INVARIANT_INVALID_SNIPPET_MODE
+			);
+		} );
 
-				expect( () =>
-					validateCanSubmitChanges( registry.select )
-				).toThrow( INVARIANT_INVALID_SNIPPET_MODE );
-			} );
+		it( 'should throw invariant error for invalid post types', () => {
+			const settings = {
+				...validSettings,
+				postTypes: 'not-an-array',
+			};
 
-			it( 'should throw invariant error for invalid post types', () => {
-				const settings = {
-					...validSettings,
-					postTypes: 'not-an-array',
-				};
+			registry
+				.dispatch( MODULES_READER_REVENUE_MANAGER )
+				.setSettings( settings );
 
-				registry
-					.dispatch( MODULES_READER_REVENUE_MANAGER )
-					.setSettings( settings );
+			expect( () => validateCanSubmitChanges( registry.select ) ).toThrow(
+				INVARIANT_INVALID_POST_TYPES
+			);
+		} );
 
-				expect( () =>
-					validateCanSubmitChanges( registry.select )
-				).toThrow( INVARIANT_INVALID_POST_TYPES );
-			} );
+		it( 'should throw invariant error for post types with non-string elements', () => {
+			const settings = {
+				...validSettings,
+				postTypes: [ 'post', 123, true ],
+			};
 
-			it( 'should throw invariant error for post types with non-string elements', () => {
-				const settings = {
-					...validSettings,
-					postTypes: [ 'post', 123, true ],
-				};
+			registry
+				.dispatch( MODULES_READER_REVENUE_MANAGER )
+				.setSettings( settings );
 
-				registry
-					.dispatch( MODULES_READER_REVENUE_MANAGER )
-					.setSettings( settings );
+			expect( () => validateCanSubmitChanges( registry.select ) ).toThrow(
+				INVARIANT_INVALID_POST_TYPES
+			);
+		} );
 
-				expect( () =>
-					validateCanSubmitChanges( registry.select )
-				).toThrow( INVARIANT_INVALID_POST_TYPES );
-			} );
+		it( 'should throw invariant error if at least 1 post type is not selected', () => {
+			const settings = {
+				...validSettings,
+				postTypes: [],
+			};
 
-			it( 'should throw invariant error if at least 1 post type is not selected', () => {
-				const settings = {
-					...validSettings,
-					postTypes: [],
-				};
+			registry
+				.dispatch( MODULES_READER_REVENUE_MANAGER )
+				.setSettings( settings );
 
-				registry
-					.dispatch( MODULES_READER_REVENUE_MANAGER )
-					.setSettings( settings );
+			expect( () => validateCanSubmitChanges( registry.select ) ).toThrow(
+				INVARIANT_INVALID_POST_TYPES
+			);
+		} );
 
-				expect( () =>
-					validateCanSubmitChanges( registry.select )
-				).toThrow( INVARIANT_INVALID_POST_TYPES );
-			} );
+		it( 'should not throw invariant error if no post types are selected and the snippet mode is different', () => {
+			const settings = {
+				...validSettings,
+				postTypes: [],
+				snippetMode: 'per_post',
+			};
 
-			it( 'should not throw invariant error if no post types are selected and the snippet mode is different', () => {
-				const settings = {
-					...validSettings,
-					postTypes: [],
-					snippetMode: 'per_post',
-				};
+			registry
+				.dispatch( MODULES_READER_REVENUE_MANAGER )
+				.setSettings( settings );
 
-				registry
-					.dispatch( MODULES_READER_REVENUE_MANAGER )
-					.setSettings( settings );
+			expect( () =>
+				validateCanSubmitChanges( registry.select )
+			).not.toThrow( INVARIANT_INVALID_POST_TYPES );
+		} );
 
-				expect( () =>
-					validateCanSubmitChanges( registry.select )
-				).not.toThrow( INVARIANT_INVALID_POST_TYPES );
-			} );
+		it( 'should throw invariant error for invalid product ID', () => {
+			const settings = {
+				...validSettings,
+				productID: [ 'not-a-string' ],
+			};
 
-			it( 'should throw invariant error for invalid product ID', () => {
-				const settings = {
-					...validSettings,
-					productID: [ 'not-a-string' ],
-				};
+			registry
+				.dispatch( MODULES_READER_REVENUE_MANAGER )
+				.setSettings( settings );
 
-				registry
-					.dispatch( MODULES_READER_REVENUE_MANAGER )
-					.setSettings( settings );
+			expect( () => validateCanSubmitChanges( registry.select ) ).toThrow(
+				INVARIANT_INVALID_PRODUCT_ID
+			);
+		} );
 
-				expect( () =>
-					validateCanSubmitChanges( registry.select )
-				).toThrow( INVARIANT_INVALID_PRODUCT_ID );
-			} );
+		it( 'should throw invariant error for invalid product IDs', () => {
+			const settings = {
+				...validSettings,
+				productIDs: 'not-an-array',
+			};
 
-			it( 'should throw invariant error for invalid product IDs', () => {
-				const settings = {
-					...validSettings,
-					productIDs: 'not-an-array',
-				};
+			registry
+				.dispatch( MODULES_READER_REVENUE_MANAGER )
+				.setSettings( settings );
 
-				registry
-					.dispatch( MODULES_READER_REVENUE_MANAGER )
-					.setSettings( settings );
+			expect( () => validateCanSubmitChanges( registry.select ) ).toThrow(
+				INVARIANT_INVALID_PRODUCT_IDS
+			);
+		} );
 
-				expect( () =>
-					validateCanSubmitChanges( registry.select )
-				).toThrow( INVARIANT_INVALID_PRODUCT_IDS );
-			} );
+		it( 'should throw invariant error for product IDs with non-string elements', () => {
+			const settings = {
+				...validSettings,
+				productIDs: [ 'valid', 123, true ],
+			};
 
-			it( 'should throw invariant error for product IDs with non-string elements', () => {
-				const settings = {
-					...validSettings,
-					productIDs: [ 'valid', 123, true ],
-				};
+			registry
+				.dispatch( MODULES_READER_REVENUE_MANAGER )
+				.setSettings( settings );
 
-				registry
-					.dispatch( MODULES_READER_REVENUE_MANAGER )
-					.setSettings( settings );
+			expect( () => validateCanSubmitChanges( registry.select ) ).toThrow(
+				INVARIANT_INVALID_PRODUCT_IDS
+			);
+		} );
 
-				expect( () =>
-					validateCanSubmitChanges( registry.select )
-				).toThrow( INVARIANT_INVALID_PRODUCT_IDS );
-			} );
+		it( 'should throw invariant error for invalid payment option', () => {
+			const settings = {
+				...validSettings,
+				paymentOption: [ 'not-a-string' ],
+			};
 
-			it( 'should throw invariant error for invalid payment option', () => {
-				const settings = {
-					...validSettings,
-					paymentOption: [ 'not-a-string' ],
-				};
+			registry
+				.dispatch( MODULES_READER_REVENUE_MANAGER )
+				.setSettings( settings );
 
-				registry
-					.dispatch( MODULES_READER_REVENUE_MANAGER )
-					.setSettings( settings );
+			expect( () => validateCanSubmitChanges( registry.select ) ).toThrow(
+				INVARIANT_INVALID_PAYMENT_OPTION
+			);
+		} );
 
-				expect( () =>
-					validateCanSubmitChanges( registry.select )
-				).toThrow( INVARIANT_INVALID_PAYMENT_OPTION );
-			} );
+		it( 'should throw invariant error for invalid content policy status', () => {
+			const settings = {
+				...validSettings,
+				contentPolicyStatus: 'not-an-object',
+			};
 
-			if ( withRRMPolicyViolations ) {
-				it( 'should throw invariant error for invalid content policy status', () => {
-					const settings = {
-						...validSettings,
-						contentPolicyStatus: 'not-an-object',
-					};
+			registry
+				.dispatch( MODULES_READER_REVENUE_MANAGER )
+				.setSettings( settings );
 
-					registry
-						.dispatch( MODULES_READER_REVENUE_MANAGER )
-						.setSettings( settings );
-
-					expect( () =>
-						validateCanSubmitChanges( registry.select )
-					).toThrow( INVARIANT_INVALID_CONTENT_POLICY_STATUS );
-				} );
-			}
-		}
-	);
+			expect( () => validateCanSubmitChanges( registry.select ) ).toThrow(
+				INVARIANT_INVALID_CONTENT_POLICY_STATUS
+			);
+		} );
+	} );
 
 	describe( 'submitChanges', () => {
 		beforeEach( () => {

--- a/assets/js/modules/reader-revenue-manager/index.js
+++ b/assets/js/modules/reader-revenue-manager/index.js
@@ -74,7 +74,6 @@ import RRMIntroductoryOverlayNotification, {
 	RRM_INTRODUCTORY_OVERLAY_NOTIFICATION,
 } from './components/dashboard/RRMIntroductoryOverlayNotification';
 import { asyncRequireAll } from '@/js/util/async';
-import { isFeatureEnabled } from '@/js/features';
 import { requireModuleConnected } from '@/js/googlesitekit/data-requirements';
 
 export { registerStore } from './datastore';
@@ -100,9 +99,7 @@ export function registerModule( modules ) {
 		storeName: MODULES_READER_REVENUE_MANAGER,
 		SettingsEditComponent: SettingsEdit,
 		SettingsViewComponent: SettingsView,
-		...( isFeatureEnabled( 'rrmPolicyViolations' ) && {
-			SettingsStatusComponent: SettingsStatus,
-		} ),
+		SettingsStatusComponent: SettingsStatus,
 		SetupComponent: SetupMain,
 		Icon: ReaderRevenueManagerIcon,
 		features: [
@@ -368,7 +365,6 @@ export const NOTIFICATIONS = {
 		priority: PRIORITY.ERROR_LOW,
 		areaSlug: NOTIFICATION_AREAS.DASHBOARD_TOP,
 		viewContexts: [ VIEW_CONTEXT_MAIN_DASHBOARD ],
-		featureFlag: 'rrmPolicyViolations',
 		isDismissible: true,
 		checkRequirements: asyncRequireAll(
 			requireModuleConnected( MODULE_SLUG_READER_REVENUE_MANAGER ),
@@ -404,7 +400,6 @@ export const NOTIFICATIONS = {
 		priority: PRIORITY.ERROR_HIGH,
 		areaSlug: NOTIFICATION_AREAS.DASHBOARD_TOP,
 		viewContexts: [ VIEW_CONTEXT_MAIN_DASHBOARD ],
-		featureFlag: 'rrmPolicyViolations',
 		isDismissible: true,
 		checkRequirements: asyncRequireAll(
 			requireModuleConnected( MODULE_SLUG_READER_REVENUE_MANAGER ),

--- a/feature-flags.json
+++ b/feature-flags.json
@@ -3,6 +3,5 @@
 	"gtagUserData",
 	"privacySandboxModule",
 	"proactiveUserEngagement",
-	"rrmPolicyViolations",
 	"setupFlowRefresh"
 ]

--- a/includes/Modules/Reader_Revenue_Manager.php
+++ b/includes/Modules/Reader_Revenue_Manager.php
@@ -45,7 +45,6 @@ use Google\Site_Kit\Core\Tags\Guards\Tag_Verify_Guard;
 use Google\Site_Kit\Core\Tracking\Feature_Metrics_Trait;
 use Google\Site_Kit\Core\Tracking\Provides_Feature_Metrics;
 use Google\Site_Kit\Core\Util\Block_Support;
-use Google\Site_Kit\Core\Util\Feature_Flags;
 use Google\Site_Kit\Core\Util\Method_Proxy_Trait;
 use Google\Site_Kit\Core\Util\URL;
 use Google\Site_Kit\Modules\Reader_Revenue_Manager\Admin_Post_List;
@@ -219,10 +218,8 @@ final class Reader_Revenue_Manager extends Module implements Module_With_Scopes,
 						$dismissed_items->remove( $notification );
 					}
 
-					if ( Feature_Flags::enabled( 'rrmPolicyViolations' ) ) {
-						foreach ( self::POLICY_VIOLATION_NOTIFICATIONS as $notification ) {
-							$dismissed_items->remove( $notification );
-						}
+					foreach ( self::POLICY_VIOLATION_NOTIFICATIONS as $notification ) {
+						$dismissed_items->remove( $notification );
 					}
 				}
 			}
@@ -816,7 +813,7 @@ final class Reader_Revenue_Manager extends Module implements Module_With_Scopes,
 			);
 		}
 
-		if ( Feature_Flags::enabled( 'rrmPolicyViolations' ) && isset( $settings['contentPolicyStatus'] ) ) {
+		if ( isset( $settings['contentPolicyStatus'] ) ) {
 			$content_policy_status = (array) $settings['contentPolicyStatus'];
 			$content_policy_state  = $content_policy_status['contentPolicyState'] ?? '';
 

--- a/includes/Modules/Reader_Revenue_Manager/Settings.php
+++ b/includes/Modules/Reader_Revenue_Manager/Settings.php
@@ -15,7 +15,6 @@ use Google\Site_Kit\Core\Storage\Setting_With_Owned_Keys_Interface;
 use Google\Site_Kit\Core\Storage\Setting_With_Owned_Keys_Trait;
 use Google\Site_Kit\Core\Storage\Setting_With_ViewOnly_Keys_Interface;
 use Google\Site_Kit\Core\Util\BC_Functions;
-use Google\Site_Kit\Core\Util\Feature_Flags;
 use Google\Site_Kit\Core\Util\Method_Proxy_Trait;
 
 /**
@@ -80,11 +79,8 @@ class Settings extends Module_Settings implements Setting_With_Owned_Keys_Interf
 			'snippetMode'                       => 'post_types',
 			'postTypes'                         => array( 'post' ),
 			'productID'                         => 'openaccess',
+			'contentPolicyStatus'               => (object) array(),
 		);
-
-		if ( Feature_Flags::enabled( 'rrmPolicyViolations' ) ) {
-			$defaults['contentPolicyStatus'] = (object) array();
-		}
 
 		return $defaults;
 	}
@@ -189,7 +185,7 @@ class Settings extends Module_Settings implements Setting_With_Owned_Keys_Interf
 				}
 			}
 
-			if ( Feature_Flags::enabled( 'rrmPolicyViolations' ) && isset( $option['contentPolicyStatus'] ) ) {
+			if ( isset( $option['contentPolicyStatus'] ) ) {
 				// If the `contentPolicyStatus` setting is not an associative array, set it to an empty object.
 				if ( ! ( is_array( $option['contentPolicyStatus'] ) && ! BC_Functions::array_is_list( $option['contentPolicyStatus'] ) ) ) {
 					$option['contentPolicyStatus'] = (object) array();

--- a/includes/Modules/Reader_Revenue_Manager/Synchronize_Publication.php
+++ b/includes/Modules/Reader_Revenue_Manager/Synchronize_Publication.php
@@ -12,7 +12,6 @@ namespace Google\Site_Kit\Modules\Reader_Revenue_Manager;
 
 use Google\Site_Kit\Core\Permissions\Permissions;
 use Google\Site_Kit\Core\Storage\User_Options;
-use Google\Site_Kit\Core\Util\Feature_Flags;
 use Google\Site_Kit\Modules\Reader_Revenue_Manager;
 use Google\Site_Kit_Dependencies\Google\Service\SubscribewithGoogle\Publication;
 use Google\Site_Kit_Dependencies\Google\Service\SubscribewithGoogle\PaymentOptions;
@@ -127,12 +126,10 @@ class Synchronize_Publication {
 				'paymentOption'              => $this->get_payment_option( $publication ),
 			);
 
-			if ( Feature_Flags::enabled( 'rrmPolicyViolations' ) ) {
-				$content_policy_status = $publication->getContentPolicyStatus();
+			$content_policy_status = $publication->getContentPolicyStatus();
 
-				if ( $content_policy_status ) {
-					$new_settings['contentPolicyStatus'] = (array) $content_policy_status->toSimpleObject();
-				}
+			if ( $content_policy_status ) {
+				$new_settings['contentPolicyStatus'] = (array) $content_policy_status->toSimpleObject();
 			}
 
 			// Let the client know if the onboarding state has changed.

--- a/tests/phpunit/integration/Modules/Reader_Revenue_Manager/SettingsTest.php
+++ b/tests/phpunit/integration/Modules/Reader_Revenue_Manager/SettingsTest.php
@@ -65,28 +65,6 @@ class SettingsTest extends SettingsTestCase {
 				'productID'                         => 'openaccess',
 				'productIDs'                        => array(),
 				'paymentOption'                     => '',
-			),
-			get_option( Settings::OPTION ),
-			'RRM Settings should match the default values.'
-		);
-	}
-
-	public function test_get_default__with_rrm_policy_violations_enabled() {
-		$this->enable_feature( 'rrmPolicyViolations' );
-
-		$this->settings->register();
-
-		$this->assertEqualSetsWithIndex(
-			array(
-				'ownerID'                           => 0,
-				'publicationID'                     => '',
-				'publicationOnboardingState'        => '',
-				'publicationOnboardingStateChanged' => false,
-				'snippetMode'                       => 'post_types',
-				'postTypes'                         => array( 'post' ),
-				'productID'                         => 'openaccess',
-				'productIDs'                        => array(),
-				'paymentOption'                     => '',
 				'contentPolicyStatus'               => (object) array(),
 			),
 			get_option( Settings::OPTION ),
@@ -150,6 +128,37 @@ class SettingsTest extends SettingsTestCase {
 			'paymentOption with invalid type'              => array( 'paymentOption', array(), '' ),
 			'paymentOption with number'                    => array( 'paymentOption', 123, '' ),
 			'paymentOption with boolean'                   => array( 'paymentOption', true, '' ),
+
+			// Validate contentPolicyStatus.
+			'contentPolicyStatus with populated object'    => array(
+				'contentPolicyStatus',
+				array(
+					'contentPolicyState' => 'CONTENT_POLICY_VIOLATION_GRACE_PERIOD',
+				),
+				array(
+					'contentPolicyState' => 'CONTENT_POLICY_VIOLATION_GRACE_PERIOD',
+				),
+			),
+			'contentPolicyStatus with empty object'        => array(
+				'contentPolicyStatus',
+				(object) array(),
+				(object) array(),
+			),
+			'contentPolicyStatus with empty array'         => array(
+				'contentPolicyStatus',
+				array(),
+				(object) array(),
+			),
+			'contentPolicyStatus with number'              => array(
+				'contentPolicyStatus',
+				123,
+				(object) array(),
+			),
+			'contentPolicyStatus with boolean'             => array(
+				'contentPolicyStatus',
+				true,
+				(object) array(),
+			),
 		);
 	}
 
@@ -157,63 +166,6 @@ class SettingsTest extends SettingsTestCase {
 	 * @dataProvider data_revenue_manager_settings
 	 */
 	public function test_reader_revenue_manager_settings_sanitization( $setting, $value, $expected_value ) {
-		$this->settings->register();
-
-		$options_key = $this->get_option_name();
-		delete_option( $options_key );
-
-		$options             = $this->settings->get();
-		$options[ $setting ] = $value;
-		$this->settings->set( $options );
-		$options = get_option( $options_key );
-		$this->assertEquals( $expected_value, $options[ $setting ], 'RRM Settings sanitization should match expected value.' );
-	}
-
-	public function data_revenue_manager_settings__with_rrm_policy_violations_enabled() {
-		$settings = array_merge(
-			$this->data_revenue_manager_settings(),
-			array(
-				'contentPolicyStatus with populated object' => array(
-					'contentPolicyStatus',
-					array(
-						'contentPolicyState' => 'CONTENT_POLICY_VIOLATION_GRACE_PERIOD',
-					),
-					array(
-						'contentPolicyState' => 'CONTENT_POLICY_VIOLATION_GRACE_PERIOD',
-					),
-				),
-				'contentPolicyStatus with empty object' => array(
-					'contentPolicyStatus',
-					(object) array(),
-					(object) array(),
-				),
-				'contentPolicyStatus with empty array'  => array(
-					'contentPolicyStatus',
-					array(),
-					(object) array(),
-				),
-				'contentPolicyStatus with number'       => array(
-					'contentPolicyStatus',
-					123,
-					(object) array(),
-				),
-				'contentPolicyStatus with boolean'      => array(
-					'contentPolicyStatus',
-					true,
-					(object) array(),
-				),
-			)
-		);
-
-		return $settings;
-	}
-
-	/**
-	 * @dataProvider data_revenue_manager_settings__with_rrm_policy_violations_enabled
-	 */
-	public function test_reader_revenue_manager_settings_sanitization__with_rrm_policy_violations_enabled( $setting, $value, $expected_value ) {
-		$this->enable_feature( 'rrmPolicyViolations' );
-
 		$this->settings->register();
 
 		$options_key = $this->get_option_name();

--- a/tests/phpunit/integration/Modules/Reader_Revenue_Manager/Synchronize_PublicationTest.php
+++ b/tests/phpunit/integration/Modules/Reader_Revenue_Manager/Synchronize_PublicationTest.php
@@ -296,8 +296,6 @@ class Synchronize_PublicationTest extends TestCase {
 	}
 
 	public function test_synchronize_content_policy_status() {
-		$this->enable_feature( 'rrmPolicyViolations' );
-
 		$this->fake_sync_publication();
 
 		$this->assertTrue( $this->reader_revenue_manager->is_connected(), 'Reader Revenue Manager should be connected.' );

--- a/tests/phpunit/integration/Modules/Reader_Revenue_ManagerTest.php
+++ b/tests/phpunit/integration/Modules/Reader_Revenue_ManagerTest.php
@@ -134,8 +134,6 @@ class Reader_Revenue_ManagerTest extends TestCase {
 	}
 
 	public function test_register__reset_policy_violation_notification_dismissals_on_publication_change() {
-		$this->enable_feature( 'rrmPolicyViolations' );
-
 		$this->reader_revenue_manager->register();
 		$this->reader_revenue_manager->get_settings()->register();
 
@@ -737,27 +735,7 @@ class Reader_Revenue_ManagerTest extends TestCase {
 	public function test_get_debug_fields__content_policy_state() {
 		$this->reader_revenue_manager->get_settings()->register();
 
-		// Test that the content policy state field is not included when feature flag is disabled.
-		$this->reader_revenue_manager->get_settings()->set(
-			array(
-				'publicationID'       => 'test-publication-id',
-				'contentPolicyStatus' => array(
-					'contentPolicyState' => 'CONTENT_POLICY_VIOLATION_GRACE_PERIOD',
-				),
-			)
-		);
-
-		$debug_fields = $this->reader_revenue_manager->get_debug_fields();
-		$this->assertArrayNotHasKey(
-			'reader_revenue_manager_content_policy_state',
-			$debug_fields,
-			'Content policy state field should not be included when feature flag is disabled'
-		);
-
-		// Test that the content policy state field is included when feature flag is enabled, even if `contentPolicyStatus` is just the default value.
-		$this->enable_feature( 'rrmPolicyViolations' );
-
-		// Reset settings - `contentPolicyStatus` will be default value when feature flag is enabled.
+		// Test that the content policy state field is included with default contentPolicyStatus.
 		$this->reader_revenue_manager->get_settings()->set(
 			array(
 				'publicationID' => 'test-publication-id',
@@ -768,7 +746,7 @@ class Reader_Revenue_ManagerTest extends TestCase {
 		$this->assertArrayHasKey(
 			'reader_revenue_manager_content_policy_state',
 			$debug_fields,
-			'Content policy state field should be included when feature flag is enabled, even with default contentPolicyStatus'
+			'Content policy state field should be included even with default contentPolicyStatus'
 		);
 
 		$this->assertEquals(
@@ -777,7 +755,7 @@ class Reader_Revenue_ManagerTest extends TestCase {
 			'Content policy state field should have empty value when contentPolicyStatus is default'
 		);
 
-		// Test that the content policy state field is added with correct values when feature flag is enabled and `contentPolicyStatus` contains `contentPolicyState`.
+		// Test that the content policy state field is added with correct values when `contentPolicyStatus` contains `contentPolicyState`.
 		$this->reader_revenue_manager->get_settings()->set(
 			array(
 				'publicationID'       => 'test-publication-id',
@@ -791,7 +769,7 @@ class Reader_Revenue_ManagerTest extends TestCase {
 		$this->assertArrayHasKey(
 			'reader_revenue_manager_content_policy_state',
 			$debug_fields,
-			'Content policy state field should be included when feature flag is enabled and contentPolicyStatus is present'
+			'Content policy state field should be included when contentPolicyStatus is present'
 		);
 
 		$this->assertEquals(


### PR DESCRIPTION
## Summary

Addresses issue:

- #12232

Removes the `rrmPolicyViolations` feature flag and makes all RRM policy violation functionality unconditional, as the feature is ready for launch.

## Changes

### Feature Flag
- Removed `rrmPolicyViolations` from `feature-flags.json`

### PHP
- **Settings.php**: Removed `Feature_Flags::enabled()` check in `get_default()` and `get_sanitize_callback()` — `contentPolicyStatus` is now always included in defaults and always sanitized
- **Synchronize_Publication.php**: Removed `Feature_Flags::enabled()` check in `synchronize_publication_data()` — `contentPolicyStatus` is always synchronized
- **Reader_Revenue_Manager.php**: Removed `Feature_Flags::enabled()` checks in `register()` and `get_debug_fields()` — policy violation notification dismissals are always cleared on publication change, and the content policy state debug field is always included

### JavaScript
- **index.js**: Removed feature flag condition around `SettingsStatusComponent` registration (now always registered) and removed `featureFlag` property from both policy violation notification definitions
- **settings.js**: Removed feature flag check in `validateCanSubmitChanges()` — `contentPolicyStatus` is always validated
- **publications.js**: Removed feature flag check in `selectPublication` action — `contentPolicyStatus` is always set
- **base.js**: Removed feature flag condition — `contentPolicyStatus` is always included in `settingSlugs`
- **SettingsForm.js**: Removed `useFeature()` hook — `PolicyViolationSettingsNotice` is always rendered
- **SettingsView.js**: Removed `useFeature()` hook — `PolicyViolationSettingsNotice` is always rendered

### Storybook
- Removed `features: ['rrmPolicyViolations']` from policy violation stories in `SettingsView.stories.js`, `SettingsEdit.stories.js`, and `SettingsActiveModules.stories.js`

### Tests
- **SettingsTest.php**: Merged feature-flag-specific test cases into main test cases, removed `enable_feature()` calls
- **Reader_Revenue_ManagerTest.php**: Removed `enable_feature()` calls, made policy violation tests unconditional
- **Synchronize_PublicationTest.php**: Removed `enable_feature()` call, made sync test unconditional
- **settings.test.js**: Removed `describe.each` pattern with feature flag toggle, made `contentPolicyStatus` validation test unconditional, added `contentPolicyStatus` to `validSettings`
- **publications.test.js**: Removed `setEnabledFeatures()` calls, made `contentPolicyStatus` tests unconditional

## Steps to Reproduce

1. Verify no references to `rrmPolicyViolations` remain in the codebase
2. Run JS tests: `npx jest --testPathPattern='reader-revenue-manager/datastore/(settings|publications)'`
3. Run PHP tests: `composer run test -- --filter='Reader_Revenue_Manager'`
4. Confirm all tests pass