### PR TITLE
Fix WooCommerce conversion event values for stores that change decimal places

### DIFF
--- a/assets/js/event-providers/woocommerce.js
+++ b/assets/js/event-providers/woocommerce.js
@@ -25,6 +25,9 @@
 		purchase,
 		add_to_cart: addToCart,
 		eventsToTrack,
+		// An older cached page sends no `currencyMinorUnit`, so we fall back to
+		// two, WooCommerce's default.
+		currencyMinorUnit = 2,
 	} = global._googlesitekit?.wcdata || {};
 	const canTrackAddToCart = eventsToTrack?.includes( 'add_to_cart' );
 	const canTrackPurchase = eventsToTrack?.includes( 'purchase' );
@@ -213,12 +216,12 @@
 	 * Returns the price of a product formatted with decimal places if necessary.
 	 *
 	 * @since 1.158.0
+	 * @since n.e.x.t Changed to read the store's decimal places from the page data.
 	 *
-	 * @param {string} price                 The price to parse.
-	 * @param {number} [currencyMinorUnit=2] The number decimals to show in the currency.
+	 * @param {string} price The price to parse.
 	 * @return {number} The price of the product with decimals.
 	 */
-	function formatPrice( price, currencyMinorUnit = 2 ) {
+	function formatPrice( price ) {
 		return parseInt( price, 10 ) / 10 ** currencyMinorUnit;
 	}
 } )( global.jQuery );

--- a/assets/js/event-providers/woocommerce.js
+++ b/assets/js/event-providers/woocommerce.js
@@ -218,7 +218,7 @@
 	 * @since 1.158.0
 	 * @since n.e.x.t Changed to read the store's decimal places from the page data.
 	 *
-	 * @param {string} price The price to parse.
+	 * @param {number} price The price to parse.
 	 * @return {number} The price of the product with decimals.
 	 */
 	function formatPrice( price ) {

--- a/assets/js/event-providers/woocommerce.js
+++ b/assets/js/event-providers/woocommerce.js
@@ -25,8 +25,8 @@
 		purchase,
 		add_to_cart: addToCart,
 		eventsToTrack,
-		// An older cached page sends no `currencyMinorUnit`, so we fall back to
-		// two, WooCommerce's default.
+		// An older cached page sends no `currencyMinorUnit`. Fall back to two,
+		// the WooCommerce default.
 		currencyMinorUnit = 2,
 	} = global._googlesitekit?.wcdata || {};
 	const canTrackAddToCart = eventsToTrack?.includes( 'add_to_cart' );
@@ -216,9 +216,9 @@
 	 * Returns the price of a product formatted with decimal places if necessary.
 	 *
 	 * @since 1.158.0
-	 * @since n.e.x.t Changed to read the store's decimal places from the page data.
+	 * @since n.e.x.t Reads the store's decimal places from the page data.
 	 *
