### PR TITLE
Anchor the PUE setup overlay tooltip to the user menu on mobile

### DIFF
--- a/assets/js/components/email-reporting/SetUpEmailReportingOverlayNotification.js
+++ b/assets/js/components/email-reporting/SetUpEmailReportingOverlayNotification.js
@@ -83,6 +83,7 @@ export default function SetUpEmailReportingOverlayNotification( {
 			'google-site-kit'
 		),
 		dismissLabel: __( 'Got it', 'google-site-kit' ),
+		isCenteredOnMobile: false,
 	};
 
 	const showTooltip = useShowTooltip( tooltipSettings );

--- a/assets/js/components/email-reporting/SetUpEmailReportingOverlayNotification.test.js
+++ b/assets/js/components/email-reporting/SetUpEmailReportingOverlayNotification.test.js
@@ -24,6 +24,7 @@ import { waitFor } from '@testing-library/react';
 /**
  * Internal dependencies
  */
+import { useShowTooltip } from '@/js/components/AdminScreenTooltip';
 import Notifications from '@/js/components/notifications/Notifications';
 import {
 	VIEW_CONTEXT_MAIN_DASHBOARD,
@@ -82,6 +83,7 @@ describe( 'SetUpEmailReportingOverlayNotification', () => {
 	afterEach( () => {
 		fetchMock.reset();
 		mockShowTooltip.mockClear();
+		useShowTooltip.mockClear();
 	} );
 
 	describe( 'checkRequirements', () => {
@@ -349,6 +351,20 @@ describe( 'SetUpEmailReportingOverlayNotification', () => {
 
 			await waitFor( () =>
 				expect( mockShowTooltip ).toHaveBeenCalledTimes( 1 )
+			);
+		} );
+
+		it( 'anchors the tooltip on mobile', () => {
+			render( <NotificationComponent />, {
+				registry,
+				viewContext: VIEW_CONTEXT_MAIN_DASHBOARD,
+				features: [ 'proactiveUserEngagement' ],
+			} );
+
+			expect( useShowTooltip ).toHaveBeenCalledWith(
+				expect.objectContaining( {
+					isCenteredOnMobile: false,
+				} )
 			);
 		} );
 

--- a/assets/sass/components/tour-tooltip/_googlesitekit-tour-tooltip.scss
+++ b/assets/sass/components/tour-tooltip/_googlesitekit-tour-tooltip.scss
@@ -339,6 +339,20 @@
 	left: 195px !important;
 }
 
+// On mobile and tablet, shift the tooltip further from the edge and realign its
+// arrow with the user menu so it stays on screen.
+// !important is required to override Joyride's inline styles.
+@media (max-width: $bp-desktop) {
+
+	#react-joyride-step-0:has(.googlesitekit-tour-tooltip--user-menu) > div.__floater {
+		left: -90px !important;
+	}
+
+	#react-joyride-step-0:has(.googlesitekit-tour-tooltip--user-menu) .__floater__arrow > span {
+		left: 215px !important;
+	}
+}
+
 // !important is required to override Joyride's inline styles.
 .folded #react-joyride-step-0:has(.googlesitekit-tour-tooltip__fixed-settings-tooltip) > div.__floater {
 	left: 46px !important;

--- a/assets/sass/components/tour-tooltip/_googlesitekit-tour-tooltip.scss
+++ b/assets/sass/components/tour-tooltip/_googlesitekit-tour-tooltip.scss
@@ -339,7 +339,7 @@
 	left: 195px !important;
 }
 
-// On mobile and tablet, shift the tooltip further from the edge and realign its
+// On mobile and tablet, shift the tooltip farther from the edge and realign its
 // arrow with the user menu so it stays on screen.
 // !important is required to override Joyride's inline styles.
 @media (max-width: $bp-desktop) {


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #12710

## Relevant technical choices

- Add a mobile breakpoint so the user-menu tooltip stays on screen. Its positioning (from #11147) was desktop-only and clipped it on mobile.

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.
- [ ] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
