### PR TITLE
Bug/12279 Fix multiple notice rendering

### DIFF
--- a/assets/sass/components/email-reporting/_googlesitekit-user-settings-selection-panel.scss
+++ b/assets/sass/components/email-reporting/_googlesitekit-user-settings-selection-panel.scss
@@ -39,6 +39,10 @@
 				padding: 0 $grid-gap-desktop;
 			}
 
+			// Ensure every notice after the first notice has a margin
+			// so the notices don't render with no gap.
+			//
+			// See: https://github.com/google/site-kit-wp/issues/12279
 			.googlesitekit-notice-container:nth-of-type(n + 2) {
 				margin-top: $grid-gap-phone;
 			}


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #12279 

## Relevant technical choices

<!-- Please describe your changes. -->

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.
- [ ] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
