### PR TITLE
Add subscribed users selector and unsubscribe action to email reporting

### DIFF
--- a/assets/js/googlesitekit/datastore/site/email-reporting.js
+++ b/assets/js/googlesitekit/datastore/site/email-reporting.js
@@ -40,13 +40,25 @@ import { CORE_SITE } from './constants';
 
 const START_INVITING_USER = 'START_INVITING_USER';
 const FINISH_INVITING_USER = 'FINISH_INVITING_USER';
+const START_UNSUBSCRIBING_USER = 'START_UNSUBSCRIBING_USER';
+const FINISH_UNSUBSCRIBING_USER = 'FINISH_UNSUBSCRIBING_USER';
 const RESET_ELIGIBLE_SUBSCRIBERS = 'RESET_ELIGIBLE_SUBSCRIBERS';
-const DEFAULT_ELIGIBLE_SUBSCRIBERS_ARGS = {
+const RESET_SUBSCRIBED_USERS = 'RESET_SUBSCRIBED_USERS';
+const DEFAULT_USER_LIST_ARGS = {
 	page: 1,
 	search: '',
 };
 
-function normalizeEligibleSubscribersArgs( args = {} ) {
+/**
+ * Normalizes user list args to a whole page number and a string search term.
+ *
+ * @since 1.175.0
+ * @since n.e.x.t Renamed from normalizeEligibleSubscribersArgs.
+ *
+ * @param {Object} [args] Page and search args.
+ * @return {Object} Object with a positive integer `page` and a string `search`.
+ */
+function normalizeUserListArgs( args = {} ) {
 	const normalizedArgs = isPlainObject( args ) ? args : {};
 	const page = Number.parseInt( normalizedArgs.page, 10 );
 
@@ -54,18 +66,27 @@ function normalizeEligibleSubscribersArgs( args = {} ) {
 		page:
 			Number.isInteger( page ) && page > 0
 				? page
-				: DEFAULT_ELIGIBLE_SUBSCRIBERS_ARGS.page,
+				: DEFAULT_USER_LIST_ARGS.page,
 		search:
 			typeof normalizedArgs.search === 'string'
 				? normalizedArgs.search
-				: DEFAULT_ELIGIBLE_SUBSCRIBERS_ARGS.search,
+				: DEFAULT_USER_LIST_ARGS.search,
 	};
 }
 
-function getEligibleSubscribersCacheKey( args = {} ) {
+/**
+ * Builds the cache key a user list result is stored under.
+ *
+ * @since 1.175.0
+ * @since n.e.x.t Renamed from getEligibleSubscribersCacheKey.
+ *
+ * @param {Object} [args] Page and search args.
+ * @return {string} Cache key for the normalized args.
+ */
+function getUserListCacheKey( args = {} ) {
 	// Normalize args first so equivalent requests share one key (e.g. {} and { page: 1, search: '' }).
 	// This lets the selector/resolver reuse previously fetched results and prevents mixing results across different page/search queries.
-	return stringifyObject( normalizeEligibleSubscribersArgs( args ) );
+	return stringifyObject( normalizeUserListArgs( args ) );
 }
 
 const baseInitialState = {
@@ -73,8 +94,10 @@ const baseInitialState = {
 		settings: undefined,
 		savedSettings: undefined,
 		eligibleSubscribers: {},
+		subscribedUsers: {},
 		errors: undefined,
 		invitingUsers: {},
+		unsubscribingUsers: {},
 	},
 };
 
@@ -123,9 +146,7 @@ const fetchGetEligibleSubscribersStore = createFetchStore( {
 		} ),
 	reducerCallback: createReducer(
 		( state, eligibleSubscribers, eligibleSubscribersArgs ) => {
-			const cacheKey = getEligibleSubscribersCacheKey(
-				eligibleSubscribersArgs
-			);
+			const cacheKey = getUserListCacheKey( eligibleSubscribersArgs );
 			// Persist the response under its query key so future identical requests can be served from store state.
 			state.emailReporting.eligibleSubscribers[ cacheKey ] =
 				eligibleSubscribers;
@@ -137,7 +158,36 @@ const fetchGetEligibleSubscribersStore = createFetchStore( {
 			'eligibleSubscribersArgs should be an object.'
 		);
 
-		return normalizeEligibleSubscribersArgs( eligibleSubscribersArgs );
+		return normalizeUserListArgs( eligibleSubscribersArgs );
+	},
+	validateParams: ( { page, search } = {} ) => {
+		invariant(
+			Number.isInteger( page ) && page > 0,
+			'page should be a positive integer.'
+		);
+		invariant( typeof search === 'string', 'search should be a string.' );
+	},
+} );
+
+const fetchGetSubscribedUsersStore = createFetchStore( {
+	baseName: 'getSubscribedUsers',
+	controlCallback: ( params ) =>
+		get( 'core', 'site', 'email-reporting-subscribed-users', params, {
+			useCache: false,
+		} ),
+	reducerCallback: createReducer(
+		( state, subscribedUsers, subscribedUsersArgs ) => {
+			const cacheKey = getUserListCacheKey( subscribedUsersArgs );
+			state.emailReporting.subscribedUsers[ cacheKey ] = subscribedUsers;
+		}
+	),
+	argsToParams: ( subscribedUsersArgs ) => {
+		invariant(
+			isPlainObject( subscribedUsersArgs ),
+			'subscribedUsersArgs should be an object.'
+		);
+
+		return normalizeUserListArgs( subscribedUsersArgs );
 	},
 	validateParams: ( { page, search } = {} ) => {
 		invariant(
@@ -175,9 +225,7 @@ const fetchInviteUserStore = createFetchStore( {
 					return;
 				}
 
-				const users = sanitizeEligibleSubscribersUsers(
-					cachedResult.users
-				);
+				const users = sanitizeUserListUsers( cachedResult.users );
 				const user = users.find(
 					( potentialNewlyInvitedUser ) =>
 						potentialNewlyInvitedUser.id === userID
@@ -186,6 +234,49 @@ const fetchInviteUserStore = createFetchStore( {
 				if ( user ) {
 					user.invited = true;
 				}
+			}
+		);
+	} ),
+	argsToParams: ( userID ) => ( { userID } ),
+	validateParams: ( { userID } = {} ) => {
+		invariant(
+			Number.isInteger( userID ) && userID > 0,
+			'userID should be a positive integer.'
+		);
+	},
+	isAction: true,
+} );
+
+const fetchUnsubscribeUserStore = createFetchStore( {
+	baseName: 'unsubscribeUser',
+	controlCallback: ( { userID } ) =>
+		set( 'core', 'site', 'email-reporting-unsubscribe-user', {
+			userID,
+		} ),
+	// The store keeps one subscribed-users result per page and search term, so remove
+	// the user from every cached result. getSubscribedUsers then reports the change
+	// without a refetch.
+	reducerCallback: createReducer( ( state, response, { userID } ) => {
+		Object.values( state.emailReporting.subscribedUsers ).forEach(
+			( cachedResult ) => {
+				if ( ! isPlainObject( cachedResult ) ) {
+					return;
+				}
+
+				const users = sanitizeUserListUsers( cachedResult.users );
+				const remainingUsers = users.filter(
+					( subscribedUser ) => subscribedUser.id !== userID
+				);
+
+				if ( remainingUsers.length === users.length ) {
+					return;
+				}
+
+				cachedResult.users = remainingUsers;
+				cachedResult.total = Math.max(
+					sanitizeUserListTotal( cachedResult.total ) - 1,
+					0
+				);
 			}
 		);
 	} ),
@@ -256,6 +347,41 @@ const baseActions = {
 	),
 
 	/**
+	 * Unsubscribes a user from email reports and removes them from every cached subscribed-users listing.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param {number} userID Subscribed user ID.
+	 * @return {Object} Object with `response` and `error`.
+	 */
+	unsubscribeUser: createValidatedAction(
+		( userID ) => {
+			invariant(
+				Number.isInteger( userID ) && userID > 0,
+				'userID should be a positive integer.'
+			);
+		},
+		function* ( userID ) {
+			const registry = yield commonActions.getRegistry();
+
+			registry.dispatch( CORE_SITE ).startUnsubscribingUser( userID );
+
+			try {
+				const result =
+					yield fetchUnsubscribeUserStore.actions.fetchUnsubscribeUser(
+						userID
+					);
+
+				return result;
+			} finally {
+				registry
+					.dispatch( CORE_SITE )
+					.finishUnsubscribingUser( userID );
+			}
+		}
+	),
+
+	/**
 	 * Sets email reporting enabled state.
 	 *
 	 * @since 1.165.0
@@ -306,6 +432,36 @@ const baseActions = {
 	},
 
 	/**
+	 * Marks an unsubscribe request as in progress for a user.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param {number} userID User ID.
+	 * @return {Object} Redux-style action.
+	 */
+	startUnsubscribingUser( userID ) {
+		return {
+			type: START_UNSUBSCRIBING_USER,
+			payload: { userID },
+		};
+	},
+
+	/**
+	 * Marks a user's unsubscribe request as finished.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param {number} userID User ID.
+	 * @return {Object} Redux-style action.
+	 */
+	finishUnsubscribingUser( userID ) {
+		return {
+			type: FINISH_UNSUBSCRIBING_USER,
+			payload: { userID },
+		};
+	},
+
+	/**
 	 * Resets the eligible subscribers cache.
 	 *
 	 * @since 1.177.0
@@ -322,6 +478,26 @@ const baseActions = {
 
 		return dispatch( CORE_SITE ).invalidateResolutionForStoreSelector(
 			'getEligibleSubscribers'
+		);
+	},
+
+	/**
+	 * Clears the subscribed users cache, so the next read fetches fresh data.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @return {Object} Redux-style action.
+	 */
+	*resetSubscribedUsers() {
+		const { dispatch } = yield commonActions.getRegistry();
+
+		yield {
+			type: RESET_SUBSCRIBED_USERS,
+			payload: {},
+		};
+
+		return dispatch( CORE_SITE ).invalidateResolutionForStoreSelector(
+			'getSubscribedUsers'
 		);
 	},
 };
@@ -345,9 +521,22 @@ export const baseReducer = createReducer( ( state, action ) => {
 			state.emailReporting.invitingUsers[ payload.userID ] = false;
 			break;
 		}
+		case START_UNSUBSCRIBING_USER: {
+			state.emailReporting.unsubscribingUsers[ payload.userID ] = true;
+			break;
+		}
+		case FINISH_UNSUBSCRIBING_USER: {
+			state.emailReporting.unsubscribingUsers[ payload.userID ] = false;
+			break;
+		}
 		case RESET_ELIGIBLE_SUBSCRIBERS: {
 			state.emailReporting.eligibleSubscribers =
 				baseInitialState.emailReporting.eligibleSubscribers;
+			break;
+		}
+		case RESET_SUBSCRIBED_USERS: {
+			state.emailReporting.subscribedUsers =
+				baseInitialState.emailReporting.subscribedUsers;
 			break;
 		}
 
@@ -356,15 +545,42 @@ export const baseReducer = createReducer( ( state, action ) => {
 	}
 } );
 
-function sanitizeEligibleSubscribersUsers( users ) {
+/**
+ * Returns the given users when they form an array, and an empty array otherwise.
+ *
+ * @since 1.175.0
+ * @since n.e.x.t Renamed from sanitizeEligibleSubscribersUsers.
+ *
+ * @param {Array} users Users from a user list response.
+ * @return {Array} The given users, or an empty array.
+ */
+function sanitizeUserListUsers( users ) {
 	return Array.isArray( users ) ? users : [];
 }
 
-function sanitizeEligibleSubscribersTotal( total ) {
+/**
+ * Returns the given total when it reads as a whole number of zero or more, and zero otherwise.
+ *
+ * @since 1.175.0
+ * @since n.e.x.t Renamed from sanitizeEligibleSubscribersTotal.
+ *
+ * @param {number} total Total from a user list response.
+ * @return {number} The given total, or zero.
+ */
+function sanitizeUserListTotal( total ) {
 	return Number.isInteger( total ) && total >= 0 ? total : 0;
 }
 
-function sanitizeEligibleSubscribersTotalPages( totalPages ) {
+/**
+ * Returns the given page count when it reads as a whole number of zero or more, and zero otherwise.
+ *
+ * @since 1.175.0
+ * @since n.e.x.t Renamed from sanitizeEligibleSubscribersTotalPages.
+ *
+ * @param {number} totalPages Page count from a user list response.
+ * @return {number} The given page count, or zero.
+ */
+function sanitizeUserListTotalPages( totalPages ) {
 	return Number.isInteger( totalPages ) && totalPages >= 0 ? totalPages : 0;
 }
 
@@ -382,9 +598,7 @@ const baseResolvers = {
 	},
 	*getEligibleSubscribers( eligibleSubscribersArgs = {} ) {
 		const registry = yield commonActions.getRegistry();
-		const normalizedArgs = normalizeEligibleSubscribersArgs(
-			eligibleSubscribersArgs
-		);
+		const normalizedArgs = normalizeUserListArgs( eligibleSubscribersArgs );
 		const isFetchingGetEligibleSubscribers = registry
 			.select( CORE_SITE )
 			.isFetchingGetEligibleSubscribers( normalizedArgs );
@@ -410,17 +624,17 @@ const baseResolvers = {
 			return;
 		}
 
-		const totalPages = sanitizeEligibleSubscribersTotalPages(
+		const totalPages = sanitizeUserListTotalPages(
 			firstPageResponse.totalPages
 		);
 		const shouldFetchAllPages =
-			normalizedArgs.page === DEFAULT_ELIGIBLE_SUBSCRIBERS_ARGS.page;
+			normalizedArgs.page === DEFAULT_USER_LIST_ARGS.page;
 
 		if ( ! shouldFetchAllPages || totalPages <= normalizedArgs.page ) {
 			return;
 		}
 
-		let users = sanitizeEligibleSubscribersUsers( firstPageResponse.users );
+		let users = sanitizeUserListUsers( firstPageResponse.users );
 
 		for ( let page = normalizedArgs.page + 1; page <= totalPages; page++ ) {
 			const { response } =
@@ -431,18 +645,77 @@ const baseResolvers = {
 					}
 				);
 
-			users = users.concat(
-				sanitizeEligibleSubscribersUsers( response?.users )
-			);
+			users = users.concat( sanitizeUserListUsers( response?.users ) );
 		}
 
 		if ( totalPages > normalizedArgs.page ) {
 			yield fetchGetEligibleSubscribersStore.actions.receiveGetEligibleSubscribers(
 				{
 					users,
-					total: sanitizeEligibleSubscribersTotal(
-						firstPageResponse.total
-					),
+					total: sanitizeUserListTotal( firstPageResponse.total ),
+					totalPages,
+				},
+				normalizedArgs
+			);
+		}
+	},
+	*getSubscribedUsers( subscribedUsersArgs = {} ) {
+		const registry = yield commonActions.getRegistry();
+		const normalizedArgs = normalizeUserListArgs( subscribedUsersArgs );
+		const isFetchingGetSubscribedUsers = registry
+			.select( CORE_SITE )
+			.isFetchingGetSubscribedUsers( normalizedArgs );
+
+		if ( isFetchingGetSubscribedUsers ) {
+			return;
+		}
+
+		const subscribedUsers = registry
+			.select( CORE_SITE )
+			.getSubscribedUsers( normalizedArgs );
+
+		if ( subscribedUsers !== undefined ) {
+			return;
+		}
+
+		const { response: firstPageResponse } =
+			yield fetchGetSubscribedUsersStore.actions.fetchGetSubscribedUsers(
+				normalizedArgs
+			);
+
+		if ( ! firstPageResponse ) {
+			return;
+		}
+
+		const totalPages = sanitizeUserListTotalPages(
+			firstPageResponse.totalPages
+		);
+		const shouldFetchAllPages =
+			normalizedArgs.page === DEFAULT_USER_LIST_ARGS.page;
+
+		if ( ! shouldFetchAllPages || totalPages <= normalizedArgs.page ) {
+			return;
+		}
+
+		let users = sanitizeUserListUsers( firstPageResponse.users );
+
+		for ( let page = normalizedArgs.page + 1; page <= totalPages; page++ ) {
+			const { response } =
+				yield fetchGetSubscribedUsersStore.actions.fetchGetSubscribedUsers(
+					{
+						...normalizedArgs,
+						page,
+					}
+				);
+
+			users = users.concat( sanitizeUserListUsers( response?.users ) );
+		}
+
+		if ( totalPages > normalizedArgs.page ) {
+			yield fetchGetSubscribedUsersStore.actions.receiveGetSubscribedUsers(
+				{
+					users,
+					total: sanitizeUserListTotal( firstPageResponse.total ),
 					totalPages,
 				},
 				normalizedArgs
@@ -500,12 +773,12 @@ const baseSelectors = {
 	getEligibleSubscribers: createRegistrySelector(
 		( select ) =>
 			( state, eligibleSubscribersArgs = {} ) => {
-				const normalizedArgs = normalizeEligibleSubscribersArgs(
+				const normalizedArgs = normalizeUserListArgs(
 					eligibleSubscribersArgs
 				);
 				const eligibleSubscribers =
 					state.emailReporting?.eligibleSubscribers?.[
-						getEligibleSubscribersCacheKey( normalizedArgs )
+						getUserListCacheKey( normalizedArgs )
 					];
 
 				if ( eligibleSubscribers === undefined ) {
@@ -515,9 +788,7 @@ const baseSelectors = {
 				const currentUserID = select( CORE_USER ).getID();
 
 				return {
-					users: sanitizeEligibleSubscribersUsers(
-						eligibleSubscribers.users
-					)
+					users: sanitizeUserListUsers( eligibleSubscribers.users )
 						.filter(
 							( user ) =>
 								Number( user.id ) !== Number( currentUserID )
@@ -530,15 +801,46 @@ const baseSelectors = {
 							subscribed: user.subscribed,
 							invited: user.invited,
 						} ) ),
-					total: sanitizeEligibleSubscribersTotal(
-						eligibleSubscribers.total
-					),
-					totalPages: sanitizeEligibleSubscribersTotalPages(
+					total: sanitizeUserListTotal( eligibleSubscribers.total ),
+					totalPages: sanitizeUserListTotalPages(
 						eligibleSubscribers.totalPages
 					),
 				};
 			}
 	),
+
+	/**
+	 * Gets the subscribed users list and its total for the given page and search args.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param {Object} state                 Data store's state.
+	 * @param {Object} [subscribedUsersArgs] Page and search args.
+	 * @return {(Object|undefined)} The subscribed users and their total count; `undefined` if not loaded.
+	 */
+	getSubscribedUsers( state, subscribedUsersArgs = {} ) {
+		const normalizedArgs = normalizeUserListArgs( subscribedUsersArgs );
+		const subscribedUsers =
+			state.emailReporting?.subscribedUsers?.[
+				getUserListCacheKey( normalizedArgs )
+			];
+
+		if ( subscribedUsers === undefined ) {
+			return undefined;
+		}
+
+		return {
+			users: sanitizeUserListUsers( subscribedUsers.users ).map(
+				( user ) => ( {
+					id: user.id,
+					name: user.displayName || user.name,
+					email: user.email,
+					role: user.roleDisplayName || user.role,
+				} )
+			),
+			total: sanitizeUserListTotal( subscribedUsers.total ),
+		};
+	},
 
 	/**
 	 * Gets the email reporting errors.
@@ -589,14 +891,29 @@ const baseSelectors = {
 	isInvitingUser( state, userID ) {
 		return !! state.emailReporting?.invitingUsers?.[ userID ];
 	},
+
+	/**
+	 * Checks whether a user's unsubscribe request is still running.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param {Object} state  Data store's state.
+	 * @param {number} userID User ID.
+	 * @return {boolean} True if an unsubscribe request is in progress, otherwise false.
+	 */
+	isUnsubscribingUser( state, userID ) {
+		return !! state.emailReporting?.unsubscribingUsers?.[ userID ];
+	},
 };
 
 const store = combineStores(
 	fetchGetEmailReportingSettingsStore,
 	fetchSaveEmailReportingSettingsStore,
 	fetchGetEligibleSubscribersStore,
+	fetchGetSubscribedUsersStore,
 	fetchGetEmailReportingErrorsStore,
 	fetchInviteUserStore,
+	fetchUnsubscribeUserStore,
 	{
 		initialState: baseInitialState,
 		actions: baseActions,

--- a/assets/js/googlesitekit/datastore/site/email-reporting.test.js
+++ b/assets/js/googlesitekit/datastore/site/email-reporting.test.js
@@ -37,12 +37,16 @@ describe( 'core/site Email Reporting', () => {
 	);
 	const eligibleSubscribersEndpointRegExp =
 		/email-reporting-eligible-subscribers/;
+	const subscribedUsersEndpointRegExp = /email-reporting-subscribed-users/;
 
 	const emailReportingErrorsEndpointRegExp = new RegExp(
 		'^/google-site-kit/v1/core/site/data/email-reporting-errors'
 	);
 	const inviteUserEndpointRegExp = new RegExp(
 		'^/google-site-kit/v1/core/site/data/email-reporting-invite-user'
+	);
+	const unsubscribeUserEndpointRegExp = new RegExp(
+		'^/google-site-kit/v1/core/site/data/email-reporting-unsubscribe-user'
 	);
 	const USER_ID_PARAM = 'userID';
 	const defaultEligibleSubscribersArgs = { search: '' };
@@ -62,6 +66,30 @@ describe( 'core/site Email Reporting', () => {
 			totalPages,
 			users,
 		};
+	}
+
+	/**
+	 * Mocks one subscribed-users response with the given users and waits for
+	 * `getSubscribedUsers` to resolve, so a test starts from a filled cache.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param {Array}  users  Users the endpoint answers with.
+	 * @param {Object} [args] Page and search args to resolve.
+	 * @return {Promise} Promise that resolves once the listing is in the store.
+	 */
+	async function resolveSubscribedUsers(
+		users,
+		args = defaultEligibleSubscribersArgs
+	) {
+		fetchMock.getOnce( subscribedUsersEndpointRegExp, {
+			body: createEligibleSubscribersResponse( users ),
+			status: 200,
+		} );
+
+		registry.select( CORE_SITE ).getSubscribedUsers( args );
+
+		await untilResolved( registry, CORE_SITE ).getSubscribedUsers( args );
 	}
 
 	beforeAll( () => {
@@ -369,6 +397,220 @@ describe( 'core/site Email Reporting', () => {
 			} );
 		} );
 
+		describe( 'unsubscribeUser', () => {
+			const subscribedUser = {
+				id: 123,
+				displayName: 'Subscribed User',
+				email: 'subscribed@example.com',
+				role: 'editor',
+			};
+			const otherSubscribedUser = {
+				id: 456,
+				displayName: 'Other Subscribed User',
+				email: 'other@example.com',
+				role: 'author',
+			};
+
+			it( 'posts the unsubscribe request and returns the response with no error', async () => {
+				const successResponse = { success: true };
+
+				fetchMock.postOnce( unsubscribeUserEndpointRegExp, {
+					body: successResponse,
+					status: 200,
+				} );
+
+				const { response, error } = await registry
+					.dispatch( CORE_SITE )
+					.unsubscribeUser( subscribedUser.id );
+
+				expect( fetchMock ).toHaveFetched(
+					unsubscribeUserEndpointRegExp,
+					{
+						body: {
+							data: {
+								[ USER_ID_PARAM ]: subscribedUser.id,
+							},
+						},
+					}
+				);
+				expect( response ).toEqual( successResponse );
+				expect( error ).toBeUndefined();
+			} );
+
+			it( 'returns the error and no response when the unsubscribe request fails', async () => {
+				const errorResponse = {
+					code: 'email_reporting_user_not_subscribed',
+					message: 'The user is not subscribed to email reports.',
+					data: { status: 400 },
+				};
+
+				fetchMock.postOnce( unsubscribeUserEndpointRegExp, {
+					body: errorResponse,
+					status: 400,
+				} );
+
+				const { response, error } = await registry
+					.dispatch( CORE_SITE )
+					.unsubscribeUser( subscribedUser.id );
+
+				expect( response ).toBeUndefined();
+				expect( error ).toEqual( errorResponse );
+				expect( console ).toHaveErrored();
+			} );
+
+			it( 'drops the unsubscribed user from the cached subscribed-users listing and lowers the total by one', async () => {
+				await resolveSubscribedUsers( [
+					subscribedUser,
+					otherSubscribedUser,
+				] );
+
+				fetchMock.postOnce( unsubscribeUserEndpointRegExp, {
+					body: { success: true },
+					status: 200,
+				} );
+
+				await registry
+					.dispatch( CORE_SITE )
+					.unsubscribeUser( subscribedUser.id );
+
+				expect(
+					registry
+						.select( CORE_SITE )
+						.getSubscribedUsers( defaultEligibleSubscribersArgs )
+				).toEqual( {
+					users: [
+						{
+							id: otherSubscribedUser.id,
+							name: otherSubscribedUser.displayName,
+							email: otherSubscribedUser.email,
+							role: otherSubscribedUser.role,
+						},
+					],
+					total: 1,
+				} );
+			} );
+
+			it( 'removes the user from every search cache that lists them and keeps the other terms as they were', async () => {
+				await resolveSubscribedUsers( [ subscribedUser ], {
+					search: 'subscribed',
+				} );
+				await resolveSubscribedUsers( [ otherSubscribedUser ], {
+					search: 'other',
+				} );
+
+				fetchMock.postOnce( unsubscribeUserEndpointRegExp, {
+					body: { success: true },
+					status: 200,
+				} );
+
+				await registry
+					.dispatch( CORE_SITE )
+					.unsubscribeUser( subscribedUser.id );
+
+				expect(
+					registry
+						.select( CORE_SITE )
+						.getSubscribedUsers( { search: 'subscribed' } )
+				).toEqual( { users: [], total: 0 } );
+				expect(
+					registry
+						.select( CORE_SITE )
+						.getSubscribedUsers( { search: 'other' } )
+				).toEqual( {
+					users: [
+						{
+							id: otherSubscribedUser.id,
+							name: otherSubscribedUser.displayName,
+							email: otherSubscribedUser.email,
+							role: otherSubscribedUser.role,
+						},
+					],
+					total: 1,
+				} );
+			} );
+
+			it( 'keeps a cached total at zero when the removal would go below it', async () => {
+				// The subscribed-users endpoint can return users with no `total`
+				// field, and sanitizeUserListTotal() turns that missing value into
+				// zero. Dispatching `total: 0` with one user recreates that state,
+				// so the unsubscribe would push the total under zero without the
+				// floor.
+				registry.dispatch( CORE_SITE ).receiveGetSubscribedUsers(
+					createEligibleSubscribersResponse( [ subscribedUser ], {
+						total: 0,
+					} ),
+					{ page: 1, search: '' }
+				);
+
+				fetchMock.postOnce( unsubscribeUserEndpointRegExp, {
+					body: { success: true },
+					status: 200,
+				} );
+
+				await registry
+					.dispatch( CORE_SITE )
+					.unsubscribeUser( subscribedUser.id );
+
+				const [ cachedResult ] = Object.values(
+					registry.stores[ CORE_SITE ].store.getState().emailReporting
+						.subscribedUsers
+				);
+
+				expect( cachedResult.total ).toBe( 0 );
+			} );
+
+			it( 'keeps the cached subscribed-users listing unchanged when the unsubscribe fails', async () => {
+				await resolveSubscribedUsers( [
+					subscribedUser,
+					otherSubscribedUser,
+				] );
+
+				fetchMock.postOnce( unsubscribeUserEndpointRegExp, {
+					body: {
+						code: 'email_reporting_unsubscribe_failed',
+						message:
+							'Unable to unsubscribe the user from email reports.',
+						data: { status: 500 },
+					},
+					status: 500,
+				} );
+
+				await registry
+					.dispatch( CORE_SITE )
+					.unsubscribeUser( subscribedUser.id );
+
+				const { users, total } = registry
+					.select( CORE_SITE )
+					.getSubscribedUsers( defaultEligibleSubscribersArgs );
+
+				expect( users.map( ( { id } ) => id ) ).toEqual( [
+					subscribedUser.id,
+					otherSubscribedUser.id,
+				] );
+				expect( total ).toBe( 2 );
+
+				expect( console ).toHaveErrored();
+			} );
+
+			it( 'throws unless the user ID is a positive integer', () => {
+				expect( () => {
+					registry.dispatch( CORE_SITE ).unsubscribeUser();
+				} ).toThrow( 'userID should be a positive integer.' );
+				expect( () => {
+					registry.dispatch( CORE_SITE ).unsubscribeUser( -1 );
+				} ).toThrow( 'userID should be a positive integer.' );
+				expect( () => {
+					registry.dispatch( CORE_SITE ).unsubscribeUser( 0 );
+				} ).toThrow( 'userID should be a positive integer.' );
+				expect( () => {
+					registry.dispatch( CORE_SITE ).unsubscribeUser( 1.5 );
+				} ).toThrow( 'userID should be a positive integer.' );
+				expect( () => {
+					registry.dispatch( CORE_SITE ).unsubscribeUser( '1' );
+				} ).toThrow( 'userID should be a positive integer.' );
+			} );
+		} );
+
 		describe( 'resetEligibleSubscribers', () => {
 			it( 'clears cached eligible subscribers', async () => {
 				fetchMock.get( eligibleSubscribersEndpointRegExp, {
@@ -458,6 +700,81 @@ describe( 'core/site Email Reporting', () => {
 					registry,
 					CORE_SITE
 				).getEligibleSubscribers( defaultEligibleSubscribersArgs );
+
+				expect( fetchMock ).toHaveFetchedTimes( 2 );
+			} );
+		} );
+
+		describe( 'resetSubscribedUsers', () => {
+			it( 'clears the cached subscribed-users listings for every page and search term', async () => {
+				// resetSubscribedUsers invalidates getSubscribedUsers resolution, so
+				// the resolver runs again for both cached search terms and this
+				// catch-all mock responds to both refetches.
+				fetchMock.get( subscribedUsersEndpointRegExp, {
+					body: createEligibleSubscribersResponse( [] ),
+					status: 200,
+				} );
+
+				registry
+					.dispatch( CORE_SITE )
+					.receiveGetSubscribedUsers(
+						createEligibleSubscribersResponse( [] ),
+						{
+							page: 1,
+							search: '',
+						}
+					);
+				registry
+					.dispatch( CORE_SITE )
+					.receiveGetSubscribedUsers(
+						createEligibleSubscribersResponse( [] ),
+						{
+							page: 1,
+							search: 'editor',
+						}
+					);
+
+				expect(
+					registry.select( CORE_SITE ).getSubscribedUsers( {
+						search: '',
+					} )
+				).toBeDefined();
+				expect(
+					registry.select( CORE_SITE ).getSubscribedUsers( {
+						search: 'editor',
+					} )
+				).toBeDefined();
+
+				await registry.dispatch( CORE_SITE ).resetSubscribedUsers();
+
+				expect(
+					registry.stores[ CORE_SITE ].store.getState().emailReporting
+						.subscribedUsers
+				).toEqual( {} );
+			} );
+
+			it( 'fetches again for args the store already resolved once the reset lands', async () => {
+				await resolveSubscribedUsers( [
+					{
+						id: 2,
+						displayName: 'Subscribed User',
+						email: 'subscribed@example.com',
+						role: 'editor',
+					},
+				] );
+
+				expect( fetchMock ).toHaveFetchedTimes( 1 );
+
+				await registry.dispatch( CORE_SITE ).resetSubscribedUsers();
+
+				await resolveSubscribedUsers( [
+					{
+						id: 3,
+						displayName: 'Another Subscribed User',
+						email: 'another@example.com',
+						role: 'author',
+					},
+				] );
 
 				expect( fetchMock ).toHaveFetchedTimes( 2 );
 			} );
@@ -914,6 +1231,292 @@ describe( 'core/site Email Reporting', () => {
 			} );
 		} );
 
+		describe( 'getSubscribedUsers', () => {
+			it( 'returns the cached subscribed-users listing for matching args', () => {
+				registry.dispatch( CORE_SITE ).receiveGetSubscribedUsers(
+					createEligibleSubscribersResponse( [
+						{
+							id: 2,
+							displayName: 'Subscribed User',
+							email: 'subscribed@example.com',
+							role: 'editor',
+						},
+					] ),
+					{ page: 1, search: '' }
+				);
+
+				expect(
+					registry.select( CORE_SITE ).getSubscribedUsers( {
+						search: '',
+					} )
+				).toEqual( {
+					users: [
+						{
+							id: 2,
+							name: 'Subscribed User',
+							email: 'subscribed@example.com',
+							role: 'editor',
+						},
+					],
+					total: 1,
+				} );
+			} );
+
+			it( 'keeps the current user in the subscribed-users listing', () => {
+				provideUserInfo( registry, { id: 1 } );
+
+				registry.dispatch( CORE_SITE ).receiveGetSubscribedUsers(
+					createEligibleSubscribersResponse( [
+						{
+							id: 1,
+							displayName: 'Current User',
+							email: 'current@example.com',
+							role: 'administrator',
+						},
+						{
+							id: 2,
+							displayName: 'Subscribed User',
+							email: 'subscribed@example.com',
+							role: 'editor',
+						},
+					] ),
+					{ page: 1, search: '' }
+				);
+
+				expect(
+					registry
+						.select( CORE_SITE )
+						.getSubscribedUsers( { search: '' } )
+						.users.map( ( { id } ) => id )
+				).toEqual( [ 1, 2 ] );
+			} );
+
+			it( 'returns roleDisplayName as the role when the response provides it', () => {
+				registry.dispatch( CORE_SITE ).receiveGetSubscribedUsers(
+					createEligibleSubscribersResponse( [
+						{
+							id: 2,
+							displayName: 'Subscribed User',
+							email: 'subscribed@example.com',
+							role: 'editor',
+							roleDisplayName: 'Editor',
+						},
+					] ),
+					{ page: 1, search: '' }
+				);
+
+				expect(
+					registry.select( CORE_SITE ).getSubscribedUsers( {
+						search: '',
+					} ).users[ 0 ].role
+				).toBe( 'Editor' );
+			} );
+
+			it( 'returns the role slug when the response holds no roleDisplayName', () => {
+				registry.dispatch( CORE_SITE ).receiveGetSubscribedUsers(
+					createEligibleSubscribersResponse( [
+						{
+							id: 2,
+							displayName: 'Subscribed User',
+							email: 'subscribed@example.com',
+							role: 'editor',
+						},
+					] ),
+					{ page: 1, search: '' }
+				);
+
+				expect(
+					registry.select( CORE_SITE ).getSubscribedUsers( {
+						search: '',
+					} ).users[ 0 ].role
+				).toBe( 'editor' );
+			} );
+
+			it( 'fetches page 1 with the search term on a cache miss', async () => {
+				fetchMock.getOnce( subscribedUsersEndpointRegExp, {
+					body: createEligibleSubscribersResponse( [
+						{
+							id: 2,
+							displayName: 'Search User',
+							email: 'search@example.com',
+							role: 'editor',
+						},
+					] ),
+					status: 200,
+				} );
+
+				expect(
+					registry.select( CORE_SITE ).getSubscribedUsers( {
+						search: 'search',
+					} )
+				).toBeUndefined();
+
+				await untilResolved( registry, CORE_SITE ).getSubscribedUsers( {
+					search: 'search',
+				} );
+
+				expect( fetchMock ).toHaveFetched(
+					subscribedUsersEndpointRegExp,
+					{
+						queryParams: {
+							page: 1,
+							search: 'search',
+						},
+					}
+				);
+			} );
+
+			it( "keeps each search term's results separate", async () => {
+				fetchMock.getOnce( subscribedUsersEndpointRegExp, {
+					body: createEligibleSubscribersResponse( [
+						{
+							id: 2,
+							displayName: 'Alpha User',
+							email: 'alpha@example.com',
+							role: 'editor',
+						},
+					] ),
+					status: 200,
+				} );
+
+				fetchMock.getOnce( subscribedUsersEndpointRegExp, {
+					body: createEligibleSubscribersResponse( [
+						{
+							id: 3,
+							displayName: 'Beta User',
+							email: 'beta@example.com',
+							role: 'editor',
+						},
+					] ),
+					status: 200,
+				} );
+
+				registry.select( CORE_SITE ).getSubscribedUsers( {
+					search: 'alpha',
+				} );
+				await untilResolved( registry, CORE_SITE ).getSubscribedUsers( {
+					search: 'alpha',
+				} );
+
+				registry.select( CORE_SITE ).getSubscribedUsers( {
+					search: 'beta',
+				} );
+				await untilResolved( registry, CORE_SITE ).getSubscribedUsers( {
+					search: 'beta',
+				} );
+
+				expect( fetchMock ).toHaveFetched(
+					subscribedUsersEndpointRegExp,
+					{
+						queryParams: {
+							page: 1,
+							search: 'alpha',
+						},
+					}
+				);
+				expect( fetchMock ).toHaveFetched(
+					subscribedUsersEndpointRegExp,
+					{
+						queryParams: {
+							page: 1,
+							search: 'beta',
+						},
+					}
+				);
+
+				expect(
+					registry
+						.select( CORE_SITE )
+						.getSubscribedUsers( { search: 'alpha' } )
+						.users.map( ( { name } ) => name )
+				).toEqual( [ 'Alpha User' ] );
+				expect(
+					registry
+						.select( CORE_SITE )
+						.getSubscribedUsers( { search: 'beta' } )
+						.users.map( ( { name } ) => name )
+				).toEqual( [ 'Beta User' ] );
+			} );
+
+			it( 'fetches every page and merges the users when totalPages is greater than 1', async () => {
+				fetchMock.getOnce( subscribedUsersEndpointRegExp, {
+					body: createEligibleSubscribersResponse(
+						[
+							{
+								id: 2,
+								displayName: 'Page 1 User',
+								email: 'page1@example.com',
+								role: 'editor',
+							},
+						],
+						{ page: 1, total: 2, totalPages: 2 }
+					),
+					status: 200,
+				} );
+
+				fetchMock.getOnce( subscribedUsersEndpointRegExp, {
+					body: createEligibleSubscribersResponse(
+						[
+							{
+								id: 3,
+								displayName: 'Page 2 User',
+								email: 'page2@example.com',
+								role: 'editor',
+							},
+						],
+						{ page: 2, total: 2, totalPages: 2 }
+					),
+					status: 200,
+				} );
+
+				registry.select( CORE_SITE ).getSubscribedUsers( {
+					search: '',
+				} );
+				await untilResolved( registry, CORE_SITE ).getSubscribedUsers( {
+					search: '',
+				} );
+
+				expect(
+					registry
+						.select( CORE_SITE )
+						.getSubscribedUsers( { search: '' } )
+						.users.map( ( { name } ) => name )
+				).toEqual( [ 'Page 1 User', 'Page 2 User' ] );
+				expect( fetchMock ).toHaveFetchedTimes( 2 );
+			} );
+
+			it( 'returns undefined when the request fails', async () => {
+				fetchMock.get( /.*/, {
+					body: { error: 'something went wrong' },
+					status: 500,
+				} );
+
+				expect(
+					registry.select( CORE_SITE ).getSubscribedUsers( {
+						search: '',
+					} )
+				).toBeUndefined();
+
+				await untilResolved( registry, CORE_SITE ).getSubscribedUsers( {
+					search: '',
+				} );
+
+				expect(
+					registry.select( CORE_SITE ).getSubscribedUsers( {
+						search: '',
+					} )
+				).toBeUndefined();
+
+				await waitForDefaultTimeouts();
+
+				expect( fetchMock ).toHaveFetched(
+					subscribedUsersEndpointRegExp
+				);
+
+				expect( console ).toHaveErrored();
+			} );
+		} );
+
 		describe( 'getEmailReportingErrors', () => {
 			it( 'uses a resolver to make a network request', async () => {
 				const emailReportingErrors = {
@@ -1025,6 +1628,90 @@ describe( 'core/site Email Reporting', () => {
 				expect( registry.select( CORE_SITE ).isInvitingUser( 3 ) ).toBe(
 					false
 				);
+			} );
+		} );
+
+		describe( 'isUnsubscribingUser', () => {
+			it( 'reads true while the unsubscribe request runs and false after it settles', async () => {
+				const unsubscribingUserID = 47;
+				const unsubscribedUserID = 48;
+
+				freezeFetch( unsubscribeUserEndpointRegExp );
+
+				expect(
+					registry
+						.select( CORE_SITE )
+						.isUnsubscribingUser( unsubscribingUserID )
+				).toBe( false );
+
+				registry
+					.dispatch( CORE_SITE )
+					.unsubscribeUser( unsubscribingUserID );
+
+				expect(
+					registry
+						.select( CORE_SITE )
+						.isUnsubscribingUser( unsubscribingUserID )
+				).toBe( true );
+
+				fetchMock.postOnce( unsubscribeUserEndpointRegExp, {
+					body: { success: true },
+					status: 200,
+				} );
+
+				await registry
+					.dispatch( CORE_SITE )
+					.unsubscribeUser( unsubscribedUserID );
+
+				expect(
+					registry
+						.select( CORE_SITE )
+						.isUnsubscribingUser( unsubscribedUserID )
+				).toBe( false );
+			} );
+
+			it( "tracks each user's unsubscribe request on its own", async () => {
+				fetchMock.post(
+					unsubscribeUserEndpointRegExp,
+					( _url, options ) => {
+						const requestBody =
+							typeof options.body === 'string'
+								? JSON.parse( options.body )
+								: options.body;
+						const userID = requestBody?.data?.[ USER_ID_PARAM ];
+
+						if ( userID === 2 ) {
+							return new Promise( () => {} );
+						}
+
+						return {
+							body: { success: true },
+							status: 200,
+						};
+					}
+				);
+
+				registry.dispatch( CORE_SITE ).unsubscribeUser( 2 );
+
+				expect(
+					registry.select( CORE_SITE ).isUnsubscribingUser( 2 )
+				).toBe( true );
+				expect(
+					registry.select( CORE_SITE ).isUnsubscribingUser( 3 )
+				).toBe( false );
+
+				const { response, error } = await registry
+					.dispatch( CORE_SITE )
+					.unsubscribeUser( 3 );
+
+				expect( response ).toEqual( { success: true } );
+				expect( error ).toBeUndefined();
+				expect(
+					registry.select( CORE_SITE ).isUnsubscribingUser( 2 )
+				).toBe( true );
+				expect(
+					registry.select( CORE_SITE ).isUnsubscribingUser( 3 )
+				).toBe( false );
 			} );
 		} );
 	} );

--- a/assets/js/googlesitekit/datastore/site/email-reporting.test.js
+++ b/assets/js/googlesitekit/datastore/site/email-reporting.test.js
@@ -49,9 +49,9 @@ describe( 'core/site Email Reporting', () => {
 		'^/google-site-kit/v1/core/site/data/email-reporting-unsubscribe-user'
 	);
 	const USER_ID_PARAM = 'userID';
-	const defaultEligibleSubscribersArgs = { search: '' };
+	const defaultUserListArgs = { search: '' };
 
-	function createEligibleSubscribersResponse( users, args = {} ) {
+	function createUserListResponse( users, args = {} ) {
 		const page = Number.isInteger( args.page ) ? args.page : 1;
 		const total = Number.isInteger( args.total )
 			? args.total
@@ -78,12 +78,9 @@ describe( 'core/site Email Reporting', () => {
 	 * @param {Object} [args] Page and search args to resolve.
 	 * @return {Promise} Promise that resolves once the listing is in the store.
 	 */
-	async function resolveSubscribedUsers(
-		users,
-		args = defaultEligibleSubscribersArgs
-	) {
+	async function resolveSubscribedUsers( users, args = defaultUserListArgs ) {
 		fetchMock.getOnce( subscribedUsersEndpointRegExp, {
-			body: createEligibleSubscribersResponse( users ),
+			body: createUserListResponse( users ),
 			status: 200,
 		} );
 
@@ -285,7 +282,7 @@ describe( 'core/site Email Reporting', () => {
 
 				// First, resolve eligible subscribers with the user not yet invited.
 				fetchMock.getOnce( eligibleSubscribersEndpointRegExp, {
-					body: createEligibleSubscribersResponse( [
+					body: createUserListResponse( [
 						{
 							id: userID,
 							displayName: 'Test User',
@@ -302,15 +299,15 @@ describe( 'core/site Email Reporting', () => {
 
 				registry
 					.select( CORE_SITE )
-					.getEligibleSubscribers( defaultEligibleSubscribersArgs );
+					.getEligibleSubscribers( defaultUserListArgs );
 				await untilResolved(
 					registry,
 					CORE_SITE
-				).getEligibleSubscribers( defaultEligibleSubscribersArgs );
+				).getEligibleSubscribers( defaultUserListArgs );
 
 				const subscribersBefore = registry
 					.select( CORE_SITE )
-					.getEligibleSubscribers( defaultEligibleSubscribersArgs );
+					.getEligibleSubscribers( defaultUserListArgs );
 				expect( subscribersBefore.users[ 0 ].invited ).toBe( false );
 
 				// Now invite the user successfully.
@@ -324,7 +321,7 @@ describe( 'core/site Email Reporting', () => {
 				// The user should now be marked as invited in the store.
 				const subscribersAfter = registry
 					.select( CORE_SITE )
-					.getEligibleSubscribers( defaultEligibleSubscribersArgs );
+					.getEligibleSubscribers( defaultUserListArgs );
 				expect( subscribersAfter.users[ 0 ].invited ).toBe( true );
 			} );
 
@@ -333,7 +330,7 @@ describe( 'core/site Email Reporting', () => {
 
 				// First, resolve eligible subscribers with the user not yet invited.
 				fetchMock.getOnce( eligibleSubscribersEndpointRegExp, {
-					body: createEligibleSubscribersResponse( [
+					body: createUserListResponse( [
 						{
 							id: userID,
 							displayName: 'Test User',
@@ -350,11 +347,11 @@ describe( 'core/site Email Reporting', () => {
 
 				registry
 					.select( CORE_SITE )
-					.getEligibleSubscribers( defaultEligibleSubscribersArgs );
+					.getEligibleSubscribers( defaultUserListArgs );
 				await untilResolved(
 					registry,
 					CORE_SITE
-				).getEligibleSubscribers( defaultEligibleSubscribersArgs );
+				).getEligibleSubscribers( defaultUserListArgs );
 
 				// Now invite a user that fails.
 				fetchMock.postOnce( inviteUserEndpointRegExp, {
@@ -372,7 +369,7 @@ describe( 'core/site Email Reporting', () => {
 				// The user should still NOT be marked as invited.
 				const subscribersAfter = registry
 					.select( CORE_SITE )
-					.getEligibleSubscribers( defaultEligibleSubscribersArgs );
+					.getEligibleSubscribers( defaultUserListArgs );
 				expect( subscribersAfter.users[ 0 ].invited ).toBe( false );
 
 				expect( console ).toHaveErrored();
@@ -476,7 +473,7 @@ describe( 'core/site Email Reporting', () => {
 				expect(
 					registry
 						.select( CORE_SITE )
-						.getSubscribedUsers( defaultEligibleSubscribersArgs )
+						.getSubscribedUsers( defaultUserListArgs )
 				).toEqual( {
 					users: [
 						{
@@ -530,13 +527,12 @@ describe( 'core/site Email Reporting', () => {
 			} );
 
 			it( 'keeps a cached total at zero when the removal would go below it', async () => {
-				// The subscribed-users endpoint can return users with no `total`
-				// field, and sanitizeUserListTotal() turns that missing value into
-				// zero. Dispatching `total: 0` with one user recreates that state,
-				// so the unsubscribe would push the total under zero without the
-				// floor.
+				// sanitizeUserListTotal() reads a missing or malformed total as
+				// zero, so a cached subscribed-users listing can hold one
+				// subscribed user against a total of zero. The zero floor is what
+				// keeps the removal from taking that total below zero.
 				registry.dispatch( CORE_SITE ).receiveGetSubscribedUsers(
-					createEligibleSubscribersResponse( [ subscribedUser ], {
+					createUserListResponse( [ subscribedUser ], {
 						total: 0,
 					} ),
 					{ page: 1, search: '' }
@@ -581,7 +577,7 @@ describe( 'core/site Email Reporting', () => {
 
 				const { users, total } = registry
 					.select( CORE_SITE )
-					.getSubscribedUsers( defaultEligibleSubscribersArgs );
+					.getSubscribedUsers( defaultUserListArgs );
 
 				expect( users.map( ( { id } ) => id ) ).toEqual( [
 					subscribedUser.id,
@@ -614,20 +610,20 @@ describe( 'core/site Email Reporting', () => {
 		describe( 'resetEligibleSubscribers', () => {
 			it( 'clears cached eligible subscribers', async () => {
 				fetchMock.get( eligibleSubscribersEndpointRegExp, {
-					body: createEligibleSubscribersResponse( [] ),
+					body: createUserListResponse( [] ),
 					status: 200,
 				} );
 
 				registry
 					.dispatch( CORE_SITE )
 					.receiveGetEligibleSubscribers(
-						createEligibleSubscribersResponse( [] ),
+						createUserListResponse( [] ),
 						{ page: 1, search: '' }
 					);
 				registry
 					.dispatch( CORE_SITE )
 					.receiveGetEligibleSubscribers(
-						createEligibleSubscribersResponse( [] ),
+						createUserListResponse( [] ),
 						{ page: 1, search: 'editor' }
 					);
 
@@ -654,7 +650,7 @@ describe( 'core/site Email Reporting', () => {
 				provideUserInfo( registry, { id: 1 } );
 
 				fetchMock.getOnce( eligibleSubscribersEndpointRegExp, {
-					body: createEligibleSubscribersResponse( [
+					body: createUserListResponse( [
 						{
 							id: 2,
 							displayName: 'Eligible User',
@@ -669,18 +665,18 @@ describe( 'core/site Email Reporting', () => {
 
 				registry
 					.select( CORE_SITE )
-					.getEligibleSubscribers( defaultEligibleSubscribersArgs );
+					.getEligibleSubscribers( defaultUserListArgs );
 				await untilResolved(
 					registry,
 					CORE_SITE
-				).getEligibleSubscribers( defaultEligibleSubscribersArgs );
+				).getEligibleSubscribers( defaultUserListArgs );
 
 				expect( fetchMock ).toHaveFetchedTimes( 1 );
 
 				await registry.dispatch( CORE_SITE ).resetEligibleSubscribers();
 
 				fetchMock.getOnce( eligibleSubscribersEndpointRegExp, {
-					body: createEligibleSubscribersResponse( [
+					body: createUserListResponse( [
 						{
 							id: 3,
 							displayName: 'Another Eligible User',
@@ -695,11 +691,11 @@ describe( 'core/site Email Reporting', () => {
 
 				registry
 					.select( CORE_SITE )
-					.getEligibleSubscribers( defaultEligibleSubscribersArgs );
+					.getEligibleSubscribers( defaultUserListArgs );
 				await untilResolved(
 					registry,
 					CORE_SITE
-				).getEligibleSubscribers( defaultEligibleSubscribersArgs );
+				).getEligibleSubscribers( defaultUserListArgs );
 
 				expect( fetchMock ).toHaveFetchedTimes( 2 );
 			} );
@@ -711,28 +707,22 @@ describe( 'core/site Email Reporting', () => {
 				// the resolver runs again for both cached search terms and this
 				// catch-all mock responds to both refetches.
 				fetchMock.get( subscribedUsersEndpointRegExp, {
-					body: createEligibleSubscribersResponse( [] ),
+					body: createUserListResponse( [] ),
 					status: 200,
 				} );
 
 				registry
 					.dispatch( CORE_SITE )
-					.receiveGetSubscribedUsers(
-						createEligibleSubscribersResponse( [] ),
-						{
-							page: 1,
-							search: '',
-						}
-					);
+					.receiveGetSubscribedUsers( createUserListResponse( [] ), {
+						page: 1,
+						search: '',
+					} );
 				registry
 					.dispatch( CORE_SITE )
-					.receiveGetSubscribedUsers(
-						createEligibleSubscribersResponse( [] ),
-						{
-							page: 1,
-							search: 'editor',
-						}
-					);
+					.receiveGetSubscribedUsers( createUserListResponse( [] ), {
+						page: 1,
+						search: 'editor',
+					} );
 
 				expect(
 					registry.select( CORE_SITE ).getSubscribedUsers( {
@@ -890,7 +880,7 @@ describe( 'core/site Email Reporting', () => {
 				provideUserInfo( registry, { id: 1 } );
 
 				registry.dispatch( CORE_SITE ).receiveGetEligibleSubscribers(
-					createEligibleSubscribersResponse( [
+					createUserListResponse( [
 						{
 							id: 1,
 							displayName: 'Current User',
@@ -935,7 +925,7 @@ describe( 'core/site Email Reporting', () => {
 				provideUserInfo( registry, { id: 1 } );
 
 				registry.dispatch( CORE_SITE ).receiveGetEligibleSubscribers(
-					createEligibleSubscribersResponse( [
+					createUserListResponse( [
 						{
 							id: 2,
 							displayName: 'Eligible User',
@@ -973,7 +963,7 @@ describe( 'core/site Email Reporting', () => {
 				provideUserInfo( registry, { id: 1 } );
 
 				registry.dispatch( CORE_SITE ).receiveGetEligibleSubscribers(
-					createEligibleSubscribersResponse( [
+					createUserListResponse( [
 						{
 							id: 2,
 							displayName: 'Eligible User',
@@ -997,7 +987,7 @@ describe( 'core/site Email Reporting', () => {
 				provideUserInfo( registry, { id: 1 } );
 
 				fetchMock.getOnce( eligibleSubscribersEndpointRegExp, {
-					body: createEligibleSubscribersResponse( [
+					body: createUserListResponse( [
 						{
 							id: 2,
 							displayName: 'Search User',
@@ -1036,7 +1026,7 @@ describe( 'core/site Email Reporting', () => {
 				provideUserInfo( registry, { id: 1 } );
 
 				fetchMock.getOnce( eligibleSubscribersEndpointRegExp, {
-					body: createEligibleSubscribersResponse( [
+					body: createUserListResponse( [
 						{
 							id: 2,
 							displayName: 'Alpha User',
@@ -1050,7 +1040,7 @@ describe( 'core/site Email Reporting', () => {
 				} );
 
 				fetchMock.getOnce( eligibleSubscribersEndpointRegExp, {
-					body: createEligibleSubscribersResponse( [
+					body: createUserListResponse( [
 						{
 							id: 3,
 							displayName: 'Beta User',
@@ -1100,7 +1090,7 @@ describe( 'core/site Email Reporting', () => {
 				provideUserInfo( registry, { id: 1 } );
 
 				fetchMock.getOnce( eligibleSubscribersEndpointRegExp, {
-					body: createEligibleSubscribersResponse(
+					body: createUserListResponse(
 						[
 							{
 								id: 2,
@@ -1117,7 +1107,7 @@ describe( 'core/site Email Reporting', () => {
 				} );
 
 				fetchMock.getOnce( eligibleSubscribersEndpointRegExp, {
-					body: createEligibleSubscribersResponse(
+					body: createUserListResponse(
 						[
 							{
 								id: 3,
@@ -1153,7 +1143,7 @@ describe( 'core/site Email Reporting', () => {
 				provideUserInfo( registry, { id: 1 } );
 
 				fetchMock.getOnce( eligibleSubscribersEndpointRegExp, {
-					body: createEligibleSubscribersResponse(
+					body: createUserListResponse(
 						[
 							{
 								id: 3,
@@ -1234,7 +1224,7 @@ describe( 'core/site Email Reporting', () => {
 		describe( 'getSubscribedUsers', () => {
 			it( 'returns the cached subscribed-users listing for matching args', () => {
 				registry.dispatch( CORE_SITE ).receiveGetSubscribedUsers(
-					createEligibleSubscribersResponse( [
+					createUserListResponse( [
 						{
 							id: 2,
 							displayName: 'Subscribed User',
@@ -1266,7 +1256,7 @@ describe( 'core/site Email Reporting', () => {
 				provideUserInfo( registry, { id: 1 } );
 
 				registry.dispatch( CORE_SITE ).receiveGetSubscribedUsers(
-					createEligibleSubscribersResponse( [
+					createUserListResponse( [
 						{
 							id: 1,
 							displayName: 'Current User',
@@ -1293,7 +1283,7 @@ describe( 'core/site Email Reporting', () => {
 
 			it( 'returns roleDisplayName as the role when the response provides it', () => {
 				registry.dispatch( CORE_SITE ).receiveGetSubscribedUsers(
-					createEligibleSubscribersResponse( [
+					createUserListResponse( [
 						{
 							id: 2,
 							displayName: 'Subscribed User',
@@ -1314,7 +1304,7 @@ describe( 'core/site Email Reporting', () => {
 
 			it( 'returns the role slug when the response holds no roleDisplayName', () => {
 				registry.dispatch( CORE_SITE ).receiveGetSubscribedUsers(
-					createEligibleSubscribersResponse( [
+					createUserListResponse( [
 						{
 							id: 2,
 							displayName: 'Subscribed User',
@@ -1334,7 +1324,7 @@ describe( 'core/site Email Reporting', () => {
 
 			it( 'fetches page 1 with the search term on a cache miss', async () => {
 				fetchMock.getOnce( subscribedUsersEndpointRegExp, {
-					body: createEligibleSubscribersResponse( [
+					body: createUserListResponse( [
 						{
 							id: 2,
 							displayName: 'Search User',
@@ -1368,7 +1358,7 @@ describe( 'core/site Email Reporting', () => {
 
 			it( "keeps each search term's results separate", async () => {
 				fetchMock.getOnce( subscribedUsersEndpointRegExp, {
-					body: createEligibleSubscribersResponse( [
+					body: createUserListResponse( [
 						{
 							id: 2,
 							displayName: 'Alpha User',
@@ -1380,7 +1370,7 @@ describe( 'core/site Email Reporting', () => {
 				} );
 
 				fetchMock.getOnce( subscribedUsersEndpointRegExp, {
-					body: createEligibleSubscribersResponse( [
+					body: createUserListResponse( [
 						{
 							id: 3,
 							displayName: 'Beta User',
@@ -1440,7 +1430,7 @@ describe( 'core/site Email Reporting', () => {
 
 			it( 'fetches every page and merges the users when totalPages is greater than 1', async () => {
 				fetchMock.getOnce( subscribedUsersEndpointRegExp, {
-					body: createEligibleSubscribersResponse(
+					body: createUserListResponse(
 						[
 							{
 								id: 2,
@@ -1455,7 +1445,7 @@ describe( 'core/site Email Reporting', () => {
 				} );
 
 				fetchMock.getOnce( subscribedUsersEndpointRegExp, {
-					body: createEligibleSubscribersResponse(
+					body: createUserListResponse(
 						[
 							{
 								id: 3,
@@ -1483,6 +1473,49 @@ describe( 'core/site Email Reporting', () => {
 						.users.map( ( { name } ) => name )
 				).toEqual( [ 'Page 1 User', 'Page 2 User' ] );
 				expect( fetchMock ).toHaveFetchedTimes( 2 );
+			} );
+
+			it( 'returns only the requested subscribed-users page when the caller asks for a page after the first', async () => {
+				fetchMock.getOnce( subscribedUsersEndpointRegExp, {
+					body: createUserListResponse(
+						[
+							{
+								id: 3,
+								displayName: 'Page 2 User',
+								email: 'page2@example.com',
+								role: 'editor',
+							},
+						],
+						{ page: 2, total: 2, totalPages: 2 }
+					),
+					status: 200,
+				} );
+
+				registry.select( CORE_SITE ).getSubscribedUsers( {
+					page: 2,
+					search: '',
+				} );
+				await untilResolved( registry, CORE_SITE ).getSubscribedUsers( {
+					page: 2,
+					search: '',
+				} );
+
+				expect( fetchMock ).toHaveFetchedTimes( 1 );
+				expect( fetchMock ).toHaveFetched(
+					subscribedUsersEndpointRegExp,
+					{
+						queryParams: {
+							page: 2,
+							search: '',
+						},
+					}
+				);
+				expect(
+					registry
+						.select( CORE_SITE )
+						.getSubscribedUsers( { page: 2, search: '' } )
+						.users.map( ( { name } ) => name )
+				).toEqual( [ 'Page 2 User' ] );
 			} );
 
 			it( 'returns undefined when the request fails', async () => {


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Related issue(s):

- Resolves #13101

## Relevant technical choices

- Renames the shared helpers from eligible-subscribers names to user-list names, such as `normalizeEligibleSubscribersArgs` to `normalizeUserListArgs`, since both subscriber lists, `getEligibleSubscribers` and `getSubscribedUsers`, call them now.

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.
- [ ] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
