### PR TITLE
Fix spacing above CTA button in email templates

### DIFF
--- a/includes/Core/Email_Reporting/templates/error-email/parts/content.php
+++ b/includes/Core/Email_Reporting/templates/error-email/parts/content.php
@@ -50,8 +50,8 @@ $warning_icon_url = $get_asset_url( 'warning-icon' );
 			 * and to future-proof if HTML tags are added to content later.
 			 */
 			?>
-			<?php foreach ( $body as $paragraph ) : ?>
-			<p class="text-primary" style="font-size: 14px; line-height: 20px; font-weight: 400; color: #161B18; margin: 0 0 16px 0;">
+			<?php foreach ( $body as $index => $paragraph ) : ?>
+			<p class="text-primary" style="font-size: 14px; line-height: 20px; font-weight: 400; color: #161B18; margin: 0 0 <?php echo count( $body ) - 1 === $index ? '20px' : '16px'; ?> 0;">
 				<?php
 				echo wp_kses(
 					$paragraph,

--- a/includes/Core/Email_Reporting/templates/subscription-confirmation/parts/content.php
+++ b/includes/Core/Email_Reporting/templates/subscription-confirmation/parts/content.php
@@ -44,8 +44,8 @@ $envelope_url = $get_asset_url( 'subscription-envelope-graphic' );
 			</h1>
 
 			<?php /* Body paragraphs from Content_Map. */ ?>
-			<?php foreach ( $body as $paragraph ) : ?>
-			<p class="text-primary" style="font-size: 14px; line-height: 20px; font-weight: 400; color: #161B18; margin: 0 0 16px 0;">
+			<?php foreach ( $body as $index => $paragraph ) : ?>
+			<p class="text-primary" style="font-size: 14px; line-height: 20px; font-weight: 400; color: #161B18; margin: 0 0 <?php echo count( $body ) - 1 === $index ? '20px' : '16px'; ?> 0;">
 				<?php echo wp_kses( $paragraph, array( 'strong' => array() ) ); ?>
 			</p>
 			<?php endforeach; ?>


### PR DESCRIPTION
## Summary

Addresses issue:

- #12344

## Relevant technical choices

The subscription-confirmation and error-email templates had a fixed `16px` bottom margin on all body paragraphs, resulting in only 16px spacing above the CTA button. The invitation-email template already handled this correctly by applying `20px` to the last paragraph.

This change applies the same conditional pattern from the invitation template to both affected templates:
- Track the loop index via `foreach ( $body as $index => $paragraph )`
- Use `count( $body ) - 1 === $index ? '20px' : '16px'` for the last paragraph's bottom margin

This ensures consistent 20px spacing above the CTA button across all three email templates while keeping the 16px spacing between intermediate paragraphs.

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.
- [ ] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.