### PR TITLE
Change formatting of Email Report gettext links.

### DIFF
--- a/includes/Core/Email_Reporting/Content_Map.php
+++ b/includes/Core/Email_Reporting/Content_Map.php
@@ -193,23 +193,23 @@ class Content_Map {
 			// out of translation strings. Inline color styles are required
 			// because many email clients strip or ignore CSS classes.
 			'error-email-permissions-search-console' => array(
-				/* translators: 1: opening anchor tag for help link, 2: closing anchor tag */
-				__( 'We were unable to generate your reports due to insufficient permissions in Search Console. To fix this, contact your administrator or %1$sget help%2$s.', 'google-site-kit' ),
+				/* translators: 1: help link URL, 2: help link style CSS */
+				__( 'We were unable to generate your reports due to insufficient permissions in Search Console. To fix this, contact your administrator or <a class="link" href="%1$s" style="%2$s">get help</a>.', 'google-site-kit' ),
 				__( 'Report delivery will automatically resume once the issue is resolved.', 'google-site-kit' ),
 			),
 			'error-email-permissions-analytics-4'    => array(
-				/* translators: 1: opening anchor tag for help link, 2: closing anchor tag */
-				__( 'We were unable to generate your reports due to insufficient permissions in Analytics. To fix this, contact your administrator or %1$sget help%2$s.', 'google-site-kit' ),
+				/* translators: 1: help link URL, 2: help link style CSS */
+				__( 'We were unable to generate your reports due to insufficient permissions in Analytics. To fix this, contact your administrator or <a class="link" href="%1$s" style="%2$s">get help</a>.', 'google-site-kit' ),
 				__( 'Report delivery will automatically resume once the issue is resolved.', 'google-site-kit' ),
 			),
 			'error-email-report-search-console'      => array(
-				/* translators: 1: opening anchor tag for settings link, 2: closing anchor tag, 3: opening anchor tag for help link, 4: closing anchor tag */
-				__( 'We were unable to generate your report because data loading failed for Search Console. To fix this, go to %1$sSearch Console settings%2$s in Site Kit or %3$sget help%4$s.', 'google-site-kit' ),
+				/* translators: 1: Search Console settings link URL, 2: Search Console settings link style CSS, 3: help link URL, 4: help link style CSS */
+				__( 'We were unable to generate your report because data loading failed for Search Console. To fix this, go to <a class="link" href="%1$s" style="%2$s">Search Console settings</a> in Site Kit or <a class="link" href="%3$s" style="%4$s">get help</a>.', 'google-site-kit' ),
 				__( 'Report delivery will automatically resume once the issue is resolved.', 'google-site-kit' ),
 			),
 			'error-email-report-analytics-4'         => array(
-				/* translators: 1: opening anchor tag for settings link, 2: closing anchor tag, 3: opening anchor tag for help link, 4: closing anchor tag */
-				__( 'We were unable to generate your report because data loading failed for Analytics. To fix this, go to %1$sAnalytics settings%2$s in Site Kit or %3$sget help%4$s.', 'google-site-kit' ),
+				/* translators: 1: Analytics settings link URL, 2: Analytics settings link style CSS, 3: help link URL, 4: help link style CSS */
+				__( 'We were unable to generate your report because data loading failed for Analytics. To fix this, go to <a class="link" href="%1$s" style="%2$s">Analytics settings</a> in Site Kit or <a class="link" href="%3$s" style="%4$s">get help</a>.', 'google-site-kit' ),
 				__( 'Report delivery will automatically resume once the issue is resolved.', 'google-site-kit' ),
 			),
 		);
