### PR TITLE
Update RRM module description

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,3 @@
 # Contributing and Maintaining
 
-Any kind of contributions to Site Kit by Google are welcome. Head over to the [Contributor Handhook](https://github.com/google/site-kit-wp/wiki) to get started, or directly to the [Engineering set up quickstart](https://github.com/google/site-kit-wp/wiki/Engineering#set-up-site-kit-project) to set up Sit Kit locally. :wink:
+Any kind of contributions to Site Kit by Google are welcome. Head over to the [Contributor Handbook](https://github.com/google/site-kit-wp/wiki) to get started, or directly to the [Engineering set up quickstart](https://github.com/google/site-kit-wp/wiki/Engineering#set-up-site-kit-project) to set up Site Kit locally. :wink:

--- a/assets/js/googlesitekit/modules/datastore/__fixtures__/list.json
+++ b/assets/js/googlesitekit/modules/datastore/__fixtures__/list.json
@@ -104,7 +104,7 @@
 	{
 		"slug": "reader-revenue-manager",
 		"name": "Reader Revenue Manager",
-		"description": "Reader Revenue Manager helps publishers grow, retain, and engage their audiences, creating new revenue opportunities",
+		"description": "Add simple CTAs to your pages that ask readers to sign up for your newsletter, complete a survey, make a contribution, or subscribe",
 		"homepage": "https://readerrevenue.withgoogle.com/",
 		"internal": false,
 		"order": 10,

--- a/includes/Modules/Reader_Revenue_Manager.php
+++ b/includes/Modules/Reader_Revenue_Manager.php
@@ -594,7 +594,7 @@ final class Reader_Revenue_Manager extends Module implements Module_With_Scopes,
 		return array(
 			'slug'        => self::MODULE_SLUG,
 			'name'        => _x( 'Reader Revenue Manager', 'Service name', 'google-site-kit' ),
-			'description' => __( 'Reader Revenue Manager helps publishers grow, retain, and engage their audiences, creating new revenue opportunities', 'google-site-kit' ),
+			'description' => __( 'Add simple CTAs to your pages that ask readers to sign up for your newsletter, complete a survey, make a contribution, or subscribe', 'google-site-kit' ),
 			'homepage'    => 'https://publishercenter.google.com',
 		);
 	}

--- a/tests/phpunit/integration/Modules/Reader_Revenue_ManagerTest.php
+++ b/tests/phpunit/integration/Modules/Reader_Revenue_ManagerTest.php
@@ -166,7 +166,7 @@ class Reader_Revenue_ManagerTest extends TestCase {
 		$this->assertEquals( 'reader-revenue-manager', $this->reader_revenue_manager->slug, 'Reader Revenue Manager module slug should be correct.' );
 		$this->assertEquals( 'Reader Revenue Manager', $this->reader_revenue_manager->name, 'Reader Revenue Manager module name should be correct.' );
 		$this->assertEquals( 'https://publishercenter.google.com', $this->reader_revenue_manager->homepage, 'Reader Revenue Manager module homepage should be correct.' );
-		$this->assertEquals( 'Reader Revenue Manager helps publishers grow, retain, and engage their audiences, creating new revenue opportunities', $this->reader_revenue_manager->description, 'Reader Revenue Manager module description should be correct.' );
+		$this->assertEquals( 'Add simple CTAs to your pages that ask readers to sign up for your newsletter, complete a survey, make a contribution, or subscribe', $this->reader_revenue_manager->description, 'Reader Revenue Manager module description should be correct.' );
 		$this->assertEquals( 10, $this->reader_revenue_manager->order, 'Reader Revenue Manager module order should be correct.' ); // Since order is not set, it uses the default value.
 	}
 


### PR DESCRIPTION
Resolves #12639.

## Summary
- Updates the Reader Revenue Manager module description in `Reader_Revenue_Manager.php` (`setup_info`) and the matching `__fixtures__/list.json` to: *"Add simple CTAs to your pages that ask readers to sign up for your newsletter, complete a survey, make a contribution, or subscribe"*.
- Aligns the corresponding assertion in `Reader_Revenue_ManagerTest.php`.
- Drive-by: fixes two typos in `CONTRIBUTING.md` (`Handhook` -> `Handbook`, `Sit Kit` -> `Site Kit`).

## Test plan
- [x] PHPUnit: `Reader_Revenue_ManagerTest` passes with the updated description.
- [x] Visual check in *Site Kit Settings -> Connect More Services* shows the new RRM description.
- [x] VRT reference images regenerated where applicable.