### PR TITLE
Fix fatal error on WooCommerce refund handling

### DIFF
--- a/includes/Core/Conversion_Tracking/Conversion_Event_Providers/WooCommerce.php
+++ b/includes/Core/Conversion_Tracking/Conversion_Event_Providers/WooCommerce.php
@@ -620,7 +620,11 @@ class WooCommerce extends Conversion_Events_Provider {
 		// If there isn't a valid order for this ID, or if this order
 		// already has a purchase event tracked for it, return early
 		// and don't output the script tag to track the purchase event.
-		if ( ! $order || $order->get_meta( '_googlesitekit_ga_purchase_event_tracked' ) === '1' ) {
+		if (
+			! $order ||
+			! $order instanceof WC_Order ||
+			$order->get_meta( '_googlesitekit_ga_purchase_event_tracked' ) === '1'
+		) {
 			return;
 		}
 


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Related issue(s):

- Resolves #13270 

## Relevant technical choices

This PR resolves #13270 by adding a type guard for `WC_Order`.

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.
- [ ] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [x] Ensure the PR has the correct target branch.
- [x] Double-check that the PR is okay to be merged.
- [x] Ensure the corresponding issue has a ZenHub release assigned.
- [x] Add a changelog message to the issue.
