### PR TITLE
Enhancement/12432 Omit invitation email footer utility links in HTML and plain-text

### DIFF
--- a/includes/Core/Email_Reporting/Batch_Error_Notifier.php
+++ b/includes/Core/Email_Reporting/Batch_Error_Notifier.php
@@ -293,6 +293,7 @@ class Batch_Error_Notifier {
 				'unsubscribe_url' => $email_settings_url,
 			),
 			'graphic'                => Content_Map::get_graphic_config( 'error-email' ),
+			'footer_type'            => 'standard',
 		);
 	}
 

--- a/includes/Core/Email_Reporting/Email_Template_Formatter.php
+++ b/includes/Core/Email_Reporting/Email_Template_Formatter.php
@@ -394,6 +394,7 @@ class Email_Template_Formatter {
 				'unsubscribe_url' => $email_settings_url,
 			),
 			'graphic'                => Content_Map::get_graphic_config( 'subscription-confirmation' ),
+			'footer_type'            => 'standard',
 		);
 	}
 

--- a/includes/Core/Email_Reporting/Plain_Text_Formatter.php
+++ b/includes/Core/Email_Reporting/Plain_Text_Formatter.php
@@ -90,6 +90,7 @@ class Plain_Text_Formatter {
 		$footer_copy     = $data['footer']['copy'] ?? '';
 		$body            = $data['body'] ?? array();
 		$unsubscribe_url = $data['footer']['unsubscribe_url'] ?? '';
+		$footer_type     = $data['footer_type'] ?? 'standard';
 
 		$lines = array(
 			__( 'Site Kit by Google', 'google-site-kit' ),
@@ -135,7 +136,10 @@ class Plain_Text_Formatter {
 			$lines[] = $footer_copy;
 		}
 
-		$lines = self::append_footer_links( $lines, $unsubscribe_url );
+		// Mirror the HTML `footer_type` branch: `inline` skips utility links.
+		if ( 'inline' !== $footer_type ) {
+			$lines = self::append_footer_links( $lines, $unsubscribe_url );
+		}
 
 		return implode( "\n", $lines );
 	}

--- a/includes/Core/Email_Reporting/REST_Email_Reporting_Controller.php
+++ b/includes/Core/Email_Reporting/REST_Email_Reporting_Controller.php
@@ -606,6 +606,7 @@ class REST_Email_Reporting_Controller {
 				'copy' => __( 'You received this email because your site admin invited you to use Site Kit email reports feature', 'google-site-kit' ),
 			),
 			'graphic'                => Content_Map::get_graphic_config( 'invitation-email' ),
+			'footer_type'            => 'inline',
 		);
 	}
 

--- a/includes/Core/Email_Reporting/templates/simple-email/template.php
+++ b/includes/Core/Email_Reporting/templates/simple-email/template.php
@@ -24,6 +24,7 @@ $body               = $data['body'];
 $cta                = $data['primary_call_to_action'];
 $footer             = $data['footer'];
 $graphic            = $data['graphic'] ?? array();
+$footer_type        = $data['footer_type'] ?? 'standard';
 $get_asset_url      = $data['get_asset_url'];
 $render_part        = $data['render_part'];
 $render_shared_part = $data['render_shared_part'];
@@ -91,18 +92,30 @@ $render_shared_part = $data['render_shared_part'];
 								)
 							);
 							?>
-							<?php
-							// Shared footer renders the footer copy and utility links
-							// (Manage Subscription if available, Privacy Policy, Help Center).
-							$render_shared_part(
-								'footer',
-								array(
-									'cta'                => array(), // CTA is in content, not footer.
-									'footer'             => $footer,
-									'render_shared_part' => $render_shared_part,
-								)
-							);
-							?>
+							<?php if ( 'inline' === $footer_type ) : ?>
+								<?php /* Inline footer (invitation-email style: just copy text, no unsubscribe/links). */ ?>
+							<table role="presentation" width="100%" style="margin-top: 12px;">
+								<tr>
+									<td style="text-align: left;">
+										<p class="text-secondary" style="font-size: 12px; line-height: 16px; font-weight: 500; color: #6C726E; margin: 0;">
+											<?php echo esc_html( $footer['copy'] ?? '' ); ?>
+										</p>
+									</td>
+								</tr>
+							</table>
+							<?php else : ?>
+								<?php
+								// Standard shared footer with unsubscribe and links.
+								$render_shared_part(
+									'footer',
+									array(
+										'cta'    => array(), // CTA is in content, not footer.
+										'footer' => $footer,
+										'render_shared_part' => $render_shared_part,
+									)
+								);
+								?>
+							<?php endif; ?>
 						</td>
 					</tr>
 				</table>

