### PR TITLE
Fix zero data notification and Key Metrics widgets shown to view-only user without permission.

### DIFF
--- a/assets/js/components/DashboardMainApp.js
+++ b/assets/js/components/DashboardMainApp.js
@@ -39,7 +39,6 @@ import {
 	ANCHOR_ID_SITE_GOALS,
 	ANCHOR_ID_SPEED,
 	ANCHOR_ID_TRAFFIC,
-	VIEW_CONTEXT_MAIN_DASHBOARD,
 } from '@/js/googlesitekit/constants';
 import { CORE_SITE } from '@/js/googlesitekit/datastore/site/constants';
 import {
@@ -67,6 +66,7 @@ import { useFeature } from '@/js/hooks/useFeature';
 import useFormValue from '@/js/hooks/useFormValue';
 import { useMonitorInternetConnection } from '@/js/hooks/useMonitorInternetConnection';
 import useQueryArg from '@/js/hooks/useQueryArg';
+import useViewContext from '@/js/hooks/useViewContext';
 import useViewOnly from '@/js/hooks/useViewOnly';
 import { AudienceSelectionPanel } from '@/js/modules/analytics-4/components/audience-segmentation/dashboard';
 import SiteGoalsIntroModalBanner from '@/js/modules/analytics-4/components/site-goals/notifications/IntroModalBanner';
@@ -137,8 +137,8 @@ export default function DashboardMainApp() {
 
 	const [ showSurveyPortal, setShowSurveyPortal ] = useState( false );
 
+	const viewContext = useViewContext();
 	const viewOnlyDashboard = useViewOnly();
-
 	const breakpoint = useBreakpoint();
 
 	const [ widgetArea, setWidgetArea ] = useQueryArg( 'widgetArea' );
@@ -327,10 +327,7 @@ export default function DashboardMainApp() {
 		).isItemDismissed( INITIAL_SETUP_NOTIFICATION_TIMEOUT_SLUG );
 		const queuedHeaderNotifications = select(
 			CORE_NOTIFICATIONS
-		).getQueuedNotifications(
-			VIEW_CONTEXT_MAIN_DASHBOARD,
-			NOTIFICATION_GROUPS.DEFAULT
-		);
+		).getQueuedNotifications( viewContext, NOTIFICATION_GROUPS.DEFAULT );
 		const firstHeaderNotificationID =
 			queuedHeaderNotifications?.[ 0 ]?.id || null;
 

--- a/assets/js/googlesitekit/widgets/register-defaults.js
+++ b/assets/js/googlesitekit/widgets/register-defaults.js
@@ -46,7 +46,6 @@ import {
 } from '@/js/modules/analytics-4/components/audience-segmentation/dashboard';
 import ConnectGA4CTAWidget from '@/js/modules/analytics-4/components/widgets/ConnectGA4CTAWidget';
 import { MODULE_SLUG_ANALYTICS_4 } from '@/js/modules/analytics-4/constants';
-import { MODULE_SLUG_SEARCH_CONSOLE } from '@/js/modules/search-console/constants';
 import { WIDGET_AREA_STYLES } from './datastore/constants';
 import * as WIDGET_AREAS from './default-areas';
 import * as WIDGET_CONTEXTS from './default-contexts';
@@ -113,25 +112,12 @@ export function registerDefaults( widgetsAPI ) {
 			priority: 1,
 			CTA: ChangeMetricsLink,
 			filterActiveWidgets( select, areaWidgets ) {
-				const canViewSharedAnalytics = select(
-					CORE_USER
-				).hasAccessToShareableModule( MODULE_SLUG_ANALYTICS_4 );
-
-				const canViewSharedSearchConsole = select(
-					CORE_USER
-				).hasAccessToShareableModule( MODULE_SLUG_SEARCH_CONSOLE );
-
 				// Prevent showing only one widget tile in this area when
 				// only Search Console is shared.
 				// See: https://github.com/google/site-kit-wp/issues/7435
-				const hasOnlyOneWidget =
-					areaWidgets.length === 1 &&
-					allKeyMetricsTileWidgets.includes( areaWidgets[ 0 ].slug );
-
 				if (
-					! canViewSharedAnalytics ||
-					! canViewSharedSearchConsole ||
-					hasOnlyOneWidget
+					areaWidgets.length === 1 &&
+					allKeyMetricsTileWidgets.includes( areaWidgets[ 0 ].slug )
 				) {
 					return [];
 				}

--- a/assets/js/googlesitekit/widgets/register-defaults.js
+++ b/assets/js/googlesitekit/widgets/register-defaults.js
@@ -46,6 +46,7 @@ import {
 } from '@/js/modules/analytics-4/components/audience-segmentation/dashboard';
 import ConnectGA4CTAWidget from '@/js/modules/analytics-4/components/widgets/ConnectGA4CTAWidget';
 import { MODULE_SLUG_ANALYTICS_4 } from '@/js/modules/analytics-4/constants';
+import { MODULE_SLUG_SEARCH_CONSOLE } from '@/js/modules/search-console/constants';
 import { WIDGET_AREA_STYLES } from './datastore/constants';
 import * as WIDGET_AREAS from './default-areas';
 import * as WIDGET_CONTEXTS from './default-contexts';
@@ -112,12 +113,25 @@ export function registerDefaults( widgetsAPI ) {
 			priority: 1,
 			CTA: ChangeMetricsLink,
 			filterActiveWidgets( select, areaWidgets ) {
+				const canViewSharedAnalytics = select(
+					CORE_USER
+				).hasAccessToShareableModule( MODULE_SLUG_ANALYTICS_4 );
+
+				const canViewSharedSearchConsole = select(
+					CORE_USER
+				).hasAccessToShareableModule( MODULE_SLUG_SEARCH_CONSOLE );
+
 				// Prevent showing only one widget tile in this area when
 				// only Search Console is shared.
 				// See: https://github.com/google/site-kit-wp/issues/7435
-				if (
+				const hasOnlyOneWidget =
 					areaWidgets.length === 1 &&
-					allKeyMetricsTileWidgets.includes( areaWidgets[ 0 ].slug )
+					allKeyMetricsTileWidgets.includes( areaWidgets[ 0 ].slug );
+
+				if (
+					! canViewSharedAnalytics ||
+					! canViewSharedSearchConsole ||
+					hasOnlyOneWidget
 				) {
 					return [];
 				}


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #12869

## Relevant technical choices

Digging into this I found that the underlying issue seemed to be that the notifications were being registered twice, once with `viewContext` as `VIEW_CONTEXT_MAIN_DASHBOARD` and again with `VIEW_CONTEXT_MAIN_DASHBOARD_VIEW_ONLY`. The cause seemed to be here:

https://github.com/google/site-kit-wp/blob/23415c2a61ae6565b1ea1a73b897758745525140/assets/js/components/DashboardMainApp.js#L328-L333

To resolve this issue I passed the `viewContext` to `getQueuedNotifications()`. This appears to resolve the issue with notifications being inappropriately shown to view-only users without any changes to the notification requirements.

Note that I did not change the requirements for `zero-data-notification` as per the IB. The IB says that it should be shown "if user cannot access both modules", but the existing check shows the notification if the user has access to _either_ module. As far as I can tell the notice still seems appropriate when only one of the modules is shared, so I left this unchanged. Now that the current check works as expected, it should be appropriately hidden for users without access to either module.

<!-- Please describe your changes. -->

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [x] Run the code.
- [x] Ensure the acceptance criteria are satisfied.
- [x] Reassess the implementation with the IB.
- [x] Ensure no unrelated changes are included.
- [x] Ensure CI checks pass.
- [x] Check Storybook where applicable.
- [x] Ensure there is a QA Brief.
- [x] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [x] Ensure the PR has the correct target branch.
- [x] Double-check that the PR is okay to be merged.
- [x] Ensure the corresponding issue has a ZenHub release assigned.
- [x] Add a changelog message to the issue.
