### PR TITLE
fix(auth): restore g_csrf_token CSRF validation in Sign In With Google

### DIFF
--- a/includes/Modules/Sign_In_With_Google/Authenticator.php
+++ b/includes/Modules/Sign_In_With_Google/Authenticator.php
@@ -33,8 +33,9 @@ class Authenticator implements Authenticator_Interface {
 	/**
 	 * Error codes.
 	 */
-	const ERROR_INVALID_REQUEST = 'googlesitekit_auth_invalid_request';
-	const ERROR_SIGNIN_FAILED   = 'googlesitekit_auth_failed';
+	const ERROR_INVALID_REQUEST    = 'googlesitekit_auth_invalid_request';
+	const ERROR_INVALID_CSRF_TOKEN = 'googlesitekit_auth_invalid_g_csrf_token';
+	const ERROR_SIGNIN_FAILED      = 'googlesitekit_auth_failed';
 
 	/**
 	 * User meta key marking users created via Sign in with Google.
@@ -81,6 +82,15 @@ class Authenticator implements Authenticator_Interface {
 	 * @return string Redirect URL.
 	 */
 	public function authenticate_user( Input $input ) {
+		// Validate the CSRF token set by the Google Identity Services library.
+		// The library sets the same token in both the g_csrf_token cookie and the
+		// POST body; comparing them prevents cross-site request forgery.
+		$csrf_cookie = $input->filter( INPUT_COOKIE, 'g_csrf_token' );
+		$csrf_post   = $input->filter( INPUT_POST, 'g_csrf_token' );
+		if ( ! $csrf_cookie || ! $csrf_post || ! hash_equals( $csrf_cookie, $csrf_post ) ) {
+			return $this->get_error_redirect_url( self::ERROR_INVALID_CSRF_TOKEN );
+		}
+
 		$credential = $input->filter( INPUT_POST, 'credential' );
 
 		$user    = null;


### PR DESCRIPTION
## Summary

Restores the `g_csrf_token` CSRF validation in `Authenticator::authenticate_user()` that was inadvertently removed in commit `0803e42d` (PR #9687, November 2024).

## Background

Google's GIS (Google Identity Services) library sets an identical `g_csrf_token` value in **both** a cookie and the POST body when the user clicks the Sign In With Google button. The server **must** compare these two values before processing the credential — this is the CSRF mitigation documented in the [GIS server-side verification guide](https://developers.google.com/identity/gsi/web/guides/verify-google-id-token#verify-the-google-id-token-on-your-server-side).

The check existed in the original implementation (constant `ERROR_INVALID_CSRF_TOKEN` and the validation block in `authenticate_user`), but was dropped without replacement.

## Impact Without the Check

An attacker can host a page that auto-submits a valid Google credential via CSRF POST to `wp-login.php?action=googlesitekit_auth`:

```html
<form method="POST" action="https://victim.com/wp-login.php?action=googlesitekit_auth">
  <input name="credential" value="[ATTACKER_VALID_GOOGLE_JWT]">
</form>
<script>document.forms[0].submit();</script>
```

Because the plugin never validates `g_csrf_token`, the server processes the credential. If the attacker's Google account email matches an existing WordPress account, `find_user()` permanently links the attacker's Google credential to that account — the attacker can then sign in as that user at any time.

## Fix

Restores the original two-line validation using `hash_equals()` (constant-time comparison) and re-adds the `ERROR_INVALID_CSRF_TOKEN` error code constant.

```php
$csrf_cookie = $input->filter( INPUT_COOKIE, 'g_csrf_token' );
$csrf_post   = $input->filter( INPUT_POST, 'g_csrf_token' );
if ( ! $csrf_cookie || ! $csrf_post || ! hash_equals( $csrf_cookie, $csrf_post ) ) {
    return $this->get_error_redirect_url( self::ERROR_INVALID_CSRF_TOKEN );
}
```

## Testing

- Normal Sign In With Google flow: GIS library sets `g_csrf_token` in both cookie and POST body automatically — valid requests pass unchanged.
- CSRF attempt without the cookie/token: rejected with `ERROR_INVALID_CSRF_TOKEN`.

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have signed the Contributor License Agreement (see https://cla.developers.google.com/).

---

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.