### PR TITLE
Enhancement/12537 allow widgets to declare an optional pdf configuration for PDF export

### DIFF
--- a/assets/js/googlesitekit/widgets/datastore/__snapshots__/widgets.test.js.snap
+++ b/assets/js/googlesitekit/widgets/datastore/__snapshots__/widgets.test.js.snap
@@ -15,6 +15,7 @@ exports[`core/widgets Widgets selectors getWidget returns a widget if one exists
   "isActive": undefined,
   "isPreloaded": undefined,
   "modules": [],
+  "pdf": undefined,
   "priority": 10,
   "slug": "TestWidget",
   "width": "quarter",

--- a/assets/js/googlesitekit/widgets/datastore/widgets.js
+++ b/assets/js/googlesitekit/widgets/datastore/widgets.js
@@ -98,7 +98,7 @@ export const actions = {
 	 * @param {Function}              [settings.isActive]          Optional. Callback function to determine if the widget is active.
 	 * @param {Function}              [settings.isPreloaded]       Optional. Callback function to determine if the widget should be preloaded if not active (requires isActive).
 	 * @param {Array.<string>}        [settings.hideOnBreakpoints] Optional. Hide widget on selected breakpoints. Array with any of: `BREAKPOINT_SMALL`, `BREAKPOINT_TABLET`, `BREAKPOINT_DESKTOP`, `BREAKPOINT_XLARGE`.
-	 * @param {WidgetPDFConfig}       [settings.pdf]               Optional. PDF export configuration for this widget. When present, downstream consumers can include this widget in the PDF export by filtering `getWidgets( areaSlug ).filter( ( w ) => !! w.pdf )`.
+	 * @param {WidgetPDFConfig}       [settings.pdf]               Optional. PDF export configuration for this widget.
 	 * @return {Object} Redux-style action.
 	 */
 	registerWidget(

--- a/assets/js/googlesitekit/widgets/datastore/widgets.js
+++ b/assets/js/googlesitekit/widgets/datastore/widgets.js
@@ -55,7 +55,7 @@ export const initialState = {
  *
  * @typedef {Object} WidgetPDFConfig
  * @property {WPComponent} Component React component (from `@react-pdf/renderer`) used to render this widget in the PDF. Receives `{ data, chartImages }` props.
- * @property {Function}    getData   Async function `( { registry, dates, signal } ) => ( { data, chartImages? } )`. Loads all reports the widget needs and optionally rasterises charts to data URIs. `data` is a widget-shaped object the `Component` knows how to render. `chartImages` is an optional `Record<string, string>` of JPEG data URIs keyed by chart name.
+ * @property {Function}    getData   Async function `( { registry, dates, signal } ) => ( { data, chartImages? } )`. Loads all reports the widget needs and optionally rasterizes charts to data URIs. `data` is a widget-shaped object the `Component` knows how to render. `chartImages` is an optional `Record<string, string>` of JPEG data URIs keyed by chart name.
  * @property {string}      [label]   Optional. The widget's sub-section heading within its area, also used as the child checkbox label in the sidesheet. Required when an area contains more than one PDF widget; may be omitted when the widget is the sole PDF widget in its area (the `PDFSubSection` heading is suppressed in that case regardless).
  */
 

--- a/assets/js/googlesitekit/widgets/datastore/widgets.js
+++ b/assets/js/googlesitekit/widgets/datastore/widgets.js
@@ -48,6 +48,17 @@ export const initialState = {
 	widgetStates: {},
 };
 
+/**
+ * PDF export configuration for a widget.
+ *
+ * @since n.e.x.t
+ *
+ * @typedef {Object} WidgetPDFConfig
+ * @property {WPComponent} Component React component (from `@react-pdf/renderer`) used to render this widget in the PDF. Receives `{ data, chartImages }` props.
+ * @property {Function}    getData   Async function `( { registry, dates, signal } ) => ( { data, chartImages? } )`. Loads all reports the widget needs and optionally rasterises charts to data URIs. `data` is a widget-shaped object the `Component` knows how to render. `chartImages` is an optional `Record<string, string>` of JPEG data URIs keyed by chart name.
+ * @property {string}      [label]   Optional. The widget's sub-section heading within its area, also used as the child checkbox label in the sidesheet. Required when an area contains more than one PDF widget; may be omitted when the widget is the sole PDF widget in its area (the `PDFSubSection` heading is suppressed in that case regardless).
+ */
+
 export const actions = {
 	/**
 	 * Assigns an existing widget (by slug) to a widget area(s).
@@ -75,6 +86,7 @@ export const actions = {
 	 * @since 1.9.0
 	 * @since 1.12.0  Added wrapWidget setting.
 	 * @since 1.138.0 Added hideOnBreakpoints setting.
+	 * @since n.e.x.t Added pdf setting.
 	 *
 	 * @param {string}                slug                         Widget's slug.
 	 * @param {Object}                settings                     Widget's settings.
@@ -86,6 +98,7 @@ export const actions = {
 	 * @param {Function}              [settings.isActive]          Optional. Callback function to determine if the widget is active.
 	 * @param {Function}              [settings.isPreloaded]       Optional. Callback function to determine if the widget should be preloaded if not active (requires isActive).
 	 * @param {Array.<string>}        [settings.hideOnBreakpoints] Optional. Hide widget on selected breakpoints. Array with any of: `BREAKPOINT_SMALL`, `BREAKPOINT_TABLET`, `BREAKPOINT_DESKTOP`, `BREAKPOINT_XLARGE`.
+	 * @param {WidgetPDFConfig}       [settings.pdf]               Optional. PDF export configuration for this widget. When present, downstream consumers can include this widget in the PDF export by filtering `getWidgets( areaSlug ).filter( ( w ) => !! w.pdf )`.
 	 * @return {Object} Redux-style action.
 	 */
 	registerWidget(
@@ -99,6 +112,7 @@ export const actions = {
 			isActive,
 			isPreloaded,
 			hideOnBreakpoints,
+			pdf,
 		} = {}
 	) {
 		const allWidths = Object.values( WIDGET_WIDTHS );
@@ -123,6 +137,7 @@ export const actions = {
 					isActive,
 					isPreloaded,
 					hideOnBreakpoints,
+					pdf,
 				},
 			},
 			type: REGISTER_WIDGET,

--- a/assets/js/googlesitekit/widgets/datastore/widgets.test.js
+++ b/assets/js/googlesitekit/widgets/datastore/widgets.test.js
@@ -566,6 +566,49 @@ describe( 'core/widgets Widgets', () => {
 				expect( widgets[ 1 ].slug ).toBe( 'TestWidget1' );
 				expect( widgets[ 2 ].slug ).toBe( 'TestWidget2' );
 			} );
+
+			it( 'should return the pdf field on widgets in the area', () => {
+				function PDFComponent() {
+					return null;
+				}
+				// eslint-disable-next-line require-await
+				async function getData() {
+					return { data: {} };
+				}
+				const pdf = {
+					Component: PDFComponent,
+					getData,
+					label: 'Test Widget',
+				};
+
+				registry
+					.dispatch( CORE_WIDGETS )
+					.registerWidgetArea( 'dashboard-header', {
+						title: 'Dashboard Header',
+						style: 'boxes',
+					} );
+				registry
+					.dispatch( CORE_WIDGETS )
+					.assignWidgetArea( 'dashboard-header', 'dashboard' );
+				registry
+					.dispatch( CORE_WIDGETS )
+					.registerWidget( 'TestWidget', {
+						Component() {
+							return <div>Hello test.</div>;
+						},
+						pdf,
+					} );
+				registry
+					.dispatch( CORE_WIDGETS )
+					.assignWidget( 'TestWidget', 'dashboard-header' );
+
+				const widgets = registry
+					.select( CORE_WIDGETS )
+					.getWidgets( 'dashboard-header' );
+
+				expect( widgets ).toHaveLength( 1 );
+				expect( widgets[ 0 ].pdf ).toBe( pdf );
+			} );
 		} );
 
 		describe( 'isWidgetActive', () => {

--- a/assets/js/googlesitekit/widgets/datastore/widgets.test.js
+++ b/assets/js/googlesitekit/widgets/datastore/widgets.test.js
@@ -216,6 +216,49 @@ describe( 'core/widgets Widgets', () => {
 				expect( container.firstChild ).toMatchSnapshot();
 			} );
 
+			it( 'should store the pdf field unchanged and expose it via getWidget and getWidgets', () => {
+				function PDFComponent() {
+					return null;
+				}
+				// eslint-disable-next-line require-await
+				async function getData() {
+					return { data: {} };
+				}
+				const pdf = {
+					Component: PDFComponent,
+					getData,
+					label: 'Test Widget',
+				};
+
+				registry
+					.dispatch( CORE_WIDGETS )
+					.registerWidgetArea( 'dashboard-header', {
+						title: 'Dashboard Header',
+						subtitle: 'Cool stuff for yoursite.com',
+						style: 'boxes',
+					} );
+				registry
+					.dispatch( CORE_WIDGETS )
+					.assignWidgetArea( 'dashboard-header', 'dashboard' );
+
+				registry.dispatch( CORE_WIDGETS ).registerWidget( slug, {
+					Component: WidgetComponent,
+					pdf,
+				} );
+				registry
+					.dispatch( CORE_WIDGETS )
+					.assignWidget( slug, 'dashboard-header' );
+
+				expect(
+					registry.select( CORE_WIDGETS ).getWidget( slug ).pdf
+				).toBe( pdf );
+
+				const [ widget ] = registry
+					.select( CORE_WIDGETS )
+					.getWidgets( 'dashboard-header' );
+				expect( widget.pdf ).toBe( pdf );
+			} );
+
 			it( 'should not overwrite an existing widget', () => {
 				function WidgetOne() {
 					return <div>Hello world!</div>;

--- a/assets/js/googlesitekit/widgets/datastore/widgets.test.js
+++ b/assets/js/googlesitekit/widgets/datastore/widgets.test.js
@@ -216,7 +216,7 @@ describe( 'core/widgets Widgets', () => {
 				expect( container.firstChild ).toMatchSnapshot();
 			} );
 
-			it( 'should store the pdf field unchanged and expose it via getWidget and getWidgets', () => {
+			it( 'should store the pdf field unchanged in widget state', () => {
 				function PDFComponent() {
 					return null;
 				}
@@ -230,35 +230,12 @@ describe( 'core/widgets Widgets', () => {
 					label: 'Test Widget',
 				};
 
-				registry
-					.dispatch( CORE_WIDGETS )
-					.registerWidgetArea( 'dashboard-header', {
-						title: 'Dashboard Header',
-						subtitle: 'Cool stuff for yoursite.com',
-						style: 'boxes',
-					} );
-				registry
-					.dispatch( CORE_WIDGETS )
-					.assignWidgetArea( 'dashboard-header', 'dashboard' );
-
 				registry.dispatch( CORE_WIDGETS ).registerWidget( slug, {
 					Component: WidgetComponent,
 					pdf,
 				} );
-				registry
-					.dispatch( CORE_WIDGETS )
-					.assignWidget( slug, 'dashboard-header' );
 
-				expect(
-					registry.select( CORE_WIDGETS ).getWidget( slug ).pdf
-				).toBe( pdf );
-
-				const widgets = registry
-					.select( CORE_WIDGETS )
-					.getWidgets( 'dashboard-header' );
-
-				expect( widgets ).toHaveLength( 1 );
-				expect( widgets[ 0 ].pdf ).toBe( pdf );
+				expect( store.getState().widgets[ slug ].pdf ).toBe( pdf );
 			} );
 
 			it( 'should not overwrite an existing widget', () => {

--- a/assets/js/googlesitekit/widgets/datastore/widgets.test.js
+++ b/assets/js/googlesitekit/widgets/datastore/widgets.test.js
@@ -787,6 +787,35 @@ describe( 'core/widgets Widgets', () => {
 					registry.select( CORE_WIDGETS ).getWidget( 'NotRealWidget' )
 				).toBe( null );
 			} );
+
+			it( 'returns the pdf field on the registered widget', () => {
+				function PDFComponent() {
+					return null;
+				}
+				// eslint-disable-next-line require-await
+				async function getData() {
+					return { data: {} };
+				}
+				const pdf = {
+					Component: PDFComponent,
+					getData,
+					label: 'Test Widget',
+				};
+
+				registry
+					.dispatch( CORE_WIDGETS )
+					.registerWidget( 'TestWidget', {
+						Component() {
+							return <div>Hello test.</div>;
+						},
+						pdf,
+					} );
+
+				expect(
+					registry.select( CORE_WIDGETS ).getWidget( 'TestWidget' )
+						.pdf
+				).toBe( pdf );
+			} );
 		} );
 	} );
 } );

--- a/assets/js/googlesitekit/widgets/datastore/widgets.test.js
+++ b/assets/js/googlesitekit/widgets/datastore/widgets.test.js
@@ -253,10 +253,12 @@ describe( 'core/widgets Widgets', () => {
 					registry.select( CORE_WIDGETS ).getWidget( slug ).pdf
 				).toBe( pdf );
 
-				const [ widget ] = registry
+				const widgets = registry
 					.select( CORE_WIDGETS )
 					.getWidgets( 'dashboard-header' );
-				expect( widget.pdf ).toBe( pdf );
+
+				expect( widgets ).toHaveLength( 1 );
+				expect( widgets[ 0 ].pdf ).toBe( pdf );
 			} );
 
 			it( 'should not overwrite an existing widget', () => {

--- a/assets/js/googlesitekit/widgets/index.js
+++ b/assets/js/googlesitekit/widgets/index.js
@@ -35,7 +35,7 @@ export { registerDefaults as registerWidgets } from './register-defaults';
  *
  * @typedef {Object} WidgetPDFConfig
  * @property {WPComponent} Component React component (from `@react-pdf/renderer`) used to render this widget in the PDF. Receives `{ data, chartImages }` props.
- * @property {Function}    getData   Async function `( { registry, dates, signal } ) => ( { data, chartImages? } )`. Loads all reports the widget needs and optionally rasterises charts to data URIs. `data` is a widget-shaped object the `Component` knows how to render. `chartImages` is an optional `Record<string, string>` of JPEG data URIs keyed by chart name.
+ * @property {Function}    getData   Async function `( { registry, dates, signal } ) => ( { data, chartImages? } )`. Loads all reports the widget needs and optionally rasterizes charts to data URIs. `data` is a widget-shaped object the `Component` knows how to render. `chartImages` is an optional `Record<string, string>` of JPEG data URIs keyed by chart name.
  * @property {string}      [label]   Optional. The widget's sub-section heading within its area, also used as the child checkbox label in the sidesheet. Required when an area contains more than one PDF widget; may be omitted when the widget is the sole PDF widget in its area (the `PDFSubSection` heading is suppressed in that case regardless).
  */
 

--- a/assets/js/googlesitekit/widgets/index.js
+++ b/assets/js/googlesitekit/widgets/index.js
@@ -102,7 +102,7 @@ export function createWidgets( registry ) {
 		 * @param {boolean}               [settings.wrapWidget]        Optional. Whether to wrap the component with the <Widget> wrapper. Default is: true.
 		 * @param {string|Array.<string>} [settings.modules]           Optional. Widget's associated moduels.
 		 * @param {Array.<string>}        [settings.hideOnBreakpoints] Optional. Hide widget on selected breakpoints. Array with any of: `BREAKPOINT_SMALL`, `BREAKPOINT_TABLET`, `BREAKPOINT_DESKTOP`, `BREAKPOINT_XLARGE`.
-		 * @param {WidgetPDFConfig}       [settings.pdf]               Optional. PDF export configuration for this widget. When present, downstream consumers can include this widget in the PDF export by filtering `getWidgets( areaSlug ).filter( ( w ) => !! w.pdf )`.
+		 * @param {WidgetPDFConfig}       [settings.pdf]               Optional. PDF export configuration for this widget.
 		 * @param {(string|Array)}        [widgetAreaSlugs]            Optional. Widget area slug(s).
 		 */
 		registerWidget( slug, settings, widgetAreaSlugs ) {

--- a/assets/js/googlesitekit/widgets/index.js
+++ b/assets/js/googlesitekit/widgets/index.js
@@ -29,6 +29,17 @@ export { registerStore } from './datastore';
 export { registerDefaults as registerWidgets } from './register-defaults';
 
 /**
+ * PDF export configuration for a widget.
+ *
+ * @since n.e.x.t
+ *
+ * @typedef {Object} WidgetPDFConfig
+ * @property {WPComponent} Component React component (from `@react-pdf/renderer`) used to render this widget in the PDF. Receives `{ data, chartImages }` props.
+ * @property {Function}    getData   Async function `( { registry, dates, signal } ) => ( { data, chartImages? } )`. Loads all reports the widget needs and optionally rasterises charts to data URIs. `data` is a widget-shaped object the `Component` knows how to render. `chartImages` is an optional `Record<string, string>` of JPEG data URIs keyed by chart name.
+ * @property {string}      [label]   Optional. The widget's sub-section heading within its area, also used as the child checkbox label in the sidesheet. Required when an area contains more than one PDF widget; may be omitted when the widget is the sole PDF widget in its area (the `PDFSubSection` heading is suppressed in that case regardless).
+ */
+
+/**
  * Creates a new instance of Widgets.
  *
  * @since 1.26.0
@@ -81,6 +92,7 @@ export function createWidgets( registry ) {
 		 * Registers a widget.
 		 *
 		 * @since 1.9.0
+		 * @since n.e.x.t Added pdf setting.
 		 *
 		 * @param {string}                slug                         Widget's slug.
 		 * @param {Object}                settings                     Widget's settings.
@@ -90,6 +102,7 @@ export function createWidgets( registry ) {
 		 * @param {boolean}               [settings.wrapWidget]        Optional. Whether to wrap the component with the <Widget> wrapper. Default is: true.
 		 * @param {string|Array.<string>} [settings.modules]           Optional. Widget's associated moduels.
 		 * @param {Array.<string>}        [settings.hideOnBreakpoints] Optional. Hide widget on selected breakpoints. Array with any of: `BREAKPOINT_SMALL`, `BREAKPOINT_TABLET`, `BREAKPOINT_DESKTOP`, `BREAKPOINT_XLARGE`.
+		 * @param {WidgetPDFConfig}       [settings.pdf]               Optional. PDF export configuration for this widget. When present, downstream consumers can include this widget in the PDF export by filtering `getWidgets( areaSlug ).filter( ( w ) => !! w.pdf )`.
 		 * @param {(string|Array)}        [widgetAreaSlugs]            Optional. Widget area slug(s).
 		 */
 		registerWidget( slug, settings, widgetAreaSlugs ) {


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #12537

## Relevant technical choices

* Pulled `pdf`'s per-property descriptions into a `WidgetPDFConfig` typedef defined in each of the two touched files and referenced from `@param settings.pdf`, mirroring `WidgetComponentProps` in `assets/js/googlesitekit/widgets/util/get-widget-component-props.js` so the public-API JSDoc and the datastore JSDoc carry identical field docs.
* Wrote "rasterizes" instead of the IB's "rasterises" in the `getData` description for codebase consistency.

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.
- [ ] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
