### PR TITLE
Render plain-text email footer utility links as a readable list

### DIFF
--- a/includes/Core/Email_Reporting/Plain_Text_Formatter.php
+++ b/includes/Core/Email_Reporting/Plain_Text_Formatter.php
@@ -133,12 +133,6 @@ class Plain_Text_Formatter {
 		// Footer copy.
 		if ( ! empty( $footer_copy ) ) {
 			$lines[] = $footer_copy;
-			$lines[] = '';
-		}
-
-		// Unsubscribe link.
-		if ( ! empty( $unsubscribe_url ) ) {
-			$lines[] = self::format_link( __( 'Unsubscribe', 'google-site-kit' ), $unsubscribe_url );
 		}
 
 		$lines = self::append_footer_links( $lines, $unsubscribe_url );
@@ -293,12 +287,6 @@ class Plain_Text_Formatter {
 		// Footer copy.
 		if ( ! empty( $footer['copy'] ) ) {
 			$lines[] = $footer['copy'];
-			$lines[] = '';
-		}
-
-		// Unsubscribe link.
-		if ( ! empty( $footer['unsubscribe_url'] ) ) {
-			$lines[] = self::format_link( __( 'Unsubscribe', 'google-site-kit' ), $footer['unsubscribe_url'] );
 		}
 
 		$lines = self::append_footer_links( $lines, $footer['unsubscribe_url'] ?? '' );
@@ -307,25 +295,27 @@ class Plain_Text_Formatter {
 	}
 
 	/**
-	 * Appends the hardcoded footer utility links to the lines buffer.
+	 * Appends the footer utility links to the lines buffer.
 	 *
-	 * Gates the block on the unsubscribe URL to match the HTML footer
-	 * template, and prepends a blank separator line so the links render
-	 * as a readable list.
+	 * Privacy Policy and Help center always render. Unsubscribe and
+	 * Manage subscription are only added when the unsubscribe URL is
+	 * available, matching the HTML footer template.
 	 *
 	 * @since n.e.x.t
 	 *
 	 * @param array  $lines           Lines buffer to append to.
-	 * @param string $unsubscribe_url Unsubscribe URL used for the manage subscription link.
+	 * @param string $unsubscribe_url Unsubscribe URL used for the unsubscribe and manage subscription links.
 	 * @return array Updated lines buffer.
 	 */
 	protected static function append_footer_links( array $lines, string $unsubscribe_url ): array {
-		if ( empty( $unsubscribe_url ) ) {
-			return $lines;
+		$lines[] = '';
+
+		if ( ! empty( $unsubscribe_url ) ) {
+			$lines[] = self::format_link( __( 'Unsubscribe', 'google-site-kit' ), $unsubscribe_url );
+			$lines[] = '';
+			$lines[] = self::format_link( __( 'Manage subscription', 'google-site-kit' ), $unsubscribe_url );
 		}
 
-		$lines[] = '';
-		$lines[] = self::format_link( __( 'Manage subscription', 'google-site-kit' ), $unsubscribe_url );
 		$lines[] = self::format_link( __( 'Privacy Policy', 'google-site-kit' ), 'https://policies.google.com/privacy' );
 		$lines[] = self::format_link( __( 'Help center', 'google-site-kit' ), add_query_arg( 'doc', 'get-support', 'https://sitekit.withgoogle.com/support/' ) );
 

--- a/includes/Core/Email_Reporting/Plain_Text_Formatter.php
+++ b/includes/Core/Email_Reporting/Plain_Text_Formatter.php
@@ -139,13 +139,9 @@ class Plain_Text_Formatter {
 		// Unsubscribe link.
 		if ( ! empty( $unsubscribe_url ) ) {
 			$lines[] = self::format_link( __( 'Unsubscribe', 'google-site-kit' ), $unsubscribe_url );
-			$lines[] = '';
 		}
 
-		// Footer links (hardcoded to match HTML footer template).
-		$lines[] = self::format_link( __( 'Manage subscription', 'google-site-kit' ), $unsubscribe_url );
-		$lines[] = self::format_link( __( 'Privacy Policy', 'google-site-kit' ), 'https://policies.google.com/privacy' );
-		$lines[] = self::format_link( __( 'Help center', 'google-site-kit' ), add_query_arg( 'doc', 'get-support', 'https://sitekit.withgoogle.com/support/' ) );
+		$lines = self::append_footer_links( $lines, $unsubscribe_url );
 
 		return implode( "\n", $lines );
 	}
@@ -303,18 +299,37 @@ class Plain_Text_Formatter {
 		// Unsubscribe link.
 		if ( ! empty( $footer['unsubscribe_url'] ) ) {
 			$lines[] = self::format_link( __( 'Unsubscribe', 'google-site-kit' ), $footer['unsubscribe_url'] );
-			$lines[] = '';
 		}
 
-		// Footer links (hardcoded to match HTML footer template).
-		$unsubscribe_url = $footer['unsubscribe_url'] ?? '';
-		if ( ! empty( $unsubscribe_url ) ) {
-			$lines[] = self::format_link( __( 'Manage subscription', 'google-site-kit' ), $unsubscribe_url );
-			$lines[] = self::format_link( __( 'Privacy Policy', 'google-site-kit' ), 'https://policies.google.com/privacy' );
-			$lines[] = self::format_link( __( 'Help center', 'google-site-kit' ), add_query_arg( 'doc', 'get-support', 'https://sitekit.withgoogle.com/support/' ) );
-		}
+		$lines = self::append_footer_links( $lines, $footer['unsubscribe_url'] ?? '' );
 
 		return implode( "\n", $lines );
+	}
+
+	/**
+	 * Appends the hardcoded footer utility links to the lines buffer.
+	 *
+	 * Gates the block on the unsubscribe URL to match the HTML footer
+	 * template, and prepends a blank separator line so the links render
+	 * as a readable list.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param array  $lines           Lines buffer to append to.
+	 * @param string $unsubscribe_url Unsubscribe URL used for the manage subscription link.
+	 * @return array Updated lines buffer.
+	 */
+	protected static function append_footer_links( array $lines, string $unsubscribe_url ): array {
+		if ( empty( $unsubscribe_url ) ) {
+			return $lines;
+		}
+
+		$lines[] = '';
+		$lines[] = self::format_link( __( 'Manage subscription', 'google-site-kit' ), $unsubscribe_url );
+		$lines[] = self::format_link( __( 'Privacy Policy', 'google-site-kit' ), 'https://policies.google.com/privacy' );
+		$lines[] = self::format_link( __( 'Help center', 'google-site-kit' ), add_query_arg( 'doc', 'get-support', 'https://sitekit.withgoogle.com/support/' ) );
+
+		return $lines;
 	}
 
 	/**

--- a/includes/Core/Email_Reporting/templates/parts/footer.php
+++ b/includes/Core/Email_Reporting/templates/parts/footer.php
@@ -47,38 +47,42 @@
 			<?php endif; ?>
 			<?php
 			// Footer links are hardcoded to ensure consistent order across all email types.
-			$footer_links = array(
-				array(
+			$footer_links = array();
+			if ( ! empty( $footer['unsubscribe_url'] ) ) {
+				$footer_links[] = array(
 					'label' => __( 'Manage subscription', 'google-site-kit' ),
-					'url'   => $footer['unsubscribe_url'] ?? '',
-				),
-				array(
-					'label' => __( 'Privacy Policy', 'google-site-kit' ),
-					'url'   => 'https://policies.google.com/privacy',
-				),
-				array(
-					'label' => __( 'Help center', 'google-site-kit' ),
-					'url'   => add_query_arg( 'doc', 'get-support', 'https://sitekit.withgoogle.com/support/' ),
-				),
+					'url'   => $footer['unsubscribe_url'],
+				);
+			}
+			$footer_links[] = array(
+				'label' => __( 'Privacy Policy', 'google-site-kit' ),
+				'url'   => 'https://policies.google.com/privacy',
 			);
+			$footer_links[] = array(
+				'label' => __( 'Help center', 'google-site-kit' ),
+				'url'   => add_query_arg( 'doc', 'get-support', 'https://sitekit.withgoogle.com/support/' ),
+			);
+
+			$footer_links_count = count( $footer_links );
+			$cell_width         = round( 100 / $footer_links_count, 2 ) . '%';
+			$alignments         = 3 === $footer_links_count
+				? array( 'left', 'center', 'right' )
+				: array_fill( 0, $footer_links_count, 'center' );
 			?>
-			<?php if ( ! empty( $footer['unsubscribe_url'] ) ) : ?>
-				<table role="presentation" width="100%" style="font-size:12px; line-height:18px;">
-					<tr>
-						<?php
-						$alignments = array( 'left', 'center', 'right' );
-						foreach ( $footer_links as $index => $footer_link ) :
-							$align = isset( $alignments[ $index ] ) ? $alignments[ $index ] : 'center';
-							?>
-							<td width="33.33%" style="text-align:<?php echo esc_attr( $align ); ?>;">
-								<a class="text-secondary" href="<?php echo esc_url( $footer_link['url'] ); ?>" style="color:#6C726E; text-decoration:none; font-size:12px; line-height:16px; font-weight:500;" target="_blank" rel="noopener">
-									<?php echo esc_html( $footer_link['label'] ); ?>
-								</a>
-							</td>
-						<?php endforeach; ?>
-					</tr>
-				</table>
-			<?php endif; ?>
+			<table role="presentation" width="100%" style="font-size:12px; line-height:18px;">
+				<tr>
+					<?php
+					foreach ( $footer_links as $index => $footer_link ) :
+						$align = $alignments[ $index ] ?? 'center';
+						?>
+						<td width="<?php echo esc_attr( $cell_width ); ?>" style="text-align:<?php echo esc_attr( $align ); ?>;">
+							<a class="text-secondary" href="<?php echo esc_url( $footer_link['url'] ); ?>" style="color:#6C726E; text-decoration:none; font-size:12px; line-height:16px; font-weight:500;" target="_blank" rel="noopener">
+								<?php echo esc_html( $footer_link['label'] ); ?>
+							</a>
+						</td>
+					<?php endforeach; ?>
+				</tr>
+			</table>
 		</td>
 	</tr>
 </table>

--- a/tests/phpunit/integration/Core/Email_Reporting/Plain_Text_FormatterTest.php
+++ b/tests/phpunit/integration/Core/Email_Reporting/Plain_Text_FormatterTest.php
@@ -220,6 +220,25 @@ class Plain_Text_FormatterTest extends TestCase {
 		$this->assertStringContainsString( $expected_footer_block, $result, 'Footer utility links should appear as a separate-line list preceded by a blank separator line.' );
 	}
 
+	public function test_format_footer_omits_utility_links_without_unsubscribe_url() {
+		$cta = array(
+			'label' => 'View dashboard',
+			'url'   => 'https://example.com/dashboard',
+		);
+
+		$footer = array(
+			'copy'            => 'You received this email because you signed up.',
+			'unsubscribe_url' => '',
+		);
+
+		$result = Plain_Text_Formatter::format_footer( $cta, $footer );
+
+		$this->assertStringNotContainsString( 'Unsubscribe:', $result, 'Footer should omit Unsubscribe link without unsubscribe URL.' );
+		$this->assertStringNotContainsString( 'Manage subscription:', $result, 'Footer should omit Manage subscription link without unsubscribe URL.' );
+		$this->assertStringNotContainsString( 'Privacy Policy:', $result, 'Footer should omit Privacy Policy link without unsubscribe URL.' );
+		$this->assertStringNotContainsString( 'Help center:', $result, 'Footer should omit Help center link without unsubscribe URL.' );
+	}
+
 	public function test_format_section_dispatches_to_metrics_section() {
 		$section = array(
 			'title'            => 'How many people are finding my site?',

--- a/tests/phpunit/integration/Core/Email_Reporting/Plain_Text_FormatterTest.php
+++ b/tests/phpunit/integration/Core/Email_Reporting/Plain_Text_FormatterTest.php
@@ -207,6 +207,8 @@ class Plain_Text_FormatterTest extends TestCase {
 			array(
 				'',
 				'',
+				'Unsubscribe: https://example.com/unsubscribe',
+				'',
 				'Manage subscription: https://example.com/unsubscribe',
 				'Privacy Policy: https://policies.google.com/privacy',
 				'Help center: ' . add_query_arg( 'doc', 'get-support', 'https://sitekit.withgoogle.com/support/' ),
@@ -216,11 +218,10 @@ class Plain_Text_FormatterTest extends TestCase {
 		$this->assertStringContainsString( str_repeat( '-', 50 ), $result, 'Footer should contain separator line.' );
 		$this->assertStringContainsString( 'View dashboard: https://example.com/dashboard', $result, 'Footer should contain CTA link.' );
 		$this->assertStringContainsString( 'You received this email because you signed up.', $result, 'Footer should contain copy text.' );
-		$this->assertStringContainsString( 'Unsubscribe: https://example.com/unsubscribe', $result, 'Footer should contain unsubscribe link as separate line.' );
 		$this->assertStringContainsString( $expected_footer_block, $result, 'Footer utility links should appear as a separate-line list preceded by a blank separator line.' );
 	}
 
-	public function test_format_footer_omits_utility_links_without_unsubscribe_url() {
+	public function test_format_footer_omits_manage_subscription_without_unsubscribe_url() {
 		$cta = array(
 			'label' => 'View dashboard',
 			'url'   => 'https://example.com/dashboard',
@@ -233,10 +234,10 @@ class Plain_Text_FormatterTest extends TestCase {
 
 		$result = Plain_Text_Formatter::format_footer( $cta, $footer );
 
-		$this->assertStringNotContainsString( 'Unsubscribe:', $result, 'Footer should omit Unsubscribe link without unsubscribe URL.' );
+		$this->assertStringNotContainsString( 'Unsubscribe:', $result, 'Footer should omit standalone Unsubscribe link.' );
 		$this->assertStringNotContainsString( 'Manage subscription:', $result, 'Footer should omit Manage subscription link without unsubscribe URL.' );
-		$this->assertStringNotContainsString( 'Privacy Policy:', $result, 'Footer should omit Privacy Policy link without unsubscribe URL.' );
-		$this->assertStringNotContainsString( 'Help center:', $result, 'Footer should omit Help center link without unsubscribe URL.' );
+		$this->assertStringContainsString( 'Privacy Policy: https://policies.google.com/privacy', $result, 'Footer should always contain Privacy Policy link.' );
+		$this->assertStringContainsString( 'Help center: ' . add_query_arg( 'doc', 'get-support', 'https://sitekit.withgoogle.com/support/' ), $result, 'Footer should always contain Help center link.' );
 	}
 
 	public function test_format_section_dispatches_to_metrics_section() {
@@ -351,6 +352,8 @@ class Plain_Text_FormatterTest extends TestCase {
 			array(
 				'',
 				'',
+				'Unsubscribe: https://example.com/unsubscribe',
+				'',
 				'Manage subscription: https://example.com/unsubscribe',
 				'Privacy Policy: https://policies.google.com/privacy',
 				'Help center: ' . add_query_arg( 'doc', 'get-support', 'https://sitekit.withgoogle.com/support/' ),
@@ -366,7 +369,6 @@ class Plain_Text_FormatterTest extends TestCase {
 		$this->assertStringContainsString( 'Learn more: https://sitekit.withgoogle.com/support/?doc=email-reporting', $result, 'Simple email should contain Learn more link.' );
 		$this->assertStringContainsString( 'Get your report: https://example.com/wp-admin/admin.php?page=googlesitekit-dashboard', $result, 'Simple email should contain CTA link.' );
 		$this->assertStringContainsString( 'You received this email because your site admin invited you', $result, 'Simple email should contain footer copy.' );
-		$this->assertStringContainsString( 'Unsubscribe: https://example.com/unsubscribe', $result, 'Simple email should contain unsubscribe link.' );
 		$this->assertStringContainsString( $expected_footer_block, $result, 'Footer utility links should appear as a separate-line list preceded by a blank separator line.' );
 	}
 
@@ -417,9 +419,10 @@ class Plain_Text_FormatterTest extends TestCase {
 		$this->assertStringContainsString( 'You have been invited to receive performance reports', $result, 'Simple email should contain title text.' );
 		$this->assertStringNotContainsString( 'This preheader should not appear in plain text output', $result, 'Simple email should not contain preheader text.' );
 		$this->assertStringNotContainsString( 'Learn more:', $result, 'Simple email should not contain Learn more link when URL is empty.' );
+		$this->assertStringNotContainsString( 'Unsubscribe:', $result, 'Simple email should not contain a standalone Unsubscribe link.' );
 		$this->assertStringNotContainsString( 'Manage subscription:', $result, 'Simple email should omit Manage subscription link when unsubscribe URL is missing.' );
-		$this->assertStringNotContainsString( 'Privacy Policy:', $result, 'Simple email should omit Privacy Policy link when unsubscribe URL is missing.' );
-		$this->assertStringNotContainsString( 'Help center:', $result, 'Simple email should omit Help center link when unsubscribe URL is missing.' );
+		$this->assertStringContainsString( 'Privacy Policy: https://policies.google.com/privacy', $result, 'Simple email should always contain Privacy Policy link.' );
+		$this->assertStringContainsString( 'Help center: ' . add_query_arg( 'doc', 'get-support', 'https://sitekit.withgoogle.com/support/' ), $result, 'Simple email should always contain Help center link.' );
 	}
 
 	public function test_convert_links_to_text__converts_anchor_tags() {

--- a/tests/phpunit/integration/Core/Email_Reporting/Plain_Text_FormatterTest.php
+++ b/tests/phpunit/integration/Core/Email_Reporting/Plain_Text_FormatterTest.php
@@ -202,13 +202,22 @@ class Plain_Text_FormatterTest extends TestCase {
 
 		$result = Plain_Text_Formatter::format_footer( $cta, $footer );
 
+		$expected_footer_block = implode(
+			"\n",
+			array(
+				'',
+				'',
+				'Manage subscription: https://example.com/unsubscribe',
+				'Privacy Policy: https://policies.google.com/privacy',
+				'Help center: ' . add_query_arg( 'doc', 'get-support', 'https://sitekit.withgoogle.com/support/' ),
+			)
+		);
+
 		$this->assertStringContainsString( str_repeat( '-', 50 ), $result, 'Footer should contain separator line.' );
 		$this->assertStringContainsString( 'View dashboard: https://example.com/dashboard', $result, 'Footer should contain CTA link.' );
 		$this->assertStringContainsString( 'You received this email because you signed up.', $result, 'Footer should contain copy text.' );
 		$this->assertStringContainsString( 'Unsubscribe: https://example.com/unsubscribe', $result, 'Footer should contain unsubscribe link as separate line.' );
-		$this->assertStringContainsString( 'Manage subscription: https://example.com/unsubscribe', $result, 'Footer should contain hardcoded manage subscription link.' );
-		$this->assertStringContainsString( 'Privacy Policy: https://policies.google.com/privacy', $result, 'Footer should contain hardcoded privacy policy link.' );
-		$this->assertStringContainsString( 'Help center:', $result, 'Footer should contain hardcoded help center link.' );
+		$this->assertStringContainsString( $expected_footer_block, $result, 'Footer utility links should appear as a separate-line list preceded by a blank separator line.' );
 	}
 
 	public function test_format_section_dispatches_to_metrics_section() {

--- a/tests/phpunit/integration/Core/Email_Reporting/Plain_Text_FormatterTest.php
+++ b/tests/phpunit/integration/Core/Email_Reporting/Plain_Text_FormatterTest.php
@@ -417,6 +417,9 @@ class Plain_Text_FormatterTest extends TestCase {
 		$this->assertStringContainsString( 'You have been invited to receive performance reports', $result, 'Simple email should contain title text.' );
 		$this->assertStringNotContainsString( 'This preheader should not appear in plain text output', $result, 'Simple email should not contain preheader text.' );
 		$this->assertStringNotContainsString( 'Learn more:', $result, 'Simple email should not contain Learn more link when URL is empty.' );
+		$this->assertStringNotContainsString( 'Manage subscription:', $result, 'Simple email should omit Manage subscription link when unsubscribe URL is missing.' );
+		$this->assertStringNotContainsString( 'Privacy Policy:', $result, 'Simple email should omit Privacy Policy link when unsubscribe URL is missing.' );
+		$this->assertStringNotContainsString( 'Help center:', $result, 'Simple email should omit Help center link when unsubscribe URL is missing.' );
 	}
 
 	public function test_convert_links_to_text__converts_anchor_tags() {

--- a/tests/phpunit/integration/Core/Email_Reporting/Plain_Text_FormatterTest.php
+++ b/tests/phpunit/integration/Core/Email_Reporting/Plain_Text_FormatterTest.php
@@ -339,11 +339,23 @@ class Plain_Text_FormatterTest extends TestCase {
 				'url'   => 'https://example.com/wp-admin/admin.php?page=googlesitekit-dashboard',
 			),
 			'footer'                 => array(
-				'copy' => 'You received this email because your site admin invited you to use Site Kit email reports feature',
+				'copy'            => 'You received this email because your site admin invited you to use Site Kit email reports feature',
+				'unsubscribe_url' => 'https://example.com/unsubscribe',
 			),
 		);
 
 		$result = Plain_Text_Formatter::format_simple_email( $data );
+
+		$expected_footer_block = implode(
+			"\n",
+			array(
+				'',
+				'',
+				'Manage subscription: https://example.com/unsubscribe',
+				'Privacy Policy: https://policies.google.com/privacy',
+				'Help center: ' . add_query_arg( 'doc', 'get-support', 'https://sitekit.withgoogle.com/support/' ),
+			)
+		);
 
 		$this->assertStringContainsString( 'Site Kit by Google', $result, 'Simple email should contain Site Kit branding.' );
 		$this->assertStringContainsString( 'example.com', $result, 'Simple email should contain site domain.' );
@@ -354,6 +366,8 @@ class Plain_Text_FormatterTest extends TestCase {
 		$this->assertStringContainsString( 'Learn more: https://sitekit.withgoogle.com/support/?doc=email-reporting', $result, 'Simple email should contain Learn more link.' );
 		$this->assertStringContainsString( 'Get your report: https://example.com/wp-admin/admin.php?page=googlesitekit-dashboard', $result, 'Simple email should contain CTA link.' );
 		$this->assertStringContainsString( 'You received this email because your site admin invited you', $result, 'Simple email should contain footer copy.' );
+		$this->assertStringContainsString( 'Unsubscribe: https://example.com/unsubscribe', $result, 'Simple email should contain unsubscribe link.' );
+		$this->assertStringContainsString( $expected_footer_block, $result, 'Footer utility links should appear as a separate-line list preceded by a blank separator line.' );
 	}
 
 	public function test_format_simple_email_strips_html_from_title() {


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #12432

## Relevant technical choices

<!-- Please describe your changes. -->
- The helper gates the utility block on `unsubscribe_url` to match the HTML footer template at `templates/parts/footer.php`. This fixes the broken `Manage subscription:` line with no URL on invitation emails.
- Tests now check the whole utility-links block in one assertion (each link on its own line, in order, with a blank separator above) instead of three separate presence checks.
- I added type hints and a return type on the helper (`array $lines, string $unsubscribe_url ): array`) to match the IB's example and newer files in this folder. Every other method in `Plain_Text_Formatter` is type-hint-free though, so let me know if you'd prefer them dropped for file-level consistency.
- Heads up: the AC's "each item on its own line" was already true before this PR (since commit `3e28c066a6`). What actually changes for users is the new blank line above the block and hiding the block on invitation emails. The rest is refactor.
- **Out of scope:** the invitation body still says "You can unsubscribe..." even though the recipient isn't subscribed yet (see the "After" section). That copy lives in `Content_Map`, not the formatter. Flagging so it can be raised separately.

<details>
<summary>Before</summary>

<img width="2336" height="1602" alt="CleanShot 2026-05-04 at 17 10 12@2x" src="https://github.com/user-attachments/assets/40fc4414-995f-4b59-8ddb-99003b8c82a6" />


</details>

<details>
<summary>After</summary>

<img width="2328" height="1480" alt="CleanShot 2026-05-04 at 20 54 45@2x" src="https://github.com/user-attachments/assets/e644fc1b-b0ca-469b-955b-9e9444881182" />

</details>

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.
- [ ] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
