### PR TITLE
Extract `ModuleSetup` routines into hooks

### DIFF
--- a/assets/js/components/setup/ModuleSetup.js
+++ b/assets/js/components/setup/ModuleSetup.js
@@ -22,42 +22,34 @@
 import classnames from 'classnames';
 import PropTypes from 'prop-types';
 import { useMount } from 'react-use';
-import { useCallbackOne } from 'use-memo-one';
 
 /**
  * WordPress dependencies
  */
 import { Fragment, useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { addQueryArgs, getQueryArgs } from '@wordpress/url';
 
 /**
  * Internal dependencies
  */
-import { useDispatch, useRegistry, useSelect } from 'googlesitekit-data';
+import { useRegistry, useSelect } from 'googlesitekit-data';
 import Header from '@/js/components/Header';
 import HelpMenu from '@/js/components/help/HelpMenu';
 import ProgressIndicator from '@/js/components/ProgressIndicator';
 import ExitSetup from '@/js/components/setup/ExitSetup';
-import { deleteItem } from '@/js/googlesitekit/api/cache';
-import { CORE_LOCATION } from '@/js/googlesitekit/datastore/location/constants';
-import { CORE_SITE } from '@/js/googlesitekit/datastore/site/constants';
 import { CORE_MODULES } from '@/js/googlesitekit/modules/datastore/constants';
 import { useFeature } from '@/js/hooks/useFeature';
-import useForwardableParams from '@/js/hooks/useForwardableParams';
 import useQueryArg from '@/js/hooks/useQueryArg';
 import useViewContext from '@/js/hooks/useViewContext';
 import { Cell, Grid, Row } from '@/js/material-components';
 import { MODULE_SLUG_ANALYTICS_4 } from '@/js/modules/analytics-4/constants';
-import { trackEvent } from '@/js/util';
+import { useFinishSetup, useModuleSetupTracking } from './hooks';
 import ModuleSetupFooter from './ModuleSetupFooter';
 
 export default function ModuleSetup( { moduleSlug } ) {
 	const viewContext = useViewContext();
-	const { navigateTo } = useDispatch( CORE_LOCATION );
 	const setupFlowRefreshEnabled = useFeature( 'setupFlowRefresh' );
 	const [ showProgress ] = useQueryArg( 'showProgress' );
-	const forwardableParams = useForwardableParams();
 
 	const isInitialSetupFlow =
 		setupFlowRefreshEnabled &&
@@ -70,61 +62,28 @@ export default function ModuleSetup( { moduleSlug } ) {
 
 	const registry = useRegistry();
 
-	/**
-	 * When module setup done, we redirect the user to Site Kit dashboard.
-	 *
-	 * @since 1.0.0
-	 * @since 1.18.0 Added optional redirectURL parameter.
-	 *
-	 * @param {string} [redirectURL] URL to redirect to when complete. Defaults to Site Kit dashboard.
-	 */
-	const finishSetup = useCallbackOne(
-		async ( redirectURL ) => {
-			await deleteItem( 'module_setup' );
+	const finishSetup = useFinishSetup(
+		moduleSlug,
+		isInitialSetupFlow
+			? {
+					gaTrackingEventArgs: {
+						category: `${ viewContext }_setup`,
+						action: 'setup_flow_v3_complete_analytics_step',
+					},
+			  }
+			: {}
+	);
 
-			if ( isInitialSetupFlow ) {
-				await trackEvent(
-					`${ viewContext }_setup`,
-					'setup_flow_v3_complete_analytics_step'
-				);
-			} else {
-				await trackEvent(
-					'moduleSetup',
-					'complete_module_setup',
-					moduleSlug
-				);
-			}
-
-			if ( redirectURL ) {
-				navigateTo(
-					addQueryArgs( redirectURL, {
-						...forwardableParams,
-						...getQueryArgs( redirectURL ),
-					} )
-				);
-				return;
-			}
-
-			const { select, resolveSelect } = registry;
-			await resolveSelect( CORE_SITE ).getSiteInfo();
-			const adminURL = select( CORE_SITE ).getAdminURL(
-				'googlesitekit-dashboard',
-				{
-					...forwardableParams,
-					notification: 'authentication_success',
-					slug: moduleSlug,
-				}
-			);
-			navigateTo( adminURL );
-		},
-		[
-			forwardableParams,
-			registry,
-			navigateTo,
-			moduleSlug,
-			viewContext,
-			isInitialSetupFlow,
-		]
+	const { trackCancel: onCancelButtonClick } = useModuleSetupTracking(
+		moduleSlug,
+		isInitialSetupFlow
+			? {
+					viewGATrackingEventArgs: {
+						category: `${ viewContext }_setup`,
+						action: 'setup_flow_v3_view_analytics_step',
+					},
+			  }
+			: {}
 	);
 
 	const onCompleteSetup = module?.onCompleteSetup;
@@ -132,23 +91,6 @@ export default function ModuleSetup( { moduleSlug } ) {
 		() => onCompleteSetup( registry, finishSetup ),
 		[ onCompleteSetup, registry, finishSetup ]
 	);
-
-	const onCancelButtonClick = useCallback( async () => {
-		await trackEvent( 'moduleSetup', 'cancel_module_setup', moduleSlug );
-	}, [ moduleSlug ] );
-
-	useMount( () => {
-		if ( isInitialSetupFlow ) {
-			trackEvent(
-				`${ viewContext }_setup`,
-				'setup_flow_v3_view_analytics_step'
-			);
-
-			return;
-		}
-
-		trackEvent( 'moduleSetup', 'view_module_setup', moduleSlug );
-	} );
 
 	// Add the initial setup class to the body when the component mounts.
 	useMount( () => {

--- a/assets/js/components/setup/ModuleSetup.test.js
+++ b/assets/js/components/setup/ModuleSetup.test.js
@@ -28,7 +28,7 @@ import * as analyticsFixtures from '@/js/modules/analytics-4/datastore/__fixture
 import { MODULES_ANALYTICS_4 } from '@/js/modules/analytics-4/datastore/constants';
 import * as tracking from '@/js/util/tracking';
 import { mockLocation } from '@tests/js/mock-browser-utils';
-import { act, fireEvent, render, waitFor } from '@tests/js/test-utils';
+import { act, fireEvent, render } from '@tests/js/test-utils';
 import {
 	createTestRegistry,
 	provideModuleRegistrations,
@@ -215,7 +215,9 @@ describe( 'ModuleSetup', () => {
 			it( 'tracks only the initial setup analytics view event', () => {
 				expect( mockTrackEvent ).toHaveBeenCalledWith(
 					`${ VIEW_CONTEXT_MODULE_SETUP }_setup`,
-					'setup_flow_v3_view_analytics_step'
+					'setup_flow_v3_view_analytics_step',
+					undefined,
+					undefined
 				);
 
 				expect( mockTrackEvent ).toHaveBeenCalledTimes( 1 );
@@ -272,7 +274,8 @@ describe( 'ModuleSetup', () => {
 				expect( mockTrackEvent ).toHaveBeenCalledWith(
 					'moduleSetup',
 					'view_module_setup',
-					MODULE_SLUG_ANALYTICS_4
+					MODULE_SLUG_ANALYTICS_4,
+					undefined
 				);
 
 				expect( mockTrackEvent ).toHaveBeenCalledTimes( 1 );
@@ -313,182 +316,5 @@ describe( 'ModuleSetup', () => {
 		).toBeInTheDocument();
 
 		expect( container ).toMatchSnapshot();
-	} );
-
-	describe( 'forwardable params', () => {
-		const customRedirectURL =
-			'http://example.com/wp-admin/admin.php?page=googlesitekit-dashboard&slug=analytics-4&reAuth=true';
-
-		function registerFinishSetupModule( moduleSlug, setupHandler ) {
-			registry.dispatch( CORE_MODULES ).registerModule( moduleSlug, {
-				slug: moduleSlug,
-				storeName: `modules/${ moduleSlug }`,
-				SetupComponent: ( { finishSetup } ) => (
-					<button
-						onClick={ () => setupHandler( finishSetup ) }
-						type="button"
-					>
-						Trigger finish setup
-					</button>
-				),
-			} );
-
-			provideModules( registry, [
-				{
-					slug: moduleSlug,
-					active: false,
-					connected: false,
-				},
-			] );
-		}
-
-		it( 'should not override existing params in redirect URL with forwarded params', async () => {
-			const moduleSlug = 'test-module';
-
-			global.location.href =
-				'http://example.com/wp-admin/admin.php?page=googlesitekit-dashboard&panel=email-reporting&notification=authentication_success';
-
-			const customRedirectURLWithNotification =
-				'http://example.com/wp-admin/admin.php?page=googlesitekit-dashboard&slug=ads&notification=ads_success';
-
-			registerFinishSetupModule( moduleSlug, ( finishSetup ) =>
-				finishSetup( customRedirectURLWithNotification )
-			);
-
-			const { getByRole, waitForRegistry } = render(
-				<ModuleSetup moduleSlug={ moduleSlug } />,
-				{
-					registry,
-					viewContext: VIEW_CONTEXT_MODULE_SETUP,
-				}
-			);
-
-			await waitForRegistry();
-
-			await act( () => {
-				fireEvent.click(
-					getByRole( 'button', { name: 'Trigger finish setup' } )
-				);
-			} );
-
-			await waitFor( () =>
-				expect( global.location.assign ).toHaveBeenCalled()
-			);
-
-			const redirectURL = new URL(
-				global.location.assign.mock.calls[ 0 ][ 0 ]
-			);
-			expect( redirectURL.searchParams.get( 'notification' ) ).toEqual(
-				'ads_success'
-			);
-		} );
-
-		it( 'should preserve forwarded params for custom redirect URL', async () => {
-			const moduleSlug = 'test-module';
-
-			global.location.href =
-				'http://example.com/wp-admin/admin.php?page=googlesitekit-dashboard&panel=email-reporting';
-
-			registerFinishSetupModule( moduleSlug, ( finishSetup ) =>
-				finishSetup( customRedirectURL )
-			);
-
-			const { getByRole, waitForRegistry } = render(
-				<ModuleSetup moduleSlug={ moduleSlug } />,
-				{
-					registry,
-					viewContext: VIEW_CONTEXT_MODULE_SETUP,
-				}
-			);
-
-			await waitForRegistry();
-			await waitFor( () =>
-				expect(
-					getByRole( 'button', { name: 'Trigger finish setup' } )
-				).toBeInTheDocument()
-			);
-
-			await act( () => {
-				fireEvent.click(
-					getByRole( 'button', { name: 'Trigger finish setup' } )
-				);
-			} );
-
-			await act( async () => {
-				await waitFor( () =>
-					expect( global.location.assign ).toHaveBeenCalled()
-				);
-			} );
-
-			const redirectURL = new URL(
-				global.location.assign.mock.calls[ 0 ][ 0 ]
-			);
-			expect( redirectURL.searchParams.get( 'page' ) ).toEqual(
-				'googlesitekit-dashboard'
-			);
-			expect( redirectURL.searchParams.get( 'slug' ) ).toEqual(
-				'analytics-4'
-			);
-			expect( redirectURL.searchParams.get( 'reAuth' ) ).toEqual(
-				'true'
-			);
-			expect( redirectURL.searchParams.get( 'panel' ) ).toEqual(
-				'email-reporting'
-			);
-		} );
-
-		it( 'should preserve forwarded params for default dashboard redirect URL', async () => {
-			const moduleSlug = 'test-module';
-
-			global.location.href =
-				'http://example.com/wp-admin/admin.php?page=googlesitekit-dashboard&panel=email-reporting';
-
-			registerFinishSetupModule( moduleSlug, ( finishSetup ) =>
-				finishSetup()
-			);
-
-			const { getByRole, waitForRegistry } = render(
-				<ModuleSetup moduleSlug={ moduleSlug } />,
-				{
-					registry,
-					viewContext: VIEW_CONTEXT_MODULE_SETUP,
-				}
-			);
-
-			await waitForRegistry();
-			await waitFor( () =>
-				expect(
-					getByRole( 'button', { name: 'Trigger finish setup' } )
-				).toBeInTheDocument()
-			);
-
-			await act( () => {
-				fireEvent.click(
-					getByRole( 'button', { name: 'Trigger finish setup' } )
-				);
-			} );
-
-			await act( async () => {
-				await waitFor( () =>
-					expect( global.location.assign ).toHaveBeenCalled()
-				);
-			} );
-
-			const redirectURL = new URL(
-				global.location.assign.mock.calls[ 0 ][ 0 ]
-			);
-			expect( redirectURL.searchParams.get( 'page' ) ).toEqual(
-				'googlesitekit-dashboard'
-			);
-			expect( redirectURL.searchParams.get( 'notification' ) ).toEqual(
-				'authentication_success'
-			);
-			expect( redirectURL.searchParams.get( 'slug' ) ).toEqual(
-				moduleSlug
-			);
-			expect( redirectURL.searchParams.get( 'panel' ) ).toEqual(
-				'email-reporting'
-			);
-		} );
 	} );
 } );

--- a/assets/js/components/setup/hooks/index.ts
+++ b/assets/js/components/setup/hooks/index.ts
@@ -20,6 +20,7 @@ export { default as useFinishSetup } from './useFinishSetup';
 export { default as useModuleSetupTracking } from './useModuleSetupTracking';
 export type {
 	FinishSetupCallback,
+	ModuleSetupGATrackingEventArgs,
 	UseFinishSetupOptions,
 	UseModuleSetupTrackingOptions,
 	UseModuleSetupTrackingReturn,

--- a/assets/js/components/setup/hooks/index.ts
+++ b/assets/js/components/setup/hooks/index.ts
@@ -1,0 +1,26 @@
+/**
+ * Module setup hooks.
+ *
+ * Site Kit by Google, Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { default as useFinishSetup } from './useFinishSetup';
+export { default as useModuleSetupTracking } from './useModuleSetupTracking';
+export type {
+	FinishSetupCallback,
+	UseFinishSetupOptions,
+	UseModuleSetupTrackingOptions,
+	UseModuleSetupTrackingReturn,
+} from './types';

--- a/assets/js/components/setup/hooks/types.ts
+++ b/assets/js/components/setup/hooks/types.ts
@@ -1,0 +1,60 @@
+/**
+ * Module setup hooks types.
+ *
+ * Site Kit by Google, Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import { GATrackingEventArgs } from '@/js/types/GATrackingEventArgs';
+
+/**
+ * Options for the `useFinishSetup` hook.
+ *
+ * @since n.e.x.t
+ */
+export interface UseFinishSetupOptions {
+	gaTrackingEventArgs?: GATrackingEventArgs;
+}
+
+/**
+ * Options for the `useModuleSetupTracking` hook.
+ *
+ * @since n.e.x.t
+ */
+export interface UseModuleSetupTrackingOptions {
+	viewGATrackingEventArgs?: GATrackingEventArgs;
+	cancelGATrackingEventArgs?: GATrackingEventArgs;
+}
+
+/**
+ * Callback returned by `useFinishSetup`.
+ *
+ * Clears the module setup cache, tracks a completion event, and redirects
+ * the user to the Site Kit dashboard or an optional custom URL.
+ *
+ * @since n.e.x.t
+ */
+export type FinishSetupCallback = ( redirectURL?: string ) => Promise< void >;
+
+/**
+ * Return value of the `useModuleSetupTracking` hook.
+ *
+ * @since n.e.x.t
+ */
+export interface UseModuleSetupTrackingReturn {
+	trackCancel: () => Promise< void >;
+}

--- a/assets/js/components/setup/hooks/types.ts
+++ b/assets/js/components/setup/hooks/types.ts
@@ -22,12 +22,24 @@
 import { GATrackingEventArgs } from '@/js/types/GATrackingEventArgs';
 
 /**
+ * GA tracking event args for module setup hooks.
+ *
+ * Requires `category` and `action`; `label` and `value` remain optional.
+ *
+ * @since n.e.x.t
+ */
+export type ModuleSetupGATrackingEventArgs = Required<
+	Pick< GATrackingEventArgs, 'category' | 'action' >
+> &
+	Pick< GATrackingEventArgs, 'label' | 'value' >;
+
+/**
  * Options for the `useFinishSetup` hook.
  *
  * @since n.e.x.t
  */
 export interface UseFinishSetupOptions {
-	gaTrackingEventArgs?: GATrackingEventArgs;
+	gaTrackingEventArgs?: ModuleSetupGATrackingEventArgs;
 }
 
 /**
@@ -36,8 +48,8 @@ export interface UseFinishSetupOptions {
  * @since n.e.x.t
  */
 export interface UseModuleSetupTrackingOptions {
-	viewGATrackingEventArgs?: GATrackingEventArgs;
-	cancelGATrackingEventArgs?: GATrackingEventArgs;
+	viewGATrackingEventArgs?: ModuleSetupGATrackingEventArgs;
+	cancelGATrackingEventArgs?: ModuleSetupGATrackingEventArgs;
 }
 
 /**

--- a/assets/js/components/setup/hooks/useFinishSetup.test.ts
+++ b/assets/js/components/setup/hooks/useFinishSetup.test.ts
@@ -1,0 +1,210 @@
+/**
+ * `useFinishSetup` hook tests.
+ *
+ * Site Kit by Google, Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import { type Registry } from '@/js/googlesitekit-data';
+import { deleteItem, getItem, setItem } from '@/js/googlesitekit/api/cache';
+import { VIEW_CONTEXT_MODULE_SETUP } from '@/js/googlesitekit/constants';
+import * as tracking from '@/js/util/tracking';
+import { mockLocation } from '@tests/js/mock-browser-utils';
+import {
+	act,
+	createTestRegistry,
+	provideSiteInfo,
+	renderHook,
+	waitFor,
+} from '@tests/js/test-utils';
+import useFinishSetup from './useFinishSetup';
+
+const mockTrackEvent = jest.spyOn( tracking, 'trackEvent' );
+mockTrackEvent.mockImplementation( () => Promise.resolve() );
+
+function getLocationAssignURL(): string {
+	return ( global.location.assign as jest.Mock ).mock
+		.calls[ 0 ][ 0 ] as string;
+}
+
+describe( 'useFinishSetup', () => {
+	mockLocation();
+
+	let registry: Registry;
+
+	beforeEach( async () => {
+		registry = createTestRegistry() as Registry;
+		provideSiteInfo( registry );
+		mockTrackEvent.mockClear();
+		await setItem( 'module_setup', true );
+	} );
+
+	afterEach( async () => {
+		await deleteItem( 'module_setup' );
+	} );
+
+	it( 'should clear the module_setup cache when finishing setup', async () => {
+		const { result } = renderHook( () => useFinishSetup( 'test-module' ), {
+			registry,
+			viewContext: VIEW_CONTEXT_MODULE_SETUP,
+		} );
+
+		expect( ( await getItem( 'module_setup' ) ).cacheHit ).toBe( true );
+
+		await act( async () => {
+			await result.current();
+		} );
+
+		expect( ( await getItem( 'module_setup' ) ).cacheHit ).toBe( false );
+	} );
+
+	it( 'should track the standard complete_module_setup event by default', async () => {
+		const { result } = renderHook( () => useFinishSetup( 'test-module' ), {
+			registry,
+			viewContext: VIEW_CONTEXT_MODULE_SETUP,
+		} );
+
+		await act( async () => {
+			await result.current();
+		} );
+
+		expect( mockTrackEvent ).toHaveBeenCalledWith(
+			'moduleSetup',
+			'complete_module_setup',
+			'test-module',
+			undefined
+		);
+	} );
+
+	it( 'should track a custom completion event when gaTrackingEventArgs is provided', async () => {
+		const { result } = renderHook(
+			() =>
+				useFinishSetup( 'analytics-4', {
+					gaTrackingEventArgs: {
+						category: `${ VIEW_CONTEXT_MODULE_SETUP }_setup`,
+						action: 'setup_flow_v3_complete_analytics_step',
+					},
+				} ),
+			{ registry, viewContext: VIEW_CONTEXT_MODULE_SETUP }
+		);
+
+		await act( async () => {
+			await result.current();
+		} );
+
+		expect( mockTrackEvent ).toHaveBeenCalledWith(
+			`${ VIEW_CONTEXT_MODULE_SETUP }_setup`,
+			'setup_flow_v3_complete_analytics_step',
+			undefined,
+			undefined
+		);
+	} );
+
+	it( 'should redirect to the default dashboard URL with expected query args', async () => {
+		global.location.href =
+			'http://example.com/wp-admin/admin.php?page=googlesitekit-dashboard&panel=email-reporting';
+
+		const { result } = renderHook( () => useFinishSetup( 'test-module' ), {
+			registry,
+			viewContext: VIEW_CONTEXT_MODULE_SETUP,
+		} );
+
+		await act( async () => {
+			await result.current();
+		} );
+
+		await waitFor( () =>
+			expect( global.location.assign ).toHaveBeenCalled()
+		);
+
+		const redirectURL = new URL( getLocationAssignURL() );
+
+		expect( redirectURL.searchParams.get( 'page' ) ).toEqual(
+			'googlesitekit-dashboard'
+		);
+		expect( redirectURL.searchParams.get( 'notification' ) ).toEqual(
+			'authentication_success'
+		);
+		expect( redirectURL.searchParams.get( 'slug' ) ).toEqual(
+			'test-module'
+		);
+		expect( redirectURL.searchParams.get( 'panel' ) ).toEqual(
+			'email-reporting'
+		);
+	} );
+
+	it( 'should preserve forwarded params for a custom redirect URL', async () => {
+		const customRedirectURL =
+			'http://example.com/wp-admin/admin.php?page=googlesitekit-dashboard&slug=analytics-4&reAuth=true';
+
+		global.location.href =
+			'http://example.com/wp-admin/admin.php?page=googlesitekit-dashboard&panel=email-reporting';
+
+		const { result } = renderHook( () => useFinishSetup( 'test-module' ), {
+			registry,
+			viewContext: VIEW_CONTEXT_MODULE_SETUP,
+		} );
+
+		await act( async () => {
+			await result.current( customRedirectURL );
+		} );
+
+		await waitFor( () =>
+			expect( global.location.assign ).toHaveBeenCalled()
+		);
+
+		const redirectURL = new URL( getLocationAssignURL() );
+
+		expect( redirectURL.searchParams.get( 'page' ) ).toEqual(
+			'googlesitekit-dashboard'
+		);
+		expect( redirectURL.searchParams.get( 'slug' ) ).toEqual(
+			'analytics-4'
+		);
+		expect( redirectURL.searchParams.get( 'reAuth' ) ).toEqual( 'true' );
+		expect( redirectURL.searchParams.get( 'panel' ) ).toEqual(
+			'email-reporting'
+		);
+	} );
+
+	it( 'should not override existing params in a custom redirect URL with forwarded params', async () => {
+		const customRedirectURLWithNotification =
+			'http://example.com/wp-admin/admin.php?page=googlesitekit-dashboard&slug=ads&notification=ads_success';
+
+		global.location.href =
+			'http://example.com/wp-admin/admin.php?page=googlesitekit-dashboard&panel=email-reporting&notification=authentication_success';
+
+		const { result } = renderHook( () => useFinishSetup( 'test-module' ), {
+			registry,
+			viewContext: VIEW_CONTEXT_MODULE_SETUP,
+		} );
+
+		await act( async () => {
+			await result.current( customRedirectURLWithNotification );
+		} );
+
+		await waitFor( () =>
+			expect( global.location.assign ).toHaveBeenCalled()
+		);
+
+		const redirectURL = new URL( getLocationAssignURL() );
+
+		expect( redirectURL.searchParams.get( 'notification' ) ).toEqual(
+			'ads_success'
+		);
+	} );
+} );

--- a/assets/js/components/setup/hooks/useFinishSetup.ts
+++ b/assets/js/components/setup/hooks/useFinishSetup.ts
@@ -24,7 +24,6 @@ import { useCallbackOne } from 'use-memo-one';
 /**
  * WordPress dependencies
  */
-import { useMemo } from '@wordpress/element';
 import { addQueryArgs, getQueryArgs } from '@wordpress/url';
 
 /**
@@ -35,9 +34,12 @@ import { deleteItem } from '@/js/googlesitekit/api/cache';
 import { CORE_LOCATION } from '@/js/googlesitekit/datastore/location/constants';
 import { CORE_SITE } from '@/js/googlesitekit/datastore/site/constants';
 import useForwardableParams from '@/js/hooks/useForwardableParams';
-import { GATrackingEventArgs } from '@/js/types/GATrackingEventArgs';
 import { trackEvent } from '@/js/util';
-import { FinishSetupCallback, UseFinishSetupOptions } from './types';
+import {
+	FinishSetupCallback,
+	ModuleSetupGATrackingEventArgs,
+	UseFinishSetupOptions,
+} from './types';
 
 /**
  * Returns a callback to complete module setup.
@@ -65,24 +67,18 @@ export default function useFinishSetup(
 	// shape instead.
 	const registry = useRegistry() as unknown as Registry;
 
-	const defaultGATrackingEventArgs = useMemo(
-		(): GATrackingEventArgs => ( {
-			category: 'moduleSetup',
-			action: 'complete_module_setup',
-			label: moduleSlug,
-		} ),
-		[ moduleSlug ]
-	);
+	const defaultGATrackingEventArgs: ModuleSetupGATrackingEventArgs = {
+		category: 'moduleSetup',
+		action: 'complete_module_setup',
+		label: moduleSlug,
+	};
 
-	const resolvedGATrackingEventArgs: GATrackingEventArgs =
+	const { category, action, label, value } =
 		gaTrackingEventArgs ?? defaultGATrackingEventArgs;
 
 	return useCallbackOne(
 		async ( redirectURL?: string ) => {
 			await deleteItem( 'module_setup' );
-
-			const { category, action, label, value } =
-				resolvedGATrackingEventArgs;
 
 			await trackEvent( category, action, label, value );
 
@@ -109,7 +105,10 @@ export default function useFinishSetup(
 			navigateTo( adminURL );
 		},
 		[
-			resolvedGATrackingEventArgs,
+			category,
+			action,
+			label,
+			value,
 			forwardableParams,
 			registry,
 			navigateTo,

--- a/assets/js/components/setup/hooks/useFinishSetup.ts
+++ b/assets/js/components/setup/hooks/useFinishSetup.ts
@@ -1,0 +1,119 @@
+/**
+ * `useFinishSetup` hook.
+ *
+ * Site Kit by Google, Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import { useCallbackOne } from 'use-memo-one';
+
+/**
+ * WordPress dependencies
+ */
+import { useMemo } from '@wordpress/element';
+import { addQueryArgs, getQueryArgs } from '@wordpress/url';
+
+/**
+ * Internal dependencies
+ */
+import { type Registry, useDispatch, useRegistry } from 'googlesitekit-data';
+import { deleteItem } from '@/js/googlesitekit/api/cache';
+import { CORE_LOCATION } from '@/js/googlesitekit/datastore/location/constants';
+import { CORE_SITE } from '@/js/googlesitekit/datastore/site/constants';
+import useForwardableParams from '@/js/hooks/useForwardableParams';
+import { GATrackingEventArgs } from '@/js/types/GATrackingEventArgs';
+import { trackEvent } from '@/js/util';
+import { FinishSetupCallback, UseFinishSetupOptions } from './types';
+
+/**
+ * Returns a callback to complete module setup.
+ *
+ * Clears the module setup cache, tracks a completion event, and redirects
+ * the user to the Site Kit dashboard or an optional custom URL.
+ *
+ * @since n.e.x.t
+ *
+ * @param moduleSlug                  Module slug.
+ * @param options                     Hook options.
+ * @param options.gaTrackingEventArgs Optional. GA tracking event args. Defaults to the standard `complete_module_setup` event for the module slug.
+ * @return Async callback to finish module setup.
+ */
+export default function useFinishSetup(
+	moduleSlug: string,
+	{ gaTrackingEventArgs }: UseFinishSetupOptions = {}
+): FinishSetupCallback {
+	const { navigateTo } = useDispatch( CORE_LOCATION );
+	const forwardableParams = useForwardableParams();
+
+	// `@wordpress/data` types `useRegistry()` as returning `Function`, which
+	// does not overlap with `Registry`. Casting through `unknown` tells
+	// TypeScript to treat the runtime registry object as Site Kit's registry
+	// shape instead.
+	const registry = useRegistry() as unknown as Registry;
+
+	const defaultGATrackingEventArgs = useMemo(
+		(): GATrackingEventArgs => ( {
+			category: 'moduleSetup',
+			action: 'complete_module_setup',
+			label: moduleSlug,
+		} ),
+		[ moduleSlug ]
+	);
+
+	const resolvedGATrackingEventArgs: GATrackingEventArgs =
+		gaTrackingEventArgs ?? defaultGATrackingEventArgs;
+
+	return useCallbackOne(
+		async ( redirectURL?: string ) => {
+			await deleteItem( 'module_setup' );
+
+			const { category, action, label, value } =
+				resolvedGATrackingEventArgs;
+
+			await trackEvent( category, action, label, value );
+
+			if ( redirectURL ) {
+				navigateTo(
+					addQueryArgs( redirectURL, {
+						...forwardableParams,
+						...getQueryArgs( redirectURL ),
+					} )
+				);
+				return;
+			}
+
+			const { select, resolveSelect } = registry;
+			await resolveSelect( CORE_SITE ).getSiteInfo();
+			const adminURL = select( CORE_SITE ).getAdminURL(
+				'googlesitekit-dashboard',
+				{
+					...forwardableParams,
+					notification: 'authentication_success',
+					slug: moduleSlug,
+				}
+			);
+			navigateTo( adminURL );
+		},
+		[
+			resolvedGATrackingEventArgs,
+			forwardableParams,
+			registry,
+			navigateTo,
+			moduleSlug,
+		]
+	);
+}

--- a/assets/js/components/setup/hooks/useModuleSetupTracking.test.ts
+++ b/assets/js/components/setup/hooks/useModuleSetupTracking.test.ts
@@ -1,0 +1,132 @@
+/**
+ * `useModuleSetupTracking` hook tests.
+ *
+ * Site Kit by Google, Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import { type Registry } from '@/js/googlesitekit-data';
+import { VIEW_CONTEXT_MODULE_SETUP } from '@/js/googlesitekit/constants';
+import { MODULE_SLUG_ANALYTICS_4 } from '@/js/modules/analytics-4/constants';
+import * as tracking from '@/js/util/tracking';
+import { act, createTestRegistry, renderHook } from '@tests/js/test-utils';
+import useModuleSetupTracking from './useModuleSetupTracking';
+
+const mockTrackEvent = jest.spyOn( tracking, 'trackEvent' );
+mockTrackEvent.mockImplementation( () => Promise.resolve() );
+
+describe( 'useModuleSetupTracking', () => {
+	let registry: Registry;
+
+	beforeEach( () => {
+		registry = createTestRegistry() as Registry;
+		mockTrackEvent.mockClear();
+	} );
+
+	it( 'should track the standard view_module_setup event on mount', () => {
+		renderHook( () => useModuleSetupTracking( MODULE_SLUG_ANALYTICS_4 ), {
+			registry,
+			viewContext: VIEW_CONTEXT_MODULE_SETUP,
+		} );
+
+		expect( mockTrackEvent ).toHaveBeenCalledWith(
+			'moduleSetup',
+			'view_module_setup',
+			MODULE_SLUG_ANALYTICS_4,
+			undefined
+		);
+		expect( mockTrackEvent ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'should track a custom view event on mount when provided', () => {
+		renderHook(
+			() =>
+				useModuleSetupTracking( MODULE_SLUG_ANALYTICS_4, {
+					viewGATrackingEventArgs: {
+						category: `${ VIEW_CONTEXT_MODULE_SETUP }_setup`,
+						action: 'setup_flow_v3_view_analytics_step',
+					},
+				} ),
+			{
+				registry,
+				viewContext: VIEW_CONTEXT_MODULE_SETUP,
+			}
+		);
+
+		expect( mockTrackEvent ).toHaveBeenCalledWith(
+			`${ VIEW_CONTEXT_MODULE_SETUP }_setup`,
+			'setup_flow_v3_view_analytics_step',
+			undefined,
+			undefined
+		);
+		expect( mockTrackEvent ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'should track the cancel_module_setup event when trackCancel is invoked', async () => {
+		const { result } = renderHook(
+			() => useModuleSetupTracking( 'test-module' ),
+			{
+				registry,
+				viewContext: VIEW_CONTEXT_MODULE_SETUP,
+			}
+		);
+
+		mockTrackEvent.mockClear();
+
+		await act( async () => {
+			await result.current.trackCancel();
+		} );
+
+		expect( mockTrackEvent ).toHaveBeenCalledWith(
+			'moduleSetup',
+			'cancel_module_setup',
+			'test-module',
+			undefined
+		);
+		expect( mockTrackEvent ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'should track a custom cancel event when provided', async () => {
+		const { result } = renderHook(
+			() =>
+				useModuleSetupTracking( 'test-module', {
+					cancelGATrackingEventArgs: {
+						category: 'customCategory',
+						action: 'custom_cancel_action',
+						label: 'custom-label',
+					},
+				} ),
+			{
+				registry,
+				viewContext: VIEW_CONTEXT_MODULE_SETUP,
+			}
+		);
+
+		mockTrackEvent.mockClear();
+
+		await act( async () => {
+			await result.current.trackCancel();
+		} );
+
+		expect( mockTrackEvent ).toHaveBeenCalledWith(
+			'customCategory',
+			'custom_cancel_action',
+			'custom-label',
+			undefined
+		);
+	} );
+} );

--- a/assets/js/components/setup/hooks/useModuleSetupTracking.ts
+++ b/assets/js/components/setup/hooks/useModuleSetupTracking.ts
@@ -24,14 +24,14 @@ import { useMount } from 'react-use';
 /**
  * WordPress dependencies
  */
-import { useCallback, useMemo } from '@wordpress/element';
+import { useCallback } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
-import { GATrackingEventArgs } from '@/js/types/GATrackingEventArgs';
 import { trackEvent } from '@/js/util';
 import {
+	ModuleSetupGATrackingEventArgs,
 	UseModuleSetupTrackingOptions,
 	UseModuleSetupTrackingReturn,
 } from './types';
@@ -57,28 +57,22 @@ export default function useModuleSetupTracking(
 		cancelGATrackingEventArgs,
 	}: UseModuleSetupTrackingOptions = {}
 ): UseModuleSetupTrackingReturn {
-	const defaultViewGATrackingEventArgs = useMemo(
-		(): GATrackingEventArgs => ( {
-			category: 'moduleSetup',
-			action: 'view_module_setup',
-			label: moduleSlug,
-		} ),
-		[ moduleSlug ]
-	);
+	const defaultViewGATrackingEventArgs: ModuleSetupGATrackingEventArgs = {
+		category: 'moduleSetup',
+		action: 'view_module_setup',
+		label: moduleSlug,
+	};
 
-	const defaultCancelGATrackingEventArgs = useMemo(
-		(): GATrackingEventArgs => ( {
-			category: 'moduleSetup',
-			action: 'cancel_module_setup',
-			label: moduleSlug,
-		} ),
-		[ moduleSlug ]
-	);
+	const defaultCancelGATrackingEventArgs: ModuleSetupGATrackingEventArgs = {
+		category: 'moduleSetup',
+		action: 'cancel_module_setup',
+		label: moduleSlug,
+	};
 
-	const resolvedViewGATrackingEventArgs: GATrackingEventArgs =
+	const resolvedViewGATrackingEventArgs: ModuleSetupGATrackingEventArgs =
 		viewGATrackingEventArgs ?? defaultViewGATrackingEventArgs;
 
-	const resolvedCancelGATrackingEventArgs: GATrackingEventArgs =
+	const resolvedCancelGATrackingEventArgs: ModuleSetupGATrackingEventArgs =
 		cancelGATrackingEventArgs ?? defaultCancelGATrackingEventArgs;
 
 	useMount( () => {
@@ -88,12 +82,12 @@ export default function useModuleSetupTracking(
 		trackEvent( category, action, label, value );
 	} );
 
-	const trackCancel = useCallback( async () => {
-		const { category, action, label, value } =
-			resolvedCancelGATrackingEventArgs;
+	const { category, action, label, value } =
+		resolvedCancelGATrackingEventArgs;
 
+	const trackCancel = useCallback( async () => {
 		await trackEvent( category, action, label, value );
-	}, [ resolvedCancelGATrackingEventArgs ] );
+	}, [ category, action, label, value ] );
 
 	return { trackCancel };
 }

--- a/assets/js/components/setup/hooks/useModuleSetupTracking.ts
+++ b/assets/js/components/setup/hooks/useModuleSetupTracking.ts
@@ -1,0 +1,99 @@
+/**
+ * `useModuleSetupTracking` hook.
+ *
+ * Site Kit by Google, Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import { useMount } from 'react-use';
+
+/**
+ * WordPress dependencies
+ */
+import { useCallback, useMemo } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { GATrackingEventArgs } from '@/js/types/GATrackingEventArgs';
+import { trackEvent } from '@/js/util';
+import {
+	UseModuleSetupTrackingOptions,
+	UseModuleSetupTrackingReturn,
+} from './types';
+
+/**
+ * Tracks module setup view and cancel events.
+ *
+ * Fires a view event on mount. Returns a `trackCancel` callback for setup
+ * cancellation tracking.
+ *
+ * @since n.e.x.t
+ *
+ * @param moduleSlug                        Module slug.
+ * @param options                           Hook options.
+ * @param options.viewGATrackingEventArgs   Optional. GA tracking event args for setup view. Defaults to the standard `view_module_setup` event for the module slug.
+ * @param options.cancelGATrackingEventArgs Optional. GA tracking event args for setup cancel. Defaults to the standard `cancel_module_setup` event for the module slug.
+ * @return Object with a callback to track setup cancellation.
+ */
+export default function useModuleSetupTracking(
+	moduleSlug: string,
+	{
+		viewGATrackingEventArgs,
+		cancelGATrackingEventArgs,
+	}: UseModuleSetupTrackingOptions = {}
+): UseModuleSetupTrackingReturn {
+	const defaultViewGATrackingEventArgs = useMemo(
+		(): GATrackingEventArgs => ( {
+			category: 'moduleSetup',
+			action: 'view_module_setup',
+			label: moduleSlug,
+		} ),
+		[ moduleSlug ]
+	);
+
+	const defaultCancelGATrackingEventArgs = useMemo(
+		(): GATrackingEventArgs => ( {
+			category: 'moduleSetup',
+			action: 'cancel_module_setup',
+			label: moduleSlug,
+		} ),
+		[ moduleSlug ]
+	);
+
+	const resolvedViewGATrackingEventArgs: GATrackingEventArgs =
+		viewGATrackingEventArgs ?? defaultViewGATrackingEventArgs;
+
+	const resolvedCancelGATrackingEventArgs: GATrackingEventArgs =
+		cancelGATrackingEventArgs ?? defaultCancelGATrackingEventArgs;
+
+	useMount( () => {
+		const { category, action, label, value } =
+			resolvedViewGATrackingEventArgs;
+
+		trackEvent( category, action, label, value );
+	} );
+
+	const trackCancel = useCallback( async () => {
+		const { category, action, label, value } =
+			resolvedCancelGATrackingEventArgs;
+
+		await trackEvent( category, action, label, value );
+	}, [ resolvedCancelGATrackingEventArgs ] );
+
+	return { trackCancel };
+}

--- a/assets/js/googlesitekit/data/types.ts
+++ b/assets/js/googlesitekit/data/types.ts
@@ -16,5 +16,24 @@
  * limitations under the License.
  */
 
+/**
+ * WordPress dependencies
+ */
+import type { WPDataRegistry } from '@wordpress/data/build-types/registry';
+
 /* eslint-disable @typescript-eslint/no-explicit-any -- The `Select` type is intentionally generic for now. */
+
+/**
+ * Site Kit data store selector function type.
+ */
 export type Select = ( select: any ) => any;
+
+/**
+ * Site Kit data registry type.
+ *
+ * Extends WordPress's `WPDataRegistry` with `resolveSelect`, which exists on
+ * the runtime registry but is absent from the `@wordpress/data` registry types.
+ */
+export type Registry = WPDataRegistry & {
+	resolveSelect: WPDataRegistry[ 'select' ];
+};


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #12975 

## Relevant technical choices

This PR extracts `ModuleSetup` routines into hooks so that they can be consumed independently.

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [x] Run the code.
- [x] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [x] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [x] Ensure there is a QA Brief.
- [x] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [x] Ensure the PR has the correct target branch.
- [x] Double-check that the PR is okay to be merged.
- [x] Ensure the corresponding issue has a ZenHub release assigned.
- [x] Add a changelog message to the issue.
