### PR TITLE
Use Display Name for Custom Roles (#12431)

### DIFF
--- a/modules/util/format-role.js
+++ b/modules/util/format-role.js
@@ -1,0 +1,1 @@
+export function formatRoleForDisplay(role,rolesMap){if(!role||typeof role!=="string")return"";const r=rolesMap?.[role];if(r?.display_name)return r.display_name;return role.split("_").map(p=>p.charAt(0).toUpperCase()+p.slice(1).toLowerCase()).join(" ")}


### PR DESCRIPTION
New utility formatRoleForDisplay() returns human-readable role name from WP display_name or Title Case fallback. Closes #12431