### PR TITLE
Fix: Tooltip gets cut off when closing welcome modal.

### DIFF
--- a/assets/js/components/AdminScreenTooltip/AdminScreenTooltip.js
+++ b/assets/js/components/AdminScreenTooltip/AdminScreenTooltip.js
@@ -50,6 +50,7 @@ export function AdminScreenTooltip() {
 		content,
 		dismissLabel,
 		gaTrackingEventLabel,
+		floaterProps,
 	} = useSelect(
 		( select ) =>
 			select( CORE_UI ).getValue( 'admin-screen-tooltip' ) || {
@@ -115,6 +116,7 @@ export function AdminScreenTooltip() {
 			dismissLabel={ dismissLabel }
 			onView={ handleViewTooltip }
 			onDismiss={ handleDismissTooltip }
+			{ ...( floaterProps && { floaterProps } ) }
 		/>
 	);
 }

--- a/assets/js/components/AdminScreenTooltip/AdminScreenTooltip.js
+++ b/assets/js/components/AdminScreenTooltip/AdminScreenTooltip.js
@@ -116,7 +116,7 @@ export function AdminScreenTooltip() {
 			dismissLabel={ dismissLabel }
 			onView={ handleViewTooltip }
 			onDismiss={ handleDismissTooltip }
-			{ ...( floaterProps && { floaterProps } ) }
+			floaterProps={ floaterProps }
 		/>
 	);
 }

--- a/assets/js/components/AdminScreenTooltip/AdminScreenTooltip.test.js
+++ b/assets/js/components/AdminScreenTooltip/AdminScreenTooltip.test.js
@@ -341,7 +341,7 @@ describe( 'AdminMenuTooltip', () => {
 		);
 	} );
 
-	it( 'should render successfully when floaterProps is provided in the tooltip state', async () => {
+	it( 'should pass floaterProps to the JoyrideTooltip component when provided in the tooltip state', async () => {
 		await registry.dispatch( CORE_UI ).setValue( 'admin-screen-tooltip', {
 			isTooltipVisible: true,
 			title: 'Test Title',
@@ -380,5 +380,12 @@ describe( 'AdminMenuTooltip', () => {
 			);
 			expect( tooltip ).toBeInTheDocument();
 		} );
+
+		const floaterArrowSpan = document.querySelector(
+			'.__floater__arrow > span'
+		);
+		expect( floaterArrowSpan ).toHaveStyle(
+			'margin-top: 42px; margin-bottom: 42px;'
+		);
 	} );
 } );

--- a/assets/js/components/AdminScreenTooltip/AdminScreenTooltip.test.js
+++ b/assets/js/components/AdminScreenTooltip/AdminScreenTooltip.test.js
@@ -340,4 +340,45 @@ describe( 'AdminMenuTooltip', () => {
 			'test-label'
 		);
 	} );
+
+	it( 'should render successfully when floaterProps is provided in the tooltip state', async () => {
+		await registry.dispatch( CORE_UI ).setValue( 'admin-screen-tooltip', {
+			isTooltipVisible: true,
+			title: 'Test Title',
+			content: 'Test Content',
+			dismissLabel: 'Got it',
+			tooltipSlug: 'test-tooltip-slug',
+			floaterProps: {
+				styles: {
+					arrow: {
+						margin: 42,
+					},
+				},
+			},
+		} );
+
+		render(
+			<div className="googlesitekit-plugin">
+				<div id="adminmenu">
+					<a href="http://test.test/wp-admin/admin.php?page=googlesitekit-settings">
+						Settings
+					</a>
+				</div>
+				<AdminScreenTooltip />
+			</div>,
+			{ registry }
+		);
+
+		// Wait for Joyride tooltip's useInterval to render.
+		act( () => {
+			jest.advanceTimersByTime( 1000 );
+		} );
+
+		await waitFor( () => {
+			const tooltip = document.querySelector(
+				'.googlesitekit-tour-tooltip'
+			);
+			expect( tooltip ).toBeInTheDocument();
+		} );
+	} );
 } );

