### PR TITLE
Fix: No scroll when Analytics activation errors on the splash screen

### DIFF
--- a/assets/js/components/setup/SetupUsingProxyWithSignIn/AnalyticsActivationErrorNotification.tsx
+++ b/assets/js/components/setup/SetupUsingProxyWithSignIn/AnalyticsActivationErrorNotification.tsx
@@ -19,7 +19,7 @@
 /**
  * External dependencies
  */
-import { FC } from 'react';
+import { FC, useEffect } from 'react';
 
 /**
  * WordPress dependencies
@@ -31,6 +31,8 @@ import { __ } from '@wordpress/i18n';
  */
 import Notice from '@/js/components/Notice';
 import { NOTICE_TYPES } from '@/js/components/Notice/constants';
+import { useBreakpoint } from '@/js/hooks/useBreakpoint';
+import { getNavigationalScrollTop } from '@/js/util/scroll';
 
 interface AnalyticsActivationErrorNotificationProps {
 	onRetry?: () => void;
@@ -39,9 +41,24 @@ interface AnalyticsActivationErrorNotificationProps {
 export const ANALYTICS_ACTIVATION_ERROR_NOTIFICATION =
 	'analytics-activation-error-notification';
 
+const ANALYTICS_ACTIVATION_ERROR_NOTIFICATION_SELECTOR =
+	'.googlesitekit-setup__analytics-activation-error-notification';
+
 const AnalyticsActivationErrorNotification: FC<
 	AnalyticsActivationErrorNotificationProps
 > = ( { onRetry }: AnalyticsActivationErrorNotificationProps ) => {
+	const breakpoint = useBreakpoint();
+
+	useEffect( () => {
+		global.scrollTo( {
+			top: getNavigationalScrollTop(
+				ANALYTICS_ACTIVATION_ERROR_NOTIFICATION_SELECTOR,
+				breakpoint
+			),
+			behavior: 'smooth',
+		} );
+	}, [ breakpoint ] );
+
 	return (
 		<Notice
 			className="googlesitekit-setup__analytics-activation-error-notification"


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Related issue(s):

- Resolves #

## Relevant technical choices

<!-- Please describe your changes. -->

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [ ] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.
- [ ] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
