### PR TITLE
Honor WooCommerce currency decimals in conversion events.

### DIFF
--- a/assets/js/event-providers/woocommerce.js
+++ b/assets/js/event-providers/woocommerce.js
@@ -21,6 +21,7 @@
 
 	const {
 		currency: globalCurrency,
+		currency_minor_unit: globalCurrencyMinorUnit = 2,
 		products: globalProducts,
 		purchase,
 		add_to_cart: addToCart,
@@ -32,7 +33,15 @@
 	if ( addToCart && canTrackAddToCart ) {
 		const { price } = addToCart;
 
-		const eventData = formatEventData( price, globalCurrency, addToCart );
+		const eventData = formatEventData(
+			price,
+			globalCurrency,
+			addToCart,
+			null,
+			null,
+			null,
+			globalCurrencyMinorUnit
+		);
 
 		global._googlesitekit?.gtagEvent?.( 'add_to_cart', eventData );
 	}
@@ -46,7 +55,8 @@
 			items,
 			id,
 			totals.shipping_total,
-			totals.tax_total
+			totals.tax_total,
+			globalCurrencyMinorUnit
 		);
 
 		// User data is already normalized from WooCommerce.php.
@@ -82,7 +92,11 @@
 			const eventData = formatEventData(
 				price,
 				globalCurrency,
-				productData
+				productData,
+				null,
+				null,
+				null,
+				globalCurrencyMinorUnit
 			);
 			global._googlesitekit?.gtagEvent?.( 'add_to_cart', eventData );
 		} );
@@ -126,7 +140,11 @@
 				const eventData = formatEventData(
 					price,
 					globalCurrency,
-					productData
+					productData,
+					null,
+					null,
+					null,
+					globalCurrencyMinorUnit
 				);
 
 				global._googlesitekit?.gtagEvent?.( 'add_to_cart', eventData );
@@ -140,10 +158,11 @@
 		products,
 		transactionID = null,
 		shipping = null,