--- a/assets/js/components/JoyrideTooltip.js
+++ b/assets/js/components/JoyrideTooltip.js
@@ -33,7 +33,10 @@ import { useEffect, useState, useRef } from '@wordpress/element';
  */
 import TourTooltip from './TourTooltip';
 import Portal from './Portal';
-import { joyrideStyles, floaterProps } from './TourTooltips';
+import {
+	joyrideStyles,
+	floaterProps as defaultFloaterProps,
+} from './TourTooltips';
 import {
 	BREAKPOINT_SMALL,
 	BREAKPOINT_TABLET,
@@ -180,7 +183,7 @@ export default function JoyrideTooltip( props ) {
 				callback={ callback }
 				disableOverlay={ disableOverlay }
 				spotlightPadding={ 0 }
-				floaterProps={ floaterProps }
+				floaterProps={ defaultFloaterProps }
 				locale={ joyrideLocale }
 				steps={ steps }
 				styles={ {
@@ -216,4 +219,5 @@ JoyrideTooltip.propTypes = {
 	slug: PropTypes.string,
 	placement: PropTypes.string,
 	onView: PropTypes.func,
+	floaterProps: PropTypes.object,
 };

--- a/assets/js/components/JoyrideTooltip.js
+++ b/assets/js/components/JoyrideTooltip.js
@@ -59,6 +59,7 @@ export default function JoyrideTooltip( props ) {
 		onView = () => {},
 		onTourStart = () => {},
 		onTourEnd = () => {},
+		floaterProps = {},
 	} = props;
 
 	function checkIfTargetExists() {
@@ -142,6 +143,7 @@ export default function JoyrideTooltip( props ) {
 			placement,
 			cta,
 			className,
+			floaterProps,
 		},
 	];
 

--- a/assets/js/components/WelcomeModal.test.tsx
+++ b/assets/js/components/WelcomeModal.test.tsx
@@ -419,6 +419,13 @@ describe( 'WelcomeModal', () => {
 				content:
 					'You can always take the dashboard tour from the help menu',
 				dismissLabel: 'Got it',
+				floaterProps: {
+					styles: {
+						arrow: {
+							margin: 42,
+						},
+					},
+				},
 			} );
 
 			await waitFor( () => {
@@ -897,6 +904,13 @@ describe( 'WelcomeModal', () => {
 				content:
 					'You can always take the dashboard tour from the help menu',
 				dismissLabel: 'Got it',
+				floaterProps: {
+					styles: {
+						arrow: {
+							margin: 42,
+						},
+					},
+				},
 			} );
 
 			await waitFor( () => {

--- a/assets/js/components/WelcomeModal.tsx
+++ b/assets/js/components/WelcomeModal.tsx
@@ -181,6 +181,13 @@ export default function WelcomeModal() {
 		),
 		dismissLabel: __( 'Got it', 'google-site-kit' ),
 		gaTrackingEventLabel: VARIANT_TRACKING_LABELS[ modalVariant ],
+		floaterProps: {
+			styles: {
+				arrow: {
+					margin: 42,
+				},
+			},
+		},
 	};
 
 	const showTooltip = useShowTooltip( tooltipSettings );


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #12253

## Relevant technical choices

<!-- Please describe your changes. -->

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [x] Run the code.
- [x] Ensure the acceptance criteria are satisfied.
- [x] Reassess the implementation with the IB.
- [x] Ensure no unrelated changes are included.
- [x] Ensure CI checks pass.
- [x] Check Storybook where applicable.
- [x] Ensure there is a QA Brief.
- [x] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [x] Ensure the PR has the correct target branch.
- [x] Double-check that the PR is okay to be merged.
- [x] Ensure the corresponding issue has a ZenHub release assigned.
- [x] Add a changelog message to the issue.
