### PR TITLE
Fix the missing first-column header in the search queries PDF

### DIFF
--- a/assets/js/modules/search-console/components/dashboard/DashboardPopularKeywordsWidget/DashboardPopularKeywordsWidgetPDF.test.tsx
+++ b/assets/js/modules/search-console/components/dashboard/DashboardPopularKeywordsWidget/DashboardPopularKeywordsWidgetPDF.test.tsx
@@ -69,18 +69,17 @@ describe( 'DashboardPopularKeywordsWidgetPDF', () => {
 		expect( json ).toContain( 'Top search queries for your site' );
 	} );
 
-	it( 'renders the Clicks and Impressions headers in order, with no header on the query column', () => {
+	it( 'renders the Search query, Clicks, and Impressions headers in order', () => {
 		const json = renderJSON( { data: DATA } );
 
-		// The query column has no header.
-		expect( json ).not.toContain( 'Search query' );
+		expect( json ).toContain( 'Search query' );
 
-		const headerPositions = [ 'Clicks', 'Impressions' ].map( ( header ) =>
-			json.indexOf( header )
+		const headerPositions = [ 'Search query', 'Clicks', 'Impressions' ].map(
+			( header ) => json.indexOf( header )
 		);
 
-		// The Clicks and Impressions headers both appear, with Clicks before
-		// Impressions.
+		// All three headers appear, in the order Search query, then Clicks,
+		// then Impressions.
 		expect( headerPositions ).not.toContain( -1 );
 		expect( headerPositions ).toEqual(
 			[ ...headerPositions ].sort(

--- a/assets/js/modules/search-console/components/dashboard/DashboardPopularKeywordsWidget/DashboardPopularKeywordsWidgetPDF.tsx
+++ b/assets/js/modules/search-console/components/dashboard/DashboardPopularKeywordsWidget/DashboardPopularKeywordsWidgetPDF.tsx
@@ -85,8 +85,7 @@ const DashboardPopularKeywordsWidgetPDF: FC< PDFWidgetComponentProps > = ( {
 
 	const columns: Array< PDFTableColumn< SearchQueryRow > > = [
 		{
-			// The query column has no header.
-			header: '',
+			header: __( 'Search query', 'google-site-kit' ),
 			// 66.7% of the 1084px row (723px).
 			width: '66.7%',
 			// Show the rank number before the query. The query links to its


### PR DESCRIPTION
The query column now displays the 'Search query' header, ensuring consistent labeling with the Clicks and Impressions headers. This improves clarity for users reviewing the PDF output.

## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #13073

## Relevant technical choices

* Implementation follows the IB.

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.
- [ ] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
