### PR TITLE
Improve the Site Goals tour start and final step CTA

### DIFF
--- a/assets/js/modules/analytics-4/components/site-goals/feature-tours/site-goals.test.ts
+++ b/assets/js/modules/analytics-4/components/site-goals/feature-tours/site-goals.test.ts
@@ -21,8 +21,22 @@
  */
 import { getSiteGoalsTour } from './site-goals';
 
+// Adds the tour's first step target to the page, so `checkRequirements`
+// resolves right away. The `afterEach` below removes it.
+function appendTourTarget() {
+	const target = document.createElement( 'div' );
+	target.className = 'googlesitekit-site-goals-primary-action';
+	document.body.appendChild( target );
+}
+
 describe( 'getSiteGoalsTour', () => {
 	const baseParams = { isEcommerceOnly: false, hasBreakdownNotice: true };
+
+	afterEach( () => {
+		document
+			.querySelectorAll( '.googlesitekit-site-goals-primary-action' )
+			.forEach( ( target ) => target.remove() );
+	} );
 
 	it( 'should return the Site Goals tour with the right slug', () => {
 		const tour = getSiteGoalsTour( baseParams );
@@ -30,7 +44,7 @@ describe( 'getSiteGoalsTour', () => {
 		expect( tour.slug ).toBe( 'site-goals-feature-tour' );
 	} );
 
-	it( 'should be repeatable so the user can replay it from the Help menu', () => {
+	it( 'should be repeatable so the tour can start again on demand', () => {
 		const tour = getSiteGoalsTour( baseParams );
 
 		expect( tour.isRepeatable ).toBe( true );
@@ -114,5 +128,71 @@ describe( 'getSiteGoalsTour', () => {
 		expect( tour.steps[ 1 ].content ).toMatch(
 			/WooCommerce or Easy Digital Downloads/
 		);
+	} );
+
+	it( 'should resolve checkRequirements right away when the first step target is on the page', async () => {
+		appendTourTarget();
+
+		const tour = getSiteGoalsTour( baseParams );
+
+		await expect( tour.checkRequirements() ).resolves.toBe( true );
+	} );
+
+	it( 'should keep checkRequirements waiting until the first step target renders', async () => {
+		const tour = getSiteGoalsTour( baseParams );
+
+		const requirementsPromise = tour.checkRequirements();
+
+		let isResolved = false;
+		requirementsPromise.then( () => {
+			isResolved = true;
+		} );
+
+		// Give checkRequirements time to look for the target. It must keep
+		// waiting while the target is missing.
+		await new Promise( ( resolve ) => {
+			setTimeout( resolve, 300 );
+		} );
+		expect( isResolved ).toBe( false );
+
+		appendTourTarget();
+
+		await expect( requirementsPromise ).resolves.toBe( true );
+	} );
+
+	it( 'should resolve checkRequirements after five seconds when the target never renders', async () => {
+		jest.useFakeTimers();
+
+		const tour = getSiteGoalsTour( baseParams );
+		const requirementsPromise = tour.checkRequirements();
+
+		// Run all 20 timers of 250ms each. This is the full five-second
+		// wait.
+		for ( let check = 0; check < 20; check++ ) {
+			jest.advanceTimersByTime( 250 );
+			// Let the check finish before the next timer runs.
+			await Promise.resolve();
+		}
+
+		await expect( requirementsPromise ).resolves.toBe( true );
+
+		jest.useRealTimers();
+	} );
+
+	it( 'should set the "Done" label only on the last step', () => {
+		const tour = getSiteGoalsTour( {
+			...baseParams,
+			hasBreakdownNotice: true,
+		} );
+
+		expect( tour.steps[ tour.steps.length - 1 ] ).toMatchObject( {
+			locale: { last: 'Done' },
+		} );
+
+		// Only the last step sets a locale. The earlier steps keep the
+		// shared "Got it" label.
+		expect(
+			tour.steps.slice( 0, -1 ).map( ( step ) => 'locale' in step )
+		).toEqual( [ false, false ] );
 	} );
 } );

--- a/assets/js/modules/analytics-4/components/site-goals/feature-tours/site-goals.ts
+++ b/assets/js/modules/analytics-4/components/site-goals/feature-tours/site-goals.ts
@@ -29,6 +29,49 @@ import { AREA_MAIN_DASHBOARD_SITE_GOALS_PRIMARY } from '@/js/googlesitekit/widge
 
 export const SITE_GOALS_TOUR = 'site-goals-feature-tour';
 
+// The first step's target. The tour starts only after this element renders.
+const FIRST_STEP_TARGET = '.googlesitekit-site-goals-primary-action';
+
+// The widgets render the target only after their reports load. Look for
+// the target every 250ms. Stop after five seconds, so a section that
+// never loads cannot block the tour.
+const TOUR_READY_CHECK_INTERVAL_MS = 250;
+const TOUR_READY_CHECK_MAX_TOTAL_WAIT_MS = 5000;
+
+/**
+ * Waits until the Site Goals tour can start.
+ *
+ * react-joyride skips a step when its target is not on the page. A tour that
+ * starts too early skips every step and shows nothing. This check waits for
+ * the first step's target to render, five seconds at most, so the tour is
+ * never blocked. `triggerOnDemandTour` waits for this check before it starts
+ * the tour.
+ *
+ * @since n.e.x.t
+ *
+ * @return Promise that resolves to `true` once the tour can start.
+ */
+function checkSiteGoalsTourRequirements(): Promise< boolean > {
+	return new Promise( ( resolve ) => {
+		let remainingWaitMs = TOUR_READY_CHECK_MAX_TOTAL_WAIT_MS;
+
+		function checkTarget() {
+			if (
+				global.document.querySelector( FIRST_STEP_TARGET ) ||
+				remainingWaitMs <= 0
+			) {
+				resolve( true );
+				return;
+			}
+
+			remainingWaitMs -= TOUR_READY_CHECK_INTERVAL_MS;
+			global.setTimeout( checkTarget, TOUR_READY_CHECK_INTERVAL_MS );
+		}
+
+		checkTarget();
+	} );
+}
+
 const defaultStepOptions = {
 	offset: -2,
 	spotlightPadding: 0,
@@ -64,10 +107,13 @@ function gaEventCategory( viewContext: string ) {
  *
  * The tour starts when the user clicks "Show me" on the Site Goals intro modal
  * and runs on the Site Goals widget. The first step points at the key action
- * tile group and the last step points at the goal drivers. The breakdown notice
- * step is included only when `hasBreakdownNotice` is true, because that step
- * targets the notice and the notice is not always rendered. Its copy depends on
- * `isEcommerceOnly`: sales copy when `true`, leads copy when `false`.
+ * tile group and the last step points at the goal drivers. The last step's
+ * button says "Done" instead of the shared "Got it". The tour starts only
+ * after the first step's target renders, because react-joyride skips a step
+ * when its target is missing. The breakdown notice step is included only when
+ * `hasBreakdownNotice` is true, because that step targets the notice and the
+ * notice is not always rendered. Its copy depends on `isEcommerceOnly`: sales
+ * copy when `true`, leads copy when `false`.
  *
  * @since n.e.x.t
  *
@@ -111,10 +157,11 @@ export function getSiteGoalsTour( {
 		contexts: [ VIEW_CONTEXT_MAIN_DASHBOARD ],
 		gaEventCategory,
 		preloadWidgetAreas: [ AREA_MAIN_DASHBOARD_SITE_GOALS_PRIMARY ],
+		checkRequirements: checkSiteGoalsTourRequirements,
 		steps: [
 			{
 				...defaultStepOptions,
-				target: '.googlesitekit-site-goals-primary-action',
+				target: FIRST_STEP_TARGET,
 				title: __(
 					'Your main goal is front and center',
 					'google-site-kit'
@@ -133,6 +180,12 @@ export function getSiteGoalsTour( {
 					'Discover which traffic channels or locations are bringing in the best results, so you can focus on what works. Customize this list with metrics that matter the most to you.',
 					'google-site-kit'
 				),
+				// Show "Done" on the last step's button instead of the
+				// shared "Got it". react-joyride merges this over the tour
+				// locale, so all other labels stay the same.
+				locale: {
+					last: __( 'Done', 'google-site-kit' ),
+				},
 			},
 		],
 	};

--- a/assets/js/modules/analytics-4/components/site-goals/feature-tours/site-goals.ts
+++ b/assets/js/modules/analytics-4/components/site-goals/feature-tours/site-goals.ts
@@ -43,13 +43,13 @@ const TOUR_READY_CHECK_MAX_TOTAL_WAIT_MS = 5000;
  *
  * react-joyride skips a step when its target is not on the page. A tour that
  * starts too early skips every step and shows nothing. This check waits for
- * the first step's target to render, five seconds at most, so the tour is
- * never blocked. `triggerOnDemandTour` waits for this check before it starts
- * the tour.
+ * the first step's target to render. After five seconds the tour starts
+ * anyway, so the wait only delays the start and never cancels the tour.
+ * `triggerOnDemandTour` waits for this check before it starts the tour.
  *
  * @since n.e.x.t
  *
- * @return Promise that resolves to `true` once the tour can start.
+ * @return Promise that always resolves to `true`, when the target renders or the wait ends.
  */
 function checkSiteGoalsTourRequirements(): Promise< boolean > {
 	return new Promise( ( resolve ) => {

--- a/assets/js/modules/analytics-4/components/site-goals/feature-tours/site-goals.ts
+++ b/assets/js/modules/analytics-4/components/site-goals/feature-tours/site-goals.ts
@@ -29,7 +29,7 @@ import { AREA_MAIN_DASHBOARD_SITE_GOALS_PRIMARY } from '@/js/googlesitekit/widge
 
 export const SITE_GOALS_TOUR = 'site-goals-feature-tour';
 
-// The first step's target. The tour starts only after this element renders.
+// The first step's target. The tour waits for this element before it starts.
 const FIRST_STEP_TARGET = '.googlesitekit-site-goals-primary-action';
 
 // The widgets render the target only after their reports load. Look for
@@ -42,10 +42,11 @@ const TOUR_READY_CHECK_MAX_TOTAL_WAIT_MS = 5000;
  * Waits until the Site Goals tour can start.
  *
  * react-joyride skips a step when its target is not on the page. A tour that
- * starts too early skips every step and shows nothing. This check waits for
- * the first step's target to render. After five seconds the tour starts
- * anyway, so the wait only delays the start and never cancels the tour.
- * `triggerOnDemandTour` waits for this check before it starts the tour.
+ * starts too early skips every step and shows nothing. This check lets the
+ * tour start as soon as the first step's target renders. When the target is
+ * slow, the wait ends after five seconds and the tour starts anyway, so the
+ * wait never cancels the tour. `triggerOnDemandTour` waits for this check
+ * before it starts the tour.
  *
  * @since n.e.x.t
  *
@@ -108,12 +109,12 @@ function gaEventCategory( viewContext: string ) {
  * The tour starts when the user clicks "Show me" on the Site Goals intro modal
  * and runs on the Site Goals widget. The first step points at the key action
  * tile group and the last step points at the goal drivers. The last step's
- * button says "Done" instead of the shared "Got it". The tour starts only
- * after the first step's target renders, because react-joyride skips a step
- * when its target is missing. The breakdown notice step is included only when
- * `hasBreakdownNotice` is true, because that step targets the notice and the
- * notice is not always rendered. Its copy depends on `isEcommerceOnly`: sales
- * copy when `true`, leads copy when `false`.
+ * button says "Done" instead of the shared "Got it". The tour waits for the
+ * first step's target to render, five seconds at most, because react-joyride
+ * skips a step when its target is missing. The breakdown notice step is
+ * included only when `hasBreakdownNotice` is true, because that step targets
+ * the notice and the notice is not always rendered. Its copy depends on
+ * `isEcommerceOnly`: sales copy when `true`, leads copy when `false`.
  *
  * @since n.e.x.t
  *

--- a/assets/js/modules/analytics-4/components/site-goals/notifications/IntroModalBanner/index.test.js
+++ b/assets/js/modules/analytics-4/components/site-goals/notifications/IntroModalBanner/index.test.js
@@ -145,7 +145,7 @@ describe( 'IntroModal', () => {
 			.dispatch( MODULES_ANALYTICS_4 )
 			.setDetectedEvents( [ ENUM_CONVERSION_EVENTS.PURCHASE ] );
 
-		// The tour starts only after its first target is on the page.
+		// The tour waits for its first target, so add it before the click.
 		appendTourTarget();
 
 		const { getByRole } = render( <IntroModal />, {
@@ -197,9 +197,9 @@ describe( 'IntroModal', () => {
 		// to the section anchor, the same actions the navigation chip
 		// performs.
 		expect( global.location.hash ).toBe( '#site-goals' );
-		expect(
-			registry.select( CORE_UI ).getValue( ACTIVE_CONTEXT_ID )
-		).toBe( 'site-goals' );
+		expect( registry.select( CORE_UI ).getValue( ACTIVE_CONTEXT_ID ) ).toBe(
+			'site-goals'
+		);
 		expect( scrollToSpy ).toHaveBeenCalledWith( {
 			top: 12345,
 			behavior: 'smooth',

--- a/assets/js/modules/analytics-4/components/site-goals/notifications/IntroModalBanner/index.test.js
+++ b/assets/js/modules/analytics-4/components/site-goals/notifications/IntroModalBanner/index.test.js
@@ -24,6 +24,10 @@ import fetchMock from 'fetch-mock';
 /**
  * Internal dependencies
  */
+import {
+	ACTIVE_CONTEXT_ID,
+	CORE_UI,
+} from '@/js/googlesitekit/datastore/ui/constants';
 import { CORE_USER } from '@/js/googlesitekit/datastore/user/constants';
 import useNotificationEvents from '@/js/googlesitekit/notifications/hooks/useNotificationEvents';
 import { getSiteGoalsTour } from '@/js/modules/analytics-4/components/site-goals/feature-tours/site-goals';
@@ -32,8 +36,10 @@ import {
 	ENUM_CONVERSION_EVENTS,
 	MODULES_ANALYTICS_4,
 } from '@/js/modules/analytics-4/datastore/constants';
+import * as scrollUtils from '@/js/util/scroll';
 import { dismissItemEndpoint } from '@tests/js/mock-dismiss-item-endpoints';
 import {
+	act,
 	createTestRegistry,
 	fireEvent,
 	provideModules,
@@ -43,6 +49,20 @@ import {
 import IntroModal from './index';
 
 jest.mock( '@/js/googlesitekit/notifications/hooks/useNotificationEvents' );
+
+const getNavigationalScrollTopSpy = jest.spyOn(
+	scrollUtils,
+	'getNavigationalScrollTop'
+);
+const scrollToSpy = jest.spyOn( global, 'scrollTo' );
+
+// Adds the tour's first step target to the page, so `checkRequirements`
+// resolves right away. The `afterEach` below removes it.
+function appendTourTarget() {
+	const target = document.createElement( 'div' );
+	target.className = 'googlesitekit-site-goals-primary-action';
+	document.body.appendChild( target );
+}
 
 describe( 'IntroModal', () => {
 	let registry;
@@ -73,6 +93,15 @@ describe( 'IntroModal', () => {
 
 		registry.dispatch( CORE_USER ).receiveGetDismissedItems( [] );
 		registry.dispatch( CORE_USER ).receiveGetDismissedTours( [] );
+	} );
+
+	afterEach( () => {
+		document
+			.querySelectorAll( '.googlesitekit-site-goals-primary-action' )
+			.forEach( ( target ) => target.remove() );
+		global.location.hash = '';
+		getNavigationalScrollTopSpy.mockClear();
+		scrollToSpy.mockClear();
 	} );
 
 	it( 'renders ecommerce-only variant when only ecommerce conversion events exist', () => {
@@ -116,6 +145,9 @@ describe( 'IntroModal', () => {
 			.dispatch( MODULES_ANALYTICS_4 )
 			.setDetectedEvents( [ ENUM_CONVERSION_EVENTS.PURCHASE ] );
 
+		// The tour starts only after its first target is on the page.
+		appendTourTarget();
+
 		const { getByRole } = render( <IntroModal />, {
 			registry,
 		} );
@@ -129,6 +161,48 @@ describe( 'IntroModal', () => {
 					hasBreakdownNotice: true,
 				} )
 			);
+		} );
+	} );
+
+	it( 'should navigate to the Site Goals section when the user clicks "Show me"', async () => {
+		registry
+			.dispatch( MODULES_ANALYTICS_4 )
+			.setDetectedEvents( [ ENUM_CONVERSION_EVENTS.PURCHASE ] );
+
+		appendTourTarget();
+
+		// Return a known position only for the Site Goals anchor, so the
+		// scroll assertion below also checks the selector.
+		getNavigationalScrollTopSpy.mockImplementation( ( selector ) => {
+			if ( selector === '#site-goals' ) {
+				return 12345;
+			}
+
+			return 0;
+		} );
+
+		const { getByRole } = render( <IntroModal />, {
+			registry,
+		} );
+
+		// The click also dismisses the modal and starts the tour. The async
+		// act call lets those updates finish inside the test. The callback
+		// itself has nothing to await.
+		// eslint-disable-next-line require-await
+		await act( async () => {
+			fireEvent.click( getByRole( 'button', { name: /show me/i } ) );
+		} );
+
+		// The click sets the URL hash, sets the active context, and scrolls
+		// to the section anchor, the same actions the navigation chip
+		// performs.
+		expect( global.location.hash ).toBe( '#site-goals' );
+		expect(
+			registry.select( CORE_UI ).getValue( ACTIVE_CONTEXT_ID )
+		).toBe( 'site-goals' );
+		expect( scrollToSpy ).toHaveBeenCalledWith( {
+			top: 12345,
+			behavior: 'smooth',
 		} );
 	} );
 } );

--- a/assets/js/modules/analytics-4/components/site-goals/notifications/IntroModalBanner/index.tsx
+++ b/assets/js/modules/analytics-4/components/site-goals/notifications/IntroModalBanner/index.tsx
@@ -25,14 +25,21 @@ import { useState } from '@wordpress/element';
  * Internal dependencies
  */
 import { Select, useDispatch, useSelect } from 'googlesitekit-data';
+import { ANCHOR_ID_SITE_GOALS } from '@/js/googlesitekit/constants';
+import {
+	ACTIVE_CONTEXT_ID,
+	CORE_UI,
+} from '@/js/googlesitekit/datastore/ui/constants';
 import { CORE_USER } from '@/js/googlesitekit/datastore/user/constants';
 import useNotificationEvents from '@/js/googlesitekit/notifications/hooks/useNotificationEvents';
+import { useBreakpoint } from '@/js/hooks/useBreakpoint';
 import {
 	SITE_GOALS_BREAKDOWN_CUSTOM_DIMENSIONS,
 	SITE_GOALS_BREAKDOWN_NOTICE,
 } from '@/js/modules/analytics-4/components/site-goals/constants';
 import { getSiteGoalsTour } from '@/js/modules/analytics-4/components/site-goals/feature-tours/site-goals';
 import { MODULES_ANALYTICS_4 } from '@/js/modules/analytics-4/datastore/constants';
+import { getNavigationalScrollTop } from '@/js/util/scroll';
 import IntroModalEcommerce from './IntroModalEcommerce';
 import IntroModalEcommerceAndLead from './IntroModalEcommerceAndLead';
 import IntroModalLead from './IntroModalLead';
@@ -85,6 +92,9 @@ export default function IntroModal() {
 	const [ isOpen, setIsOpen ] = useState( true );
 
 	const { dismissItem, triggerOnDemandTour } = useDispatch( CORE_USER );
+	const { setValue } = useDispatch( CORE_UI );
+
+	const breakpoint = useBreakpoint();
 
 	const trackEvent = useNotificationEvents(
 		SITE_GOALS_INTRO_MODAL_BANNER
@@ -149,6 +159,24 @@ export default function IntroModal() {
 					! isBreakdownNoticeDismissed,
 			} )
 		);
+
+		// Go to the Site Goals section the same way the navigation chip
+		// does. Set the URL hash, set the section as the active context,
+		// and scroll to the section anchor. The active context makes the
+		// Site Goals widgets load right away, so the tour finds its first
+		// target. From here the navigation's scroll tracking updates the
+		// hash and the active context.
+		global.history.replaceState( {}, '', `#${ ANCHOR_ID_SITE_GOALS }` );
+
+		setValue( ACTIVE_CONTEXT_ID, ANCHOR_ID_SITE_GOALS );
+
+		global.scrollTo( {
+			top: getNavigationalScrollTop(
+				`#${ ANCHOR_ID_SITE_GOALS }`,
+				breakpoint
+			),
+			behavior: 'smooth',
+		} );
 	}
 
 	if (


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #12600

## Relevant technical choices

* Changed the last tour step's button label to "Done", as the Figma design shows.
* Made "Show me" scroll to the Site Goals section right away, the same way the navigation chip does.
* Made the tour start as soon as the Site Goals section has loaded. When the section is slow, the tour waits up to five seconds and then starts anyway, so the wait never cancels the tour.

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.
- [ ] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
