### PR TITLE
fix(security): restrict Gemini CLI filesystem access in yolo implementation workflow

### DIFF
--- a/.github/workflows/gemini.yml
+++ b/.github/workflows/gemini.yml
@@ -72,7 +72,7 @@ jobs:
           gemini --version
       - name: Run /implement command
         run: |
-          gemini --approval-mode=yolo --model=gemini-3-pro-preview "/implement ${{ inputs.issue_number }}"
+          gemini --approval-mode=yolo --sandbox --model=gemini-3-pro-preview "/implement ${{ inputs.issue_number }}"
         env:
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           GITHUB_MCP_PAT: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Adds `--sandbox` flag to the Gemini CLI invocation in `gemini.yml` to restrict filesystem access during automated issue implementation.

## Vulnerability Details

The `gemini.yml` workflow runs Gemini CLI with `--approval-mode=yolo` to automatically implement GitHub issues. The workflow:
1. Takes a GitHub issue number as `workflow_dispatch` input
2. Gemini CLI fetches the issue title + body to understand the task
3. Runs with `GEMINI_API_KEY` and `GITHUB_MCP_PAT` in environment

The issue body is **attacker-controlled content** that flows directly into the Gemini prompt. A malicious issue body could attempt prompt injection to instruct the agent to:
- Read `~/.ssh` keys, `~/.config/gcloud` credentials, or `.env` files
- Exfiltrate `GEMINI_API_KEY` or `GITHUB_MCP_PAT` by writing them into the implementation patch
- Write malicious code into the implementation that looks benign in a patch review

**Trigger:** `workflow_dispatch` only — requires a maintainer to manually trigger. This significantly limits exploitability, but does not eliminate the risk if a maintainer is socially engineered into running the workflow on a malicious issue.

## Fix

Added `--sandbox` flag which restricts Gemini CLI's filesystem access to the project directory, preventing the agent from reading files outside the workspace even if instructed to by a crafted prompt.

## References
- [Gemini CLI sandbox documentation](https://github.com/google-gemini/gemini-cli)
- [OWASP: Prompt Injection](https://owasp.org/www-project-top-10-for-large-language-model-applications/)