### PR TITLE
security: remove --approval-mode=yolo to prevent prompt injection RCE

### DIFF
--- a/.github/workflows/gemini.yml
+++ b/.github/workflows/gemini.yml
@@ -72,7 +72,7 @@ jobs:
           gemini --version
       - name: Run /implement command
         run: |
-          gemini --approval-mode=yolo --model=gemini-3-pro-preview "/implement ${{ inputs.issue_number }}"
+          gemini --model=gemini-3-pro-preview "/implement ${{ inputs.issue_number }}"
         env:
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
 
Addresses issue: Prompt injection via attacker-controlled GitHub issue body 
fed to Gemini CLI running `--approval-mode=yolo`, enabling unapproved shell 
RCE and exfiltration of `GEMINI_API_KEY` + `GITHUB_TOKEN`.
 
## Relevant technical choices
 
`--approval-mode=yolo` auto-approves ALL Gemini CLI tool calls (shell execution, 
file writes, API calls) without human confirmation. Since the workflow feeds the 
full GitHub issue body as task context, any GitHub user can open an issue containing 
a prompt injection payload. When a maintainer triggers the workflow on that issue, 
the injected instructions execute arbitrary shell commands with secrets in scope.
 
Removing `--approval-mode=yolo` restores the default approval mode which requires 
human confirmation before executing shell commands, blocking this attack vector.
 
## PR Author Checklist
 
- [x] My code is tested and passes existing unit tests.
- [x] I have signed the Contributor License Agreement.  User : XananasX  Email : Mehdiananas007@gmail.com