### PR TITLE
Update compressed size workflow source paths

### DIFF
--- a/.github/workflows/compressed-size.yml
+++ b/.github/workflows/compressed-size.yml
@@ -13,12 +13,26 @@ on:
     paths:
       - '.github/workflows/compressed-size.yml'
       - 'assets/**/*.js'
+      - 'assets/**/*.jsx'
+      - 'assets/**/*.ts'
+      - 'assets/**/*.tsx'
+      - 'assets/**/*.json'
       - '!assets/**/*.test.js'
+      - '!assets/**/*.test.jsx'
+      - '!assets/**/*.test.ts'
+      - '!assets/**/*.test.tsx'
       - '!assets/**/test/**'
+      - '!assets/**/*.stories.js'
+      - '!assets/**/*.stories.jsx'
+      - '!assets/**/*.stories.ts'
+      - '!assets/**/*.stories.tsx'
       - 'assets/**/*.scss'
       - 'assets/svg/**/*.svg'
+      - 'webpack/**/*.js'
       - '**/*.config.js'
+      - 'package.json'
       - 'package-lock.json'
+      - 'patches/**/*.patch'
 
 concurrency:
   group: compressed-size-${{ github.ref }}


### PR DESCRIPTION
## Summary

Addresses issue:

- #13194

## Relevant technical choices

- Updated the `compressed-size` workflow trigger paths to include source files that can affect resulting bundle contents.
- Added support for `.jsx`, `.ts`, `.tsx`, and `.json` source files under `assets/`.
- Added `webpack/**/*.js`, `package.json`, and `patches/**/*.patch` as relevant source/dependency inputs.
- Excluded TypeScript/JSX test files and Storybook story files that do not contribute to the resulting bundles.

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).