### PR TITLE
Align PDF panel checkbox wordings with Figma

### DIFF
--- a/assets/js/modules/adsense/widgets/index.js
+++ b/assets/js/modules/adsense/widgets/index.js
@@ -138,7 +138,7 @@ export function registerWidgets( widgets ) {
 			pdf: {
 				Component: ModuleOverviewWidgetPDF,
 				getData: getModuleOverviewPDFData,
-				label: __( 'Earning performance over time', 'google-site-kit' ),
+				label: __( 'Earning performance', 'google-site-kit' ),
 			},
 		},
 		[ AREA_MAIN_DASHBOARD_MONETIZATION_PRIMARY ]
@@ -168,7 +168,7 @@ export function registerWidgets( widgets ) {
 			pdf: {
 				Component: DashboardTopEarningPagesWidgetGA4PDF,
 				getData: getTopEarningPagesPDFData,
-				label: __( 'Earning performance', 'google-site-kit' ),
+				label: __( 'Top earning pages', 'google-site-kit' ),
 				isActive: ( select ) =>
 					select( MODULES_ANALYTICS_4 ).getAdSenseLinked() === true,
 			},

--- a/assets/js/modules/adsense/widgets/index.test.ts
+++ b/assets/js/modules/adsense/widgets/index.test.ts
@@ -44,14 +44,14 @@ describe( 'AdSense widget registrations', () => {
 		registerDefaultWidgets( widgets );
 	} );
 
-	it( 'should register the Earning performance over time PDF config on the overview widget', () => {
+	it( 'should register the Earning performance PDF config on the overview widget', () => {
 		registerWidgets( widgets );
 
 		const widget = registry
 			.select( CORE_WIDGETS )
 			.getWidget( 'adsenseModuleOverview' );
 
-		expect( widget.pdf.label ).toBe( 'Earning performance over time' );
+		expect( widget.pdf.label ).toBe( 'Earning performance' );
 		expect( widget.pdf.getData ).toBe( getModuleOverviewPDFData );
 		// The PDF component loads on demand and exposes `preload`, so the
 		// orchestrator can load its chunk before it renders.

--- a/assets/js/modules/analytics-4/widgets/index.js
+++ b/assets/js/modules/analytics-4/widgets/index.js
@@ -217,7 +217,7 @@ export function registerWidgets( widgets ) {
 			pdf: {
 				Component: PDFYourVisitorGroups,
 				getData: getAudienceTilesPDFData,
-				label: __( 'Your visitor groups', 'google-site-kit' ),
+				label: __( 'Visitor groups', 'google-site-kit' ),
 				// The PDF row needs two cards, so it renders only for two or
 				// more audiences. The dashboard tile keeps its own `isActive`,
 				// which allows a single audience.
@@ -407,7 +407,7 @@ export function registerWidgets( widgets ) {
 			pdf: {
 				Component: ModulePopularPagesWidgetGA4PDF,
 				getData: getModulePopularPagesPDFData,
-				label: __( 'Top content over time', 'google-site-kit' ),
+				label: __( 'Top content', 'google-site-kit' ),
 			},
 		},
 		[ AREA_MAIN_DASHBOARD_CONTENT_PRIMARY ]

--- a/assets/js/modules/search-console/widgets/index.js
+++ b/assets/js/modules/search-console/widgets/index.js
@@ -72,10 +72,7 @@ export function registerWidgets( widgets ) {
 			pdf: {
 				Component: DashboardPopularKeywordsWidgetPDF,
 				getData: getPopularKeywordsPDFData,
-				label: __(
-					'Top search queries for your site',
-					'google-site-kit'
-				),
+				label: __( 'Top search queries', 'google-site-kit' ),
 			},
 		},
 		[
@@ -96,7 +93,7 @@ export function registerWidgets( widgets ) {
 			pdf: {
 				Component: SearchFunnelWidgetGA4PDF,
 				getData: getSearchFunnelPDFData,
-				label: __( 'Search traffic over time', 'google-site-kit' ),
+				label: __( 'Search traffic', 'google-site-kit' ),
 			},
 		},
 		[


### PR DESCRIPTION
## Summary

Related issue(s):

- Resolves #13214

Aligns the PDF report sections selection panel's sub-section checkbox wordings with Figma. The section-level (widget-area) headings — Key metrics, Traffic, Content, Speed, Revenue — already matched Figma, so no changes were needed there.

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.
- [ ] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.