### PR TITLE
Follow-up: Fix back navigation

### DIFF
--- a/assets/js/modules/analytics-4/components/common/AccountCreate/AnalyticsAccountCreationErrorNotice.test.tsx
+++ b/assets/js/modules/analytics-4/components/common/AccountCreate/AnalyticsAccountCreationErrorNotice.test.tsx
@@ -76,15 +76,13 @@ describe( 'AnalyticsAccountCreationErrorNotice', () => {
 			).toBeInTheDocument();
 		} );
 
-		it( 'should call global.history.back when the Go to Analytics button is clicked', () => {
-			const backSpy = jest
-				.spyOn( global.history, 'back' )
-				.mockImplementation( () => {} );
+		it( 'should call onRetry when the Go to Analytics button is clicked', () => {
+			const onRetry = jest.fn();
 
 			const { getByRole } = render(
 				<AnalyticsAccountCreationErrorNotice
 					errorCode="user_cancel"
-					onRetry={ () => {} }
+					onRetry={ onRetry }
 				/>,
 				{ registry }
 			);
@@ -93,9 +91,7 @@ describe( 'AnalyticsAccountCreationErrorNotice', () => {
 				getByRole( 'button', { name: /go to analytics/i } )
 			);
 
-			expect( backSpy ).toHaveBeenCalled();
-
-			backSpy.mockRestore();
+			expect( onRetry ).toHaveBeenCalled();
 		} );
 	} );
 

--- a/assets/js/modules/analytics-4/components/common/AccountCreate/AnalyticsAccountCreationErrorNotice.tsx
+++ b/assets/js/modules/analytics-4/components/common/AccountCreate/AnalyticsAccountCreationErrorNotice.tsx
@@ -87,9 +87,7 @@ const AnalyticsAccountCreationErrorNotice: FC<
 		);
 		ctaButton = {
 			label: __( 'Go to Analytics', 'google-site-kit' ),
-			onClick: () => {
-				global.history.back();
-			},
+			onClick: onRetry,
 		};
 	} else {
 		description = createInterpolateElement(


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- https://github.com/google/site-kit-wp/issues/12876#issuecomment-4872530361

## Relevant technical choices

This PR addresses this [QA feedback](https://github.com/google/site-kit-wp/issues/12876#issuecomment-4872530361) by fixing the behavior of the "Go to Analytics" CTA, ensuring that it correctly goes to Analytics.

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [x] Run the code.
- [x] Ensure the acceptance criteria are satisfied.
- [x] Reassess the implementation with the IB.
- [x] Ensure no unrelated changes are included.
- [x] Ensure CI checks pass.
- [x] Check Storybook where applicable.
- [x] Ensure there is a QA Brief.
- [x] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [x] Ensure the PR has the correct target branch.
- [x] Double-check that the PR is okay to be merged.
- [x] Ensure the corresponding issue has a ZenHub release assigned.
- [x] Add a changelog message to the issue.
