### PR TITLE
Fix: Incorrect notification appears when setting up Ads module with PAX.

### DIFF
--- a/assets/js/components/setup/ModuleSetup.js
+++ b/assets/js/components/setup/ModuleSetup.js
@@ -28,7 +28,7 @@ import { useCallbackOne } from 'use-memo-one';
  */
 import { Fragment, useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { addQueryArgs } from '@wordpress/url';
+import { addQueryArgs, getQueryArgs } from '@wordpress/url';
 
 /**
  * Internal dependencies
@@ -95,7 +95,12 @@ export default function ModuleSetup( { moduleSlug } ) {
 			}
 
 			if ( redirectURL ) {
-				navigateTo( addQueryArgs( redirectURL, forwardableParams ) );
+				navigateTo(
+					addQueryArgs( redirectURL, {
+						...forwardableParams,
+						...getQueryArgs( redirectURL ),
+					} )
+				);
 				return;
 			}
 

--- a/assets/js/components/setup/ModuleSetup.test.js
+++ b/assets/js/components/setup/ModuleSetup.test.js
@@ -348,7 +348,7 @@ describe( 'ModuleSetup', () => {
 			const moduleSlug = 'test-module';
 
 			global.location.href =
-				'http://example.com/wp-admin/admin.php?page=googlesitekit-dashboard&panel=email-reporting&notification=ads_success';
+				'http://example.com/wp-admin/admin.php?page=googlesitekit-dashboard&panel=email-reporting&notification=authentication_success';
 
 			const customRedirectURLWithNotification =
 				'http://example.com/wp-admin/admin.php?page=googlesitekit-dashboard&slug=ads&notification=ads_success';
@@ -366,11 +366,10 @@ describe( 'ModuleSetup', () => {
 			);
 
 			await waitForRegistry();
-			await waitFor( () =>
-				expect(
-					getByRole( 'button', { name: 'Trigger finish setup' } )
-				).toBeInTheDocument()
-			);
+
+			expect(
+				getByRole( 'button', { name: 'Trigger finish setup' } )
+			).toBeInTheDocument();
 
 			await act( () => {
 				fireEvent.click(
@@ -378,11 +377,9 @@ describe( 'ModuleSetup', () => {
 				);
 			} );
 
-			await act( async () => {
-				await waitFor( () =>
-					expect( global.location.assign ).toHaveBeenCalled()
-				);
-			} );
+			await waitFor( () =>
+				expect( global.location.assign ).toHaveBeenCalled()
+			);
 
 			const redirectURL = new URL(
 				global.location.assign.mock.calls[ 0 ][ 0 ]

--- a/assets/js/components/setup/ModuleSetup.test.js
+++ b/assets/js/components/setup/ModuleSetup.test.js
@@ -367,10 +367,6 @@ describe( 'ModuleSetup', () => {
 
 			await waitForRegistry();
 
-			expect(
-				getByRole( 'button', { name: 'Trigger finish setup' } )
-			).toBeInTheDocument();
-
 			await act( () => {
 				fireEvent.click(
 					getByRole( 'button', { name: 'Trigger finish setup' } )

--- a/assets/js/components/setup/ModuleSetup.test.js
+++ b/assets/js/components/setup/ModuleSetup.test.js
@@ -344,6 +344,54 @@ describe( 'ModuleSetup', () => {
 			] );
 		}
 
+		it( 'should not override existing params in redirect URL with forwarded params', async () => {
+			const moduleSlug = 'test-module';
+
+			global.location.href =
+				'http://example.com/wp-admin/admin.php?page=googlesitekit-dashboard&panel=email-reporting&notification=ads_success';
+
+			const customRedirectURLWithNotification =
+				'http://example.com/wp-admin/admin.php?page=googlesitekit-dashboard&slug=ads&notification=ads_success';
+
+			registerFinishSetupModule( moduleSlug, ( finishSetup ) =>
+				finishSetup( customRedirectURLWithNotification )
+			);
+
+			const { getByRole, waitForRegistry } = render(
+				<ModuleSetup moduleSlug={ moduleSlug } />,
+				{
+					registry,
+					viewContext: VIEW_CONTEXT_MODULE_SETUP,
+				}
+			);
+
+			await waitForRegistry();
+			await waitFor( () =>
+				expect(
+					getByRole( 'button', { name: 'Trigger finish setup' } )
+				).toBeInTheDocument()
+			);
+
+			await act( () => {
+				fireEvent.click(
+					getByRole( 'button', { name: 'Trigger finish setup' } )
+				);
+			} );
+
+			await act( async () => {
+				await waitFor( () =>
+					expect( global.location.assign ).toHaveBeenCalled()
+				);
+			} );
+
+			const redirectURL = new URL(
+				global.location.assign.mock.calls[ 0 ][ 0 ]
+			);
+			expect( redirectURL.searchParams.get( 'notification' ) ).toEqual(
+				'ads_success'
+			);
+		} );
+
 		it( 'should preserve forwarded params for custom redirect URL', async () => {
 			const moduleSlug = 'test-module';
 


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #12539

## Relevant technical choices

<!-- Please describe your changes. -->

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.
- [ ] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [x] Ensure the PR has the correct target branch.
- [x] Double-check that the PR is okay to be merged.
- [x] Ensure the corresponding issue has a ZenHub release assigned.
- [x] Add a changelog message to the issue.
