### PR TITLE
Fix email error copy

### DIFF
--- a/includes/Core/Email_Reporting/Batch_Error_Notifier.php
+++ b/includes/Core/Email_Reporting/Batch_Error_Notifier.php
@@ -35,7 +35,6 @@ class Batch_Error_Notifier {
 	const NON_SENDABLE_CATEGORIES = array(
 		'sending_error',
 		'cron_scheduler_error',
-		'other_error',
 	);
 
 	/**
@@ -47,7 +46,6 @@ class Batch_Error_Notifier {
 	const CATEGORY_CONTENT_MAP = array(
 		'permissions_error' => 'permissions',
 		'report_error'      => 'report',
-		'network_error'     => 'network',
 		'server_error'      => 'server',
 	);
 

--- a/includes/Core/Email_Reporting/Batch_Error_Notifier.php
+++ b/includes/Core/Email_Reporting/Batch_Error_Notifier.php
@@ -271,7 +271,7 @@ class Batch_Error_Notifier {
 			$title = Content_Map::get_title( 'error-email' );
 		}
 
-		$body_args = $this->get_body_args( $content_key );
+		$body_args = Content_Map::get_body_args( $content_key, $this->golinks );
 		$body      = Content_Map::get_body_with_args( $content_key, $body_args );
 		$domain    = $this->get_site_domain();
 
@@ -297,55 +297,6 @@ class Batch_Error_Notifier {
 			'graphic'                => Content_Map::get_graphic_config( 'error-email' ),
 			'footer_type'            => 'standard',
 		);
-	}
-
-	/**
-	 * Gets sprintf arguments for Content_Map body placeholders.
-	 *
-	 * Maps each content key to the URLs that fill its `%s` / `%1$s` / `%2$s`
-	 * placeholders. Keys without placeholders return an empty array.
-	 *
-	 * @since 1.175.0
-	 *
-	 * @param string $content_key Content_Map key.
-	 * @return array Ordered sprintf arguments for the body paragraphs.
-	 */
-	private function get_body_args( $content_key ) {
-		$link_style = 'color:#108080;';
-		$help_url   = add_query_arg( 'doc', 'email-reporting', 'https://sitekit.withgoogle.com/support/' );
-
-		// URLs are internally generated (golinks, add_query_arg) and safe.
-		// Escaping is handled by wp_kses() in the HTML template and
-		// wp_strip_all_tags() in the plain text renderer.
-		switch ( $content_key ) {
-			case 'error-email-report-search-console':
-				$settings_url = add_query_arg( 'module', 'search-console', $this->golinks->get_url( 'settings' ) );
-				return array(
-					'<a class="link" href="' . $settings_url . '" style="' . $link_style . '">',
-					'</a>',
-					'<a class="link" href="' . $help_url . '" style="' . $link_style . '">',
-					'</a>',
-				);
-
-			case 'error-email-report-analytics-4':
-				$settings_url = add_query_arg( 'module', 'analytics-4', $this->golinks->get_url( 'settings' ) );
-				return array(
-					'<a class="link" href="' . $settings_url . '" style="' . $link_style . '">',
-					'</a>',
-					'<a class="link" href="' . $help_url . '" style="' . $link_style . '">',
-					'</a>',
-				);
-
-			case 'error-email-permissions-search-console':
-			case 'error-email-permissions-analytics-4':
-				return array(
-					'<a class="link" href="' . $help_url . '" style="' . $link_style . '">',
-					'</a>',
-				);
-
-			default:
-				return array();
-		}
 	}
 
 	/**

--- a/includes/Core/Email_Reporting/Content_Map.php
+++ b/includes/Core/Email_Reporting/Content_Map.php
@@ -10,6 +10,8 @@
 
 namespace Google\Site_Kit\Core\Email_Reporting;
 
+use Google\Site_Kit\Core\Golinks\Golinks;
+
 /**
  * Class for mapping email template content (titles and body).
  *
@@ -158,10 +160,10 @@ class Content_Map {
 			'invitation-email'                       => __( '%1$s%2$s%3$s invited you to receive periodic performance reports', 'google-site-kit' ),
 			'subscription-confirmation'              => __( 'Success! You’re subscribed to Site Kit reports', 'google-site-kit' ),
 			'error-email'                            => __( 'Email reports are failing to send', 'google-site-kit' ),
-			'error-email-permissions-search-console' => __( 'Action needed: your Site Kit report couldn\'t be generated', 'google-site-kit' ),
-			'error-email-permissions-analytics-4'    => __( 'Action needed: your Site Kit report couldn\'t be generated', 'google-site-kit' ),
-			'error-email-report-search-console'      => __( 'Action needed: your Site Kit report couldn\'t be generated', 'google-site-kit' ),
-			'error-email-report-analytics-4'         => __( 'Action needed: your Site Kit report couldn\'t be generated', 'google-site-kit' ),
+			'error-email-permissions-search-console' => __( 'Action needed: your Site Kit report couldn’t be generated', 'google-site-kit' ),
+			'error-email-permissions-analytics-4'    => __( 'Action needed: your Site Kit report couldn’t be generated', 'google-site-kit' ),
+			'error-email-report-search-console'      => __( 'Action needed: your Site Kit report couldn’t be generated', 'google-site-kit' ),
+			'error-email-report-analytics-4'         => __( 'Action needed: your Site Kit report couldn’t be generated', 'google-site-kit' ),
 		);
 	}
 
@@ -211,5 +213,53 @@ class Content_Map {
 				__( 'Report delivery will automatically resume once the issue is resolved.', 'google-site-kit' ),
 			),
 		);
+	}
+
+	/**
+	 * Gets sprintf arguments for body placeholders.
+	 *
+	 * Maps each content key to the styled anchor tags that fill its
+	 * `%s` / `%1$s` / `%2$s` placeholders. Keys without placeholders
+	 * return an empty array.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param string  $content_key Content key (e.g. 'error-email-report-analytics-4').
+	 * @param Golinks $golinks     Golinks instance for building URLs.
+	 * @return array Ordered sprintf arguments for the body paragraphs.
+	 */
+	public static function get_body_args( $content_key, Golinks $golinks ) {
+		$link_style = 'color:#108080;';
+		$help_url   = add_query_arg( 'doc', 'email-reporting', 'https://sitekit.withgoogle.com/support/' );
+
+		switch ( $content_key ) {
+			case 'error-email-report-search-console':
+				$settings_url = add_query_arg( 'module', 'search-console', $golinks->get_url( 'settings' ) );
+				return array(
+					'<a class="link" href="' . $settings_url . '" style="' . $link_style . '">',
+					'</a>',
+					'<a class="link" href="' . $help_url . '" style="' . $link_style . '">',
+					'</a>',
+				);
+
+			case 'error-email-report-analytics-4':
+				$settings_url = add_query_arg( 'module', 'analytics-4', $golinks->get_url( 'settings' ) );
+				return array(
+					'<a class="link" href="' . $settings_url . '" style="' . $link_style . '">',
+					'</a>',
+					'<a class="link" href="' . $help_url . '" style="' . $link_style . '">',
+					'</a>',
+				);
+
+			case 'error-email-permissions-search-console':
+			case 'error-email-permissions-analytics-4':
+				return array(
+					'<a class="link" href="' . $help_url . '" style="' . $link_style . '">',
+					'</a>',
+				);
+
+			default:
+				return array();
+		}
 	}
 }

