### PR TITLE
Fix PDF export to skip disconnected-module widgets

### DIFF
--- a/assets/js/components/pdf-export/PDFExportOrchestrator.test.tsx
+++ b/assets/js/components/pdf-export/PDFExportOrchestrator.test.tsx
@@ -737,12 +737,9 @@ describe( 'PDFExportOrchestrator', () => {
 		const analyticsGetData: jest.Mock = jest.fn( () =>
 			Promise.resolve( { data: { totalUsers: 100 } } )
 		);
-		registerPDFWidget(
-			'trafficArea',
-			'analyticsWidget',
-			analyticsGetData,
-			[ MODULE_SLUG_ANALYTICS_4 ]
-		);
+		registerPDFWidget( 'trafficArea', 'analyticsWidget', analyticsGetData, [
+			MODULE_SLUG_ANALYTICS_4,
+		] );
 		registry.dispatch( CORE_PDF ).setSelection( {
 			contextSlugs: [ CONTEXT_MAIN_DASHBOARD_TRAFFIC ],
 			widgetSlugs: [ 'analyticsWidget' ],

--- a/assets/js/components/pdf-export/PDFExportOrchestrator.test.tsx
+++ b/assets/js/components/pdf-export/PDFExportOrchestrator.test.tsx
@@ -33,10 +33,12 @@ import {
 	CONTEXT_MAIN_DASHBOARD_CONTENT,
 	CONTEXT_MAIN_DASHBOARD_TRAFFIC,
 } from '@/js/googlesitekit/widgets/default-contexts';
+import { MODULE_SLUG_ANALYTICS_4 } from '@/js/modules/analytics-4/constants';
 import * as tracking from '@/js/util/tracking';
 import {
 	act,
 	createTestRegistry,
+	provideModules,
 	provideSiteInfo,
 	provideUserInfo,
 	render,
@@ -85,6 +87,9 @@ describe( 'PDFExportOrchestrator', () => {
 			siteName: 'Example Site',
 		} );
 		provideUserInfo( registry );
+		// The orchestrator waits for the module connection state, so every
+		// test needs modules in the store.
+		provideModules( registry );
 		registry.dispatch( CORE_USER ).setReferenceDate( '2021-01-10' );
 		registry.dispatch( CORE_USER ).setDateRange( 'last-28-days' );
 
@@ -108,10 +113,23 @@ describe( 'PDFExportOrchestrator', () => {
 		global.URL.revokeObjectURL = originalRevokeObjectURL;
 	} );
 
+	/**
+	 * Registers a widget area and one pdf widget in the Traffic context, so a
+	 * test can give the orchestrator a widget to export.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param  areaSlug   Slug of the widget area.
+	 * @param  widgetSlug Slug of the pdf widget.
+	 * @param  getData    Mock for the widget's pdf `getData`.
+	 * @param  modules    Module slugs the widget depends on, if any.
+	 * @return {void}
+	 */
 	function registerPDFWidget(
 		areaSlug: string,
 		widgetSlug: string,
-		getData: jest.Mock
+		getData: jest.Mock,
+		modules?: string[]
 	) {
 		const dispatch = registry.dispatch( CORE_WIDGETS );
 		dispatch.registerWidgetArea( areaSlug, {
@@ -123,6 +141,7 @@ describe( 'PDFExportOrchestrator', () => {
 		dispatch.assignWidgetArea( areaSlug, CONTEXT_MAIN_DASHBOARD_TRAFFIC );
 		dispatch.registerWidget( widgetSlug, {
 			Component: NullComponent,
+			...( modules && { modules } ),
 			pdf: { Component: NullComponent, getData },
 		} );
 		dispatch.assignWidget( widgetSlug, areaSlug );
@@ -668,6 +687,74 @@ describe( 'PDFExportOrchestrator', () => {
 
 		expect( getData ).toHaveBeenCalledTimes( 1 );
 		expect( activeGetData ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'does not request data for a widget whose required module is disconnected', async () => {
+		provideModules( registry, [
+			{ slug: MODULE_SLUG_ANALYTICS_4, active: true, connected: false },
+		] );
+
+		const connectedGetData: jest.Mock = jest.fn( () =>
+			Promise.resolve( { data: { totalUsers: 100 } } )
+		);
+		registerPDFWidget( 'trafficArea', 'trafficWidget', connectedGetData );
+
+		const disconnectedGetData: jest.Mock = jest.fn( () =>
+			Promise.resolve( { data: { totalUsers: 100 } } )
+		);
+		registry.dispatch( CORE_WIDGETS ).registerWidget( 'analyticsWidget', {
+			Component: NullComponent,
+			modules: [ MODULE_SLUG_ANALYTICS_4 ],
+			pdf: { Component: NullComponent, getData: disconnectedGetData },
+		} );
+		registry
+			.dispatch( CORE_WIDGETS )
+			.assignWidget( 'analyticsWidget', 'trafficArea' );
+		// Select both widgets, so only the disconnected module excludes the
+		// Analytics widget, not the user's selection.
+		registry.dispatch( CORE_PDF ).setSelection( {
+			contextSlugs: [ CONTEXT_MAIN_DASHBOARD_TRAFFIC ],
+			widgetSlugs: [ 'trafficWidget', 'analyticsWidget' ],
+		} );
+
+		renderOrchestrator();
+
+		await waitFor( () => {
+			expect( registry.select( CORE_PDF ).getStatus() ).toBe( 'success' );
+		} );
+
+		// No report request runs against the disconnected module.
+		expect( disconnectedGetData ).not.toHaveBeenCalled();
+		// The connected widget still exports.
+		expect( connectedGetData ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'requests data for a widget whose required module is connected', async () => {
+		provideModules( registry, [
+			{ slug: MODULE_SLUG_ANALYTICS_4, active: true, connected: true },
+		] );
+
+		const analyticsGetData: jest.Mock = jest.fn( () =>
+			Promise.resolve( { data: { totalUsers: 100 } } )
+		);
+		registerPDFWidget(
+			'trafficArea',
+			'analyticsWidget',
+			analyticsGetData,
+			[ MODULE_SLUG_ANALYTICS_4 ]
+		);
+		registry.dispatch( CORE_PDF ).setSelection( {
+			contextSlugs: [ CONTEXT_MAIN_DASHBOARD_TRAFFIC ],
+			widgetSlugs: [ 'analyticsWidget' ],
+		} );
+
+		renderOrchestrator();
+
+		await waitFor( () => {
+			expect( registry.select( CORE_PDF ).getStatus() ).toBe( 'success' );
+		} );
+
+		expect( analyticsGetData ).toHaveBeenCalledTimes( 1 );
 	} );
 
 	it( 'fires pdf_generation_cancel with the current stage label when the user cancels', async () => {

--- a/assets/js/components/pdf-export/PDFExportOrchestrator.tsx
+++ b/assets/js/components/pdf-export/PDFExportOrchestrator.tsx
@@ -31,6 +31,7 @@ import { useCallback, useEffect, useReducer, useRef } from '@wordpress/element';
  * Internal dependencies
  */
 import {
+	Registry,
 	Select,
 	useDispatch,
 	useRegistry,
@@ -39,6 +40,7 @@ import {
 import { CORE_PDF } from '@/js/googlesitekit/datastore/pdf/constants';
 import { CORE_SITE } from '@/js/googlesitekit/datastore/site/constants';
 import { CORE_USER } from '@/js/googlesitekit/datastore/user/constants';
+import { CORE_MODULES } from '@/js/googlesitekit/modules/datastore/constants';
 import { CORE_WIDGETS } from '@/js/googlesitekit/widgets/datastore/constants';
 import {
 	PDFReportDates,
@@ -182,7 +184,10 @@ const PDFExportOrchestrator: FC< PDFExportOrchestratorProps > = ( {
 	onComplete,
 } ) => {
 	const [ , dispatch ] = useReducer( reducer, initialState );
-	const registry = useRegistry();
+	// `@wordpress/data` types `useRegistry()` as `Function`, which does not
+	// overlap with Site Kit's `Registry` type, so TypeScript needs the
+	// `unknown` step between the two.
+	const registry = useRegistry() as unknown as Registry;
 	const { setStatus, setProgress, setBlob, clearExport, clearCancelRequest } =
 		useDispatch( CORE_PDF );
 
@@ -359,10 +364,17 @@ const PDFExportOrchestrator: FC< PDFExportOrchestratorProps > = ( {
 				// PDF-aware selector). `selectedContextSlugs`,
 				// `selectedWidgetSlugs`, `dates` and `viewableModules` are
 				// snapshotted once above. Nothing below re-reads reactive state.
-				const { select } = registry as unknown as {
-					// eslint-disable-next-line @typescript-eslint/no-explicit-any -- The registry `select` is loosely typed, so `isActive` predicates can read store selectors without casting.
-					select: ( storeName: string ) => any;
-				};
+				const { resolveSelect } = registry;
+				// `Registry` types `select` as `Function`. Narrow it to
+				// `Select` so `isActivePDFWidget` can take it.
+				const select = registry.select as Select;
+
+				// Wait for modules to load, or `isModuleConnected` returns
+				// `undefined` and `isActivePDFWidget` drops every widget
+				// that needs a module from the report.
+				await resolveSelect( CORE_MODULES ).getModules();
+				throwIfAborted( signal );
+
 				const widgetsSelect = select( CORE_WIDGETS ) as {
 					getWidgetAreas: ( contextSlug: string ) => WidgetArea[];
 					getWidgets: (

--- a/assets/js/components/pdf-export/PDFSectionsSelectionPanel/PanelContent.tsx
+++ b/assets/js/components/pdf-export/PDFSectionsSelectionPanel/PanelContent.tsx
@@ -45,6 +45,7 @@ import SelectionPanelNotice from '@/js/components/SelectionPanel/SelectionPanelN
 import Typography from '@/js/components/Typography';
 import { CORE_PDF } from '@/js/googlesitekit/datastore/pdf/constants';
 import { CORE_USER } from '@/js/googlesitekit/datastore/user/constants';
+import { CORE_MODULES } from '@/js/googlesitekit/modules/datastore/constants';
 import { CORE_WIDGETS } from '@/js/googlesitekit/widgets/datastore/constants';
 import {
 	CONTEXT_MAIN_DASHBOARD_CONTENT,
@@ -85,6 +86,13 @@ const PanelContent: FC< PanelContentProps > = ( { closePanel } ) => {
 			// Wait for the viewable modules to resolve before deriving sections so
 			// a view-only dashboard never briefly shows a section it cannot fill.
 			if ( viewOnly && modules === undefined ) {
+				return [];
+			}
+
+			// Wait for modules to load. Before they load, `isModuleConnected`
+			// returns `undefined`, so the panel would treat a connected module
+			// as disconnected and leave its section out of the default selection.
+			if ( select( CORE_MODULES ).getModules() === undefined ) {
 				return [];
 			}
 

--- a/assets/js/components/pdf-export/PDFSectionsSelectionPanel/index.stories.tsx
+++ b/assets/js/components/pdf-export/PDFSectionsSelectionPanel/index.stories.tsx
@@ -35,6 +35,7 @@ import { CORE_PDF } from '@/js/googlesitekit/datastore/pdf/constants';
 import { CORE_UI } from '@/js/googlesitekit/datastore/ui/constants';
 import { CORE_WIDGETS } from '@/js/googlesitekit/widgets/datastore/constants';
 import { CONTEXT_MAIN_DASHBOARD_TRAFFIC } from '@/js/googlesitekit/widgets/default-contexts';
+import { provideModules } from '@tests/js/test-utils';
 import WithRegistrySetup from '@tests/js/WithRegistrySetup';
 import PDFSectionsSelectionPanel from './index';
 
@@ -79,6 +80,10 @@ export default {
 				registry
 					.dispatch( CORE_UI )
 					.setValue( PDF_DOWNLOAD_PANEL_OPENED_KEY, true );
+
+				// The panel lists a section only when its widgets' modules are
+				// connected, so provide module state for the story.
+				provideModules( registry );
 
 				const widgets = registry.dispatch( CORE_WIDGETS );
 				widgets.registerWidgetArea( 'pdfTrafficArea', {

--- a/assets/js/components/pdf-export/PDFSectionsSelectionPanel/index.test.tsx
+++ b/assets/js/components/pdf-export/PDFSectionsSelectionPanel/index.test.tsx
@@ -28,11 +28,13 @@ import {
 	CONTEXT_MAIN_DASHBOARD_CONTENT,
 	CONTEXT_MAIN_DASHBOARD_TRAFFIC,
 } from '@/js/googlesitekit/widgets/default-contexts';
+import { MODULE_SLUG_ANALYTICS_4 } from '@/js/modules/analytics-4/constants';
 import * as tracking from '@/js/util/tracking';
 import {
 	act,
 	createTestRegistry,
 	fireEvent,
+	provideModules,
 	render,
 	waitFor,
 } from '@tests/js/test-utils';
@@ -101,6 +103,9 @@ describe( 'PDFSectionsSelectionPanel', () => {
 
 	beforeEach( () => {
 		registry = createTestRegistry();
+		// The panel waits for module connection state before it lists sections,
+		// so every test needs modules in the store.
+		provideModules( registry );
 		registerSections( registry );
 	} );
 
@@ -151,6 +156,79 @@ describe( 'PDFSectionsSelectionPanel', () => {
 		expect(
 			queryByRole( 'checkbox', { name: /^Inactive$/ } )
 		).not.toBeInTheDocument();
+	} );
+
+	/**
+	 * Registers a Traffic-context area with one pdf widget that depends on
+	 * Analytics 4, so a test can check a module-dependent section.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @return {void}
+	 */
+	function registerAnalyticsSection() {
+		const dispatch = registry.dispatch( CORE_WIDGETS );
+		dispatch.registerWidgetArea( 'analyticsArea', {
+			title: 'Analytics',
+			pdfTitle: 'Analytics',
+			style: 'boxes',
+			priority: 2,
+		} );
+		dispatch.assignWidgetArea(
+			'analyticsArea',
+			CONTEXT_MAIN_DASHBOARD_TRAFFIC
+		);
+		dispatch.registerWidget( 'analyticsWidget', {
+			Component: NullComponent,
+			modules: [ MODULE_SLUG_ANALYTICS_4 ],
+			pdf: {
+				Component: NullComponent,
+				getData: () => Promise.resolve( { data: null } ),
+				label: 'Analytics widget',
+			},
+		} );
+		dispatch.assignWidget( 'analyticsWidget', 'analyticsArea' );
+	}
+
+	it( 'omits a section whose pdf widget requires a disconnected module', async () => {
+		provideModules( registry, [
+			{ slug: MODULE_SLUG_ANALYTICS_4, active: true, connected: false },
+		] );
+		registerAnalyticsSection();
+
+		const { findByRole, queryByRole } = render(
+			<PDFSectionsSelectionPanel />,
+			{ registry }
+		);
+
+		openPanel();
+
+		// Wait for the module-less Traffic section. Its presence proves the
+		// list has loaded before the test checks that the Analytics section
+		// is absent.
+		await findByRole( 'checkbox', { name: /^Traffic$/ } );
+
+		expect(
+			queryByRole( 'checkbox', { name: /^Analytics$/ } )
+		).not.toBeInTheDocument();
+	} );
+
+	it( 'lists a section whose pdf widget requires a connected module, and selects it by default', async () => {
+		provideModules( registry, [
+			{ slug: MODULE_SLUG_ANALYTICS_4, active: true, connected: true },
+		] );
+		registerAnalyticsSection();
+
+		const { findByRole } = render( <PDFSectionsSelectionPanel />, {
+			registry,
+		} );
+
+		openPanel();
+
+		const analyticsSection = ( await findByRole( 'checkbox', {
+			name: /^Analytics$/,
+		} ) ) as HTMLInputElement;
+		expect( analyticsSection.checked ).toBe( true );
 	} );
 
 	it( 'renders a Traffic section with its labelled widgets, all selected by default', async () => {

--- a/assets/js/components/pdf-export/PDFSectionsSelectionPanel/index.test.tsx
+++ b/assets/js/components/pdf-export/PDFSectionsSelectionPanel/index.test.tsx
@@ -23,6 +23,7 @@ import { PDF_DOWNLOAD_PANEL_OPENED_KEY } from '@/js/components/pdf-export/consta
 import { VIEW_CONTEXT_MAIN_DASHBOARD } from '@/js/googlesitekit/constants';
 import { CORE_PDF } from '@/js/googlesitekit/datastore/pdf/constants';
 import { CORE_UI } from '@/js/googlesitekit/datastore/ui/constants';
+import { CORE_MODULES } from '@/js/googlesitekit/modules/datastore/constants';
 import { CORE_WIDGETS } from '@/js/googlesitekit/widgets/datastore/constants';
 import {
 	CONTEXT_MAIN_DASHBOARD_CONTENT,
@@ -151,6 +152,17 @@ describe( 'PDFSectionsSelectionPanel', () => {
 
 		openPanel();
 
+		// The `getModules` resolver finishes after the first render and
+		// re-renders the panel. Wait for it inside `act`, so the panel
+		// doesn't re-render after the test has ended.
+		await waitFor( () => {
+			expect(
+				registry
+					.select( CORE_MODULES )
+					.hasFinishedResolution( 'getModules', [] )
+			).toBe( true );
+		} );
+
 		await findByRole( 'checkbox', { name: /^Traffic$/ } );
 
 		expect(
@@ -203,6 +215,17 @@ describe( 'PDFSectionsSelectionPanel', () => {
 
 		openPanel();
 
+		// The `getModules` resolver finishes after the first render and
+		// re-renders the panel. Wait for it inside `act`, so the panel
+		// doesn't re-render after the test has ended.
+		await waitFor( () => {
+			expect(
+				registry
+					.select( CORE_MODULES )
+					.hasFinishedResolution( 'getModules', [] )
+			).toBe( true );
+		} );
+
 		// Wait for the module-less Traffic section. Its presence proves the
 		// list has loaded before the test checks that the Analytics section
 		// is absent.
@@ -224,6 +247,17 @@ describe( 'PDFSectionsSelectionPanel', () => {
 		} );
 
 		openPanel();
+
+		// The `getModules` resolver finishes after the first render and
+		// re-renders the panel. Wait for it inside `act`, so the panel
+		// doesn't re-render after the test has ended.
+		await waitFor( () => {
+			expect(
+				registry
+					.select( CORE_MODULES )
+					.hasFinishedResolution( 'getModules', [] )
+			).toBe( true );
+		} );
 
 		const analyticsSection = ( await findByRole( 'checkbox', {
 			name: /^Analytics$/,

--- a/assets/js/components/pdf-export/pdf-widget-eligibility.test.ts
+++ b/assets/js/components/pdf-export/pdf-widget-eligibility.test.ts
@@ -1,0 +1,167 @@
+/**
+ * `isActivePDFWidget` tests.
+ *
+ * Site Kit by Google, Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import { Select } from 'googlesitekit-data';
+import { Widget } from '@/js/googlesitekit/widgets/types';
+import { MODULE_SLUG_ANALYTICS_4 } from '@/js/modules/analytics-4/constants';
+import { MODULE_SLUG_SEARCH_CONSOLE } from '@/js/modules/search-console/constants';
+import {
+	createTestRegistry,
+	muteFetch,
+	provideModules,
+} from '@tests/js/test-utils';
+import { isActivePDFWidget } from './pdf-widget-eligibility';
+
+function NullComponent() {
+	return null;
+}
+
+/**
+ * Builds a test widget with a pdf config, merging any overrides so each test
+ * sets only the fields it needs.
+ *
+ * @since n.e.x.t
+ *
+ * @param overrides Widget fields to merge over the defaults.
+ * @return The widget to pass to `isActivePDFWidget`.
+ */
+function createWidget( overrides: Partial< Widget > = {} ): Widget {
+	return {
+		slug: 'testWidget',
+		Component: NullComponent,
+		priority: 1,
+		width: 'full',
+		wrapWidget: false,
+		pdf: {
+			Component: NullComponent,
+			getData: () => Promise.resolve( { data: null } ),
+		},
+		...overrides,
+	};
+}
+
+describe( 'isActivePDFWidget', () => {
+	let registry: ReturnType< typeof createTestRegistry >;
+	let select: Select;
+
+	beforeEach( () => {
+		registry = createTestRegistry();
+		// `createTestRegistry` types `select` as `Function`. Narrow it to
+		// `Select` so the tests can pass it to `isActivePDFWidget`.
+		select = registry.select as Select;
+	} );
+
+	it( 'returns false for a widget without a pdf config', () => {
+		provideModules( registry );
+
+		const widget = createWidget( { pdf: undefined } );
+
+		expect( isActivePDFWidget( widget, select ) ).toBe( false );
+	} );
+
+	it( 'returns true for a pdf widget that depends on no module', () => {
+		provideModules( registry );
+
+		const widget = createWidget( { modules: undefined } );
+
+		expect( isActivePDFWidget( widget, select ) ).toBe( true );
+	} );
+
+	it( 'returns false when a required module is disconnected', () => {
+		provideModules( registry, [
+			{ slug: MODULE_SLUG_ANALYTICS_4, active: true, connected: false },
+		] );
+
+		const widget = createWidget( { modules: [ MODULE_SLUG_ANALYTICS_4 ] } );
+
+		expect( isActivePDFWidget( widget, select ) ).toBe( false );
+	} );
+
+	it( 'returns true when the required module is connected', () => {
+		provideModules( registry, [
+			{ slug: MODULE_SLUG_ANALYTICS_4, active: true, connected: true },
+		] );
+
+		const widget = createWidget( { modules: [ MODULE_SLUG_ANALYTICS_4 ] } );
+
+		expect( isActivePDFWidget( widget, select ) ).toBe( true );
+	} );
+
+	it( 'returns false when any required module is disconnected', () => {
+		provideModules( registry, [
+			{ slug: MODULE_SLUG_SEARCH_CONSOLE, active: true, connected: true },
+			{ slug: MODULE_SLUG_ANALYTICS_4, active: true, connected: false },
+		] );
+
+		const widget = createWidget( {
+			modules: [ MODULE_SLUG_SEARCH_CONSOLE, MODULE_SLUG_ANALYTICS_4 ],
+		} );
+
+		expect( isActivePDFWidget( widget, select ) ).toBe( false );
+	} );
+
+	it( 'returns false while modules are still loading', () => {
+		// Without `provideModules`, `isModuleConnected` returns `undefined` and
+		// starts the modules resolver. Mute its request. The test proves a
+		// not-yet-loaded module never counts as connected.
+		muteFetch(
+			new RegExp( '^/google-site-kit/v1/core/modules/data/list' )
+		);
+
+		const widget = createWidget( { modules: [ MODULE_SLUG_ANALYTICS_4 ] } );
+
+		expect( isActivePDFWidget( widget, select ) ).toBe( false );
+	} );
+
+	it( 'returns false when pdf.isActive returns false even though the module is connected', () => {
+		provideModules( registry, [
+			{ slug: MODULE_SLUG_ANALYTICS_4, active: true, connected: true },
+		] );
+
+		const widget = createWidget( {
+			modules: [ MODULE_SLUG_ANALYTICS_4 ],
+			pdf: {
+				Component: NullComponent,
+				getData: () => Promise.resolve( { data: null } ),
+				isActive: () => false,
+			},
+		} );
+
+		expect( isActivePDFWidget( widget, select ) ).toBe( false );
+	} );
+
+	it( 'returns true when pdf.isActive returns true and the module is connected', () => {
+		provideModules( registry, [
+			{ slug: MODULE_SLUG_ANALYTICS_4, active: true, connected: true },
+		] );
+
+		const widget = createWidget( {
+			modules: [ MODULE_SLUG_ANALYTICS_4 ],
+			pdf: {
+				Component: NullComponent,
+				getData: () => Promise.resolve( { data: null } ),
+				isActive: () => true,
+			},
+		} );
+
+		expect( isActivePDFWidget( widget, select ) ).toBe( true );
+	} );
+} );

--- a/assets/js/components/pdf-export/pdf-widget-eligibility.ts
+++ b/assets/js/components/pdf-export/pdf-widget-eligibility.ts
@@ -19,7 +19,10 @@
 /**
  * Internal dependencies
  */
+import type { Select } from 'googlesitekit-data';
+import { CORE_MODULES } from '@/js/googlesitekit/modules/datastore/constants';
 import type { Widget, WidgetPDFConfig } from '@/js/googlesitekit/widgets/types';
+import { normalizeWidgetModules } from '@/js/googlesitekit/widgets/util/widget-modules';
 
 /**
  * A registry widget that declares a PDF export configuration.
@@ -43,25 +46,39 @@ function hasPDFConfig( widget: Widget ): widget is WidgetWithPDF {
 /**
  * Determines whether a widget should be included in the PDF export.
  *
- * A widget is eligible when it declares a `pdf` config and either omits
- * `pdf.isActive` or its `pdf.isActive` predicate returns `true` for the current
- * store state. This is the single source of truth shared by the sidesheet
- * (which offers selectable sections) and the orchestrator (which builds the
- * document), so the two cannot drift on which widgets are PDF-eligible.
+ * A widget is eligible when it declares a `pdf` config, every module it
+ * needs is connected, and its optional `pdf.isActive` returns `true`.
+ * The sections selection panel and the orchestrator both use this
+ * function, so the panel and the report always show the same widgets.
+ *
+ * On the Site Kit dashboard, the `whenActive` HOC keeps a disconnected
+ * module's widgets off the screen. The PDF export skips that HOC, so this
+ * function checks the modules instead. Without that check, `getData` would
+ * run for a disconnected module, and the API would reject the request with
+ * the "Module must be active to request data" error.
  *
  * @since 1.183.0
+ * @since n.e.x.t Require every module in `widget.modules` to be connected.
  *
  * @param widget Registry widget.
- * @param select Registry `select` function, forwarded to `pdf.isActive`.
+ * @param select Registry `select` function.
  * @return `true` when the widget should appear in the PDF.
  */
 export function isActivePDFWidget(
 	widget: Widget,
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- The registry `select` is loosely typed, so `isActive` predicates can read store selectors without casting.
-	select: ( storeName: string ) => any
+	select: Select
 ): widget is WidgetWithPDF {
-	return (
-		hasPDFConfig( widget ) &&
-		( ! widget.pdf.isActive || widget.pdf.isActive( select ) )
+	if ( ! hasPDFConfig( widget ) ) {
+		return false;
+	}
+
+	if ( widget.pdf.isActive && ! widget.pdf.isActive( select ) ) {
+		return false;
+	}
+
+	// `isModuleConnected` returns `undefined` while modules load and `null`
+	// for an unknown module, so only `true` counts as connected.
+	return normalizeWidgetModules( widget.modules ).every(
+		( slug ) => select( CORE_MODULES ).isModuleConnected( slug ) === true
 	);
 }

--- a/assets/js/components/pdf-export/pdf-widget-eligibility.ts
+++ b/assets/js/components/pdf-export/pdf-widget-eligibility.ts
@@ -78,7 +78,7 @@ export function isActivePDFWidget(
 
 	// `isModuleConnected` returns `undefined` while modules load and `null`
 	// for an unknown module, so only `true` counts as connected.
-	return normalizeWidgetModules( widget.modules ).every(
+	return normalizeWidgetModules( widget.modules ?? [] ).every(
 		( slug ) => select( CORE_MODULES ).isModuleConnected( slug ) === true
 	);
 }


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #13071

## Relevant technical choices

* The orchestrator and `isActivePDFWidget` reuse the shared `Registry` and `Select` types from `googlesitekit-data` instead of local any-typed shapes, which also removes two `eslint-disable` lines for `no-explicit-any`.
* The sections selection panel returns an empty section list until `getModules()` loads, since a `useSelect` callback can't await a resolver.
* The panel tests live in the existing `index.test.tsx` instead of the IB's `PanelContent.test.tsx`, because the section list shows only through the rendered panel.

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.
- [ ] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
