### PR TITLE
Enhancement/12453 email link dark mode color

### DIFF
--- a/includes/Core/Email_Reporting/Content_Map.php
+++ b/includes/Core/Email_Reporting/Content_Map.php
@@ -190,8 +190,7 @@ class Content_Map {
 				__( 'We were unable to generate your report due to a server error. To fix this, contact your host. Report delivery will automatically resume once the issue is resolved.', 'google-site-kit' ),
 			),
 			// Opening/closing tag placeholders keep inline styles and HTML
-			// out of translation strings. Inline color styles are required
-			// because many email clients strip or ignore CSS classes.
+			// out of translation strings.
 			'error-email-permissions-search-console' => array(
 				/* translators: 1: help link URL, 2: help link style CSS */
 				__( 'We were unable to generate your reports due to insufficient permissions in Search Console. To fix this, contact your administrator or <a class="link" href="%1$s" style="%2$s">get help</a>.', 'google-site-kit' ),
@@ -229,7 +228,7 @@ class Content_Map {
 	 * @return array Ordered sprintf arguments for the body paragraphs.
 	 */
 	public static function get_body_args( $content_key, Golinks $golinks ) {
-		$link_style        = 'color:#108080;text-decoration:underline;';
+		$link_style        = 'text-decoration:underline;';
 		$support_base      = 'https://sitekit.withgoogle.com/support/';
 		$email_support_url = add_query_arg( 'doc', 'email-reporting-module-issues', $support_base );
 

--- a/includes/Core/Email_Reporting/templates/email-report/parts/view-more-in-dashboard.php
+++ b/includes/Core/Email_Reporting/templates/email-report/parts/view-more-in-dashboard.php
@@ -18,7 +18,7 @@ $arrow_url = $get_asset_url( 'icon-link-arrow' );
 <table role="presentation" width="100%">
 	<tr>
 		<td style="text-align:right; height: 16px;" height="16">
-			<a class="link" href="<?php echo esc_url( $url ); ?>" style="font-size:12px; line-height:16px; font-weight:500; color:#108080; text-decoration:none;">
+			<a class="link" href="<?php echo esc_url( $url ); ?>" style="font-size:12px; line-height:16px; font-weight:500; text-decoration:none;">
 				<?php echo esc_html( $label ); ?>
 				<img src="<?php echo esc_url( $arrow_url ); ?>" alt="" width="10" height="10" style="vertical-align:middle; margin-left:4px; margin-bottom: 2px;" />
 			</a>

--- a/includes/Core/Email_Reporting/templates/parts/footer.php
+++ b/includes/Core/Email_Reporting/templates/parts/footer.php
@@ -35,7 +35,7 @@
 					$unsubscribe_link = '';
 					if ( ! empty( $footer['unsubscribe_url'] ) ) {
 						$unsubscribe_link = sprintf(
-							'<a class="link" href="%s" style="color:#108080; text-decoration:none;">%s</a>',
+							'<a class="link" href="%s" style="text-decoration:none;">%s</a>',
 							esc_url( $footer['unsubscribe_url'] ),
 							esc_html__( 'here', 'google-site-kit' )
 						);

--- a/includes/Core/Email_Reporting/templates/parts/styles.php
+++ b/includes/Core/Email_Reporting/templates/parts/styles.php
@@ -76,6 +76,10 @@
 			overflow: hidden;
 		}
 
+		.link {
+			color: #108080;
+		}
+
 		/* Dark mode styles for email clients that support prefers-color-scheme */
 		@media (prefers-color-scheme: dark) {
 			body,
@@ -117,7 +121,7 @@
 			}
 
 			.link {
-				color: #93C9A8 !important;
+				color: #4BBBBB !important;
 			}
 
 			.button {
@@ -185,7 +189,7 @@
 		}
 
 		[data-ogsc] .link {
-			color: #93C9A8 !important;
+			color: #4BBBBB !important;
 		}
 
 		[data-ogsc] .button {

--- a/includes/Core/Email_Reporting/templates/simple-email/parts/content.php
+++ b/includes/Core/Email_Reporting/templates/simple-email/parts/content.php
@@ -87,7 +87,7 @@ $card_bottom_pad    = $has_bottom_graphic ? '0' : '12px';
 				);
 				?>
 				<?php if ( 0 === $index && ! empty( $learn_more_url ) ) : ?>
-				<a class="link" href="<?php echo esc_url( $learn_more_url ); ?>" style="color: #108080; text-decoration: none;" target="_blank" rel="noopener"><?php echo esc_html__( 'Learn more', 'google-site-kit' ); ?></a>
+				<a class="link" href="<?php echo esc_url( $learn_more_url ); ?>" style="text-decoration: none;" target="_blank" rel="noopener"><?php echo esc_html__( 'Learn more', 'google-site-kit' ); ?></a>
 				<?php endif; ?>
 			</p>
 			<?php endforeach; ?>

--- a/tests/phpunit/integration/Core/Email_Reporting/Batch_Error_NotifierTest.php
+++ b/tests/phpunit/integration/Core/Email_Reporting/Batch_Error_NotifierTest.php
@@ -462,8 +462,8 @@ class Batch_Error_NotifierTest extends TestCase {
 				$this->isType( 'string' ),
 				$this->isType( 'string' ),
 				$this->logicalAnd(
-					$this->stringContains( '<a class="link" href="http://example.org/wp-admin/index.php?action=googlesitekit_go&amp;to=settings&amp;module=search-console" style="color:#108080;text-decoration:underline">Search Console settings</a>' ),
-					$this->stringContains( '<a class="link" href="https://sitekit.withgoogle.com/support/?doc=email-reporting-module-issues" style="color:#108080;text-decoration:underline">get help</a>' )
+					$this->stringContains( '<a class="link" href="http://example.org/wp-admin/index.php?action=googlesitekit_go&amp;to=settings&amp;module=search-console" style="text-decoration:underline">Search Console settings</a>' ),
+					$this->stringContains( '<a class="link" href="https://sitekit.withgoogle.com/support/?doc=email-reporting-module-issues" style="text-decoration:underline">get help</a>' )
 				),
 				$this->isType( 'array' ),
 				$this->isType( 'string' )


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #12453

## Relevant technical choices

- Also dropped inline `color:#108080` from the footer "here" link in `templates/parts/footer.php`. Same bug, not in the IB list.
- Updated two assertions in `Batch_Error_NotifierTest::test_report_error_body_contains_full_links` so they match the new style attribute. The existing test hardcoded the old inline color.

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.
- [ ] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