--- a/includes/Core/Email_Reporting/templates/simple-email/template.php
+++ b/includes/Core/Email_Reporting/templates/simple-email/template.php
@@ -94,15 +94,15 @@ $render_shared_part = $data['render_shared_part'];
 							?>
 							<?php if ( 'inline' === $footer_type ) : ?>
 								<?php /* Inline footer (invitation-email style: just copy text, no unsubscribe/links). */ ?>
-							<table role="presentation" width="100%" style="margin-top: 12px;">
-								<tr>
-									<td style="text-align: left;">
-										<p class="text-secondary" style="font-size: 12px; line-height: 16px; font-weight: 500; color: #6C726E; margin: 0;">
-											<?php echo esc_html( $footer['copy'] ?? '' ); ?>
-										</p>
-									</td>
-								</tr>
-							</table>
+								<table role="presentation" width="100%" style="margin-top: 12px;">
+									<tr>
+										<td style="text-align: left;">
+											<p class="text-secondary" style="font-size: 12px; line-height: 16px; font-weight: 500; color: #6C726E; margin: 0;">
+												<?php echo esc_html( $footer['copy'] ?? '' ); ?>
+											</p>
+										</td>
+									</tr>
+								</table>
 							<?php else : ?>
 								<?php
 								// Standard shared footer with unsubscribe and links.

--- a/tests/phpunit/integration/Core/Email_Reporting/Plain_Text_FormatterTest.php
+++ b/tests/phpunit/integration/Core/Email_Reporting/Plain_Text_FormatterTest.php
@@ -397,32 +397,34 @@ class Plain_Text_FormatterTest extends TestCase {
 		$this->assertStringContainsString( 'Success! You are subscribed', $result, 'Plain title should pass through unchanged.' );
 	}
 
