### PR TITLE
Fix php-scoper patching of phpseclib

### DIFF
--- a/scoper.inc.php
+++ b/scoper.inc.php
@@ -67,8 +67,25 @@ return array(
 				);
 			}
 			if ( false !== strpos( $file_path, 'phpseclib' ) ) {
-				$contents = str_replace( "'phpseclib3\\\\", "'\\\\" . $doubled_backslash_prefix . '\\\\phpseclib3\\\\', $contents );
-				$contents = str_replace( "'\\\\phpseclib3", "'\\\\" . $doubled_backslash_prefix . '\\\\phpseclib3', $contents );
+				// phpseclib dynamically constructs FQCNs from partial strings that
+				// PHP-Scoper can't automatically prefix, e.g.:
+				// $fqmain = 'phpseclib3\Math\BigInteger\Engines\' . $main
+				//
+				// This prefixes any string-quoted 'phpseclib3' namespace reference,
+				// handling both single (\) and double (\\) backslash escaping forms
+				// that may result from php-parser's normalization of single-quoted strings.
+				//
+				// Pattern (regex):  /'\\{0,2}phpseclib3(?=\\)/
+				// '           — opening single quote of the string literal
+				// \\{0,2}     — 0, 1, or 2 literal backslashes (covers all escaping forms)
+				// phpseclib3  — the namespace root.
+				// (?=\\)      — lookahead: must be followed by a backslash (avoids false matches).
+				$prefixed_ns = str_replace( '\\', '\\\\', "\\{$prefix}\\phpseclib3" );
+				$contents    = preg_replace_callback(
+					"/'\\\\{0,2}phpseclib3(?=\\\\)/",
+					fn() => "'" . $prefixed_ns,
+					$contents
+				);
 			}
 
 			return $contents;

--- a/tests/phpunit/includes/TestCase.php
+++ b/tests/phpunit/includes/TestCase.php
@@ -123,7 +123,10 @@ class TestCase extends WP_UnitTestCase {
 	 */
 	protected function force_set_property( $class_instance, $property, $value ) {
 		$reflection_property = new \ReflectionProperty( $class_instance, $property );
-		$reflection_property->setAccessible( true );
+		// PHP < 8.1 requires this for private properties; 8.1+ ignores it; 8.5+ deprecates it.
+		if ( \PHP_VERSION_ID < 80100 ) {
+			$reflection_property->setAccessible( true );
+		}
 		$target = is_string( $class_instance ) ? null : $class_instance;
 		$reflection_property->setValue( $target, $value );
 	}
@@ -139,9 +142,13 @@ class TestCase extends WP_UnitTestCase {
 	 */
 	protected function force_get_property( $class_instance, $property ) {
 		$reflection_property = new \ReflectionProperty( $class_instance, $property );
-		$reflection_property->setAccessible( true );
+		// PHP < 8.1 requires this for private properties; 8.1+ ignores it; 8.5+ deprecates it.
+		if ( \PHP_VERSION_ID < 80100 ) {
+			$reflection_property->setAccessible( true );
+		}
+		$target = is_string( $class_instance ) ? null : $class_instance;
 
-		return $reflection_property->getValue( $class_instance );
+		return $reflection_property->getValue( $target );
 	}
 
 	/**

--- a/tests/phpunit/integration/Scoped_DependenciesTest.php
+++ b/tests/phpunit/integration/Scoped_DependenciesTest.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Scoped_DependenciesTest
+ *
+ * @package   Google\Site_Kit\Tests
+ * @copyright 2026 Google LLC
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
+ * @link      https://sitekit.withgoogle.com
+ */
+
+namespace Google\Site_Kit\Tests;
+
+use Google\Site_Kit_Dependencies\phpseclib3\Math\BigInteger;
+
+/**
+ * @group Dependencies
+ */
+class Scoped_DependenciesTest extends TestCase {
+
+	/**
+	 * Verifies that phpseclib's BigInteger resolves its engine from the scoped namespace.
+	 *
+	 * Engine selection builds FQCNs from string literals. Broken PHP-Scoper patching leaves
+	 * unprefixed `phpseclib3\...` class names; those still load when Composer's vendor tree
+	 * is present (e.g. local dev / CI), so getEngine() alone is not enough. The resolved
+	 * main engine class must live under Google\Site_Kit_Dependencies.
+	 */
+	public function test_phpseclib_biginteger_engine_can_be_resolved() {
+		$previous = $this->force_get_property( BigInteger::class, 'mainEngine' );
+		$this->force_set_property( BigInteger::class, 'mainEngine', null );
+
+		try {
+			BigInteger::getEngine();
+			$main_engine_class = $this->force_get_property( BigInteger::class, 'mainEngine' );
+		} finally {
+			$this->force_set_property( BigInteger::class, 'mainEngine', $previous );
+		}
+
+		$this->assertStringStartsWith(
+			'\\Google\\Site_Kit_Dependencies\\phpseclib3\\',
+			$main_engine_class,
+			'BigInteger must use scoped engine classes; unprefixed phpseclib3\\ indicates broken scoper patching (masked when vendor/ also defines those classes).'
+		);
+	}
+}


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #12406 

## Relevant technical choices

<!-- Please describe your changes. -->

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.
- [ ] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
