### PR TITLE
Bug/12411 Fix invite user row name and email overlap

### DIFF
--- a/assets/sass/components/email-reporting/_googlesitekit-invite-others-to-subscribe.scss
+++ b/assets/sass/components/email-reporting/_googlesitekit-invite-others-to-subscribe.scss
@@ -111,6 +111,7 @@
 		color: $c-surfaces-on-surface;
 		font-size: $fs-body-md;
 		font-weight: 500;
+		word-break: break-word;
 	}
 
 	.googlesitekit-invite-user-row__role {
@@ -123,6 +124,7 @@
 	.googlesitekit-invite-user-row__email {
 		color: $c-surfaces-on-surface;
 		font-size: $fs-body-sm;
+		word-break: break-word;
 	}
 
 	.googlesitekit-invite-user-row__action {


### PR DESCRIPTION
This change ensures that long email addresses and names will break properly within the user row, improving layout consistency and readability.

## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #12411

## Relevant technical choices

* Implementation follows the IB without deviations.

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.
- [ ] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
