### PR TITLE
Fix email link color visibility in dark mode

### DIFF
--- a/includes/Core/Email_Reporting/Content_Map.php
+++ b/includes/Core/Email_Reporting/Content_Map.php
@@ -229,7 +229,7 @@ class Content_Map {
 	 * @return array Ordered sprintf arguments for the body paragraphs.
 	 */
 	public static function get_body_args( $content_key, Golinks $golinks ) {
-		$link_style        = 'color:#108080;text-decoration:underline;';
+		$link_style        = 'text-decoration:underline;';
 		$support_base      = 'https://sitekit.withgoogle.com/support/';
 		$email_support_url = add_query_arg( 'doc', 'email-reporting-module-issues', $support_base );
 

--- a/includes/Core/Email_Reporting/templates/email-report/parts/view-more-in-dashboard.php
+++ b/includes/Core/Email_Reporting/templates/email-report/parts/view-more-in-dashboard.php
@@ -18,7 +18,7 @@ $arrow_url = $get_asset_url( 'icon-link-arrow' );
 <table role="presentation" width="100%">
 	<tr>
 		<td style="text-align:right; height: 16px;" height="16">
-			<a class="link" href="<?php echo esc_url( $url ); ?>" style="font-size:12px; line-height:16px; font-weight:500; color:#108080; text-decoration:none;">
+			<a class="link" href="<?php echo esc_url( $url ); ?>" style="font-size:12px; line-height:16px; font-weight:500; text-decoration:none;">
 				<?php echo esc_html( $label ); ?>
 				<img src="<?php echo esc_url( $arrow_url ); ?>" alt="" width="10" height="10" style="vertical-align:middle; margin-left:4px; margin-bottom: 2px;" />
 			</a>

--- a/includes/Core/Email_Reporting/templates/parts/styles.php
+++ b/includes/Core/Email_Reporting/templates/parts/styles.php
@@ -117,7 +117,7 @@
 			}
 
 			.link {
-				color: #93C9A8 !important;
+				color: #4BBBBB !important;
 			}
 
 			.button {
@@ -185,7 +185,7 @@
 		}
 
 		[data-ogsc] .link {
-			color: #93C9A8 !important;
+			color: #4BBBBB !important;
 		}
 
 		[data-ogsc] .button {
@@ -215,4 +215,9 @@
 				/* `!important` used to override inline styles in the element. */
 				width: auto !important;
 			}
+		}
+
+		/* Base link color for light mode */
+		.link {
+			color: #108080;
 		}

--- a/includes/Core/Email_Reporting/templates/simple-email/parts/content.php
+++ b/includes/Core/Email_Reporting/templates/simple-email/parts/content.php
@@ -87,7 +87,7 @@ $card_bottom_pad    = $has_bottom_graphic ? '0' : '12px';
 				);
 				?>
 				<?php if ( 0 === $index && ! empty( $learn_more_url ) ) : ?>
-				<a class="link" href="<?php echo esc_url( $learn_more_url ); ?>" style="color: #108080; text-decoration: none;" target="_blank" rel="noopener"><?php echo esc_html__( 'Learn more', 'google-site-kit' ); ?></a>
+				<a class="link" href="<?php echo esc_url( $learn_more_url ); ?>" style="text-decoration: none;" target="_blank" rel="noopener"><?php echo esc_html__( 'Learn more', 'google-site-kit' ); ?></a>
 				<?php endif; ?>
 			</p>
 			<?php endforeach; ?>

--- a/tests/phpunit/integration/Core/Email_Reporting/Batch_Error_NotifierTest.php
+++ b/tests/phpunit/integration/Core/Email_Reporting/Batch_Error_NotifierTest.php
@@ -462,8 +462,8 @@ class Batch_Error_NotifierTest extends TestCase {
 				$this->isType( 'string' ),
 				$this->isType( 'string' ),
 				$this->logicalAnd(
-					$this->stringContains( '<a class="link" href="http://example.org/wp-admin/index.php?action=googlesitekit_go&amp;to=settings&amp;module=search-console" style="color:#108080;text-decoration:underline">Search Console settings</a>' ),
-					$this->stringContains( '<a class="link" href="https://sitekit.withgoogle.com/support/?doc=email-reporting-module-issues" style="color:#108080;text-decoration:underline">get help</a>' )
+					$this->stringContains( '<a class="link" href="http://example.org/wp-admin/index.php?action=googlesitekit_go&amp;to=settings&amp;module=search-console" style="text-decoration:underline">Search Console settings</a>' ),
+					$this->stringContains( '<a class="link" href="https://sitekit.withgoogle.com/support/?doc=email-reporting-module-issues" style="text-decoration:underline">get help</a>' )
 				),
 				$this->isType( 'array' ),
 				$this->isType( 'string' )


### PR DESCRIPTION
## Summary

Addresses issue:

- #12453

## Relevant technical choices

* Updated dark-mode `.link` color from `#93C9A8` to `#4BBBBB` in both `@media (prefers-color-scheme: dark)` and `[data-ogsc]` (Outlook) sections of `styles.php`
* Removed inline `color:#108080` from link styles in `Content_Map.php`, `content.php`, and `view-more-in-dashboard.php` so dark-mode CSS can override reliably
* Added base light-mode `.link { color: #108080; }` rule in `styles.php` to maintain visual parity for non-dark-mode email clients
* Updated `Batch_Error_NotifierTest` expectations to match the new inline style output

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

## QA Brief

* Send a test email report and view it in a dark-mode email client (e.g. Spark, Outlook app with dark mode)
* Verify that links are visible with the new `#4BBBBB` color in dark mode
* Verify that links still appear as `#108080` (teal) in light mode / non-dark-mode clients
* Check error email templates that contain "get help" and "Settings" links
* Check the "Learn more" link in simple email templates
* Check the "View more in dashboard" link in report email templates