### PR TITLE
Prevent primary user setup widget from showing up alongside the CTA.

### DIFF
--- a/assets/js/modules/analytics-4/widgets/index.js
+++ b/assets/js/modules/analytics-4/widgets/index.js
@@ -232,23 +232,9 @@ export function registerWidgets( widgets ) {
 						MODULES_ANALYTICS_4
 					).getAudienceSegmentationSetupCompletedBy();
 
-				if (
+				return (
 					isAnalyticsSetupComplete &&
 					! audienceSegmentationSetupCompletedBy
-				) {
-					return true;
-				}
-
-				const availableAudiences =
-					select( MODULES_ANALYTICS_4 ).getAvailableAudiences();
-
-				const configuredAudiences =
-					select( CORE_USER ).getConfiguredAudiences();
-
-				return (
-					availableAudiences?.length &&
-					configuredAudiences === null &&
-					audienceSegmentationSetupCompletedBy === null
 				);
 			},
 		},


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #12384

## Relevant technical choices

This change ensures that the primary user setup widget is not present when analytics has not been activated from the setup flow (i.e when an existing site with GA already active suddenly has `setupFlowRefresh` enabled).

Addresses [QA](https://github.com/google/site-kit-wp/issues/12384#issuecomment-4417794088) 

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [ ] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.
- [ ] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
