### PR TITLE
Fix Undefined array key 0 warning when super admins are not zero-indexed

### DIFF
--- a/includes/Core/Authentication/Has_Multiple_Admins.php
+++ b/includes/Core/Authentication/Has_Multiple_Admins.php
@@ -92,7 +92,7 @@ class Has_Multiple_Admins {
 				// if they are also added as a local administrator.
 				$exclude_users = array();
 				if ( ! empty( $super_admins ) ) {
-					$super_admin = get_user_by( 'login', $super_admins[0] );
+					$super_admin = get_user_by( 'login', reset( $super_admins ) );
 					if ( $super_admin ) {
 						$exclude_users[] = $super_admin->ID;
 					}

--- a/tests/phpunit/integration/Core/Authentication/Has_Multiple_AdminsTest.php
+++ b/tests/phpunit/integration/Core/Authentication/Has_Multiple_AdminsTest.php
@@ -194,4 +194,32 @@ class Has_Multiple_AdminsTest extends TestCase {
 		// (One regular admin + two super admins = three admins.)
 		$this->assertEquals( 3, $this->transients->get( Has_Multiple_Admins::OPTION ), 'Transient should be updated to three admins' );
 	}
+
+	public function test_get__multisite_super_admins_non_sequential_keys() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'This test only runs on multisite.' );
+		}
+
+		// Two administrators; the first is also treated as the super admin.
+		$super_admin_id = $this->factory()->user->create( array( 'role' => 'administrator' ) );
+		$super_admin    = get_userdata( $super_admin_id );
+		$this->factory()->user->create( array( 'role' => 'administrator' ) );
+
+		// A plugin can filter get_super_admins() to a non-sequentially-keyed
+		// array; reading index 0 then misses the entry. Force that shape.
+		$GLOBALS['super_admins'] = array( 5 => $super_admin->user_login );
+
+		$has_multiple_admins = new Has_Multiple_Admins( $this->transients );
+		$has_multiple_admins->register();
+
+		$result = $has_multiple_admins->get();
+
+		unset( $GLOBALS['super_admins'] );
+
+		// The super admin at the non-zero key must be excluded from the local
+		// admin query rather than double-counted: one super admin + one other
+		// administrator = two.
+		$this->assertTrue( $result, 'Should report multiple admins.' );
+		$this->assertEquals( 2, $this->transients->get( Has_Multiple_Admins::OPTION ), 'Super admin at a non-zero key must be counted once, not twice.' );
+	}
 }


### PR DESCRIPTION
Hey team,

On multisite, `Has_Multiple_Admins::get()` reads `$super_admins[0]` to find the super admin to exclude from the local admin count. `get_super_admins()` can be filtered to return a non-sequentially-keyed array, so index 0 may not exist. That throws a PHP "Undefined array key 0" warning, and because the lookup then fails, the super admin isn't excluded and gets double-counted.

Using `reset()` takes the first element regardless of its key. The regression test forces a non-zero-keyed `super_admins` array and asserts the counted admins is 2, not 3 — without the fix the super admin is double-counted.

I verified the `reset()` versus `[0]` behaviour with a standalone check and matched the new test to your existing multisite cases in `Has_Multiple_AdminsTest`. I don't have a local multisite wp-env, so the test runs on CI. I also didn't add a changelog entry because I wasn't sure of your current per-PR format; happy to add one in whatever shape you use. I know the Google CLA needs signing before this can merge.

Closes #12671

(full disclosure: AI helped me identify the issue and verify my work)
