### PR TITLE
Enhancement: Allow block styling options for RRM buttons (#12915)

### DIFF
--- a/assets/blocks/reader-revenue-manager/common/ButtonEdit.js
+++ b/assets/blocks/reader-revenue-manager/common/ButtonEdit.js
@@ -23,9 +23,10 @@ import PropTypes from 'prop-types';
  * WordPress dependencies
  */
 import { InspectorControls, useBlockProps } from '@wordpress-core/block-editor';
-import { Notice } from '@wordpress-core/components';
+import { Notice, PanelBody, TextControl } from '@wordpress-core/components';
 import { useSelect } from '@wordpress-core/data';
 import { Fragment, useEffect, useState } from '@wordpress-core/element';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -50,6 +51,9 @@ import EditorButton from './EditorButton';
  * @param {string} props.invalidPaymentOptionWithoutModuleAccessNotice Invalid payment option without module access notice.
  * @param {string} props.noSnippetWithModuleAccessNotice               No snippet with module access notice.
  * @param {string} props.noSnippetWithoutModuleAccessNotice            No snippet without module access notice.
+ * @param {Object} props.attributes                                    Block attributes.
+ * @param {Function} props.setAttributes                               Block attribute setter.
+ * @param {string} props.className                                     Block class name.
  * @return {Element} Element to render.
  */
 export default function ButtonEdit( {
@@ -59,10 +63,21 @@ export default function ButtonEdit( {
 	invalidPaymentOptionWithoutModuleAccessNotice,
 	noSnippetWithModuleAccessNotice,
 	noSnippetWithoutModuleAccessNotice,
+	attributes,
+	setAttributes,
+	className,
 } ) {
 	const [ hasModuleAccess, setHasModuleAccess ] = useState( undefined );
 
-	const blockProps = useBlockProps();
+	const { buttonClassName } = attributes;
+	const blockProps = useBlockProps( { className } );
+
+	function handleClassChange( value ) {
+		const sanitizedValue = value.trim();
+		setAttributes( {
+			buttonClassName: sanitizedValue ? sanitizedValue : undefined,
+		} );
+	}
 
 	// Determine if the user has access to the module.
 	useEffect( () => {
@@ -117,18 +132,42 @@ export default function ButtonEdit( {
 
 	return (
 		<Fragment>
-			{ notice && (
-				<InspectorControls>
+			<InspectorControls>
+				<PanelBody
+					title={ __( 'Button settings', 'google-site-kit' ) }
+					initialOpen
+				>
+					<TextControl
+						label={ __( 'HTML class', 'google-site-kit' ) }
+						help={ __(
+							'Add optional classes to customize the button in the editor and on the frontend.',
+							'google-site-kit'
+						) }
+						value={ buttonClassName || '' }
+						onChange={ handleClassChange }
+						// Opt-in to new WordPress components styles introduced in Gutenberg 6.7+.
+						// Safe for pre-6.7 WordPress: these props are ignored in older versions.
+						// __next40pxDefaultSize - use new 40px height (replaces deprecated 36px)
+						// __nextHasNoMarginBottom - remove legacy bottom margin
+						// Ref: https://github.com/WordPress/gutenberg/pull/61132
+						__next40pxDefaultSize
+						__nextHasNoMarginBottom
+					/>
+				</PanelBody>
+				{ notice && (
 					<div className="block-editor-block-card">
 						<Notice status="warning" isDismissible={ false }>
 							{ notice }
 						</Notice>
 					</div>
-				</InspectorControls>
-			) }
+				) }
+			</InspectorControls>
 			<div { ...blockProps }>
 				<div className="googlesitekit-blocks-reader-revenue-manager">
-					<EditorButton disabled={ disabled }>
+					<EditorButton
+						className={ buttonClassName || '' }
+						disabled={ disabled }
+					>
 						{ buttonLabel }
 					</EditorButton>
 				</div>
@@ -144,4 +183,9 @@ ButtonEdit.propTypes = {
 	invalidPaymentOptionWithoutModuleAccessNotice: PropTypes.node.isRequired,
 	noSnippetWithModuleAccessNotice: PropTypes.node.isRequired,
 	noSnippetWithoutModuleAccessNotice: PropTypes.node.isRequired,
+	attributes: PropTypes.shape( {
+		buttonClassName: PropTypes.string,
+	} ).isRequired,
+	setAttributes: PropTypes.func.isRequired,
+	className: PropTypes.string,
 };

--- a/assets/blocks/reader-revenue-manager/common/ButtonEdit.js
+++ b/assets/blocks/reader-revenue-manager/common/ButtonEdit.js
@@ -53,7 +53,6 @@ import EditorButton from './EditorButton';
  * @param {string} props.noSnippetWithoutModuleAccessNotice            No snippet without module access notice.
  * @param {Object} props.attributes                                    Block attributes.
  * @param {Function} props.setAttributes                               Block attribute setter.
- * @param {string} props.className                                     Block class name.
  * @return {Element} Element to render.
  */
 export default function ButtonEdit( {
@@ -65,15 +64,14 @@ export default function ButtonEdit( {
 	noSnippetWithoutModuleAccessNotice,
 	attributes,
 	setAttributes,
-	className,
 } ) {
 	const [ hasModuleAccess, setHasModuleAccess ] = useState( undefined );
 
 	const { buttonClassName } = attributes;
-	const blockProps = useBlockProps( { className } );
+	const blockProps = useBlockProps();
 
 	function handleClassChange( value ) {
-		const sanitizedValue = value.trim();
+		const sanitizedValue = ( value || '' ).trim();
 		setAttributes( {
 			buttonClassName: sanitizedValue ? sanitizedValue : undefined,
 		} );
@@ -187,5 +185,4 @@ ButtonEdit.propTypes = {
 		buttonClassName: PropTypes.string,
 	} ).isRequired,
 	setAttributes: PropTypes.func.isRequired,
-	className: PropTypes.string,
 };

--- a/assets/blocks/reader-revenue-manager/common/EditorButton.js
+++ b/assets/blocks/reader-revenue-manager/common/EditorButton.js
@@ -25,12 +25,13 @@ import PropTypes from 'prop-types';
  */
 import GoogleLogoIcon from '@/svg/graphics/logo-g.svg';
 
-export default function EditorButton( { children, disabled } ) {
+export default function EditorButton( { children, className, disabled } ) {
 	return (
 		<button
 			disabled={ disabled }
 			className={ classnames(
 				'googlesitekit-blocks-reader-revenue-manager-button',
+				className,
 				{
 					'googlesitekit-blocks-reader-revenue-manager-button--disabled':
 						disabled,
@@ -45,5 +46,6 @@ export default function EditorButton( { children, disabled } ) {
 
 EditorButton.propTypes = {
 	children: PropTypes.node.isRequired,
+	className: PropTypes.string,
 	disabled: PropTypes.bool.isRequired,
 };

--- a/assets/blocks/reader-revenue-manager/contribute-with-google/Edit.js
+++ b/assets/blocks/reader-revenue-manager/contribute-with-google/Edit.js
@@ -32,10 +32,15 @@ import { MODULES_READER_REVENUE_MANAGER } from '@/js/modules/reader-revenue-mana
  * Contribute with Google Block Edit component.
  *
  * @since 1.148.0
+ * @since n.e.x.t Added attributes, setAttributes, and className to props.
  *
+ * @param {Object}   props               Component props.
+ * @param {Object}   props.attributes    Block attributes.
+ * @param {Function} props.setAttributes Block attribute setter.
+ * @param {string}   props.className     Block class name.
  * @return {Element} Element to render.
  */
-export default function Edit() {
+export default function Edit( { attributes, setAttributes, className } ) {
 	const publicationID = select(
 		MODULES_READER_REVENUE_MANAGER
 	).getPublicationID();
@@ -49,6 +54,9 @@ export default function Edit() {
 
 	return (
 		<ButtonEdit
+			attributes={ attributes }
+			setAttributes={ setAttributes }
+			className={ className }
 			buttonLabel={
 				/* translators: Button label for Contribute with Google. See: https://github.com/subscriptions-project/swg-js/blob/05af2d45cfcaf831a6b4d35c28f2c7b5c2e39308/src/i18n/swg-strings.ts#L58-L91 (please refer to the latest version of the file) */
 				__( 'Contribute with Google', 'google-site-kit' )

--- a/assets/blocks/reader-revenue-manager/contribute-with-google/Edit.js
+++ b/assets/blocks/reader-revenue-manager/contribute-with-google/Edit.js
@@ -32,15 +32,14 @@ import { MODULES_READER_REVENUE_MANAGER } from '@/js/modules/reader-revenue-mana
  * Contribute with Google Block Edit component.
  *
  * @since 1.148.0
- * @since n.e.x.t Added attributes, setAttributes, and className to props.
+ * @since n.e.x.t Added attributes and setAttributes to props.
  *
  * @param {Object}   props               Component props.
  * @param {Object}   props.attributes    Block attributes.
  * @param {Function} props.setAttributes Block attribute setter.
- * @param {string}   props.className     Block class name.
  * @return {Element} Element to render.
  */
-export default function Edit( { attributes, setAttributes, className } ) {
+export default function Edit( { attributes, setAttributes } ) {
 	const publicationID = select(
 		MODULES_READER_REVENUE_MANAGER
 	).getPublicationID();
@@ -56,7 +55,6 @@ export default function Edit( { attributes, setAttributes, className } ) {
 		<ButtonEdit
 			attributes={ attributes }
 			setAttributes={ setAttributes }
-			className={ className }
 			buttonLabel={
 				/* translators: Button label for Contribute with Google. See: https://github.com/subscriptions-project/swg-js/blob/05af2d45cfcaf831a6b4d35c28f2c7b5c2e39308/src/i18n/swg-strings.ts#L58-L91 (please refer to the latest version of the file) */
 				__( 'Contribute with Google', 'google-site-kit' )

--- a/assets/blocks/reader-revenue-manager/contribute-with-google/block.json
+++ b/assets/blocks/reader-revenue-manager/contribute-with-google/block.json
@@ -14,6 +14,7 @@
 		}
 	},
 	"supports": {
+		"customClassName": false,
 		"inserter": true
 	}
 }

--- a/assets/blocks/reader-revenue-manager/contribute-with-google/block.json
+++ b/assets/blocks/reader-revenue-manager/contribute-with-google/block.json
@@ -8,6 +8,11 @@
 	"icon": "google",
 	"description": "Allow users to make voluntary contributions using Reader Revenue Manager.",
 	"textdomain": "google-site-kit",
+	"attributes": {
+		"buttonClassName": {
+			"type": "string"
+		}
+	},
 	"supports": {
 		"inserter": true
 	}

--- a/assets/blocks/reader-revenue-manager/contribute-with-google/v3/block.json
+++ b/assets/blocks/reader-revenue-manager/contribute-with-google/v3/block.json
@@ -14,6 +14,7 @@
 		}
 	},
 	"supports": {
+		"customClassName": false,
 		"inserter": true
 	}
 }

--- a/assets/blocks/reader-revenue-manager/contribute-with-google/v3/block.json
+++ b/assets/blocks/reader-revenue-manager/contribute-with-google/v3/block.json
@@ -8,6 +8,11 @@
 	"icon": "google",
 	"description": "Allow users to make voluntary contributions using Reader Revenue Manager.",
 	"textdomain": "google-site-kit",
+	"attributes": {
+		"buttonClassName": {
+			"type": "string"
+		}
+	},
 	"supports": {
 		"inserter": true
 	}

--- a/assets/blocks/reader-revenue-manager/subscribe-with-google/Edit.js
+++ b/assets/blocks/reader-revenue-manager/subscribe-with-google/Edit.js
@@ -53,7 +53,6 @@ export default function Edit( { attributes, setAttributes } ) {
 
 	return (
 		<ButtonEdit
-			select={ select }
 			attributes={ attributes }
 			setAttributes={ setAttributes }
 			buttonLabel={

--- a/assets/blocks/reader-revenue-manager/subscribe-with-google/Edit.js
+++ b/assets/blocks/reader-revenue-manager/subscribe-with-google/Edit.js
@@ -32,10 +32,15 @@ import { MODULES_READER_REVENUE_MANAGER } from '@/js/modules/reader-revenue-mana
  * Subscribe with Google Block Edit component.
  *
  * @since 1.148.0
+ * @since n.e.x.t Added attributes, setAttributes, and className to props.
  *
+ * @param {Object}   props               Component props.
+ * @param {Object}   props.attributes    Block attributes.
+ * @param {Function} props.setAttributes Block attribute setter.
+ * @param {string}   props.className     Block class name.
  * @return {Element} Element to render.
  */
-export default function Edit() {
+export default function Edit( { attributes, setAttributes, className } ) {
 	const publicationID = select(
 		MODULES_READER_REVENUE_MANAGER
 	).getPublicationID();
@@ -50,6 +55,9 @@ export default function Edit() {
 	return (
 		<ButtonEdit
 			select={ select }
+			attributes={ attributes }
+			setAttributes={ setAttributes }
+			className={ className }
 			buttonLabel={
 				/* translators: Button label for Subscribe with Google. See: https://github.com/subscriptions-project/swg-js/blob/05af2d45cfcaf831a6b4d35c28f2c7b5c2e39308/src/i18n/swg-strings.ts#L24-L57 (please refer to the latest version of the file) */
 				__( 'Subscribe with Google', 'google-site-kit' )

--- a/assets/blocks/reader-revenue-manager/subscribe-with-google/Edit.js
+++ b/assets/blocks/reader-revenue-manager/subscribe-with-google/Edit.js
@@ -32,15 +32,14 @@ import { MODULES_READER_REVENUE_MANAGER } from '@/js/modules/reader-revenue-mana
  * Subscribe with Google Block Edit component.
  *
  * @since 1.148.0
- * @since n.e.x.t Added attributes, setAttributes, and className to props.
+ * @since n.e.x.t Added attributes and setAttributes to props.
  *
  * @param {Object}   props               Component props.
  * @param {Object}   props.attributes    Block attributes.
  * @param {Function} props.setAttributes Block attribute setter.
- * @param {string}   props.className     Block class name.
  * @return {Element} Element to render.
  */
-export default function Edit( { attributes, setAttributes, className } ) {
+export default function Edit( { attributes, setAttributes } ) {
 	const publicationID = select(
 		MODULES_READER_REVENUE_MANAGER
 	).getPublicationID();
@@ -57,7 +56,6 @@ export default function Edit( { attributes, setAttributes, className } ) {
 			select={ select }
 			attributes={ attributes }
 			setAttributes={ setAttributes }
-			className={ className }
 			buttonLabel={
 				/* translators: Button label for Subscribe with Google. See: https://github.com/subscriptions-project/swg-js/blob/05af2d45cfcaf831a6b4d35c28f2c7b5c2e39308/src/i18n/swg-strings.ts#L24-L57 (please refer to the latest version of the file) */
 				__( 'Subscribe with Google', 'google-site-kit' )

--- a/assets/blocks/reader-revenue-manager/subscribe-with-google/block.json
+++ b/assets/blocks/reader-revenue-manager/subscribe-with-google/block.json
@@ -14,6 +14,7 @@
 		}
 	},
 	"supports": {
+		"customClassName": false,
 		"inserter": true
 	}
 }

--- a/assets/blocks/reader-revenue-manager/subscribe-with-google/block.json
+++ b/assets/blocks/reader-revenue-manager/subscribe-with-google/block.json
@@ -8,6 +8,11 @@
 	"icon": "google",
 	"description": "Allow users to subscribe using Reader Revenue Manager to access content behind a paywall.",
 	"textdomain": "google-site-kit",
+	"attributes": {
+		"buttonClassName": {
+			"type": "string"
+		}
+	},
 	"supports": {
 		"inserter": true
 	}

--- a/assets/blocks/reader-revenue-manager/subscribe-with-google/v3/block.json
+++ b/assets/blocks/reader-revenue-manager/subscribe-with-google/v3/block.json
@@ -14,6 +14,7 @@
 		}
 	},
 	"supports": {
+		"customClassName": false,
 		"inserter": true
 	}
 }

--- a/assets/blocks/reader-revenue-manager/subscribe-with-google/v3/block.json
+++ b/assets/blocks/reader-revenue-manager/subscribe-with-google/v3/block.json
@@ -8,6 +8,11 @@
 	"icon": "google",
 	"description": "Allow users to subscribe using Reader Revenue Manager to access content behind a paywall.",
 	"textdomain": "google-site-kit",
+	"attributes": {
+		"buttonClassName": {
+			"type": "string"
+		}
+	},
 	"supports": {
 		"inserter": true
 	}

--- a/includes/Modules/Reader_Revenue_Manager/Block_Button_Trait.php
+++ b/includes/Modules/Reader_Revenue_Manager/Block_Button_Trait.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Trait Google\Site_Kit\Modules\Reader_Revenue_Manager\Block_Button_Trait
+ *
+ * @package   Google\Site_Kit\Modules\Reader_Revenue_Manager
+ * @copyright 2025 Google LLC
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
+ * @link      https://sitekit.withgoogle.com
+ */
+
+namespace Google\Site_Kit\Modules\Reader_Revenue_Manager;
+
+/**
+ * Trait for shared RRM block button functionality.
+ *
+ * @since n.e.x.t
+ * @access private
+ * @ignore
+ */
+trait Block_Button_Trait {
+
+	/**
+	 * Gets the sanitized button class attribute string.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param array $attributes Block attributes.
+	 * @return string HTML class attribute string, or empty string.
+	 */
+	protected function get_button_class_attribute( $attributes ) {
+		if ( ! is_array( $attributes ) || empty( $attributes['buttonClassName'] ) || ! is_string( $attributes['buttonClassName'] ) ) {
+			return '';
+		}
+
+		$classes = array_filter(
+			array_map(
+				'sanitize_html_class',
+				preg_split( '/\s+/', trim( $attributes['buttonClassName'] ) )
+			)
+		);
+
+		if ( empty( $classes ) ) {
+			return '';
+		}
+
+		return sprintf( ' class="%s"', esc_attr( implode( ' ', $classes ) ) );
+	}
+}

--- a/includes/Modules/Reader_Revenue_Manager/Contribute_With_Google_Block.php
+++ b/includes/Modules/Reader_Revenue_Manager/Contribute_With_Google_Block.php
@@ -24,6 +24,7 @@ use Google\Site_Kit\Core\Util\Block_Support;
  */
 class Contribute_With_Google_Block {
 	use Block_Button_Trait;
+
 	/**
 	 * Context instance.
 	 *

--- a/includes/Modules/Reader_Revenue_Manager/Contribute_With_Google_Block.php
+++ b/includes/Modules/Reader_Revenue_Manager/Contribute_With_Google_Block.php
@@ -23,6 +23,7 @@ use Google\Site_Kit\Core\Util\Block_Support;
  * @ignore
  */
 class Contribute_With_Google_Block {
+	use Block_Button_Trait;
 	/**
 	 * Context instance.
 	 *
@@ -120,30 +121,4 @@ class Contribute_With_Google_Block {
 		);
 	}
 
-	/**
-	 * Gets the sanitized button class attribute.
-	 *
-	 * @since n.e.x.t
-	 *
-	 * @param array $attributes Block attributes.
-	 * @return string Button class attribute.
-	 */
-	private function get_button_class_attribute( $attributes ) {
-		if ( ! is_array( $attributes ) || empty( $attributes['buttonClassName'] ) || ! is_string( $attributes['buttonClassName'] ) ) {
-			return '';
-		}
-
-		$classes = array_filter(
-			array_map(
-				'sanitize_html_class',
-				preg_split( '/\s+/', trim( $attributes['buttonClassName'] ) )
-			)
-		);
-
-		if ( empty( $classes ) ) {
-			return '';
-		}
-
-		return sprintf( ' class="%s"', esc_attr( implode( ' ', $classes ) ) );
-	}
 }

--- a/includes/Modules/Reader_Revenue_Manager/Contribute_With_Google_Block.php
+++ b/includes/Modules/Reader_Revenue_Manager/Contribute_With_Google_Block.php
@@ -97,10 +97,12 @@ class Contribute_With_Google_Block {
 	 * Render callback for the block.
 	 *
 	 * @since 1.148.0
+	 * @since n.e.x.t Added the `$attributes` parameter.
 	 *
+	 * @param array $attributes Block attributes.
 	 * @return string Rendered block.
 	 */
-	public function render_callback() {
+	public function render_callback( $attributes = array() ) {
 		// If the payment option is not `contributions` or the tag is not placed, do not render the block.
 		$settings = $this->settings->get();
 
@@ -112,6 +114,36 @@ class Contribute_With_Google_Block {
 
 		// Ensure the button is centered to match the editor preview.
 		// TODO: Add a stylesheet to the page and style the button container using a class.
-		return '<div style="margin: 0 auto;"><button swg-standard-button="contribution"></button></div>';
+		return sprintf(
+			'<div style="margin: 0 auto;"><button swg-standard-button="contribution"%s></button></div>',
+			$this->get_button_class_attribute( $attributes )
+		);
+	}
+
+	/**
+	 * Gets the sanitized button class attribute.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param array $attributes Block attributes.
+	 * @return string Button class attribute.
+	 */
+	private function get_button_class_attribute( $attributes ) {
+		if ( ! is_array( $attributes ) || empty( $attributes['buttonClassName'] ) || ! is_string( $attributes['buttonClassName'] ) ) {
+			return '';
+		}
+
+		$classes = array_filter(
+			array_map(
+				'sanitize_html_class',
+				preg_split( '/\s+/', trim( $attributes['buttonClassName'] ) )
+			)
+		);
+
+		if ( empty( $classes ) ) {
+			return '';
+		}
+
+		return sprintf( ' class="%s"', esc_attr( implode( ' ', $classes ) ) );
 	}
 }

--- a/includes/Modules/Reader_Revenue_Manager/Subscribe_With_Google_Block.php
+++ b/includes/Modules/Reader_Revenue_Manager/Subscribe_With_Google_Block.php
@@ -97,10 +97,12 @@ class Subscribe_With_Google_Block {
 	 * Render callback for the block.
 	 *
 	 * @since 1.148.0
+	 * @since n.e.x.t Added the `$attributes` parameter.
 	 *
+	 * @param array $attributes Block attributes.
 	 * @return string Rendered block.
 	 */
-	public function render_callback() {
+	public function render_callback( $attributes = array() ) {
 		// If the payment option is not `subscriptions` or the tag is not placed, do not render the block.
 		$settings = $this->settings->get();
 
@@ -112,6 +114,36 @@ class Subscribe_With_Google_Block {
 
 		// Ensure the button is centered to match the editor preview.
 		// TODO: Add a stylesheet to the page and style the button container using a class.
-		return '<div style="margin: 0 auto;"><button swg-standard-button="subscription"></button></div>';
+		return sprintf(
+			'<div style="margin: 0 auto;"><button swg-standard-button="subscription"%s></button></div>',
+			$this->get_button_class_attribute( $attributes )
+		);
+	}
+
+	/**
+	 * Gets the sanitized button class attribute.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param array $attributes Block attributes.
+	 * @return string Button class attribute.
+	 */
+	private function get_button_class_attribute( $attributes ) {
+		if ( ! is_array( $attributes ) || empty( $attributes['buttonClassName'] ) || ! is_string( $attributes['buttonClassName'] ) ) {
+			return '';
+		}
+
+		$classes = array_filter(
+			array_map(
+				'sanitize_html_class',
+				preg_split( '/\s+/', trim( $attributes['buttonClassName'] ) )
+			)
+		);
+
+		if ( empty( $classes ) ) {
+			return '';
+		}
+
+		return sprintf( ' class="%s"', esc_attr( implode( ' ', $classes ) ) );
 	}
 }

--- a/includes/Modules/Reader_Revenue_Manager/Subscribe_With_Google_Block.php
+++ b/includes/Modules/Reader_Revenue_Manager/Subscribe_With_Google_Block.php
@@ -24,6 +24,7 @@ use Google\Site_Kit\Core\Util\Block_Support;
  */
 class Subscribe_With_Google_Block {
 	use Block_Button_Trait;
+
 	/**
 	 * Context instance.
 	 *

--- a/includes/Modules/Reader_Revenue_Manager/Subscribe_With_Google_Block.php
+++ b/includes/Modules/Reader_Revenue_Manager/Subscribe_With_Google_Block.php
@@ -23,6 +23,7 @@ use Google\Site_Kit\Core\Util\Block_Support;
  * @ignore
  */
 class Subscribe_With_Google_Block {
+	use Block_Button_Trait;
 	/**
 	 * Context instance.
 	 *
@@ -120,30 +121,4 @@ class Subscribe_With_Google_Block {
 		);
 	}
 
-	/**
-	 * Gets the sanitized button class attribute.
-	 *
-	 * @since n.e.x.t
-	 *
-	 * @param array $attributes Block attributes.
-	 * @return string Button class attribute.
-	 */
-	private function get_button_class_attribute( $attributes ) {
-		if ( ! is_array( $attributes ) || empty( $attributes['buttonClassName'] ) || ! is_string( $attributes['buttonClassName'] ) ) {
-			return '';
-		}
-
-		$classes = array_filter(
-			array_map(
-				'sanitize_html_class',
-				preg_split( '/\s+/', trim( $attributes['buttonClassName'] ) )
-			)
-		);
-
-		if ( empty( $classes ) ) {
-			return '';
-		}
-
-		return sprintf( ' class="%s"', esc_attr( implode( ' ', $classes ) ) );
-	}
 }

--- a/tests/phpunit/integration/Modules/Reader_Revenue_Manager/Contribute_With_Google_BlockTest.php
+++ b/tests/phpunit/integration/Modules/Reader_Revenue_Manager/Contribute_With_Google_BlockTest.php
@@ -92,4 +92,22 @@ class Contribute_With_Google_BlockTest extends TestCase {
 
 		$this->assertEquals( '<div style="margin: 0 auto;"><button swg-standard-button="contribution"></button></div>', $output, 'Output should match expected markup when tag guard allows activation.' );
 	}
+
+	public function test_render_callback_with_button_class_name() {
+		$this->settings->set(
+			array(
+				'paymentOption' => 'contributions',
+				'publicationID' => 'test-publication-id',
+				'snippetMode'   => 'sitewide',
+			)
+		);
+
+		$output = $this->block->render_callback(
+			array(
+				'buttonClassName' => 'custom-class another-class invalid@class',
+			)
+		);
+
+		$this->assertEquals( '<div style="margin: 0 auto;"><button swg-standard-button="contribution" class="custom-class another-class invalidclass"></button></div>', $output, 'Output should include sanitized button classes.' );
+	}
 }

--- a/tests/phpunit/integration/Modules/Reader_Revenue_Manager/Subscribe_With_Google_BlockTest.php
+++ b/tests/phpunit/integration/Modules/Reader_Revenue_Manager/Subscribe_With_Google_BlockTest.php
@@ -92,4 +92,22 @@ class Subscribe_With_Google_BlockTest extends TestCase {
 
 		$this->assertEquals( '<div style="margin: 0 auto;"><button swg-standard-button="subscription"></button></div>', $output, 'Output should match expected markup when tag guard allows activation.' );
 	}
+
+	public function test_render_callback_with_button_class_name() {
+		$this->settings->set(
+			array(
+				'paymentOption' => 'subscriptions',
+				'publicationID' => 'test-publication-id',
+				'snippetMode'   => 'sitewide',
+			)
+		);
+
+		$output = $this->block->render_callback(
+			array(
+				'buttonClassName' => 'custom-class another-class invalid@class',
+			)
+		);
+
+		$this->assertEquals( '<div style="margin: 0 auto;"><button swg-standard-button="subscription" class="custom-class another-class invalidclass"></button></div>', $output, 'Output should include sanitized button classes.' );
+	}
 }


### PR DESCRIPTION
Register buttonClassName attribute in RRM blocks, expose an HTML class textbox in Gutenberg editor, and sanitize and render the classes on the frontend.

## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #

## Relevant technical choices

<!-- Please describe your changes. -->

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [ ] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.
- [ ] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
