### PR TITLE
Show display names for user roles in email report subscription list.

### DIFF
--- a/assets/js/components/email-reporting/InviteOthersToSubscribe/InviteUserRow.stories.js
+++ b/assets/js/components/email-reporting/InviteOthersToSubscribe/InviteUserRow.stories.js
@@ -26,7 +26,7 @@ const mockUser = {
 	displayName: 'MainAdminName',
 	name: 'MainAdminName',
 	email: 'someone@anybusiness.com',
-	role: 'administrator',
+	role: 'Administrator',
 	subscribed: false,
 };
 

--- a/assets/js/components/email-reporting/InviteOthersToSubscribe/InviteUserRow.test.js
+++ b/assets/js/components/email-reporting/InviteOthersToSubscribe/InviteUserRow.test.js
@@ -38,7 +38,7 @@ describe( 'InviteUserRow', () => {
 		id: 2,
 		name: 'MainAdminName',
 		email: 'someone@anybusiness.com',
-		role: 'administrator',
+		role: 'Administrator',
 	};
 
 	const mockOnInviteResult = jest.fn();
@@ -58,12 +58,12 @@ describe( 'InviteUserRow', () => {
 		);
 
 		expect( getByText( 'MainAdminName' ) ).toBeInTheDocument();
-		expect( getByText( '(administrator)' ) ).toBeInTheDocument();
+		expect( getByText( '(Administrator)' ) ).toBeInTheDocument();
 		expect( getByText( 'someone@anybusiness.com' ) ).toBeInTheDocument();
 	} );
 
