### PR TITLE
Fix overlapping text in invite user component

### DIFF
--- a/assets/sass/components/email-reporting/_googlesitekit-invite-others-to-subscribe.scss
+++ b/assets/sass/components/email-reporting/_googlesitekit-invite-others-to-subscribe.scss
@@ -111,6 +111,7 @@
 		color: $c-surfaces-on-surface;
 		font-size: $fs-body-md;
 		font-weight: 500;
+		word-break: break-word;
 	}
 
 	.googlesitekit-invite-user-row__role {
@@ -123,6 +124,7 @@
 	.googlesitekit-invite-user-row__email {
 		color: $c-surfaces-on-surface;
 		font-size: $fs-body-sm;
+		word-break: break-word;
 	}
 
 	.googlesitekit-invite-user-row__action {


### PR DESCRIPTION
## Summary

Addresses issue:

- #12411

## Relevant technical choices

* Added `word-break: break-word` to `.googlesitekit-invite-user-row__name` and `.googlesitekit-invite-user-row__email` CSS classes in `assets/sass/components/email-reporting/_googlesitekit-invite-others-to-subscribe.scss`
* This prevents long names, email addresses, and role labels from overflowing and overlapping the "Send invite" button
* The fix works across all screen sizes and languages (including those with longer text strings)

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

## QA Brief

* Open the email reporting subscription panel with the invite users component
* Add users with very long display names or email addresses
* Verify that the name and email text wraps properly and does not overlap the "Send invite" button
* Test across different screen sizes (mobile, tablet, desktop)
* Test with users that have long role names or names in different languages