### PR TITLE
Fix Analytics account creation in the new setup flow

### DIFF
--- a/assets/js/components/key-metrics-setup/KeyMetricsSetupApp.js
+++ b/assets/js/components/key-metrics-setup/KeyMetricsSetupApp.js
@@ -112,6 +112,17 @@ export default function KeyMetricsSetupApp() {
 		select( MODULES_SEARCH_CONSOLE ).isGatheringData();
 	} );
 
+	// Await the resolution of Analytics 4 settings before triggering
+	// the background sync of audiences and custom dimensions. This
+	// ensures propertyID is available for the sync and isSyncing
+	// check, preventing the button from being stuck in a disabled state.
+	const hasResolvedAnalytics4Settings = useSelect( ( select ) => {
+		select( MODULES_ANALYTICS_4 ).getSettings();
+		return select( MODULES_ANALYTICS_4 ).hasFinishedResolution(
+			'getSettings'
+		);
+	} );
+
 	const isSyncing = useSelect( ( select ) => {
 		const isFetchingSyncAvailableCustomDimensions =
 			select(
@@ -189,9 +200,15 @@ export default function KeyMetricsSetupApp() {
 		useDispatch( MODULES_ANALYTICS_4 );
 
 	useEffect( () => {
-		syncAvailableAudiences();
-		fetchSyncAvailableCustomDimensions();
-	}, [ syncAvailableAudiences, fetchSyncAvailableCustomDimensions ] );
+		if ( hasResolvedAnalytics4Settings ) {
+			syncAvailableAudiences();
+			fetchSyncAvailableCustomDimensions();
+		}
+	}, [
+		hasResolvedAnalytics4Settings,
+		syncAvailableAudiences,
+		fetchSyncAvailableCustomDimensions,
+	] );
 
 	const onSaveClick = useCallback( () => {
 		if ( isBusy || isSyncing ) {

--- a/assets/js/components/key-metrics-setup/KeyMetricsSetupApp.test.js
+++ b/assets/js/components/key-metrics-setup/KeyMetricsSetupApp.test.js
@@ -123,6 +123,8 @@ describe( 'KeyMetricsSetupApp', () => {
 		registry
 			.dispatch( CORE_MODULES )
 			.receiveGetModules( withConnected( MODULE_SLUG_ANALYTICS_4 ) );
+
+		registry.dispatch( MODULES_ANALYTICS_4 ).receiveGetSettings( {} );
 	} );
 
 	afterEach( () => {
@@ -345,6 +347,67 @@ describe( 'KeyMetricsSetupApp', () => {
 
 		expect( fetchMock ).toHaveFetched( syncAudiencesEndpoint );
 		expect( fetchMock ).toHaveFetched( syncCustomDimensionsEndpoint );
+	} );
+
+	it( 'should not sync audiences and custom dimensions until Analytics 4 settings have resolved', async () => {
+		const analytics4SettingsEndpoint = new RegExp(
+			'^/google-site-kit/v1/modules/analytics-4/data/settings'
+		);
+
+		// Create a fresh registry without pre-populated Analytics 4
+		// settings so getSettings resolution remains pending.
+		const freshRegistry = createTestRegistry();
+		provideUserAuthentication( freshRegistry );
+		provideSiteInfo( freshRegistry );
+		freshRegistry.dispatch( CORE_USER ).receiveGetUserInputSettings( {} );
+		freshRegistry.dispatch( CORE_USER ).receiveGetDismissedItems( [] );
+		freshRegistry.dispatch( CORE_USER ).receiveGetDismissedPrompts( {} );
+		freshRegistry.dispatch( CORE_USER ).receiveGetCapabilities( {} );
+		freshRegistry
+			.dispatch( CORE_USER )
+			.receiveGetUserAudienceSettings( {
+				configuredAudiences: null,
+				isAudienceSegmentationWidgetHidden: false,
+				didSetAudiences: false,
+			} );
+		freshRegistry.dispatch( CORE_USER ).receiveGetInitialSetupSettings( {
+			isAnalyticsSetupComplete: false,
+		} );
+		freshRegistry
+			.dispatch( CORE_MODULES )
+			.receiveGetModules( withConnected( MODULE_SLUG_ANALYTICS_4 ) );
+
+		// Freeze the Analytics 4 settings endpoint so the resolver
+		// never completes and hasFinishedResolution stays false.
+		freezeFetch( analytics4SettingsEndpoint );
+
+		fetchMock.post( syncAudiencesEndpoint, { body: [], status: 200 } );
+		fetchMock.post( syncCustomDimensionsEndpoint, {
+			body: [],
+			status: 200,
+		} );
+		fetchMock.getOnce( searchAnalyticsRegexp, {
+			body: searchConsoleFixtures.report,
+		} );
+		fetchMock.getOnce( analytics4ReportRegexp, {
+			body: analyticsFixtures.report,
+		} );
+		muteFetch( searchConsoleDataAvailableRegexp );
+		muteFetch( analytics4DataAvailableRegexp );
+
+		const { waitForRegistry } = render( <KeyMetricsSetupApp />, {
+			registry: freshRegistry,
+			viewContext: VIEW_CONTEXT_KEY_METRICS_SETUP,
+		} );
+
+		await waitForRegistry();
+
+		// Since Analytics 4 settings have not resolved, the sync
+		// actions should not have been dispatched yet.
+		expect( fetchMock ).not.toHaveFetched( syncAudiencesEndpoint );
+		expect( fetchMock ).not.toHaveFetched(
+			syncCustomDimensionsEndpoint
+		);
 	} );
 
 	it( 'should not attempt to sync again while syncing is already in progress', async () => {


### PR DESCRIPTION
## Summary

Addresses issue:

- #12194

## Relevant technical choices

When creating a new Analytics account during the setup flow, the user lands on the Key Metrics setup screen where the Complete setup button remains stuck in a disabled, in-progress state. This happens because the background sync of audiences and custom dimensions is triggered before the Analytics 4 settings (including propertyID) have been resolved from the server. As a result, propertyID resolves to undefined, causing the isSyncing check to stay true indefinitely.

This fix awaits the resolution of the MODULES_ANALYTICS_4 getSettings() resolver before triggering the background sync of audiences and custom dimensions in KeyMetricsSetupApp. This ensures propertyID is available when the sync actions are dispatched, allowing isSyncing to correctly transition to false once syncing completes.

Changes:
- Added a useSelect hook in KeyMetricsSetupApp that triggers and tracks the resolution of Analytics 4 settings via getSettings() and hasFinishedResolution('getSettings')
- Updated the sync useEffect to conditionally fire only after settings have resolved
- Added a test verifying that sync does not trigger while settings are still loading
- Pre-populated Analytics 4 settings in the test beforeEach to support the new resolver call

## Steps to reproduce

1. Set up Site Kit with the setupFlowRefresh feature flag enabled, and the Analytics checkbox selected on the splash screen
2. Create a new Analytics account as part of the setup flow
3. When landing on the Key Metrics setup screen, verify the Complete setup button is enabled and the user can proceed to the dashboard

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [ ] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.
- [ ] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.