### PR TITLE
Stop running the eligible subscribers query on every page load

### DIFF
--- a/includes/Core/Email_Reporting/REST_Email_Reporting_Controller.php
+++ b/includes/Core/Email_Reporting/REST_Email_Reporting_Controller.php
@@ -184,7 +184,6 @@ class REST_Email_Reporting_Controller {
 					$paths,
 					array(
 						'/' . REST_Routes::REST_ROOT . '/core/site/data/email-reporting',
-						'/' . REST_Routes::REST_ROOT . '/core/site/data/email-reporting-eligible-subscribers',
 						'/' . REST_Routes::REST_ROOT . '/core/site/data/email-reporting-errors',
 					)
 				);

--- a/tests/phpunit/integration/Core/Email_Reporting/REST_Email_Reporting_ControllerTest.php
+++ b/tests/phpunit/integration/Core/Email_Reporting/REST_Email_Reporting_ControllerTest.php
@@ -168,6 +168,30 @@ class REST_Email_Reporting_ControllerTest extends TestCase {
 		$this->assertTrue( has_filter( 'googlesitekit_apifetch_preload_paths' ), 'Expected API fetch preload paths filter to be registered' );
 	}
 
+	public function test_register__adds_email_reporting_and_errors_paths_but_not_eligible_subscribers() {
+		remove_all_filters( 'googlesitekit_apifetch_preload_paths' );
+
+		$this->controller->register();
+
+		$paths = apply_filters( 'googlesitekit_apifetch_preload_paths', array() );
+
+		$this->assertContains(
+			'/' . REST_Routes::REST_ROOT . '/core/site/data/email-reporting',
+			$paths,
+			'register() should add the email-reporting route to the preload paths.'
+		);
+		$this->assertContains(
+			'/' . REST_Routes::REST_ROOT . '/core/site/data/email-reporting-errors',
+			$paths,
+			'register() should add the email-reporting-errors route to the preload paths.'
+		);
+		$this->assertNotContains(
+			'/' . REST_Routes::REST_ROOT . '/core/site/data/email-reporting-eligible-subscribers',
+			$paths,
+			'register() should keep the email-reporting-eligible-subscribers route out of the preload paths, so a page load never runs its user queries.'
+		);
+	}
+
 	public function test_get_routes() {
 		$this->controller->register();
 

--- a/tests/phpunit/integration/Core/Email_Reporting/REST_Email_Reporting_ControllerTest.php
+++ b/tests/phpunit/integration/Core/Email_Reporting/REST_Email_Reporting_ControllerTest.php
@@ -168,7 +168,7 @@ class REST_Email_Reporting_ControllerTest extends TestCase {
 		$this->assertTrue( has_filter( 'googlesitekit_apifetch_preload_paths' ), 'Expected API fetch preload paths filter to be registered' );
 	}
 
-	public function test_register__adds_email_reporting_and_errors_paths() {
+	public function test_register__adds_only_the_email_reporting_and_email_reporting_errors_paths() {
 		remove_all_filters( 'googlesitekit_apifetch_preload_paths' );
 
 		$this->controller->register();
@@ -181,7 +181,7 @@ class REST_Email_Reporting_ControllerTest extends TestCase {
 				'/' . REST_Routes::REST_ROOT . '/core/site/data/email-reporting-errors',
 			),
 			$paths,
-			'register() should add only the email-reporting and email-reporting-errors preload paths.'
+			'The preload paths should hold email-reporting and email-reporting-errors and nothing else.'
 		);
 	}
 

--- a/tests/phpunit/integration/Core/Email_Reporting/REST_Email_Reporting_ControllerTest.php
+++ b/tests/phpunit/integration/Core/Email_Reporting/REST_Email_Reporting_ControllerTest.php
@@ -168,27 +168,20 @@ class REST_Email_Reporting_ControllerTest extends TestCase {
 		$this->assertTrue( has_filter( 'googlesitekit_apifetch_preload_paths' ), 'Expected API fetch preload paths filter to be registered' );
 	}
 
-	public function test_register__adds_email_reporting_and_errors_paths_but_not_eligible_subscribers() {
+	public function test_register__adds_email_reporting_and_errors_paths() {
 		remove_all_filters( 'googlesitekit_apifetch_preload_paths' );
 
 		$this->controller->register();
 
 		$paths = apply_filters( 'googlesitekit_apifetch_preload_paths', array() );
 
-		$this->assertContains(
-			'/' . REST_Routes::REST_ROOT . '/core/site/data/email-reporting',
+		$this->assertEqualSets(
+			array(
+				'/' . REST_Routes::REST_ROOT . '/core/site/data/email-reporting',
+				'/' . REST_Routes::REST_ROOT . '/core/site/data/email-reporting-errors',
+			),
 			$paths,
-			'register() should add the email-reporting route to the preload paths.'
-		);
-		$this->assertContains(
-			'/' . REST_Routes::REST_ROOT . '/core/site/data/email-reporting-errors',
-			$paths,
-			'register() should add the email-reporting-errors route to the preload paths.'
-		);
-		$this->assertNotContains(
-			'/' . REST_Routes::REST_ROOT . '/core/site/data/email-reporting-eligible-subscribers',
-			$paths,
-			'register() should keep the email-reporting-eligible-subscribers route out of the preload paths, so a page load never runs its user queries.'
+			'register() should add only the email-reporting and email-reporting-errors preload paths.'
 		);
 	}
 


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Related issue(s):

- Resolves #12857

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.
- [ ] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
