### PR TITLE
Fix plain-text email footer link formatting

### DIFF
--- a/includes/Core/Email_Reporting/Plain_Text_Formatter.php
+++ b/includes/Core/Email_Reporting/Plain_Text_Formatter.php
@@ -143,11 +143,28 @@ class Plain_Text_Formatter {
 		}
 
 		// Footer links (hardcoded to match HTML footer template).
-		$lines[] = self::format_link( __( 'Manage subscription', 'google-site-kit' ), $unsubscribe_url );
-		$lines[] = self::format_link( __( 'Privacy Policy', 'google-site-kit' ), 'https://policies.google.com/privacy' );
-		$lines[] = self::format_link( __( 'Help center', 'google-site-kit' ), add_query_arg( 'doc', 'get-support', 'https://sitekit.withgoogle.com/support/' ) );
+		$lines[] = '';
+		$lines   = self::append_footer_links( $lines, $unsubscribe_url );
 
 		return implode( "\n", $lines );
+	}
+
+	/**
+	 * Appends footer utility links as separate line entries.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param array  $lines           Existing lines array.
+	 * @param string $unsubscribe_url Unsubscribe URL for manage subscription link.
+	 * @return array Updated lines array with footer links appended.
+	 */
+	private static function append_footer_links( $lines, $unsubscribe_url ) {
+		if ( ! empty( $unsubscribe_url ) ) {
+			$lines[] = self::format_link( __( 'Manage subscription', 'google-site-kit' ), $unsubscribe_url );
+			$lines[] = self::format_link( __( 'Privacy Policy', 'google-site-kit' ), 'https://policies.google.com/privacy' );
+			$lines[] = self::format_link( __( 'Help center', 'google-site-kit' ), add_query_arg( 'doc', 'get-support', 'https://sitekit.withgoogle.com/support/' ) );
+		}
+		return $lines;
 	}
 
 	/**
@@ -308,11 +325,8 @@ class Plain_Text_Formatter {
 
 		// Footer links (hardcoded to match HTML footer template).
 		$unsubscribe_url = $footer['unsubscribe_url'] ?? '';
-		if ( ! empty( $unsubscribe_url ) ) {
-			$lines[] = self::format_link( __( 'Manage subscription', 'google-site-kit' ), $unsubscribe_url );
-			$lines[] = self::format_link( __( 'Privacy Policy', 'google-site-kit' ), 'https://policies.google.com/privacy' );
-			$lines[] = self::format_link( __( 'Help center', 'google-site-kit' ), add_query_arg( 'doc', 'get-support', 'https://sitekit.withgoogle.com/support/' ) );
-		}
+		$lines[]         = '';
+		$lines           = self::append_footer_links( $lines, $unsubscribe_url );
 
 		return implode( "\n", $lines );
 	}

--- a/tests/phpunit/integration/Core/Email_Reporting/Plain_Text_FormatterTest.php
+++ b/tests/phpunit/integration/Core/Email_Reporting/Plain_Text_FormatterTest.php
@@ -209,6 +209,12 @@ class Plain_Text_FormatterTest extends TestCase {
 		$this->assertStringContainsString( 'Manage subscription: https://example.com/unsubscribe', $result, 'Footer should contain hardcoded manage subscription link.' );
 		$this->assertStringContainsString( 'Privacy Policy: https://policies.google.com/privacy', $result, 'Footer should contain hardcoded privacy policy link.' );
 		$this->assertStringContainsString( 'Help center:', $result, 'Footer should contain hardcoded help center link.' );
+
+		// Verify footer links appear as separate line entries.
+		$lines = explode( "\n", $result );
+		$this->assertContains( 'Manage subscription: https://example.com/unsubscribe', $lines, 'Manage subscription link should be on its own line.' );
+		$this->assertContains( 'Privacy Policy: https://policies.google.com/privacy', $lines, 'Privacy Policy link should be on its own line.' );
+		$this->assertContains( 'Help center: https://sitekit.withgoogle.com/support/?doc=get-support', $lines, 'Help center link should be on its own line.' );
 	}
 
 	public function test_format_section_dispatches_to_metrics_section() {


### PR DESCRIPTION
## Summary

Addresses issue:

- #12432

## Relevant technical choices

* Added a shared `append_footer_links()` private helper method in `Plain_Text_Formatter` that appends footer utility links (Manage subscription, Privacy Policy, Help center) as separate line entries
* Added a blank separator line before the footer links block for visual clarity
* Both `format_footer()` (report emails) and `format_simple_email()` now use this shared helper
* Added test assertions to verify footer links appear as separate line entries in the output
* HTML templates remain unchanged

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

## QA Brief

* Trigger a plain-text email report and verify the footer utility links (Manage subscription, Privacy Policy, Help center) each appear on their own line
* Trigger a plain-text simple email (e.g. subscription confirmation) and verify the same footer formatting
* Verify HTML email templates are unchanged