### PR TITLE
Fix: permission callback for email-reporting EDITABLE route

### DIFF
--- a/includes/Core/Email_Reporting/REST_Email_Reporting_Controller.php
+++ b/includes/Core/Email_Reporting/REST_Email_Reporting_Controller.php
@@ -196,7 +196,7 @@ class REST_Email_Reporting_Controller {
 
 							return new WP_REST_Response( $this->settings->get() );
 						},
-						'permission_callback' => $can_access,
+						'permission_callback' => $can_manage,
 						'args'                => array(
 							'data' => array(
 								'type'       => 'object',


### PR DESCRIPTION
## Summary       

  Addresses issue:                                                                                                                                                                                                                              
   
  - #12341                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                              
  ## Relevant technical choices                                                                                                                                                                                                               

  The `core/site/data/email-reporting` EDITABLE route's `permission_callback` is changed from `$can_access` to `$can_manage`, matching every other write route in `REST_Email_Reporting_Controller`:                                            
   
  ```diff                                                                                                                                                                                                                                       
  - 'permission_callback' => $can_access,                                                                                                                                                                                                     
  + 'permission_callback' => $can_manage,                                                                                                                                                                                                       
                                                                                                                                                                                                                                              
  The $can_access closure checks VIEW_SPLASH / VIEW_DASHBOARD, which shared dashboard users (Subscribers, Contributors) satisfy. The $can_manage closure checks MANAGE_OPTIONS, restricting modification of the global email reporting setting  
  to administrators — consistent with email-reporting-invite-user, email-reporting-eligible-subscribers, and email-reporting-errors.
                                                                                                                                                                                                                                                
  PR Author Checklist                                                                                                                                                                                                                         
                                                                                                                                                                                                                                              
  - My code is tested and passes existing unit tests.
  - My code has an appropriate set of unit tests which all pass.
  - My code is backward-compatible with WordPress 5.2 and PHP 7.4.
  - My code follows the WordPress coding standards.                                                                                                                                                                                             
  - My code has proper inline documentation.
  - I have added a QA Brief on the issue linked above.                                                                                                                                                                                          
  - I have signed the Contributor License Agreement (see https://cla.developers.google.com/).                                                                                                                                                   
                                                                                                                                                                                                                                             