### PR TITLE
Fix Site Goals report error notice top spacing

### DIFF
--- a/assets/sass/components/analytics-4/_googlesitekit-site-goals.scss
+++ b/assets/sass/components/analytics-4/_googlesitekit-site-goals.scss
@@ -30,7 +30,11 @@
 		// When the whole widget fails, its report error notice needs the
 		// standard top space, not the tight 6px the tiles use.
 		.googlesitekit-widget__body:has(> .googlesitekit-cta--error) {
-			padding-top: $grid-gap-desktop;
+			padding-top: $grid-gap-phone;
+
+			@media (min-width: $bp-tablet) {
+				padding-top: $grid-gap-desktop;
+			}
 		}
 
 		.googlesitekit-widget__header-inner {

--- a/assets/sass/components/analytics-4/_googlesitekit-site-goals.scss
+++ b/assets/sass/components/analytics-4/_googlesitekit-site-goals.scss
@@ -27,6 +27,12 @@
 			padding-top: 6px;
 		}
 
+		// When the whole widget fails, its report error notice needs the
+		// standard top space, not the tight 6px the tiles use.
+		.googlesitekit-widget__body:has(> .googlesitekit-cta--error) {
+			padding-top: $grid-gap-desktop;
+		}
+
 		.googlesitekit-widget__header-inner {
 
 			@media (min-width: $bp-tablet) {


### PR DESCRIPTION
Ensure that when the whole widget fails, the report error notice receives the standard top space instead of the tight 6px used by the tiles. This improves the visual consistency of error messages.

## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #12856

## Relevant technical choices

Addressing the [QA comment](https://github.com/google/site-kit-wp/issues/12856#issuecomment-4749177238), item 1.

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.
- [ ] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
