### PR TITLE
Handle view-only user in `ConnectGA4CTAWidget`

### DIFF
--- a/assets/js/components/KeyMetrics/ConnectModuleCTATile.js
+++ b/assets/js/components/KeyMetrics/ConnectModuleCTATile.js
@@ -35,6 +35,7 @@ import { CORE_MODULES } from '@/js/googlesitekit/modules/datastore/constants';
 import { CORE_WIDGETS } from '@/js/googlesitekit/widgets/datastore/constants';
 import { AREA_MAIN_DASHBOARD_KEY_METRICS_PRIMARY } from '@/js/googlesitekit/widgets/default-areas';
 import useActivateModuleCallback from '@/js/hooks/useActivateModuleCallback';
+import useViewOnly from '@/js/hooks/useViewOnly';
 import Link from '@/js/components/Link';
 import GhostCardGreenSVG from './GhostCardGreenSVG';
 import GhostCardRedSVG from './GhostCardRedSVG';
@@ -42,6 +43,7 @@ import MetricTileHeader from './MetricTileHeader';
 import { KEY_METRICS_WIDGETS } from './key-metrics-widgets';
 
 export default function ConnectModuleCTATile( { moduleSlug } ) {
+	const isViewOnly = useViewOnly();
 	const handleConnectModule = useActivateModuleCallback( moduleSlug );
 
 	const module = useSelect( ( select ) =>
@@ -114,13 +116,15 @@ export default function ConnectModuleCTATile( { moduleSlug } ) {
 										module.name
 								  ) }
 						</p>
-						<Link onClick={ handleConnectModule } secondary>
-							{ sprintf(
-								/* translators: %s: module name */
-								__( 'Connect %s', 'google-site-kit' ),
-								module.name
-							) }
-						</Link>
+						{ ! isViewOnly && (
+							<Link onClick={ handleConnectModule } secondary>
+								{ sprintf(
+									/* translators: %s: module name */
+									__( 'Connect %s', 'google-site-kit' ),
+									module.name
+								) }
+							</Link>
+						) }
 					</div>
 				</div>
 			</div>

--- a/assets/js/modules/analytics-4/components/widgets/ConnectGA4CTAWidget.js
+++ b/assets/js/modules/analytics-4/components/widgets/ConnectGA4CTAWidget.js
@@ -45,6 +45,7 @@ import {
 } from '@/js/modules/analytics-4/constants';
 import useActivateModuleCallback from '@/js/hooks/useActivateModuleCallback';
 import useCompleteModuleActivationCallback from '@/js/hooks/useCompleteModuleActivationCallback';
+import useViewOnly from '@/js/hooks/useViewOnly';
 import { useDebounce } from '@/js/hooks/useDebounce';
 import Link from '@/js/components/Link';
 import Banner from '@/js/components/Banner';
@@ -52,6 +53,7 @@ import BannerSVGDesktop from '@/svg/graphics/banner-conversions-setup-cta.svg?ur
 import BannerSVGMobile from '@/svg/graphics/banner-conversions-setup-cta-mobile.svg?url';
 
 export default function ConnectGA4CTAWidget( { Widget, WidgetNull } ) {
+	const isViewOnly = useViewOnly();
 	const trackingRef = useRef();
 	const ga4DependantKeyMetrics = useSelect( ( select ) => {
 		const keyMetrics = select( CORE_USER ).getKeyMetrics();
@@ -167,37 +169,53 @@ export default function ConnectGA4CTAWidget( { Widget, WidgetNull } ) {
 		return <WidgetNull />;
 	}
 
+	const description = isViewOnly
+		? __(
+				'Metrics cannot be displayed without Analytics. To fix the issue, contact your administrator.',
+				'google-site-kit'
+		  )
+		: __(
+				'Metrics cannot be displayed without Analytics',
+				'google-site-kit'
+		  );
+
 	return (
 		<Widget noPadding>
 			<Banner
 				ref={ trackingRef }
 				className="googlesitekit-banner--setup-cta googlesitekit-km-connect-ga4-cta"
 				title={ __( 'Analytics is disconnected', 'google-site-kit' ) }
-				description={ __(
-					'Metrics cannot be displayed without Analytics',
-					'google-site-kit'
-				) }
-				ctaButton={ {
-					label: __( 'Connect Analytics', 'google-site-kit' ),
-					onClick: handleCTAClick,
-					disabled: inProgress,
-					inProgress,
-				} }
+				description={ description }
+				ctaButton={
+					isViewOnly
+						? undefined
+						: {
+								label: __(
+									'Connect Analytics',
+									'google-site-kit'
+								),
+								onClick: handleCTAClick,
+								disabled: inProgress,
+								inProgress,
+						  }
+				}
 				svg={ {
 					desktop: BannerSVGDesktop,
 					mobile: BannerSVGMobile,
 					verticalPosition: 'top',
 				} }
 				footer={
-					<Link
-						onClick={ () =>
-							dismissItem(
-								KM_CONNECT_GA4_CTA_WIDGET_DISMISSED_ITEM_KEY
-							)
-						}
-					>
-						{ __( 'Maybe later', 'google-site-kit' ) }
-					</Link>
+					isViewOnly ? undefined : (
+						<Link
+							onClick={ () =>
+								dismissItem(
+									KM_CONNECT_GA4_CTA_WIDGET_DISMISSED_ITEM_KEY
+								)
+							}
+						>
+							{ __( 'Maybe later', 'google-site-kit' ) }
+						</Link>
+					)
 				}
 			/>
 		</Widget>

--- a/assets/js/modules/analytics-4/components/widgets/ConnectGA4CTAWidget.stories.js
+++ b/assets/js/modules/analytics-4/components/widgets/ConnectGA4CTAWidget.stories.js
@@ -29,6 +29,11 @@ import { provideKeyMetrics } from '../../../../../../tests/js/utils';
 import { provideKeyMetricsWidgetRegistrations } from '@/js/components/KeyMetrics/test-utils';
 import { withWidgetComponentProps } from '@/js/googlesitekit/widgets/util';
 import WithRegistrySetup from '../../../../../../tests/js/WithRegistrySetup';
+import { Provider as ViewContextProvider } from '@/js/components/Root/ViewContextContext';
+import {
+	VIEW_CONTEXT_MAIN_DASHBOARD,
+	VIEW_CONTEXT_MAIN_DASHBOARD_VIEW_ONLY,
+} from '@/js/googlesitekit/constants';
 import ConnectGA4CTAWidget from './ConnectGA4CTAWidget';
 import { MODULE_SLUG_ANALYTICS_4 } from '@/js/modules/analytics-4/constants';
 
@@ -36,19 +41,27 @@ const WidgetWithComponentProps = withWidgetComponentProps(
 	'keyMetricsConnectGA4CTA'
 )( ConnectGA4CTAWidget );
 
-function Template() {
+function Template( { viewContext = VIEW_CONTEXT_MAIN_DASHBOARD } = {} ) {
 	return (
-		<div className="googlesitekit-widget-area--mainDashboardKeyMetricsPrimary">
-			<div className="googlesitekit-widget--keyMetricsConnectGA4All">
-				<WidgetWithComponentProps />
+		<ViewContextProvider value={ viewContext }>
+			<div className="googlesitekit-widget-area--mainDashboardKeyMetricsPrimary">
+				<div className="googlesitekit-widget--keyMetricsConnectGA4All">
+					<WidgetWithComponentProps />
+				</div>
 			</div>
-		</div>
+		</ViewContextProvider>
 	);
 }
 
 export const Default = Template.bind( {} );
 Default.storyName = 'ConnectGA4CTAWidget';
 Default.scenario = {};
+
+export const ViewOnly = Template.bind( {} );
+ViewOnly.storyName = 'View only user';
+ViewOnly.args = {
+	viewContext: VIEW_CONTEXT_MAIN_DASHBOARD_VIEW_ONLY,
+};
 
 export default {
 	title: 'Key Metrics/ConnectGA4CTAWidget',

--- a/assets/js/modules/analytics-4/components/widgets/ConnectGA4CTAWidget.test.js
+++ b/assets/js/modules/analytics-4/components/widgets/ConnectGA4CTAWidget.test.js
@@ -45,6 +45,7 @@ import {
 import { provideKeyMetricsWidgetRegistrations } from '@/js/components/KeyMetrics/test-utils';
 import { withWidgetComponentProps } from '@/js/googlesitekit/widgets/util';
 import { MODULE_SLUG_SEARCH_CONSOLE } from '@/js/modules/search-console/constants';
+import { VIEW_CONTEXT_MAIN_DASHBOARD_VIEW_ONLY } from '@/js/googlesitekit/constants';
 
 describe( 'ConnectGA4CTAWidget', () => {
 	let registry;
@@ -146,5 +147,55 @@ describe( 'ConnectGA4CTAWidget', () => {
 			name: /Connect Analytics/i,
 		} );
 		expect( button ).toBeInTheDocument();
+	} );
+
+	it( 'should render the administrator message without CTA or dismiss link for view-only users', async () => {
+		const keyMetricWidgets = [
+			KM_ANALYTICS_RETURNING_VISITORS,
+			KM_ANALYTICS_NEW_VISITORS,
+			KM_ANALYTICS_TOP_TRAFFIC_SOURCE,
+			KM_ANALYTICS_ENGAGED_TRAFFIC_SOURCE,
+		];
+
+		provideKeyMetrics( registry, {
+			widgetSlugs: keyMetricWidgets,
+		} );
+
+		provideKeyMetricsWidgetRegistrations(
+			registry,
+			keyMetricWidgets.reduce(
+				( acc, widget ) => ( {
+					...acc,
+					[ widget ]: { modules: [ MODULE_SLUG_ANALYTICS_4 ] },
+				} ),
+				{}
+			)
+		);
+		registry.dispatch( CORE_USER ).receiveGetDismissedItems( [] );
+
+		const {
+			container,
+			getByText,
+			queryByRole,
+			queryByText,
+			waitForRegistry,
+		} = render( <WidgetWithComponentProps />, {
+			registry,
+			viewContext: VIEW_CONTEXT_MAIN_DASHBOARD_VIEW_ONLY,
+		} );
+		await waitForRegistry();
+
+		expect(
+			container.querySelector( '.googlesitekit-banner__title' )
+		).toHaveTextContent( 'Analytics is disconnected' );
+		expect(
+			getByText(
+				/Metrics cannot be displayed without Analytics\. To fix the issue, contact your administrator\./i
+			)
+		).toBeInTheDocument();
+		expect(
+			queryByRole( 'button', { name: /Connect Analytics/i } )
+		).not.toBeInTheDocument();
+		expect( queryByText( /Maybe later/i ) ).not.toBeInTheDocument();
 	} );
 } );


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #12454 

## Relevant technical choices

This PR adds handling for view-only users in KM GA disconnected notices so that CTA to re-connect GA do not appear for them.

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [x] Run the code.
- [x] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [x] Ensure no unrelated changes are included.
- [x] Ensure CI checks pass.
- [x] Check Storybook where applicable.
- [x] Ensure there is a QA Brief.
- [x] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [x] Ensure the PR has the correct target branch.
- [x] Double-check that the PR is okay to be merged.
- [x] Ensure the corresponding issue has a ZenHub release assigned.
- [x] Add a changelog message to the issue.
