### PR TITLE
[Security bug]Fix broken access control on email-reporting write endpoint

### DIFF
--- a/includes/Core/Email_Reporting/REST_Email_Reporting_Controller.php
+++ b/includes/Core/Email_Reporting/REST_Email_Reporting_Controller.php
@@ -196,7 +196,7 @@ class REST_Email_Reporting_Controller {
 
 							return new WP_REST_Response( $this->settings->get() );
 						},
-						'permission_callback' => $can_access,
+						'permission_callback' => $can_manage,
 						'args'                => array(
 							'data' => array(
 								'type'       => 'object',


### PR DESCRIPTION
## Summary

- Fix the `core/site/data/email-reporting` POST/PUT/PATCH endpoint to use `$can_manage` (`MANAGE_OPTIONS`) instead of `$can_access` (`VIEW_SPLASH || VIEW_DASHBOARD`) as its permission callback
- This prevents non-admin users with dashboard sharing access from modifying the site-wide email reporting setting

## Issue

The write endpoint for email reporting settings used `$can_access` which maps to `VIEW_SPLASH || VIEW_DASHBOARD`. This allowed Editor-level users with a shared dashboard role to toggle the site-wide email reporting `enabled` flag via a direct REST API call, even though they have no UI access to this setting (Settings page returns HTTP 403).

All other site-wide write endpoints in the same controller already use `$can_manage`:
- `email-reporting-eligible-subscribers` (line 260)
- `email-reporting-errors` (line 292)
- `email-reporting-invite-user` (line 302)

Other site-wide settings controllers also consistently use `MANAGE_OPTIONS` for write operations:
- `core/site/data/consent-mode`
- `core/site/data/conversion-tracking`

## Test plan

- [x] Verify an admin can still toggle email reporting on/off via Settings UI
- [x] Verify a shared-dashboard Editor gets HTTP 403 when POSTing to `core/site/data/email-reporting`
- [x] Verify a shared-dashboard Editor can still GET (read) the email reporting setting
- [x] Verify no regression on other email reporting endpoints
