### PR TITLE
Fix email report comparison badges showing 0% for decimal-comma locales

### DIFF
--- a/includes/Core/Email_Reporting/Email_Template_Formatter.php
+++ b/includes/Core/Email_Reporting/Email_Template_Formatter.php
@@ -233,6 +233,23 @@ class Email_Template_Formatter {
 
 		if ( is_string( $change ) ) {
 			$change = str_replace( '%', '', $change );
+
+			// Reverse locale number formatting (for example "6,52" in a
+			// decimal-comma locale) back to a machine-parseable float before
+			// validating, so is_numeric() does not reject a legitimate value.
+			global $wp_locale;
+			if ( isset( $wp_locale ) && is_array( $wp_locale->number_format ) ) {
+				$thousands_sep = $wp_locale->number_format['thousands_sep'] ?? '';
+				$decimal_point = $wp_locale->number_format['decimal_point'] ?? '.';
+				if ( '' !== $thousands_sep ) {
+					$change = str_replace( $thousands_sep, '', $change );
+				}
+				if ( '.' !== $decimal_point ) {
+					$change = str_replace( $decimal_point, '.', $change );
+				}
+			}
+
+			$change = trim( $change );
 		}
 
 		if ( ! is_numeric( $change ) ) {

--- a/tests/phpunit/integration/Core/Email_Reporting/Email_Template_FormatterTest.php
+++ b/tests/phpunit/integration/Core/Email_Reporting/Email_Template_FormatterTest.php
@@ -181,4 +181,23 @@ class Email_Template_FormatterTest extends TestCase {
 			)
 		);
 	}
+
+	public function test_parse_change_value_handles_decimal_comma_locale() {
+		global $wp_locale;
+		$original_locale = $wp_locale;
+		$wp_locale       = (object) array(
+			'number_format' => array(
+				'decimal_point' => ',',
+				'thousands_sep' => '.',
+			),
+		);
+
+		$method = new \ReflectionMethod( $this->formatter, 'parse_change_value' );
+		$method->setAccessible( true );
+
+		$this->assertSame( 6.52, $method->invoke( $this->formatter, '6,52%' ) );
+		$this->assertSame( 1234.56, $method->invoke( $this->formatter, '1.234,56%' ) );
+
+		$wp_locale = $original_locale;
+	}
 }


### PR DESCRIPTION
## Summary

Addresses issue:

- #12867

## Relevant technical choices

Email report comparison badges render `0%` for every recipient whose WordPress user locale uses a decimal comma. `normalize_trends` formats the trend with `number_format_i18n( $number, 2 )`, so in those locales the stored trend is a string like "6,52%". `parse_change_value` strips the `%` and then calls `is_numeric( "6,52" )`, which PHP treats as false, so it returns `null` and the badge falls back to `0%`.

The fix reverses the locale number formatting inside `parse_change_value` before validating: it strips the thousands separator and converts the decimal separator back to "." using `$wp_locale->number_format` (the same source `number_format_i18n` uses), then runs `is_numeric` / `floatval` as before. On `en_US` the value is unchanged, so existing behavior is preserved.

An alternative is to keep the trend as a machine number in `normalize_trends` and localize only at render time. The `parse_change_value` change is the smaller, self-contained fix; happy to take the other approach if you'd prefer.

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
