### PR TITLE
Remove "Start a feature tour" help menu item when gathering data

### DIFF
--- a/assets/js/components/help/HelpMenu.js
+++ b/assets/js/components/help/HelpMenu.js
@@ -70,30 +70,26 @@ export default function HelpMenu( { children, showFeatureTour = false } ) {
 		select( CORE_MODULES ).isModuleActive( MODULE_SLUG_ADSENSE )
 	);
 
-	const analyticsConnected = useSelect( ( select ) =>
-		select( CORE_MODULES ).isModuleConnected( MODULE_SLUG_ANALYTICS_4 )
-	);
-
-	const analyticsGatheringData = useSelect(
+	const showFeatureTourMenuItem = useSelect(
 		( select ) => {
-			if ( ! analyticsConnected ) {
+			if ( ! showFeatureTour || ! setupFlowRefreshEnabled ) {
 				return false;
 			}
 
-			return select( MODULES_ANALYTICS_4 ).isGatheringData();
+			const analyticsConnected = select( CORE_MODULES ).isModuleConnected(
+				MODULE_SLUG_ANALYTICS_4
+			);
+
+			if ( analyticsConnected ) {
+				return (
+					select( MODULES_ANALYTICS_4 ).isGatheringData() === false
+				);
+			}
+
+			return select( MODULES_SEARCH_CONSOLE ).isGatheringData() === false;
 		},
-		[ analyticsConnected ]
+		[ showFeatureTour, setupFlowRefreshEnabled ]
 	);
-
-	const searchConsoleGatheringData = useSelect( ( select ) =>
-		select( MODULES_SEARCH_CONSOLE ).isGatheringData()
-	);
-
-	const showFeatureTourMenuItem =
-		showFeatureTour &&
-		( analyticsConnected
-			? analyticsGatheringData === false
-			: searchConsoleGatheringData === false );
 
 	const handleMenu = useCallback( () => {
 		if ( ! menuOpen ) {

--- a/assets/js/components/help/HelpMenu.js
+++ b/assets/js/components/help/HelpMenu.js
@@ -41,6 +41,9 @@ import { CORE_MODULES } from '@/js/googlesitekit/modules/datastore/constants';
 import { CORE_SITE } from '@/js/googlesitekit/datastore/site/constants';
 import { CORE_USER } from '@/js/googlesitekit/datastore/user/constants';
 import { MODULE_SLUG_ADSENSE } from '@/js/modules/adsense/constants';
+import { MODULE_SLUG_ANALYTICS_4 } from '@/js/modules/analytics-4/constants';
+import { MODULES_ANALYTICS_4 } from '@/js/modules/analytics-4/datastore/constants';
+import { MODULES_SEARCH_CONSOLE } from '@/js/modules/search-console/datastore/constants';
 import { useFeature } from '@/js/hooks/useFeature';
 import { useKeyCodesInside } from '@/js/hooks/useKeyCodesInside';
 import { useWelcomeTour } from '@/js/feature-tours/hooks/useWelcomeTour';
@@ -66,6 +69,31 @@ export default function HelpMenu( { children, showFeatureTour = false } ) {
 	const adSenseModuleActive = useSelect( ( select ) =>
 		select( CORE_MODULES ).isModuleActive( MODULE_SLUG_ADSENSE )
 	);
+
+	const analyticsConnected = useSelect( ( select ) =>
+		select( CORE_MODULES ).isModuleConnected( MODULE_SLUG_ANALYTICS_4 )
+	);
+
+	const analyticsGatheringData = useSelect(
+		( select ) => {
+			if ( ! analyticsConnected ) {
+				return false;
+			}
+
+			return select( MODULES_ANALYTICS_4 ).isGatheringData();
+		},
+		[ analyticsConnected ]
+	);
+
+	const searchConsoleGatheringData = useSelect( ( select ) =>
+		select( MODULES_SEARCH_CONSOLE ).isGatheringData()
+	);
+
+	const showFeatureTourMenuItem =
+		showFeatureTour &&
+		( analyticsConnected
+			? analyticsGatheringData === false
+			: searchConsoleGatheringData === false );
 
 	const handleMenu = useCallback( () => {
 		if ( ! menuOpen ) {
@@ -136,7 +164,7 @@ export default function HelpMenu( { children, showFeatureTour = false } ) {
 			icon: <SupportIcon width={ 24 } height={ 24 } />,
 			children: __( 'Get free support', 'google-site-kit' ),
 		},
-		...( showFeatureTour
+		...( showFeatureTourMenuItem
 			? [
 					{
 						gaEventLabel: 'start_tour',

--- a/assets/js/components/help/HelpMenu.test.tsx
+++ b/assets/js/components/help/HelpMenu.test.tsx
@@ -28,7 +28,12 @@ import {
 	fireEvent,
 	waitFor,
 } from '../../../../tests/js/test-utils';
+import { provideGatheringDataState } from 'tests/js/gathering-data-utils';
 import { CORE_USER } from '@/js/googlesitekit/datastore/user/constants';
+import { MODULE_SLUG_ANALYTICS_4 } from '@/js/modules/analytics-4/constants';
+import { MODULE_SLUG_SEARCH_CONSOLE } from '@/js/modules/search-console/constants';
+import { MODULES_ANALYTICS_4 } from '@/js/modules/analytics-4/datastore/constants';
+import { MODULES_SEARCH_CONSOLE } from '@/js/modules/search-console/datastore/constants';
 import * as tracking from '@/js/util/tracking';
 import { VIEW_CONTEXT_MAIN_DASHBOARD } from '@/js/googlesitekit/constants';
 import { useWelcomeTour } from '@/js/feature-tours/hooks/useWelcomeTour';
@@ -47,6 +52,19 @@ const mockWelcomeTour = getWelcomeTour( {
 	isActivateAnalyticsNotificationPresent: false,
 } );
 
+function provideFeatureTourMenuItemData(
+	registry: ReturnType< typeof createTestRegistry >
+) {
+	provideGatheringDataState( registry, {
+		[ MODULE_SLUG_SEARCH_CONSOLE ]: false,
+	} );
+
+	registry
+		.dispatch( MODULES_SEARCH_CONSOLE )
+		.receiveIsDataAvailableOnLoad( true );
+	registry.dispatch( MODULES_SEARCH_CONSOLE ).receiveIsGatheringData( false );
+}
+
 describe( 'HelpMenu', () => {
 	let registry: ReturnType< typeof createTestRegistry >;
 
@@ -56,6 +74,7 @@ describe( 'HelpMenu', () => {
 		provideSiteInfo( registry );
 		provideModules( registry );
 		provideUserCapabilities( registry );
+		provideFeatureTourMenuItemData( registry );
 
 		registry.dispatch( CORE_USER ).receiveGetDismissedTours( [] );
 		registry.dispatch( CORE_USER ).receiveGetDismissedItems( [] );
@@ -80,6 +99,75 @@ describe( 'HelpMenu', () => {
 
 		it( 'should not render "Start a feature tour" when `showFeatureTour` is false', () => {
 			const { queryByText } = render( <HelpMenu />, {
+				registry,
+				viewContext: VIEW_CONTEXT_MAIN_DASHBOARD,
+				features: [ 'setupFlowRefresh' ],
+			} );
+
+			expect(
+				queryByText( 'Start a feature tour' )
+			).not.toBeInTheDocument();
+		} );
+
+		it( 'should not render "Start a feature tour" when Analytics is connected and gathering data', () => {
+			provideModules( registry, [
+				{
+					slug: MODULE_SLUG_ANALYTICS_4,
+					active: true,
+					connected: true,
+				},
+			] );
+			registry
+				.dispatch( MODULES_ANALYTICS_4 )
+				.receiveIsGatheringData( true );
+
+			const { queryByText } = render( <HelpMenu showFeatureTour />, {
+				registry,
+				viewContext: VIEW_CONTEXT_MAIN_DASHBOARD,
+				features: [ 'setupFlowRefresh' ],
+			} );
+
+			expect(
+				queryByText( 'Start a feature tour' )
+			).not.toBeInTheDocument();
+		} );
+
+		it( 'should render "Start a feature tour" when Analytics is connected and not gathering data', () => {
+			provideModules( registry, [
+				{
+					slug: MODULE_SLUG_ANALYTICS_4,
+					active: true,
+					connected: true,
+				},
+			] );
+			provideGatheringDataState( registry, {
+				[ MODULE_SLUG_ANALYTICS_4 ]: false,
+			} );
+			registry
+				.dispatch( MODULES_ANALYTICS_4 )
+				.receiveIsDataAvailableOnLoad( true );
+			registry
+				.dispatch( MODULES_ANALYTICS_4 )
+				.receiveIsGatheringData( false );
+
+			const { getByText } = render( <HelpMenu showFeatureTour />, {
+				registry,
+				viewContext: VIEW_CONTEXT_MAIN_DASHBOARD,
+				features: [ 'setupFlowRefresh' ],
+			} );
+
+			expect( getByText( 'Start a feature tour' ) ).toBeInTheDocument();
+		} );
+
+		it( 'should not render "Start a feature tour" when Analytics is not connected and Search Console is gathering data', () => {
+			provideGatheringDataState( registry, {
+				[ MODULE_SLUG_SEARCH_CONSOLE ]: true,
+			} );
+			registry
+				.dispatch( MODULES_SEARCH_CONSOLE )
+				.receiveIsGatheringData( true );
+
+			const { queryByText } = render( <HelpMenu showFeatureTour />, {
 				registry,
 				viewContext: VIEW_CONTEXT_MAIN_DASHBOARD,
 				features: [ 'setupFlowRefresh' ],


### PR DESCRIPTION
<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #12523 

## Relevant technical choices

This PR removes the "Start a feature tour" help menu item when:
- Analytics is connected but in a gathering data state.
- Analytics is not connected but SC is in a gathering data state.

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [x] Run the code.
- [x] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [x] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [x] Ensure there is a QA Brief.
- [x] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [x] Ensure the PR has the correct target branch.
- [x] Double-check that the PR is okay to be merged.
- [x] Ensure the corresponding issue has a ZenHub release assigned.
- [x] Add a changelog message to the issue.
