### PR TITLE
Remove fixed width from Outlook VML dashboard button so it fits any label.

### DIFF
--- a/includes/Core/Email_Reporting/templates/parts/dashboard-link.php
+++ b/includes/Core/Email_Reporting/templates/parts/dashboard-link.php
@@ -15,7 +15,7 @@ $label = $label ?? __( 'Open dashboard', 'google-site-kit' );
 ?>
 <?php /* Outlook requires custom VML for rounded corners. */ ?>
 <!--[if mso]>
-<v:roundrect xmlns:v="urn:schemas-microsoft-com:vml" xmlns:w="urn:schemas-microsoft-com:office:word" href="<?php echo esc_url( $url ); ?>" style="mso-wrap-style:none; mso-fit-shape-to-text: true; height:36; width:134;" arcsize="50%" strokecolor="#3C7251" fillcolor="#3C7251">
+<v:roundrect xmlns:v="urn:schemas-microsoft-com:vml" xmlns:w="urn:schemas-microsoft-com:office:word" href="<?php echo esc_url( $url ); ?>" style="mso-wrap-style:none; mso-fit-shape-to-text: true; height:36;" arcsize="50%" strokecolor="#3C7251" fillcolor="#3C7251">
 <w:anchorlock/>
 <center style="font-family:Arial,sans-serif; font-size:14px; font-weight:500; color:#ffffff; text-decoration:none; mso-line-height-rule:exactly;">
 <?php echo esc_html( $label ); ?>

--- a/tests/phpunit/integration/Core/Email_Reporting/Email_Template_RendererTest.php
+++ b/tests/phpunit/integration/Core/Email_Reporting/Email_Template_RendererTest.php
@@ -89,4 +89,55 @@ class Email_Template_RendererTest extends TestCase {
 		$this->assertStringNotContainsString( 'Notice title', $html_output_without_notice, 'Expected notice title to be absent when no header notices are provided.' );
 		$this->assertStringNotContainsString( 'https://example.com/notice-cta', $html_output_without_notice, 'Expected notice CTA URL to be absent when no header notices are provided.' );
 	}
+
+	public function test_dashboard_link_renders_outlook_vml_and_html_anchor_branches() {
+		$context = new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE );
+		$golinks = new Golinks( $context );
+		$golinks->register_handler( 'dashboard', new Dashboard_Golink_Handler() );
+
+		$payload = array(
+			'total_visitors' => array(
+				'label'          => 'Total visitors',
+				'value'          => '120',
+				'change'         => 20,
+				'change_context' => 'Compared to previous 7 days',
+			),
+		);
+
+		$sections_map = new Sections_Map( $context, $payload, $golinks );
+		$renderer     = new Email_Template_Renderer( $sections_map );
+
+		$template_data = array(
+			'subject'                => 'Test subject',
+			'preheader'              => 'Test preheader',
+			'site'                   => array(
+				'domain' => 'example.com',
+				'url'    => 'https://example.com',
+			),
+			'date_range'             => array(
+				'label'   => 'Jan 1 – Jan 7',
+				'context' => 'Compared to previous 7 days',
+			),
+			'header_notices'         => array(),
+			'primary_call_to_action' => array(
+				'label' => 'View dashboard',
+				'url'   => 'https://example.com/dashboard',
+			),
+			'footer'                 => array(
+				'copy'            => 'Footer text',
+				'unsubscribe_url' => 'https://example.com/unsubscribe',
+				'links'           => array(),
+			),
+		);
+
+		$html_output = $renderer->render( 'email-report', $template_data );
+
+		$vml_matched = preg_match( '#<v:roundrect[^>]*href="https://example\.com/dashboard"[^>]*>(.*?)</v:roundrect>#s', $html_output, $vml_matches );
+		$this->assertSame( 1, $vml_matched, 'Expected an Outlook VML roundrect button linking to the dashboard.' );
+		$this->assertStringContainsString( 'View dashboard', $vml_matches[1], 'Expected the label inside the VML roundrect branch.' );
+
+		$anchor_matched = preg_match( '#<a class="button" href="https://example\.com/dashboard"[^>]*>(.*?)</a>#s', $html_output, $anchor_matches );
+		$this->assertSame( 1, $anchor_matched, 'Expected an HTML anchor button linking to the dashboard.' );
+		$this->assertStringContainsString( 'View dashboard', $anchor_matches[1], 'Expected the label inside the HTML anchor branch.' );
+	}
 }


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Related issue(s):

- Resolves #12428

## Relevant technical choices

- Removed the hardcoded `width:134` from the Outlook `v:roundrect` in the shared `dashboard-link` part, leaving `mso-wrap-style:none; mso-fit-shape-to-text: true; height:36` so Word sizes the shape to fit any label. This mirrors the existing working VML pattern in the `change-badge` part.
- The `[if !mso]` anchor branch and the `.button` styles are unchanged, so all non-Outlook clients keep their current appearance.
- Verified via Mailgun Inspect (Email on Acid client matrix): the button now renders as a fully rounded pill fitting its label in Outlook Microsoft 365 on Windows 11 (light and dark mode) for both the report email and the simple emails, with no regression in Apple Mail, Gmail, or the other previewed clients.
- Extended the renderer test to assert both the VML `v:roundrect` block and the HTML anchor are emitted with the CTA label in each branch.

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [ ] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.
- [ ] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
