### PR TITLE
Fix the PDF report to render sections in the dashboard's order

### DIFF
--- a/assets/js/components/pdf-export/PDFExportOrchestrator.test.tsx
+++ b/assets/js/components/pdf-export/PDFExportOrchestrator.test.tsx
@@ -31,6 +31,7 @@ import { CORE_USER } from '@/js/googlesitekit/datastore/user/constants';
 import { CORE_WIDGETS } from '@/js/googlesitekit/widgets/datastore/constants';
 import {
 	CONTEXT_MAIN_DASHBOARD_CONTENT,
+	CONTEXT_MAIN_DASHBOARD_SPEED,
 	CONTEXT_MAIN_DASHBOARD_TRAFFIC,
 } from '@/js/googlesitekit/widgets/default-contexts';
 import * as tracking from '@/js/util/tracking';
@@ -45,6 +46,7 @@ import {
 import { registerPDFFonts } from './pdf-fonts-react';
 import PDFExportOrchestrator from './PDFExportOrchestrator';
 import { SECTION_ICONS } from './section-icons';
+import { PDFHeaderSection, PDFReportArea } from './types';
 
 const mockTrackEvent = jest.spyOn( tracking, 'trackEvent' );
 mockTrackEvent.mockImplementation( () => Promise.resolve() );
@@ -124,6 +126,43 @@ describe( 'PDFExportOrchestrator', () => {
 		dispatch.registerWidget( widgetSlug, {
 			Component: NullComponent,
 			pdf: { Component: NullComponent, getData },
+		} );
+		dispatch.assignWidget( widgetSlug, areaSlug );
+	}
+
+	/**
+	 * Registers a PDF widget and its area in a dashboard context.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param  contextSlug The dashboard context the area belongs to.
+	 * @param  areaSlug    The widget area to register in that context.
+	 * @param  widgetSlug  The widget to register in that area.
+	 * @param  pdfTitle    The area's PDF title, shown as the report section heading.
+	 * @return {void}
+	 */
+	function registerPDFWidgetInContext(
+		contextSlug: string,
+		areaSlug: string,
+		widgetSlug: string,
+		pdfTitle: string
+	) {
+		const dispatch = registry.dispatch( CORE_WIDGETS );
+		dispatch.registerWidgetArea( areaSlug, {
+			title: 'Area',
+			pdfTitle,
+			style: 'boxes',
+			priority: 1,
+		} );
+		dispatch.assignWidgetArea( areaSlug, contextSlug );
+		dispatch.registerWidget( widgetSlug, {
+			Component: NullComponent,
+			pdf: {
+				Component: NullComponent,
+				getData: jest.fn( () =>
+					Promise.resolve( { data: { totalUsers: 100 } } )
+				),
+			},
 		} );
 		dispatch.assignWidget( widgetSlug, areaSlug );
 	}
@@ -424,6 +463,56 @@ describe( 'PDFExportOrchestrator', () => {
 		const { props } = ( pdf as jest.Mock ).mock.calls[ 0 ][ 0 ];
 		expect( props.sections ).toHaveLength( 1 );
 		expect( props.sections[ 0 ].slug ).toBe( 'sharedArea' );
+	} );
+
+	it( 'orders the sections by the dashboard, not by the stored selection', async () => {
+		registerPDFWidgetInContext(
+			CONTEXT_MAIN_DASHBOARD_TRAFFIC,
+			'trafficArea',
+			'trafficWidget',
+			'Traffic'
+		);
+		registerPDFWidgetInContext(
+			CONTEXT_MAIN_DASHBOARD_CONTENT,
+			'contentArea',
+			'contentWidget',
+			'Content'
+		);
+		registerPDFWidgetInContext(
+			CONTEXT_MAIN_DASHBOARD_SPEED,
+			'speedArea',
+			'speedWidget',
+			'Speed'
+		);
+
+		// Store the selection in reverse dashboard order. The report must
+		// still render Traffic, then Content, then Speed.
+		registry.dispatch( CORE_PDF ).setSelection( {
+			contextSlugs: [
+				CONTEXT_MAIN_DASHBOARD_SPEED,
+				CONTEXT_MAIN_DASHBOARD_CONTENT,
+				CONTEXT_MAIN_DASHBOARD_TRAFFIC,
+			],
+			widgetSlugs: [ 'speedWidget', 'contentWidget', 'trafficWidget' ],
+		} );
+
+		renderOrchestrator();
+
+		await waitFor( () => {
+			expect( registry.select( CORE_PDF ).getStatus() ).toBe( 'success' );
+		} );
+
+		const { props } = ( pdf as jest.Mock ).mock.calls[ 0 ][ 0 ];
+
+		// Sections and areas follow the dashboard's order, not the stored
+		// order.
+		const expectedAreaOrder = [ 'trafficArea', 'contentArea', 'speedArea' ];
+		expect(
+			props.sections.map( ( section: PDFHeaderSection ) => section.slug )
+		).toEqual( expectedAreaOrder );
+		expect(
+			props.areas.map( ( area: PDFReportArea ) => area.areaSlug )
+		).toEqual( expectedAreaOrder );
 	} );
 
 	it( 'should register the PDF fonts before rendering the document', async () => {

--- a/assets/js/components/pdf-export/PDFExportOrchestrator.test.tsx
+++ b/assets/js/components/pdf-export/PDFExportOrchestrator.test.tsx
@@ -465,7 +465,7 @@ describe( 'PDFExportOrchestrator', () => {
 		expect( props.sections[ 0 ].slug ).toBe( 'sharedArea' );
 	} );
 
-	it( 'orders the sections by the dashboard, not by the stored selection', async () => {
+	it( "derives the sections in the dashboard's order, not the stored order", async () => {
 		registerPDFWidgetInContext(
 			CONTEXT_MAIN_DASHBOARD_TRAFFIC,
 			'trafficArea',

--- a/assets/js/components/pdf-export/PDFExportOrchestrator.tsx
+++ b/assets/js/components/pdf-export/PDFExportOrchestrator.tsx
@@ -386,7 +386,7 @@ const PDFExportOrchestrator: FC< PDFExportOrchestratorProps > = ( {
 				const selectedWidgetSlugSet = new Set( selectedWidgetSlugs );
 
 				// Reorder the selected contexts into the dashboard's order, so
-				// the report follows the dashboard, not the stored order.
+				// the report's sections follow that order, not the stored order.
 				const selectedContextSlugSet = new Set( selectedContextSlugs );
 				const orderedSelectedContextSlugs =
 					ORDERED_MAIN_DASHBOARD_CONTEXTS.filter( ( contextSlug ) =>

--- a/assets/js/components/pdf-export/PDFExportOrchestrator.tsx
+++ b/assets/js/components/pdf-export/PDFExportOrchestrator.tsx
@@ -48,6 +48,7 @@ import {
 import useViewContext from '@/js/hooks/useViewContext';
 import useViewOnly from '@/js/hooks/useViewOnly';
 import { getPreviousDate, trackEvent } from '@/js/util';
+import { ORDERED_MAIN_DASHBOARD_CONTEXTS } from './constants';
 import { registerPDFFonts } from './pdf-fonts-react';
 import { getPDFFilename, triggerDownload } from './pdf-utils';
 import { WidgetWithPDF, isActivePDFWidget } from './pdf-widget-eligibility';
@@ -384,7 +385,15 @@ const PDFExportOrchestrator: FC< PDFExportOrchestratorProps > = ( {
 				// user kept checked, not every widget in the area.
 				const selectedWidgetSlugSet = new Set( selectedWidgetSlugs );
 
-				selectedContextSlugs.forEach( ( contextSlug: string ) => {
+				// Reorder the selected contexts into the dashboard's order, so
+				// the report follows the dashboard, not the stored order.
+				const selectedContextSlugSet = new Set( selectedContextSlugs );
+				const orderedSelectedContextSlugs =
+					ORDERED_MAIN_DASHBOARD_CONTEXTS.filter( ( contextSlug ) =>
+						selectedContextSlugSet.has( contextSlug )
+					);
+
+				orderedSelectedContextSlugs.forEach( ( contextSlug ) => {
 					const contextAreas: WidgetArea[] =
 						widgetsSelect.getWidgetAreas( contextSlug ) || [];
 

--- a/assets/js/components/pdf-export/PDFSectionsSelectionPanel/PanelContent.test.tsx
+++ b/assets/js/components/pdf-export/PDFSectionsSelectionPanel/PanelContent.test.tsx
@@ -1,0 +1,201 @@
+/**
+ * PanelContent tests.
+ *
+ * Site Kit by Google, Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import { VIEW_CONTEXT_MAIN_DASHBOARD } from '@/js/googlesitekit/constants';
+import { CORE_PDF } from '@/js/googlesitekit/datastore/pdf/constants';
+import { CORE_WIDGETS } from '@/js/googlesitekit/widgets/datastore/constants';
+import {
+	CONTEXT_MAIN_DASHBOARD_CONTENT,
+	CONTEXT_MAIN_DASHBOARD_SPEED,
+	CONTEXT_MAIN_DASHBOARD_TRAFFIC,
+} from '@/js/googlesitekit/widgets/default-contexts';
+import {
+	createTestRegistry,
+	fireEvent,
+	render,
+	waitFor,
+} from '@tests/js/test-utils';
+import PanelContent from './PanelContent';
+
+function NullComponent() {
+	return null;
+}
+
+/**
+ * The dashboard's order for the three test sections. The panel stores the
+ * selected contexts in this order, whatever order the sections were toggled.
+ */
+const DASHBOARD_ORDER = [
+	CONTEXT_MAIN_DASHBOARD_TRAFFIC,
+	CONTEXT_MAIN_DASHBOARD_CONTENT,
+	CONTEXT_MAIN_DASHBOARD_SPEED,
+];
+
+/**
+ * Registers a widget area and one PDF widget in a dashboard context, so the
+ * panel shows it as a section.
+ *
+ * @since n.e.x.t
+ *
+ * @param  registry    The test registry that holds the area and widget.
+ * @param  contextSlug The dashboard context the area belongs to.
+ * @param  areaSlug    The widget area to register in that context.
+ * @param  pdfTitle    The area's PDF title, shown as the report section heading.
+ * @param  widgetSlug  The widget to register in that area.
+ * @param  widgetLabel The widget's label in the panel.
+ * @return {void}
+ */
+function registerSection(
+	registry: ReturnType< typeof createTestRegistry >,
+	contextSlug: string,
+	areaSlug: string,
+	pdfTitle: string,
+	widgetSlug: string,
+	widgetLabel: string
+) {
+	const dispatch = registry.dispatch( CORE_WIDGETS );
+	dispatch.registerWidgetArea( areaSlug, {
+		title: pdfTitle,
+		pdfTitle,
+		style: 'boxes',
+		priority: 1,
+	} );
+	dispatch.assignWidgetArea( areaSlug, contextSlug );
+	dispatch.registerWidget( widgetSlug, {
+		Component: NullComponent,
+		priority: 1,
+		pdf: {
+			Component: NullComponent,
+			getData: () => Promise.resolve( { data: null } ),
+			label: widgetLabel,
+		},
+	} );
+	dispatch.assignWidget( widgetSlug, areaSlug );
+}
+
+/**
+ * Registers the three test sections out of order, Speed first, so a test can
+ * prove the stored order follows the dashboard, not the registration order.
+ *
+ * @since n.e.x.t
+ *
+ * @param  registry The test registry that holds the sections.
+ * @return {void}
+ */
+function registerSections( registry: ReturnType< typeof createTestRegistry > ) {
+	registerSection(
+		registry,
+		CONTEXT_MAIN_DASHBOARD_SPEED,
+		'pdfSpeedArea',
+		'Speed',
+		'pdfSpeed',
+		'Page speed'
+	);
+	registerSection(
+		registry,
+		CONTEXT_MAIN_DASHBOARD_TRAFFIC,
+		'pdfTrafficArea',
+		'Traffic',
+		'pdfTraffic',
+		'Site traffic over time'
+	);
+	registerSection(
+		registry,
+		CONTEXT_MAIN_DASHBOARD_CONTENT,
+		'pdfContentArea',
+		'Content',
+		'pdfContent',
+		'Popular content'
+	);
+}
+
+describe( 'PanelContent', () => {
+	let registry: ReturnType< typeof createTestRegistry >;
+
+	beforeEach( () => {
+		registry = createTestRegistry();
+		registerSections( registry );
+	} );
+
+	/**
+	 * Renders the panel with the test registry, on the main dashboard.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @return The testing-library render result.
+	 */
+	function renderPanel() {
+		return render( <PanelContent closePanel={ () => {} } />, {
+			registry,
+			viewContext: VIEW_CONTEXT_MAIN_DASHBOARD,
+		} );
+	}
+
+	it( "stores the context slugs in the dashboard's own order when the panel first opens", async () => {
+		const { findByRole } = renderPanel();
+
+		await findByRole( 'checkbox', { name: /^Traffic$/ } );
+
+		await waitFor( () => {
+			expect(
+				registry.select( CORE_PDF ).getSelectedContextSlugs()
+			).toEqual( DASHBOARD_ORDER );
+		} );
+	} );
+
+	it( "keeps the stored context slugs in the dashboard's order after a section is toggled off and back on", async () => {
+		const { findByRole } = renderPanel();
+
+		// Wait for the panel to select every section before toggling.
+		await waitFor( () => {
+			expect(
+				registry.select( CORE_PDF ).getSelectedContextSlugs()
+			).toEqual( DASHBOARD_ORDER );
+		} );
+
+		// Toggle the first section off. The two remaining contexts keep their
+		// dashboard order.
+		fireEvent.click(
+			await findByRole( 'checkbox', { name: /^Traffic$/ } )
+		);
+
+		await waitFor( () => {
+			expect(
+				registry.select( CORE_PDF ).getSelectedContextSlugs()
+			).toEqual( [
+				CONTEXT_MAIN_DASHBOARD_CONTENT,
+				CONTEXT_MAIN_DASHBOARD_SPEED,
+			] );
+		} );
+
+		// Toggle it back on. Its context returns to its dashboard position,
+		// not the end of the stored order.
+		fireEvent.click(
+			await findByRole( 'checkbox', { name: /^Traffic$/ } )
+		);
+
+		await waitFor( () => {
+			expect(
+				registry.select( CORE_PDF ).getSelectedContextSlugs()
+			).toEqual( DASHBOARD_ORDER );
+		} );
+	} );
+} );

--- a/assets/js/components/pdf-export/PDFSectionsSelectionPanel/PanelContent.test.tsx
+++ b/assets/js/components/pdf-export/PDFSectionsSelectionPanel/PanelContent.test.tsx
@@ -92,8 +92,9 @@ function registerSection(
 }
 
 /**
- * Registers the three test sections out of order, Speed first, so a test can
- * prove the stored order follows the dashboard, not the registration order.
+ * Registers the three test sections out of order, Speed first, so a test
+ * can prove the stored order follows the dashboard's order, not the
+ * registration order.
  *
  * @since n.e.x.t
  *
@@ -186,8 +187,8 @@ describe( 'PanelContent', () => {
 			] );
 		} );
 
-		// Toggle it back on. Its context returns to its dashboard position,
-		// not the end of the stored order.
+		// Toggle the section back on. Its context returns to its dashboard
+		// position, not the end of the stored order.
 		fireEvent.click(
 			await findByRole( 'checkbox', { name: /^Traffic$/ } )
 		);

--- a/assets/js/components/pdf-export/PDFSectionsSelectionPanel/PanelContent.tsx
+++ b/assets/js/components/pdf-export/PDFSectionsSelectionPanel/PanelContent.tsx
@@ -38,7 +38,10 @@ import { __ } from '@wordpress/i18n';
  */
 import { Select, useDispatch, useSelect } from 'googlesitekit-data';
 import { NOTICE_TYPES } from '@/js/components/Notice/constants';
-import { PDFSection } from '@/js/components/pdf-export/constants';
+import {
+	ORDERED_MAIN_DASHBOARD_CONTEXTS,
+	PDFSection,
+} from '@/js/components/pdf-export/constants';
 import { isActivePDFWidget } from '@/js/components/pdf-export/pdf-widget-eligibility';
 import { SelectionPanelContent } from '@/js/components/SelectionPanel';
 import SelectionPanelNotice from '@/js/components/SelectionPanel/SelectionPanelNotice';
@@ -46,28 +49,11 @@ import Typography from '@/js/components/Typography';
 import { CORE_PDF } from '@/js/googlesitekit/datastore/pdf/constants';
 import { CORE_USER } from '@/js/googlesitekit/datastore/user/constants';
 import { CORE_WIDGETS } from '@/js/googlesitekit/widgets/datastore/constants';
-import {
-	CONTEXT_MAIN_DASHBOARD_CONTENT,
-	CONTEXT_MAIN_DASHBOARD_KEY_METRICS,
-	CONTEXT_MAIN_DASHBOARD_MONETIZATION,
-	CONTEXT_MAIN_DASHBOARD_SITE_GOALS,
-	CONTEXT_MAIN_DASHBOARD_SPEED,
-	CONTEXT_MAIN_DASHBOARD_TRAFFIC,
-} from '@/js/googlesitekit/widgets/default-contexts';
 import type { Widget, WidgetArea } from '@/js/googlesitekit/widgets/types';
 import useViewOnly from '@/js/hooks/useViewOnly';
 import Footer from './Footer';
 import Header from './Header';
 import PDFSectionCheckboxes from './PDFSectionCheckboxes';
-
-const MAIN_DASHBOARD_CONTEXTS = [
-	CONTEXT_MAIN_DASHBOARD_KEY_METRICS,
-	CONTEXT_MAIN_DASHBOARD_SITE_GOALS,
-	CONTEXT_MAIN_DASHBOARD_TRAFFIC,
-	CONTEXT_MAIN_DASHBOARD_CONTENT,
-	CONTEXT_MAIN_DASHBOARD_SPEED,
-	CONTEXT_MAIN_DASHBOARD_MONETIZATION,
-];
 
 interface PanelContentProps {
 	closePanel: () => void;
@@ -90,7 +76,7 @@ const PanelContent: FC< PanelContentProps > = ( { closePanel } ) => {
 
 			const sections: PDFSection[] = [];
 
-			MAIN_DASHBOARD_CONTEXTS.forEach( ( contextSlug ) => {
+			ORDERED_MAIN_DASHBOARD_CONTEXTS.forEach( ( contextSlug ) => {
 				const areas: WidgetArea[] =
 					select( CORE_WIDGETS ).getWidgetAreas( contextSlug );
 
@@ -151,12 +137,17 @@ const PanelContent: FC< PanelContentProps > = ( { closePanel } ) => {
 			widgetSlugs: string[],
 			widgetContextMap: Record< string, string >
 		) => {
-			const contextSlugs = Array.from(
-				new Set(
-					widgetSlugs
-						.map( ( slug ) => widgetContextMap[ slug ] )
-						.filter( Boolean )
-				)
+			const selectedContexts = new Set(
+				widgetSlugs
+					.map( ( slug ) => widgetContextMap[ slug ] )
+					.filter( Boolean )
+			);
+
+			// Store the contexts in the dashboard's order, not the selection
+			// order, so the report's section order stays fixed across
+			// re-exports and toggles.
+			const contextSlugs = ORDERED_MAIN_DASHBOARD_CONTEXTS.filter(
+				( contextSlug ) => selectedContexts.has( contextSlug )
 			);
 
 			setSelection( { contextSlugs, widgetSlugs } );

--- a/assets/js/components/pdf-export/constants.ts
+++ b/assets/js/components/pdf-export/constants.ts
@@ -38,8 +38,8 @@ export const PDF_INTRODUCTION_OVERLAY_NOTIFICATION =
  *
  * The PDF report renders one section per selected context, in this order.
  * Both the selection panel and the export orchestrator read this list, so the
- * exported section order always follows the dashboard, whatever order the user
- * selected the widgets in.
+ * exported section order always follows the dashboard's order, whatever order
+ * the user selected the widgets in.
  *
  * @since n.e.x.t
  */

--- a/assets/js/components/pdf-export/constants.ts
+++ b/assets/js/components/pdf-export/constants.ts
@@ -16,10 +16,41 @@
  * limitations under the License.
  */
 
+/**
+ * Internal dependencies
+ */
+import {
+	CONTEXT_MAIN_DASHBOARD_CONTENT,
+	CONTEXT_MAIN_DASHBOARD_KEY_METRICS,
+	CONTEXT_MAIN_DASHBOARD_MONETIZATION,
+	CONTEXT_MAIN_DASHBOARD_SITE_GOALS,
+	CONTEXT_MAIN_DASHBOARD_SPEED,
+	CONTEXT_MAIN_DASHBOARD_TRAFFIC,
+} from '@/js/googlesitekit/widgets/default-contexts';
+
 export const PDF_DOWNLOAD_PANEL_OPENED_KEY = 'pdfDownloadPanelOpened';
 
 export const PDF_INTRODUCTION_OVERLAY_NOTIFICATION =
 	'pdf_introduction_overlay_notification';
+
+/**
+ * Main-dashboard context slugs in the dashboard's own order.
+ *
+ * The PDF report renders one section per selected context, in this order.
+ * Both the selection panel and the export orchestrator read this list, so the
+ * exported section order always follows the dashboard, whatever order the user
+ * selected the widgets in.
+ *
+ * @since n.e.x.t
+ */
+export const ORDERED_MAIN_DASHBOARD_CONTEXTS = [
+	CONTEXT_MAIN_DASHBOARD_KEY_METRICS,
+	CONTEXT_MAIN_DASHBOARD_SITE_GOALS,
+	CONTEXT_MAIN_DASHBOARD_TRAFFIC,
+	CONTEXT_MAIN_DASHBOARD_CONTENT,
+	CONTEXT_MAIN_DASHBOARD_SPEED,
+	CONTEXT_MAIN_DASHBOARD_MONETIZATION,
+];
 
 export interface PDFSectionWidget {
 	slug: string;


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #13072

## Relevant technical choices

* `pdf-export/constants.ts`: add the shared `ORDERED_MAIN_DASHBOARD_CONTEXTS` list, with the six `CONTEXT_MAIN_DASHBOARD_*` imports moved from `PanelContent.tsx`.
* `PanelContent.tsx`:
  * `commitSelection` filters the list to the selected contexts. The IB filtered `availableSections` instead.
  * `availableSections` reads the shared list, so the panel holds no list of its own.
* `PDFExportOrchestrator.tsx`: order the loop by the list before building `areas` and `sections`. The IB sorted `discoveredAreas` afterward.

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.
- [ ] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
