### PR TITLE
Show Sign in with Google button on page and post previews

### DIFF
--- a/includes/Modules/Sign_In_With_Google/Sign_In_With_Google_Block.php
+++ b/includes/Modules/Sign_In_With_Google/Sign_In_With_Google_Block.php
@@ -92,8 +92,9 @@ class Sign_In_With_Google_Block {
 	 */
 	public function render_callback( $attributes = array() ) {
 		// If the user is already signed in, do not render a Sign in
-		// with Google button.
-		if ( is_user_logged_in() ) {
+		// with Google button. The post/page preview surface is exempt so
+		// authors can see how the button will appear to logged-out readers.
+		if ( is_user_logged_in() && ! is_preview() ) {
 			return '';
 		}
 

--- a/includes/Modules/Sign_In_With_Google/Web_Tag.php
+++ b/includes/Modules/Sign_In_With_Google/Web_Tag.php
@@ -131,7 +131,8 @@ class Web_Tag extends Module_Web_Tag {
 		// Show the One Tap prompt if:
 		// 1. One Tap is enabled in settings.
 		// 2. The user is not logged in.
-		$should_show_one_tap_prompt = ! empty( $this->settings['oneTapEnabled'] ) && ! is_user_logged_in();
+		// 3. The current request is not a post/page preview.
+		$should_show_one_tap_prompt = ! empty( $this->settings['oneTapEnabled'] ) && ! is_user_logged_in() && ! is_preview();
 
 		// Set the cookie time to live to 5 minutes. If the redirect_to is
 		// empty, set the cookie to expire immediately.
@@ -146,6 +147,7 @@ class Web_Tag extends Module_Web_Tag {
 		?>
 ( () => {
 	async function handleCredentialResponse( response ) {
+		<?php if ( ! is_preview() ) : // phpcs:ignore Generic.WhiteSpace.ScopeIndent.Incorrect ?>
 		<?php if ( $is_woocommerce && ! $this->is_wp_login ) : // phpcs:ignore Generic.WhiteSpace.ScopeIndent.Incorrect ?>
 		response.integration = 'woocommerce';
 		<?php endif; // phpcs:ignore Generic.WhiteSpace.ScopeIndent.Incorrect ?>
@@ -177,6 +179,7 @@ class Web_Tag extends Module_Web_Tag {
 		} catch( error ) {
 			console.error( error );
 		}
+		<?php endif; // phpcs:ignore Generic.WhiteSpace.ScopeIndent.Incorrect ?>
 	}
 
 	if (typeof google !== 'undefined') {
@@ -194,7 +197,7 @@ class Web_Tag extends Module_Web_Tag {
 		document.getElementById( 'login' ).insertBefore( buttonDivToAddToLoginForm, document.getElementById( 'loginform' ) );
 	<?php endif; // phpcs:ignore Generic.WhiteSpace.ScopeIndent.Incorrect ?>
 
-	<?php if ( ! is_user_logged_in() || $this->is_wp_login ) : // phpcs:ignore Generic.WhiteSpace.ScopeIndent.Incorrect ?>
+	<?php if ( ! is_user_logged_in() || $this->is_wp_login || is_preview() ) : // phpcs:ignore Generic.WhiteSpace.ScopeIndent.Incorrect ?>
 			<?php
 			/**
 			 * Render SiwG buttons for all `<div>` elements with the "magic

--- a/tests/phpunit/integration/Modules/Sign_In_With_Google/Sign_In_With_Google_BlockTest.php
+++ b/tests/phpunit/integration/Modules/Sign_In_With_Google/Sign_In_With_Google_BlockTest.php
@@ -91,4 +91,29 @@ class Sign_In_With_Google_BlockTest extends TestCase {
 		$this->assertStringNotContainsString( 'data-googlesitekit-siwg-theme', $output, 'Default selection should not add theme data attribute.' );
 		$this->assertStringContainsString( 'class="googlesitekit-sign-in-with-google__frontend-output-button"', $output, 'Default output should include the base class only.' );
 	}
+
+	public function test_render_callback_returns_empty_for_logged_in_user_outside_preview() {
+		$admin_id = $this->factory()->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $admin_id );
+
+		$output = $this->block->render_callback();
+
+		$this->assertSame( '', $output, 'Logged-in users should not see the button outside of preview.' );
+	}
+
+	public function test_render_callback_renders_for_logged_in_user_when_previewing() {
+		global $wp_query;
+
+		$admin_id = $this->factory()->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $admin_id );
+
+		$previous_preview     = $wp_query->is_preview;
+		$wp_query->is_preview = true;
+
+		$output = $this->block->render_callback();
+
+		$wp_query->is_preview = $previous_preview;
+
+		$this->assertStringContainsString( 'googlesitekit-sign-in-with-google__frontend-output-button', $output, 'Logged-in admins previewing a post should see the SiwG placeholder.' );
+	}
 }

--- a/tests/phpunit/integration/Modules/Sign_In_With_Google/Web_TagTest.php
+++ b/tests/phpunit/integration/Modules/Sign_In_With_Google/Web_TagTest.php
@@ -184,7 +184,7 @@ class Web_TagTest extends TestCase {
 		$wp_query->is_preview = $previous_preview;
 
 		// Button render loop fires on preview even when the admin is logged in.
-		$this->assertStringContainsString( '.googlesitekit-sign-in-with-google__frontend-output-button', $output, 'Render loop should fire on preview pages even when the user is logged in.' );
+		$this->assertStringContainsString( 'googlesitekit-sign-in-with-google__frontend-output-button', $output, 'Render loop should fire on preview pages even when the user is logged in.' );
 		$this->assertStringContainsString( 'google.accounts.id.renderButton', $output, 'Render loop should call renderButton on preview pages.' );
 		// handleCredentialResponse body is wrapped, so no credential POST lands in the output.
 		$this->assertStringNotContainsString( "fetch('http://example.org/wp-login.php?action=googlesitekit_auth'", $output, 'Credential POST should not be rendered on preview pages.' );

--- a/tests/phpunit/integration/Modules/Sign_In_With_Google/Web_TagTest.php
+++ b/tests/phpunit/integration/Modules/Sign_In_With_Google/Web_TagTest.php
@@ -156,4 +156,39 @@ class Web_TagTest extends TestCase {
 		$this->assertTrue( has_action( 'wp_footer' ), 'wp_footer action should be registered.' );
 		$this->assertTrue( has_action( 'login_footer' ), 'login_footer action should be registered.' );
 	}
+
+	public function test_render_on_wp_footer_during_preview_renders_button_and_skips_callbacks() {
+		global $wp_query;
+
+		remove_all_actions( 'wp_footer' );
+
+		$admin_id = $this->factory()->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $admin_id );
+
+		$this->web_tag->set_settings(
+			array(
+				'clientID'      => 'test-client-id.app.googleusercontent.com',
+				'text'          => Settings::TEXT_SIGN_IN_WITH_GOOGLE['value'],
+				'theme'         => Settings::THEME_LIGHT['value'],
+				'shape'         => Settings::SHAPE_RECTANGULAR['value'],
+				'oneTapEnabled' => true,
+			)
+		);
+		$this->web_tag->register();
+
+		$previous_preview     = $wp_query->is_preview;
+		$wp_query->is_preview = true;
+
+		$output = $this->capture_action( 'wp_footer' );
+
+		$wp_query->is_preview = $previous_preview;
+
+		// Button render loop fires on preview even when the admin is logged in.
+		$this->assertStringContainsString( '.googlesitekit-sign-in-with-google__frontend-output-button', $output, 'Render loop should fire on preview pages even when the user is logged in.' );
+		$this->assertStringContainsString( 'google.accounts.id.renderButton', $output, 'Render loop should call renderButton on preview pages.' );
+		// handleCredentialResponse body is wrapped, so no credential POST lands in the output.
+		$this->assertStringNotContainsString( "fetch('http://example.org/wp-login.php?action=googlesitekit_auth'", $output, 'Credential POST should not be rendered on preview pages.' );
+		// One Tap prompt is suppressed on preview pages.
+		$this->assertStringNotContainsString( 'google.accounts.id.prompt()', $output, 'One Tap should not be invoked on preview pages.' );
+	}
 }

--- a/tests/phpunit/integration/Modules/Sign_In_With_Google/Web_TagTest.php
+++ b/tests/phpunit/integration/Modules/Sign_In_With_Google/Web_TagTest.php
@@ -191,4 +191,34 @@ class Web_TagTest extends TestCase {
 		// One Tap prompt is suppressed on preview pages.
 		$this->assertStringNotContainsString( 'google.accounts.id.prompt()', $output, 'One Tap should not be invoked on preview pages.' );
 	}
+
+	public function test_render_on_wp_footer_during_preview_for_logged_out_visitor_skips_one_tap() {
+		global $wp_query;
+
+		remove_all_actions( 'wp_footer' );
+
+		// A logged-out visitor would otherwise see One Tap when oneTapEnabled is true.
+		// The `! is_preview()` clause on $should_show_one_tap_prompt is what suppresses it here.
+		wp_set_current_user( 0 );
+
+		$this->web_tag->set_settings(
+			array(
+				'clientID'      => 'test-client-id.app.googleusercontent.com',
+				'text'          => Settings::TEXT_SIGN_IN_WITH_GOOGLE['value'],
+				'theme'         => Settings::THEME_LIGHT['value'],
+				'shape'         => Settings::SHAPE_RECTANGULAR['value'],
+				'oneTapEnabled' => true,
+			)
+		);
+		$this->web_tag->register();
+
+		$previous_preview     = $wp_query->is_preview;
+		$wp_query->is_preview = true;
+
+		$output = $this->capture_action( 'wp_footer' );
+
+		$wp_query->is_preview = $previous_preview;
+
+		$this->assertStringNotContainsString( 'google.accounts.id.prompt()', $output, 'One Tap should not be invoked on preview pages, even when the visitor is logged out.' );
+	}
 }


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #10301

## Relevant technical choices

* The render, `handleCredentialResponse`, and One Tap blocks that the IB cites in `Sign_In_With_Google.php` moved to `Web_Tag.php`.

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.
- [ ] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
