### PR TITLE
[COMMUNITY PR] Fix: Add in-progress notice to PDF export panel

### DIFF
--- a/assets/js/components/pdf-export/PDFSectionsSelectionPanel/PanelContent.test.tsx
+++ b/assets/js/components/pdf-export/PDFSectionsSelectionPanel/PanelContent.test.tsx
@@ -141,15 +141,21 @@ describe( 'PanelContent', () => {
 	/**
 	 * Renders the panel with the test registry, on the main dashboard.
 	 *
+	 * @param isOpen
 	 * @since 1.184.0
+	 *
+	 * @param {boolean} [isOpen] Optional. Whether the panel is open.
 	 *
 	 * @return The testing-library render result.
 	 */
-	function renderPanel() {
-		return render( <PanelContent closePanel={ () => {} } />, {
-			registry,
-			viewContext: VIEW_CONTEXT_MAIN_DASHBOARD,
-		} );
+	function renderPanel( isOpen = true ) {
+		return render(
+			<PanelContent closePanel={ () => {} } isOpen={ isOpen } />,
+			{
+				registry,
+				viewContext: VIEW_CONTEXT_MAIN_DASHBOARD,
+			}
+		);
 	}
 
 	it( "stores the context slugs in the dashboard's own order when the panel first opens", async () => {
@@ -199,6 +205,47 @@ describe( 'PanelContent', () => {
 			expect(
 				registry.select( CORE_PDF ).getSelectedContextSlugs()
 			).toEqual( DASHBOARD_ORDER );
+		} );
+	} );
+
+	it( 'renders the in-progress notice when the panel is open while a report is generating', async () => {
+		registry.dispatch( CORE_PDF ).startExporting();
+
+		const { findByText } = renderPanel( true );
+
+		expect(
+			await findByText( /Your report is being generated/i )
+		).toBeInTheDocument();
+	} );
+
+	it( 'does not render the in-progress notice when the panel is closed while a report is generating', async () => {
+		registry.dispatch( CORE_PDF ).startExporting();
+
+		const { queryByText, findByRole } = renderPanel( false );
+
+		// Wait for the panel to render its content.
+		await findByRole( 'button', { name: /Download report/i } );
+
+		expect(
+			queryByText( /Your report is being generated/i )
+		).not.toBeInTheDocument();
+	} );
+
+	it( 'clears the in-progress notice when the report finishes generating', async () => {
+		registry.dispatch( CORE_PDF ).startExporting();
+
+		const { findByText, queryByText } = renderPanel( true );
+
+		expect(
+			await findByText( /Your report is being generated/i )
+		).toBeInTheDocument();
+
+		registry.dispatch( CORE_PDF ).finishExporting();
+
+		await waitFor( () => {
+			expect(
+				queryByText( /Your report is being generated/i )
+			).not.toBeInTheDocument();
 		} );
 	} );
 } );

--- a/assets/js/components/pdf-export/PDFSectionsSelectionPanel/PanelContent.tsx
+++ b/assets/js/components/pdf-export/PDFSectionsSelectionPanel/PanelContent.tsx
@@ -58,9 +58,10 @@ import PDFSectionCheckboxes from './PDFSectionCheckboxes';
 
 interface PanelContentProps {
 	closePanel: () => void;
+	isOpen?: boolean;
 }
 
-const PanelContent: FC< PanelContentProps > = ( { closePanel } ) => {
+const PanelContent: FC< PanelContentProps > = ( { closePanel, isOpen } ) => {
 	const viewOnly = useViewOnly();
 
 	const availableSections = useSelect(
@@ -144,6 +145,15 @@ const PanelContent: FC< PanelContentProps > = ( { closePanel } ) => {
 
 	const selectedWidgetSlugs = useSelect(
 		( select: Select ) => select( CORE_PDF ).getSelectedWidgetSlugs(),
+		[]
+	);
+
+	const isExporting = useSelect(
+		( select: Select ) => select( CORE_PDF ).isExporting(),
+		[]
+	);
+	const exportStatus = useSelect(
+		( select: Select ) => select( CORE_PDF ).getStatus(),
 		[]
 	);
 
@@ -256,6 +266,7 @@ const PanelContent: FC< PanelContentProps > = ( { closePanel } ) => {
 	);
 
 	const hasSelection = selectedWidgetSlugs.length > 0;
+	const inFlight = !! isExporting || exportStatus === 'progress';
 
 	return (
 		<Fragment>
@@ -282,6 +293,21 @@ const PanelContent: FC< PanelContentProps > = ( { closePanel } ) => {
 							) }
 						</Typography>
 					}
+				/>
+			) }
+			{ isOpen && inFlight && (
+				<SelectionPanelNotice
+					// @ts-expect-error - The `SelectionPanelNotice` component is not yet typed.
+					className="googlesitekit-notice--side-panel googlesitekit-pdf-download-panel__notice"
+					type={ NOTICE_TYPES.WARNING }
+					title={ __(
+						'Your report is being generated',
+						'google-site-kit'
+					) }
+					description={ __(
+						'To create another report, please wait for the current download to complete.',
+						'google-site-kit'
+					) }
 				/>
 			) }
 			<Footer closePanel={ closePanel } hasSelection={ hasSelection } />

--- a/assets/js/components/pdf-export/PDFSectionsSelectionPanel/index.stories.tsx
+++ b/assets/js/components/pdf-export/PDFSectionsSelectionPanel/index.stories.tsx
@@ -63,6 +63,16 @@ function EmptyTemplate() {
 	return <PDFSectionsSelectionPanel />;
 }
 
+function GeneratingTemplate() {
+	const { startExporting } = useDispatch( CORE_PDF );
+
+	useEffect( () => {
+		startExporting();
+	}, [ startExporting ] );
+
+	return <PDFSectionsSelectionPanel />;
+}
+
 export const Default = DefaultTemplate.bind( {} );
 Default.storyName = 'Default (all selected)';
 Default.scenario = {};
@@ -70,6 +80,10 @@ Default.scenario = {};
 export const Empty = EmptyTemplate.bind( {} );
 Empty.storyName = 'All deselected (error state)';
 Empty.scenario = {};
+
+export const Generating = GeneratingTemplate.bind( {} );
+Generating.storyName = 'Generating (warning notice)';
+Generating.scenario = {};
 
 export default {
 	title: 'Components/PDFGeneration/PDFSectionsSelectionPanel',

--- a/assets/js/components/pdf-export/PDFSectionsSelectionPanel/index.tsx
+++ b/assets/js/components/pdf-export/PDFSectionsSelectionPanel/index.tsx
@@ -85,7 +85,7 @@ const PDFSectionsSelectionPanel: FC = () => {
 				isOpen={ !! isOpen }
 				closePanel={ closePanel }
 			>
-				<PanelContent closePanel={ closePanel } />
+				<PanelContent closePanel={ closePanel } isOpen={ !! isOpen } />
 			</SelectionPanel>
 		</InViewProvider>
 	);


### PR DESCRIPTION
## Addresses issue:
Fixes #13175

## Description
This PR addresses an issue where the PDF export panel failed to show the "Your report is being generated" warning notice if the panel was re-opened while a report generation was in flight. 

The `isOpen` state from the top-level selection panel is now passed down to `PanelContent.tsx`, which correctly checks both the panel state and the export state (`isExporting()` and `getStatus() === 'progress'`). This ensures the warning notice renders appropriately while preventing it from flashing momentarily during the closing animation.

## Testing
* Added tests in `PanelContent.test.tsx` to assert that the notice correctly renders, clears, and stays hidden when expected.
* Added a new Visual Regression Testing story (`Generating`) in `index.stories.tsx` to snapshot the panel while the generation notice is active.