-		tax = null
+		tax = null,
+		currencyMinorUnit = 2
 	) {
 		const formattedData = {
-			value: formatPrice( value ),
+			value: formatPrice( value, currencyMinorUnit ),
 			currency,
 			items: [],
 			googlesitekit_event_provider: 'woocommerce',
@@ -167,22 +186,26 @@
 
 		if ( products && products.length ) {
 			for ( const product of products ) {
-				formattedData.items.push( formatProductData( product ) );
+				formattedData.items.push(
+					formatProductData( product, currencyMinorUnit )
+				);
 			}
 		} else if ( products && products.id ) {
-			formattedData.items = [ formatProductData( products ) ];
+			formattedData.items = [
+				formatProductData( products, currencyMinorUnit ),
+			];
 		}
 
 		return formattedData;
 	}
 
-	function formatProductData( product ) {
+	function formatProductData( product, currencyMinorUnit = 2 ) {
 		const { id, name, price, variation, quantity, categories } = product;
 
 		const mappedItem = {
 			item_id: id,
 			item_name: name,
-			price: formatPrice( price ),
+			price: formatPrice( price, currencyMinorUnit ),
 		};
 
 		if ( quantity ) {
@@ -213,9 +236,10 @@
 	 * Returns the price of a product formatted with decimal places if necessary.
 	 *
 	 * @since 1.158.0
+	 * @since n.e.x.t Added the `currencyMinorUnit` parameter.
 	 *
 	 * @param {string} price                 The price to parse.
-	 * @param {number} [currencyMinorUnit=2] The number decimals to show in the currency.
+	 * @param {number} [currencyMinorUnit=2] The number of decimals used by the store currency, as configured in WooCommerce settings.
 	 * @return {number} The price of the product with decimals.
 	 */
 	function formatPrice( price, currencyMinorUnit = 2 ) {

--- a/assets/js/event-providers/woocommerce.test.js
+++ b/assets/js/event-providers/woocommerce.test.js
@@ -1,0 +1,252 @@
+/**
+ * WooCommerce event provider tests.
+ *
+ * Site Kit by Google, Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+
+// The IIFE in `./woocommerce` runs at require time and synchronously calls
+// `gtagEvent` for the `add_to_cart` and `purchase` events it finds on
+// `window._googlesitekit.wcdata`. Tests must set up that global and a
+// jQuery stub before requiring the file.
+
+const gtagEventCalls = [];
+
+function setupGlobals( {
+	currency = 'USD',
+	currencyMinorUnit = 2,
+	addToCart = null,
+	purchase = null,
+	products = [],
+	eventsToTrack = [ 'add_to_cart', 'purchase' ],
+} = {} ) {
+	gtagEventCalls.length = 0;
+
+	global._googlesitekit = {
+		...global._googlesitekit,
+		wcdata: {
+			currency,
+			currency_minor_unit: currencyMinorUnit,
+			products,
+			add_to_cart: addToCart,
+			purchase,
+			eventsToTrack,
+		},
+		gtagEvent: jest.fn( ( name, data ) => {
+			gtagEventCalls.push( { name, data } );
+		} ),
+	};
+
+	// Minimal jQuery stub — the WC provider only uses `body.on` and `.each`
+	// against the products DOM, neither of which needs to fire in unit tests.
+	global.jQuery = jest.fn( () => ( {
+		on: jest.fn(),
+		each: jest.fn(),
+		find: jest.fn( () => ( { attr: () => null } ) ),
+	} ) );
+	global.jQuery.fn = global.jQuery;
+}
+
+describe( 'WooCommerce event provider', () => {
+	beforeEach( () => {
+		jest.resetModules();
+	} );
+
+	afterEach( () => {
+		delete global._googlesitekit.wcdata;
+		delete global.jQuery;
+	} );
+
+	describe( 'add_to_cart value formatting', () => {
+		it( 'should divide by 100 when currency uses 2 decimal places', () => {
+			setupGlobals( {
+				currency: 'USD',
+				currencyMinorUnit: 2,
+				addToCart: {
+					id: 1,
+					name: 'Test Product',
+					price: 25075,
+				},
+			} );
+
+			require( './woocommerce' );
+
+			expect( gtagEventCalls ).toHaveLength( 1 );
+			expect( gtagEventCalls[ 0 ].name ).toBe( 'add_to_cart' );
+			expect( gtagEventCalls[ 0 ].data.value ).toBe( 250.75 );
+			expect( gtagEventCalls[ 0 ].data.items[ 0 ].price ).toBe( 250.75 );
+		} );
+
+		it( 'should divide by 10000 when currency uses 4 decimal places', () => {
+			setupGlobals( {
+				currency: 'BHD',
+				currencyMinorUnit: 4,
+				addToCart: {
+					id: 2,
+					name: 'High Precision Product',
+					price: 12345,
+				},
+			} );
+
+			require( './woocommerce' );
+
+			expect( gtagEventCalls ).toHaveLength( 1 );
+			expect( gtagEventCalls[ 0 ].name ).toBe( 'add_to_cart' );
+			expect( gtagEventCalls[ 0 ].data.value ).toBe( 1.2345 );
+			expect( gtagEventCalls[ 0 ].data.items[ 0 ].price ).toBe( 1.2345 );
+		} );
+
+		it( 'should pass the value through when currency uses 0 decimal places', () => {
+			setupGlobals( {
+				currency: 'JPY',
+				currencyMinorUnit: 0,
+				addToCart: {
+					id: 3,
+					name: 'Yen Product',
+					price: 12345,
+				},
+			} );
+
+			require( './woocommerce' );
+
+			expect( gtagEventCalls[ 0 ].data.value ).toBe( 12345 );
+			expect( gtagEventCalls[ 0 ].data.items[ 0 ].price ).toBe( 12345 );
+		} );
+
+		it( 'should divide by 1000 when currency uses 3 decimal places', () => {
+			setupGlobals( {
+				currency: 'KWD',
+				currencyMinorUnit: 3,
+				addToCart: {
+					id: 4,
+					name: 'KWD Product',
+					price: 250750,
+				},
+			} );
+
+			require( './woocommerce' );
+
+			expect( gtagEventCalls[ 0 ].data.value ).toBe( 250.75 );
+		} );
+	} );
+
+	describe( 'purchase value formatting', () => {
+		const purchaseFixture = {
+			id: 99,
+			totals: {
+				currency_code: 'USD',
+				total_price: 25075,
+				shipping_total: 500,
+				tax_total: 200,
+			},
+			items: [
+				{
+					id: 1,
+					name: 'Test Product',
+					price: 12345,
+					quantity: 2,
+				},
+			],
+		};
+
+		it( 'should divide purchase value by 100 with 2 decimal places', () => {
+			setupGlobals( {
+				currency: 'USD',
+				currencyMinorUnit: 2,
+				purchase: purchaseFixture,
+			} );
+
+			require( './woocommerce' );
+
+			expect( gtagEventCalls[ 0 ].name ).toBe( 'purchase' );
+			expect( gtagEventCalls[ 0 ].data.value ).toBe( 250.75 );
+			expect( gtagEventCalls[ 0 ].data.transaction_id ).toBe( 99 );
+			expect( gtagEventCalls[ 0 ].data.items[ 0 ].price ).toBe( 123.45 );
+		} );
+
+		it( 'should divide purchase value by 10000 with 4 decimal places', () => {
+			setupGlobals( {
+				currency: 'BHD',
+				currencyMinorUnit: 4,
+				purchase: {
+					...purchaseFixture,
+					totals: {
+						...purchaseFixture.totals,
+						total_price: 1234500,
+					},
+					items: [
+						{
+							id: 1,
+							name: 'Test Product',
+							price: 12345,
+							quantity: 2,
+						},
+					],
+				},
+			} );
+
+			require( './woocommerce' );
+
+			expect( gtagEventCalls[ 0 ].name ).toBe( 'purchase' );
+			expect( gtagEventCalls[ 0 ].data.value ).toBe( 123.45 );
+			expect( gtagEventCalls[ 0 ].data.items[ 0 ].price ).toBe( 1.2345 );
+		} );
+
+		it( 'should not fire purchase event when eventsToTrack excludes it', () => {
+			setupGlobals( {
+				currency: 'USD',
+				currencyMinorUnit: 2,
+				purchase: purchaseFixture,
+				eventsToTrack: [ 'add_to_cart' ],
+			} );
+
+			require( './woocommerce' );
+
+			expect( gtagEventCalls ).toHaveLength( 0 );
+		} );
+	} );
+
+	describe( 'fallback behavior', () => {
+		it( 'should default to 2 decimal places when currency_minor_unit is missing from wcdata', () => {
+			gtagEventCalls.length = 0;
+			global._googlesitekit = {
+				...global._googlesitekit,
+				wcdata: {
+					currency: 'USD',
+					products: [],
+					add_to_cart: { id: 1, name: 'X', price: 10000 },
+					purchase: null,
+					eventsToTrack: [ 'add_to_cart', 'purchase' ],
+				},
+				gtagEvent: jest.fn( ( name, data ) => {
+					gtagEventCalls.push( { name, data } );
+				} ),
+			};
+			global.jQuery = jest.fn( () => ( {
+				on: jest.fn(),
+				each: jest.fn(),
+				find: jest.fn( () => ( { attr: () => null } ) ),
+			} ) );
+			global.jQuery.fn = global.jQuery;
+
+			require( './woocommerce' );
+
+			expect( gtagEventCalls[ 0 ].data.value ).toBe( 100 );
+		} );
+	} );
+} );

--- a/includes/Core/Conversion_Tracking/Conversion_Event_Providers/WooCommerce.php
+++ b/includes/Core/Conversion_Tracking/Conversion_Event_Providers/WooCommerce.php
@@ -278,6 +278,7 @@ class WooCommerce extends Conversion_Events_Provider {
 						sprintf( 'window._googlesitekit.wcdata.products = %s;', wp_json_encode( $this->products ) ),
 						sprintf( 'window._googlesitekit.wcdata.add_to_cart = %s;', wp_json_encode( $this->add_to_cart ) ),
 						sprintf( 'window._googlesitekit.wcdata.currency = "%s";', esc_js( get_woocommerce_currency() ) ),
+						sprintf( 'window._googlesitekit.wcdata.currency_minor_unit = %d;', absint( wc_get_price_decimals() ) ),
 						sprintf( 'window._googlesitekit.wcdata.eventsToTrack = %s;', wp_json_encode( $events_to_track ) ),
 					)
 				);
@@ -647,6 +648,7 @@ class WooCommerce extends Conversion_Events_Provider {
 				"\n",
 				array(
 					'window._googlesitekit.wcdata = window._googlesitekit.wcdata || {};',
+					sprintf( 'window._googlesitekit.wcdata.currency_minor_unit = %d;', absint( wc_get_price_decimals() ) ),
 					sprintf( 'window._googlesitekit.wcdata.purchase = %s;', wp_json_encode( $this->get_formatted_order( $order ) ) ),
 				)
 			),

--- a/tests/phpunit/includes/wc-functions-stub.php
+++ b/tests/phpunit/includes/wc-functions-stub.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * WooCommerce function stubs for tests.
+ *
+ * Defines the small subset of WooCommerce global-namespace functions used by
+ * the Site Kit conversion-event provider so the provider can be exercised in
+ * test environments without a fully active WooCommerce plugin.
+ *
+ * @package   Google\Site_Kit\Tests
+ * @copyright 2026 Google LLC
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
+ * @link      https://sitekit.withgoogle.com
+ */
+
+if ( ! function_exists( 'wc_get_price_decimals' ) ) {
+	/**
+	 * Stub of the WooCommerce helper.
+	 *
+	 * Reads from the `woocommerce_price_decimals` option, falling back to 2
+	 * to mirror the WooCommerce default.
+	 *
+	 * @return int Number of decimal places used by the store currency.
+	 */
+	function wc_get_price_decimals() {
+		return (int) get_option( 'woocommerce_price_decimals', 2 );
+	}
+}
+
+if ( ! function_exists( 'wc_format_decimal' ) ) {
+	/**
+	 * Stub of the WooCommerce helper.
+	 *
+	 * Strips everything except digits and the decimal point.
+	 *
+	 * @param mixed $value Value to normalize.
+	 * @return string|float Normalized numeric value.
+	 */
+	function wc_format_decimal( $value ) {
+		if ( is_string( $value ) ) {
+			return preg_replace( '/[^0-9.]/', '', $value );
+		}
+		return $value;
+	}
+}
+
+if ( ! function_exists( 'get_woocommerce_currency' ) ) {
+	/**
+	 * Stub of the WooCommerce helper.
+	 *
+	 * Returns the currency code stored on the `woocommerce_currency` option,
+	 * defaulting to USD.
+	 *
+	 * @return string Currency code.
+	 */
+	function get_woocommerce_currency() {
+		return (string) get_option( 'woocommerce_currency', 'USD' );
+	}
+}
+
+if ( ! function_exists( 'is_wc_endpoint_url' ) ) {
+	/**
+	 * Stub of the WooCommerce helper.
+	 *
+	 * @param string|false $endpoint Optional endpoint to check for. Unused in tests.
+	 * @return bool Always false; the test never runs on a real WC endpoint URL.
+	 */
+	function is_wc_endpoint_url( $endpoint = false ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter
+		return false;
+	}
+}

--- a/tests/phpunit/integration/Core/Conversion_Tracking/Conversion_Event_Providers/WooCommerceTest.php
+++ b/tests/phpunit/integration/Core/Conversion_Tracking/Conversion_Event_Providers/WooCommerceTest.php
@@ -492,4 +492,86 @@ class WooCommerceTest extends TestCase {
 		// Enhanced_Conversions normalizes to lowercase and trims, but keeps other chars.
 		$this->assertEquals( '+94771770589', $result, 'Normalized phone should fall back when country is empty.' );
 	}
+
+	/**
+	 * @dataProvider formatted_price_decimals_provider
+	 * @runInSeparateProcess
+	 */
+	public function test_get_formatted_price_returns_correct_minor_units( $decimals, $value, $expected ) {
+		require_once $this->wc_functions_stub_path();
+
+		update_option( 'woocommerce_price_decimals', $decimals );
+
+		$reflection = new \ReflectionClass( $this->woocommerce );
+		$method     = $reflection->getMethod( 'get_formatted_price' );
+		$method->setAccessible( true );
+
+		$this->assertSame(
+			$expected,
+			$method->invoke( $this->woocommerce, $value ),
+			"get_formatted_price with {$decimals} decimals should produce the expected minor-unit count."
+		);
+
+		delete_option( 'woocommerce_price_decimals' );
+	}
+
+	public function formatted_price_decimals_provider() {
+		return array(
+			'2 decimals (USD) - whole units'      => array( 2, 10, 1000 ),
+			'2 decimals (USD) - fractional units' => array( 2, '10.50', 1050 ),
+			'2 decimals (USD) - 4-decimal input'  => array( 2, '10.5050', 1051 ),
+			'4 decimals (BHD) - fractional units' => array( 4, '1.2345', 12345 ),
+			'0 decimals (JPY) - whole units'      => array( 0, 500, 500 ),
+			'0 decimals (JPY) - decimal input'    => array( 0, '500.99', 501 ),
+		);
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 * @expectedDeprecated the_block_template_skip_link
+	 */
+	public function test_inline_script_emits_currency_minor_unit() {
+		require_once $this->wc_functions_stub_path();
+
+		update_option( 'woocommerce_price_decimals', 4 );
+
+		// Register a stub for the `woocommerce` dependency so the WP test
+		// environment's strict enqueue checks do not flag the provider script.
+		wp_register_script( 'woocommerce', false, array(), '0.0.0', true );
+
+		// Register the script + hooks, then enqueue so the inline data added
+		// by `wp_add_inline_script()` lands in the WP_Scripts store.
+		$this->woocommerce->register_script();
+		$this->woocommerce->register_hooks();
+		wp_enqueue_script( 'googlesitekit-events-provider-woocommerce' );
+
+		// Capture the wp_footer output (which also emits block-theme deprecations,
+		// declared above as `@expectedDeprecated`).
+		ob_start();
+		do_action( 'wp_footer' );
+		$footer = ob_get_clean();
+
+		// The inline data added by `wp_add_inline_script( ..., 'before' )` lives
+		// under the "{$handle}_before" key in `WP_Scripts::$data`. Read it
+		// directly so the test does not need to render the full page.
+		$wp_scripts  = wp_scripts();
+		$inline_data = $wp_scripts->get_data( 'googlesitekit-events-provider-woocommerce', 'before' );
+		$footer     .= is_array( $inline_data ) ? implode( "\n", $inline_data ) : '';
+
+		$this->assertStringContainsString(
+			'wcdata.currency_minor_unit = 4;',
+			$footer,
+			'wp_footer inline script should expose currency_minor_unit to the WC event provider JS.'
+		);
+
+		delete_option( 'woocommerce_price_decimals' );
+	}
+
+	/**
+	 * Path to the WooCommerce function stubs used when WooCommerce is not
+	 * active in the test environment.
+	 */
+	private function wc_functions_stub_path() {
+		return dirname( __DIR__, 4 ) . '/includes/wc-functions-stub.php';
+	}
 }


### PR DESCRIPTION
## Summary
WooCommerce `add_to_cart` and `purchase` events sent to GA4 now reflect the store's configured currency precision. Previously the JS helper that converted the integer minor-unit price back into a decimal value was hard-coded to divide by 100, so any store that set WooCommerce → Settings → General → Currency options → Number of decimals to anything other than 2 (e.g. 4 for BHD, 0 for JPY, 3 for KWD/OMR/TND) saw the wrong value arrive in GA4.

Fixes #12986

## Changes

### `includes/Core/Conversion_Tracking/Conversion_Event_Providers/WooCommerce.php`

**Before:** the `wp_footer` and `maybe_add_purchase_inline_script` inline scripts emitted the `wcdata` global with currency, products, add_to_cart, purchase, and eventsToTrack fields only. The decimal conversion happened downstream in JS, which had no way to read the store's minor-unit count.

**After:** both inline scripts also emit `window._googlesitekit.wcdata.currency_minor_unit = <absint wc_get_price_decimals()>;` so JS can recover the correct decimal precision.

```php
sprintf( 'window._googlesitekit.wcdata.currency_minor_unit = %d;', absint( wc_get_price_decimals() ) ),
```

### `assets/js/event-providers/woocommerce.js`

**Before:** `formatPrice` defaulted to `currencyMinorUnit = 2` and the value was hard-coded at every call site.

**After:** `formatPrice` keeps `= 2` as a defensive fallback but is now always called with the value read from the `wcdata` global. The new `globalCurrencyMinorUnit` is destructured alongside `globalCurrency` and passed into `formatEventData` / `formatProductData`, which in turn pass it to `formatPrice` for both the top-level `value` and each `items[].price`.

```js
const {
    currency: globalCurrency,
    currency_minor_unit: globalCurrencyMinorUnit = 2,
    ...
} = global._googlesitekit?.wcdata || {};
```

## Testing

**Test 1: PHP price formatter honors the decimals option**
1. `composer test -- --filter WooCommerceTest::test_get_formatted_price_returns_correct_minor_units`
2. Test sets `woocommerce_price_decimals` to 0, 2, and 4 and verifies `get_formatted_price()` produces the expected integer minor-unit count (e.g. 1.2345 with decimals=4 yields 12345, 500 with decimals=0 yields 500).

Result: 6 dataset cases pass.

**Test 2: inline script exposes the decimals value to JS**
1. `composer test -- --filter WooCommerceTest::test_inline_script_emits_currency_minor_unit`
2. Test registers the provider script, fires `wp_footer`, and asserts the rendered output contains `wcdata.currency_minor_unit = 4;` after setting `woocommerce_price_decimals = 4`.

Result: passes.

**Test 3: JS event provider formats values per currency decimals**
1. `BABEL_ENV=test NODE_ENV=test node_modules/.bin/jest --config tests/js/jest.config.js --rootDir . --passWithNoTests assets/js/event-providers/woocommerce.test.js`
2. Covers 0/2/3/4 decimals on both `add_to_cart` and `purchase` events, plus the fallback when `currency_minor_unit` is missing from `wcdata`.

Result: 8 tests pass.

**Test 4: lint clean**
1. `composer lint -- includes/Core/Conversion_Tracking/Conversion_Event_Providers/WooCommerce.php tests/phpunit/integration/Core/Conversion_Tracking/Conversion_Event_Providers/WooCommerceTest.php tests/phpunit/includes/wc-functions-stub.php`
2. `node_modules/.bin/eslint --no-eslintrc --config .eslintrc.json --ignore-path .eslintignore assets/js/event-providers/woocommerce.js assets/js/event-providers/woocommerce.test.js`

Result: clean.

## Manual reproduction (before this fix)

1. Set `Number of decimals` to 4 under WooCommerce → Settings → General → Currency options.
2. Add a product priced at 1.2345.
3. Open Google Tag Assistant; click Add to cart.
4. Before the fix: `dataLayer` shows `value: 123.45` and `items[0].price: 123.45`. After the fix: both show `1.2345`.