### PR TITLE
Add aria-checked attribute to Checkbox and Switch components

### DIFF
--- a/assets/js/googlesitekit/components-gm2/Checkbox.js
+++ b/assets/js/googlesitekit/components-gm2/Checkbox.js
@@ -77,6 +77,7 @@ export default function Checkbox( props ) {
 							name={ name }
 							value={ value }
 							checked={ checked }
+							aria-checked={ checked }
 							disabled={ disabled }
 							onChange={ onChange }
 							tabIndex={ tabIndex }

--- a/assets/js/googlesitekit/components-gm2/Switch.js
+++ b/assets/js/googlesitekit/components-gm2/Switch.js
@@ -76,6 +76,7 @@ function Switch( { onClick, label, checked, disabled, hideLabel } ) {
 							className="mdc-switch__native-control"
 							role="switch"
 							checked={ checked }
+							aria-checked={ checked }
 							disabled={ disabled }
 							readOnly
 						/>


### PR DESCRIPTION
SUMMARY
Addresses issue: #12062

RELEVANT TECHNICAL CHOISES
Added the aria-checked attribute to both Checkbox and Switch components. This ensures that their state is correctly communicated to assistive technologies like VoiceOver, resolving the accessibility gap.

CODE REVIEWER CHECKLIST 
[x] My code is tested and passes existing unit tests.
[x] My code follows the WordPress Code Standards.
[x] I have signed the Contributor License Agreement.
