### PR TITLE
Enhancement/10201 Skip Sign in with Google tag on the email verification interstitial

### DIFF
--- a/includes/Modules/Sign_In_With_Google.php
+++ b/includes/Modules/Sign_In_With_Google.php
@@ -696,6 +696,7 @@ final class Sign_In_With_Google extends Module implements Module_With_Inline_Dat
 	 * Registers the Sign in with Google tag.
 	 *
 	 * @since 1.159.0
+	 * @since n.e.x.t Skip on the WordPress email verification interstitial.
 	 */
 	public function register_tag() {
 		// Skip on the WordPress email verification interstitial (wp-login.php?action=confirm_admin_email).

--- a/includes/Modules/Sign_In_With_Google.php
+++ b/includes/Modules/Sign_In_With_Google.php
@@ -698,6 +698,11 @@ final class Sign_In_With_Google extends Module implements Module_With_Inline_Dat
 	 * @since 1.159.0
 	 */
 	public function register_tag() {
+		// Skip on the WordPress email verification interstitial (wp-login.php?action=confirm_admin_email).
+		if ( 'confirm_admin_email' === $this->context->input()->filter( INPUT_GET, 'action' ) ) {
+			return;
+		}
+
 		$settings  = $this->get_settings()->get();
 		$client_id = $settings['clientID'];
 

--- a/includes/Modules/Sign_In_With_Google.php
+++ b/includes/Modules/Sign_In_With_Google.php
@@ -700,7 +700,8 @@ final class Sign_In_With_Google extends Module implements Module_With_Inline_Dat
 	 */
 	public function register_tag() {
 		// Skip on the WordPress email verification interstitial (wp-login.php?action=confirm_admin_email).
-		if ( 'confirm_admin_email' === $this->context->input()->filter( INPUT_GET, 'action' ) ) {
+		$is_wp_login = false !== stripos( wp_login_url(), $_SERVER['SCRIPT_NAME'] ?? '' ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput
+		if ( $is_wp_login && 'confirm_admin_email' === $this->context->input()->filter( INPUT_GET, 'action' ) ) {
 			return;
 		}
 
@@ -720,7 +721,7 @@ final class Sign_In_With_Google extends Module implements Module_With_Inline_Dat
 		}
 
 		$tag->set_settings( $this->get_settings()->get() );
-		$tag->set_is_wp_login( false !== stripos( wp_login_url(), $_SERVER['SCRIPT_NAME'] ?? '' ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput
+		$tag->set_is_wp_login( $is_wp_login );
 		$tag->set_redirect_to( $this->context->input()->filter( INPUT_GET, 'redirect_to' ) );
 		$tag->register();
 	}

--- a/tests/phpunit/integration/Modules/Sign_In_With_GoogleTest.php
+++ b/tests/phpunit/integration/Modules/Sign_In_With_GoogleTest.php
@@ -59,6 +59,13 @@ class Sign_In_With_GoogleTest extends TestCase {
 		$_SERVER = self::$server_data;
 	}
 
+	private function enable_https_login_env() {
+		$_SERVER['HTTPS']       = 'on'; // Required because WordPress's site_url function check is_ssl which uses this var.
+		$_SERVER['SCRIPT_NAME'] = wp_login_url(); // Required because is_login() uses this var.
+		update_option( 'home', 'https://example.com/' );
+		update_option( 'siteurl', 'https://example.com/' );
+	}
+
 	public function test_magic_methods() {
 		$this->assertEquals( Sign_In_With_Google::MODULE_SLUG, $this->module->slug, 'Module slug should match constant.' );
 		$this->assertEquals( 'Sign in with Google', $this->module->name, 'Module name should match.' );
@@ -103,11 +110,7 @@ class Sign_In_With_GoogleTest extends TestCase {
 		$output = apply_filters( 'login_form_top', '' );
 		$this->assertStringNotContainsString( '<div class="googlesitekit-sign-in-with-google__frontend-output-button"></div>', $output, 'Button should not render when site is not HTTPS.' );
 
-		// Update site URL to https.
-		$_SERVER['HTTPS']       = 'on'; // Required because WordPress's site_url function check is_ssl which uses this var.
-		$_SERVER['SCRIPT_NAME'] = wp_login_url(); // Required because is_login() uses this var.
-		update_option( 'siteurl', 'https://example.com/' );
-		update_option( 'home', 'https://example.com/' );
+		$this->enable_https_login_env();
 
 		// Does not render if clientID is not set.
 		$this->module->get_settings()->set( array( 'clientID' => '' ) );
@@ -127,10 +130,7 @@ class Sign_In_With_GoogleTest extends TestCase {
 	}
 
 	public function test_register_tag_skips_on_email_verification_interstitial() {
-		$_SERVER['HTTPS']       = 'on';
-		$_SERVER['SCRIPT_NAME'] = wp_login_url();
-		update_option( 'home', 'https://example.com/' );
-		update_option( 'siteurl', 'https://example.com/' );
+		$this->enable_https_login_env();
 
 		$this->module->get_settings()->register();
 		$this->module->get_settings()->set(
@@ -180,11 +180,7 @@ class Sign_In_With_GoogleTest extends TestCase {
 		$output = apply_filters( 'comment_form_after_fields', '' );
 		$this->assertNull( $output, 'Button should not render when site does not have open user registration.' );
 
-		// Update site URL to https.
-		$_SERVER['HTTPS']       = 'on'; // Required because WordPress's site_url function check is_ssl which uses this var.
-		$_SERVER['SCRIPT_NAME'] = wp_login_url(); // Required because is_login() uses this var.
-		update_option( 'siteurl', 'https://example.com/' );
-		update_option( 'home', 'https://example.com/' );
+		$this->enable_https_login_env();
 
 		// Does not render if Show next to comments is not enabled.
 		$this->module->get_settings()->set(

--- a/tests/phpunit/integration/Modules/Sign_In_With_GoogleTest.php
+++ b/tests/phpunit/integration/Modules/Sign_In_With_GoogleTest.php
@@ -60,10 +60,10 @@ class Sign_In_With_GoogleTest extends TestCase {
 	}
 
 	private function enable_https_login_env() {
-		$_SERVER['HTTPS']       = 'on'; // Required because WordPress's site_url function check is_ssl which uses this var.
-		$_SERVER['SCRIPT_NAME'] = wp_login_url(); // Required because is_login() uses this var.
+		$_SERVER['HTTPS'] = 'on'; // Required because WordPress's site_url function check is_ssl which uses this var.
 		update_option( 'home', 'https://example.com/' );
 		update_option( 'siteurl', 'https://example.com/' );
+		$_SERVER['SCRIPT_NAME'] = wp_login_url(); // Required because is_login() uses this var. Captured after option updates so it matches wp_login_url() at register_tag() time.
 	}
 
 	public function test_magic_methods() {

--- a/tests/phpunit/integration/Modules/Sign_In_With_GoogleTest.php
+++ b/tests/phpunit/integration/Modules/Sign_In_With_GoogleTest.php
@@ -126,6 +126,38 @@ class Sign_In_With_GoogleTest extends TestCase {
 		$this->assertStringContainsString( '<div class="googlesitekit-sign-in-with-google__frontend-output-button"></div>', $output, 'Button should render when HTTPS and clientID set.' );
 	}
 
+	public function test_register_tag_skips_on_email_verification_interstitial() {
+		$_SERVER['HTTPS']       = 'on';
+		$_SERVER['SCRIPT_NAME'] = wp_login_url();
+		update_option( 'home', 'https://example.com/' );
+		update_option( 'siteurl', 'https://example.com/' );
+
+		$this->module->get_settings()->register();
+		$this->module->get_settings()->set(
+			array(
+				'clientID' => '1234567890.googleusercontent.com',
+				'text'     => Sign_In_With_Google_Settings::TEXT_CONTINUE_WITH_GOOGLE['value'],
+				'theme'    => Sign_In_With_Google_Settings::THEME_LIGHT['value'],
+				'shape'    => Sign_In_With_Google_Settings::SHAPE_RECTANGULAR['value'],
+			)
+		);
+
+		// Control: without the confirm_admin_email action, register_tag wires the SIWG marker into login_footer.
+		remove_all_actions( 'login_footer' );
+		$this->module->register_tag();
+		$output = $this->capture_action( 'login_footer' );
+		$this->assertStringContainsString( 'Sign in with Google button added by Site Kit', $output, 'Login footer should include SIWG marker on the standard login page.' );
+
+		// Guard: on the email verification interstitial, register_tag returns before instantiating Web_Tag.
+		remove_all_actions( 'login_footer' );
+		$_GET['action'] = 'confirm_admin_email';
+		$this->module->register_tag();
+		$output = $this->capture_action( 'login_footer' );
+		$this->assertStringNotContainsString( 'Sign in with Google button added by Site Kit', $output, 'Login footer should not include SIWG marker on the email verification interstitial.' );
+
+		unset( $_GET['action'] );
+	}
+
 	public function test_render_button_in_wp_comments() {
 		update_option( 'home', 'http://example.com/' );
 		update_option( 'siteurl', 'http://example.com/' );

--- a/tests/phpunit/integration/Modules/Sign_In_With_GoogleTest.php
+++ b/tests/phpunit/integration/Modules/Sign_In_With_GoogleTest.php
@@ -142,13 +142,13 @@ class Sign_In_With_GoogleTest extends TestCase {
 			)
 		);
 
-		// Control: without the confirm_admin_email action, register_tag wires the SIWG marker into login_footer.
+		// Without the `confirm_admin_email` action, `register_tag` places Sign in with Google into `login_footer`.
 		remove_all_actions( 'login_footer' );
 		$this->module->register_tag();
 		$output = $this->capture_action( 'login_footer' );
 		$this->assertStringContainsString( 'Sign in with Google button added by Site Kit', $output, 'Login footer should include SIWG marker on the standard login page.' );
 
-		// Guard: on the email verification interstitial, register_tag returns before instantiating Web_Tag.
+		// When on the email verification interstitial, `register_tag` will return before instantiating `Web_Tag`, so no Sign in with Google tag should appear.
 		remove_all_actions( 'login_footer' );
 		$_GET['action'] = 'confirm_admin_email';
 		$this->module->register_tag();


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #10201

## Relevant technical choices

* The PHPUnit test runs a positive-control branch (no `action` set -> SIWG marker IS in `login_footer`) before the IB's negative assertion, so the guard branch can't pass vacuously if `Web_Tag::render()`'s marker string ever changes.

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.
- [ ] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
