### PR TITLE
Lock email report notice colors in dark mode.

### DIFF
--- a/includes/Core/Email_Reporting/templates/email-report/parts/notice.php
+++ b/includes/Core/Email_Reporting/templates/email-report/parts/notice.php
@@ -31,12 +31,14 @@ if ( empty( $notice_title ) && empty( $notice_body ) ) {
 					style="display:block; width:24px; height:24px;" />
 			</div>
 			<?php if ( ! empty( $notice_title ) ) : ?>
-			<div style="font-size:14px; line-height:20px; font-weight:600; color:#462083;">
+			<div class="googlesitekit-email-report-notice-text"
+				style="font-size:14px; line-height:20px; font-weight:600; color:#462083;">
 				<?php echo esc_html( $notice_title ); ?>
 			</div>
 			<?php endif; ?>
 			<?php if ( ! empty( $notice_body ) ) : ?>
-			<div style="font-size:14px; line-height:20px; letter-spacing: 0.25px; color:#462083; margin-bottom:16px;">
+			<div class="googlesitekit-email-report-notice-text"
+				style="font-size:14px; line-height:20px; letter-spacing: 0.25px; color:#462083; margin-bottom:16px;">
 				<?php echo esc_html( $notice_body ); ?>
 				<?php if ( ! empty( $learn_more_label ) && ! empty( $learn_more_url ) ) : ?>
 				<a href="<?php echo esc_url( $learn_more_url ); ?>" style="color:#462083; text-decoration:underline;"
@@ -48,7 +50,7 @@ if ( empty( $notice_title ) && empty( $notice_body ) ) {
 			<table role="presentation" width="100%">
 				<tr>
 					<td align="right">
-						<a href="<?php echo esc_url( $cta_url ); ?>"
+						<a href="<?php echo esc_url( $cta_url ); ?>" class="googlesitekit-email-report-notice-cta"
 							style="display:inline-block; background:#462083; color:#FFFFFF; font-size:14px; line-height:20px; font-weight:500; text-decoration:none; padding:6px 16px; border-radius:999px;"
 							rel="noopener" target="_blank">
 							<?php echo esc_html( $cta_label ); ?>

--- a/includes/Core/Email_Reporting/templates/parts/styles.php
+++ b/includes/Core/Email_Reporting/templates/parts/styles.php
@@ -112,6 +112,17 @@
 				box-shadow: inset 0 0 0 9999px #E3D1FF !important;
 			}
 
+			.googlesitekit-email-report-notice .googlesitekit-email-report-notice-text,
+			.googlesitekit-email-report-notice .googlesitekit-email-report-notice-text a {
+				color: #462083 !important;
+			}
+
+			.googlesitekit-email-report-notice .googlesitekit-email-report-notice-cta {
+				background-color: #462083 !important;
+				box-shadow: inset 0 0 0 9999px #462083 !important;
+				color: #FFFFFF !important;
+			}
+
 			.text-primary {
 				color: #EBEEF0 !important;
 			}
@@ -178,6 +189,17 @@
 		[data-ogsc] .googlesitekit-email-report-notice .googlesitekit-email-report-notice-surface {
 			background-color: #E3D1FF !important;
 			box-shadow: inset 0 0 0 9999px #E3D1FF !important;
+		}
+
+		[data-ogsc] .googlesitekit-email-report-notice .googlesitekit-email-report-notice-text,
+		[data-ogsc] .googlesitekit-email-report-notice .googlesitekit-email-report-notice-text a {
+			color: #462083 !important;
+		}
+
+		[data-ogsc] .googlesitekit-email-report-notice .googlesitekit-email-report-notice-cta {
+			background-color: #462083 !important;
+			box-shadow: inset 0 0 0 9999px #462083 !important;
+			color: #FFFFFF !important;
 		}
 
 		[data-ogsc] .text-primary {

--- a/tests/phpunit/integration/Core/Email_Reporting/Email_Template_RendererTest.php
+++ b/tests/phpunit/integration/Core/Email_Reporting/Email_Template_RendererTest.php
@@ -90,6 +90,45 @@ class Email_Template_RendererTest extends TestCase {
 		$this->assertStringNotContainsString( 'https://example.com/notice-cta', $html_output_without_notice, 'Expected notice CTA URL to be absent when no header notices are provided.' );
 	}
 
+	public function test_email_report_notice_keeps_colors_in_dark_mode() {
+		$context = new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE );
+		$golinks = new Golinks( $context );
+		$golinks->register_handler( 'dashboard', new Dashboard_Golink_Handler() );
+
+		$payload = array(
+			'total_visitors' => array(
+				'label'          => 'Total visitors',
+				'value'          => '120',
+				'change'         => 20,
+				'change_context' => 'Compared to previous 7 days',
+			),
+		);
+
+		$sections_map  = new Sections_Map( $context, $payload, $golinks );
+		$renderer      = new Email_Template_Renderer( $sections_map );
+		$template_data = $this->get_minimal_template_data();
+
+		$template_data['header_notices'] = array(
+			array(
+				'id'               => 'analytics-setup',
+				'title'            => 'Notice title',
+				'body'             => 'Notice body',
+				'learn_more_label' => 'Learn more',
+				'learn_more_url'   => 'https://example.com/learn-more',
+				'cta_label'        => 'Set up Analytics',
+				'cta_url'          => 'https://example.com/notice-cta',
+			),
+		);
+
+		$html_output = $renderer->render( 'email-report', $template_data );
+
+		$this->assertStringContainsString( 'googlesitekit-email-report-notice-text', $html_output, 'Expected the notice text lock class in the rendered email.' );
+		$this->assertStringContainsString( 'googlesitekit-email-report-notice-cta', $html_output, 'Expected the notice CTA lock class in the rendered email.' );
+		$this->assertStringContainsString( '.googlesitekit-email-report-notice .googlesitekit-email-report-notice-text,', $html_output, 'Expected the notice text color lock rule in the rendered email.' );
+		$this->assertStringContainsString( 'color: #462083 !important;', $html_output, 'Expected the notice text color lock in the rendered email.' );
+		$this->assertStringContainsString( '[data-ogsc] .googlesitekit-email-report-notice .googlesitekit-email-report-notice-cta', $html_output, 'Expected the Outlook app notice CTA lock in the rendered email.' );
+	}
+
 	public function test_change_badge_shows_signed_value_and_is_omitted_when_change_is_null() {
 		$context = new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE );
 		$golinks = new Golinks( $context );


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Related issue(s):

- Resolves #12429 

<!-- Please describe your changes. -->

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.
- [ ] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