--- a/includes/Core/Email_Reporting/Content_Map.php
+++ b/includes/Core/Email_Reporting/Content_Map.php
@@ -155,10 +155,13 @@ class Content_Map {
 	protected static function get_all_titles() {
 		return array(
 			/* translators: 1: opening anchor tag with mailto link, 2: inviter email address, 3: closing anchor tag */
-			'invitation-email'           => __( '%1$s%2$s%3$s invited you to receive periodic performance reports', 'google-site-kit' ),
-			'subscription-confirmation'  => __( 'Success! You’re subscribed to Site Kit reports', 'google-site-kit' ),
-			'error-email'                => __( 'Email reports are failing to send', 'google-site-kit' ),
-			'error-email-cron-scheduler' => __( 'Email reports are failing to send', 'google-site-kit' ),
+			'invitation-email'                       => __( '%1$s%2$s%3$s invited you to receive periodic performance reports', 'google-site-kit' ),
+			'subscription-confirmation'              => __( 'Success! You’re subscribed to Site Kit reports', 'google-site-kit' ),
+			'error-email'                            => __( 'Email reports are failing to send', 'google-site-kit' ),
+			'error-email-permissions-search-console' => __( 'Action needed: your Site Kit report couldn\'t be generated', 'google-site-kit' ),
+			'error-email-permissions-analytics-4'    => __( 'Action needed: your Site Kit report couldn\'t be generated', 'google-site-kit' ),
+			'error-email-report-search-console'      => __( 'Action needed: your Site Kit report couldn\'t be generated', 'google-site-kit' ),
+			'error-email-report-analytics-4'         => __( 'Action needed: your Site Kit report couldn\'t be generated', 'google-site-kit' ),
 		);
 	}
 
@@ -183,9 +186,6 @@ class Content_Map {
 			),
 			'error-email'                            => array(
 				__( 'We were unable to generate your report due to a server error. To fix this, contact your host. Report delivery will automatically resume once the issue is resolved.', 'google-site-kit' ),
-			),
-			'error-email-cron-scheduler'             => array(
-				__( 'We were unable to deliver your report, likely due to a WP-Cron configuration error in your WordPress site’s system settings. To fix this, contact your administrator or get help. Report delivery will automatically resume once the issue is resolved.', 'google-site-kit' ),
 			),
 			// Opening/closing tag placeholders keep inline styles and HTML
 			// out of translation strings. Inline color styles are required

--- a/tests/phpunit/integration/Core/Email_Reporting/Batch_Error_NotifierTest.php
+++ b/tests/phpunit/integration/Core/Email_Reporting/Batch_Error_NotifierTest.php
@@ -98,7 +98,6 @@ class Batch_Error_NotifierTest extends TestCase {
 		return array(
 			'sending_error'        => array( 'sending_error' ),
 			'cron_scheduler_error' => array( 'cron_scheduler_error' ),
-			'other_error'          => array( 'other_error' ),
 		);
 	}
 
@@ -133,7 +132,6 @@ class Batch_Error_NotifierTest extends TestCase {
 		return array(
 			'permissions_error' => array( 'permissions_error', 'error-email' ),
 			'report_error'      => array( 'report_error', 'error-email' ),
-			'network_error'     => array( 'network_error', 'error-email' ),
 			'server_error'      => array( 'server_error', 'error-email' ),
 		);
 	}
@@ -357,9 +355,9 @@ class Batch_Error_NotifierTest extends TestCase {
 
 	public function test_falls_back_to_generic_error_for_unknown_module() {
 		self::factory()->user->create( array( 'role' => 'administrator' ) );
-		$this->set_up_batch_with_category_and_module( 'network_error', 'some-unknown-module' );
+		$this->set_up_batch_with_category_and_module( 'server_error', 'some-unknown-module' );
 
-		// No module-specific body for network_error + some-unknown-module, falls back to generic error-email.
+		// No module-specific body for server_error + some-unknown-module, falls back to generic error-email.
 		$expected_subject = Content_Map::get_title( 'error-email' );
 
 		$this->email_sender->method( 'build_headers' )->willReturn( array() );

--- a/tests/phpunit/integration/Core/Email_Reporting/Batch_Error_NotifierTest.php
+++ b/tests/phpunit/integration/Core/Email_Reporting/Batch_Error_NotifierTest.php
@@ -305,8 +305,7 @@ class Batch_Error_NotifierTest extends TestCase {
 		self::factory()->user->create( array( 'role' => 'administrator' ) );
 		$this->set_up_batch_with_category_and_module( $category_id, $module_slug );
 
-		// Module-specific titles were removed; all error emails use the generic error-email title.
-		$expected_subject = Content_Map::get_title( 'error-email' );
+		$expected_subject = Content_Map::get_title( $expected_content_key );
 
 		$this->batch_query->expects( $this->once() )
 			->method( 'mark_batch_admin_notified' )


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #12157

## Relevant technical choices

There was some confusion on which email copy to use. This [sheet should be used as the single source of truth](https://docs.google.com/spreadsheets/d/1DEEPVKEtMklfHIIwyLR7MTwf8eEa_8dMBb_E8cuazgE/edit?gid=0#gid=0). This PR fixes the copy.

While I was here I removed a few error keys that were removed through discusson on the error sheet and are no longer used.

I also moved `get_body_args` to the `Content_Map` as part of parallel work to decouple the tester plugin so that it doesn't duplicate copy.

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [ ] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.
- [ ] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
