### PR TITLE
fix/12366-tooltip-overlaps-selection-panel

### DIFF
--- a/assets/js/components/AdminScreenTooltip/AdminScreenTooltip.js
+++ b/assets/js/components/AdminScreenTooltip/AdminScreenTooltip.js
@@ -57,6 +57,10 @@ export function AdminScreenTooltip() {
 			}
 	);
 
+	const isSelectionPanelOpen = useSelect( ( select ) =>
+		select( CORE_UI ).getValue( 'selectionPanelOpen' )
+	);
+
 	function handleViewTooltip() {
 		trackEvent(
 			`${ viewContext }_${ tooltipSlug }`,
@@ -78,7 +82,7 @@ export function AdminScreenTooltip() {
 		setValue( 'admin-screen-tooltip', undefined );
 	}, [ setValue, tooltipSlug, viewContext, gaTrackingEventLabel ] );
 
-	if ( ! isTooltipVisible ) {
+	if ( ! isTooltipVisible || isSelectionPanelOpen ) {
 		return null;
 	}
 

--- a/assets/js/components/AdminScreenTooltip/AdminScreenTooltip.test.js
+++ b/assets/js/components/AdminScreenTooltip/AdminScreenTooltip.test.js
@@ -236,6 +236,81 @@ describe( 'AdminMenuTooltip', () => {
 		);
 	} );
 
+	it( 'should not render when isTooltipVisible is true but selectionPanelOpen is true', async () => {
+		const tooltipSlug = 'test-tooltip-slug';
+		await registry.dispatch( CORE_UI ).setValue( 'admin-screen-tooltip', {
+			isTooltipVisible: true,
+			title: 'Test Title',
+			content: 'Test Content',
+			dismissLabel: 'Got it',
+			tooltipSlug,
+		} );
+		await registry
+			.dispatch( CORE_UI )
+			.setValue( 'selectionPanelOpen', true );
+
+		render(
+			<div className="googlesitekit-plugin">
+				<div id="adminmenu">
+					<a href="http://test.test/wp-admin/admin.php?page=googlesitekit-settings">
+						Settings
+					</a>
+				</div>
+				<AdminScreenTooltip />
+			</div>,
+			{ registry }
+		);
+
+		// Advance timers to allow Joyride to attempt rendering.
+		act( () => {
+			jest.advanceTimersByTime( 1000 );
+		} );
+
+		await waitFor( () => {
+			expect(
+				document.querySelector( '.googlesitekit-tour-tooltip' )
+			).not.toBeInTheDocument();
+		} );
+	} );
+
+	it( 'should render when isTooltipVisible is true and selectionPanelOpen is false', async () => {
+		const tooltipSlug = 'test-tooltip-slug';
+		await registry.dispatch( CORE_UI ).setValue( 'admin-screen-tooltip', {
+			isTooltipVisible: true,
+			title: 'Test Title',
+			content: 'Test Content',
+			dismissLabel: 'Got it',
+			tooltipSlug,
+		} );
+		await registry
+			.dispatch( CORE_UI )
+			.setValue( 'selectionPanelOpen', false );
+
+		render(
+			<div className="googlesitekit-plugin">
+				<div id="adminmenu">
+					<a href="http://test.test/wp-admin/admin.php?page=googlesitekit-settings">
+						Settings
+					</a>
+				</div>
+				<AdminScreenTooltip />
+			</div>,
+			{ registry }
+		);
+
+		// Wait for Joyride tooltip's useInterval to render.
+		act( () => {
+			jest.advanceTimersByTime( 1000 );
+		} );
+
+		await waitFor( () => {
+			const tooltip = document.querySelector(
+				'.googlesitekit-tour-tooltip'
+			);
+			expect( tooltip ).toBeInTheDocument();
+		} );
+	} );
+
 	it( 'should use the provided tracking label when tracking GA events', async () => {
 		const tooltipSlug = 'test-tooltip-slug';
 		await registry.dispatch( CORE_UI ).setValue( 'admin-screen-tooltip', {

--- a/assets/js/components/SelectionPanel/SelectionPanel.js
+++ b/assets/js/components/SelectionPanel/SelectionPanel.js
@@ -23,9 +23,16 @@ import classnames from 'classnames';
 import PropTypes from 'prop-types';
 
 /**
+ * WordPress dependencies
+ */
+import { useEffect } from '@wordpress/element';
+
+/**
  * Internal dependencies
  */
+import { useDispatch } from 'googlesitekit-data';
 import SideSheet from '@/js/components/SideSheet';
+import { CORE_UI } from '@/js/googlesitekit/datastore/ui/constants';
 
 export default function SelectionPanel( {
 	children,
@@ -35,6 +42,16 @@ export default function SelectionPanel( {
 	closePanel,
 	className,
 } ) {
+	const { setValue } = useDispatch( CORE_UI );
+
+	useEffect( () => {
+		setValue( 'selectionPanelOpen', !! isOpen );
+
+		return () => {
+			setValue( 'selectionPanelOpen', false );
+		};
+	}, [ isOpen, setValue ] );
+
 	const classNameSelector = className
 		?.split( /\s+/ )
 		.map( ( name ) => `.${ name }` )

--- a/assets/js/components/SelectionPanel/SelectionPanel.test.tsx
+++ b/assets/js/components/SelectionPanel/SelectionPanel.test.tsx
@@ -1,0 +1,97 @@
+/**
+ * SelectionPanel component tests.
+ *
+ * Site Kit by Google, Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import {
+	act,
+	createTestRegistry,
+	render,
+	waitFor,
+} from '../../../../tests/js/test-utils';
+import { CORE_UI } from '@/js/googlesitekit/datastore/ui/constants';
+import SelectionPanel from './SelectionPanel';
+
+describe( 'SelectionPanel', () => {
+	let registry;
+
+	beforeEach( () => {
+		registry = createTestRegistry();
+	} );
+
+	it( 'sets selectionPanelOpen to true in CORE_UI when isOpen is true', async () => {
+		render(
+			<SelectionPanel isOpen={ true } closePanel={ () => {} }>
+				<div>Panel Content</div>
+			</SelectionPanel>,
+			{ registry }
+		);
+
+		await waitFor( () => {
+			expect(
+				registry.select( CORE_UI ).getValue( 'selectionPanelOpen' )
+			).toBe( true );
+		} );
+	} );
+
+	it( 'sets selectionPanelOpen to false in CORE_UI when isOpen is false', async () => {
+		// First open the panel.
+		await registry
+			.dispatch( CORE_UI )
+			.setValue( 'selectionPanelOpen', true );
+
+		render(
+			<SelectionPanel isOpen={ false } closePanel={ () => {} }>
+				<div>Panel Content</div>
+			</SelectionPanel>,
+			{ registry }
+		);
+
+		await waitFor( () => {
+			expect(
+				registry.select( CORE_UI ).getValue( 'selectionPanelOpen' )
+			).toBe( false );
+		} );
+	} );
+
+	it( 'resets selectionPanelOpen to false in CORE_UI on unmount', async () => {
+		const { unmount } = render(
+			<SelectionPanel isOpen={ true } closePanel={ () => {} }>
+				<div>Panel Content</div>
+			</SelectionPanel>,
+			{ registry }
+		);
+
+		await waitFor( () => {
+			expect(
+				registry.select( CORE_UI ).getValue( 'selectionPanelOpen' )
+			).toBe( true );
+		} );
+
+		act( () => {
+			unmount();
+		} );
+
+		await waitFor( () => {
+			expect(
+				registry.select( CORE_UI ).getValue( 'selectionPanelOpen' )
+			).toBe( false );
+		} );
+	} );
+} );


### PR DESCRIPTION
## Summary

Addresses issue: #12366

Tooltips rendered independently of `SelectionPanel` open state, causing them to overlap email reporting and other side panels when opened.

## Relevant technical choices

A shared `selectionPanelOpen` boolean key is introduced in `CORE_UI` to represent whether any `SelectionPanel` is currently open. In `assets/js/components/SelectionPanel/SelectionPanel.js`, a `useEffect` hook dispatches `setValue( 'selectionPanelOpen', !! isOpen )` whenever `isOpen` changes, and resets it to `false` on unmount to avoid stale state. In `assets/js/components/AdminScreenTooltip/AdminScreenTooltip.js`, the component reads this key via `useSelect` and returns `null` immediately when `selectionPanelOpen` is `true`, preventing any tooltip from rendering while a side panel is open.

New tests were added to `AdminScreenTooltip.test.js` covering the case where the tooltip is suppressed when `selectionPanelOpen=true` and the case where it renders normally when `selectionPanelOpen=false`. A new `SelectionPanel.test.tsx` file asserts that opening the panel sets `selectionPanelOpen=true`, closing sets `false`, and unmounting resets to `false`.

## PR Author Checklist

- [ ] Code tested and passes existing unit tests
- [ ] Appropriate unit tests added and passing
- [ ] Backward-compatible with WordPress 5.2 and PHP 7.4
- [ ] Follows WordPress coding standards
- [ ] Proper inline documentation included
- [ ] QA Brief added to linked issue
- [ ] Contributor License Agreement signed

Fixes #12366