-	it( 'renders the role slug', () => {
-		const editorUser = { ...mockUser, role: 'editor' };
+	it( 'renders the role display name', () => {
+		const editorUser = { ...mockUser, role: 'Editor' };
 
 		const { getByText } = render(
 			<InviteUserRow
@@ -73,7 +73,7 @@ describe( 'InviteUserRow', () => {
 			{ registry }
 		);
 
-		expect( getByText( '(editor)' ) ).toBeInTheDocument();
+		expect( getByText( '(Editor)' ) ).toBeInTheDocument();
 	} );
 
 	it( 'shows "Send invite" button in default state', () => {

--- a/assets/js/components/email-reporting/UserSettingsSelectionPanel/index.stories.js
+++ b/assets/js/components/email-reporting/UserSettingsSelectionPanel/index.stories.js
@@ -49,7 +49,7 @@ const mockEligibleSubscribers = [
 		displayName: 'MainAdminName',
 		name: 'MainAdminName',
 		email: 'someone@anybusiness.com',
-		role: 'administrator',
+		role: 'Administrator',
 		subscribed: false,
 	},
 	{
@@ -57,7 +57,7 @@ const mockEligibleSubscribers = [
 		displayName: 'AdminName2',
 		name: 'AdminName2',
 		email: 'anotheradminname@anybusiness.com',
-		role: 'administrator',
+		role: 'Administrator',
 		subscribed: false,
 	},
 	{
@@ -65,7 +65,7 @@ const mockEligibleSubscribers = [
 		displayName: 'AuthorName',
 		name: 'AuthorName',
 		email: 'admin2business@gmail.com',
-		role: 'author',
+		role: 'Author',
 		subscribed: false,
 	},
 ];

--- a/assets/js/googlesitekit/datastore/site/email-reporting.js
+++ b/assets/js/googlesitekit/datastore/site/email-reporting.js
@@ -524,7 +524,7 @@ const baseSelectors = {
 							id: user.id,
 							name: user.displayName || user.name,
 							email: user.email,
-							role: user.role,
+							role: user.roleDisplayName || user.role,
 							subscribed: user.subscribed,
 							invited: user.invited,
 						} ) ),

--- a/assets/js/googlesitekit/datastore/site/email-reporting.test.js
+++ b/assets/js/googlesitekit/datastore/site/email-reporting.test.js
@@ -614,6 +614,68 @@ describe( 'core/site Email Reporting', () => {
 				} );
 			} );
 
+			it( 'exposes roleDisplayName on the user role field when the API provides it', () => {
+				provideUserInfo( registry, { id: 1 } );
+
+				registry.dispatch( CORE_SITE ).receiveGetEligibleSubscribers(
+					createEligibleSubscribersResponse( [
+						{
+							id: 2,
+							displayName: 'Eligible User',
+							email: 'eligible@example.com',
+							role: 'editor',
+							roleDisplayName: 'Editor',
+							subscribed: false,
+							invited: false,
+						},
+					] ),
+					{ page: 1, search: '' }
+				);
+
+				expect(
+					registry.select( CORE_SITE ).getEligibleSubscribers( {
+						search: '',
+					} )
+				).toEqual( {
+					users: [
+						{
+							id: 2,
+							name: 'Eligible User',
+							email: 'eligible@example.com',
+							role: 'Editor',
+							subscribed: false,
+							invited: false,
+						},
+					],
+					total: 1,
+					totalPages: 1,
+				} );
+			} );
+
+			it( 'falls back to the role slug when roleDisplayName is missing', () => {
+				provideUserInfo( registry, { id: 1 } );
+
+				registry.dispatch( CORE_SITE ).receiveGetEligibleSubscribers(
+					createEligibleSubscribersResponse( [
+						{
+							id: 2,
+							displayName: 'Eligible User',
+							email: 'eligible@example.com',
+							role: 'editor',
+							subscribed: false,
+							invited: false,
+						},
+					] ),
+					{ page: 1, search: '' }
+				);
+
+				expect(
+					registry.select( CORE_SITE ).getEligibleSubscribers( {
+						search: '',
+					} ).users[ 0 ].role
+				).toBe( 'editor' );
+			} );
+
 			it( 'resolver fetches with correct params on cache miss', async () => {
 				provideUserInfo( registry, { id: 1 } );
 

--- a/assets/sass/components/email-reporting/_googlesitekit-invite-others-to-subscribe.scss
+++ b/assets/sass/components/email-reporting/_googlesitekit-invite-others-to-subscribe.scss
@@ -118,7 +118,6 @@
 		font-size: $fs-body-md;
 		font-weight: 400;
 		margin-left: 4px;
-		text-transform: capitalize;
 	}
 
 	.googlesitekit-invite-user-row__email {

--- a/includes/Core/Email_Reporting/REST_Email_Reporting_Controller.php
+++ b/includes/Core/Email_Reporting/REST_Email_Reporting_Controller.php
@@ -440,12 +440,13 @@ class REST_Email_Reporting_Controller {
 		$settings = get_user_meta( $user->ID, $meta_key, true );
 
 		return array(
-			'id'          => (int) $user->ID,
-			'displayName' => $user->display_name,
-			'email'       => $user->user_email,
-			'role'        => $this->get_primary_role( $user ),
-			'subscribed'  => is_array( $settings ) && ! empty( $settings['subscribed'] ),
-			'invited'     => $this->is_invite_rate_limited( $user->ID ),
+			'id'              => (int) $user->ID,
+			'displayName'     => $user->display_name,
+			'email'           => $user->user_email,
+			'role'            => $this->get_primary_role( $user ),
+			'roleDisplayName' => $this->get_primary_role_display_name( $user ),
+			'subscribed'      => is_array( $settings ) && ! empty( $settings['subscribed'] ),
+			'invited'         => $this->is_invite_rate_limited( $user->ID ),
 		);
 	}
 
@@ -465,6 +466,22 @@ class REST_Email_Reporting_Controller {
 		$roles = array_values( $user->roles );
 
 		return (string) reset( $roles );
+	}
+
+	/**
+	 * Gets the primary role display name of the user.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param WP_User $user User object.
+	 * @return string
+	 */
+	private function get_primary_role_display_name( WP_User $user ) {
+		$role_slug = $this->get_primary_role( $user );
+
+		$role_name = wp_roles()->get_names()[ $role_slug ] ?? $role_slug;
+
+		return translate_user_role( $role_name );
 	}
 
 	/**

--- a/tests/phpunit/integration/Core/Email_Reporting/REST_Email_Reporting_ControllerTest.php
+++ b/tests/phpunit/integration/Core/Email_Reporting/REST_Email_Reporting_ControllerTest.php
@@ -416,6 +416,40 @@ class REST_Email_Reporting_ControllerTest extends TestCase {
 		$this->assertIsInt( $data['totalPages'], 'TotalPages field should be an integer.' );
 	}
 
+	public function test_get_eligible_subscribers_user_payload_includes_role_slug_and_display_name() {
+		$current_admin = $this->create_admin_with_token( 'admin-current' );
+		$this->create_admin_with_token( 'admin-other' );
+
+		$this->unset_user_access_token( $this->primary_admin_id );
+		wp_set_current_user( $current_admin );
+
+		remove_all_filters( 'googlesitekit_rest_routes' );
+		$this->controller->register();
+		$this->register_rest_routes();
+
+		$request  = new \WP_REST_Request( 'GET', '/' . REST_Routes::REST_ROOT . '/core/site/data/email-reporting-eligible-subscribers' );
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$sample_user = $data['users'][0] ?? null;
+		$this->assertIsArray( $sample_user, 'Expected at least one subscriber in the response.' );
+
+		$this->assertArrayHasKey( 'roleDisplayName', $sample_user, 'User payload should include roleDisplayName.' );
+		$this->assertIsString( $sample_user['roleDisplayName'], 'roleDisplayName should be a string.' );
+		$this->assertSame( 'administrator', $sample_user['role'], 'role should be the role slug.' );
+
+		$this->assertSame(
+			'Administrator',
+			$sample_user['roleDisplayName'],
+			'roleDisplayName should be the translated human-readable role name.'
+		);
+		$this->assertNotSame(
+			$sample_user['role'],
+			$sample_user['roleDisplayName'],
+			'Default administrator role slug should not match its display name string.'
+		);
+	}
+
 	public function test_get_eligible_subscribers_non_matching_search_returns_empty_result() {
 		$current_admin = $this->create_admin_with_token( 'admin-current' );
 		$this->create_admin_with_token( 'admin-other' );


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #12431

## Relevant technical choices

- I deviated from the IB to get the role display name using `wp_roles()->get_names()[ $slug ]` instead of using `get_role( $slug )` which only returns the slug again instead of the display name. 
- Updated the css to remove the `text-transform: capitalize` which was previously used to create a "fake" display name.
- Updated storybook mock data.

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.
- [ ] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
