### PR TITLE
Add PageSpeed details link URL selector

### DIFF
--- a/assets/js/modules/pagespeed-insights/datastore/service.js
+++ b/assets/js/modules/pagespeed-insights/datastore/service.js
@@ -21,6 +21,13 @@
  */
 import { addQueryArgs } from '@wordpress/url';
 
+/**
+ * Internal dependencies
+ */
+import { createRegistrySelector } from 'googlesitekit-data';
+import { CORE_SITE } from '@/js/googlesitekit/datastore/site/constants';
+import { MODULES_PAGESPEED_INSIGHTS } from './constants';
+
 export const selectors = {
 	/**
 	 * Gets a URL to the service.
@@ -47,6 +54,24 @@ export const selectors = {
 			utm_source: 'sitekit',
 		} );
 	},
+
+	/**
+	 * Gets the details link URL for the module.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @return {string} Details link URL.
+	 */
+	getDetailsLinkURL: createRegistrySelector( ( select ) => () => {
+		const siteURL = select( CORE_SITE ).getReferenceSiteURL();
+
+		return select( MODULES_PAGESPEED_INSIGHTS ).getServiceURL( {
+			path: 'report',
+			query: {
+				url: siteURL,
+			},
+		} );
+	} ),
 };
 
 const store = {

--- a/assets/js/modules/pagespeed-insights/datastore/service.test.js
+++ b/assets/js/modules/pagespeed-insights/datastore/service.test.js
@@ -20,6 +20,7 @@
  *
  * Internal dependencies
  */
+import { CORE_SITE } from '@/js/googlesitekit/datastore/site/constants';
 import { CORE_USER } from '@/js/googlesitekit/datastore/user/constants';
 import { createTestRegistry } from '@tests/js/utils';
 import { MODULES_PAGESPEED_INSIGHTS } from './constants';
@@ -93,6 +94,25 @@ describe( 'module/pagespeed-insights service store', () => {
 					.getServiceURL();
 
 				expect( serviceURL ).toMatchQueryParameters( {
+					utm_source: 'sitekit',
+				} );
+			} );
+		} );
+
+		describe( 'getDetailsLinkURL', () => {
+			it( 'returns the PageSpeed report URL for the reference site', () => {
+				const referenceSiteURL = 'https://example.com/test-page/';
+				registry.dispatch( CORE_SITE ).receiveSiteInfo( {
+					referenceSiteURL,
+				} );
+
+				const detailsLinkURL = registry
+					.select( MODULES_PAGESPEED_INSIGHTS )
+					.getDetailsLinkURL();
+
+				expect( new URL( detailsLinkURL ).pathname ).toBe( '/report' );
+				expect( detailsLinkURL ).toMatchQueryParameters( {
+					url: referenceSiteURL,
 					utm_source: 'sitekit',
 				} );
 			} );


### PR DESCRIPTION
## Summary

Addresses issue:

- #10870

## Relevant technical choices

- Add a PageSpeed Insights `getDetailsLinkURL` selector that reuses `getServiceURL`.
- Build the PageSpeed report URL with the reference site URL and the existing `utm_source=sitekit` parameter.
- Add datastore coverage for the report path and both query parameters.

### Testing

- `npx jest --config=jest.config.js --runInBand --selectProjects="Site Kit" --testMatch="<rootDir>/assets/js/modules/pagespeed-insights/datastore/service.test.js"` — 5 tests passed.
- `npm run lint:js:files -- assets/js/modules/pagespeed-insights/datastore/service.js assets/js/modules/pagespeed-insights/datastore/service.test.js` — passed.
- `git diff --check` — passed.

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [ ] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.
- [ ] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.