### PR TITLE
Fix Site Goals modal and tour to wait for the section to load

### DIFF
--- a/assets/js/modules/analytics-4/components/site-goals/feature-tours/site-goals.test.ts
+++ b/assets/js/modules/analytics-4/components/site-goals/feature-tours/site-goals.test.ts
@@ -25,8 +25,14 @@ import {
 	waitForSiteGoalsSectionReady,
 } from './site-goals';
 
-// Adds the element the tour points to first, and returns it so a test can
-// mock its position. The `afterEach` in the wait tests removes it.
+/**
+ * Adds the element the tour points to first. The `afterEach` in the wait
+ * tests removes it.
+ *
+ * @since n.e.x.t
+ *
+ * @return The added element, so a test can mock its position.
+ */
 function appendTourTarget() {
 	const target = document.createElement( 'div' );
 	target.className = 'googlesitekit-site-goals-primary-action';
@@ -34,8 +40,15 @@ function appendTourTarget() {
 	return target;
 }
 
-// Adds a widget area box, the way `WidgetAreaRenderer` makes one. The
-// `afterEach` in the wait tests removes it.
+/**
+ * Adds a widget area box, the way `WidgetAreaRenderer` makes one. The
+ * `afterEach` in the wait tests removes it.
+ *
+ * @since n.e.x.t
+ *
+ * @param slug The widget area slug.
+ * @return The added widget area box.
+ */
 function appendPreloadArea( slug: string ) {
 	const area = document.createElement( 'div' );
 	area.className = `googlesitekit-widget-area--${ slug }`;
@@ -43,8 +56,15 @@ function appendPreloadArea( slug: string ) {
 	return area;
 }
 
-// Adds a gray placeholder inside an area, like the one a widget shows
-// while it loads.
+/**
+ * Adds a gray placeholder inside an area, like the one a widget shows while
+ * it loads.
+ *
+ * @since n.e.x.t
+ *
+ * @param parent The area element to add the placeholder to.
+ * @return The added placeholder element.
+ */
 function appendPlaceholder( parent: Element ) {
 	const placeholder = document.createElement( 'div' );
 	placeholder.className = 'googlesitekit-preview-block';
@@ -189,7 +209,7 @@ describe( 'waitForSiteGoalsSectionReady', () => {
 		jest.restoreAllMocks();
 	} );
 
-	it( 'finishes once the data has loaded and the target stops moving', async () => {
+	it( 'finishes once the data has loaded and the target keeps the same position', async () => {
 		jest.useFakeTimers();
 		const target = appendTourTarget();
 		// No placeholder on the page, and the target stays at the same top.
@@ -197,10 +217,10 @@ describe( 'waitForSiteGoalsSectionReady', () => {
 			top: 100,
 		} as DOMRect );
 
-		const readyPromise = waitForSiteGoalsSectionReady();
+		const isSiteGoalsReady = waitForSiteGoalsSectionReady();
 
 		let isResolved = false;
-		readyPromise.then( () => {
+		isSiteGoalsReady.then( () => {
 			isResolved = true;
 		} );
 
@@ -210,26 +230,26 @@ describe( 'waitForSiteGoalsSectionReady', () => {
 
 		// The second check sees the same top, so the wait resolves.
 		jest.advanceTimersByTime( 250 );
-		await expect( readyPromise ).resolves.toBe( true );
+		await expect( isSiteGoalsReady ).resolves.toBe( true );
 
 		jest.useRealTimers();
 	} );
 
-	it( 'keeps waiting while an area still shows a placeholder, even when the target is not moving', async () => {
+	it( 'keeps waiting while an area still shows a placeholder, even when the target keeps the same position', async () => {
 		jest.useFakeTimers();
 		appendTourTarget();
 		const area = appendPreloadArea( PRELOAD_AREA_SLUG );
 		const placeholder = appendPlaceholder( area );
 
-		const readyPromise = waitForSiteGoalsSectionReady();
+		const isSiteGoalsReady = waitForSiteGoalsSectionReady();
 
 		let isResolved = false;
-		readyPromise.then( () => {
+		isSiteGoalsReady.then( () => {
 			isResolved = true;
 		} );
 
 		// A placeholder means the data has not loaded yet, so the wait
-		// holds even though the target is not moving.
+		// holds even though the target keeps the same position.
 		for ( let check = 0; check < 4; check++ ) {
 			jest.advanceTimersByTime( 250 );
 			await Promise.resolve();
@@ -240,25 +260,25 @@ describe( 'waitForSiteGoalsSectionReady', () => {
 		placeholder.remove();
 		jest.advanceTimersByTime( 250 );
 
-		await expect( readyPromise ).resolves.toBe( true );
+		await expect( isSiteGoalsReady ).resolves.toBe( true );
 
 		jest.useRealTimers();
 	} );
 
-	it( 'keeps waiting while the target is still moving', async () => {
+	it( 'keeps waiting while the target keeps shifting position', async () => {
 		jest.useFakeTimers();
 		const target = appendTourTarget();
 		// No placeholder, but the top changes on every check, the way the
-		// page moves while the content loads.
+		// layout shifts while the content loads.
 		let nextTop = 100;
 		jest.spyOn( target, 'getBoundingClientRect' ).mockImplementation(
 			() => ( { top: ( nextTop += 20 ) } as DOMRect )
 		);
 
-		const readyPromise = waitForSiteGoalsSectionReady();
+		const isSiteGoalsReady = waitForSiteGoalsSectionReady();
 
 		let isResolved = false;
-		readyPromise.then( () => {
+		isSiteGoalsReady.then( () => {
 			isResolved = true;
 		} );
 
@@ -277,10 +297,10 @@ describe( 'waitForSiteGoalsSectionReady', () => {
 	it( 'keeps waiting while the target is missing, then finishes once it appears and stays still', async () => {
 		jest.useFakeTimers();
 
-		const readyPromise = waitForSiteGoalsSectionReady();
+		const isSiteGoalsReady = waitForSiteGoalsSectionReady();
 
 		let isResolved = false;
-		readyPromise.then( () => {
+		isSiteGoalsReady.then( () => {
 			isResolved = true;
 		} );
 
@@ -298,7 +318,7 @@ describe( 'waitForSiteGoalsSectionReady', () => {
 		await Promise.resolve();
 		jest.advanceTimersByTime( 250 );
 
-		await expect( readyPromise ).resolves.toBe( true );
+		await expect( isSiteGoalsReady ).resolves.toBe( true );
 
 		jest.useRealTimers();
 	} );
@@ -309,7 +329,7 @@ describe( 'waitForSiteGoalsSectionReady', () => {
 		const area = appendPreloadArea( PRELOAD_AREA_SLUG );
 		appendPlaceholder( area );
 
-		const readyPromise = waitForSiteGoalsSectionReady();
+		const isSiteGoalsReady = waitForSiteGoalsSectionReady();
 
 		// The placeholder never goes away, so only the 30-second limit ends
 		// the wait. Run all 120 checks of 250ms each.
@@ -319,7 +339,7 @@ describe( 'waitForSiteGoalsSectionReady', () => {
 			await Promise.resolve();
 		}
 
-		await expect( readyPromise ).resolves.toBe( true );
+		await expect( isSiteGoalsReady ).resolves.toBe( true );
 
 		jest.useRealTimers();
 	} );

--- a/assets/js/modules/analytics-4/components/site-goals/feature-tours/site-goals.test.ts
+++ b/assets/js/modules/analytics-4/components/site-goals/feature-tours/site-goals.test.ts
@@ -19,24 +19,41 @@
 /**
  * Internal dependencies
  */
-import { getSiteGoalsTour } from './site-goals';
+import {
+	SITE_GOALS_TOUR_PRELOAD_WIDGET_AREAS,
+	getSiteGoalsTour,
+	waitForSiteGoalsSectionReady,
+} from './site-goals';
 
-// Adds the tour's first step target to the page, so `checkRequirements`
-// resolves right away. The `afterEach` below removes it.
+// Adds the element the tour points to first, and returns it so a test can
+// mock its position. The `afterEach` in the wait tests removes it.
 function appendTourTarget() {
 	const target = document.createElement( 'div' );
 	target.className = 'googlesitekit-site-goals-primary-action';
 	document.body.appendChild( target );
+	return target;
+}
+
+// Adds a widget area box, the way `WidgetAreaRenderer` makes one. The
+// `afterEach` in the wait tests removes it.
+function appendPreloadArea( slug: string ) {
+	const area = document.createElement( 'div' );
+	area.className = `googlesitekit-widget-area--${ slug }`;
+	document.body.appendChild( area );
+	return area;
+}
+
+// Adds a gray placeholder inside an area, like the one a widget shows
+// while it loads.
+function appendPlaceholder( parent: Element ) {
+	const placeholder = document.createElement( 'div' );
+	placeholder.className = 'googlesitekit-preview-block';
+	parent.appendChild( placeholder );
+	return placeholder;
 }
 
 describe( 'getSiteGoalsTour', () => {
 	const baseParams = { isEcommerceOnly: false, hasBreakdownNotice: true };
-
-	afterEach( () => {
-		document
-			.querySelectorAll( '.googlesitekit-site-goals-primary-action' )
-			.forEach( ( target ) => target.remove() );
-	} );
 
 	it( 'should return the Site Goals tour with the right slug', () => {
 		const tour = getSiteGoalsTour( baseParams );
@@ -56,12 +73,24 @@ describe( 'getSiteGoalsTour', () => {
 		expect( tour.contexts ).toEqual( [ 'mainDashboard' ] );
 	} );
 
-	it( 'should preload the Site Goals widget area so the targets are in view before the first callout opens', () => {
+	it( 'should set the widget areas to load, above and including Site Goals, in page order', () => {
 		const tour = getSiteGoalsTour( baseParams );
 
+		expect( tour.preloadWidgetAreas ).toBe(
+			SITE_GOALS_TOUR_PRELOAD_WIDGET_AREAS
+		);
 		expect( tour.preloadWidgetAreas ).toEqual( [
+			'mainDashboardKeyMetricsPrimary',
+			'mainDashboardTrafficPrimary',
+			'mainDashboardTrafficAudienceSegmentation',
 			'mainDashboardSiteGoalsPrimary',
 		] );
+	} );
+
+	it( 'should wait for the Site Goals section before starting the tour', () => {
+		const tour = getSiteGoalsTour( baseParams );
+
+		expect( tour.checkRequirements ).toBe( waitForSiteGoalsSectionReady );
 	} );
 
 	it( 'should prefix the Google Analytics event category with the current view context', () => {
@@ -130,55 +159,6 @@ describe( 'getSiteGoalsTour', () => {
 		);
 	} );
 
-	it( 'should resolve checkRequirements right away when the first step target is on the page', async () => {
-		appendTourTarget();
-
-		const tour = getSiteGoalsTour( baseParams );
-
-		await expect( tour.checkRequirements() ).resolves.toBe( true );
-	} );
-
-	it( 'should keep checkRequirements waiting until the first step target renders', async () => {
-		const tour = getSiteGoalsTour( baseParams );
-
-		const requirementsPromise = tour.checkRequirements();
-
-		let isResolved = false;
-		requirementsPromise.then( () => {
-			isResolved = true;
-		} );
-
-		// Give checkRequirements time to look for the target. It must keep
-		// waiting while the target is missing.
-		await new Promise( ( resolve ) => {
-			setTimeout( resolve, 300 );
-		} );
-		expect( isResolved ).toBe( false );
-
-		appendTourTarget();
-
-		await expect( requirementsPromise ).resolves.toBe( true );
-	} );
-
-	it( 'should resolve checkRequirements after five seconds when the target never renders', async () => {
-		jest.useFakeTimers();
-
-		const tour = getSiteGoalsTour( baseParams );
-		const requirementsPromise = tour.checkRequirements();
-
-		// Run all 20 timers of 250ms each. This is the full five-second
-		// wait.
-		for ( let check = 0; check < 20; check++ ) {
-			jest.advanceTimersByTime( 250 );
-			// Let the check finish before the next timer runs.
-			await Promise.resolve();
-		}
-
-		await expect( requirementsPromise ).resolves.toBe( true );
-
-		jest.useRealTimers();
-	} );
-
 	it( 'should set the "Done" label only on the last step', () => {
 		const tour = getSiteGoalsTour( {
 			...baseParams,
@@ -194,5 +174,153 @@ describe( 'getSiteGoalsTour', () => {
 		expect(
 			tour.steps.slice( 0, -1 ).map( ( step ) => 'locale' in step )
 		).toEqual( [ false, false ] );
+	} );
+} );
+
+describe( 'waitForSiteGoalsSectionReady', () => {
+	const PRELOAD_AREA_SLUG = 'mainDashboardKeyMetricsPrimary';
+
+	afterEach( () => {
+		document
+			.querySelectorAll(
+				'.googlesitekit-site-goals-primary-action, [class*="googlesitekit-widget-area--"]'
+			)
+			.forEach( ( element ) => element.remove() );
+		jest.restoreAllMocks();
+	} );
+
+	it( 'finishes once the data has loaded and the target stops moving', async () => {
+		jest.useFakeTimers();
+		const target = appendTourTarget();
+		// No placeholder on the page, and the target stays at the same top.
+		jest.spyOn( target, 'getBoundingClientRect' ).mockReturnValue( {
+			top: 100,
+		} as DOMRect );
+
+		const readyPromise = waitForSiteGoalsSectionReady();
+
+		let isResolved = false;
+		readyPromise.then( () => {
+			isResolved = true;
+		} );
+
+		// The first check records the top, so the wait holds.
+		await Promise.resolve();
+		expect( isResolved ).toBe( false );
+
+		// The second check sees the same top, so the wait resolves.
+		jest.advanceTimersByTime( 250 );
+		await expect( readyPromise ).resolves.toBe( true );
+
+		jest.useRealTimers();
+	} );
+
+	it( 'keeps waiting while an area still shows a placeholder, even when the target is not moving', async () => {
+		jest.useFakeTimers();
+		appendTourTarget();
+		const area = appendPreloadArea( PRELOAD_AREA_SLUG );
+		const placeholder = appendPlaceholder( area );
+
+		const readyPromise = waitForSiteGoalsSectionReady();
+
+		let isResolved = false;
+		readyPromise.then( () => {
+			isResolved = true;
+		} );
+
+		// A placeholder means the data has not loaded yet, so the wait
+		// holds even though the target is not moving.
+		for ( let check = 0; check < 4; check++ ) {
+			jest.advanceTimersByTime( 250 );
+			await Promise.resolve();
+		}
+		expect( isResolved ).toBe( false );
+
+		// The data loads and the placeholder goes away, so the wait finishes.
+		placeholder.remove();
+		jest.advanceTimersByTime( 250 );
+
+		await expect( readyPromise ).resolves.toBe( true );
+
+		jest.useRealTimers();
+	} );
+
+	it( 'keeps waiting while the target is still moving', async () => {
+		jest.useFakeTimers();
+		const target = appendTourTarget();
+		// No placeholder, but the top changes on every check, the way the
+		// page moves while the content loads.
+		let nextTop = 100;
+		jest.spyOn( target, 'getBoundingClientRect' ).mockImplementation(
+			() => ( { top: ( nextTop += 20 ) } as DOMRect )
+		);
+
+		const readyPromise = waitForSiteGoalsSectionReady();
+
+		let isResolved = false;
+		readyPromise.then( () => {
+			isResolved = true;
+		} );
+
+		// Run several checks before the 30-second limit. The top never
+		// repeats, so the wait must hold.
+		for ( let check = 0; check < 10; check++ ) {
+			jest.advanceTimersByTime( 250 );
+			await Promise.resolve();
+		}
+
+		expect( isResolved ).toBe( false );
+
+		jest.useRealTimers();
+	} );
+
+	it( 'keeps waiting while the target is missing, then finishes once it appears and stays still', async () => {
+		jest.useFakeTimers();
+
+		const readyPromise = waitForSiteGoalsSectionReady();
+
+		let isResolved = false;
+		readyPromise.then( () => {
+			isResolved = true;
+		} );
+
+		// No target on the page yet, so the wait must hold.
+		for ( let check = 0; check < 4; check++ ) {
+			jest.advanceTimersByTime( 250 );
+			await Promise.resolve();
+		}
+		expect( isResolved ).toBe( false );
+
+		// The target appears and stays in place. One check records its top,
+		// the next confirms it, so the wait resolves.
+		appendTourTarget();
+		jest.advanceTimersByTime( 250 );
+		await Promise.resolve();
+		jest.advanceTimersByTime( 250 );
+
+		await expect( readyPromise ).resolves.toBe( true );
+
+		jest.useRealTimers();
+	} );
+
+	it( 'finishes after 30 seconds when the section never loads', async () => {
+		jest.useFakeTimers();
+		appendTourTarget();
+		const area = appendPreloadArea( PRELOAD_AREA_SLUG );
+		appendPlaceholder( area );
+
+		const readyPromise = waitForSiteGoalsSectionReady();
+
+		// The placeholder never goes away, so only the 30-second limit ends
+		// the wait. Run all 120 checks of 250ms each.
+		for ( let check = 0; check < 120; check++ ) {
+			jest.advanceTimersByTime( 250 );
+			// Let the check finish before the next timer runs.
+			await Promise.resolve();
+		}
+
+		await expect( readyPromise ).resolves.toBe( true );
+
+		jest.useRealTimers();
 	} );
 } );

--- a/assets/js/modules/analytics-4/components/site-goals/feature-tours/site-goals.ts
+++ b/assets/js/modules/analytics-4/components/site-goals/feature-tours/site-goals.ts
@@ -34,16 +34,20 @@ import {
 
 export const SITE_GOALS_TOUR = 'site-goals-feature-tour';
 
-// The first element the tour points to. The modal waits for it before it
-// shows. The tour waits for it before it starts.
+/**
+ * The first element the tour points to. The modal waits for it before it
+ * shows. The tour waits for it before it starts.
+ */
 const FIRST_STEP_TARGET = '.googlesitekit-site-goals-primary-action';
 
-// The widget areas at and above the Site Goals section, in the order they
-// appear on the page. Normally an area loads its data only when the user
-// scrolls to it. The tour loads all of these before it starts, so the page
-// reaches its full height first. Without this, an area that loads later would
-// push the Site Goals section down, and the tour would point at the wrong
-// place. Loading an area the site does not have has no effect.
+/**
+ * The widget areas at and above the Site Goals section, in the order they
+ * appear on the page. Normally an area loads its data only when the user
+ * scrolls to it. The tour loads all of these before it starts, so the page
+ * reaches its full height first. Without this, an area that loads later would
+ * push the Site Goals section down, and the tour would point at the wrong
+ * place. Loading an area the site does not have has no effect.
+ */
 export const SITE_GOALS_TOUR_PRELOAD_WIDGET_AREAS = [
 	AREA_MAIN_DASHBOARD_KEY_METRICS_PRIMARY,
 	AREA_MAIN_DASHBOARD_TRAFFIC_PRIMARY,
@@ -51,50 +55,41 @@ export const SITE_GOALS_TOUR_PRELOAD_WIDGET_AREAS = [
 	AREA_MAIN_DASHBOARD_SITE_GOALS_PRIMARY,
 ];
 
-// The CSS class of the gray placeholder a widget shows while it loads its
-// data. The wait below looks for this class to tell when a widget area is
-// still loading.
+/**
+ * The CSS class of the gray placeholder a widget shows while it loads its
+ * data, rendered by `PreviewBlock`. The wait below looks for this class to
+ * tell when a widget area is still loading, so keep it in sync if
+ * `PreviewBlock` renames the class.
+ */
 const LOADING_PLACEHOLDER_CLASS = 'googlesitekit-preview-block';
 
-// The CSS class on a widget area's container. Each area also carries a
-// `--<slug>` suffix, so the wait can look at one area at a time.
+/**
+ * The CSS class on a widget area's container, rendered by `WidgetAreaRenderer`.
+ * Each area also carries a `--<slug>` suffix, so the wait can look at one area
+ * at a time. Keep it in sync if `WidgetAreaRenderer` renames the class.
+ */
 const WIDGET_AREA_CLASS = 'googlesitekit-widget-area';
 
-// How often the wait checks the page (250 milliseconds), and the longest it
-// runs before it gives up (30 seconds). The limit stops a section that never
-// loads from blocking the modal or the tour.
+/**
+ * How often the wait checks the page (250 milliseconds), and the longest it
+ * runs before it gives up (30 seconds). The limit stops a section that never
+ * loads from blocking the modal or the tour.
+ */
 const SECTION_READY_CHECK_INTERVAL_MS = 250;
 const SECTION_READY_CHECK_MAX_TOTAL_WAIT_MS = 30000;
 
 /**
- * Waits until the Site Goals section has loaded and stopped moving.
+ * Waits until the Site Goals section has loaded and its layout has settled.
  *
- * The tour points at a target on the page and shows a spotlight around it.
- * The tour shows the spotlight again whenever the page moves. If the tour
- * starts while the page is still moving, the spotlight ends up in the wrong
- * place. So the page must stop moving first.
- *
- * The page moves while its widgets load. The tour loads every widget area
- * above and including the Site Goals section before it starts, so the page
- * reaches its full height up front. While a widget loads, it shows a gray
- * placeholder with a fixed height. When the data arrives, the real content
- * replaces the placeholder at a different height, which moves the target. A
- * slow network makes this take longer.
- *
- * The section is ready when all three of these are true:
- * - No widget area the tour loads still shows a placeholder, so the data has
- *   arrived.
- * - The target is on the page.
- * - The target has the same top position on two checks in a row, so the page
- *   has stopped moving.
- *
- * The modal waits for this before it shows. The tour waits for it again,
- * through `checkRequirements`, before it starts. If the section never loads
- * or the target never appears, the wait gives up after 30 seconds, so it
- * never blocks the modal or the tour.
+ * The tour draws a spotlight around its target and redraws it on every
+ * layout shift. The widget areas above and including Site Goals shift the
+ * layout as their data loads, so the tour must wait for them, or the
+ * spotlight lands in the wrong place. The wait ends once those areas have
+ * loaded and the layout settles, or after 30 seconds, so a section that
+ * never loads cannot block the modal or the tour.
  *
  * @since 1.181.0
- * @since n.e.x.t Renamed from `checkSiteGoalsTourRequirements`, exported it, and made it wait for the widget areas above Site Goals to load and the target to stop moving before the tour starts.
+ * @since n.e.x.t Renamed from `checkSiteGoalsTourRequirements`, exported it, and made it wait for the widget areas above Site Goals to load and the layout to settle before the tour starts.
  *
  * @param signal Optional `AbortSignal` to stop the wait. The hook passes one so it can cancel on unmount. The tour passes the data registry through `checkRequirements`, which is not a signal, so the wait ignores it.
  * @return Promise that resolves to `true` when the section is ready or the wait gives up, or `false` when the signal aborts.
@@ -118,7 +113,7 @@ export function waitForSiteGoalsSectionReady(
 
 			// Check whether any widget area the tour loads still shows a
 			// placeholder. A placeholder means the data has not arrived, so the
-			// target can still move.
+			// layout can still shift.
 			const isPreloadAreaLoading =
 				SITE_GOALS_TOUR_PRELOAD_WIDGET_AREAS.some( ( slug ) =>
 					global.document.querySelector(
@@ -128,8 +123,8 @@ export function waitForSiteGoalsSectionReady(
 
 			// The section is ready when all three are true: no placeholder is
 			// left, the target is on the page, and its top position matches the
-			// last check. The page has stopped moving, so the tour can start and
-			// its spotlight will not jump.
+			// last check. The layout has settled, so the tour can start and its
+			// spotlight will not jump.
 			if (
 				( target &&
 					! isPreloadAreaLoading &&
@@ -196,23 +191,16 @@ function gaEventCategory( viewContext: string ) {
 /**
  * Returns the Site Goals tour config.
  *
- * The tour starts when the user clicks "Show me" on the Site Goals intro
- * modal and runs on the Site Goals widget. The first step points at the
- * key action tile group. The last step points at the goal drivers, and
- * its button says "Done" instead of the shared "Got it".
- *
- * The tour loads every widget area above and including the Site Goals
- * section before it starts. It waits up to 30 seconds for those areas to
- * load and the target to stop moving. The target must be on the page first,
- * or react-joyride skips that step.
+ * The tour starts from the "Show me" button on the intro modal and runs on
+ * the Site Goals widget. It loads the widget areas above and including Site
+ * Goals and waits for the layout to settle before it starts, through
+ * `preloadWidgetAreas` and `checkRequirements`.
  *
  * The breakdown notice step is included only when `hasBreakdownNotice` is
- * true, because that step points at the notice and the notice is not
- * always on the page. Its copy depends on `isEcommerceOnly`: sales copy
- * when `true`, leads copy when `false`.
+ * true, since that step points at a notice that is not always on the page.
  *
  * @since 1.181.0
- * @since n.e.x.t Load every widget area above and including the Site Goals section before the tour starts, and wait for them to load and the target to stop moving.
+ * @since n.e.x.t Load every widget area above and including the Site Goals section before the tour starts, and wait for them to load and the layout to settle.
  *
  * @param params                    Tour params.
  * @param params.isEcommerceOnly    True when only ecommerce events are detected. Picks the breakdown step copy.

--- a/assets/js/modules/analytics-4/components/site-goals/feature-tours/site-goals.ts
+++ b/assets/js/modules/analytics-4/components/site-goals/feature-tours/site-goals.ts
@@ -25,51 +25,141 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { VIEW_CONTEXT_MAIN_DASHBOARD } from '@/js/googlesitekit/constants';
-import { AREA_MAIN_DASHBOARD_SITE_GOALS_PRIMARY } from '@/js/googlesitekit/widgets/default-areas';
+import {
+	AREA_MAIN_DASHBOARD_KEY_METRICS_PRIMARY,
+	AREA_MAIN_DASHBOARD_SITE_GOALS_PRIMARY,
+	AREA_MAIN_DASHBOARD_TRAFFIC_AUDIENCE_SEGMENTATION,
+	AREA_MAIN_DASHBOARD_TRAFFIC_PRIMARY,
+} from '@/js/googlesitekit/widgets/default-areas';
 
 export const SITE_GOALS_TOUR = 'site-goals-feature-tour';
 
-// The first step's target. The tour waits for this element before it starts.
+// The first element the tour points to. The modal waits for it before it
+// shows. The tour waits for it before it starts.
 const FIRST_STEP_TARGET = '.googlesitekit-site-goals-primary-action';
 
-// The widgets render the target only after their reports load. Look for
-// the target every 250ms. Stop after five seconds, so a section that
-// never loads cannot block the tour.
-const TOUR_READY_CHECK_INTERVAL_MS = 250;
-const TOUR_READY_CHECK_MAX_TOTAL_WAIT_MS = 5000;
+// The widget areas at and above the Site Goals section, in the order they
+// appear on the page. Normally an area loads its data only when the user
+// scrolls to it. The tour loads all of these before it starts, so the page
+// reaches its full height first. Without this, an area that loads later would
+// push the Site Goals section down, and the tour would point at the wrong
+// place. Loading an area the site does not have has no effect.
+export const SITE_GOALS_TOUR_PRELOAD_WIDGET_AREAS = [
+	AREA_MAIN_DASHBOARD_KEY_METRICS_PRIMARY,
+	AREA_MAIN_DASHBOARD_TRAFFIC_PRIMARY,
+	AREA_MAIN_DASHBOARD_TRAFFIC_AUDIENCE_SEGMENTATION,
+	AREA_MAIN_DASHBOARD_SITE_GOALS_PRIMARY,
+];
+
+// The CSS class of the gray placeholder a widget shows while it loads its
+// data. The wait below looks for this class to tell when a widget area is
+// still loading.
+const LOADING_PLACEHOLDER_CLASS = 'googlesitekit-preview-block';
+
+// The CSS class on a widget area's container. Each area also carries a
+// `--<slug>` suffix, so the wait can look at one area at a time.
+const WIDGET_AREA_CLASS = 'googlesitekit-widget-area';
+
+// How often the wait checks the page (250 milliseconds), and the longest it
+// runs before it gives up (30 seconds). The limit stops a section that never
+// loads from blocking the modal or the tour.
+const SECTION_READY_CHECK_INTERVAL_MS = 250;
+const SECTION_READY_CHECK_MAX_TOTAL_WAIT_MS = 30000;
 
 /**
- * Waits until the Site Goals tour can start.
+ * Waits until the Site Goals section has loaded and stopped moving.
  *
- * react-joyride skips a step when its target is not on the page. A tour that
- * starts too early skips every step and shows nothing. This check lets the
- * tour start as soon as the first step's target renders. When the target is
- * slow, the wait ends after five seconds and the tour starts anyway, so the
- * wait never cancels the tour. `triggerOnDemandTour` waits for this check
- * before it starts the tour.
+ * The tour points at a target on the page and shows a spotlight around it.
+ * The tour shows the spotlight again whenever the page moves. If the tour
+ * starts while the page is still moving, the spotlight ends up in the wrong
+ * place. So the page must stop moving first.
+ *
+ * The page moves while its widgets load. The tour loads every widget area
+ * above and including the Site Goals section before it starts, so the page
+ * reaches its full height up front. While a widget loads, it shows a gray
+ * placeholder with a fixed height. When the data arrives, the real content
+ * replaces the placeholder at a different height, which moves the target. A
+ * slow network makes this take longer.
+ *
+ * The section is ready when all three of these are true:
+ * - No widget area the tour loads still shows a placeholder, so the data has
+ *   arrived.
+ * - The target is on the page.
+ * - The target has the same top position on two checks in a row, so the page
+ *   has stopped moving.
+ *
+ * The modal waits for this before it shows. The tour waits for it again,
+ * through `checkRequirements`, before it starts. If the section never loads
+ * or the target never appears, the wait gives up after 30 seconds, so it
+ * never blocks the modal or the tour.
  *
  * @since 1.181.0
+ * @since n.e.x.t Renamed from `checkSiteGoalsTourRequirements`, exported it, and made it wait for the widget areas above Site Goals to load and the target to stop moving before the tour starts.
  *
- * @return Promise that always resolves to `true`, when the target renders or the wait ends.
+ * @param signal Optional `AbortSignal` to stop the wait. The hook passes one so it can cancel on unmount. The tour passes the data registry through `checkRequirements`, which is not a signal, so the wait ignores it.
+ * @return Promise that resolves to `true` when the section is ready or the wait gives up, or `false` when the signal aborts.
  */
-function checkSiteGoalsTourRequirements(): Promise< boolean > {
+export function waitForSiteGoalsSectionReady(
+	signal?: AbortSignal
+): Promise< boolean > {
 	return new Promise( ( resolve ) => {
-		let remainingWaitMs = TOUR_READY_CHECK_MAX_TOTAL_WAIT_MS;
+		let remainingWaitMs = SECTION_READY_CHECK_MAX_TOTAL_WAIT_MS;
+		let previousTargetTop: number | undefined;
+		let timeoutID: ReturnType< typeof setTimeout >;
 
-		function checkTarget() {
+		function checkSection() {
+			if ( signal?.aborted ) {
+				resolve( false );
+				return;
+			}
+
+			const target = global.document.querySelector( FIRST_STEP_TARGET );
+			const targetTop = target?.getBoundingClientRect().top;
+
+			// Check whether any widget area the tour loads still shows a
+			// placeholder. A placeholder means the data has not arrived, so the
+			// target can still move.
+			const isPreloadAreaLoading =
+				SITE_GOALS_TOUR_PRELOAD_WIDGET_AREAS.some( ( slug ) =>
+					global.document.querySelector(
+						`.${ WIDGET_AREA_CLASS }--${ slug } .${ LOADING_PLACEHOLDER_CLASS }`
+					)
+				);
+
+			// The section is ready when all three are true: no placeholder is
+			// left, the target is on the page, and its top position matches the
+			// last check. The page has stopped moving, so the tour can start and
+			// its spotlight will not jump.
 			if (
-				global.document.querySelector( FIRST_STEP_TARGET ) ||
+				( target &&
+					! isPreloadAreaLoading &&
+					targetTop === previousTargetTop ) ||
 				remainingWaitMs <= 0
 			) {
 				resolve( true );
 				return;
 			}
 
-			remainingWaitMs -= TOUR_READY_CHECK_INTERVAL_MS;
-			global.setTimeout( checkTarget, TOUR_READY_CHECK_INTERVAL_MS );
+			previousTargetTop = targetTop;
+			remainingWaitMs -= SECTION_READY_CHECK_INTERVAL_MS;
+			timeoutID = global.setTimeout(
+				checkSection,
+				SECTION_READY_CHECK_INTERVAL_MS
+			);
 		}
 
-		checkTarget();
+		// The hook passes an `AbortSignal` so it can stop the loop when its
+		// component unmounts. The tour passes the data registry here through
+		// `checkRequirements`, which is not a signal, so only listen for a
+		// real `AbortSignal`.
+		if ( signal instanceof AbortSignal ) {
+			signal.addEventListener( 'abort', () => {
+				global.clearTimeout( timeoutID );
+				resolve( false );
+			} );
+		}
+
+		checkSection();
 	} );
 }
 
@@ -106,21 +196,27 @@ function gaEventCategory( viewContext: string ) {
 /**
  * Returns the Site Goals tour config.
  *
- * The tour starts when the user clicks "Show me" on the Site Goals intro modal
- * and runs on the Site Goals widget. The first step points at the key action
- * tile group and the last step points at the goal drivers. The last step's
- * button says "Done" instead of the shared "Got it". The tour waits for the
- * first step's target to render, five seconds at most, because react-joyride
- * skips a step when its target is missing. The breakdown notice step is
- * included only when `hasBreakdownNotice` is true, because that step targets
- * the notice and the notice is not always rendered. Its copy depends on
- * `isEcommerceOnly`: sales copy when `true`, leads copy when `false`.
+ * The tour starts when the user clicks "Show me" on the Site Goals intro
+ * modal and runs on the Site Goals widget. The first step points at the
+ * key action tile group. The last step points at the goal drivers, and
+ * its button says "Done" instead of the shared "Got it".
+ *
+ * The tour loads every widget area above and including the Site Goals
+ * section before it starts. It waits up to 30 seconds for those areas to
+ * load and the target to stop moving. The target must be on the page first,
+ * or react-joyride skips that step.
+ *
+ * The breakdown notice step is included only when `hasBreakdownNotice` is
+ * true, because that step points at the notice and the notice is not
+ * always on the page. Its copy depends on `isEcommerceOnly`: sales copy
+ * when `true`, leads copy when `false`.
  *
  * @since 1.181.0
+ * @since n.e.x.t Load every widget area above and including the Site Goals section before the tour starts, and wait for them to load and the target to stop moving.
  *
  * @param params                    Tour params.
  * @param params.isEcommerceOnly    True when only ecommerce events are detected. Picks the breakdown step copy.
- * @param params.hasBreakdownNotice True when the breakdown notice is rendered, so its tour step has a target.
+ * @param params.hasBreakdownNotice True when the breakdown notice is shown, so its tour step has a target to point to.
  * @return The Site Goals tour config.
  */
 export function getSiteGoalsTour( {
@@ -157,8 +253,8 @@ export function getSiteGoalsTour( {
 		isRepeatable: true,
 		contexts: [ VIEW_CONTEXT_MAIN_DASHBOARD ],
 		gaEventCategory,
-		preloadWidgetAreas: [ AREA_MAIN_DASHBOARD_SITE_GOALS_PRIMARY ],
-		checkRequirements: checkSiteGoalsTourRequirements,
+		preloadWidgetAreas: SITE_GOALS_TOUR_PRELOAD_WIDGET_AREAS,
+		checkRequirements: waitForSiteGoalsSectionReady,
 		steps: [
 			{
 				...defaultStepOptions,
@@ -182,8 +278,8 @@ export function getSiteGoalsTour( {
 					'google-site-kit'
 				),
 				// Show "Done" on the last step's button instead of the
-				// shared "Got it". react-joyride merges this over the tour
-				// locale, so all other labels stay the same.
+				// shared "Got it". react-joyride uses this label on this
+				// step only and keeps the other labels.
 				locale: {
 					last: __( 'Done', 'google-site-kit' ),
 				},

--- a/assets/js/modules/analytics-4/components/site-goals/notifications/IntroModalBanner/index.stories.tsx
+++ b/assets/js/modules/analytics-4/components/site-goals/notifications/IntroModalBanner/index.stories.tsx
@@ -56,6 +56,10 @@ function Template( {
 
 	return (
 		<WithRegistrySetup func={ setupBaseRegistry }>
+			{ /* The modal waits for the element the tour points to first
+			before it shows. Add that element here so the modal shows in
+			the stories. */ }
+			<div className="googlesitekit-site-goals-primary-action" />
 			<IntroModal />
 		</WithRegistrySetup>
 	);

--- a/assets/js/modules/analytics-4/components/site-goals/notifications/IntroModalBanner/index.test.js
+++ b/assets/js/modules/analytics-4/components/site-goals/notifications/IntroModalBanner/index.test.js
@@ -62,15 +62,25 @@ const getNavigationalScrollTopSpy = jest.spyOn(
 );
 const scrollToSpy = jest.spyOn( global, 'scrollTo' );
 
-// Adds the tour's first step target to the page, so `checkRequirements`
-// resolves right away. The `afterEach` below removes it.
+/**
+ * Adds the tour's first step target to the page, so `checkRequirements`
+ * resolves right away. The `afterEach` below removes it.
+ *
+ * @since n.e.x.t
+ */
 function appendTourTarget() {
 	const target = document.createElement( 'div' );
 	target.className = 'googlesitekit-site-goals-primary-action';
 	document.body.appendChild( target );
 }
 
-// Waits until the intro modal renders its "Show me" button.
+/**
+ * Waits until the intro modal renders its "Show me" button.
+ *
+ * @since n.e.x.t
+ *
+ * @param {Function} getByRole The `getByRole` query from the render result.
+ */
 async function waitForIntroModalToShow( getByRole ) {
 	await waitFor( () => {
 		expect(

--- a/assets/js/modules/analytics-4/components/site-goals/notifications/IntroModalBanner/index.test.js
+++ b/assets/js/modules/analytics-4/components/site-goals/notifications/IntroModalBanner/index.test.js
@@ -27,11 +27,15 @@ import fetchMock from 'fetch-mock';
 import {
 	ACTIVE_CONTEXT_ID,
 	CORE_UI,
+	FORCED_IN_VIEW_WIDGET_AREAS,
 } from '@/js/googlesitekit/datastore/ui/constants';
 import { CORE_USER } from '@/js/googlesitekit/datastore/user/constants';
 import { CORE_MODULES } from '@/js/googlesitekit/modules/datastore/constants';
 import useNotificationEvents from '@/js/googlesitekit/notifications/hooks/useNotificationEvents';
-import { getSiteGoalsTour } from '@/js/modules/analytics-4/components/site-goals/feature-tours/site-goals';
+import {
+	SITE_GOALS_TOUR_PRELOAD_WIDGET_AREAS,
+	getSiteGoalsTour,
+} from '@/js/modules/analytics-4/components/site-goals/feature-tours/site-goals';
 import { MODULE_SLUG_ANALYTICS_4 } from '@/js/modules/analytics-4/constants';
 import {
 	ENUM_CONVERSION_EVENTS,
@@ -64,6 +68,15 @@ function appendTourTarget() {
 	const target = document.createElement( 'div' );
 	target.className = 'googlesitekit-site-goals-primary-action';
 	document.body.appendChild( target );
+}
+
+// Waits until the intro modal renders its "Show me" button.
+async function waitForIntroModalToShow( getByRole ) {
+	await waitFor( () => {
+		expect(
+			getByRole( 'button', { name: /show me/i } )
+		).toBeInTheDocument();
+	} );
 }
 
 describe( 'IntroModal', () => {
@@ -113,56 +126,148 @@ describe( 'IntroModal', () => {
 		scrollToSpy.mockClear();
 	} );
 
-	it( 'renders ecommerce-only variant when only ecommerce conversion events exist', () => {
+	it( 'renders ecommerce-only variant when only ecommerce conversion events exist', async () => {
 		registry
 			.dispatch( MODULES_ANALYTICS_4 )
 			.setDetectedEvents( [ ENUM_CONVERSION_EVENTS.PURCHASE ] );
+		appendTourTarget();
 
-		const { container } = render( <IntroModal />, {
+		const { container, getByRole } = render( <IntroModal />, {
 			registry,
 		} );
+
+		await waitForIntroModalToShow( getByRole );
+
 		expect( container ).toMatchSnapshot();
 	} );
 
-	it( 'renders lead-only variant when only lead conversion events exist', () => {
+	it( 'renders lead-only variant when only lead conversion events exist', async () => {
 		registry
 			.dispatch( MODULES_ANALYTICS_4 )
 			.setDetectedEvents( [ ENUM_CONVERSION_EVENTS.CONTACT ] );
+		appendTourTarget();
 
-		const { container } = render( <IntroModal />, {
+		const { container, getByRole } = render( <IntroModal />, {
 			registry,
 		} );
+
+		await waitForIntroModalToShow( getByRole );
+
 		expect( container ).toMatchSnapshot();
 	} );
 
-	it( 'renders ecommerce-and-lead variant when both conversion event types exist', () => {
+	it( 'renders ecommerce-and-lead variant when both conversion event types exist', async () => {
 		registry
 			.dispatch( MODULES_ANALYTICS_4 )
 			.setDetectedEvents( [
 				ENUM_CONVERSION_EVENTS.PURCHASE,
 				ENUM_CONVERSION_EVENTS.CONTACT,
 			] );
+		appendTourTarget();
 
-		const { container } = render( <IntroModal />, {
+		const { container, getByRole } = render( <IntroModal />, {
 			registry,
 		} );
+
+		await waitForIntroModalToShow( getByRole );
+
 		expect( container ).toMatchSnapshot();
 	} );
 
-	it( 'should start the Site Goals tour when the user clicks "Show me"', async () => {
+	it( 'renders nothing while the Site Goals section is missing', () => {
+		jest.useFakeTimers();
+
 		registry
 			.dispatch( MODULES_ANALYTICS_4 )
 			.setDetectedEvents( [ ENUM_CONVERSION_EVENTS.PURCHASE ] );
 
-		// The tour waits for its first target, so add it before the click.
+		const { container } = render( <IntroModal />, {
+			registry,
+		} );
+
+		// Two checks go by with no target on the page. The modal must keep
+		// waiting.
+		act( () => {
+			jest.advanceTimersByTime( 500 );
+		} );
+
+		expect( container ).toBeEmptyDOMElement();
+
+		jest.useRealTimers();
+	} );
+
+	it( 'renders modal after the wait limit when the section never appears', async () => {
+		jest.useFakeTimers();
+
+		registry
+			.dispatch( MODULES_ANALYTICS_4 )
+			.setDetectedEvents( [ ENUM_CONVERSION_EVENTS.PURCHASE ] );
+
+		const { getByRole } = render( <IntroModal />, {
+			registry,
+		} );
+
+		// Run all 120 ticks of 250ms each. That is the full 30-second
+		// wait. The async act lets each check finish before the next timer
+		// runs.
+		for ( let check = 0; check < 120; check++ ) {
+			// eslint-disable-next-line require-await
+			await act( async () => {
+				jest.advanceTimersByTime( 250 );
+			} );
+		}
+
+		expect(
+			getByRole( 'button', { name: /show me/i } )
+		).toBeInTheDocument();
+
+		jest.useRealTimers();
+	} );
+
+	it( 'sets the widget areas to load while waiting, then clears them when the modal is dismissed', async () => {
+		registry
+			.dispatch( MODULES_ANALYTICS_4 )
+			.setDetectedEvents( [ ENUM_CONVERSION_EVENTS.PURCHASE ] );
 		appendTourTarget();
 
 		const { getByRole } = render( <IntroModal />, {
 			registry,
 		} );
 
+		// While the modal waits, it sets the widget areas to load.
+		expect(
+			registry.select( CORE_UI ).getValue( FORCED_IN_VIEW_WIDGET_AREAS )
+		).toEqual( SITE_GOALS_TOUR_PRELOAD_WIDGET_AREAS );
+
+		await waitForIntroModalToShow( getByRole );
+
+		// The dismissal also saves the dismissed item. The async act call
+		// lets that request finish inside the test.
+		// eslint-disable-next-line require-await
+		await act( async () => {
+			fireEvent.click( getByRole( 'button', { name: /maybe later/i } ) );
+		} );
+
+		expect(
+			registry.select( CORE_UI ).getValue( FORCED_IN_VIEW_WIDGET_AREAS )
+		).toBeUndefined();
+	} );
+
+	it( 'should start the Site Goals tour when the user clicks "Show me"', async () => {
+		registry
+			.dispatch( MODULES_ANALYTICS_4 )
+			.setDetectedEvents( [ ENUM_CONVERSION_EVENTS.PURCHASE ] );
+		appendTourTarget();
+
+		const { getByRole } = render( <IntroModal />, {
+			registry,
+		} );
+
+		await waitForIntroModalToShow( getByRole );
+
 		fireEvent.click( getByRole( 'button', { name: /show me/i } ) );
 
+		// The tour waits for the section again before it starts.
 		await waitFor( () => {
 			expect( registry.select( CORE_USER ).getCurrentTour() ).toEqual(
 				getSiteGoalsTour( {
@@ -171,6 +276,12 @@ describe( 'IntroModal', () => {
 				} )
 			);
 		} );
+
+		// The modal clears the widget areas to load when it closes. The tour
+		// then sets the same list itself.
+		expect(
+			registry.select( CORE_UI ).getValue( FORCED_IN_VIEW_WIDGET_AREAS )
+		).toEqual( SITE_GOALS_TOUR_PRELOAD_WIDGET_AREAS );
 	} );
 
 	it( 'should navigate to the Site Goals section when the user clicks "Show me"', async () => {
@@ -193,6 +304,8 @@ describe( 'IntroModal', () => {
 		const { getByRole } = render( <IntroModal />, {
 			registry,
 		} );
+
+		await waitForIntroModalToShow( getByRole );
 
 		// The click also dismisses the modal and starts the tour. The async
 		// act call lets those updates finish inside the test. The callback
@@ -233,18 +346,17 @@ describe( 'IntroModal', () => {
 		expect( container ).toBeEmptyDOMElement();
 	} );
 
-	it( 'still renders for a view-only user with detected events', () => {
+	it( 'still renders for a view-only user with detected events', async () => {
 		provideUserAuthentication( registry, { authenticated: false } );
 		registry
 			.dispatch( MODULES_ANALYTICS_4 )
 			.setDetectedEvents( [ ENUM_CONVERSION_EVENTS.PURCHASE ] );
+		appendTourTarget();
 
 		const { getByRole } = render( <IntroModal />, {
 			registry,
 		} );
 
-		expect(
-			getByRole( 'button', { name: /show me/i } )
-		).toBeInTheDocument();
+		await waitForIntroModalToShow( getByRole );
 	} );
 } );

--- a/assets/js/modules/analytics-4/components/site-goals/notifications/IntroModalBanner/index.tsx
+++ b/assets/js/modules/analytics-4/components/site-goals/notifications/IntroModalBanner/index.tsx
@@ -41,6 +41,7 @@ import {
 import { getSiteGoalsTour } from '@/js/modules/analytics-4/components/site-goals/feature-tours/site-goals';
 import { MODULE_SLUG_ANALYTICS_4 } from '@/js/modules/analytics-4/constants';
 import { MODULES_ANALYTICS_4 } from '@/js/modules/analytics-4/datastore/constants';
+import { useSiteGoalsSectionReady } from '@/js/modules/analytics-4/hooks/useSiteGoalsSectionReady';
 import { getNavigationalScrollTop } from '@/js/util/scroll';
 import IntroModalEcommerce from './IntroModalEcommerce';
 import IntroModalEcommerceAndLead from './IntroModalEcommerceAndLead';
@@ -161,6 +162,26 @@ export default function IntroModal() {
 		return hasAccess !== true;
 	}, [] );
 
+	// All the checks the modal needs, apart from the section being ready.
+	// It needs at least one detected event type. If there is none, the
+	// modal never shows, so the hook below should not load the widget
+	// areas or wait.
+	const canShowSiteGoalsIntroModal =
+		hasEcommerceConversionReportingEvents !== undefined &&
+		hasLeadConversionReportingEvents !== undefined &&
+		( hasEcommerceConversionReportingEvents ||
+			hasLeadConversionReportingEvents ) &&
+		isIntroModalDismissed === false &&
+		! hasInsufficientAnalyticsAccess &&
+		isOpen;
+
+	// While the modal can show, the hook loads the widget areas above and
+	// including the Site Goals section, and reports ready once the section
+	// has loaded and stopped moving.
+	const isSiteGoalsSectionReady = useSiteGoalsSectionReady(
+		canShowSiteGoalsIntroModal
+	);
+
 	function handleClose() {
 		setIsOpen( false );
 		dismissItem( SITE_GOALS_INTRO_MODAL_BANNER );
@@ -198,13 +219,7 @@ export default function IntroModal() {
 		} );
 	}
 
-	if (
-		hasEcommerceConversionReportingEvents === undefined ||
-		hasLeadConversionReportingEvents === undefined ||
-		isIntroModalDismissed !== false ||
-		hasInsufficientAnalyticsAccess ||
-		! isOpen
-	) {
+	if ( ! canShowSiteGoalsIntroModal || ! isSiteGoalsSectionReady ) {
 		return null;
 	}
 

--- a/assets/js/modules/analytics-4/components/site-goals/notifications/IntroModalBanner/index.tsx
+++ b/assets/js/modules/analytics-4/components/site-goals/notifications/IntroModalBanner/index.tsx
@@ -177,7 +177,7 @@ export default function IntroModal() {
 
 	// While the modal can show, the hook loads the widget areas above and
 	// including the Site Goals section, and reports ready once the section
-	// has loaded and stopped moving.
+	// has loaded and its layout has settled.
 	const isSiteGoalsSectionReady = useSiteGoalsSectionReady(
 		canShowSiteGoalsIntroModal
 	);

--- a/assets/js/modules/analytics-4/hooks/useSiteGoalsSectionReady.test.ts
+++ b/assets/js/modules/analytics-4/hooks/useSiteGoalsSectionReady.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Tests for the useSiteGoalsSectionReady hook.
+ *
+ * Site Kit by Google, Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { WPDataRegistry } from '@wordpress/data/build-types/registry';
+
+/**
+ * Internal dependencies
+ */
+import {
+	CORE_UI,
+	FORCED_IN_VIEW_WIDGET_AREAS,
+} from '@/js/googlesitekit/datastore/ui/constants';
+import { SITE_GOALS_TOUR_PRELOAD_WIDGET_AREAS } from '@/js/modules/analytics-4/components/site-goals/feature-tours/site-goals';
+import { actHook, createTestRegistry, renderHook } from '@tests/js/test-utils';
+import { useSiteGoalsSectionReady } from './useSiteGoalsSectionReady';
+
+// Adds the element the Site Goals tour points to first. The hook waits for
+// this element before it reports the section loaded, so every test that needs
+// a loaded section adds it. The `afterEach` below removes it.
+function appendTourTarget() {
+	const target = document.createElement( 'div' );
+	target.className = 'googlesitekit-site-goals-primary-action';
+	document.body.appendChild( target );
+}
+
+// Moves the fake clock forward so the hook finishes waiting and reports the
+// Site Goals section as loaded. The hook reads the target's position when it
+// mounts, then again every 250 milliseconds, and finishes once two reads in a
+// row return the same position. Advancing 500 milliseconds gives the wait
+// enough time to finish. `renderHook` renders the hook with
+// `@testing-library/react-hooks`, so `actHook` is the `act` helper that
+// applies the hook's state change. Use this only after `jest.useFakeTimers()`.
+async function advanceUntilSectionLoads() {
+	// eslint-disable-next-line require-await
+	await actHook( async () => {
+		jest.advanceTimersByTime( 500 );
+	} );
+}
+
+describe( 'useSiteGoalsSectionReady', () => {
+	let registry: WPDataRegistry;
+
+	function getWidgetAreasToLoad() {
+		return registry
+			.select( CORE_UI )
+			.getValue( FORCED_IN_VIEW_WIDGET_AREAS );
+	}
+
+	beforeEach( () => {
+		registry = createTestRegistry();
+	} );
+
+	afterEach( () => {
+		document
+			.querySelectorAll( '.googlesitekit-site-goals-primary-action' )
+			.forEach( ( target ) => target.remove() );
+	} );
+
+	it( 'returns false and sets no widget areas to load when enabled is false', () => {
+		appendTourTarget();
+
+		const { result } = renderHook(
+			() => useSiteGoalsSectionReady( false ),
+			{ registry }
+		);
+
+		expect( result.current ).toBe( false );
+		expect( getWidgetAreasToLoad() ).toBeUndefined();
+	} );
+
+	it( 'sets the widget areas to load while it waits', () => {
+		appendTourTarget();
+
+		const { result } = renderHook( () => useSiteGoalsSectionReady( true ), {
+			registry,
+		} );
+
+		expect( result.current ).toBe( false );
+		expect( getWidgetAreasToLoad() ).toEqual(
+			SITE_GOALS_TOUR_PRELOAD_WIDGET_AREAS
+		);
+	} );
+
+	it( 'returns true after the Site Goals section loads and stops moving', async () => {
+		jest.useFakeTimers();
+		appendTourTarget();
+
+		const { result } = renderHook( () => useSiteGoalsSectionReady( true ), {
+			registry,
+		} );
+
+		await advanceUntilSectionLoads();
+
+		expect( result.current ).toBe( true );
+
+		// The hook keeps the widget areas to load while it stays enabled.
+		expect( getWidgetAreasToLoad() ).toEqual(
+			SITE_GOALS_TOUR_PRELOAD_WIDGET_AREAS
+		);
+
+		jest.useRealTimers();
+	} );
+
+	it( 'clears the widget areas to load on unmount', async () => {
+		jest.useFakeTimers();
+		appendTourTarget();
+
+		const { result, unmount } = renderHook(
+			() => useSiteGoalsSectionReady( true ),
+			{ registry }
+		);
+
+		await advanceUntilSectionLoads();
+
+		expect( result.current ).toBe( true );
+
+		unmount();
+
+		expect( getWidgetAreasToLoad() ).toBeUndefined();
+
+		jest.useRealTimers();
+	} );
+
+	it( 'returns to false and clears the widget areas to load when enabled becomes false', async () => {
+		jest.useFakeTimers();
+		appendTourTarget();
+
+		let enabled = true;
+		const { result, rerender } = renderHook(
+			() => useSiteGoalsSectionReady( enabled ),
+			{ registry }
+		);
+
+		await advanceUntilSectionLoads();
+
+		expect( result.current ).toBe( true );
+
+		enabled = false;
+		rerender();
+
+		expect( result.current ).toBe( false );
+		expect( getWidgetAreasToLoad() ).toBeUndefined();
+
+		jest.useRealTimers();
+	} );
+} );

--- a/assets/js/modules/analytics-4/hooks/useSiteGoalsSectionReady.test.ts
+++ b/assets/js/modules/analytics-4/hooks/useSiteGoalsSectionReady.test.ts
@@ -32,22 +32,31 @@ import { SITE_GOALS_TOUR_PRELOAD_WIDGET_AREAS } from '@/js/modules/analytics-4/c
 import { actHook, createTestRegistry, renderHook } from '@tests/js/test-utils';
 import { useSiteGoalsSectionReady } from './useSiteGoalsSectionReady';
 
-// Adds the element the Site Goals tour points to first. The hook waits for
-// this element before it reports the section loaded, so every test that needs
-// a loaded section adds it. The `afterEach` below removes it.
+/**
+ * Adds the element the Site Goals tour points to first. The hook waits for
+ * this element before it reports the section loaded, so every test that needs
+ * a loaded section adds it. The `afterEach` below removes it.
+ *
+ * @since n.e.x.t
+ *
+ * @return {void}
+ */
 function appendTourTarget() {
 	const target = document.createElement( 'div' );
 	target.className = 'googlesitekit-site-goals-primary-action';
 	document.body.appendChild( target );
 }
 
-// Moves the fake clock forward so the hook finishes waiting and reports the
-// Site Goals section as loaded. The hook reads the target's position when it
-// mounts, then again every 250 milliseconds, and finishes once two reads in a
-// row return the same position. Advancing 500 milliseconds gives the wait
-// enough time to finish. `renderHook` renders the hook with
-// `@testing-library/react-hooks`, so `actHook` is the `act` helper that
-// applies the hook's state change. Use this only after `jest.useFakeTimers()`.
+/**
+ * Moves the fake timers forward so the wait inside the hook finishes and the
+ * hook reports the Site Goals section as ready. The wait checks the target
+ * position every 250 milliseconds and finishes once two checks in a row match,
+ * so 500 milliseconds is enough. Use this only after `jest.useFakeTimers()`.
+ *
+ * @since n.e.x.t
+ *
+ * @return {void}
+ */
 async function advanceUntilSectionLoads() {
 	// eslint-disable-next-line require-await
 	await actHook( async () => {
@@ -99,7 +108,7 @@ describe( 'useSiteGoalsSectionReady', () => {
 		);
 	} );
 
-	it( 'returns true after the Site Goals section loads and stops moving', async () => {
+	it( 'returns true after the Site Goals section loads and its layout settles', async () => {
 		jest.useFakeTimers();
 		appendTourTarget();
 

--- a/assets/js/modules/analytics-4/hooks/useSiteGoalsSectionReady.ts
+++ b/assets/js/modules/analytics-4/hooks/useSiteGoalsSectionReady.ts
@@ -1,0 +1,90 @@
+/**
+ * Hook to wait for the Site Goals section to load.
+ *
+ * Site Kit by Google, Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { useEffect, useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { useDispatch } from 'googlesitekit-data';
+import {
+	CORE_UI,
+	FORCED_IN_VIEW_WIDGET_AREAS,
+} from '@/js/googlesitekit/datastore/ui/constants';
+import {
+	SITE_GOALS_TOUR_PRELOAD_WIDGET_AREAS,
+	waitForSiteGoalsSectionReady,
+} from '@/js/modules/analytics-4/components/site-goals/feature-tours/site-goals';
+
+/**
+ * Waits for the Site Goals section to load and stop moving.
+ *
+ * While `enabled` is `true`, the hook tells the widget areas above and
+ * including the Site Goals section to load their data, so the page reaches
+ * its full height before the tour starts. It returns `true` once those areas
+ * finish loading and the target the tour points to stops moving, after at
+ * most 30 seconds. When `enabled` turns `false`, or the component unmounts,
+ * the hook stops loading those areas. The widgets keep the data they already
+ * fetched, because an area stays loaded once it has come into view.
+ *
+ * @since n.e.x.t
+ *
+ * @param enabled Whether to load the widget areas and wait. While `false`, the hook reports the section as not ready.
+ * @return Whether the Site Goals section is ready.
+ */
+export function useSiteGoalsSectionReady( enabled: boolean ): boolean {
+	const [ isSectionReady, setIsSectionReady ] = useState( false );
+
+	const { setValue } = useDispatch( CORE_UI );
+
+	useEffect( () => {
+		if ( ! enabled ) {
+			setIsSectionReady( false );
+			return undefined;
+		}
+
+		setValue(
+			FORCED_IN_VIEW_WIDGET_AREAS,
+			SITE_GOALS_TOUR_PRELOAD_WIDGET_AREAS
+		);
+
+		const abortController = new AbortController();
+
+		( async () => {
+			const isReady = await waitForSiteGoalsSectionReady(
+				abortController.signal
+			);
+
+			if ( isReady ) {
+				setIsSectionReady( true );
+			}
+		} )();
+
+		return () => {
+			abortController.abort();
+			// When the user clicks "Show me", the tour sets its own list to
+			// load right after this cleanup runs.
+			setValue( FORCED_IN_VIEW_WIDGET_AREAS, undefined );
+		};
+	}, [ enabled, setValue ] );
+
+	return isSectionReady;
+}

--- a/assets/js/modules/analytics-4/hooks/useSiteGoalsSectionReady.ts
+++ b/assets/js/modules/analytics-4/hooks/useSiteGoalsSectionReady.ts
@@ -35,15 +35,16 @@ import {
 } from '@/js/modules/analytics-4/components/site-goals/feature-tours/site-goals';
 
 /**
- * Waits for the Site Goals section to load and stop moving.
+ * Waits for the Site Goals section to load and its layout to settle.
  *
  * While `enabled` is `true`, the hook tells the widget areas above and
  * including the Site Goals section to load their data, so the page reaches
  * its full height before the tour starts. It returns `true` once those areas
- * finish loading and the target the tour points to stops moving, after at
- * most 30 seconds. When `enabled` turns `false`, or the component unmounts,
- * the hook stops loading those areas. The widgets keep the data they already
- * fetched, because an area stays loaded once it has come into view.
+ * finish loading and the target the tour points to keeps the same position,
+ * after at most 30 seconds. When `enabled` turns `false`, or the component
+ * unmounts, the hook stops loading those areas. The widgets keep the data
+ * they already fetched, because an area stays loaded once it has come into
+ * view.
  *
  * @since n.e.x.t
  *


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #12885

## Relevant technical choices

- Add a placeholder check to `waitForSiteGoalsSectionReady`, not just the position check the IB planned. The position check alone passes too early on a slow connection. The placeholder has a fixed height, so the page looks ready before the data loads.
- Raise the wait limit from 5 to 30 seconds, so a slow connection can finish loading before the wait gives up and the modal and tour open anyway.


## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.
- [ ] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
