### PR TITLE
Add a getGoLinkURL selector on core/site for the PDF report

### DIFF
--- a/assets/js/googlesitekit/datastore/site/golinks.test.ts
+++ b/assets/js/googlesitekit/datastore/site/golinks.test.ts
@@ -42,7 +42,7 @@ describe( 'core/site golinks', () => {
 
 	describe( 'selectors', () => {
 		describe( 'getGoLinkURL', () => {
-			it( 'returns the expected URL shape for the `dashboard` key with no extra args', () => {
+			it( 'should return the expected URL shape for the `dashboard` key with no extra args', () => {
 				const url = registry
 					.select( CORE_SITE )
 					.getGoLinkURL( 'dashboard' );
@@ -52,7 +52,7 @@ describe( 'core/site golinks', () => {
 				);
 			} );
 
-			it( 'appends a `permaLink` arg with URL-encoded value for entity-dashboard links', () => {
+			it( 'should append a `permaLink` arg with URL-encoded value for entity-dashboard links', () => {
 				const url = registry
 					.select( CORE_SITE )
 					.getGoLinkURL( 'dashboard', {
@@ -64,7 +64,7 @@ describe( 'core/site golinks', () => {
 				);
 			} );
 
-			it( 'appends arbitrary extra query args alongside `action` and `to`', () => {
+			it( 'should append arbitrary extra query args alongside `action` and `to`', () => {
 				const url = registry
 					.select( CORE_SITE )
 					.getGoLinkURL( 'dashboard', {
@@ -77,7 +77,7 @@ describe( 'core/site golinks', () => {
 				);
 			} );
 
-			it( 'still produces a URL for keys not registered server-side', () => {
+			it( 'should still produce a URL for keys not registered server-side', () => {
 				const url = registry
 					.select( CORE_SITE )
 					.getGoLinkURL( 'no-such-handler' );
@@ -87,7 +87,7 @@ describe( 'core/site golinks', () => {
 				);
 			} );
 
-			it( 'normalizes an admin URL without a trailing slash', () => {
+			it( 'should normalize an admin URL without a trailing slash', () => {
 				registry = createTestRegistry();
 				provideSiteInfo( registry, {
 					adminURL: 'http://example.com/wp-admin',
@@ -102,7 +102,7 @@ describe( 'core/site golinks', () => {
 				);
 			} );
 
-			it( 'returns undefined when site info has not loaded', () => {
+			it( 'should return undefined when site info has not loaded', () => {
 				registry = createTestRegistry();
 
 				expect(

--- a/assets/js/googlesitekit/datastore/site/golinks.test.ts
+++ b/assets/js/googlesitekit/datastore/site/golinks.test.ts
@@ -1,0 +1,114 @@
+/**
+ * `core/site` data store, golinks tests.
+ *
+ * Site Kit by Google, Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { WPDataRegistry } from '@wordpress/data/build-types/registry';
+
+/**
+ * Internal dependencies
+ */
+import {
+	createTestRegistry,
+	provideSiteInfo,
+} from '../../../../../tests/js/utils';
+import { CORE_SITE } from './constants';
+
+describe( 'core/site golinks', () => {
+	let registry: WPDataRegistry;
+
+	beforeEach( () => {
+		registry = createTestRegistry();
+		provideSiteInfo( registry, {
+			adminURL: 'http://example.com/wp-admin/',
+		} );
+	} );
+
+	describe( 'selectors', () => {
+		describe( 'getGoLinkURL', () => {
+			it( 'returns the expected URL shape for the `dashboard` key with no extra args', () => {
+				const url = registry
+					.select( CORE_SITE )
+					.getGoLinkURL( 'dashboard' );
+
+				expect( url ).toBe(
+					'http://example.com/wp-admin/index.php?action=googlesitekit_go&to=dashboard'
+				);
+			} );
+
+			it( 'appends a `permaLink` arg with URL-encoded value for entity-dashboard links', () => {
+				const url = registry
+					.select( CORE_SITE )
+					.getGoLinkURL( 'dashboard', {
+						permaLink: 'https://example.com/page',
+					} );
+
+				expect( url ).toBe(
+					'http://example.com/wp-admin/index.php?action=googlesitekit_go&to=dashboard&permaLink=https%3A%2F%2Fexample.com%2Fpage'
+				);
+			} );
+
+			it( 'appends arbitrary extra query args alongside `action` and `to`', () => {
+				const url = registry
+					.select( CORE_SITE )
+					.getGoLinkURL( 'dashboard', {
+						foo: 'bar',
+						baz: 42,
+					} );
+
+				expect( url ).toBe(
+					'http://example.com/wp-admin/index.php?action=googlesitekit_go&to=dashboard&foo=bar&baz=42'
+				);
+			} );
+
+			it( 'still produces a URL for keys not registered server-side', () => {
+				const url = registry
+					.select( CORE_SITE )
+					.getGoLinkURL( 'no-such-handler' );
+
+				expect( url ).toBe(
+					'http://example.com/wp-admin/index.php?action=googlesitekit_go&to=no-such-handler'
+				);
+			} );
+
+			it( 'normalizes an admin URL without a trailing slash', () => {
+				registry = createTestRegistry();
+				provideSiteInfo( registry, {
+					adminURL: 'http://example.com/wp-admin',
+				} );
+
+				const url = registry
+					.select( CORE_SITE )
+					.getGoLinkURL( 'dashboard' );
+
+				expect( url ).toBe(
+					'http://example.com/wp-admin/index.php?action=googlesitekit_go&to=dashboard'
+				);
+			} );
+
+			it( 'returns undefined when site info has not loaded', () => {
+				registry = createTestRegistry();
+
+				expect(
+					registry.select( CORE_SITE ).getGoLinkURL( 'dashboard' )
+				).toBeUndefined();
+			} );
+		} );
+	} );
+} );

--- a/assets/js/googlesitekit/datastore/site/golinks.ts
+++ b/assets/js/googlesitekit/datastore/site/golinks.ts
@@ -1,0 +1,76 @@
+/**
+ * `core/site` data store: golinks.
+ *
+ * Site Kit by Google, Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { addQueryArgs } from '@wordpress/url';
+
+/**
+ * Internal dependencies
+ */
+import { createRegistrySelector, Select } from 'googlesitekit-data';
+import { CORE_SITE } from './constants';
+
+export const selectors = {
+	/**
+	 * Gets the Site Kit golink URL for a given key.
+	 *
+	 * Builds the URL of shape `{adminURL}index.php?action=googlesitekit_go&to={key}`,
+	 * appending any extra query args (e.g. `permaLink` for entity-dashboard links).
+	 *
+	 * The URL shape is deterministic from the admin URL plus the handler key, mirroring
+	 * the server-side `Golinks::get_url` contract. The server decides handler validity
+	 * at click time, so the selector still produces a URL for unknown keys.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param {Object} state  Data store's state.
+	 * @param {string} key    Golink handler key (e.g. `dashboard`).
+	 * @param {Object} [args] Optional extra query args to append.
+	 * @return {(string|undefined)} Golink URL, or `undefined` when the admin URL is not yet available.
+	 */
+	getGoLinkURL: createRegistrySelector(
+		( select: Select ) =>
+			(
+				state: unknown,
+				key: string,
+				args: Record< string, unknown > = {}
+			): string | undefined => {
+				const adminURL = select( CORE_SITE ).getSiteInfo()?.adminURL;
+
+				if ( ! adminURL ) {
+					return undefined;
+				}
+
+				const baseURL = adminURL.endsWith( '/' )
+					? adminURL
+					: `${ adminURL }/`;
+
+				return addQueryArgs( `${ baseURL }index.php`, {
+					action: 'googlesitekit_go',
+					to: key,
+					...args,
+				} );
+			}
+	),
+};
+
+export default {
+	selectors,
+};

--- a/assets/js/googlesitekit/datastore/site/index.js
+++ b/assets/js/googlesitekit/datastore/site/index.js
@@ -29,6 +29,7 @@ import consentMode from './consent-mode';
 import conversionTracking from './conversion-tracking';
 import emailReporting from './email-reporting';
 import errors from './errors';
+import golinks from './golinks';
 import googleTagGateway from './google-tag-gateway';
 import html from './html';
 import info from './info';
@@ -46,6 +47,7 @@ const store = combineStores(
 	conversionTracking,
 	emailReporting,
 	errors,
+	golinks,
 	googleTagGateway,
 	html,
 	info,


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #12583

## Relevant technical choices

* `getGoLinkURL` normalizes the trailing slash on `adminURL` before appending `index.php` and returns `undefined` while `getSiteInfo()` is still resolving, so the URL shape stays aligned with the production `trailingslashit( admin_url() )` output from `Assets.php` and matches the PHP `Golinks::get_url()` contract regardless of fixture variation or async load state.

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.
- [ ] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
