### PR TITLE
Enhancement/#13008 - Implement feature flag for RRM user settings (follow-up)

### DIFF
--- a/includes/Modules/Reader_Revenue_Manager.php
+++ b/includes/Modules/Reader_Revenue_Manager.php
@@ -50,6 +50,7 @@ use Google\Site_Kit\Core\Tags\Guards\Tag_Verify_Guard;
 use Google\Site_Kit\Core\Tracking\Feature_Metrics_Trait;
 use Google\Site_Kit\Core\Tracking\Provides_Feature_Metrics;
 use Google\Site_Kit\Core\Util\Block_Support;
+use Google\Site_Kit\Core\Util\Feature_Flags;
 use Google\Site_Kit\Core\Util\Method_Proxy_Trait;
 use Google\Site_Kit\Core\Util\URL;
 use Google\Site_Kit\Modules\Reader_Revenue_Manager\Admin_Post_List;
@@ -185,7 +186,10 @@ final class Reader_Revenue_Manager extends Module implements Module_With_Scopes,
 	public function register() {
 		$this->register_scopes_hook();
 		$this->register_feature_metrics();
-		$this->user_settings->register();
+
+		if ( Feature_Flags::enabled( 'rrmExpressSetup' ) ) {
+			$this->user_settings->register();
+		}
 
 		$synchronize_publication = new Synchronize_Publication(
 			$this,
@@ -367,26 +371,31 @@ final class Reader_Revenue_Manager extends Module implements Module_With_Scopes,
 	 * @return array Map of datapoints to their definitions.
 	 */
 	protected function get_datapoint_definitions() {
-		return array(
+		$datapoints = array(
 			'GET:publications'                       => array(
 				'service' => 'subscribewithgoogle',
 			),
 			'POST:sync-publication-onboarding-state' => array(
 				'service' => 'subscribewithgoogle',
 			),
-			'GET:user-settings'                      => new Get_User_Settings(
-				array(
-					'user_settings' => $this->user_settings,
-					'service'       => '',
-				)
-			),
-			'POST:user-settings'                     => new Save_User_Settings(
-				array(
-					'user_settings' => $this->user_settings,
-					'service'       => '',
-				)
-			),
 		);
+
+		if ( Feature_Flags::enabled( 'rrmExpressSetup' ) ) {
+			$datapoints['GET:user-settings']  = new Get_User_Settings(
+				array(
+					'user_settings' => $this->user_settings,
+					'service'       => '',
+				)
+			);
+			$datapoints['POST:user-settings'] = new Save_User_Settings(
+				array(
+					'user_settings' => $this->user_settings,
+					'service'       => '',
+				)
+			);
+		}
+
+		return $datapoints;
 	}
 
 	/**

--- a/tests/phpunit/integration/Modules/Reader_Revenue_ManagerTest.php
+++ b/tests/phpunit/integration/Modules/Reader_Revenue_ManagerTest.php
@@ -194,10 +194,23 @@ class Reader_Revenue_ManagerTest extends TestCase {
 			array(
 				'publications',
 				'sync-publication-onboarding-state',
-				'user-settings',
 			),
 			$this->reader_revenue_manager->get_datapoints(),
 			'Reader Revenue Manager module should have correct datapoints.'
+		);
+	}
+
+	public function test_get_datapoints__with_express_setup_flag() {
+		$this->enable_feature( 'rrmExpressSetup' );
+
+		$this->assertEqualSets(
+			array(
+				'publications',
+				'sync-publication-onboarding-state',
+				'user-settings',
+			),
+			$this->reader_revenue_manager->get_datapoints(),
+			'Reader Revenue Manager module should include the user settings datapoints when the express setup flag is enabled.'
 		);
 	}
 


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Related issue(s):

- Resolves #13008 

## Relevant technical choices

- This follow-up PR guards the RRM user settings REST/datastore infrastructure behind the `rrmExpressSetup` feature flag, which was missed in the original PR.

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [x] Run the code.
- [x] Ensure the acceptance criteria are satisfied.
- [x] Reassess the implementation with the IB.
- [x] Ensure no unrelated changes are included.
- [x] Ensure CI checks pass.
- [x] Check Storybook where applicable.
- [x] Ensure there is a QA Brief.
- [x] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [x] Ensure the PR has the correct target branch.
- [x] Double-check that the PR is okay to be merged.
- [x] Ensure the corresponding issue has a ZenHub release assigned.
- [x] Add a changelog message to the issue.
