### PR TITLE
Show module attribution in RRM express setup conditionally

### DIFF
--- a/assets/js/modules/reader-revenue-manager/components/setup/SetupMainExpress/ExpressSetupLayout.test.tsx
+++ b/assets/js/modules/reader-revenue-manager/components/setup/SetupMainExpress/ExpressSetupLayout.test.tsx
@@ -24,6 +24,7 @@ import {
 	BREAKPOINT_SMALL,
 	useBreakpoint,
 } from '@/js/hooks/useBreakpoint';
+import { mockLocation } from '@tests/js/mock-browser-utils';
 import { render } from '@tests/js/test-utils';
 import ExpressSetupLayout from './ExpressSetupLayout';
 
@@ -35,11 +36,15 @@ jest.mock( '@/js/hooks/useBreakpoint', () => ( {
 jest.mock( './PoweredBy', () => () => <div>Powered by RRM</div> );
 
 describe( 'ExpressSetupLayout', () => {
+	mockLocation();
+
 	beforeEach( () => {
 		( useBreakpoint as jest.Mock ).mockReturnValue( BREAKPOINT_DESKTOP );
 	} );
 
 	it( 'renders the supplied sidebar and content', () => {
+		global.location.href = 'http://example.com/';
+
 		const { getByText } = render(
 			<ExpressSetupLayout sidebar={ <div>Setup steps</div> }>
 				<div>Step content</div>
@@ -50,7 +55,21 @@ describe( 'ExpressSetupLayout', () => {
 		expect( getByText( 'Step content' ) ).toBeInTheDocument();
 	} );
 
-	it( 'renders the module attribution in the sidebar on desktop', () => {
+	it( 'does not render the module attribution when no CTA is specified', () => {
+		global.location.href = 'http://example.com/';
+
+		const { queryByText } = render(
+			<ExpressSetupLayout sidebar={ <div>Setup steps</div> }>
+				<div>Step content</div>
+			</ExpressSetupLayout>
+		);
+
+		expect( queryByText( 'Powered by RRM' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'renders the module attribution in the sidebar on desktop when a CTA is specified', () => {
+		global.location.href = 'http://example.com/?cta=newsletter-signup';
+
 		const { container, getByText } = render(
 			<ExpressSetupLayout sidebar={ <div>Setup steps</div> }>
 				<div>Step content</div>
@@ -69,8 +88,9 @@ describe( 'ExpressSetupLayout', () => {
 		).toBeInTheDocument();
 	} );
 
-	it( 'renders the module attribution in the footer on mobile', () => {
+	it( 'renders the module attribution in the footer on mobile when a CTA is specified', () => {
 		( useBreakpoint as jest.Mock ).mockReturnValue( BREAKPOINT_SMALL );
+		global.location.href = 'http://example.com/?cta=newsletter-signup';
 
 		const { getByText } = render(
 			<ExpressSetupLayout sidebar={ <div>Setup steps</div> }>

--- a/assets/js/modules/reader-revenue-manager/components/setup/SetupMainExpress/ExpressSetupLayout.tsx
+++ b/assets/js/modules/reader-revenue-manager/components/setup/SetupMainExpress/ExpressSetupLayout.tsx
@@ -29,6 +29,7 @@ import {
 	BREAKPOINT_TABLET,
 	useBreakpoint,
 } from '@/js/hooks/useBreakpoint';
+import useQueryArg from '@/js/hooks/useQueryArg';
 import { Cell, Grid, Row } from '@/js/material-components';
 import PoweredBy from './PoweredBy';
 
@@ -41,10 +42,12 @@ const ExpressSetupLayout: FC< ExpressSetupLayoutProps > = ( {
 	children,
 	sidebar,
 } ) => {
+	const [ cta ] = useQueryArg( 'cta' );
 	const breakpoint = useBreakpoint();
 	const isMobileOrTablet = [ BREAKPOINT_SMALL, BREAKPOINT_TABLET ].includes(
 		breakpoint
 	);
+	const showPoweredBy = !! cta;
 
 	return (
 		<Grid className="googlesitekit-rrm-express-setup" collapsed>
@@ -57,7 +60,7 @@ const ExpressSetupLayout: FC< ExpressSetupLayoutProps > = ( {
 				>
 					<div className="googlesitekit-rrm-express-setup__sidebar-inner">
 						{ sidebar }
-						{ ! isMobileOrTablet && <PoweredBy /> }
+						{ showPoweredBy && ! isMobileOrTablet && <PoweredBy /> }
 					</div>
 				</Cell>
 				<Cell
@@ -72,7 +75,7 @@ const ExpressSetupLayout: FC< ExpressSetupLayoutProps > = ( {
 						</Row>
 					</Grid>
 				</Cell>
-				{ isMobileOrTablet && (
+				{ showPoweredBy && isMobileOrTablet && (
 					<Cell
 						size={ 12 }
 						className="googlesitekit-rrm-express-setup__footer"


### PR DESCRIPTION
…on based on CTA presence.

## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Related issue(s):

- Resolves https://github.com/google/site-kit-wp/issues/12997#issuecomment-5177060067

## Relevant technical choices

This PR updates the RRM express setup shell so that the module attribution only appears when the user uses the express setup to set up a CTA. When the express setup is used to set up the module only, the module attribution is not required, as it is automatically implied.

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [x] Run the code.
- [x] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [x] Ensure there is a QA Brief.
- [x] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [x] Ensure the PR has the correct target branch.
- [x] Double-check that the PR is okay to be merged.
- [x] Ensure the corresponding issue has a ZenHub release assigned.
- [x] Add a changelog message to the issue.
