### PR TITLE
Scroll internal server error into view

### DIFF
--- a/assets/js/components/notifications/InternalServerError.js
+++ b/assets/js/components/notifications/InternalServerError.js
@@ -17,6 +17,11 @@
  */
 
 /**
+ * WordPress dependencies
+ */
+import { useEffect, useRef } from '@wordpress/element';
+
+/**
  * Internal dependencies
  */
 import { useSelect } from 'googlesitekit-data';
@@ -27,16 +32,28 @@ import BannerNotification, {
 import Notification from '@/js/googlesitekit/notifications/components/Notification';
 
 export default function InternalServerError() {
+	const notificationRef = useRef();
 	const error = useSelect( ( select ) =>
 		select( CORE_SITE ).getInternalServerError()
 	);
+
+	// Scroll to the notification when the error is present.
+	useEffect( () => {
+		if ( error ) {
+			notificationRef.current?.scrollIntoView( {
+				behavior: 'smooth',
+				block: 'nearest',
+				inline: 'nearest',
+			} );
+		}
+	}, [ error ] );
 
 	if ( ! error ) {
 		return null;
 	}
 
 	return (
-		<Notification id="internal-server-error">
+		<Notification id="internal-server-error" ref={ notificationRef }>
 			<BannerNotification
 				notificationID="internal-server-error"
 				type={ TYPES.ERROR }

--- a/assets/js/components/notifications/InternalServerError.js
+++ b/assets/js/components/notifications/InternalServerError.js
@@ -19,7 +19,7 @@
 /**
  * WordPress dependencies
  */
-import { useEffect, useRef } from '@wordpress/element';
+import { useEffect } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -30,32 +30,40 @@ import BannerNotification, {
 	TYPES,
 } from '@/js/googlesitekit/notifications/components/layout/BannerNotification';
 import Notification from '@/js/googlesitekit/notifications/components/Notification';
+import { useBreakpoint } from '@/js/hooks/useBreakpoint';
+import { getNavigationalScrollTop } from '@/js/util/scroll';
+
+const NOTIFICATION_ID = 'internal-server-error';
 
 export default function InternalServerError() {
-	const notificationRef = useRef();
+	const breakpoint = useBreakpoint();
 	const error = useSelect( ( select ) =>
 		select( CORE_SITE ).getInternalServerError()
 	);
 
 	// Scroll to the notification when the error is present.
 	useEffect( () => {
-		if ( error ) {
-			notificationRef.current?.scrollIntoView( {
-				behavior: 'smooth',
-				block: 'nearest',
-				inline: 'nearest',
-			} );
+		if ( ! error ) {
+			return;
 		}
-	}, [ error ] );
+
+		global.scrollTo( {
+			top: getNavigationalScrollTop(
+				`#${ NOTIFICATION_ID }`,
+				breakpoint
+			),
+			behavior: 'smooth',
+		} );
+	}, [ error, breakpoint ] );
 
 	if ( ! error ) {
 		return null;
 	}
 
 	return (
-		<Notification id="internal-server-error" ref={ notificationRef }>
+		<Notification id={ NOTIFICATION_ID }>
 			<BannerNotification
-				notificationID="internal-server-error"
+				notificationID={ NOTIFICATION_ID }
 				type={ TYPES.ERROR }
 				title={ error.title }
 				description={ error.description }

--- a/assets/js/components/notifications/InternalServerError.test.js
+++ b/assets/js/components/notifications/InternalServerError.test.js
@@ -20,14 +20,28 @@
  * Internal dependencies
  */
 import { CORE_SITE } from '@/js/googlesitekit/datastore/site/constants';
-import { mockBrowserScrolling } from '../../../../tests/js/mock-browser-utils';
+import { useBreakpoint } from '@/js/hooks/useBreakpoint';
+import * as scrollUtils from '@/js/util/scroll';
 import { createTestRegistry, render } from '../../../../tests/js/test-utils';
 import InternalServerError from './InternalServerError';
+
+jest.mock( '@/js/hooks/useBreakpoint' );
+
+const getNavigationalScrollTopSpy = jest.spyOn(
+	scrollUtils,
+	'getNavigationalScrollTop'
+);
+const scrollToSpy = jest.spyOn( global, 'scrollTo' );
 
 describe( 'InternalServerError', () => {
 	const registry = createTestRegistry();
 
-	mockBrowserScrolling();
+	beforeEach( () => {
+		registry.dispatch( CORE_SITE ).clearInternalServerError();
+		useBreakpoint.mockReturnValue( 'small' );
+		getNavigationalScrollTopSpy.mockReturnValue( 100 );
+		scrollToSpy.mockClear();
+	} );
 
 	it( 'should display the notification when the internal server error is set', () => {
 		const error = {
@@ -67,10 +81,13 @@ describe( 'InternalServerError', () => {
 
 		render( <InternalServerError />, { registry } );
 
-		expect( Element.prototype.scrollIntoView ).toHaveBeenCalledWith( {
+		expect( getNavigationalScrollTopSpy ).toHaveBeenCalledWith(
+			'#internal-server-error',
+			'small'
+		);
+		expect( scrollToSpy ).toHaveBeenCalledWith( {
+			top: 100,
 			behavior: 'smooth',
-			block: 'nearest',
-			inline: 'nearest',
 		} );
 	} );
 
@@ -79,6 +96,6 @@ describe( 'InternalServerError', () => {
 
 		render( <InternalServerError />, { registry } );
 
-		expect( Element.prototype.scrollIntoView ).not.toHaveBeenCalled();
+		expect( scrollToSpy ).not.toHaveBeenCalled();
 	} );
 } );

--- a/assets/js/components/notifications/InternalServerError.test.js
+++ b/assets/js/components/notifications/InternalServerError.test.js
@@ -20,11 +20,14 @@
  * Internal dependencies
  */
 import { CORE_SITE } from '@/js/googlesitekit/datastore/site/constants';
+import { mockBrowserScrolling } from '../../../../tests/js/mock-browser-utils';
 import { createTestRegistry, render } from '../../../../tests/js/test-utils';
 import InternalServerError from './InternalServerError';
 
 describe( 'InternalServerError', () => {
 	const registry = createTestRegistry();
+
+	mockBrowserScrolling();
 
 	it( 'should display the notification when the internal server error is set', () => {
 		const error = {
@@ -51,5 +54,31 @@ describe( 'InternalServerError', () => {
 
 		const { container } = render( <InternalServerError />, { registry } );
 		expect( container ).toBeEmptyDOMElement();
+	} );
+
+	it( 'should scroll the notification into view when the internal server error is set', () => {
+		const error = {
+			id: 'module-setup-error',
+			title: 'Test Error',
+			description: 'Error message',
+		};
+
+		registry.dispatch( CORE_SITE ).setInternalServerError( error );
+
+		render( <InternalServerError />, { registry } );
+
+		expect( Element.prototype.scrollIntoView ).toHaveBeenCalledWith( {
+			behavior: 'smooth',
+			block: 'nearest',
+			inline: 'nearest',
+		} );
+	} );
+
+	it( 'should not scroll into view when the internal server error is not set', () => {
+		registry.dispatch( CORE_SITE ).clearInternalServerError();
+
+		render( <InternalServerError />, { registry } );
+
+		expect( Element.prototype.scrollIntoView ).not.toHaveBeenCalled();
 	} );
 } );

--- a/assets/js/googlesitekit/notifications/components/Notification/index.js
+++ b/assets/js/googlesitekit/notifications/components/Notification/index.js
@@ -17,12 +17,13 @@
 /**
  * External dependencies
  */
+import useMergedRef from '@react-hook/merged-ref';
 import PropTypes from 'prop-types';
 
 /**
  * WordPress dependencies
  */
-import { useEffect, useRef, useState } from '@wordpress/element';
+import { forwardRef, useEffect, useRef, useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -33,72 +34,74 @@ import { useHasBeenViewed } from '@/js/googlesitekit/notifications/hooks/useHasB
 import useNotificationEvents from '@/js/googlesitekit/notifications/hooks/useNotificationEvents';
 import ViewedStateObserver from './ViewedStateObserver';
 
-export default function Notification( {
-	id,
-	className,
-	gaTrackingEventArgs,
-	children,
-	onView,
-} ) {
-	const ref = useRef();
-	const viewed = useHasBeenViewed( id );
-	const trackEvents = useNotificationEvents(
-		id,
-		gaTrackingEventArgs?.category,
-		{ viewAction: gaTrackingEventArgs?.viewAction }
-	);
+const Notification = forwardRef(
+	(
+		{ id, className, gaTrackingEventArgs, children, onView },
+		forwardedRef
+	) => {
+		const ref = useRef();
+		const mergedRef = useMergedRef( forwardedRef, ref );
+		const viewed = useHasBeenViewed( id );
+		const trackEvents = useNotificationEvents(
+			id,
+			gaTrackingEventArgs?.category,
+			{ viewAction: gaTrackingEventArgs?.viewAction }
+		);
 
-	const [ isViewedOnce, setIsViewedOnce ] = useState( false );
+		const [ isViewedOnce, setIsViewedOnce ] = useState( false );
 
-	const viewedDates = useSelect( ( select ) =>
-		select( CORE_NOTIFICATIONS ).getNotificationSeenDates( id )
-	);
+		const viewedDates = useSelect( ( select ) =>
+			select( CORE_NOTIFICATIONS ).getNotificationSeenDates( id )
+		);
 
-	const { dismissNotification } = useDispatch( CORE_NOTIFICATIONS );
+		const { dismissNotification } = useDispatch( CORE_NOTIFICATIONS );
 
-	// Track view once and check if notification should be dismissed.
-	useEffect( () => {
-		if ( ! isViewedOnce && viewed ) {
-			trackEvents.view(
-				gaTrackingEventArgs?.label,
-				gaTrackingEventArgs?.value
-			);
+		// Track view once and check if notification should be dismissed.
+		useEffect( () => {
+			if ( ! isViewedOnce && viewed ) {
+				trackEvents.view(
+					gaTrackingEventArgs?.label,
+					gaTrackingEventArgs?.value
+				);
 
-			onView?.();
+				onView?.();
 
-			setIsViewedOnce( true );
-		}
+				setIsViewedOnce( true );
+			}
 
-		// If the notification has been viewed on 3 distinct days, dismiss it permanently for the next view.
-		if ( viewedDates?.length >= 3 ) {
-			dismissNotification( id, { skipHidingFromQueue: true } );
-		}
-	}, [
-		viewed,
-		trackEvents,
-		isViewedOnce,
-		gaTrackingEventArgs,
-		onView,
-		viewedDates,
-		dismissNotification,
-		id,
-	] );
+			// If the notification has been viewed on 3 distinct days, dismiss it permanently for the next view.
+			if ( viewedDates?.length >= 3 ) {
+				dismissNotification( id, { skipHidingFromQueue: true } );
+			}
+		}, [
+			viewed,
+			trackEvents,
+			isViewedOnce,
+			gaTrackingEventArgs,
+			onView,
+			viewedDates,
+			dismissNotification,
+			id,
+		] );
 
-	return (
-		<section id={ id } ref={ ref } className={ className }>
-			{ children }
+		return (
+			<section id={ id } ref={ mergedRef } className={ className }>
+				{ children }
 
-			{ /* Encapsulate observer to dispose when no longer needed. */ }
-			{ ! viewed && (
-				<ViewedStateObserver
-					id={ id }
-					observeRef={ ref }
-					threshold={ 0.5 }
-				/>
-			) }
-		</section>
-	);
-}
+				{ /* Encapsulate observer to dispose when no longer needed. */ }
+				{ ! viewed && (
+					<ViewedStateObserver
+						id={ id }
+						observeRef={ ref }
+						threshold={ 0.5 }
+					/>
+				) }
+			</section>
+		);
+	}
+);
+
+export default Notification;
 
 Notification.propTypes = {
 	id: PropTypes.string,

--- a/assets/js/googlesitekit/notifications/components/Notification/index.js
+++ b/assets/js/googlesitekit/notifications/components/Notification/index.js
@@ -17,13 +17,12 @@
 /**
  * External dependencies
  */
-import useMergedRef from '@react-hook/merged-ref';
 import PropTypes from 'prop-types';
 
 /**
  * WordPress dependencies
  */
-import { forwardRef, useEffect, useRef, useState } from '@wordpress/element';
+import { useEffect, useRef, useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -34,74 +33,72 @@ import { useHasBeenViewed } from '@/js/googlesitekit/notifications/hooks/useHasB
 import useNotificationEvents from '@/js/googlesitekit/notifications/hooks/useNotificationEvents';
 import ViewedStateObserver from './ViewedStateObserver';
 
-const Notification = forwardRef(
-	(
-		{ id, className, gaTrackingEventArgs, children, onView },
-		forwardedRef
-	) => {
-		const ref = useRef();
-		const mergedRef = useMergedRef( forwardedRef, ref );
-		const viewed = useHasBeenViewed( id );
-		const trackEvents = useNotificationEvents(
-			id,
-			gaTrackingEventArgs?.category,
-			{ viewAction: gaTrackingEventArgs?.viewAction }
-		);
+export default function Notification( {
+	id,
+	className,
+	gaTrackingEventArgs,
+	children,
+	onView,
+} ) {
+	const ref = useRef();
+	const viewed = useHasBeenViewed( id );
+	const trackEvents = useNotificationEvents(
+		id,
+		gaTrackingEventArgs?.category,
+		{ viewAction: gaTrackingEventArgs?.viewAction }
+	);
 
-		const [ isViewedOnce, setIsViewedOnce ] = useState( false );
+	const [ isViewedOnce, setIsViewedOnce ] = useState( false );
 
-		const viewedDates = useSelect( ( select ) =>
-			select( CORE_NOTIFICATIONS ).getNotificationSeenDates( id )
-		);
+	const viewedDates = useSelect( ( select ) =>
+		select( CORE_NOTIFICATIONS ).getNotificationSeenDates( id )
+	);
 
-		const { dismissNotification } = useDispatch( CORE_NOTIFICATIONS );
+	const { dismissNotification } = useDispatch( CORE_NOTIFICATIONS );
 
-		// Track view once and check if notification should be dismissed.
-		useEffect( () => {
-			if ( ! isViewedOnce && viewed ) {
-				trackEvents.view(
-					gaTrackingEventArgs?.label,
-					gaTrackingEventArgs?.value
-				);
+	// Track view once and check if notification should be dismissed.
+	useEffect( () => {
+		if ( ! isViewedOnce && viewed ) {
+			trackEvents.view(
+				gaTrackingEventArgs?.label,
+				gaTrackingEventArgs?.value
+			);
 
-				onView?.();
+			onView?.();
 
-				setIsViewedOnce( true );
-			}
+			setIsViewedOnce( true );
+		}
 
-			// If the notification has been viewed on 3 distinct days, dismiss it permanently for the next view.
-			if ( viewedDates?.length >= 3 ) {
-				dismissNotification( id, { skipHidingFromQueue: true } );
-			}
-		}, [
-			viewed,
-			trackEvents,
-			isViewedOnce,
-			gaTrackingEventArgs,
-			onView,
-			viewedDates,
-			dismissNotification,
-			id,
-		] );
+		// If the notification has been viewed on 3 distinct days, dismiss it permanently for the next view.
+		if ( viewedDates?.length >= 3 ) {
+			dismissNotification( id, { skipHidingFromQueue: true } );
+		}
+	}, [
+		viewed,
+		trackEvents,
+		isViewedOnce,
+		gaTrackingEventArgs,
+		onView,
+		viewedDates,
+		dismissNotification,
+		id,
+	] );
 
-		return (
-			<section id={ id } ref={ mergedRef } className={ className }>
-				{ children }
+	return (
+		<section id={ id } ref={ ref } className={ className }>
+			{ children }
 
-				{ /* Encapsulate observer to dispose when no longer needed. */ }
-				{ ! viewed && (
-					<ViewedStateObserver
-						id={ id }
-						observeRef={ ref }
-						threshold={ 0.5 }
-					/>
-				) }
-			</section>
-		);
-	}
-);
-
-export default Notification;
+			{ /* Encapsulate observer to dispose when no longer needed. */ }
+			{ ! viewed && (
+				<ViewedStateObserver
+					id={ id }
+					observeRef={ ref }
+					threshold={ 0.5 }
+				/>
+			) }
+		</section>
+	);
+}
 
 Notification.propTypes = {
 	id: PropTypes.string,


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #12445 

## Relevant technical choices

This PR makes the internal server error scroll into view when an error occurs.

### Deviation from IB

This PR uses `getNavigationalScrollTop` instead of `scrollIntoView` as otherwise, the fixed header hides most of the notification when scrolled to.

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [x] Run the code.
- [x] Ensure the acceptance criteria are satisfied.
- [x] Reassess the implementation with the IB.
- [x] Ensure no unrelated changes are included.
- [x] Ensure CI checks pass.
- [x] Check Storybook where applicable.
- [x] Ensure there is a QA Brief.
- [x] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [x] Ensure the PR has the correct target branch.
- [x] Double-check that the PR is okay to be merged.
- [x] Ensure the corresponding issue has a ZenHub release assigned.
- [x] Add a changelog message to the issue.