-	 * @param {number} price The price to parse.
+	 * @param {number} price The price in minor units, such as 4999 for 49.99.
 	 * @return {number} The price of the product with decimals.
 	 */
 	function formatPrice( price ) {

--- a/assets/js/event-providers/woocommerce.test.js
+++ b/assets/js/event-providers/woocommerce.test.js
@@ -1,0 +1,169 @@
+/**
+ * WooCommerce conversion event provider tests.
+ *
+ * Site Kit by Google, Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Builds a product in the shape `get_formatted_product()` writes into the page.
+ *
+ * @since n.e.x.t
+ *
+ * @param {number} price The price in minor units, such as `1234` for 12.34.
+ * @return {Object} A product, shaped the way `get_formatted_product()` shapes one.
+ */
+function createProduct( price ) {
+	return {
+		id: 42,
+		name: 'Site Kit T-Shirt',
+		categories: [ { name: 'Clothing' } ],
+		price,
+		quantity: 1,
+	};
+}
+
+/**
+ * Builds an order in the shape `get_formatted_order()` writes into the order-received page.
+ *
+ * @since n.e.x.t
+ *
+ * @param {number} price The order total and its one item's price, both in minor units.
+ * @return {Object} An order, shaped the way `get_formatted_order()` shapes one.
+ */
+function createOrder( price ) {
+	return {
+		id: 99,
+		affiliation: 'Test Store',
+		totals: {
+			currency_code: 'USD',
+			tax_total: 0,
+			shipping_total: 0,
+			total_price: price,
+		},
+		items: [ createProduct( price ) ],
+	};
+}
+
+/**
+ * Loads the WooCommerce event provider script and returns the mock that caught
+ * its events.
+ *
+ * The script reads `global._googlesitekit` once, as it loads, so every case
+ * imports the module again.
+ *
+ * @since n.e.x.t
+ *
+ * @param {Object} wcdata The page data, as `window._googlesitekit.wcdata`.
+ * @return {Function} The `gtagEvent` mock, with one call per event the script sent.
+ */
+async function loadEventScript( wcdata ) {
+	const gtagEvent = jest.fn();
+
+	// The script returns at once when `jQuery` is missing, so every case needs this fake.
+	global.jQuery = () => ( { on: jest.fn(), each: jest.fn() } );
+	global._googlesitekit = { gtagEvent, wcdata };
+
+	await import( './woocommerce' );
+
+	return gtagEvent;
+}
+
+describe( 'WooCommerce conversion event provider', () => {
+	afterEach( () => {
+		delete global.jQuery;
+		delete global._googlesitekit;
+		jest.resetModules();
+	} );
+
+	// `price` is what the page holds, already multiplied into minor units.
+	const decimalPlaceCases = [
+		[ 'four decimals', 4, 123456, 12.3456 ],
+		[ 'no decimals', 0, 1234, 1234 ],
+		[ 'two decimals, the WooCommerce default', 2, 4999, 49.99 ],
+	];
+
+	it.each( decimalPlaceCases )(
+		'should send an `add_to_cart` value and item price when the store keeps prices to %s',
+		async ( _caseName, currencyMinorUnit, price, expectedPrice ) => {
+			const gtagEvent = await loadEventScript( {
+				currency: 'USD',
+				currencyMinorUnit,
+				eventsToTrack: [ 'add_to_cart', 'purchase' ],
+				add_to_cart: createProduct( price ),
+			} );
+
+			expect( gtagEvent ).toHaveBeenCalledWith( 'add_to_cart', {
+				value: expectedPrice,
+				currency: 'USD',
+				items: [
+					{
+						item_id: 42,
+						item_name: 'Site Kit T-Shirt',
+						item_category: 'Clothing',
+						price: expectedPrice,
+						quantity: 1,
+					},
+				],
+				googlesitekit_event_provider: 'woocommerce',
+			} );
+			expect( gtagEvent ).toHaveBeenCalledTimes( 1 );
+		}
+	);
+
+	it.each( decimalPlaceCases )(
+		'should send a `purchase` value and item price when the store keeps prices to %s',
+		async ( _caseName, currencyMinorUnit, price, expectedPrice ) => {
+			const gtagEvent = await loadEventScript( {
+				currency: 'USD',
+				currencyMinorUnit,
+				eventsToTrack: [ 'add_to_cart', 'purchase' ],
+				purchase: createOrder( price ),
+			} );
+
+			expect( gtagEvent ).toHaveBeenCalledWith( 'purchase', {
+				value: expectedPrice,
+				currency: 'USD',
+				transaction_id: 99,
+				shipping: 0,
+				tax: 0,
+				items: [
+					{
+						item_id: 42,
+						item_name: 'Site Kit T-Shirt',
+						item_category: 'Clothing',
+						price: expectedPrice,
+						quantity: 1,
+					},
+				],
+				googlesitekit_event_provider: 'woocommerce',
+			} );
+			expect( gtagEvent ).toHaveBeenCalledTimes( 1 );
+		}
+	);
+
+	it( 'should send an `add_to_cart` value at two decimals when the page sends no `currencyMinorUnit`', async () => {
+		const gtagEvent = await loadEventScript( {
+			currency: 'USD',
+			eventsToTrack: [ 'add_to_cart', 'purchase' ],
+			add_to_cart: createProduct( 4999 ),
+		} );
+
+		expect( gtagEvent ).toHaveBeenCalledWith(
+			'add_to_cart',
+			expect.objectContaining( { value: 49.99 } )
+		);
+		expect( gtagEvent ).toHaveBeenCalledTimes( 1 );
+	} );
+} );

--- a/assets/js/event-providers/woocommerce.test.js
+++ b/assets/js/event-providers/woocommerce.test.js
@@ -65,14 +65,20 @@ function createOrder( price ) {
  *
  * @since n.e.x.t
  *
- * @param {Object} wcdata The page data, as `window._googlesitekit.wcdata`.
+ * @param {Object} wcdata     The page data, as `window._googlesitekit.wcdata`.
+ * @param {Object} [handlers] Filled with each handler the script binds, keyed by event name.
  * @return {Function} The `gtagEvent` mock, with one call per event the script sent.
  */
-async function loadEventScript( wcdata ) {
+async function loadEventScript( wcdata, handlers = {} ) {
 	const gtagEvent = jest.fn();
 
 	// The script returns at once when `jQuery` is missing, so every case needs this fake.
-	global.jQuery = () => ( { on: jest.fn(), each: jest.fn() } );
+	global.jQuery = () => ( {
+		on: ( eventName, handler ) => {
+			handlers[ eventName ] = handler;
+		},
+		each: jest.fn(),
+	} );
 	global._googlesitekit = { gtagEvent, wcdata };
 
 	await import( './woocommerce' );
@@ -164,6 +170,42 @@ describe( 'WooCommerce conversion event provider', () => {
 			'add_to_cart',
 			expect.objectContaining( { value: 49.99 } )
 		);
+		expect( gtagEvent ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'should send an `add_to_cart` value at four decimals on the AJAX `added_to_cart` event', async () => {
+		const handlers = {};
+		const gtagEvent = await loadEventScript(
+			{
+				currency: 'USD',
+				currencyMinorUnit: 4,
+				eventsToTrack: [ 'add_to_cart', 'purchase' ],
+				products: [ createProduct( 123456 ) ],
+			},
+			handlers
+		);
+
+		expect( gtagEvent ).not.toHaveBeenCalled();
+
+		handlers.added_to_cart( {}, {}, '', {
+			jquery: '3.7.1',
+			data: () => 42,
+		} );
+
+		expect( gtagEvent ).toHaveBeenCalledWith( 'add_to_cart', {
+			value: 12.3456,
+			currency: 'USD',
+			items: [
+				{
+					item_id: 42,
+					item_name: 'Site Kit T-Shirt',
+					item_category: 'Clothing',
+					price: 12.3456,
+					quantity: 1,
+				},
+			],
+			googlesitekit_event_provider: 'woocommerce',
+		} );
 		expect( gtagEvent ).toHaveBeenCalledTimes( 1 );
 	} );
 } );

--- a/assets/js/event-providers/woocommerce.test.js
+++ b/assets/js/event-providers/woocommerce.test.js
@@ -1,5 +1,5 @@
 /**
- * WooCommerce conversion event provider tests.
+ * WooCommerce event provider script tests.
  *
  * Site Kit by Google, Copyright 2026 Google LLC
  *
@@ -17,12 +17,13 @@
  */
 
 /**
- * Builds a product in the shape `get_formatted_product()` writes into the page.
+ * Creates a product, shaped the way `get_formatted_product()` writes it into
+ * the page.
  *
  * @since n.e.x.t
  *
- * @param {number} price The price in minor units, such as `1234` for 12.34.
- * @return {Object} A product, shaped the way `get_formatted_product()` shapes one.
+ * @param {number} price The price in minor units, such as 1234 for 12.34.
+ * @return {Object} A product for `window._googlesitekit.wcdata`.
  */
 function createProduct( price ) {
 	return {
@@ -35,12 +36,13 @@ function createProduct( price ) {
 }
 
 /**
- * Builds an order in the shape `get_formatted_order()` writes into the order-received page.
+ * Creates an order holding a single product, shaped the way
+ * `get_formatted_order()` writes it into the order-received page.
  *
  * @since n.e.x.t
  *
- * @param {number} price The order total and its one item's price, both in minor units.
- * @return {Object} An order, shaped the way `get_formatted_order()` shapes one.
+ * @param {number} price The order total and the price of its one product, both in minor units.
+ * @return {Object} An order for `window._googlesitekit.wcdata`.
  */
 function createOrder( price ) {
 	return {
@@ -57,22 +59,22 @@ function createOrder( price ) {
 }
 
 /**
- * Loads the WooCommerce event provider script and returns the mock that caught
- * its events.
+ * Runs the event provider script over one set of page data.
  *
- * The script reads `global._googlesitekit` once, as it loads, so every case
- * imports the module again.
+ * The script reads `global._googlesitekit` as it loads, and only then, so each
+ * case has to import the module again.
  *
  * @since n.e.x.t
  *
  * @param {Object} wcdata     The page data, as `window._googlesitekit.wcdata`.
- * @param {Object} [handlers] Filled with each handler the script binds, keyed by event name.
- * @return {Function} The `gtagEvent` mock, with one call per event the script sent.
+ * @param {Object} [handlers] An object that receives every handler the script binds to `body`, keyed by event name.
+ * @return {Function} The `gtagEvent` mock, holding one call per event the script sent.
  */
 async function loadEventScript( wcdata, handlers = {} ) {
 	const gtagEvent = jest.fn();
 
-	// The script returns at once when `jQuery` is missing, so every case needs this fake.
+	// The script does nothing when `jQuery` is missing, so this fake has to exist
+	// before the import below.
 	global.jQuery = () => ( {
 		on: ( eventName, handler ) => {
 			handlers[ eventName ] = handler;
@@ -86,22 +88,23 @@ async function loadEventScript( wcdata, handlers = {} ) {
 	return gtagEvent;
 }
 
-describe( 'WooCommerce conversion event provider', () => {
+describe( 'WooCommerce event provider', () => {
 	afterEach( () => {
 		delete global.jQuery;
 		delete global._googlesitekit;
 		jest.resetModules();
 	} );
 
-	// `price` is what the page holds, already multiplied into minor units.
+	// Each row is the store's decimal places, the price the page holds in minor
+	// units, and the value the script should send.
 	const decimalPlaceCases = [
-		[ 'four decimals', 4, 123456, 12.3456 ],
-		[ 'no decimals', 0, 1234, 1234 ],
-		[ 'two decimals, the WooCommerce default', 2, 4999, 49.99 ],
+		[ 'four decimal places', 4, 123456, 12.3456 ],
+		[ 'zero decimal places', 0, 1234, 1234 ],
+		[ 'two decimal places, the WooCommerce default', 2, 4999, 49.99 ],
 	];
 
 	it.each( decimalPlaceCases )(
-		'should send an `add_to_cart` value and item price when the store keeps prices to %s',
+		'should send the `add_to_cart` value and item price for a store set to %s',
 		async ( _caseName, currencyMinorUnit, price, expectedPrice ) => {
 			const gtagEvent = await loadEventScript( {
 				currency: 'USD',
@@ -129,7 +132,7 @@ describe( 'WooCommerce conversion event provider', () => {
 	);
 
 	it.each( decimalPlaceCases )(
-		'should send a `purchase` value and item price when the store keeps prices to %s',
+		'should send the `purchase` value and item price for a store set to %s',
 		async ( _caseName, currencyMinorUnit, price, expectedPrice ) => {
 			const gtagEvent = await loadEventScript( {
 				currency: 'USD',
@@ -159,7 +162,7 @@ describe( 'WooCommerce conversion event provider', () => {
 		}
 	);
 
-	it( 'should send an `add_to_cart` value at two decimals when the page sends no `currencyMinorUnit`', async () => {
+	it( 'should fall back to two decimal places when the page data has no `currencyMinorUnit`', async () => {
 		const gtagEvent = await loadEventScript( {
 			currency: 'USD',
 			eventsToTrack: [ 'add_to_cart', 'purchase' ],
@@ -173,7 +176,7 @@ describe( 'WooCommerce conversion event provider', () => {
 		expect( gtagEvent ).toHaveBeenCalledTimes( 1 );
 	} );
 
-	it( 'should send an `add_to_cart` value at four decimals on the AJAX `added_to_cart` event', async () => {
+	it( "should send the `add_to_cart` value at the store's decimal places when jQuery reports `added_to_cart`", async () => {
 		const handlers = {};
 		const gtagEvent = await loadEventScript(
 			{

--- a/includes/Core/Conversion_Tracking/Conversion_Event_Providers/WooCommerce.php
+++ b/includes/Core/Conversion_Tracking/Conversion_Event_Providers/WooCommerce.php
@@ -278,6 +278,9 @@ class WooCommerce extends Conversion_Events_Provider {
 						sprintf( 'window._googlesitekit.wcdata.products = %s;', wp_json_encode( $this->products ) ),
 						sprintf( 'window._googlesitekit.wcdata.add_to_cart = %s;', wp_json_encode( $this->add_to_cart ) ),
 						sprintf( 'window._googlesitekit.wcdata.currency = "%s";', esc_js( get_woocommerce_currency() ) ),
+						// Every price on this page is already multiplied by ten to the power of the store's
+						// decimal places, so `assets/js/event-providers/woocommerce.js` divides it back out.
+						sprintf( 'window._googlesitekit.wcdata.currencyMinorUnit = %s;', wp_json_encode( absint( wc_get_price_decimals() ) ) ),
 						sprintf( 'window._googlesitekit.wcdata.eventsToTrack = %s;', wp_json_encode( $events_to_track ) ),
 					)
 				);

--- a/includes/Core/Conversion_Tracking/Conversion_Event_Providers/WooCommerce.php
+++ b/includes/Core/Conversion_Tracking/Conversion_Event_Providers/WooCommerce.php
@@ -278,8 +278,9 @@ class WooCommerce extends Conversion_Events_Provider {
 						sprintf( 'window._googlesitekit.wcdata.products = %s;', wp_json_encode( $this->products ) ),
 						sprintf( 'window._googlesitekit.wcdata.add_to_cart = %s;', wp_json_encode( $this->add_to_cart ) ),
 						sprintf( 'window._googlesitekit.wcdata.currency = "%s";', esc_js( get_woocommerce_currency() ) ),
-						// Every price on this page is already multiplied by ten to the power of the store's
-						// decimal places, so `assets/js/event-providers/woocommerce.js` divides it back out.
+						// `get_formatted_price()` multiplies every price on this page by ten to the power
+						// of the store's decimal places. `assets/js/event-providers/woocommerce.js` needs
+						// this number to divide the price back out.
 						sprintf( 'window._googlesitekit.wcdata.currencyMinorUnit = %s;', wp_json_encode( absint( wc_get_price_decimals() ) ) ),
 						sprintf( 'window._googlesitekit.wcdata.eventsToTrack = %s;', wp_json_encode( $events_to_track ) ),
 					)

--- a/tests/phpunit/includes/wc-function-fakes.php
+++ b/tests/phpunit/includes/wc-function-fakes.php
@@ -20,3 +20,74 @@ if ( ! function_exists( 'wc_get_page_permalink' ) ) {
 		return home_url( '/' . $page . '/' );
 	}
 }
+
+if ( ! function_exists( 'wc_get_price_decimals' ) ) {
+	/**
+	 * Fakes `wc_get_price_decimals()` so a test can run WooCommerce-aware code
+	 * with the plugin inactive.
+	 *
+	 * It reads the `woocommerce_price_num_decimals` option and runs the
+	 * `wc_get_price_decimals` filter, the same as the real function, so a test
+	 * can set either one.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @return int The store's decimal places, `2` unless a test overrides them.
+	 */
+	function wc_get_price_decimals() {
+		return absint( apply_filters( 'wc_get_price_decimals', get_option( 'woocommerce_price_num_decimals', 2 ) ) );
+	}
+}
+
+if ( ! function_exists( 'wc_format_decimal' ) ) {
+	/**
+	 * Fakes `wc_format_decimal()` so a test can run WooCommerce-aware code with
+	 * the plugin inactive.
+	 *
+	 * It returns the price unchanged, because every test passes one that already
+	 * reads as a plain number, such as `12.3456`. The real function also strips
+	 * the thousand separator and rewrites the decimal separator for the store's
+	 * locale.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param mixed $number The price, as a float or a string, such as `12.3456` or `'20.00'`.
+	 * @return string The same price, as a string and otherwise untouched.
+	 */
+	function wc_format_decimal( $number ) {
+		return (string) $number;
+	}
+}
+
+if ( ! function_exists( 'get_woocommerce_currency' ) ) {
+	/**
+	 * Fakes `get_woocommerce_currency()` so a test can run WooCommerce-aware
+	 * code with the plugin inactive.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @return string The store's currency code, `USD` unless a test overrides it.
+	 */
+	function get_woocommerce_currency() {
+		return apply_filters( 'woocommerce_currency', get_option( 'woocommerce_currency', 'USD' ) );
+	}
+}
+
+if ( ! function_exists( 'is_wc_endpoint_url' ) ) {
+	/**
+	 * Fakes `is_wc_endpoint_url()` so a test can run WooCommerce-aware code with
+	 * the plugin inactive.
+	 *
+	 * It always reports no endpoint, because WooCommerce isn't loaded and
+	 * registers none. The real function reads the query vars WooCommerce
+	 * registers for the cart, the checkout, and the account screens, so a test
+	 * that needs one of those screens has to replace the fake.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @return bool WooCommerce registers no endpoint here, so this is always `false`.
+	 */
+	function is_wc_endpoint_url() {
+		return false;
+	}
+}

--- a/tests/phpunit/includes/wc-function-fakes.php
+++ b/tests/phpunit/includes/wc-function-fakes.php
@@ -85,9 +85,11 @@ if ( ! function_exists( 'is_wc_endpoint_url' ) ) {
 	 *
 	 * @since n.e.x.t
 	 *
+	 * @param string|false $endpoint The endpoint to look for, such as `order-received`. This fake ignores it.
 	 * @return bool WooCommerce registers no endpoint here, so this is always `false`.
 	 */
-	function is_wc_endpoint_url() {
+	// phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found -- The fake takes the argument to match WooCommerce, and never reads it.
+	function is_wc_endpoint_url( $endpoint = false ) {
 		return false;
 	}
 }

--- a/tests/phpunit/includes/wc-function-fakes.php
+++ b/tests/phpunit/includes/wc-function-fakes.php
@@ -23,16 +23,16 @@ if ( ! function_exists( 'wc_get_page_permalink' ) ) {
 
 if ( ! function_exists( 'wc_get_price_decimals' ) ) {
 	/**
-	 * Fakes `wc_get_price_decimals()` so a test can run WooCommerce-aware code
-	 * with the plugin inactive.
+	 * Fakes `wc_get_price_decimals()` for a test that runs WooCommerce-aware code
+	 * with the WooCommerce plugin inactive.
 	 *
-	 * It reads the `woocommerce_price_num_decimals` option and runs the
-	 * `wc_get_price_decimals` filter, the same as the real function, so a test
-	 * can set either one.
+	 * Like the real function, it reads the `woocommerce_price_num_decimals`
+	 * option and runs the `wc_get_price_decimals` filter. A test can set either
+	 * one.
 	 *
 	 * @since n.e.x.t
 	 *
-	 * @return int The store's decimal places, `2` unless a test overrides them.
+	 * @return int The store's decimal places, `2` until a test changes them.
 	 */
 	function wc_get_price_decimals() {
 		return absint( apply_filters( 'wc_get_price_decimals', get_option( 'woocommerce_price_num_decimals', 2 ) ) );
@@ -41,18 +41,17 @@ if ( ! function_exists( 'wc_get_price_decimals' ) ) {
 
 if ( ! function_exists( 'wc_format_decimal' ) ) {
 	/**
-	 * Fakes `wc_format_decimal()` so a test can run WooCommerce-aware code with
-	 * the plugin inactive.
+	 * Fakes `wc_format_decimal()` for a test that runs WooCommerce-aware code
+	 * with the WooCommerce plugin inactive.
 	 *
-	 * It returns the price unchanged, because every test passes one that already
-	 * reads as a plain number, such as `12.3456`. The real function also strips
-	 * the thousand separator and rewrites the decimal separator for the store's
-	 * locale.
+	 * It hands the price back untouched, because every test passes a plain number
+	 * such as `12.3456`. The real function also removes the thousand separator
+	 * and rewrites the decimal separator for the store's locale.
 	 *
 	 * @since n.e.x.t
 	 *
 	 * @param mixed $number The price, as a float or a string, such as `12.3456` or `'20.00'`.
-	 * @return string The same price, as a string and otherwise untouched.
+	 * @return string The same price, as a string.
 	 */
 	function wc_format_decimal( $number ) {
 		return (string) $number;
@@ -61,12 +60,15 @@ if ( ! function_exists( 'wc_format_decimal' ) ) {
 
 if ( ! function_exists( 'get_woocommerce_currency' ) ) {
 	/**
-	 * Fakes `get_woocommerce_currency()` so a test can run WooCommerce-aware
-	 * code with the plugin inactive.
+	 * Fakes `get_woocommerce_currency()` for a test that runs WooCommerce-aware
+	 * code with the WooCommerce plugin inactive.
+	 *
+	 * Like the real function, it reads the `woocommerce_currency` option and runs
+	 * the `woocommerce_currency` filter. A test can set either one.
 	 *
 	 * @since n.e.x.t
 	 *
-	 * @return string The store's currency code, `USD` unless a test overrides it.
+	 * @return string The store's currency code, `USD` until a test changes it.
 	 */
 	function get_woocommerce_currency() {
 		return apply_filters( 'woocommerce_currency', get_option( 'woocommerce_currency', 'USD' ) );
@@ -75,20 +77,20 @@ if ( ! function_exists( 'get_woocommerce_currency' ) ) {
 
 if ( ! function_exists( 'is_wc_endpoint_url' ) ) {
 	/**
-	 * Fakes `is_wc_endpoint_url()` so a test can run WooCommerce-aware code with
-	 * the plugin inactive.
+	 * Fakes `is_wc_endpoint_url()` for a test that runs WooCommerce-aware code
+	 * with the WooCommerce plugin inactive.
 	 *
-	 * It always reports no endpoint, because WooCommerce isn't loaded and
-	 * registers none. The real function reads the query vars WooCommerce
-	 * registers for the cart, the checkout, and the account screens, so a test
-	 * that needs one of those screens has to replace the fake.
+	 * The real function reads the query vars WooCommerce registers for the cart
+	 * page, the checkout page, and the account pages. WooCommerce registers none
+	 * of them here, so this fake reports every page as no endpoint. A test that
+	 * needs one of those pages has to replace this fake.
 	 *
 	 * @since n.e.x.t
 	 *
 	 * @param string|false $endpoint The endpoint to look for, such as `order-received`. This fake ignores it.
-	 * @return bool WooCommerce registers no endpoint here, so this is always `false`.
+	 * @return bool Always `false`.
 	 */
-	// phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found -- The fake takes the argument to match WooCommerce, and never reads it.
+	// phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found -- The argument matches the WooCommerce signature, and the fake never reads it.
 	function is_wc_endpoint_url( $endpoint = false ) {
 		return false;
 	}

--- a/tests/phpunit/integration/Core/Conversion_Tracking/Conversion_Event_Providers/WooCommerceTest.php
+++ b/tests/phpunit/integration/Core/Conversion_Tracking/Conversion_Event_Providers/WooCommerceTest.php
@@ -13,6 +13,8 @@ use Google\Site_Kit\Core\Conversion_Tracking\Conversion_Event_Providers\WooComme
 use Google\Site_Kit\Tests\TestCase;
 use Google\Site_Kit\Tests\WC_Countries_Fake;
 
+require_once TESTS_PLUGIN_DIR . '/tests/phpunit/includes/wc-function-fakes.php';
+
 class WooCommerceTest extends TestCase {
 
 	/**
@@ -196,6 +198,61 @@ class WooCommerceTest extends TestCase {
 		$script = $this->woocommerce->register_script();
 		$this->assertInstanceOf( Script::class, $script, 'Expected script to be an instance of Script.' );
 		$this->assertTrue( wp_script_is( $handle, 'registered' ), 'Expected script to be registered.' );
+	}
+
+	/**
+	 * @dataProvider prices_by_decimal_places
+	 */
+	public function test_get_formatted_price__minor_units( $decimal_places, $price, $expected ) {
+		add_filter( 'wc_get_price_decimals', fn() => $decimal_places );
+
+		$this->assertSame(
+			$expected,
+			$this->woocommerce->get_formatted_price( $price ),
+			'get_formatted_price() should return a whole number of minor units.'
+		);
+	}
+
+	public function prices_by_decimal_places() {
+		return array(
+			'no decimals'                           => array( 0, 1234, 1234 ),
+			'two decimals, the WooCommerce default' => array( 2, 12.34, 1234 ),
+			'four decimals'                         => array( 4, 12.3456, 123456 ),
+		);
+	}
+
+	/**
+	 * @dataProvider decimal_places_script_lines
+	 */
+	public function test_register_hooks__sends_currency_minor_unit( $decimal_places, $expected_line ) {
+		add_filter( 'wc_get_price_decimals', fn() => $decimal_places );
+
+		$handle = 'googlesitekit-events-provider-' . WooCommerce::CONVERSION_EVENT_PROVIDER_SLUG;
+
+		$this->woocommerce->register_script();
+
+		// WordPress core and the active theme also hook `wp_footer`, so we clear
+		// it first and let only this provider write to the inline script.
+		remove_all_actions( 'wp_footer' );
+		$this->woocommerce->register_hooks();
+
+		do_action( 'wp_footer' );
+
+		$inline_script = implode( "\n", wp_scripts()->registered[ $handle ]->extra['before'] );
+
+		$this->assertStringContainsString(
+			$expected_line,
+			$inline_script,
+			'register_hooks() should print the decimal places wc_get_price_decimals() reports.'
+		);
+	}
+
+	public function decimal_places_script_lines() {
+		return array(
+			'no decimals'                           => array( 0, 'window._googlesitekit.wcdata.currencyMinorUnit = 0;' ),
+			'two decimals, the WooCommerce default' => array( 2, 'window._googlesitekit.wcdata.currencyMinorUnit = 2;' ),
+			'four decimals'                         => array( 4, 'window._googlesitekit.wcdata.currencyMinorUnit = 4;' ),
+		);
 	}
 
 	public function test_register_hooks() {

--- a/tests/phpunit/integration/Core/Conversion_Tracking/Conversion_Event_Providers/WooCommerceTest.php
+++ b/tests/phpunit/integration/Core/Conversion_Tracking/Conversion_Event_Providers/WooCommerceTest.php
@@ -209,15 +209,15 @@ class WooCommerceTest extends TestCase {
 		$this->assertSame(
 			$expected,
 			$this->woocommerce->get_formatted_price( $price ),
-			'get_formatted_price() should return a whole number of minor units.'
+			'get_formatted_price() should return the price with the decimal point removed.'
 		);
 	}
 
 	public function prices_by_decimal_places() {
 		return array(
-			'no decimals'                           => array( 0, 1234, 1234 ),
-			'two decimals, the WooCommerce default' => array( 2, 12.34, 1234 ),
-			'four decimals'                         => array( 4, 12.3456, 123456 ),
+			'zero decimal places'                         => array( 0, 1234, 1234 ),
+			'two decimal places, the WooCommerce default' => array( 2, 12.34, 1234 ),
+			'four decimal places'                         => array( 4, 12.3456, 123456 ),
 		);
 	}
 
@@ -231,8 +231,8 @@ class WooCommerceTest extends TestCase {
 
 		$this->woocommerce->register_script();
 
-		// WordPress core and the active theme also hook `wp_footer`, so we clear
-		// it first and let only this provider write to the inline script.
+		// WordPress core and the active theme hook `wp_footer` too. Clear it, so the
+		// `do_action()` below runs only the callback `register_hooks()` adds.
 		remove_all_actions( 'wp_footer' );
 		$this->woocommerce->register_hooks();
 
@@ -243,15 +243,15 @@ class WooCommerceTest extends TestCase {
 		$this->assertStringContainsString(
 			$expected_line,
 			$inline_script,
-			'register_hooks() should print the decimal places wc_get_price_decimals() reports.'
+			'register_hooks() should print the decimal places that wc_get_price_decimals() returns.'
 		);
 	}
 
 	public function decimal_places_script_lines() {
 		return array(
-			'no decimals'                           => array( 0, 'window._googlesitekit.wcdata.currencyMinorUnit = 0;' ),
-			'two decimals, the WooCommerce default' => array( 2, 'window._googlesitekit.wcdata.currencyMinorUnit = 2;' ),
-			'four decimals'                         => array( 4, 'window._googlesitekit.wcdata.currencyMinorUnit = 4;' ),
+			'zero decimal places'                         => array( 0, 'window._googlesitekit.wcdata.currencyMinorUnit = 0;' ),
+			'two decimal places, the WooCommerce default' => array( 2, 'window._googlesitekit.wcdata.currencyMinorUnit = 2;' ),
+			'four decimal places'                         => array( 4, 'window._googlesitekit.wcdata.currencyMinorUnit = 4;' ),
 		);
 	}
 


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Related issue(s):

- Resolves #12986


## Relevant technical choices

- `includes/Core/Conversion_Tracking/Conversion_Event_Providers/WooCommerce.php`
  - Prints `currencyMinorUnit` in the `wp_footer` block alone.
- `assets/js/event-providers/woocommerce.js`
  - `formatPrice()` takes the price alone and reads `currencyMinorUnit` from `wcdata`.
- `tests/phpunit/includes/wc-function-fakes.php`
  - Fakes four more WooCommerce functions, so the suite runs with the plugin inactive.

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.
- [ ] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
