### PR TITLE
Re-fetch email reporting next-report timestamp on each panel open.

### DIFF
--- a/assets/js/components/email-reporting/UserSettingsSelectionPanel/index.js
+++ b/assets/js/components/email-reporting/UserSettingsSelectionPanel/index.js
@@ -44,12 +44,23 @@ export default function UserSettingsSelectionPanel() {
 	);
 	const previousIsOpen = usePrevious( isOpen );
 
+	const { setValue } = useDispatch( CORE_UI );
+	const {
+		invalidateEmailReportingNextReport,
+		saveEmailReportingSettings,
+		resetEmailReportingSettings,
+	} = useDispatch( CORE_USER );
+
 	const onSideSheetOpen = useCallback( () => {
+		// Re-fetch the next report timestamp on every open, since it depends
+		// on the current time and can go stale between panel visits.
+		invalidateEmailReportingNextReport();
+
 		trackEvent(
 			`${ viewContext }_email_reports_user_settings-sidebar`,
 			'user_settings_sidebar_view'
 		);
-	}, [ viewContext ] );
+	}, [ invalidateEmailReportingNextReport, viewContext ] );
 
 	const settings = useSelect( ( select ) => {
 		if ( ! isOpen ) {
@@ -71,10 +82,6 @@ export default function UserSettingsSelectionPanel() {
 	);
 
 	const [ notice, setNotice ] = useState( null );
-
-	const { setValue } = useDispatch( CORE_UI );
-	const { saveEmailReportingSettings, resetEmailReportingSettings } =
-		useDispatch( CORE_USER );
 
 	const closePanel = useCallback( () => {
 		if ( isOpen ) {

--- a/assets/js/components/email-reporting/UserSettingsSelectionPanel/index.test.js
+++ b/assets/js/components/email-reporting/UserSettingsSelectionPanel/index.test.js
@@ -17,14 +17,8 @@
  */
 
 /**
- * WordPress dependencies
- */
-import { Fragment } from '@wordpress/element';
-
-/**
  * Internal dependencies
  */
-import { useDispatch } from 'googlesitekit-data';
 import { USER_SETTINGS_SELECTION_PANEL_OPENED_KEY } from '@/js/components/email-reporting/constants';
 import UserSettingsSelectionPanel from '@/js/components/email-reporting/UserSettingsSelectionPanel';
 import SelectionPanelFooter from '@/js/components/email-reporting/UserSettingsSelectionPanel/SelectionPanelFooter';
@@ -199,6 +193,17 @@ describe( 'UserSettingsSelectionPanel', () => {
 	} );
 
 	it( 'invalidates and re-fetches the next report timestamp each time the panel opens', async () => {
+		// The panel is opened by other components by setting the UI key to true,
+		// so we simulate that here.
+		//
+		// In case any developer looks at this later and wonders why we don't
+		// simulate a user clicking elements in this component to trigger the
+		// open/close behavior, it's because the panel is a side sheet that is
+		// rendered outside of the component tree of the button that opens it.
+		//
+		// This is the most direct way to test the behavior of the panel itself,
+		// without relying on other components to trigger it (which doesn't add
+		// any value as they'd just be triggering this CORE_UI update anyway).
 		registry
 			.dispatch( CORE_UI )
 			.setValue( USER_SETTINGS_SELECTION_PANEL_OPENED_KEY, false );
@@ -209,67 +214,40 @@ describe( 'UserSettingsSelectionPanel', () => {
 			'invalidateEmailReportingNextReport'
 		);
 
-		// Stands in for the panel's real triggers (e.g. `UserMenu`,
-		// `SettingsEmailReporting`), which open the panel by setting this
-		// same CORE_UI flag in response to a click.
-		function OpenPanelButton() {
-			const { setValue } = useDispatch( CORE_UI );
+		render( <UserSettingsSelectionPanel />, {
+			registry,
+			viewContext: VIEW_CONTEXT_MAIN_DASHBOARD,
+		} );
 
-			return (
-				<button
-					onClick={ () =>
-						setValue(
-							USER_SETTINGS_SELECTION_PANEL_OPENED_KEY,
-							true
-						)
-					}
-				>
-					Open panel
-				</button>
-			);
-		}
-
-		const { getByRole } = render(
-			<Fragment>
-				<OpenPanelButton />
-				<UserSettingsSelectionPanel />
-			</Fragment>,
-			{
-				registry,
-				viewContext: VIEW_CONTEXT_MAIN_DASHBOARD,
-			}
-		);
-
-		const dialog = document.querySelector( '[role="dialog"]' );
-
-		fireEvent.click( getByRole( 'button', { name: 'Open panel' } ) );
+		act( () => {
+			registry
+				.dispatch( CORE_UI )
+				.setValue( USER_SETTINGS_SELECTION_PANEL_OPENED_KEY, true );
+		} );
 
 		await waitFor( () =>
 			expect( invalidateSpy ).toHaveBeenCalledTimes( 1 )
 		);
-		expect( dialog ).toHaveAttribute( 'aria-hidden', 'false' );
 		expect( fetchMock ).toHaveFetchedTimes(
 			1,
 			emailReportingNextReportEndpoint
 		);
 
-		fireEvent.click(
-			document.querySelector(
-				'.googlesitekit-selection-panel-header__close'
-			)
-		);
+		act( () => {
+			registry
+				.dispatch( CORE_UI )
+				.setValue( USER_SETTINGS_SELECTION_PANEL_OPENED_KEY, false );
+		} );
 
-		await waitFor( () =>
-			expect( dialog ).toHaveAttribute( 'aria-hidden', 'true' )
-		);
-		expect( invalidateSpy ).toHaveBeenCalledTimes( 1 );
-
-		fireEvent.click( getByRole( 'button', { name: 'Open panel' } ) );
+		act( () => {
+			registry
+				.dispatch( CORE_UI )
+				.setValue( USER_SETTINGS_SELECTION_PANEL_OPENED_KEY, true );
+		} );
 
 		await waitFor( () =>
 			expect( invalidateSpy ).toHaveBeenCalledTimes( 2 )
 		);
-		expect( dialog ).toHaveAttribute( 'aria-hidden', 'false' );
 		expect( fetchMock ).toHaveFetchedTimes(
 			2,
 			emailReportingNextReportEndpoint

--- a/assets/js/components/email-reporting/UserSettingsSelectionPanel/index.test.js
+++ b/assets/js/components/email-reporting/UserSettingsSelectionPanel/index.test.js
@@ -17,8 +17,14 @@
  */
 
 /**
+ * WordPress dependencies
+ */
+import { Fragment } from '@wordpress/element';
+
+/**
  * Internal dependencies
  */
+import { useDispatch } from 'googlesitekit-data';
 import { USER_SETTINGS_SELECTION_PANEL_OPENED_KEY } from '@/js/components/email-reporting/constants';
 import UserSettingsSelectionPanel from '@/js/components/email-reporting/UserSettingsSelectionPanel';
 import SelectionPanelFooter from '@/js/components/email-reporting/UserSettingsSelectionPanel/SelectionPanelFooter';
@@ -203,40 +209,67 @@ describe( 'UserSettingsSelectionPanel', () => {
 			'invalidateEmailReportingNextReport'
 		);
 
-		render( <UserSettingsSelectionPanel />, {
-			registry,
-			viewContext: VIEW_CONTEXT_MAIN_DASHBOARD,
-		} );
+		// Stands in for the panel's real triggers (e.g. `UserMenu`,
+		// `SettingsEmailReporting`), which open the panel by setting this
+		// same CORE_UI flag in response to a click.
+		function OpenPanelButton() {
+			const { setValue } = useDispatch( CORE_UI );
 
-		act( () => {
-			registry
-				.dispatch( CORE_UI )
-				.setValue( USER_SETTINGS_SELECTION_PANEL_OPENED_KEY, true );
-		} );
+			return (
+				<button
+					onClick={ () =>
+						setValue(
+							USER_SETTINGS_SELECTION_PANEL_OPENED_KEY,
+							true
+						)
+					}
+				>
+					Open panel
+				</button>
+			);
+		}
+
+		const { getByRole } = render(
+			<Fragment>
+				<OpenPanelButton />
+				<UserSettingsSelectionPanel />
+			</Fragment>,
+			{
+				registry,
+				viewContext: VIEW_CONTEXT_MAIN_DASHBOARD,
+			}
+		);
+
+		const dialog = document.querySelector( '[role="dialog"]' );
+
+		fireEvent.click( getByRole( 'button', { name: 'Open panel' } ) );
 
 		await waitFor( () =>
 			expect( invalidateSpy ).toHaveBeenCalledTimes( 1 )
 		);
+		expect( dialog ).toHaveAttribute( 'aria-hidden', 'false' );
 		expect( fetchMock ).toHaveFetchedTimes(
 			1,
 			emailReportingNextReportEndpoint
 		);
 
-		act( () => {
-			registry
-				.dispatch( CORE_UI )
-				.setValue( USER_SETTINGS_SELECTION_PANEL_OPENED_KEY, false );
-		} );
+		fireEvent.click(
+			document.querySelector(
+				'.googlesitekit-selection-panel-header__close'
+			)
+		);
 
-		act( () => {
-			registry
-				.dispatch( CORE_UI )
-				.setValue( USER_SETTINGS_SELECTION_PANEL_OPENED_KEY, true );
-		} );
+		await waitFor( () =>
+			expect( dialog ).toHaveAttribute( 'aria-hidden', 'true' )
+		);
+		expect( invalidateSpy ).toHaveBeenCalledTimes( 1 );
+
+		fireEvent.click( getByRole( 'button', { name: 'Open panel' } ) );
 
 		await waitFor( () =>
 			expect( invalidateSpy ).toHaveBeenCalledTimes( 2 )
 		);
+		expect( dialog ).toHaveAttribute( 'aria-hidden', 'false' );
 		expect( fetchMock ).toHaveFetchedTimes(
 			2,
 			emailReportingNextReportEndpoint

--- a/assets/js/components/email-reporting/UserSettingsSelectionPanel/index.test.js
+++ b/assets/js/components/email-reporting/UserSettingsSelectionPanel/index.test.js
@@ -192,6 +192,57 @@ describe( 'UserSettingsSelectionPanel', () => {
 		);
 	} );
 
+	it( 'invalidates and re-fetches the next report timestamp each time the panel opens', async () => {
+		registry
+			.dispatch( CORE_UI )
+			.setValue( USER_SETTINGS_SELECTION_PANEL_OPENED_KEY, false );
+
+		const coreUserDispatch = registry.dispatch( CORE_USER );
+		const invalidateSpy = jest.spyOn(
+			coreUserDispatch,
+			'invalidateEmailReportingNextReport'
+		);
+
+		render( <UserSettingsSelectionPanel />, {
+			registry,
+			viewContext: VIEW_CONTEXT_MAIN_DASHBOARD,
+		} );
+
+		act( () => {
+			registry
+				.dispatch( CORE_UI )
+				.setValue( USER_SETTINGS_SELECTION_PANEL_OPENED_KEY, true );
+		} );
+
+		await waitFor( () =>
+			expect( invalidateSpy ).toHaveBeenCalledTimes( 1 )
+		);
+		expect( fetchMock ).toHaveFetchedTimes(
+			1,
+			emailReportingNextReportEndpoint
+		);
+
+		act( () => {
+			registry
+				.dispatch( CORE_UI )
+				.setValue( USER_SETTINGS_SELECTION_PANEL_OPENED_KEY, false );
+		} );
+
+		act( () => {
+			registry
+				.dispatch( CORE_UI )
+				.setValue( USER_SETTINGS_SELECTION_PANEL_OPENED_KEY, true );
+		} );
+
+		await waitFor( () =>
+			expect( invalidateSpy ).toHaveBeenCalledTimes( 2 )
+		);
+		expect( fetchMock ).toHaveFetchedTimes(
+			2,
+			emailReportingNextReportEndpoint
+		);
+	} );
+
 	it( 'calls saveEmailReportingSettings with subscribed true when subscribing', async () => {
 		const coreUserDispatch = registry.dispatch( CORE_USER );
 		const saveSpy = jest


### PR DESCRIPTION
## Summary

Related issue(s):

- #13012 (QA follow-up — addresses https://github.com/google/site-kit-wp/issues/13012#issuecomment-5181592235)

## Relevant technical choices

QA found that closing and reopening the Email Reports settings panel didn't trigger a fresh `email-reporting-next-report` request — the timestamp was only invalidated when the saved frequency changed, so a stale date could persist across panel visits even though it depends on the current time.

`onSideSheetOpen` (already fired on every panel open via `SideSheet`'s `onOpen`, not just on first mount) now also calls the existing `invalidateEmailReportingNextReport()` action, so the next-report timestamp is force-refetched each time the panel opens, in addition to the existing refetch-on-frequency-change behavior.

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.
- [ ] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
