### PR TITLE
Use build_headers() for report and invitation email sends

### DIFF
--- a/includes/Core/Email_Reporting/Email_Report_Sender.php
+++ b/includes/Core/Email_Reporting/Email_Report_Sender.php
@@ -85,7 +85,7 @@ class Email_Report_Sender {
 			$user->user_email,
 			$template_data['subject'] ?? '',
 			$html_content,
-			array(),
+			$this->email_sender->build_headers(),
 			$text_content
 		);
 

--- a/includes/Core/Email_Reporting/REST_Email_Reporting_Controller.php
+++ b/includes/Core/Email_Reporting/REST_Email_Reporting_Controller.php
@@ -402,7 +402,7 @@ class REST_Email_Reporting_Controller {
 			$user->user_email,
 			$template_data['subject'],
 			$html_content,
-			array(),
+			$this->email_sender->build_headers(),
 			$text_content
 		);
 

--- a/tests/phpunit/integration/Core/Email_Reporting/REST_Email_Reporting_ControllerTest.php
+++ b/tests/phpunit/integration/Core/Email_Reporting/REST_Email_Reporting_ControllerTest.php
@@ -627,7 +627,7 @@ class REST_Email_Reporting_ControllerTest extends TestCase {
 		$this->assertNotNull( $captured_atts, 'Invitation should call wp_mail.' );
 		$this->assertEquals( get_userdata( $invitee_id )->user_email, $captured_atts['to'], 'Invitation email should be sent to the invited user.' );
 		$this->assertStringContainsString( 'invited you to receive periodic performance reports', $captured_atts['message'], 'Invitation email body should contain invitation copy.' );
-		$this->assertContains( 'From: Site Kit <' . get_option( 'admin_email' ) . '>', $captured_atts['headers'], 'Invitation email should be sent with the Site Kit From header.' );
+		$this->assertContains( 'From: Site Kit <' . get_option( 'admin_email' ) . '>', $captured_atts['headers'], 'Invitation email should be sent with the Site Kit "From" header.' );
 	}
 
 	public function test_invite_user__returns_error_for_ineligible_user() {

--- a/tests/phpunit/integration/Core/Email_Reporting/REST_Email_Reporting_ControllerTest.php
+++ b/tests/phpunit/integration/Core/Email_Reporting/REST_Email_Reporting_ControllerTest.php
@@ -627,6 +627,7 @@ class REST_Email_Reporting_ControllerTest extends TestCase {
 		$this->assertNotNull( $captured_atts, 'Invitation should call wp_mail.' );
 		$this->assertEquals( get_userdata( $invitee_id )->user_email, $captured_atts['to'], 'Invitation email should be sent to the invited user.' );
 		$this->assertStringContainsString( 'invited you to receive periodic performance reports', $captured_atts['message'], 'Invitation email body should contain invitation copy.' );
+		$this->assertContains( 'From: Site Kit <' . get_option( 'admin_email' ) . '>', $captured_atts['headers'], 'Invitation email should be sent with the Site Kit From header.' );
 	}
 
 	public function test_invite_user__returns_error_for_ineligible_user() {

--- a/tests/phpunit/integration/Core/Email_Reporting/Worker_TaskTest.php
+++ b/tests/phpunit/integration/Core/Email_Reporting/Worker_TaskTest.php
@@ -61,6 +61,13 @@ class Worker_TaskTest extends TestCase {
 	private $email_sender;
 
 	/**
+	 * Headers returned by the mocked Email::build_headers().
+	 *
+	 * @var array
+	 */
+	private $mock_headers = array( 'From: Site Kit <wordpress@example.org>' );
+
+	/**
 	 * @var Email_Template_Renderer|\PHPUnit_Framework_MockObject_MockObject
 	 */
 	private $template_renderer;
@@ -110,7 +117,7 @@ class Worker_TaskTest extends TestCase {
 		$this->data_requests      = $this->createMock( Email_Reporting_Data_Requests::class );
 		$this->template_formatter = $this->createMock( Email_Template_Formatter::class );
 		$this->email_sender       = $this->createMock( Email::class );
-		$this->email_sender->method( 'build_headers' )->willReturn( array() );
+		$this->email_sender->method( 'build_headers' )->willReturn( $this->mock_headers );
 		$this->template_renderer         = $this->createMock( Email_Template_Renderer::class );
 		$this->template_renderer_factory = $this->createMock( Email_Template_Renderer_Factory::class );
 		$this->template_renderer_factory->method( 'create' )->willReturn( $this->template_renderer );
@@ -474,7 +481,7 @@ class Worker_TaskTest extends TestCase {
 				'report@example.com',
 				'Subject',
 				$this->stringContains( 'Email' ),
-				$this->isType( 'array' ),
+				$this->mock_headers,
 				'Plain text email content'
 			)
 			->willReturn( true );
@@ -790,7 +797,7 @@ class Worker_TaskTest extends TestCase {
 				$this->callback( fn( $to ) => in_array( $to, array( 'one@example.com', 'two@example.com' ), true ) ),
 				'Subject',
 				$this->stringContains( 'Email' ),
-				$this->isType( 'array' ),
+				$this->mock_headers,
 				'Plain text email content'
 			)
 			->willReturn( true );

--- a/tests/phpunit/integration/Core/Email_Reporting/Worker_TaskTest.php
+++ b/tests/phpunit/integration/Core/Email_Reporting/Worker_TaskTest.php
@@ -481,7 +481,7 @@ class Worker_TaskTest extends TestCase {
 				'report@example.com',
 				'Subject',
 				$this->stringContains( 'Email' ),
-				$this->mock_headers,
+				array( 'From: Site Kit <wordpress@example.org>' ),
 				'Plain text email content'
 			)
 			->willReturn( true );
@@ -797,7 +797,7 @@ class Worker_TaskTest extends TestCase {
 				$this->callback( fn( $to ) => in_array( $to, array( 'one@example.com', 'two@example.com' ), true ) ),
 				'Subject',
 				$this->stringContains( 'Email' ),
-				$this->mock_headers,
+				array( 'From: Site Kit <wordpress@example.org>' ),
 				'Plain text email content'
 			)
 			->willReturn( true );

--- a/tests/phpunit/integration/Core/Email_Reporting/Worker_TaskTest.php
+++ b/tests/phpunit/integration/Core/Email_Reporting/Worker_TaskTest.php
@@ -103,13 +103,14 @@ class Worker_TaskTest extends TestCase {
 	public function set_up() {
 		parent::set_up();
 
-		$this->context                   = new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE );
-		$this->scheduler                 = $this->createMock( Email_Reporting_Scheduler::class );
-		$this->batch_query               = $this->createMock( Email_Log_Batch_Query::class );
-		$this->limiter                   = $this->createMock( Max_Execution_Limiter::class );
-		$this->data_requests             = $this->createMock( Email_Reporting_Data_Requests::class );
-		$this->template_formatter        = $this->createMock( Email_Template_Formatter::class );
-		$this->email_sender              = $this->createMock( Email::class );
+		$this->context            = new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE );
+		$this->scheduler          = $this->createMock( Email_Reporting_Scheduler::class );
+		$this->batch_query        = $this->createMock( Email_Log_Batch_Query::class );
+		$this->limiter            = $this->createMock( Max_Execution_Limiter::class );
+		$this->data_requests      = $this->createMock( Email_Reporting_Data_Requests::class );
+		$this->template_formatter = $this->createMock( Email_Template_Formatter::class );
+		$this->email_sender       = $this->createMock( Email::class );
+		$this->email_sender->method( 'build_headers' )->willReturn( array() );
 		$this->template_renderer         = $this->createMock( Email_Template_Renderer::class );
 		$this->template_renderer_factory = $this->createMock( Email_Template_Renderer_Factory::class );
 		$this->template_renderer_factory->method( 'create' )->willReturn( $this->template_renderer );
@@ -473,7 +474,7 @@ class Worker_TaskTest extends TestCase {
 				'report@example.com',
 				'Subject',
 				$this->stringContains( 'Email' ),
-				array(),
+				$this->isType( 'array' ),
 				'Plain text email content'
 			)
 			->willReturn( true );
@@ -789,7 +790,7 @@ class Worker_TaskTest extends TestCase {
 				$this->callback( fn( $to ) => in_array( $to, array( 'one@example.com', 'two@example.com' ), true ) ),
 				'Subject',
 				$this->stringContains( 'Email' ),
-				array(),
+				$this->isType( 'array' ),
 				'Plain text email content'
 			)
 			->willReturn( true );


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #12390

## Relevant technical choices

* Stubbed `build_headers()` to return `array()` on the email sender mock in `Worker_TaskTest::setUp()` to keep the new `isType( 'array' )` assertion green, since `createMock` defaults unstubbed methods to null.

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.
- [ ] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
