### PR TITLE
Guard dismissed_wp_pointers against invalid WP meta.

### DIFF
--- a/includes/Core/Dashboard_Sharing/View_Only_Pointer.php
+++ b/includes/Core/Dashboard_Sharing/View_Only_Pointer.php
@@ -90,17 +90,11 @@ final class View_Only_Pointer {
 					}
 
 					$dismissed_wp_pointers = get_user_meta( get_current_user_id(), 'dismissed_wp_pointers', true );
-					if ( ! $dismissed_wp_pointers ) {
-						return true;
+					if ( ! is_array( $dismissed_wp_pointers ) ) {
+						$dismissed_wp_pointers = explode( ',', (string) $dismissed_wp_pointers );
 					}
-
-					$user_id               = get_current_user_id();
-					$dismissed_wp_pointers = get_user_meta( $user_id, 'dismissed_wp_pointers', true );
-					if ( $dismissed_wp_pointers ) {
-						$dismissed_wp_pointers = explode( ',', $dismissed_wp_pointers );
-						if ( in_array( self::SLUG, $dismissed_wp_pointers, true ) ) {
-							return false;
-						}
+					if ( in_array( self::SLUG, $dismissed_wp_pointers, true ) ) {
+						return false;
 					}
 
 					return true;

--- a/includes/Core/Dashboard_Sharing/View_Only_Pointer.php
+++ b/includes/Core/Dashboard_Sharing/View_Only_Pointer.php
@@ -89,11 +89,10 @@ final class View_Only_Pointer {
 						return false;
 					}
 
-					$dismissed_wp_pointers = explode(
-						',',
-						(string) get_user_meta( get_current_user_id(), 'dismissed_wp_pointers', true )
-					);
-
+					$dismissed_wp_pointers = get_user_meta( get_current_user_id(), 'dismissed_wp_pointers', true );
+					if ( ! is_array( $dismissed_wp_pointers ) ) {
+						$dismissed_wp_pointers = explode( ',', (string) $dismissed_wp_pointers );
+					}
 					if ( in_array( self::SLUG, $dismissed_wp_pointers, true ) ) {
 						return false;
 					}

--- a/includes/Core/Dashboard_Sharing/View_Only_Pointer.php
+++ b/includes/Core/Dashboard_Sharing/View_Only_Pointer.php
@@ -89,10 +89,11 @@ final class View_Only_Pointer {
 						return false;
 					}
 
-					$dismissed_wp_pointers = get_user_meta( get_current_user_id(), 'dismissed_wp_pointers', true );
-					if ( ! is_array( $dismissed_wp_pointers ) ) {
-						$dismissed_wp_pointers = explode( ',', (string) $dismissed_wp_pointers );
-					}
+					$dismissed_wp_pointers = explode(
+						',',
+						(string) get_user_meta( get_current_user_id(), 'dismissed_wp_pointers', true )
+					);
+
 					if ( in_array( self::SLUG, $dismissed_wp_pointers, true ) ) {
 						return false;
 					}

--- a/includes/Core/Email_Reporting/Email_Reporting_Pointer.php
+++ b/includes/Core/Email_Reporting/Email_Reporting_Pointer.php
@@ -136,11 +136,11 @@ final class Email_Reporting_Pointer {
 					}
 
 					// Do not show if this pointer was already dismissed via core 'dismiss-wp-pointer'.
-					$dismissed_wp_pointers = explode(
-						',',
-						(string) get_user_meta( get_current_user_id(), 'dismissed_wp_pointers', true )
-					);
-
+					$user_id               = get_current_user_id();
+					$dismissed_wp_pointers = get_user_meta( $user_id, 'dismissed_wp_pointers', true );
+					if ( ! is_array( $dismissed_wp_pointers ) ) {
+						$dismissed_wp_pointers = explode( ',', (string) $dismissed_wp_pointers );
+					}
 					if ( in_array( self::SLUG, $dismissed_wp_pointers, true ) ) {
 						return false;
 					}

--- a/includes/Core/Email_Reporting/Email_Reporting_Pointer.php
+++ b/includes/Core/Email_Reporting/Email_Reporting_Pointer.php
@@ -138,11 +138,11 @@ final class Email_Reporting_Pointer {
 					// Do not show if this pointer was already dismissed via core 'dismiss-wp-pointer'.
 					$user_id               = get_current_user_id();
 					$dismissed_wp_pointers = get_user_meta( $user_id, 'dismissed_wp_pointers', true );
-					if ( $dismissed_wp_pointers ) {
-						$dismissed_wp_pointers = explode( ',', $dismissed_wp_pointers );
-						if ( in_array( self::SLUG, $dismissed_wp_pointers, true ) ) {
-							return false;
-						}
+					if ( ! is_array( $dismissed_wp_pointers ) ) {
+						$dismissed_wp_pointers = explode( ',', (string) $dismissed_wp_pointers );
+					}
+					if ( in_array( self::SLUG, $dismissed_wp_pointers, true ) ) {
+						return false;
 					}
 
 					// If user is already subscribed to email reporting, bail early.

--- a/includes/Core/Email_Reporting/Email_Reporting_Pointer.php
+++ b/includes/Core/Email_Reporting/Email_Reporting_Pointer.php
@@ -136,11 +136,11 @@ final class Email_Reporting_Pointer {
 					}
 
 					// Do not show if this pointer was already dismissed via core 'dismiss-wp-pointer'.
-					$user_id               = get_current_user_id();
-					$dismissed_wp_pointers = get_user_meta( $user_id, 'dismissed_wp_pointers', true );
-					if ( ! is_array( $dismissed_wp_pointers ) ) {
-						$dismissed_wp_pointers = explode( ',', (string) $dismissed_wp_pointers );
-					}
+					$dismissed_wp_pointers = explode(
+						',',
+						(string) get_user_meta( get_current_user_id(), 'dismissed_wp_pointers', true )
+					);
+
 					if ( in_array( self::SLUG, $dismissed_wp_pointers, true ) ) {
 						return false;
 					}

--- a/tests/phpunit/integration/Core/Dashboard_Sharing/View_Only_PointerTest.php
+++ b/tests/phpunit/integration/Core/Dashboard_Sharing/View_Only_PointerTest.php
@@ -138,6 +138,24 @@ class View_Only_PointerTest extends TestCase {
 		$this->assertFalse( $view_only_pointer->is_active( 'index.php' ) );
 	}
 
+	public function test_active_callback__dismissed_wp_pointers_meta_is_array() {
+		$user_id = $this->create_editor_user();
+
+		$this->grant_editors_view_only_dashboard_access();
+
+		$this->register_permissions_for_user( $user_id );
+
+		// Simulate corrupted or third-party-written meta stored as an array.
+		// Reading this value must not fatal when the active_callback runs.
+		update_user_meta( $user_id, 'dismissed_wp_pointers', array( 'foo' ) );
+
+		$view_only_pointer = $this->get_registered_pointer();
+
+		// Should remain active because the array does not contain the pointer slug,
+		// and must not throw a TypeError when calling explode() on the meta value.
+		$this->assertTrue( $view_only_pointer->is_active( 'index.php' ) );
+	}
+
 	private function get_registered_pointer() {
 		$pointers = apply_filters( 'googlesitekit_admin_pointers', array() );
 		return array_pop( $pointers );

--- a/tests/phpunit/integration/Core/Email_Reporting/Email_Reporting_PointerTest.php
+++ b/tests/phpunit/integration/Core/Email_Reporting/Email_Reporting_PointerTest.php
@@ -111,6 +111,22 @@ class Email_Reporting_PointerTest extends TestCase {
 		$this->assertFalse( $pointer->is_active( 'index.php' ), 'Pointer should be inactive when the pointer was previously dismissed by the user.' );
 	}
 
+	public function test_active_callback__dismissed_wp_pointers_meta_is_array() {
+		$user_id = $this->factory()->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $user_id );
+		$this->user_options->switch_user( $user_id );
+		$this->set_user_access_token( $user_id, 'test-access-token' );
+		$this->user_options->set( Verification::OPTION, 'verified' );
+
+		// Simulate corrupted or third-party-written meta stored as an array.
+		// Reading this value must not fatal when the active_callback runs.
+		update_user_meta( $user_id, 'dismissed_wp_pointers', array( 'foo' ) );
+
+		$pointer = $this->get_registered_pointer();
+
+		$this->assertTrue( $pointer->is_active( 'index.php' ), 'Pointer should remain active when dismissed_wp_pointers meta is an array that does not contain the pointer slug, without triggering a TypeError.' );
+	}
+
 	public function test_active_callback__subscribed_user_bails() {
 		$user_id = $this->factory()->user->create( array( 'role' => 'administrator' ) );
 		wp_set_current_user( $user_id );


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #12580

## Relevant technical choices

This PR fixes a bug that prevents fatal errors in the WP dashboard if the dismissed pointers entry in the `_usermeta` table is changed to an array.

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [x] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [x] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [x] Ensure there is a QA Brief.
- [x] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [x] Ensure the PR has the correct target branch.
- [x] Double-check that the PR is okay to be merged.
- [x] Ensure the corresponding issue has a ZenHub release assigned.
- [x] Add a changelog message to the issue.
