### PR TITLE
Security: External links opened with `_blank` may allow reverse tabnabbing

### DIFF
--- a/assets/js/components/Banner/CTAButton.js
+++ b/assets/js/components/Banner/CTAButton.js
@@ -53,6 +53,7 @@ export default function CTAButton( {
 			onClick={ onClick }
 			href={ href }
 			target={ external ? '_blank' : undefined }
+			rel={ external ? 'noopener noreferrer' : undefined }
 			trailingIcon={ trailingIconToUse }
 		>
 			{ label }


### PR DESCRIPTION
## Summary

Security: External links opened with `_blank` may allow reverse tabnabbing

## Problem

**Severity**: `Medium` | **File**: `assets/js/components/Banner/CTAButton.js:L57`

The banner CTA renders links with `target="_blank"` when `external` is true, but no explicit `rel="noopener noreferrer"` is set. If the underlying `SpinnerButton` renders an `<a>` without automatically enforcing safe `rel` values, the newly opened page can access `window.opener` and potentially redirect the original admin page (reverse tabnabbing).

## Solution

When rendering external links in a new tab, always include `rel="noopener noreferrer"` alongside `target="_blank"`. If `SpinnerButton` wraps anchor rendering, enforce this in `SpinnerButton` itself as a secure default.

## Changes

- `assets/js/components/Banner/CTAButton.js` (modified)