### PR TITLE
Remove offsetDays option from getDateRangeDates().

### DIFF
--- a/assets/js/components/GoogleChart/index.js
+++ b/assets/js/components/GoogleChart/index.js
@@ -98,7 +98,7 @@ export default function GoogleChart( props ) {
 	const breakpoint = useBreakpoint();
 
 	const { startDate, endDate } = useSelect( ( select ) =>
-		select( CORE_USER ).getDateRangeDates( { offsetDays: 0 } )
+		select( CORE_USER ).getDateRangeDates()
 	);
 
 	const viewContext = useViewContext();

--- a/assets/js/components/OverlayNotification/AnalyticsAndAdSenseAccountsDetectedAsLinkedOverlayNotification.test.js
+++ b/assets/js/components/OverlayNotification/AnalyticsAndAdSenseAccountsDetectedAsLinkedOverlayNotification.test.js
@@ -37,10 +37,7 @@ import { MODULE_SLUG_ADSENSE } from '@/js/modules/adsense/constants';
 import { MODULES_ADSENSE } from '@/js/modules/adsense/datastore/constants';
 import { ADSENSE_NOTIFICATIONS } from '@/js/modules/adsense/notifications';
 import { MODULE_SLUG_ANALYTICS_4 } from '@/js/modules/analytics-4/constants';
-import {
-	DATE_RANGE_OFFSET,
-	MODULES_ANALYTICS_4,
-} from '@/js/modules/analytics-4/datastore/constants';
+import { MODULES_ANALYTICS_4 } from '@/js/modules/analytics-4/datastore/constants';
 import {
 	getAnalytics4MockResponse,
 	provideAnalytics4MockReport,
@@ -126,9 +123,7 @@ describe( 'AnalyticsAndAdSenseAccountsDetectedAsLinkedOverlayNotification', () =
 		registry.dispatch( MODULES_ADSENSE ).receiveGetSettings( {
 			accountID: adSenseAccountID,
 		} );
-		const dateRangeDates = registry
-			.select( CORE_USER )
-			.getDateRangeDates( { offsetDays: DATE_RANGE_OFFSET } );
+		const dateRangeDates = registry.select( CORE_USER ).getDateRangeDates();
 		reportOptions = {
 			...dateRangeDates,
 			dimensions: [ 'pagePath', 'adSourceName' ],

--- a/assets/js/components/adminbar/AdminBarClicks.js
+++ b/assets/js/components/adminbar/AdminBarClicks.js
@@ -30,10 +30,7 @@ import { NOTICE_STYLE } from '@/js/components/GatheringDataNotice';
 import PreviewBlock from '@/js/components/PreviewBlock';
 import { CORE_SITE } from '@/js/googlesitekit/datastore/site/constants';
 import { CORE_USER } from '@/js/googlesitekit/datastore/user/constants';
-import {
-	DATE_RANGE_OFFSET,
-	MODULES_SEARCH_CONSOLE,
-} from '@/js/modules/search-console/datastore/constants';
+import { MODULES_SEARCH_CONSOLE } from '@/js/modules/search-console/datastore/constants';
 import { calculateChange } from '@/js/util';
 import { partitionReport } from '@/js/util/partition-report';
 import sumObjectListValue from '@/js/util/sum-object-list-value';
@@ -48,7 +45,6 @@ function AdminBarClicks( { WidgetReportError } ) {
 	const { compareStartDate, endDate } = useSelect( ( select ) =>
 		select( CORE_USER ).getDateRangeDates( {
 			compare: true,
-			offsetDays: DATE_RANGE_OFFSET,
 		} )
 	);
 	const dateRangeLength = useSelect( ( select ) =>

--- a/assets/js/components/adminbar/AdminBarImpressions.js
+++ b/assets/js/components/adminbar/AdminBarImpressions.js
@@ -30,10 +30,7 @@ import { NOTICE_STYLE } from '@/js/components/GatheringDataNotice';
 import PreviewBlock from '@/js/components/PreviewBlock';
 import { CORE_SITE } from '@/js/googlesitekit/datastore/site/constants';
 import { CORE_USER } from '@/js/googlesitekit/datastore/user/constants';
-import {
-	DATE_RANGE_OFFSET,
-	MODULES_SEARCH_CONSOLE,
-} from '@/js/modules/search-console/datastore/constants';
+import { MODULES_SEARCH_CONSOLE } from '@/js/modules/search-console/datastore/constants';
 import { calculateChange } from '@/js/util';
 import { partitionReport } from '@/js/util/partition-report';
 import sumObjectListValue from '@/js/util/sum-object-list-value';
@@ -48,7 +45,6 @@ function AdminBarImpressions( { WidgetReportError } ) {
 	const { compareStartDate, endDate } = useSelect( ( select ) =>
 		select( CORE_USER ).getDateRangeDates( {
 			compare: true,
-			offsetDays: DATE_RANGE_OFFSET,
 		} )
 	);
 	const dateRangeLength = useSelect( ( select ) =>

--- a/assets/js/components/adminbar/AdminBarSessionsGA4.js
+++ b/assets/js/components/adminbar/AdminBarSessionsGA4.js
@@ -30,10 +30,7 @@ import { NOTICE_STYLE } from '@/js/components/GatheringDataNotice';
 import PreviewBlock from '@/js/components/PreviewBlock';
 import { CORE_SITE } from '@/js/googlesitekit/datastore/site/constants';
 import { CORE_USER } from '@/js/googlesitekit/datastore/user/constants';
-import {
-	DATE_RANGE_OFFSET,
-	MODULES_ANALYTICS_4,
-} from '@/js/modules/analytics-4/datastore/constants';
+import { MODULES_ANALYTICS_4 } from '@/js/modules/analytics-4/datastore/constants';
 import { calculateChange } from '@/js/util';
 
 function AdminBarSessionsGA4( { WidgetReportError } ) {
@@ -46,7 +43,6 @@ function AdminBarSessionsGA4( { WidgetReportError } ) {
 	const dateRangeDates = useSelect( ( select ) =>
 		select( CORE_USER ).getDateRangeDates( {
 			compare: true,
-			offsetDays: DATE_RANGE_OFFSET,
 		} )
 	);
 	const reportArgs = {

--- a/assets/js/components/adminbar/AdminBarUniqueVisitorsGA4.js
+++ b/assets/js/components/adminbar/AdminBarUniqueVisitorsGA4.js
@@ -30,10 +30,7 @@ import { NOTICE_STYLE } from '@/js/components/GatheringDataNotice';
 import PreviewBlock from '@/js/components/PreviewBlock';
 import { CORE_SITE } from '@/js/googlesitekit/datastore/site/constants';
 import { CORE_USER } from '@/js/googlesitekit/datastore/user/constants';
-import {
-	DATE_RANGE_OFFSET,
-	MODULES_ANALYTICS_4,
-} from '@/js/modules/analytics-4/datastore/constants';
+import { MODULES_ANALYTICS_4 } from '@/js/modules/analytics-4/datastore/constants';
 import { calculateChange } from '@/js/util';
 
 function AdminBarUniqueVisitorsGA4( { WidgetReportError } ) {
@@ -46,7 +43,6 @@ function AdminBarUniqueVisitorsGA4( { WidgetReportError } ) {
 	const dateRangeDates = useSelect( ( select ) =>
 		select( CORE_USER ).getDateRangeDates( {
 			compare: true,
-			offsetDays: DATE_RANGE_OFFSET,
 		} )
 	);
 	const reportArgs = {

--- a/assets/js/components/wp-dashboard/WPDashboardClicks.js
+++ b/assets/js/components/wp-dashboard/WPDashboardClicks.js
@@ -34,10 +34,7 @@ import DataBlock from '@/js/components/DataBlock';
 import { NOTICE_STYLE } from '@/js/components/GatheringDataNotice';
 import PreviewBlock from '@/js/components/PreviewBlock';
 import { CORE_USER } from '@/js/googlesitekit/datastore/user/constants';
-import {
-	DATE_RANGE_OFFSET,
-	MODULES_SEARCH_CONSOLE,
-} from '@/js/modules/search-console/datastore/constants';
+import { MODULES_SEARCH_CONSOLE } from '@/js/modules/search-console/datastore/constants';
 import { calculateChange } from '@/js/util';
 import { partitionReport } from '@/js/util/partition-report';
 import sumObjectListValue from '@/js/util/sum-object-list-value';
@@ -49,7 +46,6 @@ function WPDashboardClicks( { WPDashboardReportError } ) {
 	const { compareStartDate, endDate } = useSelect( ( select ) =>
 		select( CORE_USER ).getDateRangeDates( {
 			compare: true,
-			offsetDays: DATE_RANGE_OFFSET,
 		} )
 	);
 	const dateRangeLength = useSelect( ( select ) =>

--- a/assets/js/components/wp-dashboard/WPDashboardImpressions.js
+++ b/assets/js/components/wp-dashboard/WPDashboardImpressions.js
@@ -34,10 +34,7 @@ import DataBlock from '@/js/components/DataBlock';
 import { NOTICE_STYLE } from '@/js/components/GatheringDataNotice';
 import PreviewBlock from '@/js/components/PreviewBlock';
 import { CORE_USER } from '@/js/googlesitekit/datastore/user/constants';
-import {
-	DATE_RANGE_OFFSET,
-	MODULES_SEARCH_CONSOLE,
-} from '@/js/modules/search-console/datastore/constants';
+import { MODULES_SEARCH_CONSOLE } from '@/js/modules/search-console/datastore/constants';
 import { calculateChange } from '@/js/util';
 import { partitionReport } from '@/js/util/partition-report';
 import sumObjectListValue from '@/js/util/sum-object-list-value';
@@ -49,7 +46,6 @@ function WPDashboardImpressions( { WPDashboardReportError } ) {
 	const { compareStartDate, endDate } = useSelect( ( select ) =>
 		select( CORE_USER ).getDateRangeDates( {
 			compare: true,
-			offsetDays: DATE_RANGE_OFFSET,
 		} )
 	);
 	const dateRangeLength = useSelect( ( select ) =>

--- a/assets/js/components/wp-dashboard/WPDashboardPopularPagesGA4.js
+++ b/assets/js/components/wp-dashboard/WPDashboardPopularPagesGA4.js
@@ -39,19 +39,14 @@ import TableOverflowContainer from '@/js/components/TableOverflowContainer';
 import Typography from '@/js/components/Typography';
 import { CORE_USER } from '@/js/googlesitekit/datastore/user/constants';
 import { ZeroDataMessage } from '@/js/modules/analytics-4/components/common';
-import {
-	DATE_RANGE_OFFSET,
-	MODULES_ANALYTICS_4,
-} from '@/js/modules/analytics-4/datastore/constants';
+import { MODULES_ANALYTICS_4 } from '@/js/modules/analytics-4/datastore/constants';
 import { numFmt } from '@/js/util';
 
 export default function WPDashboardPopularPagesGA4( {
 	WPDashboardReportError,
 } ) {
 	const dateRangeDates = useSelect( ( select ) =>
-		select( CORE_USER ).getDateRangeDates( {
-			offsetDays: DATE_RANGE_OFFSET,
-		} )
+		select( CORE_USER ).getDateRangeDates()
 	);
 
 	const isGatheringData = useInViewSelect( ( select ) =>

--- a/assets/js/components/wp-dashboard/WPDashboardSessionDurationGA4.js
+++ b/assets/js/components/wp-dashboard/WPDashboardSessionDurationGA4.js
@@ -34,10 +34,7 @@ import DataBlock from '@/js/components/DataBlock';
 import { NOTICE_STYLE } from '@/js/components/GatheringDataNotice';
 import PreviewBlock from '@/js/components/PreviewBlock';
 import { CORE_USER } from '@/js/googlesitekit/datastore/user/constants';
-import {
-	DATE_RANGE_OFFSET,
-	MODULES_ANALYTICS_4,
-} from '@/js/modules/analytics-4/datastore/constants';
+import { MODULES_ANALYTICS_4 } from '@/js/modules/analytics-4/datastore/constants';
 import { calculateChange } from '@/js/util';
 
 function WPDashboardSessionDurationGA4( { WPDashboardReportError } ) {
@@ -47,7 +44,6 @@ function WPDashboardSessionDurationGA4( { WPDashboardReportError } ) {
 	const dateRangeDates = useSelect( ( select ) =>
 		select( CORE_USER ).getDateRangeDates( {
 			compare: true,
-			offsetDays: DATE_RANGE_OFFSET,
 		} )
 	);
 

--- a/assets/js/components/wp-dashboard/WPDashboardUniqueVisitorsChartGA4.js
+++ b/assets/js/components/wp-dashboard/WPDashboardUniqueVisitorsChartGA4.js
@@ -32,10 +32,7 @@ import GoogleChart from '@/js/components/GoogleChart';
 import Typography from '@/js/components/Typography';
 import { CORE_UI } from '@/js/googlesitekit/datastore/ui/constants';
 import { CORE_USER } from '@/js/googlesitekit/datastore/user/constants';
-import {
-	DATE_RANGE_OFFSET,
-	MODULES_ANALYTICS_4,
-} from '@/js/modules/analytics-4/datastore/constants';
+import { MODULES_ANALYTICS_4 } from '@/js/modules/analytics-4/datastore/constants';
 import { extractAnalytics4DashboardData } from '@/js/modules/analytics-4/utils/extract-dashboard-data';
 import { stringToDate } from '@/js/util';
 import { UNIQUE_VISITORS_CHART_OPTIONS } from './chart-options';
@@ -57,7 +54,6 @@ export default function WPDashboardUniqueVisitorsChartGA4( props ) {
 		( select ) =>
 			select( CORE_USER ).getDateRangeDates( {
 				compare: true,
-				offsetDays: DATE_RANGE_OFFSET,
 			} )
 	);
 

--- a/assets/js/components/wp-dashboard/WPDashboardUniqueVisitorsGA4.js
+++ b/assets/js/components/wp-dashboard/WPDashboardUniqueVisitorsGA4.js
@@ -34,10 +34,7 @@ import DataBlock from '@/js/components/DataBlock';
 import { NOTICE_STYLE } from '@/js/components/GatheringDataNotice';
 import PreviewBlock from '@/js/components/PreviewBlock';
 import { CORE_USER } from '@/js/googlesitekit/datastore/user/constants';
-import {
-	DATE_RANGE_OFFSET,
-	MODULES_ANALYTICS_4,
-} from '@/js/modules/analytics-4/datastore/constants';
+import { MODULES_ANALYTICS_4 } from '@/js/modules/analytics-4/datastore/constants';
 import { calculateChange } from '@/js/util';
 
 function WPDashboardUniqueVisitorsGA4( { WPDashboardReportError } ) {
@@ -47,7 +44,6 @@ function WPDashboardUniqueVisitorsGA4( { WPDashboardReportError } ) {
 	const dateRangeDates = useSelect( ( select ) =>
 		select( CORE_USER ).getDateRangeDates( {
 			compare: true,
-			offsetDays: DATE_RANGE_OFFSET,
 		} )
 	);
 

--- a/assets/js/googlesitekit/datastore/user/date-range.js
+++ b/assets/js/googlesitekit/datastore/user/date-range.js
@@ -146,27 +146,15 @@ export const selectors = {
 	 * @param {Object}  state                   The current data store's state.
 	 * @param {Object}  [options]               Options parameter. Default is: {}.
 	 * @param {boolean} [options.compare]       Set to true if date ranges to compare should be included. Default is: false.
-	 * @param {number}  [options.offsetDays]    Number of days to offset. Default is: 0.
 	 * @param {string}  [options.referenceDate] Used for testing to set a static date. Default is the datastore's reference date.
 	 * @return {DateRangeReturnObj}             Object containing dates for date ranges.
 	 */
 	getDateRangeDates(
 		state,
-		{
-			compare = false,
-			offsetDays,
-			referenceDate = state.referenceDate,
-		} = {}
+		{ compare = false, referenceDate = state.referenceDate } = {}
 	) {
-		if ( offsetDays === undefined ) {
-			global.console.warn(
-				'getDateRangeDates was called without offsetDays'
-			);
-			offsetDays = 0;
-		}
-
 		const dateRange = selectors.getDateRange( state );
-		const endDate = getPreviousDate( referenceDate, offsetDays );
+		const endDate = getPreviousDate( referenceDate, 0 );
 		const matches = dateRange.match( '-(.*)-' );
 		const numberOfDays = Number( matches ? matches[ 1 ] : 28 );
 		const startDate = getPreviousDate( endDate, numberOfDays - 1 );

--- a/assets/js/googlesitekit/datastore/user/date-range.test.js
+++ b/assets/js/googlesitekit/datastore/user/date-range.test.js
@@ -103,30 +103,9 @@ describe( 'core/user date-range', () => {
 						...additionalOptions,
 					} )
 				).toEqual( expected );
-
-				if ( additionalOptions.offsetDays === undefined ) {
-					// eslint-disable-next-line no-console
-					expect( console.warn ).toHaveBeenCalled();
-				}
 			}
 
-			describe( 'with date range and w/o offset', () => {
-				beforeAll( () => {
-					jest.spyOn( console, 'warn' ).mockImplementation(
-						() => {}
-					);
-				} );
-
-				afterAll( () => {
-					// eslint-disable-next-line no-console
-					console.warn.mockRestore();
-				} );
-
-				afterEach( () => {
-					// eslint-disable-next-line no-console
-					console.warn.mockClear();
-				} );
-
+			describe( 'with date range', () => {
 				// [ dateRange, expectedReturnDates ]
 				const valuesToTest = [
 					[
@@ -151,59 +130,11 @@ describe( 'core/user date-range', () => {
 				);
 			} );
 
-			describe( 'with date range & offset', () => {
-				// [ dateRange, offsetDays, expectedReturnDates ]
+			describe( 'with date range & compare', () => {
+				// [ dateRange, expectedReturnDates ]
 				const valuesToTest = [
 					[
 						'last-1-days',
-						0,
-						{ startDate: '2020-09-24', endDate: '2020-09-24' },
-					],
-					[
-						'last-7-days',
-						0,
-						{ startDate: '2020-09-18', endDate: '2020-09-24' },
-					],
-					[
-						'last-30-days',
-						0,
-						{ startDate: '2020-08-26', endDate: '2020-09-24' },
-					],
-					[
-						'last-1-days',
-						3,
-						{ startDate: '2020-09-21', endDate: '2020-09-21' },
-					],
-					[
-						'last-7-days',
-						3,
-						{ startDate: '2020-09-15', endDate: '2020-09-21' },
-					],
-					[
-						'last-30-days',
-						3,
-						{ startDate: '2020-08-23', endDate: '2020-09-21' },
-					],
-				];
-
-				const testName =
-					'should return proper dates for "%s" & offsetDays %s';
-				it.each( valuesToTest )(
-					testName,
-					( dateRange, offsetDays, expected ) => {
-						createDateRangeTest( dateRange, expected, {
-							offsetDays,
-						} );
-					}
-				);
-			} );
-
-			describe( 'with date range, offset, & compare', () => {
-				// [ dateRange, offsetDays, expectedReturnDates ]
-				const valuesToTest = [
-					[
-						'last-1-days',
-						0,
 						{
 							startDate: '2020-09-24',
 							endDate: '2020-09-24',
@@ -213,7 +144,6 @@ describe( 'core/user date-range', () => {
 					],
 					[
 						'last-7-days',
-						0,
 						{
 							startDate: '2020-09-18',
 							endDate: '2020-09-24',
@@ -223,7 +153,6 @@ describe( 'core/user date-range', () => {
 					],
 					[
 						'last-30-days',
-						0,
 						{
 							startDate: '2020-08-26',
 							endDate: '2020-09-24',
@@ -231,49 +160,16 @@ describe( 'core/user date-range', () => {
 							compareEndDate: '2020-08-25',
 						},
 					],
-					[
-						'last-1-days',
-						3,
-						{
-							startDate: '2020-09-21',
-							endDate: '2020-09-21',
-							compareStartDate: '2020-09-20',
-							compareEndDate: '2020-09-20',
-						},
-					],
-					[
-						'last-7-days',
-						3,
-						{
-							startDate: '2020-09-15',
-							endDate: '2020-09-21',
-							compareStartDate: '2020-09-08',
-							compareEndDate: '2020-09-14',
-						},
-					],
-					[
-						'last-30-days',
-						3,
-						{
-							startDate: '2020-08-23',
-							endDate: '2020-09-21',
-							compareStartDate: '2020-07-24',
-							compareEndDate: '2020-08-22',
-						},
-					],
 				];
 
 				const testName =
-					'should return proper dates for "%s" & offsetDays %s, & compare';
-				it.each( valuesToTest )(
-					testName,
-					( dateRange, offsetDays, expected ) => {
-						createDateRangeTest( dateRange, expected, {
-							offsetDays,
-							compare: true,
-						} );
-					}
-				);
+					'should return proper dates for "%s" & compare';
+
+				it.each( valuesToTest )( testName, ( dateRange, expected ) => {
+					createDateRangeTest( dateRange, expected, {
+						compare: true,
+					} );
+				} );
 			} );
 		} );
 

--- a/assets/js/googlesitekit/notifications/register-defaults.js
+++ b/assets/js/googlesitekit/notifications/register-defaults.js
@@ -71,10 +71,7 @@ import {
 import { CORE_MODULES } from '@/js/googlesitekit/modules/datastore/constants';
 import { MODULE_SLUG_ADSENSE } from '@/js/modules/adsense/constants';
 import { MODULE_SLUG_ANALYTICS_4 } from '@/js/modules/analytics-4/constants';
-import {
-	DATE_RANGE_OFFSET,
-	MODULES_ANALYTICS_4,
-} from '@/js/modules/analytics-4/datastore/constants';
+import { MODULES_ANALYTICS_4 } from '@/js/modules/analytics-4/datastore/constants';
 import { isZeroReport } from '@/js/modules/analytics-4/utils';
 import { MODULE_SLUG_SEARCH_CONSOLE } from '@/js/modules/search-console/constants';
 import { MODULES_SEARCH_CONSOLE } from '@/js/modules/search-console/datastore/constants';
@@ -297,11 +294,8 @@ export const DEFAULT_NOTIFICATIONS = {
 				return false;
 			}
 
-			const { startDate, endDate } = select(
-				CORE_USER
-			).getDateRangeDates( {
-				offsetDays: DATE_RANGE_OFFSET,
-			} );
+			const { startDate, endDate } =
+				select( CORE_USER ).getDateRangeDates();
 
 			const reportOptions = {
 				startDate,

--- a/assets/js/modules/ads/components/common/PAXEmbeddedApp.js
+++ b/assets/js/modules/ads/components/common/PAXEmbeddedApp.js
@@ -41,7 +41,6 @@ import {
 	createPaxServices,
 	formatPaxDate,
 } from '@/js/modules/ads/pax';
-import { DATE_RANGE_OFFSET } from '@/js/modules/analytics-4/datastore/constants';
 
 export default function PAXEmbeddedApp( {
 	displayMode = 'default',
@@ -62,9 +61,7 @@ export default function PAXEmbeddedApp( {
 			return {};
 		}
 
-		return select( CORE_USER ).getDateRangeDates( {
-			offsetDays: DATE_RANGE_OFFSET,
-		} );
+		return select( CORE_USER ).getDateRangeDates();
 	} );
 
 	const isAdBlockerActive = useSelect( ( select ) =>

--- a/assets/js/modules/ads/datastore/constants.js
+++ b/assets/js/modules/ads/datastore/constants.js
@@ -22,9 +22,6 @@ export const ADWORDS_SCOPE = 'https://www.googleapis.com/auth/adwords';
 export const SUPPORT_CONTENT_SCOPE =
 	'https://www.googleapis.com/auth/supportcontent';
 
-// Date range offset days for Ads report requests.
-export const DATE_RANGE_OFFSET = 0;
-
 export const ADS_MODULE_SETUP_BANNER_PROMPT_DISMISSED_KEY =
 	'ads_module_setup_banner_prompt_dismissed_key';
 

--- a/assets/js/modules/ads/pax/services.js
+++ b/assets/js/modules/ads/pax/services.js
@@ -33,10 +33,7 @@ import apiFetch from '@wordpress/api-fetch';
 import { set } from 'googlesitekit-api';
 import { CORE_SITE } from '@/js/googlesitekit/datastore/site/constants';
 import { CORE_USER } from '@/js/googlesitekit/datastore/user/constants';
-import {
-	DATE_RANGE_OFFSET,
-	MODULES_ADS,
-} from '@/js/modules/ads/datastore/constants';
+import { MODULES_ADS } from '@/js/modules/ads/datastore/constants';
 import { formatPaxDate } from './utils';
 
 async function restFetchWpPages() {
@@ -208,9 +205,7 @@ export function createPaxServices( registry, options = {} ) {
 			get: async () => {
 				const { startDate, endDate } = registry
 					.select( CORE_USER )
-					.getDateRangeDates( {
-						offsetDays: DATE_RANGE_OFFSET,
-					} );
+					.getDateRangeDates();
 
 				return {
 					startDate: formatPaxDate( startDate ),

--- a/assets/js/modules/adsense/components/dashboard/DashboardTopEarningPagesWidgetGA4.js
+++ b/assets/js/modules/adsense/components/dashboard/DashboardTopEarningPagesWidgetGA4.js
@@ -50,10 +50,7 @@ import {
 import { MODULES_ADSENSE } from '@/js/modules/adsense/datastore/constants';
 import { ZeroDataMessage } from '@/js/modules/analytics-4/components/common';
 import { MODULE_SLUG_ANALYTICS_4 } from '@/js/modules/analytics-4/constants';
-import {
-	DATE_RANGE_OFFSET,
-	MODULES_ANALYTICS_4,
-} from '@/js/modules/analytics-4/datastore/constants';
+import { MODULES_ANALYTICS_4 } from '@/js/modules/analytics-4/datastore/constants';
 import { generateDateRangeArgs } from '@/js/modules/analytics-4/utils/report-date-range-args';
 import { numFmt, trackEvent } from '@/js/util';
 import whenActive from '@/js/util/when-active';
@@ -70,9 +67,7 @@ function DashboardTopEarningPagesWidgetGA4( {
 	);
 
 	const { startDate, endDate } = useSelect( ( select ) =>
-		select( CORE_USER ).getDateRangeDates( {
-			offsetDays: DATE_RANGE_OFFSET,
-		} )
+		select( CORE_USER ).getDateRangeDates()
 	);
 
 	const adSenseAccountID = useSelect( ( select ) =>

--- a/assets/js/modules/adsense/components/module/ModuleOverviewWidget/Footer.js
+++ b/assets/js/modules/adsense/components/module/ModuleOverviewWidget/Footer.js
@@ -28,19 +28,14 @@ import { useSelect } from 'googlesitekit-data';
 import SourceLink from '@/js/components/SourceLink';
 import { CORE_USER } from '@/js/googlesitekit/datastore/user/constants';
 import useViewOnly from '@/js/hooks/useViewOnly';
-import {
-	DATE_RANGE_OFFSET,
-	MODULES_ADSENSE,
-} from '@/js/modules/adsense/datastore/constants';
+import { MODULES_ADSENSE } from '@/js/modules/adsense/datastore/constants';
 import { generateDateRangeArgs } from '@/js/modules/adsense/util/report-date-range-args';
 
 function Footer() {
 	const viewOnlyDashboard = useViewOnly();
 
 	const dateRangeDates = useSelect( ( select ) =>
-		select( CORE_USER ).getDateRangeDates( {
-			offsetDays: DATE_RANGE_OFFSET,
-		} )
+		select( CORE_USER ).getDateRangeDates()
 	);
 
 	const accountSiteURL = useSelect( ( select ) => {

--- a/assets/js/modules/adsense/components/module/ModuleOverviewWidget/index.js
+++ b/assets/js/modules/adsense/components/module/ModuleOverviewWidget/index.js
@@ -35,10 +35,7 @@ import PreviewBlock from '@/js/components/PreviewBlock';
 import { CORE_USER } from '@/js/googlesitekit/datastore/user/constants';
 import useViewOnly from '@/js/hooks/useViewOnly';
 import { MODULE_SLUG_ADSENSE } from '@/js/modules/adsense/constants';
-import {
-	DATE_RANGE_OFFSET,
-	MODULES_ADSENSE,
-} from '@/js/modules/adsense/datastore/constants';
+import { MODULES_ADSENSE } from '@/js/modules/adsense/datastore/constants';
 import {
 	SITE_STATUS_ADDED,
 	legacyAccountStatuses,
@@ -76,7 +73,6 @@ function ModuleOverviewWidget( { Widget, WidgetReportError } ) {
 		( select ) =>
 			select( CORE_USER ).getDateRangeDates( {
 				compare: true,
-				offsetDays: DATE_RANGE_OFFSET,
 			} )
 	);
 

--- a/assets/js/modules/adsense/components/widgets/TopEarningContentWidget.js
+++ b/assets/js/modules/adsense/components/widgets/TopEarningContentWidget.js
@@ -42,10 +42,7 @@ import {
 import useViewOnly from '@/js/hooks/useViewOnly';
 import { AdSenseLinkCTA } from '@/js/modules/adsense/components/common';
 import { MODULE_SLUG_ADSENSE } from '@/js/modules/adsense/constants';
-import {
-	DATE_RANGE_OFFSET,
-	MODULES_ADSENSE,
-} from '@/js/modules/adsense/datastore/constants';
+import { MODULES_ADSENSE } from '@/js/modules/adsense/datastore/constants';
 import { ZeroDataMessage } from '@/js/modules/analytics-4/components/common';
 import ConnectGA4CTATileWidget from '@/js/modules/analytics-4/components/widgets/ConnectGA4CTATileWidget';
 import { MODULE_SLUG_ANALYTICS_4 } from '@/js/modules/analytics-4/constants';
@@ -58,9 +55,7 @@ function TopEarningContentWidget( { Widget } ) {
 	const viewOnlyDashboard = useViewOnly();
 
 	const dates = useSelect( ( select ) =>
-		select( CORE_USER ).getDateRangeDates( {
-			offsetDays: DATE_RANGE_OFFSET,
-		} )
+		select( CORE_USER ).getDateRangeDates()
 	);
 
 	const adSenseAccountID = useSelect( ( select ) =>

--- a/assets/js/modules/adsense/components/widgets/TopEarningContentWidget.test.js
+++ b/assets/js/modules/adsense/components/widgets/TopEarningContentWidget.test.js
@@ -26,10 +26,7 @@ import {
 import { withConnected } from '@/js/googlesitekit/modules/datastore/__fixtures__';
 import { getWidgetComponentProps } from '@/js/googlesitekit/widgets/util';
 import { MODULE_SLUG_ADSENSE } from '@/js/modules/adsense/constants';
-import {
-	DATE_RANGE_OFFSET,
-	MODULES_ADSENSE,
-} from '@/js/modules/adsense/datastore/constants';
+import { MODULES_ADSENSE } from '@/js/modules/adsense/datastore/constants';
 import { MODULE_SLUG_ANALYTICS_4 } from '@/js/modules/analytics-4/constants';
 import { MODULES_ANALYTICS_4 } from '@/js/modules/analytics-4/datastore/constants';
 import {
@@ -76,9 +73,7 @@ describe( 'TopEarningContentWidget', () => {
 
 	it( 'should render correctly with the expected metrics', async () => {
 		const pageTitlesReportOptions = {
-			...registry
-				.select( CORE_USER )
-				.getDateRangeDates( { offsetDays: DATE_RANGE_OFFSET } ),
+			...registry.select( CORE_USER ).getDateRangeDates(),
 			dimensionFilters: {
 				pagePath: new Array( 3 )
 					.fill( '' )
@@ -109,9 +104,7 @@ describe( 'TopEarningContentWidget', () => {
 			} );
 
 		provideAnalytics4MockReport( registry, {
-			...registry
-				.select( CORE_USER )
-				.getDateRangeDates( { offsetDays: DATE_RANGE_OFFSET } ),
+			...registry.select( CORE_USER ).getDateRangeDates(),
 			dimensions: [ 'pagePath', 'adSourceName' ],
 			metrics: [ { name: 'totalAdRevenue' } ],
 			dimensionFilters: {

--- a/assets/js/modules/adsense/datastore/constants.js
+++ b/assets/js/modules/adsense/datastore/constants.js
@@ -18,9 +18,6 @@
 
 export const MODULES_ADSENSE = 'modules/adsense';
 
-// Date range offset days for AdSense report requests.
-export const DATE_RANGE_OFFSET = 0;
-
 export const API_STATE_READY = 'READY';
 export const API_STATE_NEEDS_ATTENTION = 'NEEDS_ATTENTION';
 export const API_STATE_REQUIRES_REVIEW = 'REQUIRES_REVIEW';

--- a/assets/js/modules/adsense/notifications/index.js
+++ b/assets/js/modules/adsense/notifications/index.js
@@ -49,10 +49,7 @@ import {
 	MODULES_ADSENSE,
 } from '@/js/modules/adsense/datastore/constants';
 import { MODULE_SLUG_ANALYTICS_4 } from '@/js/modules/analytics-4/constants';
-import {
-	DATE_RANGE_OFFSET,
-	MODULES_ANALYTICS_4,
-} from '@/js/modules/analytics-4/datastore/constants';
+import { MODULES_ANALYTICS_4 } from '@/js/modules/analytics-4/datastore/constants';
 import { isZeroReport } from '@/js/modules/analytics-4/utils';
 
 export const ADSENSE_NOTIFICATIONS = {
@@ -150,11 +147,8 @@ export const ADSENSE_NOTIFICATIONS = {
 			await resolveSelect( MODULES_ADSENSE ).getSettings();
 			const adSenseAccountID = select( MODULES_ADSENSE ).getAccountID();
 
-			const { startDate, endDate } = select(
-				CORE_USER
-			).getDateRangeDates( {
-				offsetDays: DATE_RANGE_OFFSET,
-			} );
+			const { startDate, endDate } =
+				select( CORE_USER ).getDateRangeDates();
 
 			const reportArgs = {
 				startDate,

--- a/assets/js/modules/analytics-4/components/audience-segmentation/dashboard/AudienceAreaFooter.js
+++ b/assets/js/modules/analytics-4/components/audience-segmentation/dashboard/AudienceAreaFooter.js
@@ -30,18 +30,13 @@ import { CORE_USER } from '@/js/googlesitekit/datastore/user/constants';
 import { CORE_MODULES } from '@/js/googlesitekit/modules/datastore/constants';
 import useViewOnly from '@/js/hooks/useViewOnly';
 import { MODULE_SLUG_ANALYTICS_4 } from '@/js/modules/analytics-4/constants';
-import {
-	DATE_RANGE_OFFSET,
-	MODULES_ANALYTICS_4,
-} from '@/js/modules/analytics-4/datastore/constants';
+import { MODULES_ANALYTICS_4 } from '@/js/modules/analytics-4/datastore/constants';
 
 export default function AudienceAreaFooter() {
 	const viewOnlyDashboard = useViewOnly();
 
 	const dates = useSelect( ( select ) =>
-		select( CORE_USER ).getDateRangeDates( {
-			offsetDays: DATE_RANGE_OFFSET,
-		} )
+		select( CORE_USER ).getDateRangeDates()
 	);
 
 	const sourceLinkURL = useSelect( ( select ) => {

--- a/assets/js/modules/analytics-4/components/audience-segmentation/dashboard/AudienceSelectionPanel/AudienceItems.js
+++ b/assets/js/modules/analytics-4/components/audience-segmentation/dashboard/AudienceSelectionPanel/AudienceItems.js
@@ -38,7 +38,6 @@ import { CORE_USER } from '@/js/googlesitekit/datastore/user/constants';
 import useViewOnly from '@/js/hooks/useViewOnly';
 import {
 	AUDIENCE_ITEM_NEW_BADGE_SLUG_PREFIX,
-	DATE_RANGE_OFFSET,
 	MODULES_ANALYTICS_4,
 } from '@/js/modules/analytics-4/datastore/constants';
 import { WEEK_IN_SECONDS } from '@/js/util';
@@ -101,9 +100,7 @@ export default function AudienceItems( { savedItemSlugs = [] } ) {
 		const isSiteKitAudiencePartialData =
 			hasAudiencePartialData( siteKitAudiences );
 
-		const dateRangeDates = select( CORE_USER ).getDateRangeDates( {
-			offsetDays: DATE_RANGE_OFFSET,
-		} );
+		const dateRangeDates = select( CORE_USER ).getDateRangeDates();
 
 		// Get the user count for the available Site Kit audiences using the `newVsReturning` dimension
 		// to avoid the partial data state for these audiences.

--- a/assets/js/modules/analytics-4/components/audience-segmentation/dashboard/AudienceSelectionPanel/SyncErrorNotice.test.js
+++ b/assets/js/modules/analytics-4/components/audience-segmentation/dashboard/AudienceSelectionPanel/SyncErrorNotice.test.js
@@ -24,10 +24,7 @@ import { CORE_SITE } from '@/js/googlesitekit/datastore/site/constants';
 import { CORE_UI } from '@/js/googlesitekit/datastore/ui/constants';
 import { CORE_USER } from '@/js/googlesitekit/datastore/user/constants';
 import { availableAudiences } from '@/js/modules/analytics-4/datastore/__fixtures__';
-import {
-	DATE_RANGE_OFFSET,
-	MODULES_ANALYTICS_4,
-} from '@/js/modules/analytics-4/datastore/constants';
+import { MODULES_ANALYTICS_4 } from '@/js/modules/analytics-4/datastore/constants';
 import { ERROR_REASON_INSUFFICIENT_PERMISSIONS } from '@/js/util/errors';
 import * as tracking from '@/js/util/tracking';
 import {
@@ -82,9 +79,7 @@ describe( 'ErrorNotice', () => {
 			return args;
 		}
 
-		const dates = select( CORE_USER ).getDateRangeDates( {
-			offsetDays: DATE_RANGE_OFFSET,
-		} );
+		const dates = select( CORE_USER ).getDateRangeDates();
 
 		const options = args[ 0 ] || {};
 

--- a/assets/js/modules/analytics-4/components/audience-segmentation/dashboard/AudienceSelectionPanel/index.test.js
+++ b/assets/js/modules/analytics-4/components/audience-segmentation/dashboard/AudienceSelectionPanel/index.test.js
@@ -37,7 +37,6 @@ import { CORE_UI } from '@/js/googlesitekit/datastore/ui/constants';
 import { CORE_USER } from '@/js/googlesitekit/datastore/user/constants';
 import {
 	AUDIENCE_ITEM_NEW_BADGE_SLUG_PREFIX,
-	DATE_RANGE_OFFSET,
 	EDIT_SCOPE,
 	MODULES_ANALYTICS_4,
 } from '@/js/modules/analytics-4/datastore/constants';
@@ -107,9 +106,7 @@ describe( 'AudienceSelectionPanel', () => {
 		} );
 
 		registry.dispatch( CORE_USER ).setReferenceDate( '2024-03-28' );
-		const dateRangeDates = registry
-			.select( CORE_USER )
-			.getDateRangeDates( { offsetDays: DATE_RANGE_OFFSET } );
+		const dateRangeDates = registry.select( CORE_USER ).getDateRangeDates();
 		baseReportOptions = {
 			...dateRangeDates,
 			metrics: [ { name: 'totalUsers' } ],

--- a/assets/js/modules/analytics-4/components/audience-segmentation/dashboard/AudienceTilesWidget/AudienceTile/AudienceTilePagesMetricContent.js
+++ b/assets/js/modules/analytics-4/components/audience-segmentation/dashboard/AudienceTilesWidget/AudienceTile/AudienceTilePagesMetricContent.js
@@ -39,10 +39,7 @@ import {
 } from '@/js/hooks/useBreakpoint';
 import useViewContext from '@/js/hooks/useViewContext';
 import useViewOnly from '@/js/hooks/useViewOnly';
-import {
-	DATE_RANGE_OFFSET,
-	MODULES_ANALYTICS_4,
-} from '@/js/modules/analytics-4/datastore/constants';
+import { MODULES_ANALYTICS_4 } from '@/js/modules/analytics-4/datastore/constants';
 import { numFmt, trackEvent } from '@/js/util';
 import withIntersectionObserver from '@/js/util/withIntersectionObserver';
 import AudienceTileNoData from './AudienceTileNoData';
@@ -73,9 +70,7 @@ export default function AudienceTilePagesMetricContent( {
 	const hasDimensionValues = !! validDimensionValues.length;
 
 	const dates = useSelect( ( select ) =>
-		select( CORE_USER ).getDateRangeDates( {
-			offsetDays: DATE_RANGE_OFFSET,
-		} )
+		select( CORE_USER ).getDateRangeDates()
 	);
 
 	function handleCreateCustomDimension() {

--- a/assets/js/modules/analytics-4/components/audience-segmentation/dashboard/AudienceTilesWidget/AudienceTile/index.stories.js
+++ b/assets/js/modules/analytics-4/components/audience-segmentation/dashboard/AudienceTilesWidget/AudienceTile/index.stories.js
@@ -26,10 +26,7 @@ import {
 } from '@/js/googlesitekit/constants';
 import { CORE_USER } from '@/js/googlesitekit/datastore/user/constants';
 import { withWidgetComponentProps } from '@/js/googlesitekit/widgets/util';
-import {
-	DATE_RANGE_OFFSET,
-	MODULES_ANALYTICS_4,
-} from '@/js/modules/analytics-4/datastore/constants';
+import { MODULES_ANALYTICS_4 } from '@/js/modules/analytics-4/datastore/constants';
 import { getPreviousDate } from '@/js/util';
 import { provideUserAuthentication } from '@tests/js/utils';
 import WithRegistrySetup from '@tests/js/WithRegistrySetup';
@@ -236,9 +233,7 @@ AudiencePartialData.args = {
 			propertyID: '12345',
 		} );
 
-		const { startDate } = registry.select( CORE_USER ).getDateRangeDates( {
-			offsetDays: DATE_RANGE_OFFSET,
-		} );
+		const { startDate } = registry.select( CORE_USER ).getDateRangeDates();
 
 		const dataAvailabilityDate = Number(
 			getPreviousDate( startDate, -1 ).replace( /-/g, '' )
@@ -274,9 +269,7 @@ TopContentPartialData.args = {
 			propertyID: '12345',
 		} );
 
-		const { startDate } = registry.select( CORE_USER ).getDateRangeDates( {
-			offsetDays: DATE_RANGE_OFFSET,
-		} );
+		const { startDate } = registry.select( CORE_USER ).getDateRangeDates();
 
 		const dataAvailabilityDate = Number(
 			getPreviousDate( startDate, -1 ).replace( /-/g, '' )

--- a/assets/js/modules/analytics-4/components/audience-segmentation/dashboard/AudienceTilesWidget/AudienceTile/index.test.js
+++ b/assets/js/modules/analytics-4/components/audience-segmentation/dashboard/AudienceTilesWidget/AudienceTile/index.test.js
@@ -36,10 +36,7 @@ import { CORE_USER } from '@/js/googlesitekit/datastore/user/constants';
 import { withWidgetComponentProps } from '@/js/googlesitekit/widgets/util';
 import CustomDimensionErrorModal from '@/js/modules/analytics-4/components/audience-segmentation/dashboard/CustomDimensionErrorModal.tsx';
 import { MODULE_SLUG_ANALYTICS_4 } from '@/js/modules/analytics-4/constants';
-import {
-	DATE_RANGE_OFFSET,
-	MODULES_ANALYTICS_4,
-} from '@/js/modules/analytics-4/datastore/constants';
+import { MODULES_ANALYTICS_4 } from '@/js/modules/analytics-4/datastore/constants';
 import { provideCustomDimensionError } from '@/js/modules/analytics-4/utils/custom-dimensions';
 import { getAnalytics4MockResponse } from '@/js/modules/analytics-4/utils/data-mock';
 import { getPreviousDate } from '@/js/util';
@@ -188,7 +185,6 @@ describe( 'AudienceTile', () => {
 		} );
 
 		const dates = registry.select( CORE_USER ).getDateRangeDates( {
-			offsetDays: DATE_RANGE_OFFSET,
 			compare: true,
 		} );
 

--- a/assets/js/modules/analytics-4/components/audience-segmentation/dashboard/AudienceTilesWidget/index.stories.js
+++ b/assets/js/modules/analytics-4/components/audience-segmentation/dashboard/AudienceTilesWidget/index.stories.js
@@ -28,10 +28,7 @@ import { CORE_USER } from '@/js/googlesitekit/datastore/user/constants';
 import { withWidgetComponentProps } from '@/js/googlesitekit/widgets/util';
 import { MODULE_SLUG_ANALYTICS_4 } from '@/js/modules/analytics-4/constants';
 import { availableAudiences } from '@/js/modules/analytics-4/datastore/__fixtures__';
-import {
-	DATE_RANGE_OFFSET,
-	MODULES_ANALYTICS_4,
-} from '@/js/modules/analytics-4/datastore/constants';
+import { MODULES_ANALYTICS_4 } from '@/js/modules/analytics-4/datastore/constants';
 import {
 	STRATEGY_ZIP,
 	getAnalytics4MockResponse,
@@ -232,9 +229,7 @@ DefaultWithZeroTile.args = {
 			options: reportOptions,
 		} );
 
-		const { startDate } = registry.select( CORE_USER ).getDateRangeDates( {
-			offsetDays: DATE_RANGE_OFFSET,
-		} );
+		const { startDate } = registry.select( CORE_USER ).getDateRangeDates();
 		const audienceDate = Number( startDate.replace( /-/g, '' ) );
 		const dataAvailabilityDate = Number(
 			getPreviousDate( startDate, -1 ).replace( /-/g, '' )
@@ -353,9 +348,7 @@ TwoTilesWithZeroTile.args = {
 			options: reportOptions,
 		} );
 
-		const { startDate } = registry.select( CORE_USER ).getDateRangeDates( {
-			offsetDays: DATE_RANGE_OFFSET,
-		} );
+		const { startDate } = registry.select( CORE_USER ).getDateRangeDates();
 		const audienceDate = Number( startDate.replace( /-/g, '' ) );
 		const dataAvailabilityDate = Number(
 			getPreviousDate( startDate, -1 ).replace( /-/g, '' )
@@ -414,9 +407,7 @@ ZeroTileWithPlaceholder.args = {
 			options: reportOptions,
 		} );
 
-		const { startDate } = registry.select( CORE_USER ).getDateRangeDates( {
-			offsetDays: DATE_RANGE_OFFSET,
-		} );
+		const { startDate } = registry.select( CORE_USER ).getDateRangeDates();
 		const dataAvailabilityDate = Number(
 			getPreviousDate( startDate, -1 ).replace( /-/g, '' )
 		);
@@ -446,9 +437,7 @@ DefaultAudiencesPartialData.args = {
 			.dispatch( MODULES_ANALYTICS_4 )
 			.receiveIsGatheringData( false );
 
-		const { startDate } = registry.select( CORE_USER ).getDateRangeDates( {
-			offsetDays: DATE_RANGE_OFFSET,
-		} );
+		const { startDate } = registry.select( CORE_USER ).getDateRangeDates();
 		const dataAvailabilityDate = Number(
 			getPreviousDate( startDate, -1 ).replace( /-/g, '' )
 		);
@@ -485,9 +474,7 @@ SiteKitAudiencesPartialData.args = {
 			.dispatch( MODULES_ANALYTICS_4 )
 			.receiveIsGatheringData( false );
 
-		const { startDate } = registry.select( CORE_USER ).getDateRangeDates( {
-			offsetDays: DATE_RANGE_OFFSET,
-		} );
+		const { startDate } = registry.select( CORE_USER ).getDateRangeDates();
 
 		const dataAvailabilityDate = Number(
 			getPreviousDate( startDate, -1 ).replace( /-/g, '' )
@@ -609,9 +596,7 @@ SingleTileErrored.args = {
 		'properties/12345/audiences/3', // New visitors
 	],
 	setupRegistry: ( registry ) => {
-		const dates = registry.select( CORE_USER ).getDateRangeDates( {
-			offsetDays: DATE_RANGE_OFFSET,
-		} );
+		const dates = registry.select( CORE_USER ).getDateRangeDates();
 
 		const { startDate, endDate } = dates;
 
@@ -862,9 +847,7 @@ export default {
 
 				const { startDate } = registry
 					.select( CORE_USER )
-					.getDateRangeDates( {
-						offsetDays: DATE_RANGE_OFFSET,
-					} );
+					.getDateRangeDates();
 
 				const audienceDate = Number( startDate.replace( /-/g, '' ) );
 

--- a/assets/js/modules/analytics-4/components/audience-segmentation/dashboard/AudienceTilesWidget/index.test.js
+++ b/assets/js/modules/analytics-4/components/audience-segmentation/dashboard/AudienceTilesWidget/index.test.js
@@ -24,10 +24,7 @@ import { CORE_USER } from '@/js/googlesitekit/datastore/user/constants';
 import { withWidgetComponentProps } from '@/js/googlesitekit/widgets/util';
 import { MODULE_SLUG_ANALYTICS_4 } from '@/js/modules/analytics-4/constants';
 import { availableAudiences } from '@/js/modules/analytics-4/datastore/__fixtures__';
-import {
-	DATE_RANGE_OFFSET,
-	MODULES_ANALYTICS_4,
-} from '@/js/modules/analytics-4/datastore/constants';
+import { MODULES_ANALYTICS_4 } from '@/js/modules/analytics-4/datastore/constants';
 import { getAnalytics4MockResponse } from '@/js/modules/analytics-4/utils/data-mock';
 import { getPreviousDate } from '@/js/util';
 import {
@@ -73,7 +70,6 @@ function provideAudienceTilesMockReport(
 	} = {}
 ) {
 	const dates = registry.select( CORE_USER ).getDateRangeDates( {
-		offsetDays: DATE_RANGE_OFFSET,
 		compare: true,
 	} );
 
@@ -483,7 +479,6 @@ describe( 'AudienceTilesWidget', () => {
 		];
 
 		const dates = registry.select( CORE_USER ).getDateRangeDates( {
-			offsetDays: DATE_RANGE_OFFSET,
 			compare: true,
 		} );
 
@@ -599,7 +594,6 @@ describe( 'AudienceTilesWidget', () => {
 		];
 
 		const dates = registry.select( CORE_USER ).getDateRangeDates( {
-			offsetDays: DATE_RANGE_OFFSET,
 			compare: true,
 		} );
 

--- a/assets/js/modules/analytics-4/components/dashboard/DashboardAllTrafficWidgetGA4/DataSourceLink.js
+++ b/assets/js/modules/analytics-4/components/dashboard/DashboardAllTrafficWidgetGA4/DataSourceLink.js
@@ -32,7 +32,6 @@ import { CORE_UI } from '@/js/googlesitekit/datastore/ui/constants';
 import { CORE_USER } from '@/js/googlesitekit/datastore/user/constants';
 import useViewOnly from '@/js/hooks/useViewOnly';
 import {
-	DATE_RANGE_OFFSET,
 	MODULES_ANALYTICS_4,
 	UI_DIMENSION_NAME,
 } from '@/js/modules/analytics-4/datastore/constants';
@@ -56,7 +55,6 @@ export default function DataSourceLink() {
 			CORE_USER
 		).getDateRangeDates( {
 			compare: true,
-			offsetDays: DATE_RANGE_OFFSET,
 		} );
 
 		const reportArgs = {

--- a/assets/js/modules/analytics-4/components/dashboard/DashboardAllTrafficWidgetGA4/UserCountGraph.js
+++ b/assets/js/modules/analytics-4/components/dashboard/DashboardAllTrafficWidgetGA4/UserCountGraph.js
@@ -37,7 +37,6 @@ import { CORE_UI } from '@/js/googlesitekit/datastore/ui/constants';
 import { CORE_USER } from '@/js/googlesitekit/datastore/user/constants';
 import useViewOnly from '@/js/hooks/useViewOnly';
 import {
-	DATE_RANGE_OFFSET,
 	MODULES_ANALYTICS_4,
 	UI_DIMENSION_COLOR,
 } from '@/js/modules/analytics-4/datastore/constants';
@@ -51,9 +50,7 @@ export default function UserCountGraph( props ) {
 	const isViewOnly = useViewOnly();
 
 	const { startDate, endDate } = useSelect( ( select ) =>
-		select( CORE_USER ).getDateRangeDates( {
-			offsetDays: DATE_RANGE_OFFSET,
-		} )
+		select( CORE_USER ).getDateRangeDates()
 	);
 
 	const graphLineColor = useSelect(

--- a/assets/js/modules/analytics-4/components/dashboard/DashboardAllTrafficWidgetGA4/index.js
+++ b/assets/js/modules/analytics-4/components/dashboard/DashboardAllTrafficWidgetGA4/index.js
@@ -31,7 +31,6 @@ import useViewOnly from '@/js/hooks/useViewOnly';
 import { Cell, Grid, Row } from '@/js/material-components/layout';
 import { MODULE_SLUG_ANALYTICS_4 } from '@/js/modules/analytics-4/constants';
 import {
-	DATE_RANGE_OFFSET,
 	MODULES_ANALYTICS_4,
 	UI_ALL_TRAFFIC_LOADED,
 	UI_DIMENSION_NAME,
@@ -88,7 +87,6 @@ function DashboardAllTrafficWidgetGA4( props ) {
 	const { compareStartDate, compareEndDate } = useSelect( ( select ) =>
 		select( CORE_USER ).getDateRangeDates( {
 			compare: true,
-			offsetDays: DATE_RANGE_OFFSET,
 		} )
 	);
 

--- a/assets/js/modules/analytics-4/components/dashboard/DashboardAllTrafficWidgetGA4/index.test.js
+++ b/assets/js/modules/analytics-4/components/dashboard/DashboardAllTrafficWidgetGA4/index.test.js
@@ -22,10 +22,7 @@
 import { CORE_USER } from '@/js/googlesitekit/datastore/user/constants';
 import { withWidgetComponentProps } from '@/js/googlesitekit/widgets/util';
 import { MODULE_SLUG_ANALYTICS_4 } from '@/js/modules/analytics-4/constants';
-import {
-	DATE_RANGE_OFFSET,
-	MODULES_ANALYTICS_4,
-} from '@/js/modules/analytics-4/datastore/constants';
+import { MODULES_ANALYTICS_4 } from '@/js/modules/analytics-4/datastore/constants';
 import { provideAnalytics4MockReport } from '@/js/modules/analytics-4/utils/data-mock';
 import { mockSurveyEndpoints } from '@tests/js/mock-survey-endpoints';
 import { render } from '@tests/js/test-utils';
@@ -66,7 +63,6 @@ describe( 'DashboardAllTrafficWidgetGA4', () => {
 
 		const dates = registry.select( CORE_USER ).getDateRangeDates( {
 			compare: true,
-			offsetDays: DATE_RANGE_OFFSET,
 		} );
 
 		baseOptions = {

--- a/assets/js/modules/analytics-4/components/dashboard/DashboardOverallPageMetricsWidgetGA4.js
+++ b/assets/js/modules/analytics-4/components/dashboard/DashboardOverallPageMetricsWidgetGA4.js
@@ -37,10 +37,7 @@ import WidgetHeaderTitle from '@/js/googlesitekit/widgets/components/WidgetHeade
 import useViewOnly from '@/js/hooks/useViewOnly';
 import { Cell, Grid } from '@/js/material-components/layout';
 import { MODULE_SLUG_ANALYTICS_4 } from '@/js/modules/analytics-4/constants';
-import {
-	DATE_RANGE_OFFSET,
-	MODULES_ANALYTICS_4,
-} from '@/js/modules/analytics-4/datastore/constants';
+import { MODULES_ANALYTICS_4 } from '@/js/modules/analytics-4/datastore/constants';
 import { calculateOverallPageMetricsData } from '@/js/modules/analytics-4/utils/overall-page-metrics';
 import { getURLPath } from '@/js/util';
 import whenActive from '@/js/util/when-active';
@@ -54,7 +51,6 @@ function DashboardOverallPageMetricsWidgetGA4( { Widget, WidgetReportError } ) {
 
 	const dates = useSelect( ( select ) =>
 		select( CORE_USER ).getDateRangeDates( {
-			offsetDays: DATE_RANGE_OFFSET,
 			compare: true,
 		} )
 	);

--- a/assets/js/modules/analytics-4/components/module/ModulePopularPagesWidgetGA4/Footer.js
+++ b/assets/js/modules/analytics-4/components/module/ModulePopularPagesWidgetGA4/Footer.js
@@ -28,18 +28,13 @@ import { useSelect } from 'googlesitekit-data';
 import SourceLink from '@/js/components/SourceLink';
 import { CORE_USER } from '@/js/googlesitekit/datastore/user/constants';
 import useViewOnly from '@/js/hooks/useViewOnly';
-import {
-	DATE_RANGE_OFFSET,
-	MODULES_ANALYTICS_4,
-} from '@/js/modules/analytics-4/datastore/constants';
+import { MODULES_ANALYTICS_4 } from '@/js/modules/analytics-4/datastore/constants';
 
 export default function Footer() {
 	const viewOnlyDashboard = useViewOnly();
 
 	const dates = useSelect( ( select ) =>
-		select( CORE_USER ).getDateRangeDates( {
-			offsetDays: DATE_RANGE_OFFSET,
-		} )
+		select( CORE_USER ).getDateRangeDates()
 	);
 	const sourceLinkURL = useSelect( ( select ) => {
 		if ( viewOnlyDashboard ) {

--- a/assets/js/modules/analytics-4/components/module/ModulePopularPagesWidgetGA4/index.js
+++ b/assets/js/modules/analytics-4/components/module/ModulePopularPagesWidgetGA4/index.js
@@ -45,10 +45,7 @@ import {
 import useViewOnly from '@/js/hooks/useViewOnly';
 import { ZeroDataMessage } from '@/js/modules/analytics-4/components/common';
 import { MODULE_SLUG_ANALYTICS_4 } from '@/js/modules/analytics-4/constants';
-import {
-	DATE_RANGE_OFFSET,
-	MODULES_ANALYTICS_4,
-} from '@/js/modules/analytics-4/datastore/constants';
+import { MODULES_ANALYTICS_4 } from '@/js/modules/analytics-4/datastore/constants';
 import { numFmt } from '@/js/util';
 import whenActive from '@/js/util/when-active';
 import Footer from './Footer';
@@ -64,9 +61,7 @@ function ModulePopularPagesWidgetGA4( props ) {
 	);
 
 	const dates = useSelect( ( select ) =>
-		select( CORE_USER ).getDateRangeDates( {
-			offsetDays: DATE_RANGE_OFFSET,
-		} )
+		select( CORE_USER ).getDateRangeDates()
 	);
 
 	const viewOnlyDashboard = useViewOnly();

--- a/assets/js/modules/analytics-4/components/site-goals/goal-drivers/CitiesGoalDriver.tsx
+++ b/assets/js/modules/analytics-4/components/site-goals/goal-drivers/CitiesGoalDriver.tsx
@@ -47,10 +47,7 @@ import {
 	getDimensionFiltersForEvents,
 	normalizePrimaryEvents,
 } from '@/js/modules/analytics-4/components/site-goals/goal-drivers/utils';
-import {
-	DATE_RANGE_OFFSET,
-	MODULES_ANALYTICS_4,
-} from '@/js/modules/analytics-4/datastore/constants';
+import { MODULES_ANALYTICS_4 } from '@/js/modules/analytics-4/datastore/constants';
 import { numFmt } from '@/js/util';
 
 interface ReportRow {
@@ -69,10 +66,7 @@ const CitiesGoalDriver: FC< GoalDriverComponentProps > = ( {
 	onExpandableRowsChange,
 } ) => {
 	const dates = useSelect(
-		( select: Select ) =>
-			select( CORE_USER ).getDateRangeDates( {
-				offsetDays: DATE_RANGE_OFFSET,
-			} ),
+		( select: Select ) => select( CORE_USER ).getDateRangeDates(),
 		[]
 	);
 	const reportOptions = useMemo( () => {

--- a/assets/js/modules/analytics-4/components/site-goals/goal-drivers/CountriesGoalDriver.tsx
+++ b/assets/js/modules/analytics-4/components/site-goals/goal-drivers/CountriesGoalDriver.tsx
@@ -47,10 +47,7 @@ import {
 	getDimensionFiltersForEvents,
 	normalizePrimaryEvents,
 } from '@/js/modules/analytics-4/components/site-goals/goal-drivers/utils';
-import {
-	DATE_RANGE_OFFSET,
-	MODULES_ANALYTICS_4,
-} from '@/js/modules/analytics-4/datastore/constants';
+import { MODULES_ANALYTICS_4 } from '@/js/modules/analytics-4/datastore/constants';
 import { numFmt } from '@/js/util';
 
 interface ReportRow {
@@ -69,10 +66,7 @@ const CountriesGoalDriver: FC< GoalDriverComponentProps > = ( {
 	onExpandableRowsChange,
 } ) => {
 	const dates = useSelect(
-		( select: Select ) =>
-			select( CORE_USER ).getDateRangeDates( {
-				offsetDays: DATE_RANGE_OFFSET,
-			} ),
+		( select: Select ) => select( CORE_USER ).getDateRangeDates(),
 		[]
 	);
 	const reportOptions = useMemo( () => {

--- a/assets/js/modules/analytics-4/components/site-goals/goal-drivers/DeviceTypeGoalDriver.tsx
+++ b/assets/js/modules/analytics-4/components/site-goals/goal-drivers/DeviceTypeGoalDriver.tsx
@@ -47,10 +47,7 @@ import {
 	getDimensionFiltersForEvents,
 	normalizePrimaryEvents,
 } from '@/js/modules/analytics-4/components/site-goals/goal-drivers/utils';
-import {
-	DATE_RANGE_OFFSET,
-	MODULES_ANALYTICS_4,
-} from '@/js/modules/analytics-4/datastore/constants';
+import { MODULES_ANALYTICS_4 } from '@/js/modules/analytics-4/datastore/constants';
 import { numFmt } from '@/js/util';
 
 interface ReportRow {
@@ -69,10 +66,7 @@ const DeviceTypeGoalDriver: FC< GoalDriverComponentProps > = ( {
 	onExpandableRowsChange,
 } ) => {
 	const dates = useSelect(
-		( select: Select ) =>
-			select( CORE_USER ).getDateRangeDates( {
-				offsetDays: DATE_RANGE_OFFSET,
-			} ),
+		( select: Select ) => select( CORE_USER ).getDateRangeDates(),
 		[]
 	);
 	const reportOptions = useMemo( () => {

--- a/assets/js/modules/analytics-4/components/site-goals/goal-drivers/TopAuthorsGoalDriver.stories.tsx
+++ b/assets/js/modules/analytics-4/components/site-goals/goal-drivers/TopAuthorsGoalDriver.stories.tsx
@@ -26,10 +26,7 @@ import { ReactElement } from 'react';
  */
 import { CORE_USER } from '@/js/googlesitekit/datastore/user/constants';
 import { MODULE_SLUG_ANALYTICS_4 } from '@/js/modules/analytics-4/constants';
-import {
-	DATE_RANGE_OFFSET,
-	MODULES_ANALYTICS_4,
-} from '@/js/modules/analytics-4/datastore/constants';
+import { MODULES_ANALYTICS_4 } from '@/js/modules/analytics-4/datastore/constants';
 import { Story } from '@/js/types/Story';
 import {
 	provideModules,
@@ -111,9 +108,7 @@ function getTopAuthorsReportOptions(
 	registry: Parameters< typeof provideModules >[ 0 ],
 	goalType = GOAL_TYPES.ECOMMERCE
 ) {
-	const dates = registry.select( CORE_USER ).getDateRangeDates( {
-		offsetDays: DATE_RANGE_OFFSET,
-	} );
+	const dates = registry.select( CORE_USER ).getDateRangeDates();
 	const dimensionFilters = {
 		eventName: {
 			filterType: 'inListFilter',

--- a/assets/js/modules/analytics-4/components/site-goals/goal-drivers/TopAuthorsGoalDriver.tsx
+++ b/assets/js/modules/analytics-4/components/site-goals/goal-drivers/TopAuthorsGoalDriver.tsx
@@ -50,7 +50,6 @@ import {
 	normalizePrimaryEvents,
 } from '@/js/modules/analytics-4/components/site-goals/goal-drivers/utils';
 import {
-	DATE_RANGE_OFFSET,
 	EDIT_SCOPE,
 	FORM_CUSTOM_DIMENSIONS_CREATE,
 	MODULES_ANALYTICS_4,
@@ -73,10 +72,7 @@ const TopAuthorsGoalDriver: FC< GoalDriverComponentProps > = ( {
 	onExpandableRowsChange,
 } ) => {
 	const dates = useSelect(
-		( select: Select ) =>
-			select( CORE_USER ).getDateRangeDates( {
-				offsetDays: DATE_RANGE_OFFSET,
-			} ),
+		( select: Select ) => select( CORE_USER ).getDateRangeDates(),
 		[]
 	);
 	const eventNames = useMemo(

--- a/assets/js/modules/analytics-4/components/site-goals/goal-drivers/TopPagesGoalDriver.tsx
+++ b/assets/js/modules/analytics-4/components/site-goals/goal-drivers/TopPagesGoalDriver.tsx
@@ -47,10 +47,7 @@ import {
 	getDimensionFiltersForEvents,
 	normalizePrimaryEvents,
 } from '@/js/modules/analytics-4/components/site-goals/goal-drivers/utils';
-import {
-	DATE_RANGE_OFFSET,
-	MODULES_ANALYTICS_4,
-} from '@/js/modules/analytics-4/datastore/constants';
+import { MODULES_ANALYTICS_4 } from '@/js/modules/analytics-4/datastore/constants';
 import { decodeAmpersand } from '@/js/modules/analytics-4/utils';
 import { numFmt } from '@/js/util';
 
@@ -71,10 +68,7 @@ const TopPagesGoalDriver: FC< GoalDriverComponentProps > = ( {
 } ) => {
 	const headerLabel = __( 'Events', 'google-site-kit' );
 	const dates = useSelect(
-		( select: Select ) =>
-			select( CORE_USER ).getDateRangeDates( {
-				offsetDays: DATE_RANGE_OFFSET,
-			} ),
+		( select: Select ) => select( CORE_USER ).getDateRangeDates(),
 		[]
 	);
 	const reportOptions = useMemo( () => {
@@ -185,9 +179,7 @@ const TopPagesGoalDriver: FC< GoalDriverComponentProps > = ( {
 				return {};
 			}
 
-			const reportDates = select( CORE_USER ).getDateRangeDates( {
-				offsetDays: DATE_RANGE_OFFSET,
-			} );
+			const reportDates = select( CORE_USER ).getDateRangeDates();
 
 			if ( ! reportDates ) {
 				return {};

--- a/assets/js/modules/analytics-4/components/site-goals/goal-drivers/TopTrafficChannelsGoalDriver.tsx
+++ b/assets/js/modules/analytics-4/components/site-goals/goal-drivers/TopTrafficChannelsGoalDriver.tsx
@@ -47,10 +47,7 @@ import {
 	getDimensionFiltersForEvents,
 	normalizePrimaryEvents,
 } from '@/js/modules/analytics-4/components/site-goals/goal-drivers/utils';
-import {
-	DATE_RANGE_OFFSET,
-	MODULES_ANALYTICS_4,
-} from '@/js/modules/analytics-4/datastore/constants';
+import { MODULES_ANALYTICS_4 } from '@/js/modules/analytics-4/datastore/constants';
 import { numFmt } from '@/js/util';
 
 interface ReportRow {
@@ -69,10 +66,7 @@ const TopTrafficChannelsGoalDriver: FC< GoalDriverComponentProps > = ( {
 	onExpandableRowsChange,
 } ) => {
 	const dates = useSelect(
-		( select: Select ) =>
-			select( CORE_USER ).getDateRangeDates( {
-				offsetDays: DATE_RANGE_OFFSET,
-			} ),
+		( select: Select ) => select( CORE_USER ).getDateRangeDates(),
 		[]
 	);
 	const eventNames = useMemo(

--- a/assets/js/modules/analytics-4/components/site-goals/goal-drivers/TopTrafficChannelsRateGoalDriver.tsx
+++ b/assets/js/modules/analytics-4/components/site-goals/goal-drivers/TopTrafficChannelsRateGoalDriver.tsx
@@ -47,10 +47,7 @@ import {
 	getDimensionFiltersForEvents,
 	normalizePrimaryEvents,
 } from '@/js/modules/analytics-4/components/site-goals/goal-drivers/utils';
-import {
-	DATE_RANGE_OFFSET,
-	MODULES_ANALYTICS_4,
-} from '@/js/modules/analytics-4/datastore/constants';
+import { MODULES_ANALYTICS_4 } from '@/js/modules/analytics-4/datastore/constants';
 import { numFmt } from '@/js/util';
 
 interface ReportRow {
@@ -69,10 +66,7 @@ const TopTrafficChannelsRateGoalDriver: FC< GoalDriverComponentProps > = ( {
 	onExpandableRowsChange,
 } ) => {
 	const dates = useSelect(
-		( select: Select ) =>
-			select( CORE_USER ).getDateRangeDates( {
-				offsetDays: DATE_RANGE_OFFSET,
-			} ),
+		( select: Select ) => select( CORE_USER ).getDateRangeDates(),
 		[]
 	);
 	const reportOptions = useMemo( () => {

--- a/assets/js/modules/analytics-4/components/site-goals/goal-drivers/VisitorTypeGoalDriver.tsx
+++ b/assets/js/modules/analytics-4/components/site-goals/goal-drivers/VisitorTypeGoalDriver.tsx
@@ -47,10 +47,7 @@ import {
 	getDimensionFiltersForEvents,
 	normalizePrimaryEvents,
 } from '@/js/modules/analytics-4/components/site-goals/goal-drivers/utils';
-import {
-	DATE_RANGE_OFFSET,
-	MODULES_ANALYTICS_4,
-} from '@/js/modules/analytics-4/datastore/constants';
+import { MODULES_ANALYTICS_4 } from '@/js/modules/analytics-4/datastore/constants';
 import { numFmt } from '@/js/util';
 
 interface ReportRow {
@@ -74,10 +71,7 @@ const VisitorTypeGoalDriver: FC< GoalDriverComponentProps > = ( {
 	onExpandableRowsChange,
 } ) => {
 	const dates = useSelect(
-		( select: Select ) =>
-			select( CORE_USER ).getDateRangeDates( {
-				offsetDays: DATE_RANGE_OFFSET,
-			} ),
+		( select: Select ) => select( CORE_USER ).getDateRangeDates(),
 		[]
 	);
 	const eventNames = useMemo(

--- a/assets/js/modules/analytics-4/components/site-goals/widgets/LeadGenerationPerformanceWidget.stories.tsx
+++ b/assets/js/modules/analytics-4/components/site-goals/widgets/LeadGenerationPerformanceWidget.stories.tsx
@@ -50,7 +50,7 @@ import {
 import WithRegistrySetup from '@tests/js/WithRegistrySetup';
 import LeadGenerationPerformanceWidget from './LeadGenerationPerformanceWidget';
 
-// Reference date: 2020-09-07, offsetDays: 0, 28-day range with comparison.
+// Reference date: 2020-09-07, 28-day range with comparison.
 const dates = {
 	startDate: '2020-08-11',
 	endDate: '2020-09-07',

--- a/assets/js/modules/analytics-4/components/site-goals/widgets/LeadGenerationPerformanceWidget.test.tsx
+++ b/assets/js/modules/analytics-4/components/site-goals/widgets/LeadGenerationPerformanceWidget.test.tsx
@@ -30,7 +30,6 @@ import {
 } from '@/js/modules/analytics-4/components/site-goals/goal-drivers/constants';
 import { MODULE_SLUG_ANALYTICS_4 } from '@/js/modules/analytics-4/constants';
 import {
-	DATE_RANGE_OFFSET,
 	ENUM_CONVERSION_EVENTS,
 	MODULES_ANALYTICS_4,
 } from '@/js/modules/analytics-4/datastore/constants';
@@ -84,9 +83,7 @@ describe( 'LeadGenerationPerformanceWidget', () => {
 			loading = false,
 		}: { empty?: boolean; loading?: boolean } = {}
 	) {
-		const dates = registry.select( CORE_USER ).getDateRangeDates( {
-			offsetDays: DATE_RANGE_OFFSET,
-		} );
+		const dates = registry.select( CORE_USER ).getDateRangeDates();
 
 		const dimensionFilters = {
 			eventName: {
@@ -485,7 +482,6 @@ describe( 'LeadGenerationPerformanceWidget', () => {
 			.setDetectedEvents( [ ENUM_CONVERSION_EVENTS.GENERATE_LEAD ] );
 
 		const dates = registry.select( CORE_USER ).getDateRangeDates( {
-			offsetDays: DATE_RANGE_OFFSET,
 			compare: true,
 		} );
 
@@ -540,7 +536,6 @@ describe( 'LeadGenerationPerformanceWidget', () => {
 			.setDetectedEvents( [ ENUM_CONVERSION_EVENTS.GENERATE_LEAD ] );
 
 		const dates = registry.select( CORE_USER ).getDateRangeDates( {
-			offsetDays: DATE_RANGE_OFFSET,
 			compare: true,
 		} );
 
@@ -575,7 +570,6 @@ describe( 'LeadGenerationPerformanceWidget', () => {
 			] );
 
 		const dates = registry.select( CORE_USER ).getDateRangeDates( {
-			offsetDays: DATE_RANGE_OFFSET,
 			compare: true,
 		} );
 
@@ -679,7 +673,6 @@ describe( 'LeadGenerationPerformanceWidget', () => {
 			.setDetectedEvents( [ ENUM_CONVERSION_EVENTS.SUBMIT_LEAD_FORM ] );
 
 		const dates = registry.select( CORE_USER ).getDateRangeDates( {
-			offsetDays: DATE_RANGE_OFFSET,
 			compare: true,
 		} );
 
@@ -723,7 +716,6 @@ describe( 'LeadGenerationPerformanceWidget', () => {
 			.setDetectedEvents( [ ENUM_CONVERSION_EVENTS.GENERATE_LEAD ] );
 
 		const dates = registry.select( CORE_USER ).getDateRangeDates( {
-			offsetDays: DATE_RANGE_OFFSET,
 			compare: true,
 		} );
 
@@ -769,7 +761,6 @@ describe( 'LeadGenerationPerformanceWidget', () => {
 			.setDetectedEvents( [ ENUM_CONVERSION_EVENTS.GENERATE_LEAD ] );
 
 		const dates = registry.select( CORE_USER ).getDateRangeDates( {
-			offsetDays: DATE_RANGE_OFFSET,
 			compare: true,
 		} );
 
@@ -814,14 +805,11 @@ describe( 'LeadGenerationPerformanceWidget', () => {
 			.setDetectedEvents( [ ENUM_CONVERSION_EVENTS.GENERATE_LEAD ] );
 
 		const dates = registry.select( CORE_USER ).getDateRangeDates( {
-			offsetDays: DATE_RANGE_OFFSET,
 			compare: true,
 		} );
 		const goalDriverDates = registry
 			.select( CORE_USER )
-			.getDateRangeDates( {
-				offsetDays: DATE_RANGE_OFFSET,
-			} );
+			.getDateRangeDates();
 
 		const leadEventsReport = buildLeadEventsReportOptions( dates, [
 			ENUM_CONVERSION_EVENTS.GENERATE_LEAD,
@@ -895,7 +883,6 @@ describe( 'LeadGenerationPerformanceWidget', () => {
 			.setDetectedEvents( [ ENUM_CONVERSION_EVENTS.GENERATE_LEAD ] );
 
 		const dates = registry.select( CORE_USER ).getDateRangeDates( {
-			offsetDays: DATE_RANGE_OFFSET,
 			compare: true,
 		} );
 
@@ -930,7 +917,6 @@ describe( 'LeadGenerationPerformanceWidget', () => {
 			] );
 
 		const dates = registry.select( CORE_USER ).getDateRangeDates( {
-			offsetDays: DATE_RANGE_OFFSET,
 			compare: true,
 		} );
 

--- a/assets/js/modules/analytics-4/components/site-goals/widgets/LeadGenerationPerformanceWidget.tsx
+++ b/assets/js/modules/analytics-4/components/site-goals/widgets/LeadGenerationPerformanceWidget.tsx
@@ -59,10 +59,7 @@ import {
 } from '@/js/modules/analytics-4/components/site-goals/utils/formats';
 import { processReports } from '@/js/modules/analytics-4/components/site-goals/utils/reports';
 import { VisitorEngagementTiles } from '@/js/modules/analytics-4/components/site-goals/visitor-engagement';
-import {
-	DATE_RANGE_OFFSET,
-	MODULES_ANALYTICS_4,
-} from '@/js/modules/analytics-4/datastore/constants';
+import { MODULES_ANALYTICS_4 } from '@/js/modules/analytics-4/datastore/constants';
 import { ReportOptions } from '@/js/modules/analytics-4/datastore/types';
 import { numFmt } from '@/js/util';
 
@@ -126,7 +123,6 @@ const LeadGenerationPerformanceWidget: FC<
 	const dates = useSelect(
 		( select: Select ) =>
 			select( CORE_USER ).getDateRangeDates( {
-				offsetDays: DATE_RANGE_OFFSET,
 				compare: true,
 			} ),
 		[]

--- a/assets/js/modules/analytics-4/components/site-goals/widgets/OnlineStorePerformanceWidget.stories.tsx
+++ b/assets/js/modules/analytics-4/components/site-goals/widgets/OnlineStorePerformanceWidget.stories.tsx
@@ -50,7 +50,7 @@ import {
 import WithRegistrySetup from '@tests/js/WithRegistrySetup';
 import OnlineStorePerformanceWidget from './OnlineStorePerformanceWidget';
 
-// Reference date: 2020-09-07, offsetDays: 0, 28-day range with comparison.
+// Reference date: 2020-09-07, 28-day range with comparison.
 const dates = {
 	startDate: '2020-08-11',
 	endDate: '2020-09-07',

--- a/assets/js/modules/analytics-4/components/site-goals/widgets/OnlineStorePerformanceWidget.test.tsx
+++ b/assets/js/modules/analytics-4/components/site-goals/widgets/OnlineStorePerformanceWidget.test.tsx
@@ -35,7 +35,6 @@ import {
 } from '@/js/modules/analytics-4/components/site-goals/goal-drivers/constants';
 import { MODULE_SLUG_ANALYTICS_4 } from '@/js/modules/analytics-4/constants';
 import {
-	DATE_RANGE_OFFSET,
 	ENUM_CONVERSION_EVENTS,
 	MODULES_ANALYTICS_4,
 } from '@/js/modules/analytics-4/datastore/constants';
@@ -98,9 +97,7 @@ describe( 'OnlineStorePerformanceWidget', () => {
 			loading = false,
 		}: { empty?: boolean; loading?: boolean } = {}
 	) {
-		const dates = registry.select( CORE_USER ).getDateRangeDates( {
-			offsetDays: DATE_RANGE_OFFSET,
-		} );
+		const dates = registry.select( CORE_USER ).getDateRangeDates();
 
 		const dimensionFilters = {
 			eventName: {
@@ -541,7 +538,6 @@ describe( 'OnlineStorePerformanceWidget', () => {
 			.setDetectedEvents( [ ENUM_CONVERSION_EVENTS.PURCHASE ] );
 
 		const dates = registry.select( CORE_USER ).getDateRangeDates( {
-			offsetDays: DATE_RANGE_OFFSET,
 			compare: true,
 		} );
 
@@ -597,7 +593,6 @@ describe( 'OnlineStorePerformanceWidget', () => {
 			.setDetectedEvents( [ ENUM_CONVERSION_EVENTS.PURCHASE ] );
 
 		const dates = registry.select( CORE_USER ).getDateRangeDates( {
-			offsetDays: DATE_RANGE_OFFSET,
 			compare: true,
 		} );
 
@@ -630,7 +625,6 @@ describe( 'OnlineStorePerformanceWidget', () => {
 			.setDetectedEvents( [ ENUM_CONVERSION_EVENTS.ADD_TO_CART ] );
 
 		const dates = registry.select( CORE_USER ).getDateRangeDates( {
-			offsetDays: DATE_RANGE_OFFSET,
 			compare: true,
 		} );
 
@@ -671,7 +665,6 @@ describe( 'OnlineStorePerformanceWidget', () => {
 			] );
 
 		const dates = registry.select( CORE_USER ).getDateRangeDates( {
-			offsetDays: DATE_RANGE_OFFSET,
 			compare: true,
 		} );
 
@@ -713,7 +706,6 @@ describe( 'OnlineStorePerformanceWidget', () => {
 			.setDetectedEvents( [ ENUM_CONVERSION_EVENTS.PURCHASE ] );
 
 		const dates = registry.select( CORE_USER ).getDateRangeDates( {
-			offsetDays: DATE_RANGE_OFFSET,
 			compare: true,
 		} );
 
@@ -758,7 +750,6 @@ describe( 'OnlineStorePerformanceWidget', () => {
 			.setDetectedEvents( [ ENUM_CONVERSION_EVENTS.PURCHASE ] );
 
 		const dates = registry.select( CORE_USER ).getDateRangeDates( {
-			offsetDays: DATE_RANGE_OFFSET,
 			compare: true,
 		} );
 
@@ -805,7 +796,6 @@ describe( 'OnlineStorePerformanceWidget', () => {
 			.setDetectedEvents( [ ENUM_CONVERSION_EVENTS.PURCHASE ] );
 
 		const dates = registry.select( CORE_USER ).getDateRangeDates( {
-			offsetDays: DATE_RANGE_OFFSET,
 			compare: true,
 		} );
 
@@ -851,14 +841,11 @@ describe( 'OnlineStorePerformanceWidget', () => {
 			.setDetectedEvents( [ ENUM_CONVERSION_EVENTS.PURCHASE ] );
 
 		const dates = registry.select( CORE_USER ).getDateRangeDates( {
-			offsetDays: DATE_RANGE_OFFSET,
 			compare: true,
 		} );
 		const goalDriverDates = registry
 			.select( CORE_USER )
-			.getDateRangeDates( {
-				offsetDays: DATE_RANGE_OFFSET,
-			} );
+			.getDateRangeDates();
 
 		const primaryEventReport = buildPrimaryEventReportOptions(
 			dates,
@@ -933,7 +920,6 @@ describe( 'OnlineStorePerformanceWidget', () => {
 			.setDetectedEvents( [ ENUM_CONVERSION_EVENTS.PURCHASE ] );
 
 		const dates = registry.select( CORE_USER ).getDateRangeDates( {
-			offsetDays: DATE_RANGE_OFFSET,
 			compare: true,
 		} );
 
@@ -968,7 +954,6 @@ describe( 'OnlineStorePerformanceWidget', () => {
 			] );
 
 		const dates = registry.select( CORE_USER ).getDateRangeDates( {
-			offsetDays: DATE_RANGE_OFFSET,
 			compare: true,
 		} );
 
@@ -1031,7 +1016,6 @@ describe( 'OnlineStorePerformanceWidget', () => {
 			] );
 
 		const dates = registry.select( CORE_USER ).getDateRangeDates( {
-			offsetDays: DATE_RANGE_OFFSET,
 			compare: true,
 		} );
 
@@ -1079,7 +1063,6 @@ describe( 'OnlineStorePerformanceWidget', () => {
 			] );
 
 		const dates = registry.select( CORE_USER ).getDateRangeDates( {
-			offsetDays: DATE_RANGE_OFFSET,
 			compare: true,
 		} );
 
@@ -1140,7 +1123,6 @@ describe( 'OnlineStorePerformanceWidget', () => {
 		} );
 
 		const dates = registry.select( CORE_USER ).getDateRangeDates( {
-			offsetDays: DATE_RANGE_OFFSET,
 			compare: true,
 		} );
 
@@ -1173,7 +1155,6 @@ describe( 'OnlineStorePerformanceWidget', () => {
 			.setDetectedEvents( [ ENUM_CONVERSION_EVENTS.ADD_TO_CART ] );
 
 		const dates = registry.select( CORE_USER ).getDateRangeDates( {
-			offsetDays: DATE_RANGE_OFFSET,
 			compare: true,
 		} );
 

--- a/assets/js/modules/analytics-4/components/site-goals/widgets/OnlineStorePerformanceWidget.tsx
+++ b/assets/js/modules/analytics-4/components/site-goals/widgets/OnlineStorePerformanceWidget.tsx
@@ -64,10 +64,7 @@ import {
 	VisitorEngagementTiles,
 	resolveVisitorEngagementSelectionState,
 } from '@/js/modules/analytics-4/components/site-goals/visitor-engagement';
-import {
-	DATE_RANGE_OFFSET,
-	MODULES_ANALYTICS_4,
-} from '@/js/modules/analytics-4/datastore/constants';
+import { MODULES_ANALYTICS_4 } from '@/js/modules/analytics-4/datastore/constants';
 import { ReportOptions } from '@/js/modules/analytics-4/datastore/types';
 import { numFmt } from '@/js/util';
 
@@ -221,7 +218,6 @@ const OnlineStorePerformanceWidget: FC<
 	const dates = useSelect(
 		( select: Select ) =>
 			select( CORE_USER ).getDateRangeDates( {
-				offsetDays: DATE_RANGE_OFFSET,
 				compare: true,
 			} ),
 		[]

--- a/assets/js/modules/analytics-4/components/widgets/EngagedTrafficSourceWidget.js
+++ b/assets/js/modules/analytics-4/components/widgets/EngagedTrafficSourceWidget.js
@@ -37,10 +37,7 @@ import {
 	KM_ANALYTICS_ENGAGED_TRAFFIC_SOURCE,
 } from '@/js/googlesitekit/datastore/user/constants';
 import { MODULE_SLUG_ANALYTICS_4 } from '@/js/modules/analytics-4/constants';
-import {
-	DATE_RANGE_OFFSET,
-	MODULES_ANALYTICS_4,
-} from '@/js/modules/analytics-4/datastore/constants';
+import { MODULES_ANALYTICS_4 } from '@/js/modules/analytics-4/datastore/constants';
 import { numFmt } from '@/js/util';
 import whenActive from '@/js/util/when-active';
 import ConnectGA4CTATileWidget from './ConnectGA4CTATileWidget';
@@ -50,7 +47,6 @@ function EngagedTrafficSourceWidget( props ) {
 
 	const dates = useSelect( ( select ) =>
 		select( CORE_USER ).getDateRangeDates( {
-			offsetDays: DATE_RANGE_OFFSET,
 			compare: true,
 		} )
 	);

--- a/assets/js/modules/analytics-4/components/widgets/EngagedTrafficSourceWidget.test.js
+++ b/assets/js/modules/analytics-4/components/widgets/EngagedTrafficSourceWidget.test.js
@@ -27,7 +27,6 @@ import { withConnected } from '@/js/googlesitekit/modules/datastore/__fixtures__
 import { getWidgetComponentProps } from '@/js/googlesitekit/widgets/util';
 import { MODULE_SLUG_ANALYTICS_4 } from '@/js/modules/analytics-4/constants';
 import * as analyticsFixtures from '@/js/modules/analytics-4/datastore/__fixtures__';
-import { DATE_RANGE_OFFSET } from '@/js/modules/analytics-4/datastore/constants';
 import { provideAnalytics4MockReport } from '@/js/modules/analytics-4/utils/data-mock';
 import {
 	ERROR_INTERNAL_SERVER_ERROR,
@@ -70,7 +69,6 @@ describe( 'EngagedTrafficSourceWidget', () => {
 	it( 'should render correctly with the expected metrics', async () => {
 		provideAnalytics4MockReport( registry, {
 			...registry.select( CORE_USER ).getDateRangeDates( {
-				offsetDays: DATE_RANGE_OFFSET,
 				compare: true,
 			} ),
 			dimensions: [ 'sessionDefaultChannelGroup' ],

--- a/assets/js/modules/analytics-4/components/widgets/LeastEngagingPagesWidget.js
+++ b/assets/js/modules/analytics-4/components/widgets/LeastEngagingPagesWidget.js
@@ -37,10 +37,7 @@ import {
 import useViewOnly from '@/js/hooks/useViewOnly';
 import { ZeroDataMessage } from '@/js/modules/analytics-4/components/common';
 import { MODULE_SLUG_ANALYTICS_4 } from '@/js/modules/analytics-4/constants';
-import {
-	DATE_RANGE_OFFSET,
-	MODULES_ANALYTICS_4,
-} from '@/js/modules/analytics-4/datastore/constants';
+import { MODULES_ANALYTICS_4 } from '@/js/modules/analytics-4/datastore/constants';
 import { decodeAmpersand } from '@/js/modules/analytics-4/utils';
 import { numFmt } from '@/js/util';
 import whenActive from '@/js/util/when-active';
@@ -52,9 +49,7 @@ function LeastEngagingPagesWidget( props ) {
 	const viewOnlyDashboard = useViewOnly();
 
 	const dates = useSelect( ( select ) =>
-		select( CORE_USER ).getDateRangeDates( {
-			offsetDays: DATE_RANGE_OFFSET,
-		} )
+		select( CORE_USER ).getDateRangeDates()
 	);
 
 	const pageViewsReportOptions = {

--- a/assets/js/modules/analytics-4/components/widgets/LeastEngagingPagesWidget.test.js
+++ b/assets/js/modules/analytics-4/components/widgets/LeastEngagingPagesWidget.test.js
@@ -26,10 +26,7 @@ import {
 import { withConnected } from '@/js/googlesitekit/modules/datastore/__fixtures__';
 import { getWidgetComponentProps } from '@/js/googlesitekit/widgets/util';
 import { MODULE_SLUG_ANALYTICS_4 } from '@/js/modules/analytics-4/constants';
-import {
-	DATE_RANGE_OFFSET,
-	MODULES_ANALYTICS_4,
-} from '@/js/modules/analytics-4/datastore/constants';
+import { MODULES_ANALYTICS_4 } from '@/js/modules/analytics-4/datastore/constants';
 import {
 	STRATEGY_ZIP,
 	getAnalytics4MockResponse,
@@ -68,9 +65,7 @@ describe( 'LeastEngagingPagesWidget', () => {
 
 	it( 'should render correctly with the expected metrics', async () => {
 		const pageViewsReportOptions = {
-			...registry
-				.select( CORE_USER )
-				.getDateRangeDates( { offsetDays: DATE_RANGE_OFFSET } ),
+			...registry.select( CORE_USER ).getDateRangeDates(),
 			dimensions: [ 'pagePath' ],
 			metrics: [ { name: 'screenPageViews' } ],
 			orderby: [
@@ -83,9 +78,7 @@ describe( 'LeastEngagingPagesWidget', () => {
 				'analytics-4_least-engaging-pages-widget_widget_pageViewsReportOptions',
 		};
 		const pageTitlesReportOptions = {
-			...registry
-				.select( CORE_USER )
-				.getDateRangeDates( { offsetDays: DATE_RANGE_OFFSET } ),
+			...registry.select( CORE_USER ).getDateRangeDates(),
 			dimensionFilters: {
 				pagePath: new Array( 3 )
 					.fill( '' )
@@ -134,9 +127,7 @@ describe( 'LeastEngagingPagesWidget', () => {
 			) || 0;
 
 		const reportOptions = {
-			...registry
-				.select( CORE_USER )
-				.getDateRangeDates( { offsetDays: DATE_RANGE_OFFSET } ),
+			...registry.select( CORE_USER ).getDateRangeDates(),
 			dimensions: [ 'pagePath' ],
 			metrics: [ 'bounceRate', 'screenPageViews' ],
 			orderby: [

--- a/assets/js/modules/analytics-4/components/widgets/MostEngagingPagesWidget.js
+++ b/assets/js/modules/analytics-4/components/widgets/MostEngagingPagesWidget.js
@@ -37,10 +37,7 @@ import {
 import useViewOnly from '@/js/hooks/useViewOnly';
 import { ZeroDataMessage } from '@/js/modules/analytics-4/components/common';
 import { MODULE_SLUG_ANALYTICS_4 } from '@/js/modules/analytics-4/constants';
-import {
-	DATE_RANGE_OFFSET,
-	MODULES_ANALYTICS_4,
-} from '@/js/modules/analytics-4/datastore/constants';
+import { MODULES_ANALYTICS_4 } from '@/js/modules/analytics-4/datastore/constants';
 import { decodeAmpersand } from '@/js/modules/analytics-4/utils';
 import { numFmt } from '@/js/util';
 import whenActive from '@/js/util/when-active';
@@ -52,9 +49,7 @@ function MostEngagingPagesWidget( props ) {
 	const viewOnlyDashboard = useViewOnly();
 
 	const dates = useSelect( ( select ) =>
-		select( CORE_USER ).getDateRangeDates( {
-			offsetDays: DATE_RANGE_OFFSET,
-		} )
+		select( CORE_USER ).getDateRangeDates()
 	);
 
 	const pageViewsReportOptions = {

--- a/assets/js/modules/analytics-4/components/widgets/MostEngagingPagesWidget.test.js
+++ b/assets/js/modules/analytics-4/components/widgets/MostEngagingPagesWidget.test.js
@@ -26,10 +26,7 @@ import {
 import { withConnected } from '@/js/googlesitekit/modules/datastore/__fixtures__';
 import { getWidgetComponentProps } from '@/js/googlesitekit/widgets/util';
 import { MODULE_SLUG_ANALYTICS_4 } from '@/js/modules/analytics-4/constants';
-import {
-	DATE_RANGE_OFFSET,
-	MODULES_ANALYTICS_4,
-} from '@/js/modules/analytics-4/datastore/constants';
+import { MODULES_ANALYTICS_4 } from '@/js/modules/analytics-4/datastore/constants';
 import {
 	STRATEGY_ZIP,
 	getAnalytics4MockResponse,
@@ -68,9 +65,7 @@ describe( 'MostEngagingPagesWidget', () => {
 
 	it( 'should render correctly with the expected metrics', async () => {
 		const pageViewsReportOptions = {
-			...registry
-				.select( CORE_USER )
-				.getDateRangeDates( { offsetDays: DATE_RANGE_OFFSET } ),
+			...registry.select( CORE_USER ).getDateRangeDates(),
 			dimensions: [ 'pagePath' ],
 			metrics: [ { name: 'screenPageViews' } ],
 			limit: 1,
@@ -79,9 +74,7 @@ describe( 'MostEngagingPagesWidget', () => {
 		};
 
 		const pageTitlesReportOptions = {
-			...registry
-				.select( CORE_USER )
-				.getDateRangeDates( { offsetDays: DATE_RANGE_OFFSET } ),
+			...registry.select( CORE_USER ).getDateRangeDates(),
 			dimensionFilters: {
 				pagePath: new Array( 3 )
 					.fill( '' )
@@ -128,9 +121,7 @@ describe( 'MostEngagingPagesWidget', () => {
 			) || 0;
 
 		const reportOptions = {
-			...registry
-				.select( CORE_USER )
-				.getDateRangeDates( { offsetDays: DATE_RANGE_OFFSET } ),
+			...registry.select( CORE_USER ).getDateRangeDates(),
 			dimensions: [ 'pagePath' ],
 			metrics: [ 'engagementRate', 'screenPageViews' ],
 			orderby: [

--- a/assets/js/modules/analytics-4/components/widgets/NewVisitorsWidget.js
+++ b/assets/js/modules/analytics-4/components/widgets/NewVisitorsWidget.js
@@ -37,10 +37,7 @@ import {
 	KM_ANALYTICS_NEW_VISITORS,
 } from '@/js/googlesitekit/datastore/user/constants';
 import { MODULE_SLUG_ANALYTICS_4 } from '@/js/modules/analytics-4/constants';
-import {
-	DATE_RANGE_OFFSET,
-	MODULES_ANALYTICS_4,
-} from '@/js/modules/analytics-4/datastore/constants';
+import { MODULES_ANALYTICS_4 } from '@/js/modules/analytics-4/datastore/constants';
 import { numFmt } from '@/js/util/i18n';
 import whenActive from '@/js/util/when-active';
 import ConnectGA4CTATileWidget from './ConnectGA4CTATileWidget';
@@ -48,7 +45,6 @@ import ConnectGA4CTATileWidget from './ConnectGA4CTATileWidget';
 function NewVisitorsWidget( { Widget } ) {
 	const dates = useSelect( ( select ) =>
 		select( CORE_USER ).getDateRangeDates( {
-			offsetDays: DATE_RANGE_OFFSET,
 			compare: true,
 		} )
 	);

--- a/assets/js/modules/analytics-4/components/widgets/NewVisitorsWidget.test.js
+++ b/assets/js/modules/analytics-4/components/widgets/NewVisitorsWidget.test.js
@@ -27,7 +27,6 @@ import { withConnected } from '@/js/googlesitekit/modules/datastore/__fixtures__
 import { getWidgetComponentProps } from '@/js/googlesitekit/widgets/util';
 import { MODULE_SLUG_ANALYTICS_4 } from '@/js/modules/analytics-4/constants';
 import * as analyticsFixtures from '@/js/modules/analytics-4/datastore/__fixtures__';
-import { DATE_RANGE_OFFSET } from '@/js/modules/analytics-4/datastore/constants';
 import { provideAnalytics4MockReport } from '@/js/modules/analytics-4/utils/data-mock';
 import {
 	ERROR_INTERNAL_SERVER_ERROR,
@@ -70,7 +69,6 @@ describe( 'NewVisitorsWidget', () => {
 	it( 'should render correctly with the expected metrics', async () => {
 		provideAnalytics4MockReport( registry, {
 			...registry.select( CORE_USER ).getDateRangeDates( {
-				offsetDays: DATE_RANGE_OFFSET,
 				compare: true,
 			} ),
 			dimensions: [ 'newVsReturning' ],

--- a/assets/js/modules/analytics-4/components/widgets/PagesPerVisitWidget.js
+++ b/assets/js/modules/analytics-4/components/widgets/PagesPerVisitWidget.js
@@ -37,10 +37,7 @@ import {
 	KM_ANALYTICS_PAGES_PER_VISIT,
 } from '@/js/googlesitekit/datastore/user/constants';
 import { MODULE_SLUG_ANALYTICS_4 } from '@/js/modules/analytics-4/constants';
-import {
-	DATE_RANGE_OFFSET,
-	MODULES_ANALYTICS_4,
-} from '@/js/modules/analytics-4/datastore/constants';
+import { MODULES_ANALYTICS_4 } from '@/js/modules/analytics-4/datastore/constants';
 import { numFmt } from '@/js/util/i18n';
 import whenActive from '@/js/util/when-active';
 import ConnectGA4CTATileWidget from './ConnectGA4CTATileWidget';
@@ -48,7 +45,6 @@ import ConnectGA4CTATileWidget from './ConnectGA4CTATileWidget';
 function PagesPerVisitWidget( { Widget } ) {
 	const dates = useSelect( ( select ) =>
 		select( CORE_USER ).getDateRangeDates( {
-			offsetDays: DATE_RANGE_OFFSET,
 			compare: true,
 		} )
 	);

--- a/assets/js/modules/analytics-4/components/widgets/PagesPerVisitWidget.test.js
+++ b/assets/js/modules/analytics-4/components/widgets/PagesPerVisitWidget.test.js
@@ -26,10 +26,7 @@ import {
 import { withConnected } from '@/js/googlesitekit/modules/datastore/__fixtures__';
 import { getWidgetComponentProps } from '@/js/googlesitekit/widgets/util';
 import { MODULE_SLUG_ANALYTICS_4 } from '@/js/modules/analytics-4/constants';
-import {
-	DATE_RANGE_OFFSET,
-	MODULES_ANALYTICS_4,
-} from '@/js/modules/analytics-4/datastore/constants';
+import { MODULES_ANALYTICS_4 } from '@/js/modules/analytics-4/datastore/constants';
 import { getAnalytics4MockResponse } from '@/js/modules/analytics-4/utils/data-mock';
 import {
 	ERROR_INTERNAL_SERVER_ERROR,
@@ -65,7 +62,6 @@ describe( 'PagesPerVisitWidget', () => {
 	it( 'should render correctly with the expected metrics', async () => {
 		const reportOptions = {
 			...registry.select( CORE_USER ).getDateRangeDates( {
-				offsetDays: DATE_RANGE_OFFSET,
 				compare: true,
 			} ),
 			metrics: [

--- a/assets/js/modules/analytics-4/components/widgets/PopularAuthorsWidget.js
+++ b/assets/js/modules/analytics-4/components/widgets/PopularAuthorsWidget.js
@@ -40,10 +40,7 @@ import {
 } from '@/js/googlesitekit/datastore/user/constants';
 import { ZeroDataMessage } from '@/js/modules/analytics-4/components/common';
 import { MODULE_SLUG_ANALYTICS_4 } from '@/js/modules/analytics-4/constants';
-import {
-	DATE_RANGE_OFFSET,
-	MODULES_ANALYTICS_4,
-} from '@/js/modules/analytics-4/datastore/constants';
+import { MODULES_ANALYTICS_4 } from '@/js/modules/analytics-4/datastore/constants';
 import withCustomDimensions from '@/js/modules/analytics-4/utils/withCustomDimensions';
 import { numFmt } from '@/js/util';
 import whenActive from '@/js/util/when-active';
@@ -58,9 +55,7 @@ import ConnectGA4CTATileWidget from './ConnectGA4CTATileWidget';
  * @return {Object} The report options.
  */
 function getPopularAuthorsWidgetReportOptions( select ) {
-	const dates = select( CORE_USER ).getDateRangeDates( {
-		offsetDays: DATE_RANGE_OFFSET,
-	} );
+	const dates = select( CORE_USER ).getDateRangeDates();
 
 	return {
 		...dates,

--- a/assets/js/modules/analytics-4/components/widgets/PopularAuthorsWidget.test.js
+++ b/assets/js/modules/analytics-4/components/widgets/PopularAuthorsWidget.test.js
@@ -27,10 +27,7 @@ import {
 import { withConnected } from '@/js/googlesitekit/modules/datastore/__fixtures__';
 import { getWidgetComponentProps } from '@/js/googlesitekit/widgets/util';
 import { MODULE_SLUG_ANALYTICS_4 } from '@/js/modules/analytics-4/constants';
-import {
-	DATE_RANGE_OFFSET,
-	MODULES_ANALYTICS_4,
-} from '@/js/modules/analytics-4/datastore/constants';
+import { MODULES_ANALYTICS_4 } from '@/js/modules/analytics-4/datastore/constants';
 import { provideCustomDimensionError } from '@/js/modules/analytics-4/utils/custom-dimensions';
 import { provideAnalytics4MockReport } from '@/js/modules/analytics-4/utils/data-mock';
 import {
@@ -90,9 +87,7 @@ describe( 'PopularAuthorsWidget', () => {
 
 	it( 'should render correctly with the expected metrics', async () => {
 		const reportOptions = {
-			...registry.select( CORE_USER ).getDateRangeDates( {
-				offsetDays: DATE_RANGE_OFFSET,
-			} ),
+			...registry.select( CORE_USER ).getDateRangeDates(),
 			dimensions: [ 'customEvent:googlesitekit_post_author' ],
 			dimensionFilters: {
 				'customEvent:googlesitekit_post_author': {

--- a/assets/js/modules/analytics-4/components/widgets/PopularContentWidget.js
+++ b/assets/js/modules/analytics-4/components/widgets/PopularContentWidget.js
@@ -37,10 +37,7 @@ import {
 import useViewOnly from '@/js/hooks/useViewOnly';
 import { ZeroDataMessage } from '@/js/modules/analytics-4/components/common';
 import { MODULE_SLUG_ANALYTICS_4 } from '@/js/modules/analytics-4/constants';
-import {
-	DATE_RANGE_OFFSET,
-	MODULES_ANALYTICS_4,
-} from '@/js/modules/analytics-4/datastore/constants';
+import { MODULES_ANALYTICS_4 } from '@/js/modules/analytics-4/datastore/constants';
 import { decodeAmpersand } from '@/js/modules/analytics-4/utils';
 import { numFmt } from '@/js/util';
 import whenActive from '@/js/util/when-active';
@@ -52,9 +49,7 @@ function PopularContentWidget( props ) {
 	const viewOnlyDashboard = useViewOnly();
 
 	const dates = useSelect( ( select ) =>
-		select( CORE_USER ).getDateRangeDates( {
-			offsetDays: DATE_RANGE_OFFSET,
-		} )
+		select( CORE_USER ).getDateRangeDates()
 	);
 
 	const reportOptions = {

--- a/assets/js/modules/analytics-4/components/widgets/PopularContentWidget.test.js
+++ b/assets/js/modules/analytics-4/components/widgets/PopularContentWidget.test.js
@@ -26,10 +26,7 @@ import {
 import { withConnected } from '@/js/googlesitekit/modules/datastore/__fixtures__';
 import { getWidgetComponentProps } from '@/js/googlesitekit/widgets/util';
 import { MODULE_SLUG_ANALYTICS_4 } from '@/js/modules/analytics-4/constants';
-import {
-	DATE_RANGE_OFFSET,
-	MODULES_ANALYTICS_4,
-} from '@/js/modules/analytics-4/datastore/constants';
+import { MODULES_ANALYTICS_4 } from '@/js/modules/analytics-4/datastore/constants';
 import {
 	STRATEGY_ZIP,
 	getAnalytics4MockResponse,
@@ -66,9 +63,7 @@ describe( 'PopularContentWidget', () => {
 
 	it( 'should render correctly with the expected metrics', async () => {
 		const reportOptions = {
-			...registry.select( CORE_USER ).getDateRangeDates( {
-				offsetDays: DATE_RANGE_OFFSET,
-			} ),
+			...registry.select( CORE_USER ).getDateRangeDates(),
 			dimensions: [ 'pagePath' ],
 			metrics: [ { name: 'screenPageViews' } ],
 			orderby: [
@@ -83,9 +78,7 @@ describe( 'PopularContentWidget', () => {
 		};
 
 		const pageTitlesReportOptions = {
-			...registry.select( CORE_USER ).getDateRangeDates( {
-				offsetDays: DATE_RANGE_OFFSET,
-			} ),
+			...registry.select( CORE_USER ).getDateRangeDates(),
 			dimensionFilters: {
 				pagePath: new Array( 3 )
 					.fill( '' )

--- a/assets/js/modules/analytics-4/components/widgets/PopularProductsWidget.js
+++ b/assets/js/modules/analytics-4/components/widgets/PopularProductsWidget.js
@@ -50,10 +50,7 @@ import {
 } from '@/js/googlesitekit/datastore/user/constants';
 import useViewOnly from '@/js/hooks/useViewOnly';
 import { MODULE_SLUG_ANALYTICS_4 } from '@/js/modules/analytics-4/constants';
-import {
-	DATE_RANGE_OFFSET,
-	MODULES_ANALYTICS_4,
-} from '@/js/modules/analytics-4/datastore/constants';
+import { MODULES_ANALYTICS_4 } from '@/js/modules/analytics-4/datastore/constants';
 import { decodeAmpersand } from '@/js/modules/analytics-4/utils';
 import withCustomDimensions from '@/js/modules/analytics-4/utils/withCustomDimensions';
 import { numFmt } from '@/js/util';
@@ -69,9 +66,7 @@ import ConnectGA4CTATileWidget from './ConnectGA4CTATileWidget';
  * @return {Object} The report options.
  */
 function getPopularProductsWidgetReportOptions( select ) {
-	const dates = select( CORE_USER ).getDateRangeDates( {
-		offsetDays: DATE_RANGE_OFFSET,
-	} );
+	const dates = select( CORE_USER ).getDateRangeDates();
 
 	const productPostType = select( CORE_SITE ).getProductPostType();
 
@@ -108,9 +103,7 @@ function PopularProductsWidget( props ) {
 	);
 
 	const dates = useSelect( ( select ) =>
-		select( CORE_USER ).getDateRangeDates( {
-			offsetDays: DATE_RANGE_OFFSET,
-		} )
+		select( CORE_USER ).getDateRangeDates()
 	);
 
 	const { setValue } = useDispatch( CORE_UI );

--- a/assets/js/modules/analytics-4/components/widgets/PopularProductsWidget.test.js
+++ b/assets/js/modules/analytics-4/components/widgets/PopularProductsWidget.test.js
@@ -33,10 +33,7 @@ import {
 import { withConnected } from '@/js/googlesitekit/modules/datastore/__fixtures__';
 import { getWidgetComponentProps } from '@/js/googlesitekit/widgets/util';
 import { MODULE_SLUG_ANALYTICS_4 } from '@/js/modules/analytics-4/constants';
-import {
-	DATE_RANGE_OFFSET,
-	MODULES_ANALYTICS_4,
-} from '@/js/modules/analytics-4/datastore/constants';
+import { MODULES_ANALYTICS_4 } from '@/js/modules/analytics-4/datastore/constants';
 import { provideCustomDimensionError } from '@/js/modules/analytics-4/utils/custom-dimensions';
 import {
 	STRATEGY_ZIP,
@@ -106,9 +103,7 @@ describe( 'PopularProductsWidget', () => {
 
 	it( 'should render correctly with the expected metrics', async () => {
 		const reportOptions = {
-			...registry.select( CORE_USER ).getDateRangeDates( {
-				offsetDays: DATE_RANGE_OFFSET,
-			} ),
+			...registry.select( CORE_USER ).getDateRangeDates(),
 			dimensions: [ 'pagePath' ],
 			dimensionFilters: {
 				'customEvent:googlesitekit_post_type': {
@@ -131,9 +126,7 @@ describe( 'PopularProductsWidget', () => {
 		};
 
 		const pageTitlesReportOptions = {
-			...registry.select( CORE_USER ).getDateRangeDates( {
-				offsetDays: DATE_RANGE_OFFSET,
-			} ),
+			...registry.select( CORE_USER ).getDateRangeDates(),
 			dimensionFilters: {
 				pagePath: new Array( 3 )
 					.fill( '' )

--- a/assets/js/modules/analytics-4/components/widgets/ReturningVisitorsWidget.js
+++ b/assets/js/modules/analytics-4/components/widgets/ReturningVisitorsWidget.js
@@ -37,10 +37,7 @@ import {
 	KM_ANALYTICS_RETURNING_VISITORS,
 } from '@/js/googlesitekit/datastore/user/constants';
 import { MODULE_SLUG_ANALYTICS_4 } from '@/js/modules/analytics-4/constants';
-import {
-	DATE_RANGE_OFFSET,
-	MODULES_ANALYTICS_4,
-} from '@/js/modules/analytics-4/datastore/constants';
+import { MODULES_ANALYTICS_4 } from '@/js/modules/analytics-4/datastore/constants';
 import { numFmt } from '@/js/util';
 import whenActive from '@/js/util/when-active';
 import ConnectGA4CTATileWidget from './ConnectGA4CTATileWidget';
@@ -48,7 +45,6 @@ import ConnectGA4CTATileWidget from './ConnectGA4CTATileWidget';
 function ReturningVisitorsWidget( { Widget } ) {
 	const dates = useSelect( ( select ) =>
 		select( CORE_USER ).getDateRangeDates( {
-			offsetDays: DATE_RANGE_OFFSET,
 			compare: true,
 		} )
 	);

--- a/assets/js/modules/analytics-4/components/widgets/ReturningVisitorsWidget.test.js
+++ b/assets/js/modules/analytics-4/components/widgets/ReturningVisitorsWidget.test.js
@@ -27,7 +27,6 @@ import { withConnected } from '@/js/googlesitekit/modules/datastore/__fixtures__
 import { getWidgetComponentProps } from '@/js/googlesitekit/widgets/util';
 import { MODULE_SLUG_ANALYTICS_4 } from '@/js/modules/analytics-4/constants';
 import * as analyticsFixtures from '@/js/modules/analytics-4/datastore/__fixtures__';
-import { DATE_RANGE_OFFSET } from '@/js/modules/analytics-4/datastore/constants';
 import { provideAnalytics4MockReport } from '@/js/modules/analytics-4/utils/data-mock';
 import {
 	ERROR_INTERNAL_SERVER_ERROR,
@@ -70,7 +69,6 @@ describe( 'ReturningVisitorsWidget', () => {
 	it( 'should render correctly with the expected metrics', async () => {
 		const reportOptions = {
 			...registry.select( CORE_USER ).getDateRangeDates( {
-				offsetDays: DATE_RANGE_OFFSET,
 				compare: true,
 			} ),
 			dimensions: [ 'newVsReturning' ],

--- a/assets/js/modules/analytics-4/components/widgets/TopCategoriesWidget.js
+++ b/assets/js/modules/analytics-4/components/widgets/TopCategoriesWidget.js
@@ -40,10 +40,7 @@ import {
 } from '@/js/googlesitekit/datastore/user/constants';
 import { ZeroDataMessage } from '@/js/modules/analytics-4/components/common';
 import { MODULE_SLUG_ANALYTICS_4 } from '@/js/modules/analytics-4/constants';
-import {
-	DATE_RANGE_OFFSET,
-	MODULES_ANALYTICS_4,
-} from '@/js/modules/analytics-4/datastore/constants';
+import { MODULES_ANALYTICS_4 } from '@/js/modules/analytics-4/datastore/constants';
 import { splitCategories } from '@/js/modules/analytics-4/utils';
 import withCustomDimensions from '@/js/modules/analytics-4/utils/withCustomDimensions';
 import { listFormat, numFmt } from '@/js/util';
@@ -59,9 +56,7 @@ import ConnectGA4CTATileWidget from './ConnectGA4CTATileWidget';
  * @return {Object} The report options.
  */
 function getReportOptions( select ) {
-	const dates = select( CORE_USER ).getDateRangeDates( {
-		offsetDays: DATE_RANGE_OFFSET,
-	} );
+	const dates = select( CORE_USER ).getDateRangeDates();
 
 	return {
 		...dates,

--- a/assets/js/modules/analytics-4/components/widgets/TopCategoriesWidget.test.js
+++ b/assets/js/modules/analytics-4/components/widgets/TopCategoriesWidget.test.js
@@ -27,10 +27,7 @@ import {
 import { withConnected } from '@/js/googlesitekit/modules/datastore/__fixtures__';
 import { getWidgetComponentProps } from '@/js/googlesitekit/widgets/util';
 import { MODULE_SLUG_ANALYTICS_4 } from '@/js/modules/analytics-4/constants';
-import {
-	DATE_RANGE_OFFSET,
-	MODULES_ANALYTICS_4,
-} from '@/js/modules/analytics-4/datastore/constants';
+import { MODULES_ANALYTICS_4 } from '@/js/modules/analytics-4/datastore/constants';
 import { provideCustomDimensionError } from '@/js/modules/analytics-4/utils/custom-dimensions';
 import { provideAnalytics4MockReport } from '@/js/modules/analytics-4/utils/data-mock';
 import {
@@ -95,9 +92,7 @@ describe( 'TopCategoriesWidget', () => {
 
 	it( 'should render correctly with the expected metrics', async () => {
 		const reportOptions = {
-			...registry.select( CORE_USER ).getDateRangeDates( {
-				offsetDays: DATE_RANGE_OFFSET,
-			} ),
+			...registry.select( CORE_USER ).getDateRangeDates(),
 			dimensions: [ 'customEvent:googlesitekit_post_categories' ],
 			dimensionFilters: {
 				'customEvent:googlesitekit_post_categories': {

--- a/assets/js/modules/analytics-4/components/widgets/TopCitiesDrivingAddToCartWidget.js
+++ b/assets/js/modules/analytics-4/components/widgets/TopCitiesDrivingAddToCartWidget.js
@@ -35,19 +35,14 @@ import {
 } from '@/js/googlesitekit/datastore/user/constants';
 import { ZeroDataMessage } from '@/js/modules/analytics-4/components/common';
 import { MODULE_SLUG_ANALYTICS_4 } from '@/js/modules/analytics-4/constants';
-import {
-	DATE_RANGE_OFFSET,
-	MODULES_ANALYTICS_4,
-} from '@/js/modules/analytics-4/datastore/constants';
+import { MODULES_ANALYTICS_4 } from '@/js/modules/analytics-4/datastore/constants';
 import { numFmt } from '@/js/util';
 import whenActive from '@/js/util/when-active';
 import ConnectGA4CTATileWidget from './ConnectGA4CTATileWidget';
 
 function TopCitiesDrivingAddToCartWidget( { Widget } ) {
 	const dates = useSelect( ( select ) =>
-		select( CORE_USER ).getDateRangeDates( {
-			offsetDays: DATE_RANGE_OFFSET,
-		} )
+		select( CORE_USER ).getDateRangeDates()
 	);
 
 	const detectedEvents = useSelect( ( select ) =>

--- a/assets/js/modules/analytics-4/components/widgets/TopCitiesDrivingAddToCartWidget.test.js
+++ b/assets/js/modules/analytics-4/components/widgets/TopCitiesDrivingAddToCartWidget.test.js
@@ -27,7 +27,6 @@ import { withConnected } from '@/js/googlesitekit/modules/datastore/__fixtures__
 import { getWidgetComponentProps } from '@/js/googlesitekit/widgets/util';
 import { MODULE_SLUG_ANALYTICS_4 } from '@/js/modules/analytics-4/constants';
 import {
-	DATE_RANGE_OFFSET,
 	ENUM_CONVERSION_EVENTS,
 	MODULES_ANALYTICS_4,
 } from '@/js/modules/analytics-4/datastore/constants';
@@ -67,9 +66,7 @@ describe( 'TopCitiesDrivingAddToCartWidget', () => {
 
 	it( 'should render correctly with the expected metrics', async () => {
 		const reportOptions = {
-			...registry.select( CORE_USER ).getDateRangeDates( {
-				offsetDays: DATE_RANGE_OFFSET,
-			} ),
+			...registry.select( CORE_USER ).getDateRangeDates(),
 			dimensions: [ 'city' ],
 			dimensionFilters: {
 				city: {

--- a/assets/js/modules/analytics-4/components/widgets/TopCitiesDrivingLeadsWidget.js
+++ b/assets/js/modules/analytics-4/components/widgets/TopCitiesDrivingLeadsWidget.js
@@ -36,7 +36,6 @@ import {
 import { ZeroDataMessage } from '@/js/modules/analytics-4/components/common';
 import { MODULE_SLUG_ANALYTICS_4 } from '@/js/modules/analytics-4/constants';
 import {
-	DATE_RANGE_OFFSET,
 	ENUM_CONVERSION_EVENTS,
 	MODULES_ANALYTICS_4,
 } from '@/js/modules/analytics-4/datastore/constants';
@@ -46,9 +45,7 @@ import ConnectGA4CTATileWidget from './ConnectGA4CTATileWidget';
 
 function TopCitiesDrivingLeadsWidget( { Widget } ) {
 	const dates = useSelect( ( select ) =>
-		select( CORE_USER ).getDateRangeDates( {
-			offsetDays: DATE_RANGE_OFFSET,
-		} )
+		select( CORE_USER ).getDateRangeDates()
 	);
 
 	const detectedEvents = useSelect( ( select ) =>

--- a/assets/js/modules/analytics-4/components/widgets/TopCitiesDrivingLeadsWidget.test.js
+++ b/assets/js/modules/analytics-4/components/widgets/TopCitiesDrivingLeadsWidget.test.js
@@ -27,7 +27,6 @@ import { withConnected } from '@/js/googlesitekit/modules/datastore/__fixtures__
 import { getWidgetComponentProps } from '@/js/googlesitekit/widgets/util';
 import { MODULE_SLUG_ANALYTICS_4 } from '@/js/modules/analytics-4/constants';
 import {
-	DATE_RANGE_OFFSET,
 	ENUM_CONVERSION_EVENTS,
 	MODULES_ANALYTICS_4,
 } from '@/js/modules/analytics-4/datastore/constants';
@@ -67,9 +66,7 @@ describe( 'TopCitiesDrivingLeadsWidget', () => {
 
 	it( 'should render correctly with the expected metrics', async () => {
 		const reportOptions = {
-			...registry.select( CORE_USER ).getDateRangeDates( {
-				offsetDays: DATE_RANGE_OFFSET,
-			} ),
+			...registry.select( CORE_USER ).getDateRangeDates(),
 			dimensions: [ 'city', 'eventName' ],
 			dimensionFilters: {
 				eventName: {

--- a/assets/js/modules/analytics-4/components/widgets/TopCitiesDrivingPurchasesWidget.js
+++ b/assets/js/modules/analytics-4/components/widgets/TopCitiesDrivingPurchasesWidget.js
@@ -35,19 +35,14 @@ import {
 } from '@/js/googlesitekit/datastore/user/constants';
 import { ZeroDataMessage } from '@/js/modules/analytics-4/components/common';
 import { MODULE_SLUG_ANALYTICS_4 } from '@/js/modules/analytics-4/constants';
-import {
-	DATE_RANGE_OFFSET,
-	MODULES_ANALYTICS_4,
-} from '@/js/modules/analytics-4/datastore/constants';
+import { MODULES_ANALYTICS_4 } from '@/js/modules/analytics-4/datastore/constants';
 import { numFmt } from '@/js/util';
 import whenActive from '@/js/util/when-active';
 import ConnectGA4CTATileWidget from './ConnectGA4CTATileWidget';
 
 function TopCitiesDrivingPurchasesWidget( { Widget } ) {
 	const dates = useSelect( ( select ) =>
-		select( CORE_USER ).getDateRangeDates( {
-			offsetDays: DATE_RANGE_OFFSET,
-		} )
+		select( CORE_USER ).getDateRangeDates()
 	);
 
 	const detectedEvents = useSelect( ( select ) =>

--- a/assets/js/modules/analytics-4/components/widgets/TopCitiesDrivingPurchasesWidget.test.js
+++ b/assets/js/modules/analytics-4/components/widgets/TopCitiesDrivingPurchasesWidget.test.js
@@ -27,7 +27,6 @@ import { withConnected } from '@/js/googlesitekit/modules/datastore/__fixtures__
 import { getWidgetComponentProps } from '@/js/googlesitekit/widgets/util';
 import { MODULE_SLUG_ANALYTICS_4 } from '@/js/modules/analytics-4/constants';
 import {
-	DATE_RANGE_OFFSET,
 	ENUM_CONVERSION_EVENTS,
 	MODULES_ANALYTICS_4,
 } from '@/js/modules/analytics-4/datastore/constants';
@@ -67,9 +66,7 @@ describe( 'TopCitiesDrivingPurchasesWidget', () => {
 
 	it( 'should render correctly with the expected metrics', async () => {
 		const reportOptions = {
-			...registry.select( CORE_USER ).getDateRangeDates( {
-				offsetDays: DATE_RANGE_OFFSET,
-			} ),
+			...registry.select( CORE_USER ).getDateRangeDates(),
 			dimensions: [ 'city' ],
 			dimensionFilters: {
 				city: {

--- a/assets/js/modules/analytics-4/components/widgets/TopCitiesWidget.js
+++ b/assets/js/modules/analytics-4/components/widgets/TopCitiesWidget.js
@@ -35,10 +35,7 @@ import {
 } from '@/js/googlesitekit/datastore/user/constants';
 import { ZeroDataMessage } from '@/js/modules/analytics-4/components/common';
 import { MODULE_SLUG_ANALYTICS_4 } from '@/js/modules/analytics-4/constants';
-import {
-	DATE_RANGE_OFFSET,
-	MODULES_ANALYTICS_4,
-} from '@/js/modules/analytics-4/datastore/constants';
+import { MODULES_ANALYTICS_4 } from '@/js/modules/analytics-4/datastore/constants';
 import { reportRowsWithSetValues } from '@/js/modules/analytics-4/utils/report-rows-with-set-values';
 import { numFmt } from '@/js/util';
 import whenActive from '@/js/util/when-active';
@@ -46,9 +43,7 @@ import ConnectGA4CTATileWidget from './ConnectGA4CTATileWidget';
 
 function TopCitiesWidget( { Widget } ) {
 	const dates = useSelect( ( select ) =>
-		select( CORE_USER ).getDateRangeDates( {
-			offsetDays: DATE_RANGE_OFFSET,
-		} )
+		select( CORE_USER ).getDateRangeDates()
 	);
 
 	const topCitiesReportOptions = {

--- a/assets/js/modules/analytics-4/components/widgets/TopCitiesWidget.test.js
+++ b/assets/js/modules/analytics-4/components/widgets/TopCitiesWidget.test.js
@@ -27,7 +27,6 @@ import { withConnected } from '@/js/googlesitekit/modules/datastore/__fixtures__
 import { getWidgetComponentProps } from '@/js/googlesitekit/widgets/util';
 import { MODULE_SLUG_ANALYTICS_4 } from '@/js/modules/analytics-4/constants';
 import * as analyticsFixtures from '@/js/modules/analytics-4/datastore/__fixtures__';
-import { DATE_RANGE_OFFSET } from '@/js/modules/analytics-4/datastore/constants';
 import { provideAnalytics4MockReport } from '@/js/modules/analytics-4/utils/data-mock';
 import {
 	ERROR_INTERNAL_SERVER_ERROR,
@@ -67,9 +66,7 @@ describe( 'TopCitiesWidget', () => {
 
 	it( 'should render correctly with the expected metrics', async () => {
 		const reportOptions = {
-			...registry.select( CORE_USER ).getDateRangeDates( {
-				offsetDays: DATE_RANGE_OFFSET,
-			} ),
+			...registry.select( CORE_USER ).getDateRangeDates(),
 			dimensions: [ 'city' ],
 			metrics: [ { name: 'totalUsers' } ],
 			orderby: [

--- a/assets/js/modules/analytics-4/components/widgets/TopConvertingTrafficSourceWidget.js
+++ b/assets/js/modules/analytics-4/components/widgets/TopConvertingTrafficSourceWidget.js
@@ -37,10 +37,7 @@ import {
 } from '@/js/googlesitekit/datastore/user/constants';
 import { useInViewSelect } from '@/js/hooks/useInViewSelect';
 import { MODULE_SLUG_ANALYTICS_4 } from '@/js/modules/analytics-4/constants';
-import {
-	DATE_RANGE_OFFSET,
-	MODULES_ANALYTICS_4,
-} from '@/js/modules/analytics-4/datastore/constants';
+import { MODULES_ANALYTICS_4 } from '@/js/modules/analytics-4/datastore/constants';
 import { numFmt } from '@/js/util';
 import whenActive from '@/js/util/when-active';
 import ConnectGA4CTATileWidget from './ConnectGA4CTATileWidget';
@@ -48,7 +45,6 @@ import ConnectGA4CTATileWidget from './ConnectGA4CTATileWidget';
 function TopConvertingTrafficSourceWidget( { Widget } ) {
 	const dates = useSelect( ( select ) =>
 		select( CORE_USER ).getDateRangeDates( {
-			offsetDays: DATE_RANGE_OFFSET,
 			compare: true,
 		} )
 	);

--- a/assets/js/modules/analytics-4/components/widgets/TopConvertingTrafficSourceWidget.test.js
+++ b/assets/js/modules/analytics-4/components/widgets/TopConvertingTrafficSourceWidget.test.js
@@ -27,10 +27,7 @@ import { withConnected } from '@/js/googlesitekit/modules/datastore/__fixtures__
 import { getWidgetComponentProps } from '@/js/googlesitekit/widgets/util';
 import { MODULE_SLUG_ANALYTICS_4 } from '@/js/modules/analytics-4/constants';
 import * as analyticsFixtures from '@/js/modules/analytics-4/datastore/__fixtures__';
-import {
-	DATE_RANGE_OFFSET,
-	MODULES_ANALYTICS_4,
-} from '@/js/modules/analytics-4/datastore/constants';
+import { MODULES_ANALYTICS_4 } from '@/js/modules/analytics-4/datastore/constants';
 import {
 	getAnalytics4MockResponse,
 	provideAnalytics4MockReport,
@@ -77,7 +74,6 @@ describe( 'TopConvertingTrafficSourceWidget', () => {
 	it( 'should render correctly with the expected metrics', async () => {
 		const reportOptions = {
 			...registry.select( CORE_USER ).getDateRangeDates( {
-				offsetDays: DATE_RANGE_OFFSET,
 				compare: true,
 			} ),
 			dimensions: [ 'sessionDefaultChannelGroup' ],
@@ -106,7 +102,6 @@ describe( 'TopConvertingTrafficSourceWidget', () => {
 	it( 'renders correctly with no data in the comparison date range', async () => {
 		const reportOptions = {
 			...registry.select( CORE_USER ).getDateRangeDates( {
-				offsetDays: DATE_RANGE_OFFSET,
 				compare: true,
 			} ),
 			dimensions: [ 'sessionDefaultChannelGroup' ],

--- a/assets/js/modules/analytics-4/components/widgets/TopCountriesWidget.js
+++ b/assets/js/modules/analytics-4/components/widgets/TopCountriesWidget.js
@@ -35,10 +35,7 @@ import {
 } from '@/js/googlesitekit/datastore/user/constants';
 import { ZeroDataMessage } from '@/js/modules/analytics-4/components/common';
 import { MODULE_SLUG_ANALYTICS_4 } from '@/js/modules/analytics-4/constants';
-import {
-	DATE_RANGE_OFFSET,
-	MODULES_ANALYTICS_4,
-} from '@/js/modules/analytics-4/datastore/constants';
+import { MODULES_ANALYTICS_4 } from '@/js/modules/analytics-4/datastore/constants';
 import { reportRowsWithSetValues } from '@/js/modules/analytics-4/utils/report-rows-with-set-values';
 import { numFmt } from '@/js/util';
 import whenActive from '@/js/util/when-active';
@@ -46,9 +43,7 @@ import ConnectGA4CTATileWidget from './ConnectGA4CTATileWidget';
 
 function TopCountriesWidget( { Widget } ) {
 	const dates = useSelect( ( select ) =>
-		select( CORE_USER ).getDateRangeDates( {
-			offsetDays: DATE_RANGE_OFFSET,
-		} )
+		select( CORE_USER ).getDateRangeDates()
 	);
 
 	const topCountriesReportOptions = {

--- a/assets/js/modules/analytics-4/components/widgets/TopCountriesWidget.test.js
+++ b/assets/js/modules/analytics-4/components/widgets/TopCountriesWidget.test.js
@@ -27,7 +27,6 @@ import { withConnected } from '@/js/googlesitekit/modules/datastore/__fixtures__
 import { getWidgetComponentProps } from '@/js/googlesitekit/widgets/util';
 import { MODULE_SLUG_ANALYTICS_4 } from '@/js/modules/analytics-4/constants';
 import * as analyticsFixtures from '@/js/modules/analytics-4/datastore/__fixtures__';
-import { DATE_RANGE_OFFSET } from '@/js/modules/analytics-4/datastore/constants';
 import { provideAnalytics4MockReport } from '@/js/modules/analytics-4/utils/data-mock';
 import {
 	ERROR_INTERNAL_SERVER_ERROR,
@@ -67,9 +66,7 @@ describe( 'TopCountriesWidget', () => {
 
 	it( 'should render correctly with the expected metrics', async () => {
 		provideAnalytics4MockReport( registry, {
-			...registry
-				.select( CORE_USER )
-				.getDateRangeDates( { offsetDays: DATE_RANGE_OFFSET } ),
+			...registry.select( CORE_USER ).getDateRangeDates(),
 			dimensions: [ 'country' ],
 			metrics: [ { name: 'totalUsers' } ],
 			orderby: [

--- a/assets/js/modules/analytics-4/components/widgets/TopDeviceDrivingPurchasesWidget.js
+++ b/assets/js/modules/analytics-4/components/widgets/TopDeviceDrivingPurchasesWidget.js
@@ -37,10 +37,7 @@ import {
 	KM_ANALYTICS_TOP_DEVICE_DRIVING_PURCHASES,
 } from '@/js/googlesitekit/datastore/user/constants';
 import { MODULE_SLUG_ANALYTICS_4 } from '@/js/modules/analytics-4/constants';
-import {
-	DATE_RANGE_OFFSET,
-	MODULES_ANALYTICS_4,
-} from '@/js/modules/analytics-4/datastore/constants';
+import { MODULES_ANALYTICS_4 } from '@/js/modules/analytics-4/datastore/constants';
 import { numFmt } from '@/js/util';
 import whenActive from '@/js/util/when-active';
 import ConnectGA4CTATileWidget from './ConnectGA4CTATileWidget';
@@ -48,7 +45,6 @@ import ConnectGA4CTATileWidget from './ConnectGA4CTATileWidget';
 function TopDeviceDrivingPurchases( { Widget } ) {
 	const dates = useSelect( ( select ) =>
 		select( CORE_USER ).getDateRangeDates( {
-			offsetDays: DATE_RANGE_OFFSET,
 			compare: true,
 		} )
 	);

--- a/assets/js/modules/analytics-4/components/widgets/TopDeviceDrivingPurchasesWidget.test.js
+++ b/assets/js/modules/analytics-4/components/widgets/TopDeviceDrivingPurchasesWidget.test.js
@@ -27,7 +27,6 @@ import { withConnected } from '@/js/googlesitekit/modules/datastore/__fixtures__
 import { getWidgetComponentProps } from '@/js/googlesitekit/widgets/util';
 import { MODULE_SLUG_ANALYTICS_4 } from '@/js/modules/analytics-4/constants';
 import {
-	DATE_RANGE_OFFSET,
 	ENUM_CONVERSION_EVENTS,
 	MODULES_ANALYTICS_4,
 } from '@/js/modules/analytics-4/datastore/constants';
@@ -66,7 +65,6 @@ describe( 'TopDeviceDrivingPurchasesWidget', () => {
 
 	it( 'should render correctly with the expected metrics', async () => {
 		const dates = registry.select( CORE_USER ).getDateRangeDates( {
-			offsetDays: DATE_RANGE_OFFSET,
 			compare: true,
 		} );
 

--- a/assets/js/modules/analytics-4/components/widgets/TopPagesDrivingLeadsWidget.js
+++ b/assets/js/modules/analytics-4/components/widgets/TopPagesDrivingLeadsWidget.js
@@ -38,7 +38,6 @@ import useViewOnly from '@/js/hooks/useViewOnly';
 import { ZeroDataMessage } from '@/js/modules/analytics-4/components/common';
 import { MODULE_SLUG_ANALYTICS_4 } from '@/js/modules/analytics-4/constants';
 import {
-	DATE_RANGE_OFFSET,
 	ENUM_CONVERSION_EVENTS,
 	MODULES_ANALYTICS_4,
 } from '@/js/modules/analytics-4/datastore/constants';
@@ -53,9 +52,7 @@ function TopPagesDrivingLeadsWidget( props ) {
 	const viewOnlyDashboard = useViewOnly();
 
 	const dates = useSelect( ( select ) =>
-		select( CORE_USER ).getDateRangeDates( {
-			offsetDays: DATE_RANGE_OFFSET,
-		} )
+		select( CORE_USER ).getDateRangeDates()
 	);
 
 	const detectedEvents = useSelect( ( select ) =>

--- a/assets/js/modules/analytics-4/components/widgets/TopPagesDrivingLeadsWidget.test.js
+++ b/assets/js/modules/analytics-4/components/widgets/TopPagesDrivingLeadsWidget.test.js
@@ -27,7 +27,6 @@ import { withConnected } from '@/js/googlesitekit/modules/datastore/__fixtures__
 import { getWidgetComponentProps } from '@/js/googlesitekit/widgets/util';
 import { MODULE_SLUG_ANALYTICS_4 } from '@/js/modules/analytics-4/constants';
 import {
-	DATE_RANGE_OFFSET,
 	ENUM_CONVERSION_EVENTS,
 	MODULES_ANALYTICS_4,
 } from '@/js/modules/analytics-4/datastore/constants';
@@ -70,9 +69,7 @@ describe( 'TopPagesDrivingLeadsWidget', () => {
 	} );
 
 	it( 'should render correctly with the expected metrics', async () => {
-		const dates = registry.select( CORE_USER ).getDateRangeDates( {
-			offsetDays: DATE_RANGE_OFFSET,
-		} );
+		const dates = registry.select( CORE_USER ).getDateRangeDates();
 
 		const reportOptions = {
 			...dates,

--- a/assets/js/modules/analytics-4/components/widgets/TopReturningVisitorPages.js
+++ b/assets/js/modules/analytics-4/components/widgets/TopReturningVisitorPages.js
@@ -37,10 +37,7 @@ import {
 import useViewOnly from '@/js/hooks/useViewOnly';
 import { ZeroDataMessage } from '@/js/modules/analytics-4/components/common';
 import { MODULE_SLUG_ANALYTICS_4 } from '@/js/modules/analytics-4/constants';
-import {
-	DATE_RANGE_OFFSET,
-	MODULES_ANALYTICS_4,
-} from '@/js/modules/analytics-4/datastore/constants';
+import { MODULES_ANALYTICS_4 } from '@/js/modules/analytics-4/datastore/constants';
 import { decodeAmpersand } from '@/js/modules/analytics-4/utils';
 import { numFmt } from '@/js/util';
 import whenActive from '@/js/util/when-active';
@@ -52,9 +49,7 @@ function TopReturningVisitorPages( props ) {
 	const viewOnlyDashboard = useViewOnly();
 
 	const dates = useSelect( ( select ) =>
-		select( CORE_USER ).getDateRangeDates( {
-			offsetDays: DATE_RANGE_OFFSET,
-		} )
+		select( CORE_USER ).getDateRangeDates()
 	);
 
 	const reportOptions = {

--- a/assets/js/modules/analytics-4/components/widgets/TopReturningVisitorPages.test.js
+++ b/assets/js/modules/analytics-4/components/widgets/TopReturningVisitorPages.test.js
@@ -26,10 +26,7 @@ import {
 import { withConnected } from '@/js/googlesitekit/modules/datastore/__fixtures__';
 import { getWidgetComponentProps } from '@/js/googlesitekit/widgets/util';
 import { MODULE_SLUG_ANALYTICS_4 } from '@/js/modules/analytics-4/constants';
-import {
-	DATE_RANGE_OFFSET,
-	MODULES_ANALYTICS_4,
-} from '@/js/modules/analytics-4/datastore/constants';
+import { MODULES_ANALYTICS_4 } from '@/js/modules/analytics-4/datastore/constants';
 import {
 	STRATEGY_ZIP,
 	getAnalytics4MockResponse,
@@ -67,9 +64,7 @@ describe( 'TopReturningVisitorPages', () => {
 	} );
 
 	it( 'should render correctly with the expected metrics', async () => {
-		const dates = registry.select( CORE_USER ).getDateRangeDates( {
-			offsetDays: DATE_RANGE_OFFSET,
-		} );
+		const dates = registry.select( CORE_USER ).getDateRangeDates();
 
 		const reportOptions = {
 			...dates,

--- a/assets/js/modules/analytics-4/components/widgets/TopTrafficSourceDrivingAddToCartWidget.js
+++ b/assets/js/modules/analytics-4/components/widgets/TopTrafficSourceDrivingAddToCartWidget.js
@@ -38,7 +38,6 @@ import {
 } from '@/js/googlesitekit/datastore/user/constants';
 import { MODULE_SLUG_ANALYTICS_4 } from '@/js/modules/analytics-4/constants';
 import {
-	DATE_RANGE_OFFSET,
 	ENUM_CONVERSION_EVENTS,
 	MODULES_ANALYTICS_4,
 } from '@/js/modules/analytics-4/datastore/constants';
@@ -49,7 +48,6 @@ import ConnectGA4CTATileWidget from './ConnectGA4CTATileWidget';
 function TopTrafficSourceDrivingAddToCartWidget( { Widget } ) {
 	const dates = useSelect( ( select ) =>
 		select( CORE_USER ).getDateRangeDates( {
-			offsetDays: DATE_RANGE_OFFSET,
 			compare: true,
 		} )
 	);

--- a/assets/js/modules/analytics-4/components/widgets/TopTrafficSourceDrivingAddToCartWidget.test.js
+++ b/assets/js/modules/analytics-4/components/widgets/TopTrafficSourceDrivingAddToCartWidget.test.js
@@ -27,7 +27,6 @@ import { withConnected } from '@/js/googlesitekit/modules/datastore/__fixtures__
 import { getWidgetComponentProps } from '@/js/googlesitekit/widgets/util';
 import { MODULE_SLUG_ANALYTICS_4 } from '@/js/modules/analytics-4/constants';
 import {
-	DATE_RANGE_OFFSET,
 	ENUM_CONVERSION_EVENTS,
 	MODULES_ANALYTICS_4,
 } from '@/js/modules/analytics-4/datastore/constants';
@@ -66,7 +65,6 @@ describe( 'TopTrafficSourceDrivingAddToCartWidget', () => {
 
 	it( 'should render correctly with the expected metrics', async () => {
 		const dates = registry.select( CORE_USER ).getDateRangeDates( {
-			offsetDays: DATE_RANGE_OFFSET,
 			compare: true,
 		} );
 		const reportOptions = [
@@ -110,7 +108,6 @@ describe( 'TopTrafficSourceDrivingAddToCartWidget', () => {
 
 	it( 'should render the loading state while resolving the report', async () => {
 		const dates = registry.select( CORE_USER ).getDateRangeDates( {
-			offsetDays: DATE_RANGE_OFFSET,
 			compare: true,
 		} );
 		const reportOptions = [

--- a/assets/js/modules/analytics-4/components/widgets/TopTrafficSourceDrivingLeadsWidget.js
+++ b/assets/js/modules/analytics-4/components/widgets/TopTrafficSourceDrivingLeadsWidget.js
@@ -38,7 +38,6 @@ import {
 } from '@/js/googlesitekit/datastore/user/constants';
 import { MODULE_SLUG_ANALYTICS_4 } from '@/js/modules/analytics-4/constants';
 import {
-	DATE_RANGE_OFFSET,
 	ENUM_CONVERSION_EVENTS,
 	MODULES_ANALYTICS_4,
 } from '@/js/modules/analytics-4/datastore/constants';
@@ -65,7 +64,6 @@ function getDateRangeIndex( reportRows, dateRangeSlug ) {
 function TopTrafficSourceDrivingLeadsWidget( { Widget } ) {
 	const dates = useSelect( ( select ) =>
 		select( CORE_USER ).getDateRangeDates( {
-			offsetDays: DATE_RANGE_OFFSET,
 			compare: true,
 		} )
 	);

--- a/assets/js/modules/analytics-4/components/widgets/TopTrafficSourceDrivingLeadsWidget.test.js
+++ b/assets/js/modules/analytics-4/components/widgets/TopTrafficSourceDrivingLeadsWidget.test.js
@@ -27,7 +27,6 @@ import { withConnected } from '@/js/googlesitekit/modules/datastore/__fixtures__
 import { getWidgetComponentProps } from '@/js/googlesitekit/widgets/util';
 import { MODULE_SLUG_ANALYTICS_4 } from '@/js/modules/analytics-4/constants';
 import {
-	DATE_RANGE_OFFSET,
 	ENUM_CONVERSION_EVENTS,
 	MODULES_ANALYTICS_4,
 } from '@/js/modules/analytics-4/datastore/constants';
@@ -67,7 +66,6 @@ describe( 'TopTrafficSourceDrivingLeadsWidget', () => {
 
 	it( 'should render correctly with the expected metrics', async () => {
 		const dates = registry.select( CORE_USER ).getDateRangeDates( {
-			offsetDays: DATE_RANGE_OFFSET,
 			compare: true,
 		} );
 		const reportOptions = [
@@ -124,7 +122,6 @@ describe( 'TopTrafficSourceDrivingLeadsWidget', () => {
 
 	it( 'should render the loading state while resolving the report', async () => {
 		const dates = registry.select( CORE_USER ).getDateRangeDates( {
-			offsetDays: DATE_RANGE_OFFSET,
 			compare: true,
 		} );
 		const reportOptions = [

--- a/assets/js/modules/analytics-4/components/widgets/TopTrafficSourceDrivingPurchasesWidget.js
+++ b/assets/js/modules/analytics-4/components/widgets/TopTrafficSourceDrivingPurchasesWidget.js
@@ -37,10 +37,7 @@ import {
 	KM_ANALYTICS_TOP_TRAFFIC_SOURCE_DRIVING_PURCHASES,
 } from '@/js/googlesitekit/datastore/user/constants';
 import { MODULE_SLUG_ANALYTICS_4 } from '@/js/modules/analytics-4/constants';
-import {
-	DATE_RANGE_OFFSET,
-	MODULES_ANALYTICS_4,
-} from '@/js/modules/analytics-4/datastore/constants';
+import { MODULES_ANALYTICS_4 } from '@/js/modules/analytics-4/datastore/constants';
 import { numFmt } from '@/js/util';
 import whenActive from '@/js/util/when-active';
 import ConnectGA4CTATileWidget from './ConnectGA4CTATileWidget';
@@ -48,7 +45,6 @@ import ConnectGA4CTATileWidget from './ConnectGA4CTATileWidget';
 function TopTrafficSourceDrivingPurchasesWidget( { Widget } ) {
 	const dates = useSelect( ( select ) =>
 		select( CORE_USER ).getDateRangeDates( {
-			offsetDays: DATE_RANGE_OFFSET,
 			compare: true,
 		} )
 	);

--- a/assets/js/modules/analytics-4/components/widgets/TopTrafficSourceDrivingPurchasesWidget.test.js
+++ b/assets/js/modules/analytics-4/components/widgets/TopTrafficSourceDrivingPurchasesWidget.test.js
@@ -27,7 +27,6 @@ import { withConnected } from '@/js/googlesitekit/modules/datastore/__fixtures__
 import { getWidgetComponentProps } from '@/js/googlesitekit/widgets/util';
 import { MODULE_SLUG_ANALYTICS_4 } from '@/js/modules/analytics-4/constants';
 import {
-	DATE_RANGE_OFFSET,
 	ENUM_CONVERSION_EVENTS,
 	MODULES_ANALYTICS_4,
 } from '@/js/modules/analytics-4/datastore/constants';
@@ -67,7 +66,6 @@ describe( 'TopTrafficSourceDrivingPurchasesWidget', () => {
 
 	it( 'should render correctly with the expected metrics', async () => {
 		const dates = registry.select( CORE_USER ).getDateRangeDates( {
-			offsetDays: DATE_RANGE_OFFSET,
 			compare: true,
 		} );
 		const reportOptions = [
@@ -111,7 +109,6 @@ describe( 'TopTrafficSourceDrivingPurchasesWidget', () => {
 
 	it( 'should render the loading state while resolving the report', async () => {
 		const dates = registry.select( CORE_USER ).getDateRangeDates( {
-			offsetDays: DATE_RANGE_OFFSET,
 			compare: true,
 		} );
 		const reportOptions = [

--- a/assets/js/modules/analytics-4/components/widgets/TopTrafficSourceWidget.js
+++ b/assets/js/modules/analytics-4/components/widgets/TopTrafficSourceWidget.js
@@ -37,10 +37,7 @@ import {
 	KM_ANALYTICS_TOP_TRAFFIC_SOURCE,
 } from '@/js/googlesitekit/datastore/user/constants';
 import { MODULE_SLUG_ANALYTICS_4 } from '@/js/modules/analytics-4/constants';
-import {
-	DATE_RANGE_OFFSET,
-	MODULES_ANALYTICS_4,
-} from '@/js/modules/analytics-4/datastore/constants';
+import { MODULES_ANALYTICS_4 } from '@/js/modules/analytics-4/datastore/constants';
 import { numFmt } from '@/js/util';
 import whenActive from '@/js/util/when-active';
 import ConnectGA4CTATileWidget from './ConnectGA4CTATileWidget';
@@ -48,7 +45,6 @@ import ConnectGA4CTATileWidget from './ConnectGA4CTATileWidget';
 function TopTrafficSourceWidget( { Widget } ) {
 	const dates = useSelect( ( select ) =>
 		select( CORE_USER ).getDateRangeDates( {
-			offsetDays: DATE_RANGE_OFFSET,
 			compare: true,
 		} )
 	);

--- a/assets/js/modules/analytics-4/components/widgets/TopTrafficSourceWidget.test.js
+++ b/assets/js/modules/analytics-4/components/widgets/TopTrafficSourceWidget.test.js
@@ -27,10 +27,7 @@ import { withConnected } from '@/js/googlesitekit/modules/datastore/__fixtures__
 import { getWidgetComponentProps } from '@/js/googlesitekit/widgets/util';
 import { MODULE_SLUG_ANALYTICS_4 } from '@/js/modules/analytics-4/constants';
 import * as analyticsFixtures from '@/js/modules/analytics-4/datastore/__fixtures__';
-import {
-	DATE_RANGE_OFFSET,
-	MODULES_ANALYTICS_4,
-} from '@/js/modules/analytics-4/datastore/constants';
+import { MODULES_ANALYTICS_4 } from '@/js/modules/analytics-4/datastore/constants';
 import {
 	getAnalytics4MockResponse,
 	provideAnalytics4MockReport,
@@ -67,7 +64,6 @@ describe( 'TopTrafficSourceWidget', () => {
 		registry = createTestRegistry();
 		registry.dispatch( CORE_USER ).setReferenceDate( '2020-09-08' );
 		dateRangeDates = registry.select( CORE_USER ).getDateRangeDates( {
-			offsetDays: DATE_RANGE_OFFSET,
 			compare: true,
 		} );
 		provideKeyMetrics( registry );

--- a/assets/js/modules/analytics-4/components/widgets/VisitLengthWidget.js
+++ b/assets/js/modules/analytics-4/components/widgets/VisitLengthWidget.js
@@ -37,10 +37,7 @@ import {
 	KM_ANALYTICS_VISIT_LENGTH,
 } from '@/js/googlesitekit/datastore/user/constants';
 import { MODULE_SLUG_ANALYTICS_4 } from '@/js/modules/analytics-4/constants';
-import {
-	DATE_RANGE_OFFSET,
-	MODULES_ANALYTICS_4,
-} from '@/js/modules/analytics-4/datastore/constants';
+import { MODULES_ANALYTICS_4 } from '@/js/modules/analytics-4/datastore/constants';
 import { numFmt } from '@/js/util/i18n';
 import whenActive from '@/js/util/when-active';
 import ConnectGA4CTATileWidget from './ConnectGA4CTATileWidget';
@@ -48,7 +45,6 @@ import ConnectGA4CTATileWidget from './ConnectGA4CTATileWidget';
 function VisitLengthWidget( { Widget } ) {
 	const dates = useSelect( ( select ) =>
 		select( CORE_USER ).getDateRangeDates( {
-			offsetDays: DATE_RANGE_OFFSET,
 			compare: true,
 		} )
 	);

--- a/assets/js/modules/analytics-4/components/widgets/VisitLengthWidget.test.js
+++ b/assets/js/modules/analytics-4/components/widgets/VisitLengthWidget.test.js
@@ -26,10 +26,7 @@ import {
 import { withConnected } from '@/js/googlesitekit/modules/datastore/__fixtures__';
 import { getWidgetComponentProps } from '@/js/googlesitekit/widgets/util';
 import { MODULE_SLUG_ANALYTICS_4 } from '@/js/modules/analytics-4/constants';
-import {
-	DATE_RANGE_OFFSET,
-	MODULES_ANALYTICS_4,
-} from '@/js/modules/analytics-4/datastore/constants';
+import { MODULES_ANALYTICS_4 } from '@/js/modules/analytics-4/datastore/constants';
 import { provideAnalytics4MockReport } from '@/js/modules/analytics-4/utils/data-mock';
 import {
 	ERROR_INTERNAL_SERVER_ERROR,
@@ -63,7 +60,6 @@ describe( 'VisitLengthWidget', () => {
 	it( 'should render correctly with the expected metrics', async () => {
 		const reportOptions = {
 			...registry.select( CORE_USER ).getDateRangeDates( {
-				offsetDays: DATE_RANGE_OFFSET,
 				compare: true,
 			} ),
 			metrics: [

--- a/assets/js/modules/analytics-4/components/widgets/VisitsPerVisitorWidget.js
+++ b/assets/js/modules/analytics-4/components/widgets/VisitsPerVisitorWidget.js
@@ -37,10 +37,7 @@ import {
 	KM_ANALYTICS_VISITS_PER_VISITOR,
 } from '@/js/googlesitekit/datastore/user/constants';
 import { MODULE_SLUG_ANALYTICS_4 } from '@/js/modules/analytics-4/constants';
-import {
-	DATE_RANGE_OFFSET,
-	MODULES_ANALYTICS_4,
-} from '@/js/modules/analytics-4/datastore/constants';
+import { MODULES_ANALYTICS_4 } from '@/js/modules/analytics-4/datastore/constants';
 import { numFmt } from '@/js/util';
 import whenActive from '@/js/util/when-active';
 import ConnectGA4CTATileWidget from './ConnectGA4CTATileWidget';
@@ -48,7 +45,6 @@ import ConnectGA4CTATileWidget from './ConnectGA4CTATileWidget';
 function VisitsPerVisitorWidget( { Widget } ) {
 	const dates = useSelect( ( select ) =>
 		select( CORE_USER ).getDateRangeDates( {
-			offsetDays: DATE_RANGE_OFFSET,
 			compare: true,
 		} )
 	);

--- a/assets/js/modules/analytics-4/components/widgets/VisitsPerVisitorWidget.test.js
+++ b/assets/js/modules/analytics-4/components/widgets/VisitsPerVisitorWidget.test.js
@@ -26,10 +26,7 @@ import {
 import { withConnected } from '@/js/googlesitekit/modules/datastore/__fixtures__';
 import { getWidgetComponentProps } from '@/js/googlesitekit/widgets/util';
 import { MODULE_SLUG_ANALYTICS_4 } from '@/js/modules/analytics-4/constants';
-import {
-	DATE_RANGE_OFFSET,
-	MODULES_ANALYTICS_4,
-} from '@/js/modules/analytics-4/datastore/constants';
+import { MODULES_ANALYTICS_4 } from '@/js/modules/analytics-4/datastore/constants';
 import { provideAnalytics4MockReport } from '@/js/modules/analytics-4/utils/data-mock';
 import {
 	ERROR_INTERNAL_SERVER_ERROR,
@@ -65,7 +62,6 @@ describe( 'VisitsPerVisitorWidget', () => {
 	it( 'should render correctly with the expected metrics', async () => {
 		const reportOptions = {
 			...registry.select( CORE_USER ).getDateRangeDates( {
-				offsetDays: DATE_RANGE_OFFSET,
 				compare: true,
 			} ),
 			metrics: [

--- a/assets/js/modules/analytics-4/datastore/audiences.js
+++ b/assets/js/modules/analytics-4/datastore/audiences.js
@@ -36,7 +36,6 @@ import { isInsufficientPermissionsError } from '@/js/util/errors';
 import {
 	AUDIENCE_ITEM_NEW_BADGE_SLUG_PREFIX,
 	CUSTOM_DIMENSION_DEFINITIONS,
-	DATE_RANGE_OFFSET,
 	MODULES_ANALYTICS_4,
 	RESOURCE_TYPE_AUDIENCE,
 	SITE_KIT_AUDIENCE_DEFINITIONS,
@@ -188,10 +187,7 @@ async function getInitialConfiguredAudiences( registry, availableAudiences ) {
 
 		const endDate = select( CORE_USER ).getReferenceDate();
 
-		const startDate = getPreviousDate(
-			endDate,
-			90 + DATE_RANGE_OFFSET // Add offset to ensure we have data for the entirety of the last 90 days.
-		);
+		const startDate = getPreviousDate( endDate, 90 );
 
 		const { audienceResourceNames, error } =
 			await getNonZeroDataAudiencesSortedByTotalUsers(
@@ -977,9 +973,9 @@ const baseSelectors = {
 	getAudiencesUserCountReportOptions: createRegistrySelector(
 		( select ) =>
 			( state, audiences, { startDate, endDate } = {} ) => {
-				const dateRangeDates = select( CORE_USER ).getDateRangeDates( {
-					offsetDays: DATE_RANGE_OFFSET,
-				} );
+				const dateRangeDates = select( CORE_USER ).getDateRangeDates(
+					{}
+				);
 
 				return {
 					startDate: startDate || dateRangeDates.startDate,
@@ -1067,9 +1063,7 @@ const baseSelectors = {
 	 */
 	getSiteKitAudiencesUserCountReportOptions: createRegistrySelector(
 		( select ) => () => {
-			const dateRangeDates = select( CORE_USER ).getDateRangeDates( {
-				offsetDays: DATE_RANGE_OFFSET,
-			} );
+			const dateRangeDates = select( CORE_USER ).getDateRangeDates();
 
 			return {
 				startDate: dateRangeDates.startDate,

--- a/assets/js/modules/analytics-4/datastore/audiences.js
+++ b/assets/js/modules/analytics-4/datastore/audiences.js
@@ -973,9 +973,7 @@ const baseSelectors = {
 	getAudiencesUserCountReportOptions: createRegistrySelector(
 		( select ) =>
 			( state, audiences, { startDate, endDate } = {} ) => {
-				const dateRangeDates = select( CORE_USER ).getDateRangeDates(
-					{}
-				);
+				const dateRangeDates = select( CORE_USER ).getDateRangeDates();
 
 				return {
 					startDate: startDate || dateRangeDates.startDate,

--- a/assets/js/modules/analytics-4/datastore/audiences.test.js
+++ b/assets/js/modules/analytics-4/datastore/audiences.test.js
@@ -55,7 +55,6 @@ import {
 	AUDIENCE_FILTER_SCOPE_ENUM,
 	AUDIENCE_ITEM_NEW_BADGE_SLUG_PREFIX,
 	CUSTOM_DIMENSION_DEFINITIONS,
-	DATE_RANGE_OFFSET,
 	MODULES_ANALYTICS_4,
 	SITE_KIT_AUDIENCE_DEFINITIONS,
 } from './constants';
@@ -593,10 +592,7 @@ describe( 'modules/analytics-4 audiences', () => {
 			const testPropertyID = propertiesFixture[ 0 ]._id;
 
 			const referenceDate = '2024-05-10';
-			const startDate = getPreviousDate(
-				referenceDate,
-				90 + DATE_RANGE_OFFSET
-			);
+			const startDate = getPreviousDate( referenceDate, 90 );
 
 			const availableNewVisitorsAudienceFixture =
 				availableAudiencesFixture[ 2 ];
@@ -1847,10 +1843,7 @@ describe( 'modules/analytics-4 audiences', () => {
 			const testPropertyID = propertiesFixture[ 0 ]._id;
 
 			const referenceDate = '2024-05-10';
-			const startDate = getPreviousDate(
-				referenceDate,
-				90 + DATE_RANGE_OFFSET
-			);
+			const startDate = getPreviousDate( referenceDate, 90 );
 
 			const availableNewVisitorsAudienceFixture =
 				availableAudiencesFixture[ 2 ];
@@ -2738,9 +2731,7 @@ describe( 'modules/analytics-4 audiences', () => {
 
 				const { startDate, endDate } = registry
 					.select( CORE_USER )
-					.getDateRangeDates( {
-						offsetDays: DATE_RANGE_OFFSET,
-					} );
+					.getDateRangeDates();
 
 				expect( reportOptions ).toEqual( {
 					...expectedReportOptions,

--- a/assets/js/modules/analytics-4/datastore/constants.js
+++ b/assets/js/modules/analytics-4/datastore/constants.js
@@ -30,9 +30,6 @@ export const FORM_SETUP = 'analyticsSetup';
 
 export const MAX_WEBDATASTREAMS_PER_BATCH = 10;
 
-// Date range offset days for Analytics 4 report requests.
-export const DATE_RANGE_OFFSET = 0;
-
 export const GTM_SCOPE = 'https://www.googleapis.com/auth/tagmanager.readonly';
 
 export const ENHANCED_MEASUREMENT_FORM = 'enhanced-measurement-form';

--- a/assets/js/modules/analytics-4/datastore/partial-data.js
+++ b/assets/js/modules/analytics-4/datastore/partial-data.js
@@ -35,7 +35,6 @@ import { CORE_USER } from '@/js/googlesitekit/datastore/user/constants';
 import { MODULE_SLUG_ANALYTICS_4 } from '@/js/modules/analytics-4/constants';
 import { getDateString } from '@/js/util';
 import {
-	DATE_RANGE_OFFSET,
 	MODULES_ANALYTICS_4,
 	RESOURCE_TYPES,
 	RESOURCE_TYPE_AUDIENCE,
@@ -297,9 +296,7 @@ const baseSelectors = {
 				return true;
 			}
 
-			const { startDate } = select( CORE_USER ).getDateRangeDates( {
-				offsetDays: DATE_RANGE_OFFSET,
-			} );
+			const { startDate } = select( CORE_USER ).getDateRangeDates();
 
 			// TODO: use `replaceAll` instead when we upgrade our Node version.
 			const startDateYYYYMMDD = Number( startDate.replace( /-/g, '' ) );

--- a/assets/js/modules/analytics-4/datastore/partial-data.test.js
+++ b/assets/js/modules/analytics-4/datastore/partial-data.test.js
@@ -29,11 +29,7 @@ import {
 	untilResolved,
 } from '@tests/js/utils';
 import { properties } from './__fixtures__';
-import {
-	DATE_RANGE_OFFSET,
-	MODULES_ANALYTICS_4,
-	RESOURCE_TYPE_AUDIENCE,
-} from './constants';
+import { MODULES_ANALYTICS_4, RESOURCE_TYPE_AUDIENCE } from './constants';
 
 const testAudience1 = {
 	name: 'properties/12345/audiences/12345',
@@ -382,9 +378,7 @@ describe( 'modules/analytics-4 partial data', () => {
 
 				const { startDate } = registry
 					.select( CORE_USER )
-					.getDateRangeDates( {
-						offsetDays: DATE_RANGE_OFFSET,
-					} );
+					.getDateRangeDates();
 
 				const audience1Date = Number( startDate.replace( /-/g, '' ) );
 				const audience2Date = Number(
@@ -428,9 +422,7 @@ describe( 'modules/analytics-4 partial data', () => {
 
 				const { startDate } = registry
 					.select( CORE_USER )
-					.getDateRangeDates( {
-						offsetDays: DATE_RANGE_OFFSET,
-					} );
+					.getDateRangeDates();
 
 				const dataAvailabilityDate = Number(
 					getPreviousDate( startDate, -1 ).replace( /-/g, '' )
@@ -463,9 +455,7 @@ describe( 'modules/analytics-4 partial data', () => {
 
 				const { startDate } = registry
 					.select( CORE_USER )
-					.getDateRangeDates( {
-						offsetDays: DATE_RANGE_OFFSET,
-					} );
+					.getDateRangeDates();
 
 				const dataAvailabilityDate = Number(
 					getPreviousDate( startDate, -1 ).replace( /-/g, '' )
@@ -511,9 +501,7 @@ describe( 'modules/analytics-4 partial data', () => {
 
 				const { startDate } = registry
 					.select( CORE_USER )
-					.getDateRangeDates( {
-						offsetDays: DATE_RANGE_OFFSET,
-					} );
+					.getDateRangeDates();
 
 				const dataAvailabilityDate = Number(
 					getPreviousDate( startDate, -1 ).replace( /-/g, '' )
@@ -553,9 +541,7 @@ describe( 'modules/analytics-4 partial data', () => {
 
 				const { startDate } = registry
 					.select( CORE_USER )
-					.getDateRangeDates( {
-						offsetDays: DATE_RANGE_OFFSET,
-					} );
+					.getDateRangeDates();
 
 				const dataAvailabilityDate = Number(
 					getPreviousDate( startDate, -1 ).replace( /-/g, '' )
@@ -595,9 +581,7 @@ describe( 'modules/analytics-4 partial data', () => {
 
 				const { startDate } = registry
 					.select( CORE_USER )
-					.getDateRangeDates( {
-						offsetDays: DATE_RANGE_OFFSET,
-					} );
+					.getDateRangeDates();
 
 				const dataAvailabilityDate = Number(
 					getPreviousDate( startDate, -1 ).replace( /-/g, '' )

--- a/assets/js/modules/analytics-4/datastore/report.js
+++ b/assets/js/modules/analytics-4/datastore/report.js
@@ -47,7 +47,7 @@ import {
 } from '@/js/modules/analytics-4/utils';
 import { validateReport } from '@/js/modules/analytics-4/utils/validation';
 import { DAY_IN_SECONDS, dateSub, stringifyObject } from '@/js/util';
-import { DATE_RANGE_OFFSET, MODULES_ANALYTICS_4 } from './constants';
+import { MODULES_ANALYTICS_4 } from './constants';
 
 const fetchGetReportStore = createFetchStore( {
 	baseName: 'getReport',
@@ -381,7 +381,6 @@ const baseSelectors = {
 			CORE_USER
 		).getDateRangeDates( {
 			compare: true,
-			offsetDays: DATE_RANGE_OFFSET,
 		} );
 
 		const args = {

--- a/assets/js/modules/analytics-4/datastore/report.test.js
+++ b/assets/js/modules/analytics-4/datastore/report.test.js
@@ -33,7 +33,7 @@ import {
 	untilResolved,
 } from '@tests/js/utils';
 import * as fixtures from './__fixtures__';
-import { DATE_RANGE_OFFSET, MODULES_ANALYTICS_4 } from './constants';
+import { MODULES_ANALYTICS_4 } from './constants';
 
 describe( 'modules/analytics-4 report', () => {
 	let registry;
@@ -541,7 +541,6 @@ describe( 'modules/analytics-4 report', () => {
 								.select( CORE_USER )
 								.getDateRangeDates( {
 									compare: true,
-									offsetDays: DATE_RANGE_OFFSET,
 								} );
 
 							// `getSampleReportArgs` uses `compareStartDate` as `startDate`.
@@ -656,7 +655,6 @@ describe( 'modules/analytics-4 report', () => {
 				// Calculate expected dates using the same method as `getSampleReportArgs`.
 				const dates = registry.select( CORE_USER ).getDateRangeDates( {
 					compare: true,
-					offsetDays: DATE_RANGE_OFFSET,
 				} );
 
 				const args = registry

--- a/assets/js/modules/analytics-4/hooks/useAllTrafficWidgetReport.js
+++ b/assets/js/modules/analytics-4/hooks/useAllTrafficWidgetReport.js
@@ -24,10 +24,7 @@ import { CORE_SITE } from '@/js/googlesitekit/datastore/site/constants';
 import { CORE_USER } from '@/js/googlesitekit/datastore/user/constants';
 import useViewOnly from '@/js/hooks/useViewOnly';
 import { MODULE_SLUG_ANALYTICS_4 } from '@/js/modules/analytics-4/constants';
-import {
-	DATE_RANGE_OFFSET,
-	MODULES_ANALYTICS_4,
-} from '@/js/modules/analytics-4/datastore/constants';
+import { MODULES_ANALYTICS_4 } from '@/js/modules/analytics-4/datastore/constants';
 
 /**
  * Gets report information for the Dashboard All Traffic GA4 widget.
@@ -53,7 +50,6 @@ export default function useAllTrafficWidgetReport( reportOptions = {} ) {
 	const { startDate, endDate } = useSelect( ( select ) =>
 		select( CORE_USER ).getDateRangeDates( {
 			compare: true,
-			offsetDays: DATE_RANGE_OFFSET,
 		} )
 	);
 

--- a/assets/js/modules/analytics-4/hooks/useAllTrafficWidgetReport.test.js
+++ b/assets/js/modules/analytics-4/hooks/useAllTrafficWidgetReport.test.js
@@ -20,7 +20,6 @@
  * Internal dependencies
  */
 import { CORE_USER } from '@/js/googlesitekit/datastore/user/constants';
-import { DATE_RANGE_OFFSET } from '@/js/modules/analytics-4/datastore/constants';
 import { getAnalytics4MockResponse } from '@/js/modules/analytics-4/utils/data-mock';
 import { ERROR_INTERNAL_SERVER_ERROR } from '@/js/util/errors';
 import { actHook, renderHook } from '@tests/js/test-utils';
@@ -86,7 +85,6 @@ describe( 'useAllTrafficWidgetReport', () => {
 		const reportArgs = {
 			...registry.select( CORE_USER ).getDateRangeDates( {
 				compare: true,
-				offsetDays: DATE_RANGE_OFFSET,
 			} ),
 			metrics: [ { name: 'totalUsers' } ],
 		};

--- a/assets/js/modules/analytics-4/hooks/useAudienceTilesReports.js
+++ b/assets/js/modules/analytics-4/hooks/useAudienceTilesReports.js
@@ -21,10 +21,7 @@
  */
 import { useInViewSelect, useSelect } from 'googlesitekit-data';
 import { CORE_USER } from '@/js/googlesitekit/datastore/user/constants';
-import {
-	DATE_RANGE_OFFSET,
-	MODULES_ANALYTICS_4,
-} from '@/js/modules/analytics-4/datastore/constants';
+import { MODULES_ANALYTICS_4 } from '@/js/modules/analytics-4/datastore/constants';
 
 /**
  * Checks if the audience reports are loaded for the given report options.
@@ -157,7 +154,6 @@ export default function useAudienceTilesReports( {
 
 	const dates = useSelect( ( select ) =>
 		select( CORE_USER ).getDateRangeDates( {
-			offsetDays: DATE_RANGE_OFFSET,
 			compare: true,
 		} )
 	);

--- a/assets/js/modules/search-console/components/dashboard/DashboardPopularKeywordsWidget.js
+++ b/assets/js/modules/search-console/components/dashboard/DashboardPopularKeywordsWidget.js
@@ -34,10 +34,7 @@ import { CORE_SITE } from '@/js/googlesitekit/datastore/site/constants';
 import { CORE_USER } from '@/js/googlesitekit/datastore/user/constants';
 import useViewOnly from '@/js/hooks/useViewOnly';
 import { ZeroDataMessage } from '@/js/modules/search-console/components/common';
-import {
-	DATE_RANGE_OFFSET,
-	MODULES_SEARCH_CONSOLE,
-} from '@/js/modules/search-console/datastore/constants';
+import { MODULES_SEARCH_CONSOLE } from '@/js/modules/search-console/datastore/constants';
 import { generateDateRangeArgs } from '@/js/modules/search-console/util';
 import { numFmt } from '@/js/util';
 
@@ -51,9 +48,7 @@ export default function DashboardPopularKeywordsWidget( props ) {
 	);
 
 	const dateRangeDates = useSelect( ( select ) =>
-		select( CORE_USER ).getDateRangeDates( {
-			offsetDays: DATE_RANGE_OFFSET,
-		} )
+		select( CORE_USER ).getDateRangeDates()
 	);
 
 	const reportArgs = {
@@ -151,9 +146,7 @@ export default function DashboardPopularKeywordsWidget( props ) {
 					if ( viewOnlyDashboard ) {
 						return null;
 					}
-					const dates = select( CORE_USER ).getDateRangeDates( {
-						offsetDays: DATE_RANGE_OFFSET,
-					} );
+					const dates = select( CORE_USER ).getDateRangeDates();
 					const entityURL = select( CORE_SITE ).getCurrentEntityURL();
 					return select( MODULES_SEARCH_CONSOLE ).getServiceReportURL(
 						{

--- a/assets/js/modules/search-console/components/dashboard/SearchFunnelWidgetGA4/Footer.js
+++ b/assets/js/modules/search-console/components/dashboard/SearchFunnelWidgetGA4/Footer.js
@@ -35,15 +35,9 @@ import SourceLink from '@/js/components/SourceLink';
 import { CORE_SITE } from '@/js/googlesitekit/datastore/site/constants';
 import { CORE_USER } from '@/js/googlesitekit/datastore/user/constants';
 import useViewOnly from '@/js/hooks/useViewOnly';
-import {
-	DATE_RANGE_OFFSET as DATE_RANGE_OFFSET_ANALYTICS,
-	MODULES_ANALYTICS_4,
-} from '@/js/modules/analytics-4/datastore/constants';
+import { MODULES_ANALYTICS_4 } from '@/js/modules/analytics-4/datastore/constants';
 import { MODULE_SLUG_SEARCH_CONSOLE } from '@/js/modules/search-console/constants';
-import {
-	DATE_RANGE_OFFSET,
-	MODULES_SEARCH_CONSOLE,
-} from '@/js/modules/search-console/datastore/constants';
+import { MODULES_SEARCH_CONSOLE } from '@/js/modules/search-console/datastore/constants';
 import { generateDateRangeArgs } from '@/js/modules/search-console/util';
 import { getURLPath, untrailingslashit } from '@/js/util';
 
@@ -59,7 +53,6 @@ function SourceLinkAnalytics4() {
 		const url = select( CORE_SITE ).getCurrentEntityURL();
 		const dates = select( CORE_USER ).getDateRangeDates( {
 			compare: true,
-			offsetDays: DATE_RANGE_OFFSET_ANALYTICS,
 		} );
 
 		const reportArgs = {
@@ -107,9 +100,7 @@ function SourceLinkSearch( { metric } ) {
 				select( CORE_SITE ).getReferenceSiteURL()
 			);
 			const url = select( CORE_SITE ).getCurrentEntityURL();
-			const dateRangeDates = select( CORE_USER ).getDateRangeDates( {
-				offsetDays: DATE_RANGE_OFFSET,
-			} );
+			const dateRangeDates = select( CORE_USER ).getDateRangeDates();
 
 			const serviceURLArgs = {
 				resource_id: getPropertyID(),

--- a/assets/js/modules/search-console/components/dashboard/SearchFunnelWidgetGA4/index.js
+++ b/assets/js/modules/search-console/components/dashboard/SearchFunnelWidgetGA4/index.js
@@ -38,15 +38,9 @@ import { CORE_USER } from '@/js/googlesitekit/datastore/user/constants';
 import { CORE_MODULES } from '@/js/googlesitekit/modules/datastore/constants';
 import useViewOnly from '@/js/hooks/useViewOnly';
 import { MODULE_SLUG_ANALYTICS_4 } from '@/js/modules/analytics-4/constants';
-import {
-	DATE_RANGE_OFFSET as DATE_RANGE_OFFSET_ANALYTICS,
-	MODULES_ANALYTICS_4,
-} from '@/js/modules/analytics-4/datastore/constants';
+import { MODULES_ANALYTICS_4 } from '@/js/modules/analytics-4/datastore/constants';
 import { MODULE_SLUG_SEARCH_CONSOLE } from '@/js/modules/search-console/constants';
-import {
-	DATE_RANGE_OFFSET,
-	MODULES_SEARCH_CONSOLE,
-} from '@/js/modules/search-console/datastore/constants';
+import { MODULES_SEARCH_CONSOLE } from '@/js/modules/search-console/datastore/constants';
 import Chart from './Chart';
 import Footer from './Footer';
 import Header from './Header';
@@ -88,13 +82,11 @@ function SearchFunnelWidgetGA4( { Widget, WidgetReportError } ) {
 	const { endDate, compareStartDate } = useSelect( ( select ) =>
 		select( CORE_USER ).getDateRangeDates( {
 			compare: true,
-			offsetDays: DATE_RANGE_OFFSET,
 		} )
 	);
 	const ga4Dates = useSelect( ( select ) =>
 		select( CORE_USER ).getDateRangeDates( {
 			compare: true,
-			offsetDays: DATE_RANGE_OFFSET_ANALYTICS,
 		} )
 	);
 

--- a/assets/js/modules/search-console/components/widgets/PopularKeywordsWidget.js
+++ b/assets/js/modules/search-console/components/widgets/PopularKeywordsWidget.js
@@ -41,10 +41,7 @@ import {
 } from '@/js/googlesitekit/datastore/user/constants';
 import useViewOnly from '@/js/hooks/useViewOnly';
 import { ZeroDataMessage } from '@/js/modules/search-console/components/common';
-import {
-	DATE_RANGE_OFFSET,
-	MODULES_SEARCH_CONSOLE,
-} from '@/js/modules/search-console/datastore/constants';
+import { MODULES_SEARCH_CONSOLE } from '@/js/modules/search-console/datastore/constants';
 import { generateDateRangeArgs } from '@/js/modules/search-console/util';
 import { numFmt } from '@/js/util';
 
@@ -52,9 +49,7 @@ export default function PopularKeywordsWidget( { Widget } ) {
 	const viewOnlyDashboard = useViewOnly();
 
 	const dates = useSelect( ( select ) =>
-		select( CORE_USER ).getDateRangeDates( {
-			offsetDays: DATE_RANGE_OFFSET,
-		} )
+		select( CORE_USER ).getDateRangeDates()
 	);
 
 	const reportOptions = {

--- a/assets/js/modules/search-console/components/widgets/PopularKeywordsWidget.test.js
+++ b/assets/js/modules/search-console/components/widgets/PopularKeywordsWidget.test.js
@@ -26,10 +26,7 @@ import {
 import { withConnected } from '@/js/googlesitekit/modules/datastore/__fixtures__';
 import { getWidgetComponentProps } from '@/js/googlesitekit/widgets/util';
 import { MODULE_SLUG_SEARCH_CONSOLE } from '@/js/modules/search-console/constants';
-import {
-	DATE_RANGE_OFFSET,
-	MODULES_SEARCH_CONSOLE,
-} from '@/js/modules/search-console/datastore/constants';
+import { MODULES_SEARCH_CONSOLE } from '@/js/modules/search-console/datastore/constants';
 import { provideSearchConsoleMockReport } from '@/js/modules/search-console/util/data-mock';
 import {
 	ERROR_INTERNAL_SERVER_ERROR,
@@ -66,9 +63,7 @@ describe( 'PopularKeywordsWidget', () => {
 
 	it( 'should render correctly with the expected metrics', async () => {
 		const reportOptions = {
-			...registry.select( CORE_USER ).getDateRangeDates( {
-				offsetDays: DATE_RANGE_OFFSET,
-			} ),
+			...registry.select( CORE_USER ).getDateRangeDates(),
 			dimensions: 'query',
 			limit: 100,
 			reportID:

--- a/assets/js/modules/search-console/datastore/constants.js
+++ b/assets/js/modules/search-console/datastore/constants.js
@@ -17,6 +17,3 @@
  */
 
 export const MODULES_SEARCH_CONSOLE = 'modules/search-console';
-
-// Date range offset days for Search Console report requests.
-export const DATE_RANGE_OFFSET = 0;

--- a/assets/js/modules/search-console/datastore/report.js
+++ b/assets/js/modules/search-console/datastore/report.js
@@ -43,7 +43,7 @@ import {
 	isValidDateRange,
 	isValidStringularItems,
 } from '@/js/util/report-validation';
-import { DATE_RANGE_OFFSET, MODULES_SEARCH_CONSOLE } from './constants';
+import { MODULES_SEARCH_CONSOLE } from './constants';
 
 const fetchGetReportStore = createFetchStore( {
 	baseName: 'getReport',
@@ -219,7 +219,6 @@ const baseSelectors = {
 			CORE_USER
 		).getDateRangeDates( {
 			compare: true,
-			offsetDays: DATE_RANGE_OFFSET,
 		} );
 
 		const args = {

--- a/assets/js/modules/search-console/datastore/report.test.js
+++ b/assets/js/modules/search-console/datastore/report.test.js
@@ -31,7 +31,7 @@ import {
 	untilResolved,
 } from '@tests/js/utils';
 import * as fixtures from './__fixtures__';
-import { DATE_RANGE_OFFSET, MODULES_SEARCH_CONSOLE } from './constants';
+import { MODULES_SEARCH_CONSOLE } from './constants';
 
 describe( 'modules/search-console report', () => {
 	const searchAnalyticsRegexp = new RegExp(
@@ -330,7 +330,6 @@ describe( 'modules/search-console report', () => {
 
 				const dates = registry.select( CORE_USER ).getDateRangeDates( {
 					compare: true,
-					offsetDays: DATE_RANGE_OFFSET,
 				} );
 
 				const args = registry

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
 		"postinstall": "node -e \"process.env.SKIP_PATCH_PACKAGE || require('child_process').execSync('patch-package', {stdio:'inherit'})\"",
 		"preinstall": "./bin/check-node-version.js",
 		"typecheck": "tsc --noEmit",
-		"typecheck-staged": "tsc-files assets/js/types/svg.d.ts assets/js/types/equivalent-key-map.d.ts"
+		"typecheck-staged": "tsc-files assets/js/types/svg.d.ts assets/js/types/equivalent-key-map.d.ts tests/js/types/jest-matchers.d.ts"
 	},
 	"browserslist": [
 		"extends @wordpress/browserslist-config"


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #11658

## Relevant technical choices

- Removes `offsetDays` option from `getDateRangeDates()`.
- Updates all uses of `getDateRangeDates()` to remove any use of the option in components and tests.
- Removes the `DATE_RANGE_OFFSET` constants used to pass to the option.
- Removes tests for the `offsetDays` option.
- Adds `tests/js/types/jest-matchers.d.ts` to `typecheck-staged` to resolve type errors in the pre-commit hook when updating tests written with TypeScript.

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [x] Run the code.
- [x] Ensure the acceptance criteria are satisfied.
- [x] Reassess the implementation with the IB.
- [x] Ensure no unrelated changes are included.
- [x] Ensure CI checks pass.
- [x] Check Storybook where applicable.
- [x] Ensure there is a QA Brief.
- [x] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [x] Ensure the PR has the correct target branch.
- [x] Double-check that the PR is okay to be merged.
- [x] Ensure the corresponding issue has a ZenHub release assigned.
- [x] Add a changelog message to the issue.
