### PR TITLE
Enhancement/12627 email reporting enabled metric

### DIFF
--- a/includes/Core/Email_Reporting/Email_Reporting.php
+++ b/includes/Core/Email_Reporting/Email_Reporting.php
@@ -333,6 +333,7 @@ class Email_Reporting implements Provides_Feature_Metrics {
 	 * Gets feature metrics for email reporting.
 	 *
 	 * @since 1.173.0
+	 * @since n.e.x.t Added email_reporting_enabled metric.
 	 *
 	 * @return array
 	 */
@@ -341,6 +342,7 @@ class Email_Reporting implements Provides_Feature_Metrics {
 		$batch_counts     = $this->email_log_batch_query->get_batch_counts( $latest_batch_ids );
 
 		return array(
+			'email_reporting_enabled'           => $this->settings->is_email_reporting_enabled(),
 			'email_reporting_total_sent'        => $this->email_log_batch_query->get_total_count_by_status( Email_Log::STATUS_SENT ),
 			'email_reporting_total_failed'      => $this->email_log_batch_query->get_total_count_by_status( Email_Log::STATUS_FAILED ),
 			'email_reporting_last_batch_sent'   => $batch_counts['sent'],

--- a/tests/phpunit/integration/Core/Email_Reporting/Email_ReportingTest.php
+++ b/tests/phpunit/integration/Core/Email_Reporting/Email_ReportingTest.php
@@ -106,6 +106,20 @@ class Email_ReportingTest extends TestCase {
 		}
 	}
 
+	public function test_get_feature_metrics__email_reporting_enabled_reflects_setting() {
+		$email_reporting = $this->create_email_reporting();
+		$settings        = new Email_Reporting_Settings( $this->options );
+
+		$metrics = $email_reporting->get_feature_metrics();
+		$this->assertIsBool( $metrics['email_reporting_enabled'], 'email_reporting_enabled metric should be a boolean.' );
+		$this->assertTrue( $metrics['email_reporting_enabled'], 'email_reporting_enabled metric should be true by default.' );
+
+		$settings->set( array( 'enabled' => false ) );
+
+		$metrics = $email_reporting->get_feature_metrics();
+		$this->assertFalse( $metrics['email_reporting_enabled'], 'email_reporting_enabled metric should be false after disabling the setting.' );
+	}
+
 	public function test_get_feature_metrics__counts_completed_batch_correctly() {
 		$this->register_email_log();
 		$this->delete_email_logs();

--- a/tests/phpunit/integration/Core/Email_Reporting/Email_ReportingTest.php
+++ b/tests/phpunit/integration/Core/Email_Reporting/Email_ReportingTest.php
@@ -50,6 +50,8 @@ class Email_ReportingTest extends TestCase {
 		$this->reset_feature_flag = $this->enable_feature( 'proactiveUserEngagement' );
 
 		delete_option( Email_Reporting_Settings::OPTION );
+
+		( new Email_Reporting_Settings( $this->options ) )->register();
 	}
 
 	public function tear_down() {
@@ -78,6 +80,7 @@ class Email_ReportingTest extends TestCase {
 		$metrics         = $email_reporting->get_feature_metrics();
 
 		$expected_keys = array(
+			'email_reporting_enabled',
 			'email_reporting_total_sent',
 			'email_reporting_total_failed',
 			'email_reporting_last_batch_sent',
@@ -95,6 +98,10 @@ class Email_ReportingTest extends TestCase {
 		$metrics         = $email_reporting->get_feature_metrics();
 
 		foreach ( $metrics as $key => $value ) {
+			if ( 'email_reporting_enabled' === $key ) {
+				continue;
+			}
+
 			$this->assertIsInt( $value, sprintf( 'Metric %s should be an integer.', $key ) );
 		}
 	}
@@ -142,6 +149,7 @@ class Email_ReportingTest extends TestCase {
 
 		$metrics = apply_filters( 'googlesitekit_feature_metrics', array() );
 
+		$this->assertArrayHasKey( 'email_reporting_enabled', $metrics, 'Feature metrics should include email reporting enabled.' );
 		$this->assertArrayHasKey( 'email_reporting_total_sent', $metrics, 'Feature metrics should include email reporting total sent.' );
 		$this->assertArrayHasKey( 'email_reporting_total_failed', $metrics, 'Feature metrics should include email reporting total failed.' );
 		$this->assertArrayHasKey( 'email_reporting_last_batch_sent', $metrics, 'Feature metrics should include email reporting last batch sent.' );

--- a/tests/phpunit/integration/Core/Email_Reporting/Email_ReportingTest.php
+++ b/tests/phpunit/integration/Core/Email_Reporting/Email_ReportingTest.php
@@ -98,6 +98,8 @@ class Email_ReportingTest extends TestCase {
 		$metrics         = $email_reporting->get_feature_metrics();
 
 		foreach ( $metrics as $key => $value ) {
+			// This setting is a boolean and tested below, so don't
+			// expect this one to be an integer.
 			if ( 'email_reporting_enabled' === $key ) {
 				continue;
 			}


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #12627

## Relevant technical choices

- `set_up()` now calls `Email_Reporting_Settings::register()` so the default `enabled => true` is exposed via
  `get_option()` for tests that exercise `get_feature_metrics()` without calling `Email_Reporting->register()`.

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.
- [ ] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
