### PR TITLE
Enhancement/12467 Replace Email mock in Email_Report_SenderTest with the WP-PHPUnit mock mailer

### DIFF
--- a/tests/phpunit/includes/Pre_WP_Mail_Skip_Trait.php
+++ b/tests/phpunit/includes/Pre_WP_Mail_Skip_Trait.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Pre_WP_Mail_Skip_Trait
+ *
+ * @package   Google\Site_Kit\Tests
+ * @copyright 2026 Google LLC
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
+ * @link      https://sitekit.withgoogle.com
+ */
+
+namespace Google\Site_Kit\Tests;
+
+trait Pre_WP_Mail_Skip_Trait {
+
+	/**
+	 * Skips the test if the pre_wp_mail filter (WordPress 5.7+) isn't available.
+	 */
+	protected function skip_if_pre_wp_mail_unsupported() {
+		if ( version_compare( $GLOBALS['wp_version'], '5.7', '<' ) ) {
+			$this->markTestSkipped( 'This test requires WordPress 5.7 or higher for the pre_wp_mail filter.' );
+		}
+	}
+}

--- a/tests/phpunit/integration/Core/Email/EmailTest.php
+++ b/tests/phpunit/integration/Core/Email/EmailTest.php
@@ -11,6 +11,7 @@
 namespace Google\Site_Kit\Tests\Core\Email;
 
 use Google\Site_Kit\Core\Email\Email;
+use Google\Site_Kit\Tests\Pre_WP_Mail_Skip_Trait;
 use Google\Site_Kit\Tests\TestCase;
 use WP_Error;
 
@@ -18,6 +19,8 @@ use WP_Error;
  * @group Email
  */
 class EmailTest extends TestCase {
+
+	use Pre_WP_Mail_Skip_Trait;
 
 	/**
 	 * @var Email
@@ -221,15 +224,6 @@ class EmailTest extends TestCase {
 		$this->assertEquals( 'text/html', $captured_initial_content_type, 'PHPMailer ContentType should be text/html from the default Site Kit header before AltBody upgrade.' );
 		$this->assertEquals( 'Plain text content', $captured_alt_body, 'AltBody should be set so PHPMailer can produce a multipart/alternative message.' );
 		$this->assertStringStartsWith( 'multipart/alternative', $captured_final_content_type, 'PHPMailer should upgrade ContentType to multipart/alternative when AltBody is set alongside the default text/html Content-Type.' );
-	}
-
-	/**
-	 * Skips the test if the pre_wp_mail filter (WordPress 5.7+) isn't available.
-	 */
-	private function skip_if_pre_wp_mail_unsupported() {
-		if ( version_compare( $GLOBALS['wp_version'], '5.7', '<' ) ) {
-			$this->markTestSkipped( 'This test requires WordPress 5.7 or higher for the pre_wp_mail filter.' );
-		}
 	}
 
 	/**

--- a/tests/phpunit/integration/Core/Email_Reporting/Email_Report_SenderTest.php
+++ b/tests/phpunit/integration/Core/Email_Reporting/Email_Report_SenderTest.php
@@ -14,6 +14,7 @@ use Google\Site_Kit\Core\Email\Email;
 use Google\Site_Kit\Core\Email_Reporting\Email_Report_Sender;
 use Google\Site_Kit\Core\Email_Reporting\Email_Template_Renderer;
 use Google\Site_Kit\Core\Email_Reporting\Email_Template_Renderer_Factory;
+use Google\Site_Kit\Tests\Pre_WP_Mail_Skip_Trait;
 use Google\Site_Kit\Tests\TestCase;
 use WP_Error;
 
@@ -21,6 +22,8 @@ use WP_Error;
  * @group Email_Reporting
  */
 class Email_Report_SenderTest extends TestCase {
+
+	use Pre_WP_Mail_Skip_Trait;
 
 	private $email_report_sender;
 	private $email_template_renderer_factory;
@@ -95,15 +98,6 @@ class Email_Report_SenderTest extends TestCase {
 			$this->assertCount( 0, tests_retrieve_phpmailer_instance()->mock_sent, 'No email should have been delivered on the failure path.' );
 		} finally {
 			remove_filter( 'pre_wp_mail', $short_circuit_callback );
-		}
-	}
-
-	/**
-	 * Skips the test if the pre_wp_mail filter (WordPress 5.7+) isn't available.
-	 */
-	private function skip_if_pre_wp_mail_unsupported() {
-		if ( version_compare( $GLOBALS['wp_version'], '5.7', '<' ) ) {
-			$this->markTestSkipped( 'This test requires WordPress 5.7 or higher for the pre_wp_mail filter.' );
 		}
 	}
 }

