### PR TITLE
Enhancement/12632 add default text/html Content-Type header to outgoing emails

### DIFF
--- a/includes/Core/Email/Email.php
+++ b/includes/Core/Email/Email.php
@@ -72,12 +72,12 @@ class Email {
 	 *
 	 * @since 1.168.0
 	 * @since 1.170.0 Added $text_content parameter for plain text alternative.
-	 * @since n.e.x.t Inject default Content-Type: text/html header when no caller Content-Type is supplied.
+	 * @since n.e.x.t Inject default text/html Content-Type when none is supplied.
 	 *
 	 * @param string|array $to           Array or comma-separated list of email addresses to send message.
 	 * @param string       $subject      Email subject.
 	 * @param string       $content      Message contents (HTML).
-	 * @param array        $headers      Optional. Additional headers. A default Content-Type: text/html; charset=UTF-8 is added when no caller Content-Type is supplied. Default empty array.
+	 * @param array        $headers      Optional. Additional headers. A default text/html Content-Type is added when none is supplied. Default empty array.
 	 * @param string       $text_content Optional. Plain text alternative content. Default empty string.
 	 * @return bool|WP_Error True if the email was sent successfully, WP_Error on failure.
 	 */
@@ -110,7 +110,7 @@ class Email {
 	 *
 	 * @since 1.168.0
 	 * @since 1.170.0 Added $text_content parameter for plain text alternative.
-	 * @since n.e.x.t Inject default Content-Type: text/html header when no caller Content-Type is supplied.
+	 * @since n.e.x.t Inject default text/html Content-Type when none is supplied.
 	 *
 	 * @param string|array $to           Array or comma-separated list of email addresses to send message.
 	 * @param string       $subject      Email subject.
@@ -126,9 +126,8 @@ class Email {
 			$headers = array();
 		}
 
-		// Default to HTML for wp_mail replacements that bypass the
-		// phpmailer_init hook below. PHPMailer upgrades this to
-		// multipart/alternative when AltBody is attached.
+		// Default to text/html so wp_mail replacements that don't fire
+		// phpmailer_init still deliver as HTML.
 		if ( ! $this->headers_contain_content_type( $headers ) ) {
 			$headers[] = 'Content-Type: text/html; charset=UTF-8';
 		}
@@ -157,8 +156,7 @@ class Email {
 	/**
 	 * Checks whether the headers array already contains a Content-Type header.
 	 *
-	 * Detection is case-insensitive so any caller-supplied Content-Type is
-	 * respected verbatim and the default text/html value isn't added on top.
+	 * Detection is case-insensitive and skips non-string entries.
 	 *
 	 * @since n.e.x.t
 	 *

--- a/includes/Core/Email/Email.php
+++ b/includes/Core/Email/Email.php
@@ -119,7 +119,7 @@ class Email {
 	 * @param string       $text_content Optional. Plain text alternative content. Default empty string.
 	 * @return bool Whether the email was sent successfully.
 	 */
-	protected function send_email_and_catch_errors( $to, $subject, $content, $headers, $text_content = '' ) {
+	protected function send_email_and_catch_errors( $to, $subject, $content, $headers = array(), $text_content = '' ) {
 		add_action( 'wp_mail_failed', array( $this, 'set_last_error' ) );
 
 		if ( ! is_array( $headers ) ) {

--- a/includes/Core/Email/Email.php
+++ b/includes/Core/Email/Email.php
@@ -64,17 +64,20 @@ class Email {
 	/**
 	 * Sends an email using wp_mail with error tracking.
 	 *
-	 * Wraps wp_mail with a scoped listener for wp_mail_failed hook
-	 * to capture any errors during sending. When text_content is provided,
-	 * it will be set as the AltBody for multipart/alternative MIME emails.
+	 * Captures wp_mail_failed errors during sending. Adds a default
+	 * Content-Type: text/html; charset=UTF-8 header when no caller header is
+	 * supplied, so wp_mail replacements that bypass PHPMailer still deliver
+	 * HTML. When text_content is provided, it's set as the AltBody for
+	 * multipart/alternative MIME emails.
 	 *
 	 * @since 1.168.0
 	 * @since 1.170.0 Added $text_content parameter for plain text alternative.
+	 * @since n.e.x.t Inject default Content-Type: text/html header when no caller Content-Type is supplied.
 	 *
 	 * @param string|array $to           Array or comma-separated list of email addresses to send message.
 	 * @param string       $subject      Email subject.
 	 * @param string       $content      Message contents (HTML).
-	 * @param array        $headers      Optional. Additional headers. Default empty array.
+	 * @param array        $headers      Optional. Additional headers. A default Content-Type: text/html; charset=UTF-8 is added when no caller Content-Type is supplied. Default empty array.
 	 * @param string       $text_content Optional. Plain text alternative content. Default empty string.
 	 * @return bool|WP_Error True if the email was sent successfully, WP_Error on failure.
 	 */
@@ -98,14 +101,12 @@ class Email {
 	/**
 	 * Sends an email via wp_mail while capturing any errors.
 	 *
-	 * Attaches a temporary listener to the wp_mail_failed hook to capture
-	 * any errors that occur during sending. Injects a default
-	 * Content-Type: text/html header when no caller-supplied Content-Type is
-	 * present, so any wp_mail implementation that respects the headers
-	 * argument treats the body as HTML. When text_content is provided, uses
-	 * the phpmailer_init hook to set AltBody for multipart MIME emails;
-	 * PHPMailer then upgrades the content type to multipart/alternative and
-	 * attaches the plain text alternate.
+	 * Attaches a temporary listener to wp_mail_failed to capture errors during
+	 * sending. Injects a default Content-Type: text/html header when no caller
+	 * Content-Type is present, so wp_mail replacements that respect the headers
+	 * argument deliver HTML. When text_content is set, uses phpmailer_init to
+	 * attach it as AltBody. PHPMailer then upgrades the content type to
+	 * multipart/alternative.
 	 *
 	 * @since 1.168.0
 	 * @since 1.170.0 Added $text_content parameter for plain text alternative.
@@ -125,12 +126,9 @@ class Email {
 			$headers = array();
 		}
 
-		// Ensure the email is delivered as HTML by default. wp_mail
-		// implementations that bypass PHPMailer (and therefore the
-		// phpmailer_init hook below) still receive the correct Content-Type
-		// via the headers argument. When PHPMailer is active and text_content
-		// is provided, this is upgraded to multipart/alternative as the
-		// AltBody is attached.
+		// Default to HTML for wp_mail replacements that bypass the
+		// phpmailer_init hook below. PHPMailer upgrades this to
+		// multipart/alternative when AltBody is attached.
 		if ( ! $this->headers_contain_content_type( $headers ) ) {
 			$headers[] = 'Content-Type: text/html; charset=UTF-8';
 		}
@@ -157,11 +155,10 @@ class Email {
 	}
 
 	/**
-	 * Checks whether the supplied headers array already contains a Content-Type header.
+	 * Checks whether the headers array already contains a Content-Type header.
 	 *
-	 * Detection is case-insensitive so a caller-supplied Content-Type
-	 * (e.g. content-type:, CONTENT-TYPE:) is respected verbatim and not
-	 * double-set with the default text/html value.
+	 * Detection is case-insensitive so any caller-supplied Content-Type is
+	 * respected verbatim and the default text/html value isn't added on top.
 	 *
 	 * @since n.e.x.t
 	 *

--- a/includes/Core/Email/Email.php
+++ b/includes/Core/Email/Email.php
@@ -99,11 +99,17 @@ class Email {
 	 * Sends an email via wp_mail while capturing any errors.
 	 *
 	 * Attaches a temporary listener to the wp_mail_failed hook to capture
-	 * any errors that occur during sending. When text_content is provided,
-	 * uses phpmailer_init hook to set AltBody for multipart MIME emails.
+	 * any errors that occur during sending. Injects a default
+	 * Content-Type: text/html header when no caller-supplied Content-Type is
+	 * present, so any wp_mail implementation that respects the headers
+	 * argument treats the body as HTML. When text_content is provided, uses
+	 * the phpmailer_init hook to set AltBody for multipart MIME emails;
+	 * PHPMailer then upgrades the content type to multipart/alternative and
+	 * attaches the plain text alternate.
 	 *
 	 * @since 1.168.0
 	 * @since 1.170.0 Added $text_content parameter for plain text alternative.
+	 * @since n.e.x.t Inject default Content-Type: text/html header when no caller Content-Type is supplied.
 	 *
 	 * @param string|array $to           Array or comma-separated list of email addresses to send message.
 	 * @param string       $subject      Email subject.
@@ -114,6 +120,20 @@ class Email {
 	 */
 	protected function send_email_and_catch_errors( $to, $subject, $content, $headers, $text_content = '' ) {
 		add_action( 'wp_mail_failed', array( $this, 'set_last_error' ) );
+
+		if ( ! is_array( $headers ) ) {
+			$headers = array();
+		}
+
+		// Ensure the email is delivered as HTML by default. wp_mail
+		// implementations that bypass PHPMailer (and therefore the
+		// phpmailer_init hook below) still receive the correct Content-Type
+		// via the headers argument. When PHPMailer is active and text_content
+		// is provided, this is upgraded to multipart/alternative as the
+		// AltBody is attached.
+		if ( ! $this->headers_contain_content_type( $headers ) ) {
+			$headers[] = 'Content-Type: text/html; charset=UTF-8';
+		}
 
 		// Set up AltBody for multipart MIME email if text content is provided.
 		$alt_body_callback = null;
@@ -134,6 +154,32 @@ class Email {
 		}
 
 		return $result;
+	}
+
+	/**
+	 * Checks whether the supplied headers array already contains a Content-Type header.
+	 *
+	 * Detection is case-insensitive so a caller-supplied Content-Type
+	 * (e.g. content-type:, CONTENT-TYPE:) is respected verbatim and not
+	 * double-set with the default text/html value.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param array $headers Headers array passed to wp_mail.
+	 * @return bool True if a Content-Type header is present, false otherwise.
+	 */
+	private function headers_contain_content_type( array $headers ): bool {
+		foreach ( $headers as $header ) {
+			if ( ! is_string( $header ) ) {
+				continue;
+			}
+
+			if ( 0 === stripos( ltrim( $header ), 'Content-Type:' ) ) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	/**

--- a/tests/phpunit/integration/Core/Email/EmailTest.php
+++ b/tests/phpunit/integration/Core/Email/EmailTest.php
@@ -56,22 +56,11 @@ class EmailTest extends TestCase {
 	}
 
 	public function test_send() {
-		// The pre_wp_mail filter was introduced in WordPress 5.7.
-		if ( version_compare( $GLOBALS['wp_version'], '5.7', '<' ) ) {
-			$this->markTestSkipped( 'This test requires WordPress 5.7 or higher for the pre_wp_mail filter.' );
-		}
+		$this->skip_if_pre_wp_mail_unsupported();
 
 		// Use pre_wp_mail to simulate successful email sending and capture attributes.
 		$captured_atts = null;
-		add_filter(
-			'pre_wp_mail',
-			function ( $short_circuit, $atts ) use ( &$captured_atts ) {
-				$captured_atts = $atts;
-				return true;
-			},
-			10,
-			2
-		);
+		$this->capture_wp_mail_atts( $captured_atts );
 
 		$to      = 'test@example.com';
 		$subject = 'Test Subject';
@@ -88,10 +77,7 @@ class EmailTest extends TestCase {
 	}
 
 	public function test_send_failure() {
-		// The pre_wp_mail filter was introduced in WordPress 5.7.
-		if ( version_compare( $GLOBALS['wp_version'], '5.7', '<' ) ) {
-			$this->markTestSkipped( 'This test requires WordPress 5.7 or higher for the pre_wp_mail filter.' );
-		}
+		$this->skip_if_pre_wp_mail_unsupported();
 
 		// Force wp_mail failure using pre_wp_mail filter.
 		$captured_atts = null;
@@ -127,21 +113,10 @@ class EmailTest extends TestCase {
 	}
 
 	public function test_send_adds_default_content_type_header_when_none_supplied() {
-		// The pre_wp_mail filter was introduced in WordPress 5.7.
-		if ( version_compare( $GLOBALS['wp_version'], '5.7', '<' ) ) {
-			$this->markTestSkipped( 'This test requires WordPress 5.7 or higher for the pre_wp_mail filter.' );
-		}
+		$this->skip_if_pre_wp_mail_unsupported();
 
 		$captured_atts = null;
-		add_filter(
-			'pre_wp_mail',
-			function ( $short_circuit, $atts ) use ( &$captured_atts ) {
-				$captured_atts = $atts;
-				return true;
-			},
-			10,
-			2
-		);
+		$this->capture_wp_mail_atts( $captured_atts );
 
 		$this->email->send( 'test@example.com', 'Test Subject', '<p>HTML Content</p>' );
 
@@ -152,24 +127,14 @@ class EmailTest extends TestCase {
 			$captured_atts['headers'],
 			'Default text/html Content-Type header should be present when no caller Content-Type is supplied.'
 		);
+		$this->assertSingleContentTypeHeader( $captured_atts['headers'] );
 	}
 
 	public function test_send_preserves_caller_supplied_content_type_header() {
-		// The pre_wp_mail filter was introduced in WordPress 5.7.
-		if ( version_compare( $GLOBALS['wp_version'], '5.7', '<' ) ) {
-			$this->markTestSkipped( 'This test requires WordPress 5.7 or higher for the pre_wp_mail filter.' );
-		}
+		$this->skip_if_pre_wp_mail_unsupported();
 
 		$captured_atts = null;
-		add_filter(
-			'pre_wp_mail',
-			function ( $short_circuit, $atts ) use ( &$captured_atts ) {
-				$captured_atts = $atts;
-				return true;
-			},
-			10,
-			2
-		);
+		$this->capture_wp_mail_atts( $captured_atts );
 
 		$caller_content_type = 'Content-Type: text/plain; charset=ISO-8859-1';
 		$this->email->send(
@@ -190,24 +155,14 @@ class EmailTest extends TestCase {
 			$captured_atts['headers'],
 			'Default Content-Type should not be added when a caller Content-Type is already present.'
 		);
+		$this->assertSingleContentTypeHeader( $captured_atts['headers'] );
 	}
 
 	public function test_send_preserves_caller_supplied_content_type_header_case_insensitive() {
-		// The pre_wp_mail filter was introduced in WordPress 5.7.
-		if ( version_compare( $GLOBALS['wp_version'], '5.7', '<' ) ) {
-			$this->markTestSkipped( 'This test requires WordPress 5.7 or higher for the pre_wp_mail filter.' );
-		}
+		$this->skip_if_pre_wp_mail_unsupported();
 
 		$captured_atts = null;
-		add_filter(
-			'pre_wp_mail',
-			function ( $short_circuit, $atts ) use ( &$captured_atts ) {
-				$captured_atts = $atts;
-				return true;
-			},
-			10,
-			2
-		);
+		$this->capture_wp_mail_atts( $captured_atts );
 
 		$caller_content_type = 'content-type: text/plain; charset=UTF-8';
 		$this->email->send(
@@ -228,6 +183,92 @@ class EmailTest extends TestCase {
 			$captured_atts['headers'],
 			'Default Content-Type should not be added when a Content-Type header is present in any case.'
 		);
+		$this->assertSingleContentTypeHeader( $captured_atts['headers'] );
+	}
+
+	public function test_send_preserves_multipart_alternative_when_text_content_provided() {
+		$captured_content_type = null;
+		$captured_alt_body     = null;
+		$captured_message_type = null;
+
+		add_action(
+			'phpmailer_init',
+			function ( $phpmailer ) use ( &$captured_content_type, &$captured_alt_body, &$captured_message_type ) {
+				$captured_content_type = $phpmailer->ContentType;
+				// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- PHPMailer property.
+				$captured_alt_body = $phpmailer->AltBody;
+
+				// Trigger setMessageType after Site Kit's AltBody hook (priority 10)
+				// to verify PHPMailer still picks multipart/alternative now that
+				// we inject a default Content-Type: text/html header.
+				$phpmailer->setMessageType();
+				$captured_message_type = $phpmailer->message_type;
+
+				// Prevent actual send by clearing recipients.
+				$phpmailer->clearAllRecipients();
+			},
+			999 // Run after Site Kit's hook (priority 10).
+		);
+
+		// Don't assert on send()'s return. It'll fail with no recipients,
+		// and we only care about the captured PHPMailer state.
+		$this->email->send(
+			'test@example.com',
+			'Test Subject',
+			'<html><body>HTML Content</body></html>',
+			array(),
+			'Plain text content'
+		);
+
+		$this->assertEquals( 'text/html', $captured_content_type, 'PHPMailer ContentType should be text/html from the default Site Kit header before AltBody upgrade.' );
+		$this->assertEquals( 'Plain text content', $captured_alt_body, 'AltBody should be set so PHPMailer can produce a multipart/alternative message.' );
+		$this->assertEquals( 'alt', $captured_message_type, 'PHPMailer message_type should be "alt" (multipart/alternative) when AltBody is set alongside the default text/html Content-Type.' );
+	}
+
+	/**
+	 * Skips the current test when the pre_wp_mail filter isn't available.
+	 *
+	 * The pre_wp_mail filter was introduced in WordPress 5.7.
+	 */
+	private function skip_if_pre_wp_mail_unsupported() {
+		if ( version_compare( $GLOBALS['wp_version'], '5.7', '<' ) ) {
+			$this->markTestSkipped( 'This test requires WordPress 5.7 or higher for the pre_wp_mail filter.' );
+		}
+	}
+
+	/**
+	 * Captures wp_mail arguments via pre_wp_mail and short-circuits delivery.
+	 *
+	 * @param array|null $captured_atts Reference filled with wp_mail args once send is invoked.
+	 *
+	 * @param-out array $captured_atts
+	 */
+	private function capture_wp_mail_atts( &$captured_atts ) {
+		add_filter(
+			'pre_wp_mail',
+			function ( $short_circuit, $atts ) use ( &$captured_atts ) {
+				$captured_atts = $atts;
+				return true;
+			},
+			10,
+			2
+		);
+	}
+
+	/**
+	 * Asserts that exactly one Content-Type header is present in the headers array.
+	 *
+	 * @param array $headers Headers array captured from wp_mail.
+	 */
+	private function assertSingleContentTypeHeader( array $headers ) {
+		$content_type_headers = array_filter(
+			$headers,
+			static function ( $header ) {
+				return is_string( $header ) && 0 === stripos( ltrim( $header ), 'Content-Type:' );
+			}
+		);
+
+		$this->assertCount( 1, $content_type_headers, 'Exactly one Content-Type header should be present.' );
 	}
 
 	public function test_get_last_error() {
@@ -263,10 +304,7 @@ class EmailTest extends TestCase {
 	}
 
 	public function test_send_does_not_set_alt_body_when_text_content_empty() {
-		// The pre_wp_mail filter was introduced in WordPress 5.7.
-		if ( version_compare( $GLOBALS['wp_version'], '5.7', '<' ) ) {
-			$this->markTestSkipped( 'This test requires WordPress 5.7 or higher for the pre_wp_mail filter.' );
-		}
+		$this->skip_if_pre_wp_mail_unsupported();
 
 		$alt_body_was_set = false;
 
@@ -302,10 +340,7 @@ class EmailTest extends TestCase {
 	}
 
 	public function test_send_removes_phpmailer_init_hook_after_send() {
-		// The pre_wp_mail filter was introduced in WordPress 5.7.
-		if ( version_compare( $GLOBALS['wp_version'], '5.7', '<' ) ) {
-			$this->markTestSkipped( 'This test requires WordPress 5.7 or higher for the pre_wp_mail filter.' );
-		}
+		$this->skip_if_pre_wp_mail_unsupported();
 
 		// Use pre_wp_mail to simulate successful email sending.
 		add_filter(

--- a/tests/phpunit/integration/Core/Email/EmailTest.php
+++ b/tests/phpunit/integration/Core/Email/EmailTest.php
@@ -198,20 +198,18 @@ class EmailTest extends TestCase {
 				// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- PHPMailer property.
 				$captured_alt_body = $phpmailer->AltBody;
 
-				// Run preSend after Site Kit's AltBody hook (priority 10) to trigger
-				// PHPMailer's body construction, which upgrades ContentType to
-				// multipart/alternative when AltBody is set.
+				// Trigger body construction so PHPMailer applies its multipart/alternative
+				// upgrade for the attached AltBody.
 				$phpmailer->preSend();
 				$captured_final_content_type = $phpmailer->ContentType;
 
-				// Prevent actual send by clearing recipients.
+				// Block delivery by clearing recipients.
 				$phpmailer->clearAllRecipients();
 			},
 			999 // Run after Site Kit's hook (priority 10).
 		);
 
-		// Don't assert on send()'s return. It'll fail with no recipients,
-		// and we only care about the captured PHPMailer state.
+		// send() fails on the cleared recipients. Only the captured state matters.
 		$this->email->send(
 			'test@example.com',
 			'Test Subject',
@@ -226,9 +224,7 @@ class EmailTest extends TestCase {
 	}
 
 	/**
-	 * Skips the current test when the pre_wp_mail filter isn't available.
-	 *
-	 * The pre_wp_mail filter was introduced in WordPress 5.7.
+	 * Skips the test if the pre_wp_mail filter (WordPress 5.7+) isn't available.
 	 */
 	private function skip_if_pre_wp_mail_unsupported() {
 		if ( version_compare( $GLOBALS['wp_version'], '5.7', '<' ) ) {
@@ -239,7 +235,7 @@ class EmailTest extends TestCase {
 	/**
 	 * Captures wp_mail arguments via pre_wp_mail and short-circuits delivery.
 	 *
-	 * @param array|null $captured_atts Reference filled with wp_mail args once send is invoked.
+	 * @param array|null $captured_atts Reference filled with wp_mail args.
 	 *
 	 * @param-out array $captured_atts
 	 */

--- a/tests/phpunit/integration/Core/Email/EmailTest.php
+++ b/tests/phpunit/integration/Core/Email/EmailTest.php
@@ -187,22 +187,22 @@ class EmailTest extends TestCase {
 	}
 
 	public function test_send_preserves_multipart_alternative_when_text_content_provided() {
-		$captured_content_type = null;
-		$captured_alt_body     = null;
-		$captured_message_type = null;
+		$captured_initial_content_type = null;
+		$captured_alt_body             = null;
+		$captured_final_content_type   = null;
 
 		add_action(
 			'phpmailer_init',
-			function ( $phpmailer ) use ( &$captured_content_type, &$captured_alt_body, &$captured_message_type ) {
-				$captured_content_type = $phpmailer->ContentType;
+			function ( $phpmailer ) use ( &$captured_initial_content_type, &$captured_alt_body, &$captured_final_content_type ) {
+				$captured_initial_content_type = $phpmailer->ContentType;
 				// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- PHPMailer property.
 				$captured_alt_body = $phpmailer->AltBody;
 
-				// Trigger setMessageType after Site Kit's AltBody hook (priority 10)
-				// to verify PHPMailer still picks multipart/alternative now that
-				// we inject a default Content-Type: text/html header.
-				$phpmailer->setMessageType();
-				$captured_message_type = $phpmailer->message_type;
+				// Run preSend after Site Kit's AltBody hook (priority 10) to trigger
+				// PHPMailer's body construction, which upgrades ContentType to
+				// multipart/alternative when AltBody is set.
+				$phpmailer->preSend();
+				$captured_final_content_type = $phpmailer->ContentType;
 
 				// Prevent actual send by clearing recipients.
 				$phpmailer->clearAllRecipients();
@@ -220,9 +220,9 @@ class EmailTest extends TestCase {
 			'Plain text content'
 		);
 
-		$this->assertEquals( 'text/html', $captured_content_type, 'PHPMailer ContentType should be text/html from the default Site Kit header before AltBody upgrade.' );
+		$this->assertEquals( 'text/html', $captured_initial_content_type, 'PHPMailer ContentType should be text/html from the default Site Kit header before AltBody upgrade.' );
 		$this->assertEquals( 'Plain text content', $captured_alt_body, 'AltBody should be set so PHPMailer can produce a multipart/alternative message.' );
-		$this->assertEquals( 'alt', $captured_message_type, 'PHPMailer message_type should be "alt" (multipart/alternative) when AltBody is set alongside the default text/html Content-Type.' );
+		$this->assertStringStartsWith( 'multipart/alternative', $captured_final_content_type, 'PHPMailer should upgrade ContentType to multipart/alternative when AltBody is set alongside the default text/html Content-Type.' );
 	}
 
 	/**

--- a/tests/phpunit/integration/Core/Email/EmailTest.php
+++ b/tests/phpunit/integration/Core/Email/EmailTest.php
@@ -126,6 +126,110 @@ class EmailTest extends TestCase {
 		$this->assertEquals( $content, $captured_atts['message'], 'Content should match.' );
 	}
 
+	public function test_send_adds_default_content_type_header_when_none_supplied() {
+		// The pre_wp_mail filter was introduced in WordPress 5.7.
+		if ( version_compare( $GLOBALS['wp_version'], '5.7', '<' ) ) {
+			$this->markTestSkipped( 'This test requires WordPress 5.7 or higher for the pre_wp_mail filter.' );
+		}
+
+		$captured_atts = null;
+		add_filter(
+			'pre_wp_mail',
+			function ( $short_circuit, $atts ) use ( &$captured_atts ) {
+				$captured_atts = $atts;
+				return true;
+			},
+			10,
+			2
+		);
+
+		$this->email->send( 'test@example.com', 'Test Subject', '<p>HTML Content</p>' );
+
+		$this->assertNotNull( $captured_atts, 'Attributes should be captured.' );
+		$this->assertIsArray( $captured_atts['headers'], 'Headers should be passed as an array.' );
+		$this->assertContains(
+			'Content-Type: text/html; charset=UTF-8',
+			$captured_atts['headers'],
+			'Default text/html Content-Type header should be present when no caller Content-Type is supplied.'
+		);
+	}
+
+	public function test_send_preserves_caller_supplied_content_type_header() {
+		// The pre_wp_mail filter was introduced in WordPress 5.7.
+		if ( version_compare( $GLOBALS['wp_version'], '5.7', '<' ) ) {
+			$this->markTestSkipped( 'This test requires WordPress 5.7 or higher for the pre_wp_mail filter.' );
+		}
+
+		$captured_atts = null;
+		add_filter(
+			'pre_wp_mail',
+			function ( $short_circuit, $atts ) use ( &$captured_atts ) {
+				$captured_atts = $atts;
+				return true;
+			},
+			10,
+			2
+		);
+
+		$caller_content_type = 'Content-Type: text/plain; charset=ISO-8859-1';
+		$this->email->send(
+			'test@example.com',
+			'Test Subject',
+			'Plain content',
+			array( $caller_content_type )
+		);
+
+		$this->assertNotNull( $captured_atts, 'Attributes should be captured.' );
+		$this->assertContains(
+			$caller_content_type,
+			$captured_atts['headers'],
+			'Caller-supplied Content-Type should be preserved verbatim.'
+		);
+		$this->assertNotContains(
+			'Content-Type: text/html; charset=UTF-8',
+			$captured_atts['headers'],
+			'Default Content-Type should not be added when a caller Content-Type is already present.'
+		);
+	}
+
+	public function test_send_preserves_caller_supplied_content_type_header_case_insensitive() {
+		// The pre_wp_mail filter was introduced in WordPress 5.7.
+		if ( version_compare( $GLOBALS['wp_version'], '5.7', '<' ) ) {
+			$this->markTestSkipped( 'This test requires WordPress 5.7 or higher for the pre_wp_mail filter.' );
+		}
+
+		$captured_atts = null;
+		add_filter(
+			'pre_wp_mail',
+			function ( $short_circuit, $atts ) use ( &$captured_atts ) {
+				$captured_atts = $atts;
+				return true;
+			},
+			10,
+			2
+		);
+
+		$caller_content_type = 'content-type: text/plain; charset=UTF-8';
+		$this->email->send(
+			'test@example.com',
+			'Test Subject',
+			'Plain content',
+			array( $caller_content_type )
+		);
+
+		$this->assertNotNull( $captured_atts, 'Attributes should be captured.' );
+		$this->assertContains(
+			$caller_content_type,
+			$captured_atts['headers'],
+			'Lowercase caller Content-Type should be preserved verbatim.'
+		);
+		$this->assertNotContains(
+			'Content-Type: text/html; charset=UTF-8',
+			$captured_atts['headers'],
+			'Default Content-Type should not be added when a Content-Type header is present in any case.'
+		);
+	}
+
 	public function test_get_last_error() {
 		$this->assertNull( $this->email->get_last_error(), 'Last error should be null initially.' );
 	}


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #12632

## Relevant technical choices

* Added defensive guards beyond the IB-specified shape (coerce non-array `$headers`, skip non-string entries, and `ltrim` before matching `Content-Type:`) so the injection logic is safe against unusual caller inputs.
* New tests go beyond the IB's stated coverage: `assertSingleContentTypeHeader` asserts exactly one `Content-Type` header is present (catching accidental duplicate emission), and the multipart-preservation test calls `$phpmailer->preSend()` from a priority-999 `phpmailer_init` listener to observe PHPMailer's runtime upgrade to `multipart/alternative` after `AltBody` attaches.

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.
- [ ] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