@@ -229,41 +229,41 @@ class Content_Map {
 	 * @return array Ordered sprintf arguments for the body paragraphs.
 	 */
 	public static function get_body_args( $content_key, Golinks $golinks ) {
-		$link_style    = 'color:#108080;';
-		$support_base  = 'https://sitekit.withgoogle.com/support/';
-		$module_issues = add_query_arg( 'doc', 'email-reporting-module-issues', $support_base );
+		$link_style        = 'color:#108080;';
+		$support_base      = 'https://sitekit.withgoogle.com/support/';
+		$email_support_url = add_query_arg( 'doc', 'email-reporting-module-issues', $support_base );
 
 		switch ( $content_key ) {
 			case 'error-email-report-search-console':
 				$settings_url = add_query_arg( 'module', 'search-console', $golinks->get_url( 'settings' ) );
 				return array(
-					'<a class="link" href="' . $settings_url . '" style="' . $link_style . '">',
-					'</a>',
-					'<a class="link" href="' . $module_issues . '" style="' . $link_style . '">',
-					'</a>',
+					$settings_url,
+					$link_style,
+					$email_support_url,
+					$link_style,
 				);
 
 			case 'error-email-report-analytics-4':
 				$settings_url = add_query_arg( 'module', 'analytics-4', $golinks->get_url( 'settings' ) );
 				return array(
-					'<a class="link" href="' . $settings_url . '" style="' . $link_style . '">',
-					'</a>',
-					'<a class="link" href="' . $module_issues . '" style="' . $link_style . '">',
-					'</a>',
+					$settings_url,
+					$link_style,
+					$email_support_url,
+					$link_style,
 				);
 
 			case 'error-email-permissions-search-console':
 				$permissions_url = add_query_arg( 'error_id', 'search-console_insufficient_permissions', $support_base );
 				return array(
-					'<a class="link" href="' . $permissions_url . '" style="' . $link_style . '">',
-					'</a>',
+					$permissions_url,
+					$link_style,
 				);
 
 			case 'error-email-permissions-analytics-4':
 				$permissions_url = add_query_arg( 'error_id', 'analytics-4_insufficient_permissions', $support_base );
 				return array(
-					'<a class="link" href="' . $permissions_url . '" style="' . $link_style . '">',
-					'</a>',
+					$permissions_url,
+					$link_style,
 				);
 
 			default:

--- a/includes/Core/Email_Reporting/Content_Map.php
+++ b/includes/Core/Email_Reporting/Content_Map.php
@@ -229,7 +229,7 @@ class Content_Map {
 	 * @return array Ordered sprintf arguments for the body paragraphs.
 	 */
 	public static function get_body_args( $content_key, Golinks $golinks ) {
-		$link_style        = 'color:#108080;';
+		$link_style        = 'color:#108080;text-decoration:underline;';
 		$support_base      = 'https://sitekit.withgoogle.com/support/';
 		$email_support_url = add_query_arg( 'doc', 'email-reporting-module-issues', $support_base );
 

--- a/includes/Core/Email_Reporting/templates/simple-email/parts/content.php
+++ b/includes/Core/Email_Reporting/templates/simple-email/parts/content.php
@@ -79,6 +79,7 @@ $card_bottom_pad    = $has_bottom_graphic ? '0' : '12px';
 					array(
 						'strong' => array(),
 						'a'      => array(
+							'class' => array(),
 							'href'  => array(),
 							'style' => array(),
 						),

--- a/tests/phpunit/integration/Core/Email_Reporting/Batch_Error_NotifierTest.php
+++ b/tests/phpunit/integration/Core/Email_Reporting/Batch_Error_NotifierTest.php
@@ -451,6 +451,24 @@ class Batch_Error_NotifierTest extends TestCase {
 		);
 	}
 
+	public function test_report_error_body_contains_full_link() {
+		self::factory()->user->create( array( 'role' => 'administrator' ) );
+		$this->set_up_batch_with_category_and_module( 'report_error', 'search-console' );
+
+		$this->email_sender->method( 'build_headers' )->willReturn( array() );
+		$this->email_sender->expects( $this->atLeastOnce() )
+			->method( 'send' )
+			->with(
+				$this->isType( 'string' ),
+				$this->isType( 'string' ),
+				$this->stringContains( '<a class="link" href="http://example.org/wp-admin/index.php?action=googlesitekit_go&amp;to=settings&amp;module=' . $module_slug . '" style="color:#108080; text-decoration:none;">Search Console settings</a>' ),
+				$this->isType( 'array' ),
+				$this->isType( 'string' )
+			);
+
+		$this->create_notifier()->maybe_notify( 'batch-1' );
+	}
+
 	/**
 	 * @dataProvider data_permissions_error_body_contains_help_link
 	 */

--- a/tests/phpunit/integration/Core/Email_Reporting/Batch_Error_NotifierTest.php
+++ b/tests/phpunit/integration/Core/Email_Reporting/Batch_Error_NotifierTest.php
@@ -451,7 +451,7 @@ class Batch_Error_NotifierTest extends TestCase {
 		);
 	}
 
-	public function test_report_error_body_contains_full_link() {
+	public function test_report_error_body_contains_full_links() {
 		self::factory()->user->create( array( 'role' => 'administrator' ) );
 		$this->set_up_batch_with_category_and_module( 'report_error', 'search-console' );
 
@@ -461,7 +461,10 @@ class Batch_Error_NotifierTest extends TestCase {
 			->with(
 				$this->isType( 'string' ),
 				$this->isType( 'string' ),
-				$this->stringContains( '<a class="link" href="http://example.org/wp-admin/index.php?action=googlesitekit_go&amp;to=settings&amp;module=search-console" style="color:#108080; text-decoration:none;">Search Console settings</a>' ),
+				$this->logicalAnd(
+					$this->stringContains( '<a class="link" href="http://example.org/wp-admin/index.php?action=googlesitekit_go&amp;to=settings&amp;module=search-console" style="color:#108080;text-decoration:underline">Search Console settings</a>' ),
+					$this->stringContains( '<a class="link" href="https://sitekit.withgoogle.com/support/?doc=email-reporting-module-issues" style="color:#108080;text-decoration:underline">get help</a>' )
+				),
 				$this->isType( 'array' ),
 				$this->isType( 'string' )
 			);

--- a/tests/phpunit/integration/Core/Email_Reporting/Batch_Error_NotifierTest.php
+++ b/tests/phpunit/integration/Core/Email_Reporting/Batch_Error_NotifierTest.php
@@ -461,7 +461,7 @@ class Batch_Error_NotifierTest extends TestCase {
 			->with(
 				$this->isType( 'string' ),
 				$this->isType( 'string' ),
-				$this->stringContains( '<a class="link" href="http://example.org/wp-admin/index.php?action=googlesitekit_go&amp;to=settings&amp;module=' . $module_slug . '" style="color:#108080; text-decoration:none;">Search Console settings</a>' ),
+				$this->stringContains( '<a class="link" href="http://example.org/wp-admin/index.php?action=googlesitekit_go&amp;to=settings&amp;module=search-console" style="color:#108080; text-decoration:none;">Search Console settings</a>' ),
 				$this->isType( 'array' ),
 				$this->isType( 'string' )
 			);

--- a/tests/phpunit/integration/Core/Email_Reporting/Content_MapTest.php
+++ b/tests/phpunit/integration/Core/Email_Reporting/Content_MapTest.php
@@ -199,8 +199,8 @@ class Content_MapTest extends TestCase {
 		$args = Content_Map::get_body_args( 'error-email-report-search-console', $this->build_golinks() );
 
 		$this->assertNotEmpty( $args, 'Body args should not be empty for SC report error.' );
-		$help_anchor = end( $args ) === '</a>' ? $args[ count( $args ) - 2 ] : '';
-		$this->assertStringContainsString( 'doc=email-reporting-module-issues', $help_anchor, 'SC report error should link to module-issues doc.' );
+		$this->assertStringContainsString( 'module=search-console', $args[0], 'SC report error should link to search console settings.' );
+		$this->assertStringContainsString( 'doc=email-reporting-module-issues', $args[2], 'SC report error should link to module-issues doc.' );
 	}
 
 	public function test_get_body_args_uses_module_issues_doc_for_analytics_4_report_error() {


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #12479

## Relevant technical choices

I took a more simplified (and straightforward) approach than what was proposed in the IB, which seemed a bit overly complicated upon further reflection.

I added tests to make sure the correct, translated strings appear in the email body.

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.
- [ ] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