--- a/tests/phpunit/integration/Core/Email_Reporting/Email_Report_SenderTest.php
+++ b/tests/phpunit/integration/Core/Email_Reporting/Email_Report_SenderTest.php
@@ -45,7 +45,6 @@ class Email_Report_SenderTest extends TestCase {
 		$renderer->method( 'render_text' )->willReturn( 'Report Content' );
 
 		$this->email_template_renderer_factory->method( 'create' )->willReturn( $renderer );
-		$this->email->method( 'send' )->willReturn( true );
 
 		$result = $this->email_report_sender->send(
 			$this->user,
@@ -54,6 +53,13 @@ class Email_Report_SenderTest extends TestCase {
 		);
 
 		$this->assertTrue( $result, 'Email report should be sent successfully.' );
+
+		$mailer = tests_retrieve_phpmailer_instance();
+		$this->assertCount( 1, $mailer->mock_sent, 'Exactly one email should have been queued by wp_mail.' );
+
+		$sent = $mailer->get_sent();
+		$this->assertSame( $this->user->user_email, $sent->to[0][0], 'Email should be addressed to the report recipient.' );
+		$this->assertSame( 'Test Report', $sent->subject, 'Email subject should match the template subject.' );
 	}
 
 	public function test_send__failed() {

--- a/tests/phpunit/integration/Core/Email_Reporting/Email_Report_SenderTest.php
+++ b/tests/phpunit/integration/Core/Email_Reporting/Email_Report_SenderTest.php
@@ -24,16 +24,19 @@ class Email_Report_SenderTest extends TestCase {
 
 	private $email_report_sender;
 	private $email_template_renderer_factory;
-	private $email;
 	private $user;
 
 	public function set_up() {
 		parent::set_up();
 
+		reset_phpmailer_instance();
+
 		$this->user                            = self::factory()->user->create_and_get();
 		$this->email_template_renderer_factory = $this->createMock( Email_Template_Renderer_Factory::class );
-		$this->email                           = $this->createMock( Email::class );
-		$this->email_report_sender             = new Email_Report_Sender( $this->email_template_renderer_factory, $this->email );
+		$this->email_report_sender             = new Email_Report_Sender(
+			$this->email_template_renderer_factory,
+			new Email()
+		);
 	}
 
 	public function test_send__success() {

--- a/tests/phpunit/integration/Core/Email_Reporting/Email_Report_SenderTest.php
+++ b/tests/phpunit/integration/Core/Email_Reporting/Email_Report_SenderTest.php
@@ -63,25 +63,47 @@ class Email_Report_SenderTest extends TestCase {
 	}
 
 	public function test_send__failed() {
+		$this->skip_if_pre_wp_mail_unsupported();
+
 		$renderer = $this->createMock( Email_Template_Renderer::class );
 		$renderer->method( 'render' )->willReturn( '<html>Report</html>' );
 		$renderer->method( 'render_text' )->willReturn( 'Report' );
 
 		$this->email_template_renderer_factory->method( 'create' )->willReturn( $renderer );
-		$this->email->method( 'send' )->willReturn(
-			new WP_Error( 'wp_mail_failed', __( 'Failed to send email.', 'google-site-kit' ) )
-		);
 
-		$result = $this->email_report_sender->send(
-			$this->user,
-			array(),
-			array( 'subject' => 'Test Report' )
-		);
+		$short_circuit_callback = function () {
+			do_action(
+				'wp_mail_failed',
+				new WP_Error( 'wp_mail_failed', __( 'Failed to send email.', 'google-site-kit' ) )
+			);
+			return false;
+		};
+		add_filter( 'pre_wp_mail', $short_circuit_callback );
 
-		$this->assertWPError( $result, 'Email report sending should fail with a WP_Error.' );
-		$this->assertSame( 'wp_mail_failed', $result->get_error_code(), 'Error code should match.' );
-		$error_data = $result->get_error_data();
-		$this->assertArrayHasKey( 'category_id', $error_data, 'Error data should contain category_id.' );
-		$this->assertSame( 'sending_error', $error_data['category_id'], 'category_id should be sending_error.' );
+		try {
+			$result = $this->email_report_sender->send(
+				$this->user,
+				array(),
+				array( 'subject' => 'Test Report' )
+			);
+
+			$this->assertWPError( $result, 'Email report sending should fail with a WP_Error.' );
+			$this->assertSame( 'wp_mail_failed', $result->get_error_code(), 'Error code should match.' );
+			$error_data = $result->get_error_data();
+			$this->assertArrayHasKey( 'category_id', $error_data, 'Error data should contain category_id.' );
+			$this->assertSame( 'sending_error', $error_data['category_id'], 'category_id should be sending_error.' );
+			$this->assertCount( 0, tests_retrieve_phpmailer_instance()->mock_sent, 'No email should have been delivered on the failure path.' );
+		} finally {
+			remove_filter( 'pre_wp_mail', $short_circuit_callback );
+		}
+	}
+
+	/**
+	 * Skips the test if the pre_wp_mail filter (WordPress 5.7+) isn't available.
+	 */
+	private function skip_if_pre_wp_mail_unsupported() {
+		if ( version_compare( $GLOBALS['wp_version'], '5.7', '<' ) ) {
+			$this->markTestSkipped( 'This test requires WordPress 5.7 or higher for the pre_wp_mail filter.' );
+		}
 	}
 }


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #12467

## Relevant technical choices

* Implementation follows the IB without deviations.

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.
- [ ] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
