### PR TITLE
Fix order for modules filter in Email Reporting to fix second admin module access via dashboard sharing bug.

### DIFF
--- a/includes/Core/Email_Reporting/Email_Reporting_Data_Requests.php
+++ b/includes/Core/Email_Reporting/Email_Reporting_Data_Requests.php
@@ -392,11 +392,26 @@ class Email_Reporting_Data_Requests {
 				continue;
 			}
 
+			// Module owner; data fetch uses their own (= owner) tokens.
+			if ( $user->ID === $this->get_module_owner_id( $slug ) ) {
+				$allowed[ $slug ] = $module;
+				continue;
+			}
+
+			// Recipient's role is in the module's shared roles; the data fetch
+			// resolves to the owner's OAuth client in Module::get_oauth_client_for_datapoint(),
+			// matching the dashboard-sharing path. Applies to any role (editor,
+			// admin, etc.) whose role is in sharedRoles.
+			if ( user_can( $user, Permissions::READ_SHARED_MODULE_DATA, $slug ) ) {
+				$allowed[ $slug ] = $module;
+				continue;
+			}
+
+			// Admin not in shared roles; preserves the authenticated-admin-with-
+			// own-Google path: preflight with the recipient's own tokens and only
+			// include the module if they personally have access.
 			if ( user_can( $user, Permissions::MANAGE_OPTIONS ) ) {
-				if (
-					$module instanceof Module_With_Service_Entity
-					&& $user->ID !== $this->get_module_owner_id( $slug )
-				) {
+				if ( $module instanceof Module_With_Service_Entity ) {
 					$access = $module->check_service_entity_access();
 
 					if ( true !== $access ) {
@@ -405,12 +420,6 @@ class Email_Reporting_Data_Requests {
 				}
 
 				$allowed[ $slug ] = $module;
-				continue;
-			}
-
-			if ( user_can( $user, Permissions::READ_SHARED_MODULE_DATA, $slug ) ) {
-				$allowed[ $slug ] = $module;
-				continue;
 			}
 		}
 

--- a/includes/Core/Email_Reporting/Email_Reporting_Data_Requests.php
+++ b/includes/Core/Email_Reporting/Email_Reporting_Data_Requests.php
@@ -167,14 +167,14 @@ class Email_Reporting_Data_Requests {
 		try {
 			$this->maybe_reset_runtime_caches_for_user_change( $user_id );
 
-			$active_modules = $this->modules->get_active_modules();
+			$shareable_modules = $this->modules->get_shareable_modules();
 
 			if ( ! empty( $allowed_module_slugs ) ) {
 				// Flip slugs to keys so we can intersect by module slug.
-				$active_modules = array_intersect_key( $active_modules, array_flip( $allowed_module_slugs ) );
+				$shareable_modules = array_intersect_key( $shareable_modules, array_flip( $allowed_module_slugs ) );
 			}
 
-			$available_modules = $this->filter_modules_for_user( $active_modules, $user );
+			$available_modules = $this->filter_modules_for_user( $shareable_modules, $user );
 
 			if ( empty( $available_modules ) ) {
 				return array();
@@ -388,7 +388,7 @@ class Email_Reporting_Data_Requests {
 		$allowed = array();
 
 		foreach ( $modules as $slug => $module ) {
-			if ( ! $module->is_connected() || $module->is_recoverable() ) {
+			if ( $module->is_recoverable() ) {
 				continue;
 			}
 


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #12564

## Relevant technical choices

<!-- Please describe your changes. -->

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [ ] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.
- [ ] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
