### PR TITLE
Add OAuth callback state validation

### DIFF
--- a/includes/Core/Authentication/Clients/OAuth_Client.php
+++ b/includes/Core/Authentication/Clients/OAuth_Client.php
@@ -40,6 +40,7 @@ final class OAuth_Client extends OAuth_Client_Base {
 	const OPTION_ADDITIONAL_AUTH_SCOPES = 'googlesitekit_additional_auth_scopes';
 	const OPTION_REDIRECT_URL           = 'googlesitekit_redirect_url';
 	const OPTION_ERROR_REDIRECT_URL     = 'googlesitekit_error_redirect_url';
+	const OPTION_OAUTH_STATE            = 'googlesitekit_oauth_state';
 	const CRON_REFRESH_PROFILE_DATA     = 'googlesitekit_cron_refresh_profile_data';
 
 	/**
@@ -372,10 +373,13 @@ final class OAuth_Client extends OAuth_Client_Base {
 
 		$this->user_options->set( self::OPTION_REDIRECT_URL, $redirect_url );
 		$this->user_options->set( self::OPTION_ERROR_REDIRECT_URL, $error_redirect_url );
+		$state = wp_generate_uuid4();
+		$this->user_options->set( self::OPTION_OAUTH_STATE, $state );
 
 		// Ensure the latest required scopes are requested.
 		$scopes = array_merge( $this->get_required_scopes(), $additional_scopes );
 		$this->get_client()->setScopes( array_unique( $scopes ) );
+		$this->get_client()->setState( $state );
 
 		return add_query_arg(
 			$this->google_proxy->get_metadata_fields(),
@@ -416,14 +420,27 @@ final class OAuth_Client extends OAuth_Client_Base {
 		// If the OAuth redirects with an error code, handle it.
 		if ( ! empty( $error_code ) ) {
 			$this->user_options->set( self::OPTION_ERROR_CODE, $error_code );
+			$this->user_options->delete( self::OPTION_OAUTH_STATE );
 			wp_safe_redirect( $this->get_authorize_user_redirect_url_for_error() );
 			exit();
 		}
 
 		if ( ! $this->credentials->has() ) {
 			$this->user_options->set( self::OPTION_ERROR_CODE, 'oauth_credentials_not_exist' );
+			$this->user_options->delete( self::OPTION_OAUTH_STATE );
 			wp_safe_redirect( $this->get_authorize_user_redirect_url_for_error() );
 			exit();
+		}
+
+		if ( ! empty( $code ) ) {
+			$state        = $this->context->input()->filter( INPUT_GET, 'state' );
+			$stored_state = $this->user_options->get( self::OPTION_OAUTH_STATE );
+			if ( empty( $stored_state ) || empty( $state ) || ! hash_equals( (string) $stored_state, (string) $state ) ) {
+				$this->user_options->set( self::OPTION_ERROR_CODE, 'oauth_state_mismatch' );
+				$this->user_options->delete( self::OPTION_OAUTH_STATE );
+				wp_safe_redirect( $this->get_authorize_user_redirect_url_for_error() );
+				exit();
+			}
 		}
 
 		try {
@@ -454,6 +471,7 @@ final class OAuth_Client extends OAuth_Client_Base {
 
 		// Update the access token and refresh token.
 		$this->set_token( $token_response );
+		$this->user_options->delete( self::OPTION_OAUTH_STATE );
 
 		// Store the previously granted scopes for use in the action below before they're updated.
 		$previous_scopes = $this->get_granted_scopes();

--- a/tests/phpunit/integration/Core/Authentication/Clients/OAuth_ClientTest.php
+++ b/tests/phpunit/integration/Core/Authentication/Clients/OAuth_ClientTest.php
@@ -312,6 +312,8 @@ class OAuth_ClientTest extends TestCase {
 		 */
 		$this->assertEquals( add_query_arg( 'oauth2callback', 1, admin_url( 'index.php' ) ), $params['redirect_uri'], 'Authentication request should use fixed OAuth callback URI.' );
 		$this->assertEquals( $client_id, $params['client_id'], 'Authentication request should use connected client ID.' );
+		$this->assertNotEmpty( $params['state'], 'Authentication request should include an OAuth state parameter.' );
+		$this->assertEquals( $user_options->get( OAuth_Client::OPTION_OAUTH_STATE ), $params['state'], 'Authentication state should match the stored state.' );
 		$this->assertEqualSets(
 			explode( ' ', $params['scope'] ),
 			$base_scopes,
@@ -429,6 +431,7 @@ class OAuth_ClientTest extends TestCase {
 		// If all goes smooth, we expect to be redirected to $success_redirect
 		$success_redirect = admin_url( 'success-redirect' );
 		$client->get_authentication_url( $success_redirect );
+		$_GET['state'] = $user_options->get( OAuth_Client::OPTION_OAUTH_STATE );
 
 		$this->mock_google_client( $client );
 
@@ -446,6 +449,39 @@ class OAuth_ClientTest extends TestCase {
 		$this->assertEquals( 'fresh@foo.com', $profile['email'], 'Authorization should store People API email.' );
 		$this->assertEquals( 'https://example.com/fresh.jpg', $profile['photo'], 'Authorization should store People API photo.' );
 		$this->assertEquals( 'Dr Funkenstein', $profile['full_name'], 'Authorization should store People API display name.' );
+		$this->assertFalse( $user_options->get( OAuth_Client::OPTION_OAUTH_STATE ), 'Successful authorization should clear stored OAuth state.' );
+	}
+
+	public function test_authorize_user__rejects_mismatched_oauth_state() {
+		$user_id = $this->factory()->user->create();
+		wp_set_current_user( $user_id );
+		$context      = new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE, new MutableInput() );
+		$user_options = new User_Options( $context );
+		$client       = new OAuth_Client( $context, null, $user_options );
+
+		$this->fake_site_connection();
+		$client->get_authentication_url( admin_url( 'success-redirect' ) );
+
+		$_GET['code']  = 'test-code';
+		$_GET['state'] = 'attacker-controlled-state';
+
+		$google_client_mock = $this->getMockBuilder( 'Google\Site_Kit\Core\Authentication\Clients\Google_Site_Kit_Client' )
+			->setMethods( array( 'fetchAccessTokenWithAuthCode' ) )->getMock();
+
+		$google_client_mock->expects( $this->never() )
+			->method( 'fetchAccessTokenWithAuthCode' );
+
+		$this->force_set_property( $client, 'google_client', $google_client_mock );
+
+		try {
+			$client->authorize_user();
+			$this->fail( 'Expected to throw a RedirectException!' );
+		} catch ( RedirectException $redirect ) {
+			$this->assertEquals( 'oauth_state_mismatch', $user_options->get( OAuth_Client::OPTION_ERROR_CODE ), 'OAuth callback should reject mismatched state.' );
+			$this->assertEquals( admin_url( 'admin.php?page=googlesitekit-splash' ), $redirect->get_location(), 'State mismatch should redirect to the OAuth error page.' );
+		}
+
+		$this->assertFalse( $user_options->get( OAuth_Client::OPTION_ACCESS_TOKEN ), 'State mismatch should not store an access token.' );
 	}
 
 	public function test_authorize_user__with_show_search_console() {
@@ -576,6 +612,7 @@ class OAuth_ClientTest extends TestCase {
 		$client           = new OAuth_Client( $context, null, $user_options, null, null, null, null, $transients );
 		$success_redirect = admin_url( 'success-redirect' );
 		$client->get_authentication_url( $success_redirect );
+		$_GET['state'] = $user_options->get( OAuth_Client::OPTION_OAUTH_STATE );
 
 		// Mock Google client for token fetching.
 		$google_client_mock = $this->getMockBuilder( 'Google\Site_Kit\Core\Authentication\Clients\Google_Site_Kit_Client' )
@@ -639,6 +676,7 @@ class OAuth_ClientTest extends TestCase {
 		// Create a new client instance to test the second attempt.
 		$client2 = new OAuth_Client( $context, null, $user_options, null, null, null, null, $transients );
 		$client2->get_authentication_url( $success_redirect );
+		$_GET['state'] = $user_options->get( OAuth_Client::OPTION_OAUTH_STATE );
 
 		// For the second client, we can verify it never calls `fetchAccessTokenWithAuthCode`
 		// by setting up a mock that will fail the test if called.


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- N/A

## Relevant technical choices

Adds per-user OAuth state handling to Site Kit authentication: the state is stored when the auth URL is created, sent with the Google OAuth request, validated before exchanging an authorization code, and cleared after terminal callback outcomes.

Tested with focused OAuth client PHPUnit coverage, PHPCS for the touched files, PHP syntax checks, and `git diff --check`.

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.
- [ ] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.

