### PR TITLE
Ensure the ToS can be accepted / rejected following an initial rejection.

### DIFF
--- a/includes/Modules/Analytics_4.php
+++ b/includes/Modules/Analytics_4.php
@@ -1131,9 +1131,6 @@ final class Analytics_4 extends Module implements Module_With_Inline_Data, Modul
 			exit;
 		}
 
-		// At this point, the accountTicketId is a match and params are loaded, so we can safely delete the transient.
-		$this->transients->delete( $account_ticket_transient_key );
-
 		// Next, check for a returned error.
 		$error = $input->filter( INPUT_GET, 'error' );
 		if ( ! empty( $error ) ) {
@@ -1142,6 +1139,9 @@ final class Analytics_4 extends Module implements Module_With_Inline_Data, Modul
 			);
 			exit;
 		}
+
+		// As the account has been created without an error, we can safely delete the transient.
+		$this->transients->delete( $account_ticket_transient_key );
 
 		$account_id = htmlspecialchars( $input->filter( INPUT_GET, 'accountId' ) ?? '' );
 

--- a/tests/phpunit/integration/Modules/Analytics_4Test.php
+++ b/tests/phpunit/integration/Modules/Analytics_4Test.php
@@ -445,8 +445,8 @@ class Analytics_4Test extends TestCase {
 				$redirect->get_location(),
 				'Should redirect to dashboard with user cancel error.'
 			);
-			// Ensure transient was deleted by the method despite error.
-			$this->assertFalse( get_transient( $account_ticked_id_transient ), 'Account ticket transient should be deleted when user cancels.' );
+			// Ensure transient is not deleted by the method when there is an error.
+			$this->assertEquals( $_GET['accountTicketId'], get_transient( $account_ticked_id_transient ), 'Account ticket transient should not be deleted when user cancels.' );
 		}
 		unset( $_GET['error'] );
 	}
@@ -634,8 +634,8 @@ class Analytics_4Test extends TestCase {
 				$redirect->get_location(),
 				'Should redirect to Analytics setup screen with the account creation error code.'
 			);
-			// Ensure transient was deleted by the method despite error.
-			$this->assertFalse( get_transient( $account_ticked_id_transient ), 'Account ticket transient should be deleted when user cancels.' );
+			// Ensure transient was not deleted by the method when there is an error.
+			$this->assertEquals( $_GET['accountTicketId'], get_transient( $account_ticked_id_transient ), 'Account ticket transient should not be deleted when user cancels.' );
 		}
 		unset( $_GET['error'] );
 	}


### PR DESCRIPTION
## Summary

Addresses issue:

- #12377 

## Relevant technical choices

This is a fix to ensure that the ToS screen can be accepted / rejected in the case where the user initially rejects the ToS, is returned to the Analytics setup screen with an error, and then goes back to the ToS screen to resubmit the form.

The solution is to ensure the account ticket ID transient isn't deleted in the case of an error, as we'll still need it when returning to the Analytics setup screen after the user revisits the ToS screen.

This change isn't behind the `setupFlowRefresh` feature flag, as it won't impact the non-SFR flow - the transient will expire after 15 mins, and is overridden when entering the account creation flow again anyway.

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [ ] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.
- [ ] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