-	public function test_format_simple_email_with_missing_data() {
+	public function test_format_simple_email_renders_inline_footer_without_utility_links() {
 		$data = array(
 			'site'                   => array(
 				'domain' => 'example.com',
 			),
-			'title'                  => 'You have been invited to receive performance reports',
+			'title'                  => 'admin@example.com invited you to receive periodic performance reports',
 			'preheader'              => 'This preheader should not appear in plain text output',
 			'body'                   => array(),
 			'learn_more_url'         => '',
 			'primary_call_to_action' => array(),
 			'footer'                 => array(
-				'copy' => '',
+				'copy' => 'You received this email because your site admin invited you to use Site Kit email reports feature',
 			),
+			'footer_type'            => 'inline',
 		);
 
 		$result = Plain_Text_Formatter::format_simple_email( $data );
 
-		$this->assertStringContainsString( 'Site Kit by Google', $result, 'Simple email should contain Site Kit branding even with missing data.' );
+		$this->assertStringContainsString( 'Site Kit by Google', $result, 'Simple email should contain Site Kit branding.' );
 		$this->assertStringContainsString( 'example.com', $result, 'Simple email should contain site domain.' );
-		$this->assertStringContainsString( 'You have been invited to receive performance reports', $result, 'Simple email should contain title text.' );
+		$this->assertStringContainsString( 'admin@example.com invited you to receive periodic performance reports', $result, 'Simple email should contain title text.' );
 		$this->assertStringNotContainsString( 'This preheader should not appear in plain text output', $result, 'Simple email should not contain preheader text.' );
 		$this->assertStringNotContainsString( 'Learn more:', $result, 'Simple email should not contain Learn more link when URL is empty.' );
-		$this->assertStringNotContainsString( 'Unsubscribe:', $result, 'Simple email should not contain a standalone Unsubscribe link.' );
-		$this->assertStringNotContainsString( 'Manage Subscription:', $result, 'Simple email should omit Manage Subscription link when unsubscribe URL is missing.' );
-		$this->assertStringContainsString( 'Privacy Policy: https://policies.google.com/privacy', $result, 'Simple email should always contain Privacy Policy link.' );
-		$this->assertStringContainsString( 'Help Center: ' . add_query_arg( 'doc', 'get-support', 'https://sitekit.withgoogle.com/support/' ), $result, 'Simple email should always contain Help Center link.' );
+		$this->assertStringContainsString( 'You received this email because your site admin invited you', $result, 'Inline footer should contain footer copy.' );
+		$this->assertStringNotContainsString( 'Unsubscribe:', $result, 'Inline footer should omit Unsubscribe link.' );
+		$this->assertStringNotContainsString( 'Manage Subscription:', $result, 'Inline footer should omit Manage Subscription link.' );
+		$this->assertStringNotContainsString( 'Privacy Policy:', $result, 'Inline footer should omit Privacy Policy link.' );
+		$this->assertStringNotContainsString( 'Help Center:', $result, 'Inline footer should omit Help Center link.' );
 	}
 
 	public function test_convert_links_to_text__converts_anchor_tags() {

--- a/tests/phpunit/integration/Core/Email_Reporting/Plain_Text_FormatterTest.php
+++ b/tests/phpunit/integration/Core/Email_Reporting/Plain_Text_FormatterTest.php
@@ -427,6 +427,26 @@ class Plain_Text_FormatterTest extends TestCase {
 		$this->assertStringNotContainsString( 'Help Center:', $result, 'Inline footer should omit Help Center link.' );
 	}
 
+	public function test_format_simple_email_omits_manage_subscription_without_unsubscribe_url() {
+		$data = array(
+			'site'                   => array( 'domain' => 'example.com' ),
+			'title'                  => 'You have been invited to receive performance reports',
+			'body'                   => array(),
+			'primary_call_to_action' => array(),
+			'footer'                 => array(
+				'copy'            => 'You received this email because you signed up.',
+				'unsubscribe_url' => '',
+			),
+		);
+
+		$result = Plain_Text_Formatter::format_simple_email( $data );
+
+		$this->assertStringNotContainsString( 'Unsubscribe:', $result, 'Simple email should omit standalone Unsubscribe link.' );
+		$this->assertStringNotContainsString( 'Manage Subscription:', $result, 'Simple email should omit Manage Subscription link without unsubscribe URL.' );
+		$this->assertStringContainsString( 'Privacy Policy: https://policies.google.com/privacy', $result, 'Simple email should always contain Privacy Policy link.' );
+		$this->assertStringContainsString( 'Help Center: ' . add_query_arg( 'doc', 'get-support', 'https://sitekit.withgoogle.com/support/' ), $result, 'Simple email should always contain Help Center link.' );
+	}
+
 	public function test_convert_links_to_text__converts_anchor_tags() {
 		$html = 'Contact your administrator or <a href="https://example.com/help">get help</a>.';
 


### PR DESCRIPTION
Implement logic to differentiate between standard and inline footers in the email reporting system. This change allows for more flexible footer rendering based on the specified footer type.

## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #12432

## Relevant technical choices

* Reverts PR #12690 per the post-merge QA call (invitation footer stays copy-only in both formats), overriding the original AC's "HTML templates remain unchanged" line.
* Plain-text branches on the same `footer_type` signal as the HTML template, not `unsubscribe_url` presence, keeping the discriminator explicit and consistent across formats.
* Renamed `test_format_simple_email_with_missing_data` to `test_format_simple_email_renders_inline_footer_without_utility_links` and rebuilt its data around the invitation payload (`footer_type => 'inline'`).

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.
- [ ] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
