### PR TITLE
Add left padding to the Site Goals tour notice spotlight

### DIFF
--- a/assets/js/modules/analytics-4/components/site-goals/feature-tours/site-goals.ts
+++ b/assets/js/modules/analytics-4/components/site-goals/feature-tours/site-goals.ts
@@ -96,6 +96,13 @@ export function getSiteGoalsTour( {
 					'Want to know which specific form is bringing in the most interest? You can break these numbers down to see the performance of each individual form on your site.',
 					'google-site-kit'
 			  ),
+		styles: {
+			spotlight: {
+				...defaultStepOptions.styles.spotlight,
+				paddingInlineStart: '24px',
+				marginInlineStart: '-24px',
+			},
+		},
 	};
 
 	return {


### PR DESCRIPTION
Enhance the visual presentation of the Site Goals tour by adding padding and margin adjustments to the spotlight styles.

## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #12600

## Relevant technical choices

<!-- Please describe your changes. -->

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.
- [ ] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
