### PR TITLE
Add email_reporting_enabled feature metric (#12627)

### DIFF
--- a/includes/Core/Email_Reporting/Email_Reporting.php
+++ b/includes/Core/Email_Reporting/Email_Reporting.php
@@ -346,6 +346,7 @@ class Email_Reporting implements Provides_Feature_Metrics {
 			'email_reporting_last_batch_sent'   => $batch_counts['sent'],
 			'email_reporting_last_batch_failed' => $batch_counts['failed'],
 			'email_reporting_subscribers'       => $this->subscribed_users_query->get_subscriber_count(),
+			'email_reporting_enabled'           => $this->settings->is_email_reporting_enabled(),
 		);
 	}
 }

--- a/tests/phpunit/integration/Core/Email_Reporting/Email_ReportingTest.php
+++ b/tests/phpunit/integration/Core/Email_Reporting/Email_ReportingTest.php
@@ -83,6 +83,7 @@ class Email_ReportingTest extends TestCase {
 			'email_reporting_last_batch_sent',
 			'email_reporting_last_batch_failed',
 			'email_reporting_subscribers',
+			'email_reporting_enabled',
 		);
 
 		foreach ( $expected_keys as $key ) {
@@ -94,9 +95,30 @@ class Email_ReportingTest extends TestCase {
 		$email_reporting = $this->create_email_reporting();
 		$metrics         = $email_reporting->get_feature_metrics();
 
+		$boolean_metrics = array( 'email_reporting_enabled' );
+
 		foreach ( $metrics as $key => $value ) {
+			if ( in_array( $key, $boolean_metrics, true ) ) {
+				continue;
+			}
 			$this->assertIsInt( $value, sprintf( 'Metric %s should be an integer.', $key ) );
 		}
+	}
+
+	public function test_get_feature_metrics__email_reporting_enabled_reflects_setting() {
+		$email_reporting = $this->create_email_reporting();
+		$email_reporting->register();
+
+		$metrics = $email_reporting->get_feature_metrics();
+		$this->assertIsBool( $metrics['email_reporting_enabled'], 'email_reporting_enabled should be a boolean.' );
+		$this->assertTrue( $metrics['email_reporting_enabled'], 'email_reporting_enabled should default to true.' );
+
+		$settings = new Email_Reporting_Settings( $this->options );
+		$settings->set( array( 'enabled' => false ) );
+
+		$metrics = $email_reporting->get_feature_metrics();
+		$this->assertIsBool( $metrics['email_reporting_enabled'], 'email_reporting_enabled should remain a boolean after disabling.' );
+		$this->assertFalse( $metrics['email_reporting_enabled'], 'email_reporting_enabled should be false after disabling the setting.' );
 	}
 
 	public function test_get_feature_metrics__counts_completed_batch_correctly() {
@@ -147,6 +169,7 @@ class Email_ReportingTest extends TestCase {
 		$this->assertArrayHasKey( 'email_reporting_last_batch_sent', $metrics, 'Feature metrics should include email reporting last batch sent.' );
 		$this->assertArrayHasKey( 'email_reporting_last_batch_failed', $metrics, 'Feature metrics should include email reporting last batch failed.' );
 		$this->assertArrayHasKey( 'email_reporting_subscribers', $metrics, 'Feature metrics should include email reporting subscribers.' );
+		$this->assertArrayHasKey( 'email_reporting_enabled', $metrics, 'Feature metrics should include email reporting enabled flag.' );
 	}
 
 	public function test_register_schedules_initiators_when_enabled() {


### PR DESCRIPTION
## Summary

Addresses issue:

- #12627

## Relevant technical choices

Adds a new `email_reporting_enabled` key to the `Email_Reporting::get_feature_metrics()` array, sourced from the site-wide `Email_Reporting_Settings::is_email_reporting_enabled()`. The value is a native boolean (`true`/`false`) — intentionally not coerced to integer — so that the metric can be analyzed directly as a flag rather than as a count.

The existing integer-only assertion in `test_get_feature_metrics__returns_integers()` is updated to skip the new boolean metric via an explicit allow-list, keeping the integer guarantee for all numeric metrics intact.

A new dedicated test (`test_get_feature_metrics__email_reporting_enabled_reflects_setting`) verifies that the metric:
- is a boolean,
- defaults to `true` (matching `Email_Reporting_Settings` defaults),
- becomes `false` after `Email_Reporting_Settings::set( array( 'enabled' => false ) )`.

`test_get_feature_metrics__returns_expected_keys()` and `test_register__adds_email_reporting_feature_metrics()` were extended to assert the presence of the new key.

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).