### PR TITLE
Enhancement/11341 Add user meta marking users created via Sign in with Google

### DIFF
--- a/includes/Modules/Sign_In_With_Google/Authenticator.php
+++ b/includes/Modules/Sign_In_With_Google/Authenticator.php
@@ -12,6 +12,7 @@ namespace Google\Site_Kit\Modules\Sign_In_With_Google;
 
 use Google\Site_Kit\Core\Storage\User_Options;
 use Google\Site_Kit\Core\Util\Input;
+use Google\Site_Kit\Modules\Sign_In_With_Google;
 use WP_Error;
 use WP_User;
 
@@ -34,6 +35,11 @@ class Authenticator implements Authenticator_Interface {
 	 */
 	const ERROR_INVALID_REQUEST = 'googlesitekit_auth_invalid_request';
 	const ERROR_SIGNIN_FAILED   = 'googlesitekit_auth_failed';
+
+	/**
+	 * User meta key marking users created via Sign in with Google.
+	 */
+	const CREATED_BY_META_KEY = 'googlesitekitpersistent_created_by';
 
 	/**
 	 * User options instance.
@@ -256,8 +262,8 @@ class Authenticator implements Authenticator_Interface {
 				'last_name'    => $payload['family_name'],
 				'role'         => $default_role,
 				'meta_input'   => array(
-					$this->user_options->get_meta_key( Hashed_User_ID::OPTION )               => $g_user_hid,
-					$this->user_options->get_meta_key( 'googlesitekitpersistent_created_by' ) => 'sign-in-with-google',
+					$this->user_options->get_meta_key( Hashed_User_ID::OPTION )    => $g_user_hid,
+					$this->user_options->get_meta_key( self::CREATED_BY_META_KEY ) => Sign_In_With_Google::MODULE_SLUG,
 				),
 			)
 		);

--- a/includes/Modules/Sign_In_With_Google/Authenticator.php
+++ b/includes/Modules/Sign_In_With_Google/Authenticator.php
@@ -256,7 +256,8 @@ class Authenticator implements Authenticator_Interface {
 				'last_name'    => $payload['family_name'],
 				'role'         => $default_role,
 				'meta_input'   => array(
-					$this->user_options->get_meta_key( Hashed_User_ID::OPTION ) => $g_user_hid,
+					$this->user_options->get_meta_key( Hashed_User_ID::OPTION )               => $g_user_hid,
+					$this->user_options->get_meta_key( 'googlesitekitpersistent_created_by' ) => 'sign-in-with-google',
 				),
 			)
 		);

--- a/includes/Modules/Sign_In_With_Google/Authenticator.php
+++ b/includes/Modules/Sign_In_With_Google/Authenticator.php
@@ -251,7 +251,7 @@ class Authenticator implements Authenticator_Interface {
 		// Get the default role for new users.
 		$default_role = $this->get_default_role();
 
-		// Create a new user.
+		// Create a new user. User meta is persisted after insert because wp_insert_user's meta_input was added in WordPress 5.9.
 		$user_id = wp_insert_user(
 			array(
 				'user_pass'    => wp_generate_password( 64 ),
@@ -261,16 +261,17 @@ class Authenticator implements Authenticator_Interface {
 				'first_name'   => $payload['given_name'],
 				'last_name'    => $payload['family_name'],
 				'role'         => $default_role,
-				'meta_input'   => array(
-					$this->user_options->get_meta_key( Hashed_User_ID::OPTION )    => $g_user_hid,
-					$this->user_options->get_meta_key( self::CREATED_BY_META_KEY ) => Sign_In_With_Google::MODULE_SLUG,
-				),
 			)
 		);
 
 		if ( is_wp_error( $user_id ) ) {
 			return new WP_Error( self::ERROR_SIGNIN_FAILED );
 		}
+
+		$user_options = clone $this->user_options;
+		$user_options->switch_user( $user_id );
+		$user_options->set( Hashed_User_ID::OPTION, $g_user_hid );
+		$user_options->set( self::CREATED_BY_META_KEY, Sign_In_With_Google::MODULE_SLUG );
 
 		// Add the user to the current site if it is a multisite.
 		if ( is_multisite() ) {

--- a/includes/Modules/Sign_In_With_Google/Authenticator.php
+++ b/includes/Modules/Sign_In_With_Google/Authenticator.php
@@ -253,7 +253,8 @@ class Authenticator implements Authenticator_Interface {
 		// Get the default role for new users.
 		$default_role = $this->get_default_role();
 
-		// Create a new user. User meta is persisted after insert because wp_insert_user's meta_input was added in WordPress 5.9.
+		// Create a new user.
+		// User meta is persisted after wp_insert_user because its meta_input parameter requires WordPress 5.9 and the plugin floor is 5.2.
 		$user_id = wp_insert_user(
 			array(
 				'user_pass'    => wp_generate_password( 64 ),

--- a/includes/Modules/Sign_In_With_Google/Authenticator.php
+++ b/includes/Modules/Sign_In_With_Google/Authenticator.php
@@ -38,6 +38,8 @@ class Authenticator implements Authenticator_Interface {
 
 	/**
 	 * User meta key marking users created via Sign in with Google.
+	 *
+	 * @note This option is prefixed differently so that it will persist across disconnect/reset.
 	 */
 	const CREATED_BY_META_KEY = 'googlesitekitpersistent_created_by';
 

--- a/tests/phpunit/integration/Modules/Sign_In_With_Google/AuthenticatorTest.php
+++ b/tests/phpunit/integration/Modules/Sign_In_With_Google/AuthenticatorTest.php
@@ -165,6 +165,11 @@ class AuthenticatorTest extends TestCase {
 			get_user_meta( $user->ID, $user_options->get_meta_key( Authenticator::CREATED_BY_META_KEY ), true ),
 			'Newly created user should be marked as created via Sign in with Google.'
 		);
+		$this->assertEquals(
+			md5( self::$new_user_payload['sub'] ),
+			$user_options->get( Hashed_User_ID::OPTION ),
+			'Newly created user should have the hashed Google user ID persisted.'
+		);
 	}
 
 	/**
@@ -193,6 +198,11 @@ class AuthenticatorTest extends TestCase {
 			Sign_In_With_Google::MODULE_SLUG,
 			get_user_meta( $user->ID, $user_options->get_meta_key( Authenticator::CREATED_BY_META_KEY ), true ),
 			'Newly created user on multisite should be marked as created via Sign in with Google.'
+		);
+		$this->assertEquals(
+			md5( self::$new_user_payload['sub'] ),
+			$user_options->get( Hashed_User_ID::OPTION ),
+			'Newly created user on multisite should have the hashed Google user ID persisted.'
 		);
 	}
 

--- a/tests/phpunit/integration/Modules/Sign_In_With_Google/AuthenticatorTest.php
+++ b/tests/phpunit/integration/Modules/Sign_In_With_Google/AuthenticatorTest.php
@@ -157,6 +157,13 @@ class AuthenticatorTest extends TestCase {
 		$this->assertEquals( self::$new_user_payload['family_name'], $user->last_name, 'New user last name should match payload.' );
 
 		$this->assertTrue( in_array( 'editor', $user->roles, true ), 'New user role should be editor.' );
+
+		$user_options = new User_Options( new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE ), $user->ID );
+		$this->assertEquals(
+			'sign-in-with-google',
+			get_user_meta( $user->ID, $user_options->get_meta_key( 'googlesitekitpersistent_created_by' ), true ),
+			'Newly created user should be marked as created via Sign in with Google.'
+		);
 	}
 
 	/**

--- a/tests/phpunit/integration/Modules/Sign_In_With_Google/AuthenticatorTest.php
+++ b/tests/phpunit/integration/Modules/Sign_In_With_Google/AuthenticatorTest.php
@@ -12,6 +12,7 @@ namespace Google\Site_Kit\Tests\Modules\Sign_In_With_Google;
 
 use Google\Site_Kit\Context;
 use Google\Site_Kit\Core\Storage\User_Options;
+use Google\Site_Kit\Modules\Sign_In_With_Google;
 use Google\Site_Kit\Modules\Sign_In_With_Google\Authenticator;
 use Google\Site_Kit\Modules\Sign_In_With_Google\Hashed_User_ID;
 use Google\Site_Kit\Modules\Sign_In_With_Google\Profile_Reader_Interface;
@@ -160,8 +161,8 @@ class AuthenticatorTest extends TestCase {
 
 		$user_options = new User_Options( new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE ), $user->ID );
 		$this->assertEquals(
-			'sign-in-with-google',
-			get_user_meta( $user->ID, $user_options->get_meta_key( 'googlesitekitpersistent_created_by' ), true ),
+			Sign_In_With_Google::MODULE_SLUG,
+			get_user_meta( $user->ID, $user_options->get_meta_key( Authenticator::CREATED_BY_META_KEY ), true ),
 			'Newly created user should be marked as created via Sign in with Google.'
 		);
 	}
@@ -186,6 +187,13 @@ class AuthenticatorTest extends TestCase {
 
 		$blog_id = get_current_blog_id();
 		$this->assertTrue( is_user_member_of_blog( $user->ID, $blog_id ), 'New user should be member of current blog.' );
+
+		$user_options = new User_Options( new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE ), $user->ID );
+		$this->assertEquals(
+			Sign_In_With_Google::MODULE_SLUG,
+			get_user_meta( $user->ID, $user_options->get_meta_key( Authenticator::CREATED_BY_META_KEY ), true ),
+			'Newly created user on multisite should be marked as created via Sign in with Google.'
+		);
 	}
 
 	/**


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #11341

## Relevant technical choices

* `meta_input` on `wp_insert_user` only works on WP 5.9+, but the plugin floor is WP 5.2. So `create_user` now sets both `Hashed_User_ID::OPTION` and the new `CREATED_BY_META_KEY` via `User_Options::set()` after the insert, matching `find_user`.
* This also fixes a latent bug where the hashed user ID was silently dropped on WP 5.2-5.8. Tests now cover both keys.

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.
- [ ] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.