### PR TITLE
Fix line chart tooltip stacking above the header and navigation on scroll

### DIFF
--- a/assets/sass/components/global/_googlesitekit-chart.scss
+++ b/assets/sass/components/global/_googlesitekit-chart.scss
@@ -59,6 +59,7 @@
 	// This is the only way to have this style override the inline style.
 	height: fit-content !important;
 	width: fit-content !important;
+	z-index: 8;
 
 	.google-visualization-tooltip-item-list {
 		margin: 0.5em 0;


### PR DESCRIPTION
## Summary

Fixes #13235 — clicking a point on the line chart in "Find out how your audience is growing" pins its tooltip open; scrolling then moves the tooltip up over the sticky header and navigation chips instead of behind them.

#4360 and #4496 fixed this same class of bug for the other dashboard charts (PieChart tooltip), via PR #4549, which added `z-index: 8;` to the PieChart tooltip selector in three SCSS files. The `.googlesitekit-chart--LineChart div.google-visualization-tooltip` selector — sitting right next to the PieChart one in the same file — never got that treatment, so the line chart's tooltip (used by the "audience growing" widget's `UserCountGraph`) was left with no z-index at all.

**Fix:** add the same `z-index: 8;` to the LineChart tooltip selector in `_googlesitekit-chart.scss`, matching the existing PieChart rule immediately below it. Confirmed the header's z-index (11, in `_googlesitekit-header.scss`) is higher, so this correctly puts the tooltip behind it.

## Verification
- [x] Confirmed via the Storybook `Loaded` story for `DashboardAllTrafficWidgetGA4` (which renders the `UserCountGraph` line chart with real data) that pinning a tooltip and inspecting the live rendered element shows `z-index: 8` actually applied — not just present in source, but compiled and loaded in the browser
- [x] `npx stylelint` on the changed file — clean
- [x] No new Storybook stories/VRT needed — this fixes stacking behavior on an already-covered chart selector, same as the precedent PR (#4549), which also didn't add new stories