### PR TITLE
Bug/#12281 - Show error notification when an OAuth error occurs

### DIFF
--- a/assets/js/googlesitekit/datastore/site/index.js
+++ b/assets/js/googlesitekit/datastore/site/index.js
@@ -57,7 +57,9 @@ const store = combineStores(
 	notifications,
 	cache,
 	createErrorStore( CORE_SITE ),
-	createSnapshotStore( CORE_SITE, { pick: [ 'conversionTracking' ] } )
+	createSnapshotStore( CORE_SITE, {
+		keysToSnapshot: [ 'conversionTracking' ],
+	} )
 );
 
 export const initialState = store.initialState;

--- a/assets/js/googlesitekit/datastore/site/index.test.js
+++ b/assets/js/googlesitekit/datastore/site/index.test.js
@@ -19,7 +19,10 @@
 /**
  * Internal dependencies
  */
-import { createTestRegistry } from '../../../../../tests/js/utils';
+import {
+	createTestRegistry,
+	provideSiteInfo,
+} from '../../../../../tests/js/utils';
 import { initialState } from './index';
 import { CORE_SITE } from './constants';
 
@@ -37,6 +40,33 @@ describe( 'core/site store', () => {
 			const state = store.getState();
 
 			expect( state ).toEqual( initialState );
+		} );
+	} );
+
+	describe( 'snapshot and restore', () => {
+		it( 'does not overwrite siteInfo when restoring a snapshot', async () => {
+			provideSiteInfo( registry, {
+				setupErrorMessage: null,
+				setupErrorCode: null,
+			} );
+
+			await registry.dispatch( CORE_SITE ).createSnapshot();
+
+			// Simulate the page reload after OAuth error by providing
+			// site info with an error message.
+			provideSiteInfo( registry, {
+				setupErrorMessage: 'An error occurred',
+				setupErrorCode: 'access_denied',
+			} );
+
+			// Restore the snapshot (simulating what happens on page load).
+			await registry.dispatch( CORE_SITE ).restoreSnapshot();
+
+			// The setupErrorMessage should still be present because
+			// the snapshot only includes conversionTracking, not siteInfo.
+			expect( registry.select( CORE_SITE ).getSetupErrorMessage() ).toBe(
+				'An error occurred'
+			);
 		} );
 	} );
 } );


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #12281 

## Relevant technical choices

<!-- Please describe your changes. -->

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [x] Run the code.
- [x] Ensure the acceptance criteria are satisfied.
- [x] Reassess the implementation with the IB.
- [x] Ensure no unrelated changes are included.
- [x] Ensure CI checks pass.
- [x] Check Storybook where applicable.
- [x] Ensure there is a QA Brief.
- [x] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [x] Ensure the PR has the correct target branch.
- [x] Double-check that the PR is okay to be merged.
- [x] Ensure the corresponding issue has a ZenHub release assigned.
- [x] Add a changelog message to the issue.
