### PR TITLE
Use P typography component for paragraphs

### DIFF
--- a/assets/js/components/ActivateAnalyticsCTA/NormalCTAContent.tsx
+++ b/assets/js/components/ActivateAnalyticsCTA/NormalCTAContent.tsx
@@ -27,6 +27,8 @@ import { __ } from '@wordpress/i18n';
  */
 import { Button, SpinnerButton } from 'googlesitekit-components';
 import Link from '@/js/components/Link';
+import { SIZE_MEDIUM } from '@/js/components/Typography/constants';
+import P from '@/js/components/Typography/P';
 import AnalyticsIcon from '@/svg/graphics/analytics.svg';
 
 type TrackEvents = {
@@ -62,7 +64,10 @@ const NormalCTAContent = forwardRef< HTMLDivElement, NormalCTAContentProps >(
 				<div className="googlesitekit-activate-analytics-cta__icon">
 					<AnalyticsIcon width={ 28 } height={ 31 } />
 				</div>
-				<p className="googlesitekit-activate-analytics-cta__description">
+				<P
+					className="googlesitekit-activate-analytics-cta__description"
+					size={ SIZE_MEDIUM }
+				>
 					{ createInterpolateElement(
 						__(
 							'See how many people visit your site from Search and track how you’re achieving your goals. <a>Learn more</a>',
@@ -82,7 +87,7 @@ const NormalCTAContent = forwardRef< HTMLDivElement, NormalCTAContentProps >(
 							),
 						}
 					) }
-				</p>
+				</P>
 			</div>
 			<div className="googlesitekit-activate-analytics-cta__actions">
 				{ /* @ts-expect-error `Button` component is not yet typed. */ }

--- a/assets/js/components/ActivateAnalyticsCTA/index.js
+++ b/assets/js/components/ActivateAnalyticsCTA/index.js
@@ -34,6 +34,8 @@ import { SpinnerButton } from 'googlesitekit-components';
 import { useDispatch, useSelect } from 'googlesitekit-data';
 import ErrorCTAContent from '@/js/components/ActivateAnalyticsCTA/ErrorCTAContent';
 import NormalCTAContent from '@/js/components/ActivateAnalyticsCTA/NormalCTAContent';
+import { SIZE_MEDIUM } from '@/js/components/Typography/constants';
+import P from '@/js/components/Typography/P';
 import { CORE_LOCATION } from '@/js/googlesitekit/datastore/location/constants';
 import { CORE_SITE } from '@/js/googlesitekit/datastore/site/constants';
 import { CORE_USER } from '@/js/googlesitekit/datastore/user/constants';
@@ -219,12 +221,15 @@ export default function ActivateAnalyticsCTA( {
 					{ children }
 				</div>
 				<div className="googlesitekit-analytics-cta__details">
-					<p className="googlesitekit-analytics-cta--description">
+					<P
+						className="googlesitekit-analytics-cta--description"
+						size={ SIZE_MEDIUM }
+					>
 						{ __(
 							'See how many people visit your site from Search and track how you’re achieving your goals',
 							'google-site-kit'
 						) }
-					</p>
+					</P>
 					<SpinnerButton
 						onClick={ onClickCallback }
 						isSaving={ inProgress }

--- a/assets/js/components/Banner/HelpText.js
+++ b/assets/js/components/Banner/HelpText.js
@@ -20,16 +20,23 @@
 import classnames from 'classnames';
 import PropTypes from 'prop-types';
 
+/**
+ * Internal dependencies
+ */
+import { SIZE_SMALL } from '@/js/components/Typography/constants';
+import P from '@/js/components/Typography/P';
+
 export default function HelpText( { className, children } ) {
 	return (
-		<p
+		<P
 			className={ classnames(
 				'googlesitekit-banner__help-text',
 				className
 			) }
+			size={ SIZE_SMALL }
 		>
 			{ children }
-		</p>
+		</P>
 	);
 }
 

--- a/assets/js/components/Banner/Title.js
+++ b/assets/js/components/Banner/Title.js
@@ -20,11 +20,36 @@
 import classnames from 'classnames';
 import PropTypes from 'prop-types';
 
+/**
+ * Internal dependencies
+ */
+import {
+	SIZE_MEDIUM,
+	SIZE_SMALL,
+	TYPE_HEADLINE,
+	TYPE_TITLE,
+} from '@/js/components/Typography/constants';
+import P from '@/js/components/Typography/P';
+import {
+	BREAKPOINT_SMALL,
+	BREAKPOINT_TABLET,
+	useBreakpoint,
+} from '@/js/hooks/useBreakpoint';
+
 export default function Title( { className, children } ) {
+	const breakpoint = useBreakpoint();
+
+	const type = breakpoint === BREAKPOINT_SMALL ? TYPE_TITLE : TYPE_HEADLINE;
+	const size = breakpoint === BREAKPOINT_TABLET ? SIZE_SMALL : SIZE_MEDIUM;
+
 	return (
-		<p className={ classnames( 'googlesitekit-banner__title', className ) }>
+		<P
+			className={ classnames( 'googlesitekit-banner__title', className ) }
+			size={ size }
+			type={ type }
+		>
 			{ children }
-		</p>
+		</P>
 	);
 }
 

--- a/assets/js/components/KeyMetrics/AddMetricCTATile.js
+++ b/assets/js/components/KeyMetrics/AddMetricCTATile.js
@@ -33,6 +33,8 @@ import { ENTER, SPACE } from '@wordpress/keycodes';
  * Internal dependencies
  */
 import { useDispatch } from 'googlesitekit-data';
+import { SIZE_SMALL } from '@/js/components/Typography/constants';
+import P from '@/js/components/Typography/P';
 import { CORE_UI } from '@/js/googlesitekit/datastore/ui/constants';
 import useViewContext from '@/js/hooks/useViewContext';
 import { trackEvent } from '@/js/util';
@@ -90,9 +92,12 @@ export default function AddMetricCTATile( { Widget } ) {
 				<div className="googlesitekit-km-add-metric-cta-tile__icon">
 					<PlusIcon width={ 16 } height={ 16 } />
 				</div>
-				<p className="googlesitekit-km-add-metric-cta-tile__text">
+				<P
+					className="googlesitekit-km-add-metric-cta-tile__text"
+					size={ SIZE_SMALL }
+				>
 					{ __( 'Add a metric', 'google-site-kit' ) }
-				</p>
+				</P>
 			</div>
 		</Widget>
 	);

--- a/assets/js/components/KeyMetrics/ConnectModuleCTATile.js
+++ b/assets/js/components/KeyMetrics/ConnectModuleCTATile.js
@@ -32,6 +32,8 @@ import { __, sprintf } from '@wordpress/i18n';
  */
 import { useSelect } from 'googlesitekit-data';
 import Link from '@/js/components/Link';
+import { SIZE_MEDIUM } from '@/js/components/Typography/constants';
+import P from '@/js/components/Typography/P';
 import { CORE_MODULES } from '@/js/googlesitekit/modules/datastore/constants';
 import { CORE_WIDGETS } from '@/js/googlesitekit/widgets/datastore/constants';
 import { AREA_MAIN_DASHBOARD_KEY_METRICS_PRIMARY } from '@/js/googlesitekit/widgets/default-areas';
@@ -97,7 +99,10 @@ export default function ConnectModuleCTATile( { moduleSlug } ) {
 					) }
 
 					<div className="googlesitekit-km-connect-module-cta-tile__content">
-						<p className="googlesitekit-km-connect-module-cta-tile__text">
+						<P
+							className="googlesitekit-km-connect-module-cta-tile__text"
+							size={ SIZE_MEDIUM }
+						>
 							{ combinedMetrics
 								? sprintf(
 										/* translators: %s: module name */
@@ -115,7 +120,7 @@ export default function ConnectModuleCTATile( { moduleSlug } ) {
 										),
 										module.name
 								  ) }
-						</p>
+						</P>
 						{ ! isViewOnly && (
 							<Link onClick={ handleConnectModule } secondary>
 								{ sprintf(

--- a/assets/js/components/KeyMetrics/MetricTileNumeric.js
+++ b/assets/js/components/KeyMetrics/MetricTileNumeric.js
@@ -25,6 +25,13 @@ import PropTypes from 'prop-types';
  * Internal dependencies
  */
 import ChangeBadge from '@/js/components/ChangeBadge';
+import {
+	SIZE_MEDIUM,
+	SIZE_SMALL,
+	TYPE_LABEL,
+} from '@/js/components/Typography/constants';
+import P from '@/js/components/Typography/P';
+import { BREAKPOINT_SMALL, useBreakpoint } from '@/js/hooks/useBreakpoint';
 import { expandNumFmtOptions, numFmt } from '@/js/util';
 import MetricTileWrapper from './MetricTileWrapper';
 
@@ -36,6 +43,8 @@ export default function MetricTileNumeric( {
 	currentValue,
 	...props
 } ) {
+	const breakpoint = useBreakpoint();
+
 	const formatOptions = expandNumFmtOptions( metricValueFormat );
 
 	return (
@@ -47,9 +56,17 @@ export default function MetricTileNumeric( {
 				<div className="googlesitekit-km-widget-tile__metric">
 					{ numFmt( metricValue, formatOptions ) }
 				</div>
-				<p className="googlesitekit-km-widget-tile__subtext">
+				<P
+					className="googlesitekit-km-widget-tile__subtext"
+					size={
+						breakpoint === BREAKPOINT_SMALL
+							? SIZE_SMALL
+							: SIZE_MEDIUM
+					}
+					type={ TYPE_LABEL }
+				>
 					{ subText }
-				</p>
+				</P>
 			</div>
 			<div className="googlesitekit-km-widget-tile__metric-change-container">
 				<ChangeBadge

--- a/assets/js/components/KeyMetrics/MetricTileTablePlainText.js
+++ b/assets/js/components/KeyMetrics/MetricTileTablePlainText.js
@@ -21,11 +21,21 @@
  */
 import PropTypes from 'prop-types';
 
+/**
+ * Internal dependencies
+ */
+import { SIZE_SMALL, TYPE_BODY } from '@/js/components/Typography/constants';
+import P from '@/js/components/Typography/P';
+
 export default function MetricTileTablePlainText( { content } ) {
 	return (
-		<p className="googlesitekit-km-widget-tile__table-plain-text">
+		<P
+			className="googlesitekit-km-widget-tile__table-plain-text"
+			size={ SIZE_SMALL }
+			type={ TYPE_BODY }
+		>
 			{ content }
-		</p>
+		</P>
 	);
 }
 

--- a/assets/js/components/KeyMetrics/MetricTileText.js
+++ b/assets/js/components/KeyMetrics/MetricTileText.js
@@ -25,6 +25,13 @@ import PropTypes from 'prop-types';
  * Internal dependencies
  */
 import ChangeBadge from '@/js/components/ChangeBadge';
+import {
+	SIZE_MEDIUM,
+	SIZE_SMALL,
+	TYPE_LABEL,
+} from '@/js/components/Typography/constants';
+import P from '@/js/components/Typography/P';
+import { BREAKPOINT_SMALL, useBreakpoint } from '@/js/hooks/useBreakpoint';
 import { expandNumFmtOptions } from '@/js/util';
 import MetricTileWrapper from './MetricTileWrapper';
 
@@ -36,6 +43,8 @@ export default function MetricTileText( {
 	currentValue,
 	...props
 } ) {
+	const breakpoint = useBreakpoint();
+
 	const formatOptions = expandNumFmtOptions( metricValueFormat );
 
 	return (
@@ -47,9 +56,17 @@ export default function MetricTileText( {
 				<div className="googlesitekit-km-widget-tile__metric">
 					{ metricValue }
 				</div>
-				<p className="googlesitekit-km-widget-tile__subtext">
+				<P
+					className="googlesitekit-km-widget-tile__subtext"
+					size={
+						breakpoint === BREAKPOINT_SMALL
+							? SIZE_SMALL
+							: SIZE_MEDIUM
+					}
+					type={ TYPE_LABEL }
+				>
 					{ subText }
-				</p>
+				</P>
 			</div>
 			<div className="googlesitekit-km-widget-tile__metric-change-container">
 				<ChangeBadge

--- a/assets/js/components/KeyMetrics/MetricsSelectionPanel/SelectionPanelFooter.js
+++ b/assets/js/components/KeyMetrics/MetricsSelectionPanel/SelectionPanelFooter.js
@@ -40,6 +40,13 @@ import { __, sprintf } from '@wordpress/i18n';
 import { Button, SpinnerButton } from 'googlesitekit-components';
 import { useSelect } from 'googlesitekit-data';
 import PreviewBlock from '@/js/components/PreviewBlock';
+import {
+	SIZE_MEDIUM,
+	SIZE_SMALL,
+	TYPE_LABEL,
+} from '@/js/components/Typography/constants';
+import P from '@/js/components/Typography/P';
+import { BREAKPOINT_SMALL, useBreakpoint } from '@/js/hooks/useBreakpoint';
 import { MODULES_ANALYTICS_4 } from '@/js/modules/analytics-4/datastore/constants';
 import { safelySort } from '@/js/util';
 
@@ -56,6 +63,8 @@ export default function SelectionPanelFooter( {
 	closePanel = () => {},
 	isFullScreen = false,
 } ) {
+	const breakpoint = useBreakpoint();
+
 	const [ finalButtonText, setFinalButtonText ] = useState( null );
 	const [ wasSaved, setWasSaved ] = useState( false );
 	const isLoading = useSelect( ( select ) =>
@@ -132,7 +141,11 @@ export default function SelectionPanelFooter( {
 	const itemCountElement = isLoading ? (
 		<PreviewBlock width="89px" height="20px" />
 	) : (
-		<p className="googlesitekit-selection-panel-footer__item-count">
+		<P
+			className="googlesitekit-selection-panel-footer__item-count"
+			size={ breakpoint === BREAKPOINT_SMALL ? SIZE_SMALL : SIZE_MEDIUM }
+			type={ TYPE_LABEL }
+		>
 			{ createInterpolateElement(
 				sprintf(
 					/* translators: 1: Number of selected items. 2: Maximum number of items that can be selected. */
@@ -149,7 +162,7 @@ export default function SelectionPanelFooter( {
 					),
 				}
 			) }
-		</p>
+		</P>
 	);
 
 	return (

--- a/assets/js/components/KeyMetrics/MetricsSelectionPanel/__snapshots__/index.test.js.snap
+++ b/assets/js/components/KeyMetrics/MetricsSelectionPanel/__snapshots__/index.test.js.snap
@@ -272,7 +272,7 @@ exports[`MetricsSelectionPanel Header should render correctly 1`] = `
                 </span>
               </button>
               <p
-                class="googlesitekit-selection-panel-footer__item-count"
+                class="googlesitekit-typography googlesitekit-selection-panel-footer__item-count googlesitekit-typography--label googlesitekit-typography--medium"
               >
                 2 selected 
                 <span
@@ -575,7 +575,7 @@ exports[`MetricsSelectionPanel Header should render correctly with the \`setupFl
                 </span>
               </button>
               <p
-                class="googlesitekit-selection-panel-footer__item-count"
+                class="googlesitekit-typography googlesitekit-selection-panel-footer__item-count googlesitekit-typography--label googlesitekit-typography--medium"
               >
                 2 selected 
                 <span

--- a/assets/js/components/ModalDialog.js
+++ b/assets/js/components/ModalDialog.js
@@ -40,6 +40,12 @@ import {
 	DialogTitle,
 	SpinnerButton,
 } from 'googlesitekit-components';
+import {
+	SIZE_MEDIUM,
+	SIZE_SMALL,
+	TYPE_LABEL,
+} from '@/js/components/Typography/constants';
+import P from '@/js/components/Typography/P';
 import ExclamationIcon from '@/svg/icons/warning.svg';
 
 function ModalDialog( {
@@ -82,7 +88,17 @@ function ModalDialog( {
 			</DialogTitle>
 			{
 				// Ensure we don't render anything at all if subtitle is falsy, as Dialog expects all its children to be elements and a falsy value will result in an error.
-				subtitle ? <p className="mdc-dialog__lead">{ subtitle }</p> : []
+				subtitle ? (
+					<P
+						className="mdc-dialog__lead"
+						size={ SIZE_MEDIUM }
+						type={ TYPE_LABEL }
+					>
+						{ subtitle }
+					</P>
+				) : (
+					[]
+				)
 			}
 			<DialogContent>
 				{ hasProvides && (
@@ -104,9 +120,10 @@ function ModalDialog( {
 				{ notes.length > 0 && (
 					<section className="mdc-dialog__notes">
 						{ notes.map( ( Note, index ) => (
-							<p
+							<P
 								className="mdc-dialog__note"
 								key={ `note-${ index }` }
+								size={ SIZE_SMALL }
 							>
 								{ typeof Note === 'string' &&
 									createInterpolateElement(
@@ -123,7 +140,7 @@ function ModalDialog( {
 										}
 									) }
 								{ typeof Note === 'function' && <Note /> }
-							</p>
+							</P>
 						) ) }
 					</section>
 				) }

--- a/assets/js/components/Notice/Title.tsx
+++ b/assets/js/components/Notice/Title.tsx
@@ -25,6 +25,9 @@ interface TitleProps {
 }
 
 const Title: FC< TitleProps > = ( { className, children } ) => {
+	{
+		/* TODO: 11266 -- Use P typography component and remove CSS overrides. */
+	}
 	return (
 		<p className={ classnames( 'googlesitekit-notice__title', className ) }>
 			{ children }

--- a/assets/js/components/OverlayCard/Description.js
+++ b/assets/js/components/OverlayCard/Description.js
@@ -21,9 +21,22 @@
  */
 import PropTypes from 'prop-types';
 
+/**
+ * Internal dependencies
+ */
+import { SIZE_MEDIUM, SIZE_SMALL } from '@/js/components/Typography/constants';
+import P from '@/js/components/Typography/P';
+import { BREAKPOINT_SMALL, useBreakpoint } from '@/js/hooks/useBreakpoint';
+
 export default function Description( { children } ) {
+	const breakpoint = useBreakpoint();
+
+	const size = breakpoint === BREAKPOINT_SMALL ? SIZE_SMALL : SIZE_MEDIUM;
+
 	return (
-		<p className="googlesitekit-overlay-card__description">{ children }</p>
+		<P className="googlesitekit-overlay-card__description" size={ size }>
+			{ children }
+		</P>
 	);
 }
 

--- a/assets/js/components/OverlayCard/Title.js
+++ b/assets/js/components/OverlayCard/Title.js
@@ -25,14 +25,26 @@ import PropTypes from 'prop-types';
  * Internal dependencies
  */
 import Typography from '@/js/components/Typography';
+import {
+	SIZE_MEDIUM,
+	SIZE_SMALL,
+	TYPE_HEADLINE,
+	TYPE_TITLE,
+} from '@/js/components/Typography/constants';
+import { BREAKPOINT_SMALL, useBreakpoint } from '@/js/hooks/useBreakpoint';
 
 export default function Title( { children } ) {
+	const breakpoint = useBreakpoint();
+
+	const size = breakpoint === BREAKPOINT_SMALL ? SIZE_MEDIUM : SIZE_SMALL;
+	const type = breakpoint === BREAKPOINT_SMALL ? TYPE_TITLE : TYPE_HEADLINE;
+
 	return (
 		<Typography
 			as="h3"
-			size="medium"
-			type="title"
 			className="googlesitekit-overlay-card__title"
+			size={ size }
+			type={ type }
 		>
 			{ children }
 		</Typography>

--- a/assets/js/components/ReportError.js
+++ b/assets/js/components/ReportError.js
@@ -33,6 +33,8 @@ import { removeQueryArgs } from '@wordpress/url';
  * Internal dependencies
  */
 import { useSelect } from 'googlesitekit-data';
+import { SIZE_MEDIUM } from '@/js/components/Typography/constants';
+import P from '@/js/components/Typography/P';
 import { CORE_MODULES } from '@/js/googlesitekit/modules/datastore/constants';
 import useViewOnly from '@/js/hooks/useViewOnly';
 import {
@@ -139,13 +141,13 @@ export default function ReportError( {
 						message={ errorForNotice.message }
 					/>
 				) : (
-					<p key={ errorForNotice.message }>
+					<P key={ errorForNotice.message } size={ SIZE_MEDIUM }>
 						{ purify.sanitize( errorForNotice.message, {
 							// Ensures no HTML tags are passed as they would be
 							// escaped by React and appear as strings.
 							ALLOWED_TAGS: [],
 						} ) }
-					</p>
+					</P>
 				);
 			} ) }
 		</Fragment>

--- a/assets/js/components/SelectionPanel/SelectionPanelFooter.js
+++ b/assets/js/components/SelectionPanel/SelectionPanelFooter.js
@@ -40,6 +40,13 @@ import { __, sprintf } from '@wordpress/i18n';
 import { Button, SpinnerButton } from 'googlesitekit-components';
 import { useSelect } from 'googlesitekit-data';
 import PreviewBlock from '@/js/components/PreviewBlock';
+import {
+	SIZE_MEDIUM,
+	SIZE_SMALL,
+	TYPE_LABEL,
+} from '@/js/components/Typography/constants';
+import P from '@/js/components/Typography/P';
+import { BREAKPOINT_SMALL, useBreakpoint } from '@/js/hooks/useBreakpoint';
 import { MODULES_ANALYTICS_4 } from '@/js/modules/analytics-4/datastore/constants';
 import { safelySort } from '@/js/util';
 
@@ -55,6 +62,8 @@ export default function SelectionPanelFooter( {
 	isOpen,
 	closePanel = () => {},
 } ) {
+	const breakpoint = useBreakpoint();
+
 	const [ finalButtonText, setFinalButtonText ] = useState( null );
 	const [ wasSaved, setWasSaved ] = useState( false );
 
@@ -125,7 +134,11 @@ export default function SelectionPanelFooter( {
 	const itemCountElement = isLoading ? (
 		<PreviewBlock width="89px" height="20px" />
 	) : (
-		<p className="googlesitekit-selection-panel-footer__item-count">
+		<P
+			className="googlesitekit-selection-panel-footer__item-count"
+			size={ breakpoint === BREAKPOINT_SMALL ? SIZE_SMALL : SIZE_MEDIUM }
+			type={ TYPE_LABEL }
+		>
 			{ createInterpolateElement(
 				sprintf(
 					/* translators: 1: Number of selected items. 2: Maximum number of items that can be selected. */
@@ -142,7 +155,7 @@ export default function SelectionPanelFooter( {
 					),
 				}
 			) }
-		</p>
+		</P>
 	);
 
 	return (

--- a/assets/js/components/SelectionPanel/SelectionPanelItems.js
+++ b/assets/js/components/SelectionPanel/SelectionPanelItems.js
@@ -27,6 +27,12 @@ import PropTypes from 'prop-types';
 import { Fragment } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
+/**
+ * Internal dependencies
+ */
+import { SIZE_SMALL, TYPE_LABEL } from '@/js/components/Typography/constants';
+import P from '@/js/components/Typography/P';
+
 export default function SelectionPanelItems( {
 	currentSelectionTitle = __( 'Current selection', 'google-site-kit' ),
 	availableItemsTitle = __( 'Additional items', 'google-site-kit' ),
@@ -58,16 +64,24 @@ export default function SelectionPanelItems( {
 				// additional items if there are already saved items.
 				savedItemSlugs.length !== 0 && (
 					<Fragment>
-						<p className="googlesitekit-selection-panel-items__subheading">
+						<P
+							className="googlesitekit-selection-panel-items__subheading"
+							size={ SIZE_SMALL }
+							type={ TYPE_LABEL }
+						>
 							{ currentSelectionTitle }
-						</p>
+						</P>
 						<div className="googlesitekit-selection-panel-items__subsection">
 							{ renderItems( availableSavedItems ) }
 						</div>
 						{ availableUnsavedItemsCount > 0 && (
-							<p className="googlesitekit-selection-panel-items__subheading">
+							<P
+								className="googlesitekit-selection-panel-items__subheading"
+								size={ SIZE_SMALL }
+								type={ TYPE_LABEL }
+							>
 								{ availableItemsTitle }
-							</p>
+							</P>
 						) }
 					</Fragment>
 				)

--- a/assets/js/components/UserMenu/Details.js
+++ b/assets/js/components/UserMenu/Details.js
@@ -25,6 +25,12 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { useSelect } from 'googlesitekit-data';
+import {
+	SIZE_MEDIUM,
+	SIZE_SMALL,
+	TYPE_LABEL,
+} from '@/js/components/Typography/constants';
+import P from '@/js/components/Typography/P';
 import { CORE_USER } from '@/js/googlesitekit/datastore/user/constants';
 
 export default function Details() {
@@ -49,15 +55,20 @@ export default function Details() {
 				/>
 			) }
 			<div className="googlesitekit-user-menu__details-info">
-				<p className="googlesitekit-user-menu__details-info__name">
+				<P
+					className="googlesitekit-user-menu__details-info__name"
+					size={ SIZE_MEDIUM }
+					type={ TYPE_LABEL }
+				>
 					{ userFullName }
-				</p>
-				<p
-					className="googlesitekit-user-menu__details-info__email"
+				</P>
+				<P
 					aria-label={ __( 'Email', 'google-site-kit' ) }
+					className="googlesitekit-user-menu__details-info__email"
+					size={ SIZE_SMALL }
 				>
 					{ userEmail }
-				</p>
+				</P>
 			</div>
 		</div>
 	);

--- a/assets/js/components/adminbar/AdminBarApp.js
+++ b/assets/js/components/adminbar/AdminBarApp.js
@@ -27,6 +27,8 @@ import { __, _n, sprintf } from '@wordpress/i18n';
  */
 import { useSelect } from 'googlesitekit-data';
 import Link from '@/js/components/Link';
+import { SIZE_MEDIUM } from '@/js/components/Typography/constants';
+import P from '@/js/components/Typography/P';
 import { CORE_SITE } from '@/js/googlesitekit/datastore/site/constants';
 import { CORE_USER } from '@/js/googlesitekit/datastore/user/constants';
 import useViewContext from '@/js/hooks/useViewContext';
@@ -74,7 +76,10 @@ export default function AdminBarApp() {
 							{ currentEntityTitle
 								? decodeHTMLEntity( currentEntityTitle )
 								: currentEntityURL }
-							<p className="googlesitekit-adminbar__title--date-range">
+							<P
+								className="googlesitekit-adminbar__title--date-range"
+								size={ SIZE_MEDIUM }
+							>
 								{ sprintf(
 									/* translators: %s: number of days */
 									_n(
@@ -85,7 +90,7 @@ export default function AdminBarApp() {
 									),
 									dateRangeLength
 								) }
-							</p>
+							</P>
 						</div>
 					</Cell>
 

--- a/assets/js/components/adminbar/__snapshots__/AdminBarWidgets.test.js.snap
+++ b/assets/js/components/adminbar/__snapshots__/AdminBarWidgets.test.js.snap
@@ -236,7 +236,7 @@ exports[`AdminBarWidgets should render the Admin Bar Widgets, including the Acti
           class="googlesitekit-analytics-cta__details"
         >
           <p
-            class="googlesitekit-analytics-cta--description"
+            class="googlesitekit-typography googlesitekit-analytics-cta--description googlesitekit-typography--body googlesitekit-typography--medium"
           >
             See how many people visit your site from Search and track how you’re achieving your goals
           </p>

--- a/assets/js/components/consent-mode/ConsentModeSwitch.js
+++ b/assets/js/components/consent-mode/ConsentModeSwitch.js
@@ -32,6 +32,7 @@ import { useDispatch, useSelect } from 'googlesitekit-data';
 import ErrorNotice from '@/js/components/ErrorNotice';
 import Link from '@/js/components/Link';
 import LoadingWrapper from '@/js/components/LoadingWrapper';
+import { SIZE_SMALL } from '@/js/components/Typography/constants';
 import P from '@/js/components/Typography/P';
 import { CORE_SITE } from '@/js/googlesitekit/datastore/site/constants';
 import { CORE_USER } from '@/js/googlesitekit/datastore/user/constants';
@@ -133,12 +134,15 @@ export default function ConsentModeSwitch( { loading } ) {
 				}
 				{ saveError && <ErrorNotice message={ saveError.message } /> }
 				{ ! loading && isConsentModeEnabled && (
-					<p className="googlesitekit-settings-consent-mode-switch__enabled-notice">
+					<P
+						className="googlesitekit-settings-consent-mode-switch__enabled-notice"
+						size={ SIZE_SMALL }
+					>
 						{ __(
 							'Site Kit added the necessary code to your tag to comply with consent mode.',
 							'google-site-kit'
 						) }
-					</p>
+					</P>
 				) }
 				{
 					<LoadingWrapper
@@ -151,7 +155,7 @@ export default function ConsentModeSwitch( { loading } ) {
 						tabletWidth="540px"
 						tabletHeight="84px"
 					>
-						<P>
+						<P className="googlesitekit-settings-consent-mode-switch-description">
 							{ createInterpolateElement(
 								__(
 									'Consent mode will help adjust tracking on your site, so only visitors who have explicitly given consent are tracked. <br />This is required in some parts of the world, like the European Economic Area. <a>Learn more</a>',

--- a/assets/js/components/consent-mode/WPConsentAPIRequirement.js
+++ b/assets/js/components/consent-mode/WPConsentAPIRequirement.js
@@ -23,6 +23,8 @@ import PropTypes from 'prop-types';
  * Internal dependencies
  */
 import Typography from '@/js/components/Typography';
+import { SIZE_SMALL } from '@/js/components/Typography/constants';
+import P from '@/js/components/Typography/P';
 
 export default function WPConsentAPIRequirement( {
 	title,
@@ -31,12 +33,20 @@ export default function WPConsentAPIRequirement( {
 } ) {
 	return (
 		<div className="googlesitekit-settings-consent-mode-requirement">
-			<Typography as="h4" size="large" type="title">
+			<Typography
+				as="h4"
+				className="googlesitekit-settings-consent-mode-requirement__title"
+				size="medium"
+				type="title"
+			>
 				{ title }
 			</Typography>
-			<p className="googlesitekit-settings-consent-mode-requirement__description">
+			<P
+				className="googlesitekit-settings-consent-mode-requirement__description"
+				size={ SIZE_SMALL }
+			>
 				{ description }
-			</p>
+			</P>
 			<footer className="googlesitekit-settings-consent-mode-requirement__footer">
 				{ footer }
 			</footer>

--- a/assets/js/components/consent-mode/WPConsentAPIRequirements.js
+++ b/assets/js/components/consent-mode/WPConsentAPIRequirements.js
@@ -32,6 +32,8 @@ import ErrorNotice from '@/js/components/ErrorNotice';
 import Link from '@/js/components/Link';
 import Notice from '@/js/components/Notice';
 import { NOTICE_TYPES } from '@/js/components/Notice/constants';
+import { SIZE_SMALL } from '@/js/components/Typography/constants';
+import P from '@/js/components/Typography/P';
 import SpinnerButton from '@/js/googlesitekit/components-gm2/SpinnerButton';
 import { CORE_SITE } from '@/js/googlesitekit/datastore/site/constants';
 import useViewContext from '@/js/hooks/useViewContext';
@@ -98,12 +100,15 @@ export default function WPConsentAPIRequirements() {
 
 	return (
 		<Fragment>
-			<p className="googlesitekit-settings-consent-mode-requirements__description">
+			<P
+				className="googlesitekit-settings-consent-mode-requirements__description"
+				size={ SIZE_SMALL }
+			>
 				{ __(
 					'In order for consent mode to work properly, these requirements must be met:',
 					'google-site-kit'
 				) }
-			</p>
+			</P>
 			<Grid className="googlesitekit-settings-consent-mode-requirements__grid">
 				<Row>
 					<Cell { ...cellProps }>

--- a/assets/js/components/consent-mode/__snapshots__/ConsentModeSetupCTABanner.test.js.snap
+++ b/assets/js/components/consent-mode/__snapshots__/ConsentModeSetupCTABanner.test.js.snap
@@ -24,7 +24,7 @@ exports[`ConsentModeSetupCTABanner should render the banner 1`] = `
                 class="googlesitekit-banner__content"
               >
                 <p
-                  class="googlesitekit-banner__title"
+                  class="googlesitekit-typography googlesitekit-banner__title googlesitekit-typography--headline googlesitekit-typography--medium"
                 >
                   Enable consent mode to preserve tracking for your Ads campaigns
                 </p>

--- a/assets/js/components/dashboard-sharing/DashboardSharingDialog/Footer/Notice.js
+++ b/assets/js/components/dashboard-sharing/DashboardSharingDialog/Footer/Notice.js
@@ -26,6 +26,8 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { useSelect } from 'googlesitekit-data';
+import { SIZE_SMALL } from '@/js/components/Typography/constants';
+import P from '@/js/components/Typography/P';
 import { CORE_MODULES } from '@/js/googlesitekit/modules/datastore/constants';
 
 export default function Notice() {
@@ -40,7 +42,10 @@ export default function Notice() {
 	);
 
 	return (
-		<p className="googlesitekit-dashboard-sharing-settings__notice">
+		<P
+			className="googlesitekit-dashboard-sharing-settings__notice"
+			size={ SIZE_SMALL }
+		>
 			{ haveSharingSettingsChangedManagement && canSubmitSharingChanges && (
 				<span>
 					{ createInterpolateElement(
@@ -69,6 +74,6 @@ export default function Notice() {
 						) }
 					</span>
 				) }
-		</p>
+		</P>
 	);
 }

--- a/assets/js/components/dashboard-sharing/DashboardSharingDialog/index.js
+++ b/assets/js/components/dashboard-sharing/DashboardSharingDialog/index.js
@@ -19,7 +19,6 @@
 /**
  * External dependencies
  */
-import classnames from 'classnames';
 import { useEvent, useKey, useWindowScroll } from 'react-use';
 
 /**
@@ -50,6 +49,8 @@ import {
 import Link from '@/js/components/Link';
 import Portal from '@/js/components/Portal';
 import Typography from '@/js/components/Typography';
+import { SIZE_MEDIUM, SIZE_SMALL } from '@/js/components/Typography/constants';
+import P from '@/js/components/Typography/P';
 import { CORE_SITE } from '@/js/googlesitekit/datastore/site/constants';
 import { CORE_UI } from '@/js/googlesitekit/datastore/ui/constants';
 import { CORE_MODULES } from '@/js/googlesitekit/modules/datastore/constants';
@@ -58,6 +59,7 @@ import { Dialog, DialogContent, DialogFooter } from '@/js/material-components';
 import ShareIcon from '@/svg/icons/share.svg';
 import Footer from './Footer';
 
+// eslint-disable-next-line complexity -- TODO: -- 11266 Reduce complexity.
 export default function DashboardSharingDialog() {
 	const [ shouldFocusResetButton, setShouldFocusResetButton ] =
 		useState( false );
@@ -234,14 +236,11 @@ export default function DashboardSharingDialog() {
 								) }
 							</Typography>
 
-							<p
-								className={ classnames(
-									'googlesitekit-dialog__subtitle',
-									{
-										'googlesitekit-dialog__subtitle--emphasis':
-											resetDialogOpen,
-									}
-								) }
+							<P
+								className="googlesitekit-dialog__subtitle"
+								size={
+									resetDialogOpen ? SIZE_MEDIUM : SIZE_SMALL
+								}
 							>
 								{ settingsDialogOpen && (
 									<span>
@@ -276,7 +275,7 @@ export default function DashboardSharingDialog() {
 										) }
 									</span>
 								) }
-							</p>
+							</P>
 						</div>
 					</div>
 

--- a/assets/js/components/dashboard-sharing/DashboardSharingSettings/ModuleManageAccess.js
+++ b/assets/js/components/dashboard-sharing/DashboardSharingSettings/ModuleManageAccess.js
@@ -32,6 +32,8 @@ import { Icon, info } from '@wordpress/icons';
  * Internal dependencies
  */
 import { Select, Tooltip } from 'googlesitekit-components';
+import { SIZE_SMALL } from '@/js/components/Typography/constants';
+import P from '@/js/components/Typography/P';
 
 const viewAccessOptions = [
 	{
@@ -54,7 +56,10 @@ export default function ModuleManageAccess( {
 } ) {
 	if ( sharedOwnershipModule ) {
 		return (
-			<p className="googlesitekit-dashboard-sharing-settings__note">
+			<P
+				className="googlesitekit-dashboard-sharing-settings__note"
+				size={ SIZE_SMALL }
+			>
 				<span>
 					{ __(
 						'Any admin signed in with Google',
@@ -72,7 +77,7 @@ export default function ModuleManageAccess( {
 						<Icon icon={ info } size={ 18 } />
 					</span>
 				</Tooltip>
-			</p>
+			</P>
 		);
 	}
 
@@ -91,7 +96,10 @@ export default function ModuleManageAccess( {
 
 	if ( ownerUsername ) {
 		return (
-			<p className="googlesitekit-dashboard-sharing-settings__note">
+			<P
+				className="googlesitekit-dashboard-sharing-settings__note"
+				size={ SIZE_SMALL }
+			>
 				{ createInterpolateElement(
 					sprintf(
 						/* translators: %s: user who manages the module. */
@@ -132,7 +140,7 @@ export default function ModuleManageAccess( {
 						<Icon icon={ info } size={ 18 } />
 					</span>
 				</Tooltip>
-			</p>
+			</P>
 		);
 	}
 

--- a/assets/js/components/dashboard-sharing/DashboardSharingSettings/ModuleViewAccess.js
+++ b/assets/js/components/dashboard-sharing/DashboardSharingSettings/ModuleViewAccess.js
@@ -34,6 +34,8 @@ import UserRoleSelect from '@/js/components/dashboard-sharing/UserRoleSelect';
 import Link from '@/js/components/Link';
 import Notice from '@/js/components/Notice';
 import { NOTICE_TYPES } from '@/js/components/Notice/constants';
+import { SIZE_SMALL } from '@/js/components/Typography/constants';
+import P from '@/js/components/Typography/P';
 
 const ModuleViewAccess = forwardRef(
 	(
@@ -82,12 +84,15 @@ const ModuleViewAccess = forwardRef(
 		}
 
 		return (
-			<p className="googlesitekit-dashboard-sharing-settings__note">
+			<P
+				className="googlesitekit-dashboard-sharing-settings__note"
+				size={ SIZE_SMALL }
+			>
 				{ __(
 					'Contact managing user to manage view access',
 					'google-site-kit'
 				) }
-			</p>
+			</P>
 		);
 	}
 );

--- a/assets/js/components/google-tag-gateway/GoogleTagGatewayToggle.js
+++ b/assets/js/components/google-tag-gateway/GoogleTagGatewayToggle.js
@@ -127,6 +127,7 @@ export default function GoogleTagGatewayToggle( { className } ) {
 					</div>
 				</div>
 			) }
+			{ /* TODO: 11266 -- Use P typography component and remove CSS overrides. */ }
 			<p className="googlesitekit-module-settings-group__helper-text">
 				{ createInterpolateElement(
 					__(

--- a/assets/js/components/legacy-setup/SetupUsingGCP.js
+++ b/assets/js/components/legacy-setup/SetupUsingGCP.js
@@ -38,6 +38,8 @@ import Header from '@/js/components/Header';
 import HelpMenu from '@/js/components/help/HelpMenu';
 import Layout from '@/js/components/layout/Layout';
 import Typography from '@/js/components/Typography';
+import { SIZE_MEDIUM } from '@/js/components/Typography/constants';
+import P from '@/js/components/Typography/P';
 import { clearCache } from '@/js/googlesitekit/api/cache';
 import { CORE_SITE } from '@/js/googlesitekit/datastore/site/constants';
 import {
@@ -338,12 +340,17 @@ class SetupUsingGCP extends Component {
 																	'google-site-kit'
 																) }
 															</Typography>
-															<p className="googlesitekit-setup__description">
+															<P
+																className="googlesitekit-setup__description"
+																size={
+																	SIZE_MEDIUM
+																}
+															>
 																{ __(
 																	'Please sign into your Google account to begin.',
 																	'google-site-kit'
 																) }
-															</p>
+															</P>
 															<Button
 																href="#"
 																onClick={

--- a/assets/js/components/legacy-setup/search-console.js
+++ b/assets/js/components/legacy-setup/search-console.js
@@ -38,6 +38,7 @@ import {
 	TextField,
 } from 'googlesitekit-components';
 import Typography from '@/js/components/Typography';
+import { SIZE_MEDIUM } from '@/js/components/Typography/constants';
 import P from '@/js/components/Typography/P';
 import { MODULE_SLUG_SEARCH_CONSOLE } from '@/js/modules/search-console/constants';
 import { trackEvent } from '@/js/util';
@@ -254,12 +255,15 @@ class SearchConsole extends Component {
 						'google-site-kit'
 					) }
 				</Typography>
-				<p className="googlesitekit-setup-module__text--no-margin">
+				<P
+					className="googlesitekit-setup-module__text--no-margin"
+					size={ SIZE_MEDIUM }
+				>
 					{ __(
 						'Your Search Console is set up with Site Kit.',
 						'google-site-kit'
 					) }
-				</p>
+				</P>
 				{ /* TODO This needs a continue button or redirect. */ }
 			</section>
 		);
@@ -335,7 +339,12 @@ class SearchConsole extends Component {
 				</Typography>
 
 				{ errorMsg && 0 < errorMsg.length && (
-					<p className="googlesitekit-error-text">{ errorMsg }</p>
+					<P
+						className="googlesitekit-error-text"
+						size={ SIZE_MEDIUM }
+					>
+						{ errorMsg }
+					</P>
 				) }
 
 				{ isAuthenticated && shouldSetup && this.renderForm() }

--- a/assets/js/components/legacy-setup/site-verification.js
+++ b/assets/js/components/legacy-setup/site-verification.js
@@ -33,6 +33,7 @@ import { __ } from '@wordpress/i18n';
 import { get, set } from 'googlesitekit-api';
 import { Button, ProgressBar, TextField } from 'googlesitekit-components';
 import Typography from '@/js/components/Typography';
+import { SIZE_MEDIUM } from '@/js/components/Typography/constants';
 import P from '@/js/components/Typography/P';
 import { trackEvent, validateJSON } from '@/js/util';
 
@@ -221,12 +222,15 @@ class SiteVerification extends Component {
 					{ __( 'Verify URL', 'google-site-kit' ) }
 				</Typography>
 
-				<p className="googlesitekit-wizard-step__text">
+				<P
+					className="googlesitekit-wizard-step__text"
+					size={ SIZE_MEDIUM }
+				>
 					{ __(
 						'Congratulations, your site has been verified!',
 						'google-site-kit'
 					) }
-				</p>
+				</P>
 			</Fragment>
 		);
 	}
@@ -250,15 +254,23 @@ class SiteVerification extends Component {
 					{ __( 'Verify URL', 'google-site-kit' ) }
 				</Typography>
 
-				<p className="googlesitekit-wizard-step__text">
+				<P
+					className="googlesitekit-wizard-step__text"
+					size={ SIZE_MEDIUM }
+				>
 					{ __(
 						'We will need to verify your URL for Site Kit.',
 						'google-site-kit'
 					) }
-				</p>
+				</P>
 
 				{ errorMsg && 0 < errorMsg.length && (
-					<p className="googlesitekit-error-text">{ errorMsg }</p>
+					<P
+						className="googlesitekit-error-text"
+						size={ SIZE_MEDIUM }
+					>
+						{ errorMsg }
+					</P>
 				) }
 
 				{ isAuthenticated && this.renderForm() }

--- a/assets/js/components/legacy-setup/wizard-progress-step.js
+++ b/assets/js/components/legacy-setup/wizard-progress-step.js
@@ -30,6 +30,8 @@ import { Component } from '@wordpress/element';
 /**
  * Internal dependencies
  */
+import { SIZE_MEDIUM } from '@/js/components/Typography/constants';
+import P from '@/js/components/Typography/P';
 import CheckIcon from '@/svg/icons/check.svg';
 import ExclamationIcon from '@/svg/icons/exclamation.svg';
 
@@ -98,9 +100,12 @@ class WizardProgressStep extends Component {
 						) }
 					</div>
 				</div>
-				<p className="googlesitekit-wizard-progress-step__text">
+				<P
+					className="googlesitekit-wizard-progress-step__text"
+					size={ SIZE_MEDIUM }
+				>
 					{ title }
-				</p>
+				</P>
 			</div>
 		);
 	}

--- a/assets/js/components/legacy-setup/wizard-step-authentication.js
+++ b/assets/js/components/legacy-setup/wizard-step-authentication.js
@@ -33,6 +33,7 @@ import { __, _x } from '@wordpress/i18n';
 import { Button } from 'googlesitekit-components';
 import OptIn from '@/js/components/OptIn';
 import Typography from '@/js/components/Typography';
+import { SIZE_MEDIUM } from '@/js/components/Typography/constants';
 import P from '@/js/components/Typography/P';
 import { setItem } from '@/js/googlesitekit/api/cache';
 import { VIEW_CONTEXT_SPLASH } from '@/js/googlesitekit/constants';
@@ -101,12 +102,15 @@ class WizardStepAuthentication extends Component {
 								) }
 							</P>
 							{ needReauthenticate && (
-								<p className="googlesitekit-error-text">
+								<P
+									className="googlesitekit-error-text"
+									size={ SIZE_MEDIUM }
+								>
 									{ __(
 										'You did not grant access to one or more of the requested scopes. Please grant all scopes that you are prompted for.',
 										'google-site-kit'
 									) }
-								</p>
+								</P>
 							) }
 							<P>
 								<Button onClick={ this.onButtonClick }>

--- a/assets/js/components/notifications/CTA.js
+++ b/assets/js/components/notifications/CTA.js
@@ -28,6 +28,8 @@ import PropTypes from 'prop-types';
 import { Button } from 'googlesitekit-components';
 import Link from '@/js/components/Link';
 import Typography from '@/js/components/Typography';
+import { SIZE_MEDIUM } from '@/js/components/Typography/constants';
+import P from '@/js/components/Typography/P';
 
 function CTA( {
 	title,
@@ -76,9 +78,12 @@ function CTA( {
 					</Typography>
 				) }
 				{ description && typeof description === 'string' && (
-					<p className="googlesitekit-cta__description">
+					<P
+						className="googlesitekit-cta__description"
+						size={ SIZE_MEDIUM }
+					>
 						{ description }
-					</p>
+					</P>
 				) }
 				{ description && typeof description !== 'string' && (
 					<div className="googlesitekit-cta__description">

--- a/assets/js/components/notifications/__snapshots__/ActivateAnalyticsNotification.test.tsx.snap
+++ b/assets/js/components/notifications/__snapshots__/ActivateAnalyticsNotification.test.tsx.snap
@@ -24,7 +24,7 @@ exports[`ActivateAnalyticsNotification should render correctly 1`] = `
                 class="googlesitekit-banner__content"
               >
                 <p
-                  class="googlesitekit-banner__title"
+                  class="googlesitekit-typography googlesitekit-banner__title googlesitekit-typography--headline googlesitekit-typography--medium"
                 >
                   Understand how visitors interact with your content
                 </p>
@@ -98,7 +98,7 @@ exports[`ActivateAnalyticsNotification should render with a "Don’t show again"
                 class="googlesitekit-banner__content"
               >
                 <p
-                  class="googlesitekit-banner__title"
+                  class="googlesitekit-typography googlesitekit-banner__title googlesitekit-typography--headline googlesitekit-typography--medium"
                 >
                   Understand how visitors interact with your content
                 </p>

--- a/assets/js/components/notifications/__snapshots__/ConnectMoreServicesNotification.test.tsx.snap
+++ b/assets/js/components/notifications/__snapshots__/ConnectMoreServicesNotification.test.tsx.snap
@@ -24,7 +24,7 @@ exports[`ConnectMoreServicesNotification component behaviour should render corre
                 class="googlesitekit-banner__content"
               >
                 <p
-                  class="googlesitekit-banner__title"
+                  class="googlesitekit-typography googlesitekit-banner__title googlesitekit-typography--headline googlesitekit-typography--medium"
                 >
                   Boost your site’s performance by enhancing your dashboard
                 </p>

--- a/assets/js/components/notifications/__snapshots__/SiteKitSetupSuccessNotification.test.tsx.snap
+++ b/assets/js/components/notifications/__snapshots__/SiteKitSetupSuccessNotification.test.tsx.snap
@@ -24,7 +24,7 @@ exports[`SiteKitSetupSuccessNotification should render the banner 1`] = `
                 class="googlesitekit-banner__content"
               >
                 <p
-                  class="googlesitekit-banner__title"
+                  class="googlesitekit-typography googlesitekit-banner__title googlesitekit-typography--headline googlesitekit-typography--medium"
                 >
                   Congrats on completing the setup for Site Kit!
                 </p>

--- a/assets/js/components/settings/SettingsActiveModule/__snapshots__/ConfirmDisconnect.test.js.snap
+++ b/assets/js/components/settings/SettingsActiveModule/__snapshots__/ConfirmDisconnect.test.js.snap
@@ -118,7 +118,7 @@ exports[`ConfirmDisconnect should render the Ads Disconnect ModalDialog with a d
               class="mdc-dialog__notes"
             >
               <p
-                class="mdc-dialog__note"
+                class="googlesitekit-typography mdc-dialog__note googlesitekit-typography--body googlesitekit-typography--small"
               >
                 <strong>
                   Note:

--- a/assets/js/components/settings/SettingsAdmin.js
+++ b/assets/js/components/settings/SettingsAdmin.js
@@ -29,6 +29,8 @@ import Layout from '@/js/components/layout/Layout';
 import OptIn from '@/js/components/OptIn';
 import PreviewBlock from '@/js/components/PreviewBlock';
 import ResetButton from '@/js/components/ResetButton';
+import { SIZE_MEDIUM } from '@/js/components/Typography/constants';
+import P from '@/js/components/Typography/P';
 import { CORE_USER } from '@/js/googlesitekit/datastore/user/constants';
 import { CORE_MODULES } from '@/js/googlesitekit/modules/datastore/constants';
 import { useFeature } from '@/js/hooks/useFeature';
@@ -186,7 +188,10 @@ export default function SettingsAdmin() {
 							<Row>
 								<Cell size={ 12 }>
 									<div className="googlesitekit-settings-module__meta-items">
-										<p className="googlesitekit-settings-module__status">
+										<P
+											className="googlesitekit-settings-module__status"
+											size={ SIZE_MEDIUM }
+										>
 											{ __(
 												'Site Kit is connected',
 												'google-site-kit'
@@ -197,7 +202,7 @@ export default function SettingsAdmin() {
 													height={ 8 }
 												/>
 											</span>
-										</p>
+										</P>
 									</div>
 								</Cell>
 							</Row>

--- a/assets/js/components/settings/SettingsGroup.js
+++ b/assets/js/components/settings/SettingsGroup.js
@@ -26,6 +26,7 @@ import PropTypes from 'prop-types';
  * Internal dependencies
  */
 import Typography from '@/js/components/Typography';
+import { SIZE_MEDIUM, TYPE_TITLE } from '@/js/components/Typography/constants';
 
 export default function SettingsGroup( { title, children, className } ) {
 	return (
@@ -35,7 +36,12 @@ export default function SettingsGroup( { title, children, className } ) {
 				className
 			) }
 		>
-			<Typography as="h4" size="medium" type="title">
+			<Typography
+				as="h4"
+				className="googlesitekit-module-settings-group__title"
+				size={ SIZE_MEDIUM }
+				type={ TYPE_TITLE }
+			>
 				{ title }
 			</Typography>
 			{ children }

--- a/assets/js/components/settings/SettingsStatuses.js
+++ b/assets/js/components/settings/SettingsStatuses.js
@@ -31,6 +31,8 @@ import { __ } from '@wordpress/i18n';
  */
 import { ProgressBar } from 'googlesitekit-components';
 import Typography from '@/js/components/Typography';
+import { SIZE_MEDIUM } from '@/js/components/Typography/constants';
+import P from '@/js/components/Typography/P';
 
 export default function SettingsStatuses( { statuses } ) {
 	if ( ! statuses || statuses.length === 0 ) {
@@ -46,11 +48,14 @@ export default function SettingsStatuses( { statuses } ) {
 			);
 		}
 		return (
-			<p className="googlesitekit-settings-module__meta-item-data">
+			<P
+				className="googlesitekit-settings-module__meta-item-data"
+				size={ SIZE_MEDIUM }
+			>
 				{ status
 					? __( 'Enabled', 'google-site-kit' )
 					: __( 'Disabled', 'google-site-kit' ) }
-			</p>
+			</P>
 		);
 	}
 

--- a/assets/js/components/settings/SetupModule.js
+++ b/assets/js/components/settings/SetupModule.js
@@ -39,6 +39,8 @@ import NewBadge from '@/js/components/NewBadge.js';
 import ModuleSettingsWarning from '@/js/components/notifications/ModuleSettingsWarning.js';
 import Spinner from '@/js/components/Spinner';
 import Typography from '@/js/components/Typography';
+import { SIZE_MEDIUM } from '@/js/components/Typography/constants';
+import P from '@/js/components/Typography/P';
 import { setItem } from '@/js/googlesitekit/api/cache';
 import { CORE_LOCATION } from '@/js/googlesitekit/datastore/location/constants';
 import { CORE_SITE } from '@/js/googlesitekit/datastore/site/constants';
@@ -132,11 +134,17 @@ export default function SetupModule( { slug, name, description } ) {
 					) }
 				</div>
 			</div>
-			<p className="googlesitekit-settings-connect-module__text">
+			<P
+				className="googlesitekit-settings-connect-module__text"
+				size={ SIZE_MEDIUM }
+			>
 				{ description }
-			</p>
+			</P>
 
-			<p className="googlesitekit-settings-connect-module__cta">
+			<P
+				className="googlesitekit-settings-connect-module__cta"
+				size={ SIZE_MEDIUM }
+			>
 				<Link
 					onClick={ onSetup }
 					href=""
@@ -149,7 +157,7 @@ export default function SetupModule( { slug, name, description } ) {
 						name
 					) }
 				</Link>
-			</p>
+			</P>
 
 			<ModuleSettingsWarning slug={ slug } />
 		</div>

--- a/assets/js/components/settings/__snapshots__/SettingsGroup.test.js.snap
+++ b/assets/js/components/settings/__snapshots__/SettingsGroup.test.js.snap
@@ -6,7 +6,7 @@ exports[`SettingsGroup renders correctly 1`] = `
     class="googlesitekit-module-settings-group"
   >
     <h4
-      class="googlesitekit-typography googlesitekit-typography--title googlesitekit-typography--medium"
+      class="googlesitekit-typography googlesitekit-module-settings-group__title googlesitekit-typography--title googlesitekit-typography--medium"
     >
       Test Title
     </h4>

--- a/assets/js/components/setup/DefaultModuleSetup.tsx
+++ b/assets/js/components/setup/DefaultModuleSetup.tsx
@@ -26,6 +26,8 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { type Select, useSelect } from 'googlesitekit-data';
+import { SIZE_SMALL, TYPE_TITLE } from '@/js/components/Typography/constants';
+import P from '@/js/components/Typography/P';
 import { CORE_MODULES } from '@/js/googlesitekit/modules/datastore/constants';
 import { Cell, Grid, Row } from '@/js/material-components';
 import { useFinishSetup, useModuleSetupTracking } from './hooks';
@@ -64,12 +66,16 @@ export default function DefaultModuleSetup( {
 								<Grid>
 									<Row>
 										<Cell size={ 12 }>
-											<p className="googlesitekit-setup__intro-title">
+											<P
+												className="googlesitekit-setup__intro-title"
+												size={ SIZE_SMALL }
+												type={ TYPE_TITLE }
+											>
 												{ __(
 													'Connect Service',
 													'google-site-kit'
 												) }
-											</p>
+											</P>
 											<SetupComponent
 												module={ module }
 												finishSetup={ finishSetup }

--- a/assets/js/components/setup/SetupUsingProxyViewOnly/LegacySplashViewOnlyContent.js
+++ b/assets/js/components/setup/SetupUsingProxyViewOnly/LegacySplashViewOnlyContent.js
@@ -34,6 +34,7 @@ import { Button } from 'googlesitekit-components';
 import Link from '@/js/components/Link';
 import OptIn from '@/js/components/OptIn';
 import Typography from '@/js/components/Typography';
+import { SIZE_MEDIUM } from '@/js/components/Typography/constants';
 import P from '@/js/components/Typography/P';
 import { Cell, Row } from '@/js/material-components';
 import SideKickSVG from '@/svg/graphics/view-only-setup-sidekick.svg';
@@ -72,7 +73,10 @@ export default function LegacySplashViewOnlyContent( {
 				>
 					{ __( 'View-only Dashboard Access', 'google-site-kit' ) }
 				</Typography>
-				<p className="googlesitekit-setup__description">
+				<P
+					className="googlesitekit-setup__description"
+					size={ SIZE_MEDIUM }
+				>
 					{ createInterpolateElement(
 						__(
 							"An administrator has granted you access to view this site's dashboard to view stats from all shared Google services. <a>Learn more</a>",
@@ -91,7 +95,7 @@ export default function LegacySplashViewOnlyContent( {
 							),
 						}
 					) }
-				</p>
+				</P>
 				<P>
 					{ __(
 						'Get insights about how people find and use your site as well as how to improve and monetize your content, directly in your WordPress dashboard',

--- a/assets/js/components/setup/SetupUsingProxyViewOnly/SplashViewOnlyContent.js
+++ b/assets/js/components/setup/SetupUsingProxyViewOnly/SplashViewOnlyContent.js
@@ -37,6 +37,8 @@ import OptIn from '@/js/components/OptIn';
 import Services from '@/js/components/setup/Services';
 import SplashScreenshotSVG from '@/js/components/setup/SetupUsingProxyWithSignIn/SetupFlowSVG';
 import Typography from '@/js/components/Typography';
+import { SIZE_MEDIUM } from '@/js/components/Typography/constants';
+import P from '@/js/components/Typography/P';
 import {
 	BREAKPOINT_SMALL,
 	BREAKPOINT_TABLET,
@@ -70,7 +72,10 @@ export default function SplashViewOnlyContent( {
 					{ __( 'View-only Dashboard Access', 'google-site-kit' ) }
 				</Typography>
 
-				<p className="googlesitekit-setup__description googlesitekit-setup__description--view-only">
+				<P
+					className="googlesitekit-setup__description googlesitekit-setup__description--view-only"
+					size={ SIZE_MEDIUM }
+				>
 					{ createInterpolateElement(
 						__(
 							"Get insights about how people find and use your site as well as how to improve and monetize your content, directly in your WordPress dashboard. <br /> An administrator has granted you access to view this site's dashboard containing stats from these shared Google services. <a>Learn more</a>",
@@ -91,7 +96,7 @@ export default function SplashViewOnlyContent( {
 							br: <br />,
 						}
 					) }
-				</p>
+				</P>
 
 				<Services />
 

--- a/assets/js/components/setup/SetupUsingProxyWithSignIn/LegacySplashContent.js
+++ b/assets/js/components/setup/SetupUsingProxyWithSignIn/LegacySplashContent.js
@@ -34,6 +34,8 @@ import Link from '@/js/components/Link';
 import ActivateAnalyticsNotice from '@/js/components/setup/ActivateAnalyticsNotice';
 import CompatibilityChecks from '@/js/components/setup/CompatibilityChecks';
 import Typography from '@/js/components/Typography';
+import { SIZE_MEDIUM } from '@/js/components/Typography/constants';
+import P from '@/js/components/Typography/P';
 import { Cell, Row } from '@/js/material-components';
 import WelcomeAnalyticsSVG from '@/svg/graphics/welcome-analytics.svg';
 import WelcomeSVG from '@/svg/graphics/welcome.svg';
@@ -89,7 +91,10 @@ export default function LegacySplashContent( {
 					{ title }
 				</Typography>
 
-				<p className="googlesitekit-setup__description">
+				<P
+					className="googlesitekit-setup__description"
+					size={ SIZE_MEDIUM }
+				>
 					{ ! showLearnMoreLink && description }
 
 					{ showLearnMoreLink &&
@@ -112,7 +117,7 @@ export default function LegacySplashContent( {
 								),
 							}
 						) }
-				</p>
+				</P>
 				{ getHelpURL && (
 					<Link href={ getHelpURL } external>
 						{ __( 'Get help', 'google-site-kit' ) }

--- a/assets/js/components/setup/SetupUsingProxyWithSignIn/SplashContent.js
+++ b/assets/js/components/setup/SetupUsingProxyWithSignIn/SplashContent.js
@@ -36,6 +36,8 @@ import Notifications from '@/js/components/notifications/Notifications';
 import CompatibilityChecks from '@/js/components/setup/CompatibilityChecks';
 import Services from '@/js/components/setup/Services';
 import Typography from '@/js/components/Typography';
+import { SIZE_MEDIUM } from '@/js/components/Typography/constants';
+import P from '@/js/components/Typography/P';
 import { NOTIFICATION_AREAS } from '@/js/googlesitekit/notifications/constants';
 import {
 	BREAKPOINT_SMALL,
@@ -92,7 +94,10 @@ export default function SplashContent( {
 					</Typography>
 
 					{ ( showLearnMoreLink || description ) && (
-						<p className="googlesitekit-setup__description">
+						<P
+							className="googlesitekit-setup__description"
+							size={ SIZE_MEDIUM }
+						>
 							{ ! showLearnMoreLink && description }
 
 							{ showLearnMoreLink &&
@@ -117,7 +122,7 @@ export default function SplashContent( {
 										),
 									}
 								) }
-						</p>
+						</P>
 					) }
 
 					{ getHelpURL && (

--- a/assets/js/components/setup/SetupUsingProxyWithSignIn/__snapshots__/index.test.js.snap
+++ b/assets/js/components/setup/SetupUsingProxyWithSignIn/__snapshots__/index.test.js.snap
@@ -177,13 +177,13 @@ exports[`SetupUsingProxyWithSignIn should not render the Activate Analytics noti
                       class="googlesitekit-user-menu__details-info"
                     >
                       <p
-                        class="googlesitekit-user-menu__details-info__name"
+                        class="googlesitekit-typography googlesitekit-user-menu__details-info__name googlesitekit-typography--label googlesitekit-typography--medium"
                       >
                         Wapuu WordPress PhD
                       </p>
                       <p
                         aria-label="Email"
-                        class="googlesitekit-user-menu__details-info__email"
+                        class="googlesitekit-typography googlesitekit-user-menu__details-info__email googlesitekit-typography--body googlesitekit-typography--small"
                       >
                         wapuu.wordpress@gmail.com
                       </p>
@@ -280,7 +280,7 @@ exports[`SetupUsingProxyWithSignIn should not render the Activate Analytics noti
                       Set up Site Kit
                     </h1>
                     <p
-                      class="googlesitekit-setup__description"
+                      class="googlesitekit-typography googlesitekit-setup__description googlesitekit-typography--body googlesitekit-typography--medium"
                     >
                       Get insights on how people find your site, as well as how to improve and monetize your site’s content, directly in your WordPress dashboard
                     </p>
@@ -535,13 +535,13 @@ exports[`SetupUsingProxyWithSignIn should not render the progress indicator when
                       class="googlesitekit-user-menu__details-info"
                     >
                       <p
-                        class="googlesitekit-user-menu__details-info__name"
+                        class="googlesitekit-typography googlesitekit-user-menu__details-info__name googlesitekit-typography--label googlesitekit-typography--medium"
                       >
                         Wapuu WordPress PhD
                       </p>
                       <p
                         aria-label="Email"
-                        class="googlesitekit-user-menu__details-info__email"
+                        class="googlesitekit-typography googlesitekit-user-menu__details-info__email googlesitekit-typography--body googlesitekit-typography--small"
                       >
                         wapuu.wordpress@gmail.com
                       </p>
@@ -638,7 +638,7 @@ exports[`SetupUsingProxyWithSignIn should not render the progress indicator when
                       Set up Site Kit
                     </h1>
                     <p
-                      class="googlesitekit-setup__description"
+                      class="googlesitekit-typography googlesitekit-setup__description googlesitekit-typography--body googlesitekit-typography--medium"
                     >
                       Get insights on how people find your site, as well as how to improve and monetize your site’s content, directly in your WordPress dashboard
                     </p>
@@ -948,13 +948,13 @@ exports[`SetupUsingProxyWithSignIn should render the setup page, including the A
                       class="googlesitekit-user-menu__details-info"
                     >
                       <p
-                        class="googlesitekit-user-menu__details-info__name"
+                        class="googlesitekit-typography googlesitekit-user-menu__details-info__name googlesitekit-typography--label googlesitekit-typography--medium"
                       >
                         Wapuu WordPress PhD
                       </p>
                       <p
                         aria-label="Email"
-                        class="googlesitekit-user-menu__details-info__email"
+                        class="googlesitekit-typography googlesitekit-user-menu__details-info__email googlesitekit-typography--body googlesitekit-typography--small"
                       >
                         wapuu.wordpress@gmail.com
                       </p>
@@ -1051,7 +1051,7 @@ exports[`SetupUsingProxyWithSignIn should render the setup page, including the A
                       Set up Site Kit
                     </h1>
                     <p
-                      class="googlesitekit-setup__description"
+                      class="googlesitekit-typography googlesitekit-setup__description googlesitekit-typography--body googlesitekit-typography--medium"
                     >
                       Get insights on how people find your site, as well as how to improve and monetize your site’s content, directly in your WordPress dashboard
                     </p>
@@ -1280,13 +1280,13 @@ exports[`SetupUsingProxyWithSignIn with the \`setupFlowRefresh\` feature flag en
                       class="googlesitekit-user-menu__details-info"
                     >
                       <p
-                        class="googlesitekit-user-menu__details-info__name"
+                        class="googlesitekit-typography googlesitekit-user-menu__details-info__name googlesitekit-typography--label googlesitekit-typography--medium"
                       >
                         Wapuu WordPress PhD
                       </p>
                       <p
                         aria-label="Email"
-                        class="googlesitekit-user-menu__details-info__email"
+                        class="googlesitekit-typography googlesitekit-user-menu__details-info__email googlesitekit-typography--body googlesitekit-typography--small"
                       >
                         wapuu.wordpress@gmail.com
                       </p>
@@ -1524,7 +1524,9 @@ exports[`SetupUsingProxyWithSignIn with the \`setupFlowRefresh\` feature flag en
               <div
                 class="googlesitekit-setup__step-hint"
               >
-                <p>
+                <p
+                  class="googlesitekit-typography googlesitekit-typography--body googlesitekit-typography--small"
+                >
                   Why is this required?
                 </p>
                 <span
@@ -1650,13 +1652,13 @@ exports[`SetupUsingProxyWithSignIn with the \`setupFlowRefresh\` feature flag en
                       class="googlesitekit-user-menu__details-info"
                     >
                       <p
-                        class="googlesitekit-user-menu__details-info__name"
+                        class="googlesitekit-typography googlesitekit-user-menu__details-info__name googlesitekit-typography--label googlesitekit-typography--medium"
                       >
                         Wapuu WordPress PhD
                       </p>
                       <p
                         aria-label="Email"
-                        class="googlesitekit-user-menu__details-info__email"
+                        class="googlesitekit-typography googlesitekit-user-menu__details-info__email googlesitekit-typography--body googlesitekit-typography--small"
                       >
                         wapuu.wordpress@gmail.com
                       </p>
@@ -1814,7 +1816,9 @@ exports[`SetupUsingProxyWithSignIn with the \`setupFlowRefresh\` feature flag en
               <div
                 class="googlesitekit-setup__step-hint"
               >
-                <p>
+                <p
+                  class="googlesitekit-typography googlesitekit-typography--body googlesitekit-typography--small"
+                >
                   Why is this required?
                 </p>
                 <span
@@ -1940,13 +1944,13 @@ exports[`SetupUsingProxyWithSignIn with the \`setupFlowRefresh\` feature flag en
                       class="googlesitekit-user-menu__details-info"
                     >
                       <p
-                        class="googlesitekit-user-menu__details-info__name"
+                        class="googlesitekit-typography googlesitekit-user-menu__details-info__name googlesitekit-typography--label googlesitekit-typography--medium"
                       >
                         Wapuu WordPress PhD
                       </p>
                       <p
                         aria-label="Email"
-                        class="googlesitekit-user-menu__details-info__email"
+                        class="googlesitekit-typography googlesitekit-user-menu__details-info__email googlesitekit-typography--body googlesitekit-typography--small"
                       >
                         wapuu.wordpress@gmail.com
                       </p>
@@ -2184,7 +2188,9 @@ exports[`SetupUsingProxyWithSignIn with the \`setupFlowRefresh\` feature flag en
               <div
                 class="googlesitekit-setup__step-hint"
               >
-                <p>
+                <p
+                  class="googlesitekit-typography googlesitekit-typography--body googlesitekit-typography--small"
+                >
                   Why is this required?
                 </p>
                 <span
@@ -2310,13 +2316,13 @@ exports[`SetupUsingProxyWithSignIn with the \`setupFlowRefresh\` feature flag en
                       class="googlesitekit-user-menu__details-info"
                     >
                       <p
-                        class="googlesitekit-user-menu__details-info__name"
+                        class="googlesitekit-typography googlesitekit-user-menu__details-info__name googlesitekit-typography--label googlesitekit-typography--medium"
                       >
                         Wapuu WordPress PhD
                       </p>
                       <p
                         aria-label="Email"
-                        class="googlesitekit-user-menu__details-info__email"
+                        class="googlesitekit-typography googlesitekit-user-menu__details-info__email googlesitekit-typography--body googlesitekit-typography--small"
                       >
                         wapuu.wordpress@gmail.com
                       </p>
@@ -2554,7 +2560,9 @@ exports[`SetupUsingProxyWithSignIn with the \`setupFlowRefresh\` feature flag en
               <div
                 class="googlesitekit-setup__step-hint"
               >
-                <p>
+                <p
+                  class="googlesitekit-typography googlesitekit-typography--body googlesitekit-typography--small"
+                >
                   Why is this required?
                 </p>
                 <span
@@ -2680,13 +2688,13 @@ exports[`SetupUsingProxyWithSignIn with the \`setupFlowRefresh\` feature flag en
                       class="googlesitekit-user-menu__details-info"
                     >
                       <p
-                        class="googlesitekit-user-menu__details-info__name"
+                        class="googlesitekit-typography googlesitekit-user-menu__details-info__name googlesitekit-typography--label googlesitekit-typography--medium"
                       >
                         Wapuu WordPress PhD
                       </p>
                       <p
                         aria-label="Email"
-                        class="googlesitekit-user-menu__details-info__email"
+                        class="googlesitekit-typography googlesitekit-user-menu__details-info__email googlesitekit-typography--body googlesitekit-typography--small"
                       >
                         wapuu.wordpress@gmail.com
                       </p>
@@ -2924,7 +2932,9 @@ exports[`SetupUsingProxyWithSignIn with the \`setupFlowRefresh\` feature flag en
               <div
                 class="googlesitekit-setup__step-hint"
               >
-                <p>
+                <p
+                  class="googlesitekit-typography googlesitekit-typography--body googlesitekit-typography--small"
+                >
                   Why is this required?
                 </p>
                 <span

--- a/assets/js/components/setup/StepHint/index.js
+++ b/assets/js/components/setup/StepHint/index.js
@@ -25,11 +25,15 @@ import PropTypes from 'prop-types';
  * Internal dependencies
  */
 import InfoTooltip from '@/js/components/InfoTooltip';
+import { SIZE_SMALL, TYPE_BODY } from '@/js/components/Typography/constants';
+import P from '@/js/components/Typography/P';
 
 export default function StepHint( { leadingText, tooltipText } ) {
 	return (
 		<div className="googlesitekit-setup__step-hint">
-			<p>{ leadingText }</p>
+			<P size={ SIZE_SMALL } type={ TYPE_BODY }>
+				{ leadingText }
+			</P>
 			<InfoTooltip
 				tooltipClassName="googlesitekit-setup__step-hint-tooltip"
 				title={ tooltipText }

--- a/assets/js/components/setup/__snapshots__/ModuleSetup.test.js.snap
+++ b/assets/js/components/setup/__snapshots__/ModuleSetup.test.js.snap
@@ -162,7 +162,7 @@ exports[`ModuleSetup renders all elements correctly 1`] = `
                   class="mdc-layout-grid__cell mdc-layout-grid__cell--span-12"
                 >
                   <p
-                    class="googlesitekit-setup__intro-title"
+                    class="googlesitekit-typography googlesitekit-setup__intro-title googlesitekit-typography--title googlesitekit-typography--small"
                   >
                     Connect Service
                   </p>

--- a/assets/js/components/surveys/SurveyTerms.js
+++ b/assets/js/components/surveys/SurveyTerms.js
@@ -27,6 +27,8 @@ import { __ } from '@wordpress/i18n';
  */
 import { useSelect } from 'googlesitekit-data';
 import Link from '@/js/components/Link';
+import { SIZE_MEDIUM } from '@/js/components/Typography/constants';
+import P from '@/js/components/Typography/P';
 import { CORE_SITE } from '@/js/googlesitekit/datastore/site/constants';
 
 export default function SurveyTerms() {
@@ -38,7 +40,7 @@ export default function SurveyTerms() {
 	);
 
 	return (
-		<p className="googlesitekit-survey__terms">
+		<P className="googlesitekit-survey__terms" size={ SIZE_MEDIUM }>
 			{ createInterpolateElement(
 				__(
 					'By continuing, you agree to allow Google to use your answers and account info to improve services, per our <privacy>Privacy</privacy> & <terms>Terms</terms>.',
@@ -63,6 +65,6 @@ export default function SurveyTerms() {
 					),
 				}
 			) }
-		</p>
+		</P>
 	);
 }

--- a/assets/js/components/user-input/UserInputEditModeContent.js
+++ b/assets/js/components/user-input/UserInputEditModeContent.js
@@ -28,6 +28,8 @@ import { __ } from '@wordpress/i18n';
 import { Button, SpinnerButton } from 'googlesitekit-components';
 import { useDispatch, useSelect } from 'googlesitekit-data';
 import ErrorNotice from '@/js/components/ErrorNotice';
+import { SIZE_MEDIUM } from '@/js/components/Typography/constants';
+import P from '@/js/components/Typography/P';
 import { CORE_LOCATION } from '@/js/googlesitekit/datastore/location/constants';
 import { CORE_UI } from '@/js/googlesitekit/datastore/ui/constants';
 import { CORE_USER } from '@/js/googlesitekit/datastore/user/constants';
@@ -147,7 +149,9 @@ export default function UserInputEditModeContent( {
 				alignLeftOptions
 			/>
 			{ errorMessage && ! ( setupFlowRefreshEnabled && settingsView ) && (
-				<p className="googlesitekit-error-text">{ errorMessage }</p>
+				<P className="googlesitekit-error-text" size={ SIZE_MEDIUM }>
+					{ errorMessage }
+				</P>
 			) }
 			{ settingsView && (
 				<Fragment>

--- a/assets/js/components/user-input/UserInputPreview.js
+++ b/assets/js/components/user-input/UserInputPreview.js
@@ -43,6 +43,8 @@ import ErrorNotice from '@/js/components/ErrorNotice';
 import ConfirmSitePurposeChangeModal from '@/js/components/KeyMetrics/ConfirmSitePurposeChangeModal';
 import LoadingWrapper from '@/js/components/LoadingWrapper';
 import Portal from '@/js/components/Portal';
+import { SIZE_SMALL, TYPE_TITLE } from '@/js/components/Typography/constants';
+import P from '@/js/components/Typography/P';
 import { CORE_LOCATION } from '@/js/googlesitekit/datastore/location/constants';
 import { CORE_UI } from '@/js/googlesitekit/datastore/ui/constants';
 import { CORE_USER } from '@/js/googlesitekit/datastore/user/constants';
@@ -220,9 +222,13 @@ export default function UserInputPreview( props ) {
 		>
 			<div className="googlesitekit-user-input__preview-contents">
 				{ ! settingsView && (
-					<p className="googlesitekit-user-input__preview-subheader">
+					<P
+						className="googlesitekit-user-input__preview-subheader"
+						size={ SIZE_SMALL }
+						type={ TYPE_TITLE }
+					>
 						{ __( 'Review your answers', 'google-site-kit' ) }
-					</p>
+					</P>
 				) }
 				{ settingsView && (
 					<div className="googlesitekit-settings-user-input__heading-container">
@@ -231,7 +237,10 @@ export default function UserInputPreview( props ) {
 							width="275px"
 							height="16px"
 						>
-							<p className="googlesitekit-settings-user-input__heading">
+							<P
+								className="googlesitekit-settings-user-input__heading"
+								size={ SIZE_SMALL }
+							>
 								{ setupFlowRefreshEnabled
 									? __(
 											'Answer all questions to help us tailor metrics and offerings that will help you achieve your business goals',
@@ -241,7 +250,7 @@ export default function UserInputPreview( props ) {
 											'Edit your answers for more personalized metrics:',
 											'google-site-kit'
 									  ) }
-							</p>
+							</P>
 						</LoadingWrapper>
 					</div>
 				) }

--- a/assets/js/components/user-input/UserInputPreviewAnswers.js
+++ b/assets/js/components/user-input/UserInputPreviewAnswers.js
@@ -20,6 +20,8 @@
  * Internal dependencies
  */
 import LoadingWrapper from '@/js/components/LoadingWrapper';
+import { SIZE_MEDIUM } from '@/js/components/Typography/constants';
+import P from '@/js/components/Typography/P';
 
 export default function UserInputPreviewAnswers( {
 	loading,
@@ -32,7 +34,12 @@ export default function UserInputPreviewAnswers( {
 		<div className="googlesitekit-user-input__preview-answers">
 			<LoadingWrapper loading={ loading } width="340px" height="36px">
 				{ errorMessage && ! suppressError && (
-					<p className="googlesitekit-error-text">{ errorMessage }</p>
+					<P
+						className="googlesitekit-error-text"
+						size={ SIZE_MEDIUM }
+					>
+						{ errorMessage }
+					</P>
 				) }
 
 				{ ( ! errorMessage || suppressError ) &&

--- a/assets/js/components/user-input/UserInputQuestionAuthor.js
+++ b/assets/js/components/user-input/UserInputQuestionAuthor.js
@@ -30,6 +30,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { useSelect } from 'googlesitekit-data';
+import { SIZE_SMALL } from '@/js/components/Typography/constants';
 import P from '@/js/components/Typography/P';
 import { CORE_USER } from '@/js/googlesitekit/datastore/user/constants';
 
@@ -44,7 +45,7 @@ export default function UserInputQuestionAuthor( { slug } ) {
 
 	return (
 		<div className="googlesitekit-user-input__author">
-			<P>
+			<P size={ SIZE_SMALL }>
 				{ __(
 					'This question has been answered by:',
 					'google-site-kit'

--- a/assets/js/components/user-input/UserInputQuestionInfo.js
+++ b/assets/js/components/user-input/UserInputQuestionInfo.js
@@ -31,15 +31,23 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { useSelect } from 'googlesitekit-data';
+import { SIZE_MEDIUM, SIZE_SMALL } from '@/js/components/Typography/constants';
 import P from '@/js/components/Typography/P';
 import { CORE_SITE } from '@/js/googlesitekit/datastore/site/constants';
 import { CORE_USER } from '@/js/googlesitekit/datastore/user/constants';
+import {
+	BREAKPOINT_DESKTOP,
+	BREAKPOINT_XLARGE,
+	useBreakpoint,
+} from '@/js/hooks/useBreakpoint';
 import { Cell } from '@/js/material-components';
 import UserInputQuestionAuthor from './UserInputQuestionAuthor';
 import UserInputQuestionNotice from './UserInputQuestionNotice';
 import { getUserInputQuestions } from './util/constants';
 
 export default function UserInputQuestionInfo( { slug, questionNumber } ) {
+	const breakpoint = useBreakpoint();
+
 	const hasMultipleUser = useSelect( ( select ) =>
 		select( CORE_SITE ).hasMultipleAdmins()
 	);
@@ -53,6 +61,11 @@ export default function UserInputQuestionInfo( { slug, questionNumber } ) {
 	const questions = getUserInputQuestions();
 	const description = questions[ questionNumber - 1 ]?.description || '';
 
+	const descriptionSize =
+		BREAKPOINT_XLARGE === breakpoint || BREAKPOINT_DESKTOP === breakpoint
+			? SIZE_MEDIUM
+			: SIZE_SMALL;
+
 	return (
 		<Fragment>
 			<Cell
@@ -62,9 +75,12 @@ export default function UserInputQuestionInfo( { slug, questionNumber } ) {
 				smSize={ 4 }
 			>
 				{ description && (
-					<p className="googlesitekit-user-input__question-instructions--description">
+					<P
+						className="googlesitekit-user-input__question-instructions--description"
+						size={ descriptionSize }
+					>
 						{ description }
-					</p>
+					</P>
 				) }
 
 				<UserInputQuestionNotice className="googlesitekit-non-desktop-display-none" />
@@ -79,7 +95,7 @@ export default function UserInputQuestionInfo( { slug, questionNumber } ) {
 				<UserInputQuestionNotice className="googlesitekit-desktop-display-none " />
 
 				{ scope === 'site' && hasMultipleUser && (
-					<P>
+					<P size={ SIZE_SMALL }>
 						{ author
 							? __(
 									'This answer can be edited by all Site Kit admins',

--- a/assets/js/components/user-input/UserInputQuestionNotice.js
+++ b/assets/js/components/user-input/UserInputQuestionNotice.js
@@ -26,18 +26,25 @@ import classnames from 'classnames';
  */
 import { __ } from '@wordpress/i18n';
 
+/**
+ * Internal dependencies
+ */
+import { SIZE_SMALL } from '@/js/components/Typography/constants';
+import P from '@/js/components/Typography/P';
+
 export default function UserInputQuestionNotice( { className } ) {
 	return (
-		<p
+		<P
 			className={ classnames(
 				className,
 				'googlesitekit-user-input__question-notice'
 			) }
+			size={ SIZE_SMALL }
 		>
 			{ __(
 				'You can always edit your answers later in Settings',
 				'google-site-kit'
 			) }
-		</p>
+		</P>
 	);
 }

--- a/assets/js/components/user-input/UserInputSelectOptions.js
+++ b/assets/js/components/user-input/UserInputSelectOptions.js
@@ -33,9 +33,17 @@ import { ENTER } from '@wordpress/keycodes';
  */
 import { Checkbox, Radio } from 'googlesitekit-components';
 import { useDispatch, useSelect } from 'googlesitekit-data';
+import {
+	SIZE_LARGE,
+	SIZE_SMALL,
+	TYPE_BODY,
+	TYPE_TITLE,
+} from '@/js/components/Typography/constants';
+import P from '@/js/components/Typography/P';
 import { CORE_FORMS } from '@/js/googlesitekit/datastore/forms/constants';
 import { CORE_LOCATION } from '@/js/googlesitekit/datastore/location/constants';
 import { CORE_USER } from '@/js/googlesitekit/datastore/user/constants';
+import { BREAKPOINT_SMALL, useBreakpoint } from '@/js/hooks/useBreakpoint';
 import useViewContext from '@/js/hooks/useViewContext';
 import { Cell } from '@/js/material-components';
 import { trackEvent } from '@/js/util';
@@ -55,6 +63,8 @@ export default function UserInputSelectOptions( {
 	alignLeftOptions,
 	gaTrackingEventArgs,
 } ) {
+	const breakpoint = useBreakpoint();
+
 	const viewContext = useViewContext();
 	const values = useSelect(
 		( select ) => select( CORE_USER ).getUserInputSetting( slug ) || []
@@ -210,6 +220,11 @@ export default function UserInputSelectOptions( {
 		);
 	} );
 
+	const instructionsSize =
+		breakpoint === BREAKPOINT_SMALL ? SIZE_SMALL : SIZE_LARGE;
+	const instructionsType =
+		breakpoint === BREAKPOINT_SMALL ? TYPE_BODY : TYPE_TITLE;
+
 	return (
 		<Cell
 			className="googlesitekit-user-input__select-options-wrapper"
@@ -219,7 +234,11 @@ export default function UserInputSelectOptions( {
 			smSize={ 4 }
 		>
 			{ showInstructions && (
-				<p className="googlesitekit-user-input__select-instruction">
+				<P
+					className="googlesitekit-user-input__select-instruction"
+					size={ instructionsSize }
+					type={ instructionsType }
+				>
 					<span>
 						{ sprintf(
 							/* translators: %s: number of answers allowed. */
@@ -232,7 +251,7 @@ export default function UserInputSelectOptions( {
 							max
 						) }
 					</span>
-				</p>
+				</P>
 			) }
 			<div
 				className="googlesitekit-user-input__select-options"

--- a/assets/js/googlesitekit/widgets/components/__snapshots__/WidgetAreaRenderer.test.js.snap
+++ b/assets/js/googlesitekit/widgets/components/__snapshots__/WidgetAreaRenderer.test.js.snap
@@ -29,7 +29,7 @@ exports[`WidgetAreaRenderer should combine multiple widgets in RecoverableModule
                 Data Unavailable
               </h3>
               <p
-                class="googlesitekit-cta__description"
+                class="googlesitekit-typography googlesitekit-cta__description googlesitekit-typography--body googlesitekit-typography--medium"
               >
                 Search Console data was previously shared by an admin who no longer has access. Please contact another admin to restore it.
               </p>
@@ -55,7 +55,7 @@ exports[`WidgetAreaRenderer should combine multiple widgets in RecoverableModule
               Data Unavailable
             </h3>
             <p
-              class="googlesitekit-cta__description"
+              class="googlesitekit-typography googlesitekit-cta__description googlesitekit-typography--body googlesitekit-typography--medium"
             >
               Search Console data was previously shared by an admin who no longer has access. Please contact another admin to restore it.
             </p>
@@ -87,7 +87,7 @@ exports[`WidgetAreaRenderer should combine multiple widgets in RecoverableModule
                 Data Unavailable
               </h3>
               <p
-                class="googlesitekit-cta__description"
+                class="googlesitekit-typography googlesitekit-cta__description googlesitekit-typography--body googlesitekit-typography--medium"
               >
                 Search Console data was previously shared by an admin who no longer has access. Please contact another admin to restore it.
               </p>

--- a/assets/js/modules/ads/components/common/ConversionIDTextField.js
+++ b/assets/js/modules/ads/components/common/ConversionIDTextField.js
@@ -28,6 +28,8 @@ import { __ } from '@wordpress/i18n';
 import { TextField } from 'googlesitekit-components';
 import { useDispatch, useSelect } from 'googlesitekit-data';
 import Typography from '@/js/components/Typography';
+import { SIZE_MEDIUM } from '@/js/components/Typography/constants';
+import P from '@/js/components/Typography/P';
 import { useDebounce } from '@/js/hooks/useDebounce';
 import { MODULES_ADS } from '@/js/modules/ads/datastore/constants';
 import { isValidConversionID } from '@/js/modules/ads/utils/validation';
@@ -80,9 +82,12 @@ export default function ConversionIDTextField( {
 			) }
 
 			{ helperText && (
-				<p className="googlesitekit-settings-module__fields-group-helper-text">
+				<P
+					className="googlesitekit-settings-module__fields-group-helper-text"
+					size={ SIZE_MEDIUM }
+				>
 					{ helperText }
-				</p>
+				</P>
 			) }
 
 			<TextField

--- a/assets/js/modules/ads/components/settings/SettingsForm.js
+++ b/assets/js/modules/ads/components/settings/SettingsForm.js
@@ -34,6 +34,8 @@ import { NOTICE_TYPES } from '@/js/components/Notice/constants';
 import SettingsGroup from '@/js/components/settings/SettingsGroup';
 import StoreErrorNotices from '@/js/components/StoreErrorNotices';
 import Typography from '@/js/components/Typography';
+import { SIZE_MEDIUM } from '@/js/components/Typography/constants';
+import P from '@/js/components/Typography/P';
 import { CORE_SITE } from '@/js/googlesitekit/datastore/site/constants';
 import { useFeature } from '@/js/hooks/useFeature';
 import { ConversionIDTextField } from '@/js/modules/ads/components/common';
@@ -91,7 +93,10 @@ export default function SettingsForm() {
 						>
 							{ __( 'Conversion ID', 'google-site-kit' ) }
 						</Typography>
-						<p className="googlesitekit-settings-module__meta-item-data">
+						<P
+							className="googlesitekit-settings-module__meta-item-data"
+							size={ SIZE_MEDIUM }
+						>
 							{ conversionIDValue === '' &&
 								__( 'None', 'google-site-kit' ) }
 							{ conversionIDValue ||
@@ -100,7 +105,7 @@ export default function SettingsForm() {
 										value={ conversionIDValue }
 									/>
 								) ) }
-						</p>
+						</P>
 					</div>
 					<div className="googlesitekit-settings-module__meta-item">
 						<Typography
@@ -111,14 +116,17 @@ export default function SettingsForm() {
 						>
 							{ __( 'Customer ID', 'google-site-kit' ) }
 						</Typography>
-						<p className="googlesitekit-settings-module__meta-item-data">
+						<P
+							className="googlesitekit-settings-module__meta-item-data"
+							size={ SIZE_MEDIUM }
+						>
 							{ extCustomerID === '' &&
 								__( 'None', 'google-site-kit' ) }
 							{ extCustomerID ||
 								( typeof extCustomerID === 'undefined' && (
 									<DisplaySetting value={ extCustomerID } />
 								) ) }
-						</p>
+						</P>
 					</div>
 				</div>
 			) }

--- a/assets/js/modules/ads/components/settings/SettingsView.js
+++ b/assets/js/modules/ads/components/settings/SettingsView.js
@@ -35,6 +35,8 @@ import DisplaySetting from '@/js/components/DisplaySetting';
 import AdBlockerWarning from '@/js/components/notifications/AdBlockerWarning';
 import SettingsStatuses from '@/js/components/settings/SettingsStatuses';
 import Typography from '@/js/components/Typography';
+import { SIZE_MEDIUM } from '@/js/components/Typography/constants';
+import P from '@/js/components/Typography/P';
 import { CORE_SITE } from '@/js/googlesitekit/datastore/site/constants';
 import { CORE_USER } from '@/js/googlesitekit/datastore/user/constants';
 import { MODULES_ADS } from '@/js/modules/ads/datastore/constants';
@@ -107,7 +109,10 @@ export default function SettingsView() {
 						>
 							{ __( 'Conversion ID', 'google-site-kit' ) }
 						</Typography>
-						<p className="googlesitekit-settings-module__meta-item-data">
+						<P
+							className="googlesitekit-settings-module__meta-item-data"
+							size={ SIZE_MEDIUM }
+						>
 							{ conversionIDValue === '' &&
 								__( 'None', 'google-site-kit' ) }
 							{ conversionIDValue ||
@@ -116,7 +121,7 @@ export default function SettingsView() {
 										value={ conversionIDValue }
 									/>
 								) ) }
-						</p>
+						</P>
 					</div>
 					{ isPaxView && (
 						<div className="googlesitekit-settings-module__meta-item">
@@ -128,7 +133,10 @@ export default function SettingsView() {
 							>
 								{ __( 'Customer ID', 'google-site-kit' ) }
 							</Typography>
-							<p className="googlesitekit-settings-module__meta-item-data">
+							<P
+								className="googlesitekit-settings-module__meta-item-data"
+								size={ SIZE_MEDIUM }
+							>
 								{ extCustomerID === '' &&
 									__( 'None', 'google-site-kit' ) }
 								{ extCustomerID ||
@@ -137,7 +145,7 @@ export default function SettingsView() {
 											value={ extCustomerID }
 										/>
 									) ) }
-							</p>
+							</P>
 						</div>
 					) }
 				</Fragment>

--- a/assets/js/modules/ads/components/setup/SetupMain.js
+++ b/assets/js/modules/ads/components/setup/SetupMain.js
@@ -44,6 +44,8 @@ import Link from '@/js/components/Link';
 import NewBadge from '@/js/components/NewBadge';
 import AdBlockerWarning from '@/js/components/notifications/AdBlockerWarning';
 import Typography from '@/js/components/Typography';
+import { SIZE_MEDIUM } from '@/js/components/Typography/constants';
+import P from '@/js/components/Typography/P';
 import { CORE_LOCATION } from '@/js/googlesitekit/datastore/location/constants';
 import { CORE_SITE } from '@/js/googlesitekit/datastore/site/constants';
 import { CORE_USER } from '@/js/googlesitekit/datastore/user/constants';
@@ -339,7 +341,10 @@ export default function SetupMain( { finishSetup } ) {
 									) }
 									<NewBadge hasLeftSpacing />
 								</Typography>
-								<p className="instructions">
+								<P
+									className="instructions"
+									size={ SIZE_MEDIUM }
+								>
 									{ createInterpolateElement(
 										__(
 											'Create your first Ads campaign, add billing information, and choose your conversion goals. To create a new Ads account, you’ll need to grant Site Kit additional permissions during the account creation process. <a>Learn more</a>',
@@ -356,7 +361,7 @@ export default function SetupMain( { finishSetup } ) {
 											),
 										}
 									) }
-								</p>
+								</P>
 								<SpinnerButton
 									onClick={ onSetupCallback }
 									disabled={ isNavigatingToOAuthURL }
@@ -387,7 +392,10 @@ export default function SetupMain( { finishSetup } ) {
 										'google-site-kit'
 									) }
 								</Typography>
-								<p className="instructions">
+								<P
+									className="instructions"
+									size={ SIZE_MEDIUM }
+								>
 									{ createInterpolateElement(
 										__(
 											'To track conversions for your Ads campaign, you need to add your Conversion ID to Site Kit. You can always change the Conversion ID later in Site Kit Settings. <a>Learn more</a>',
@@ -405,7 +413,7 @@ export default function SetupMain( { finishSetup } ) {
 											br: <br />,
 										}
 									) }
-								</p>
+								</P>
 								<SetupForm
 									finishSetup={ finishSetup }
 									isNavigatingToOAuthURL={

--- a/assets/js/modules/adsense/components/common/AdSenseConnectCTA/Content.js
+++ b/assets/js/modules/adsense/components/common/AdSenseConnectCTA/Content.js
@@ -32,6 +32,7 @@ import { __, _x } from '@wordpress/i18n';
  * Internal dependencies
  */
 import Typography from '@/js/components/Typography';
+import { SIZE_SMALL, TYPE_TITLE } from '@/js/components/Typography/constants';
 import P from '@/js/components/Typography/P';
 import { Cell, Row } from '@/js/material-components';
 import AdSenseIcon from '@/svg/graphics/adsense.svg';
@@ -72,9 +73,13 @@ const Content = forwardRef( ( { stage, mode, onAnimationEnd }, ref ) => {
 		<Fragment>
 			<Row>
 				<Cell size={ 12 }>
-					<p className="googlesitekit-setup__intro-title">
+					<P
+						className="googlesitekit-setup__intro-title"
+						size={ SIZE_SMALL }
+						type={ TYPE_TITLE }
+					>
 						{ __( 'Connect Service', 'google-site-kit' ) }
-					</p>
+					</P>
 					<div className="googlesitekit-setup-module">
 						<div className="googlesitekit-setup-module__logo">
 							<AdSenseIcon width="33" height="33" />

--- a/assets/js/modules/adsense/components/common/UserProfile.js
+++ b/assets/js/modules/adsense/components/common/UserProfile.js
@@ -21,6 +21,8 @@
  */
 import { ProgressBar } from 'googlesitekit-components';
 import { useSelect } from 'googlesitekit-data';
+import { SIZE_MEDIUM } from '@/js/components/Typography/constants';
+import P from '@/js/components/Typography/P';
 import { CORE_USER } from '@/js/googlesitekit/datastore/user/constants';
 
 export default function UserProfile() {
@@ -37,7 +39,7 @@ export default function UserProfile() {
 	}
 
 	return (
-		<p className="googlesitekit-setup-module__user">
+		<P className="googlesitekit-setup-module__user" size={ SIZE_MEDIUM }>
 			<img
 				className="googlesitekit-setup-module__user-image"
 				src={ userPicture }
@@ -46,6 +48,6 @@ export default function UserProfile() {
 			<span className="googlesitekit-setup-module__user-email">
 				{ userEmail }
 			</span>
-		</p>
+		</P>
 	);
 }

--- a/assets/js/modules/adsense/components/settings/AdBlockingRecoveryToggle.js
+++ b/assets/js/modules/adsense/components/settings/AdBlockingRecoveryToggle.js
@@ -35,6 +35,7 @@ import { useDispatch, useSelect } from 'googlesitekit-data';
 import Link from '@/js/components/Link';
 import Notice from '@/js/components/Notice';
 import { NOTICE_TYPES } from '@/js/components/Notice/constants';
+import { SIZE_SMALL } from '@/js/components/Typography/constants';
 import P from '@/js/components/Typography/P';
 import { CORE_SITE } from '@/js/googlesitekit/datastore/site/constants';
 import useFormValue from '@/js/hooks/useFormValue';
@@ -154,7 +155,7 @@ export default function AdBlockingRecoveryToggle() {
 						onClick={ handleAdBlockingRecoveryToggleClick }
 						hideLabel={ false }
 					/>
-					<P>
+					<P size={ SIZE_SMALL }>
 						{ createInterpolateElement(
 							__(
 								'Identify site visitors that have an ad blocker browser extension installed. These site visitors will see the ad blocking recovery message created in AdSense. <a>Configure your message</a>',
@@ -182,7 +183,7 @@ export default function AdBlockingRecoveryToggle() {
 							onClick={ handleErrorProtectionToggleClick }
 							hideLabel={ false }
 						/>
-						<P>
+						<P size={ SIZE_SMALL }>
 							{ createInterpolateElement(
 								__(
 									'If a site visitor’s ad blocker browser extension blocks the message you create in AdSense, a default, non-customizable ad blocking recovery message will display instead. <a>Learn more</a>',

--- a/assets/js/modules/adsense/components/settings/SettingsView.js
+++ b/assets/js/modules/adsense/components/settings/SettingsView.js
@@ -30,6 +30,8 @@ import { useSelect } from 'googlesitekit-data';
 import DisplaySetting from '@/js/components/DisplaySetting';
 import Link from '@/js/components/Link';
 import Typography from '@/js/components/Typography';
+import { SIZE_MEDIUM } from '@/js/components/Typography/constants';
+import P from '@/js/components/Typography/P';
 import VisuallyHidden from '@/js/components/VisuallyHidden';
 import { CORE_SITE } from '@/js/googlesitekit/datastore/site/constants';
 import { ErrorNotices } from '@/js/modules/adsense/components/common';
@@ -135,9 +137,12 @@ export default function SettingsView() {
 					>
 						{ __( 'Publisher ID', 'google-site-kit' ) }
 					</Typography>
-					<p className="googlesitekit-settings-module__meta-item-data">
+					<P
+						className="googlesitekit-settings-module__meta-item-data"
+						size={ SIZE_MEDIUM }
+					>
 						<DisplaySetting value={ accountID } />
-					</p>
+					</P>
 				</div>
 				<div className="googlesitekit-settings-module__meta-item">
 					<Typography
@@ -148,7 +153,10 @@ export default function SettingsView() {
 					>
 						{ __( 'Site Status', 'google-site-kit' ) }
 					</Typography>
-					<p className="googlesitekit-settings-module__meta-item-data">
+					<P
+						className="googlesitekit-settings-module__meta-item-data"
+						size={ SIZE_MEDIUM }
+					>
 						{ siteStatusLabel + ' ' }
 						<Link
 							href={ siteStatusURL }
@@ -161,7 +169,7 @@ export default function SettingsView() {
 						>
 							{ siteStatusLinkLabel }
 						</Link>
-					</p>
+					</P>
 				</div>
 			</div>
 
@@ -175,9 +183,12 @@ export default function SettingsView() {
 					>
 						{ __( 'Account Status', 'google-site-kit' ) }
 					</Typography>
-					<p className="googlesitekit-settings-module__meta-item-data">
+					<P
+						className="googlesitekit-settings-module__meta-item-data"
+						size={ SIZE_MEDIUM }
+					>
 						{ accountStatusLabel }
-					</p>
+					</P>
 				</div>
 			</div>
 
@@ -191,9 +202,12 @@ export default function SettingsView() {
 					>
 						{ __( 'AdSense Code', 'google-site-kit' ) }
 					</Typography>
-					<p className="googlesitekit-settings-module__meta-item-data">
+					<P
+						className="googlesitekit-settings-module__meta-item-data"
+						size={ SIZE_MEDIUM }
+					>
 						{ snippetLabel }
-					</p>
+					</P>
 				</div>
 			</div>
 
@@ -207,9 +221,12 @@ export default function SettingsView() {
 					>
 						{ __( 'Excluded from ads', 'google-site-kit' ) }
 					</Typography>
-					<p className="googlesitekit-settings-module__meta-item-data">
+					<P
+						className="googlesitekit-settings-module__meta-item-data"
+						size={ SIZE_MEDIUM }
+					>
 						{ autoAdsDisabledMessage }
-					</p>
+					</P>
 				</div>
 			</div>
 
@@ -224,14 +241,17 @@ export default function SettingsView() {
 						>
 							{ __( 'Web Stories Ad Unit', 'google-site-kit' ) }
 						</Typography>
-						<p className="googlesitekit-settings-module__meta-item-data">
+						<P
+							className="googlesitekit-settings-module__meta-item-data"
+							size={ SIZE_MEDIUM }
+						>
 							{ ! webStoriesAdUnit && (
 								<span>{ __( 'None', 'google-site-kit' ) }</span>
 							) }
 							{ webStoriesAdUnit && (
 								<DisplaySetting value={ webStoriesAdUnit } />
 							) }
-						</p>
+						</P>
 					</div>
 				</div>
 			) }
@@ -253,16 +273,22 @@ export default function SettingsView() {
 								) }
 							</Typography>
 							{ ! useAdBlockingRecoverySnippet && (
-								<p className="googlesitekit-settings-module__meta-item-data">
+								<P
+									className="googlesitekit-settings-module__meta-item-data"
+									size={ SIZE_MEDIUM }
+								>
 									{ __(
 										'Ad blocking recovery message is not placed',
 										'google-site-kit'
 									) }
-								</p>
+								</P>
 							) }
 							{ useAdBlockingRecoverySnippet && (
 								<Fragment>
-									<p className="googlesitekit-settings-module__meta-item-data">
+									<P
+										className="googlesitekit-settings-module__meta-item-data"
+										size={ SIZE_MEDIUM }
+									>
 										{ useAdBlockingRecoveryErrorSnippet
 											? __(
 													'Ad blocking recovery message enabled with error protection code',
@@ -272,8 +298,11 @@ export default function SettingsView() {
 													'Ad blocking recovery message enabled without error protection code',
 													'google-site-kit'
 											  ) }
-									</p>
-									<p className="googlesitekit-settings-module__meta-item-data">
+									</P>
+									<P
+										className="googlesitekit-settings-module__meta-item-data"
+										size={ SIZE_MEDIUM }
+									>
 										{ createInterpolateElement(
 											__(
 												'Identify site visitors that have an ad blocker browser extension installed. These site visitors will see the ad blocking recovery message created in AdSense. <a>Configure your message</a>',
@@ -290,7 +319,7 @@ export default function SettingsView() {
 												),
 											}
 										) }
-									</p>
+									</P>
 								</Fragment>
 							) }
 						</div>

--- a/assets/js/modules/adsense/components/setup/AdBlockingRecoveryApp/steps/CreateMessageStep.js
+++ b/assets/js/modules/adsense/components/setup/AdBlockingRecoveryApp/steps/CreateMessageStep.js
@@ -33,6 +33,7 @@ import { Button, SpinnerButton } from 'googlesitekit-components';
 import { useDispatch, useSelect } from 'googlesitekit-data';
 import ErrorNotice from '@/js/components/ErrorNotice';
 import Link from '@/js/components/Link';
+import { SIZE_SMALL } from '@/js/components/Typography/constants';
 import P from '@/js/components/Typography/P';
 import { CORE_LOCATION } from '@/js/googlesitekit/datastore/location/constants';
 import { CORE_SITE } from '@/js/googlesitekit/datastore/site/constants';
@@ -221,12 +222,15 @@ export default function CreateMessageStep() {
 					) }
 				</div>
 				{ createMessageCTAClicked && (
-					<p className="googlesitekit-ad-blocking-recovery__create-message-footer-note">
+					<P
+						className="googlesitekit-ad-blocking-recovery__create-message-footer-note"
+						size={ SIZE_SMALL }
+					>
 						{ __(
 							'Ad blocking recovery only works if you’ve created and published your message in AdSense',
 							'google-site-kit'
 						) }
-					</p>
+					</P>
 				) }
 			</div>
 		</Fragment>

--- a/assets/js/modules/adsense/components/setup/AdBlockingRecoveryApp/steps/PlaceTagsStep.js
+++ b/assets/js/modules/adsense/components/setup/AdBlockingRecoveryApp/steps/PlaceTagsStep.js
@@ -37,6 +37,7 @@ import { Checkbox, SpinnerButton } from 'googlesitekit-components';
 import { useDispatch, useSelect } from 'googlesitekit-data';
 import ErrorNotice from '@/js/components/ErrorNotice';
 import Link from '@/js/components/Link';
+import { SIZE_MEDIUM } from '@/js/components/Typography/constants';
 import P from '@/js/components/Typography/P';
 import { CORE_SITE } from '@/js/googlesitekit/datastore/site/constants';
 import useViewContext from '@/js/hooks/useViewContext';
@@ -150,7 +151,10 @@ export default function PlaceTagsStep( { setActiveStep } ) {
 					'google-site-kit'
 				) }
 			</Checkbox>
-			<p className="googlesitekit-ad-blocking-recovery__error-protection-tag-info">
+			<P
+				className="googlesitekit-ad-blocking-recovery__error-protection-tag-info"
+				size={ SIZE_MEDIUM }
+			>
 				{ createInterpolateElement(
 					__(
 						'If a site visitor’s ad blocker browser extension blocks the message you create in AdSense, a default, non-customizable ad blocking recovery message will display instead. <a>Learn more</a>',
@@ -160,7 +164,7 @@ export default function PlaceTagsStep( { setActiveStep } ) {
 						a: <Link href={ learnMoreURL } external />,
 					}
 				) }
-			</p>
+			</P>
 			{ error && <ErrorNotice error={ error } /> }
 			<SpinnerButton
 				onClick={ onCTAClick }

--- a/assets/js/modules/adsense/components/setup/SetupCreateAccount.js
+++ b/assets/js/modules/adsense/components/setup/SetupCreateAccount.js
@@ -33,6 +33,7 @@ import { Button } from 'googlesitekit-components';
 import { useSelect } from 'googlesitekit-data';
 import SupportLink from '@/js/components/SupportLink';
 import Typography from '@/js/components/Typography';
+import { SIZE_MEDIUM } from '@/js/components/Typography/constants';
 import P from '@/js/components/Typography/P';
 import { CORE_USER } from '@/js/googlesitekit/datastore/user/constants';
 import useViewContext from '@/js/hooks/useViewContext';
@@ -92,7 +93,10 @@ export default function SetupCreateAccount() {
 				</Button>
 			</div>
 
-			<p className="googlesitekit-setup-module__footer-text">
+			<P
+				className="googlesitekit-setup-module__footer-text"
+				size={ SIZE_MEDIUM }
+			>
 				{ existingTag &&
 					sprintf(
 						/* translators: 1: client ID, 2: user email address, 3: account ID */
@@ -127,7 +131,7 @@ export default function SetupCreateAccount() {
 							),
 						}
 					) }
-			</p>
+			</P>
 		</Fragment>
 	);
 }

--- a/assets/js/modules/adsense/components/widgets/__snapshots__/ConnectAdSenseCTATileWidget.test.js.snap
+++ b/assets/js/modules/adsense/components/widgets/__snapshots__/ConnectAdSenseCTATileWidget.test.js.snap
@@ -38,7 +38,7 @@ exports[`ConnectAdSenseCTATileWidget should render a title when only a single Co
               class="googlesitekit-km-connect-module-cta-tile__content"
             >
               <p
-                class="googlesitekit-km-connect-module-cta-tile__text"
+                class="googlesitekit-typography googlesitekit-km-connect-module-cta-tile__text googlesitekit-typography--body googlesitekit-typography--medium"
               >
                 AdSense is disconnected, metric can’t be displayed
               </p>
@@ -81,7 +81,7 @@ exports[`ConnectAdSenseCTATileWidget should render the Connect AdSense CTA tile 
               class="googlesitekit-km-connect-module-cta-tile__content"
             >
               <p
-                class="googlesitekit-km-connect-module-cta-tile__text"
+                class="googlesitekit-typography googlesitekit-km-connect-module-cta-tile__text googlesitekit-typography--body googlesitekit-typography--medium"
               >
                 AdSense is disconnected, some of your metrics can’t be displayed
               </p>

--- a/assets/js/modules/analytics-4/components/audience-segmentation/dashboard/AudienceSelectionPanel/AudienceCreationNotice.js
+++ b/assets/js/modules/analytics-4/components/audience-segmentation/dashboard/AudienceSelectionPanel/AudienceCreationNotice.js
@@ -31,6 +31,8 @@ import Link from '@/js/components/Link';
 import Notice from '@/js/components/Notice';
 import { NOTICE_TYPES } from '@/js/components/Notice/constants';
 import Typography from '@/js/components/Typography';
+import { SIZE_SMALL, TYPE_LABEL } from '@/js/components/Typography/constants';
+import P from '@/js/components/Typography/P';
 import SpinnerButton, {
 	SPINNER_POSITION,
 } from '@/js/googlesitekit/components-gm2/SpinnerButton';
@@ -261,12 +263,16 @@ export default function AudienceCreationNotice() {
 	return (
 		<div className="googlesitekit-audience-selection-panel__audience-creation-notice">
 			<div className="googlesitekit-audience-selection-panel__audience-creation-notice-header">
-				<p className="googlesitekit-audience-selection-panel__audience-creation-notice-title">
+				<P
+					className="googlesitekit-audience-selection-panel__audience-creation-notice-title"
+					size={ SIZE_SMALL }
+					type={ TYPE_LABEL }
+				>
 					{ __(
 						'Create groups suggested by Site Kit',
 						'google-site-kit'
 					) }
-				</p>
+				</P>
 			</div>
 			<div className="googlesitekit-audience-selection-panel__audience-creation-notice-body">
 				{ siteKitAvailableAudiences &&
@@ -283,13 +289,16 @@ export default function AudienceCreationNotice() {
 										].displayName
 									}
 								</Typography>
-								<p className="googlesitekit-audience-selection-panel__audience-creation-notice-audience-description">
+								<P
+									className="googlesitekit-audience-selection-panel__audience-creation-notice-audience-description"
+									size={ SIZE_SMALL }
+								>
 									{
 										SITE_KIT_AUDIENCE_DEFINITIONS[
 											audienceSlug
 										].description
 									}
-								</p>
+								</P>
 							</div>
 							<div className="googlesitekit-audience-selection-panel__audience-creation-notice-audience-button">
 								<SpinnerButton

--- a/assets/js/modules/analytics-4/components/audience-segmentation/dashboard/AudienceSelectionPanel/AudienceCreationSuccessNotice.js
+++ b/assets/js/modules/analytics-4/components/audience-segmentation/dashboard/AudienceSelectionPanel/AudienceCreationSuccessNotice.js
@@ -27,6 +27,8 @@ import { __ } from '@wordpress/i18n';
  */
 import { Button } from 'googlesitekit-components';
 import { useDispatch, useSelect } from 'googlesitekit-data';
+import { SIZE_SMALL } from '@/js/components/Typography/constants';
+import P from '@/js/components/Typography/P';
 import { CORE_UI } from '@/js/googlesitekit/datastore/ui/constants';
 import useViewContext from '@/js/hooks/useViewContext';
 import { trackEvent } from '@/js/util';
@@ -67,12 +69,15 @@ export default function AudienceCreationSuccessNotice() {
 			<div className="googlesitekit-audience-selection-panel__success-notice-icon">
 				<CheckFill width={ 24 } height={ 24 } />
 			</div>
-			<p className="googlesitekit-audience-selection-panel__success-notice-message">
+			<P
+				className="googlesitekit-audience-selection-panel__success-notice-message"
+				size={ SIZE_SMALL }
+			>
 				{ __(
 					'Visitor group created successfully!',
 					'google-site-kit'
 				) }
-			</p>
+			</P>
 			<div className="googlesitekit-audience-selection-panel__success-notice-actions">
 				<Button
 					onClick={ () => {

--- a/assets/js/modules/analytics-4/components/audience-segmentation/dashboard/AudienceSelectionPanel/__snapshots__/AudienceCreationNotice.test.js.snap
+++ b/assets/js/modules/analytics-4/components/audience-segmentation/dashboard/AudienceSelectionPanel/__snapshots__/AudienceCreationNotice.test.js.snap
@@ -9,7 +9,7 @@ exports[`AudienceCreationNotice should not render the missing scope notice if th
       class="googlesitekit-audience-selection-panel__audience-creation-notice-header"
     >
       <p
-        class="googlesitekit-audience-selection-panel__audience-creation-notice-title"
+        class="googlesitekit-typography googlesitekit-audience-selection-panel__audience-creation-notice-title googlesitekit-typography--label googlesitekit-typography--small"
       >
         Create groups suggested by Site Kit
       </p>
@@ -29,7 +29,7 @@ exports[`AudienceCreationNotice should not render the missing scope notice if th
             New visitors
           </h3>
           <p
-            class="googlesitekit-audience-selection-panel__audience-creation-notice-audience-description"
+            class="googlesitekit-typography googlesitekit-audience-selection-panel__audience-creation-notice-audience-description googlesitekit-typography--body googlesitekit-typography--small"
           >
             People who visited the site for the first time
           </p>
@@ -61,7 +61,7 @@ exports[`AudienceCreationNotice should not render the missing scope notice if th
             Returning visitors
           </h3>
           <p
-            class="googlesitekit-audience-selection-panel__audience-creation-notice-audience-description"
+            class="googlesitekit-typography googlesitekit-audience-selection-panel__audience-creation-notice-audience-description googlesitekit-typography--body googlesitekit-typography--small"
           >
             People who have visited your site at least once before
           </p>
@@ -108,7 +108,7 @@ exports[`AudienceCreationNotice should render the missing scope notice if the us
       class="googlesitekit-audience-selection-panel__audience-creation-notice-header"
     >
       <p
-        class="googlesitekit-audience-selection-panel__audience-creation-notice-title"
+        class="googlesitekit-typography googlesitekit-audience-selection-panel__audience-creation-notice-title googlesitekit-typography--label googlesitekit-typography--small"
       >
         Create groups suggested by Site Kit
       </p>
@@ -128,7 +128,7 @@ exports[`AudienceCreationNotice should render the missing scope notice if the us
             New visitors
           </h3>
           <p
-            class="googlesitekit-audience-selection-panel__audience-creation-notice-audience-description"
+            class="googlesitekit-typography googlesitekit-audience-selection-panel__audience-creation-notice-audience-description googlesitekit-typography--body googlesitekit-typography--small"
           >
             People who visited the site for the first time
           </p>
@@ -160,7 +160,7 @@ exports[`AudienceCreationNotice should render the missing scope notice if the us
             Returning visitors
           </h3>
           <p
-            class="googlesitekit-audience-selection-panel__audience-creation-notice-audience-description"
+            class="googlesitekit-typography googlesitekit-audience-selection-panel__audience-creation-notice-audience-description googlesitekit-typography--body googlesitekit-typography--small"
           >
             People who have visited your site at least once before
           </p>
@@ -239,7 +239,7 @@ exports[`AudienceCreationNotice should render the notice if the user has not dis
       class="googlesitekit-audience-selection-panel__audience-creation-notice-header"
     >
       <p
-        class="googlesitekit-audience-selection-panel__audience-creation-notice-title"
+        class="googlesitekit-typography googlesitekit-audience-selection-panel__audience-creation-notice-title googlesitekit-typography--label googlesitekit-typography--small"
       >
         Create groups suggested by Site Kit
       </p>
@@ -259,7 +259,7 @@ exports[`AudienceCreationNotice should render the notice if the user has not dis
             New visitors
           </h3>
           <p
-            class="googlesitekit-audience-selection-panel__audience-creation-notice-audience-description"
+            class="googlesitekit-typography googlesitekit-audience-selection-panel__audience-creation-notice-audience-description googlesitekit-typography--body googlesitekit-typography--small"
           >
             People who visited the site for the first time
           </p>
@@ -291,7 +291,7 @@ exports[`AudienceCreationNotice should render the notice if the user has not dis
             Returning visitors
           </h3>
           <p
-            class="googlesitekit-audience-selection-panel__audience-creation-notice-audience-description"
+            class="googlesitekit-typography googlesitekit-audience-selection-panel__audience-creation-notice-audience-description googlesitekit-typography--body googlesitekit-typography--small"
           >
             People who have visited your site at least once before
           </p>
@@ -338,7 +338,7 @@ exports[`AudienceCreationNotice should render the notice if the user has not dis
       class="googlesitekit-audience-selection-panel__audience-creation-notice-header"
     >
       <p
-        class="googlesitekit-audience-selection-panel__audience-creation-notice-title"
+        class="googlesitekit-typography googlesitekit-audience-selection-panel__audience-creation-notice-title googlesitekit-typography--label googlesitekit-typography--small"
       >
         Create groups suggested by Site Kit
       </p>
@@ -358,7 +358,7 @@ exports[`AudienceCreationNotice should render the notice if the user has not dis
             Returning visitors
           </h3>
           <p
-            class="googlesitekit-audience-selection-panel__audience-creation-notice-audience-description"
+            class="googlesitekit-typography googlesitekit-audience-selection-panel__audience-creation-notice-audience-description googlesitekit-typography--body googlesitekit-typography--small"
           >
             People who have visited your site at least once before
           </p>

--- a/assets/js/modules/analytics-4/components/audience-segmentation/dashboard/AudienceTilesWidget/AudienceTile/AudienceTileCollectingData.js
+++ b/assets/js/modules/analytics-4/components/audience-segmentation/dashboard/AudienceTilesWidget/AudienceTile/AudienceTileCollectingData.js
@@ -25,18 +25,24 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
+import { SIZE_SMALL, TYPE_TITLE } from '@/js/components/Typography/constants';
+import P from '@/js/components/Typography/P';
 import AudienceTileCollectingDataImage from '@/svg/graphics/audience-segmentation-collecting-data.svg';
 
 export default function AudienceTileCollectingData() {
 	return (
 		<Fragment>
 			<AudienceTileCollectingDataImage className="googlesitekit-audience-segmentation-tile__zero-data-image" />
-			<p className="googlesitekit-audience-segmentation-tile__zero-data-description">
+			<P
+				className="googlesitekit-audience-segmentation-tile__zero-data-description"
+				size={ SIZE_SMALL }
+				type={ TYPE_TITLE }
+			>
 				{ __(
 					'Site Kit is collecting data for this group.',
 					'google-site-kit'
 				) }
-			</p>
+			</P>
 		</Fragment>
 	);
 }

--- a/assets/js/modules/analytics-4/components/audience-segmentation/dashboard/AudienceTilesWidget/AudienceTile/AudienceTileCollectingDataHideable.js
+++ b/assets/js/modules/analytics-4/components/audience-segmentation/dashboard/AudienceTilesWidget/AudienceTile/AudienceTileCollectingDataHideable.js
@@ -31,17 +31,23 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import Link from '@/js/components/Link';
+import { SIZE_SMALL, TYPE_TITLE } from '@/js/components/Typography/constants';
+import P from '@/js/components/Typography/P';
 import VisibilityIcon from '@/svg/icons/visibility.svg';
 
 export default function AudienceTileCollectingDataHideable( { onHideTile } ) {
 	return (
 		<Fragment>
-			<p className="googlesitekit-audience-segmentation-tile__zero-data-description">
+			<P
+				className="googlesitekit-audience-segmentation-tile__zero-data-description"
+				size={ SIZE_SMALL }
+				type={ TYPE_TITLE }
+			>
 				{ __(
 					'You can hide this group until data is available.',
 					'google-site-kit'
 				) }
-			</p>
+			</P>
 			<Link
 				className="googlesitekit-audience-segmentation-tile-hide-cta"
 				onClick={ onHideTile }

--- a/assets/js/modules/analytics-4/components/audience-segmentation/dashboard/AudienceTilesWidget/AudienceTile/__snapshots__/index.test.js.snap
+++ b/assets/js/modules/analytics-4/components/audience-segmentation/dashboard/AudienceTilesWidget/AudienceTile/__snapshots__/index.test.js.snap
@@ -878,12 +878,12 @@ exports[`AudienceTile with zero data, in the partial data state should render th
           >
             <svg />
             <p
-              class="googlesitekit-audience-segmentation-tile__zero-data-description"
+              class="googlesitekit-typography googlesitekit-audience-segmentation-tile__zero-data-description googlesitekit-typography--title googlesitekit-typography--small"
             >
               Site Kit is collecting data for this group.
             </p>
             <p
-              class="googlesitekit-audience-segmentation-tile__zero-data-description"
+              class="googlesitekit-typography googlesitekit-audience-segmentation-tile__zero-data-description googlesitekit-typography--title googlesitekit-typography--small"
             >
               You can hide this group until data is available.
             </p>

--- a/assets/js/modules/analytics-4/components/audience-segmentation/dashboard/AudienceTilesWidget/PlaceholderTile.js
+++ b/assets/js/modules/analytics-4/components/audience-segmentation/dashboard/AudienceTilesWidget/PlaceholderTile.js
@@ -33,6 +33,8 @@ import { __ } from '@wordpress/i18n';
 import { useDispatch, useSelect } from 'googlesitekit-data';
 import Link from '@/js/components/Link';
 import Typography from '@/js/components/Typography';
+import { SIZE_SMALL } from '@/js/components/Typography/constants';
+import P from '@/js/components/Typography/P';
 import { CORE_SITE } from '@/js/googlesitekit/datastore/site/constants';
 import { CORE_UI } from '@/js/googlesitekit/datastore/ui/constants';
 import { CORE_USER } from '@/js/googlesitekit/datastore/user/constants';
@@ -96,7 +98,10 @@ export default function PlaceholderTile( { Widget } ) {
 									'google-site-kit'
 							  ) }
 					</Typography>
-					<p className="googlesitekit-audience-segmentation-tile-placeholder__description">
+					<P
+						className="googlesitekit-audience-segmentation-tile-placeholder__description"
+						size={ SIZE_SMALL }
+					>
 						{ hasConfigurableNonDefaultAudiences
 							? createInterpolateElement(
 									__(
@@ -127,7 +132,7 @@ export default function PlaceholderTile( { Widget } ) {
 										AnalyticsLink,
 									}
 							  ) }
-					</p>
+					</P>
 				</div>
 			</div>
 		</Widget>

--- a/assets/js/modules/analytics-4/components/audience-segmentation/dashboard/AudienceTilesWidget/__snapshots__/PlaceholderTile.test.js.snap
+++ b/assets/js/modules/analytics-4/components/audience-segmentation/dashboard/AudienceTilesWidget/__snapshots__/PlaceholderTile.test.js.snap
@@ -21,7 +21,7 @@ exports[`PlaceholderTile should render correctly when there are no configurable 
             Create more visitor groups
           </h3>
           <p
-            class="googlesitekit-audience-segmentation-tile-placeholder__description"
+            class="googlesitekit-typography googlesitekit-audience-segmentation-tile-placeholder__description googlesitekit-typography--body googlesitekit-typography--small"
           >
             Learn more about how to group site visitors in 
             <a
@@ -72,7 +72,7 @@ exports[`PlaceholderTile when there are configurable non default audiences avail
             Compare your group to other groups
           </h3>
           <p
-            class="googlesitekit-audience-segmentation-tile-placeholder__description"
+            class="googlesitekit-typography googlesitekit-audience-segmentation-tile-placeholder__description googlesitekit-typography--body googlesitekit-typography--small"
           >
             <button
               class="googlesitekit-cta-link googlesitekit-cta-link--secondary"

--- a/assets/js/modules/analytics-4/components/common/EnhancedMeasurementSwitch.js
+++ b/assets/js/modules/analytics-4/components/common/EnhancedMeasurementSwitch.js
@@ -189,6 +189,7 @@ export default function EnhancedMeasurementSwitch( {
 					hideLabel={ false }
 				/>
 			) }
+			{ /* TODO: 11266 -- Use P typography component and remove CSS overrides. */ }
 			<p className="googlesitekit-module-settings-group__helper-text">
 				{ description }
 			</p>

--- a/assets/js/modules/analytics-4/components/common/MeasurementSettingRow.tsx
+++ b/assets/js/modules/analytics-4/components/common/MeasurementSettingRow.tsx
@@ -71,6 +71,7 @@ const MeasurementSettingRow: FC< MeasurementSettingRowProps > = ( {
 					<p className="googlesitekit-settings-measurement-row__title">
 						{ title }
 					</p>
+					{ /* TODO: 11266 -- Use P typography component and remove CSS overrides. */ }
 					<p className="googlesitekit-module-settings-group__helper-text">
 						{ description }
 					</p>

--- a/assets/js/modules/analytics-4/components/dashboard/DashboardAllTrafficWidgetGA4/__snapshots__/index.test.js.snap
+++ b/assets/js/modules/analytics-4/components/dashboard/DashboardAllTrafficWidgetGA4/__snapshots__/index.test.js.snap
@@ -23,7 +23,9 @@ exports[`DashboardAllTrafficWidgetGA4 should render an error state if there is a
           <div
             class="googlesitekit-cta__description"
           >
-            <p>
+            <p
+              class="googlesitekit-typography googlesitekit-typography--body googlesitekit-typography--medium"
+            >
               Request parameter is empty: metrics.
             </p>
           </div>

--- a/assets/js/modules/analytics-4/components/dashboard/EnhancedMeasurementActivationBanner/__snapshots__/SetupBanner.test.js.snap
+++ b/assets/js/modules/analytics-4/components/dashboard/EnhancedMeasurementActivationBanner/__snapshots__/SetupBanner.test.js.snap
@@ -24,7 +24,7 @@ exports[`SetupBanner should render correctly when the user does have the edit sc
                 class="googlesitekit-banner__content"
               >
                 <p
-                  class="googlesitekit-banner__title"
+                  class="googlesitekit-typography googlesitekit-banner__title googlesitekit-typography--title googlesitekit-typography--medium"
                 >
                   Understand how visitors interact with your content
                 </p>
@@ -56,7 +56,7 @@ exports[`SetupBanner should render correctly when the user does have the edit sc
                   </a>
                 </div>
                 <p
-                  class="googlesitekit-banner__help-text"
+                  class="googlesitekit-typography googlesitekit-banner__help-text googlesitekit-typography--body googlesitekit-typography--small"
                 >
                   You can always add/edit this in the Site Kit Settings
                 </p>
@@ -122,7 +122,7 @@ exports[`SetupBanner should render correctly when the user does not have the edi
                 class="googlesitekit-banner__content"
               >
                 <p
-                  class="googlesitekit-banner__title"
+                  class="googlesitekit-typography googlesitekit-banner__title googlesitekit-typography--title googlesitekit-typography--medium"
                 >
                   Understand how visitors interact with your content
                 </p>
@@ -154,7 +154,7 @@ exports[`SetupBanner should render correctly when the user does not have the edi
                   </a>
                 </div>
                 <p
-                  class="googlesitekit-banner__help-text"
+                  class="googlesitekit-typography googlesitekit-banner__help-text googlesitekit-typography--body googlesitekit-typography--small"
                 >
                   You can always add/edit this in the Site Kit Settings
                 </p>

--- a/assets/js/modules/analytics-4/components/dashboard/EnhancedMeasurementActivationBanner/__snapshots__/index.test.js.snap
+++ b/assets/js/modules/analytics-4/components/dashboard/EnhancedMeasurementActivationBanner/__snapshots__/index.test.js.snap
@@ -50,7 +50,7 @@ exports[`EnhancedMeasurementActivationBanner should render the in progress step 
                 class="googlesitekit-banner__content"
               >
                 <p
-                  class="googlesitekit-banner__title"
+                  class="googlesitekit-typography googlesitekit-banner__title googlesitekit-typography--title googlesitekit-typography--medium"
                 >
                   Understand how visitors interact with your content
                 </p>
@@ -82,7 +82,7 @@ exports[`EnhancedMeasurementActivationBanner should render the in progress step 
                   </a>
                 </div>
                 <p
-                  class="googlesitekit-banner__help-text"
+                  class="googlesitekit-typography googlesitekit-banner__help-text googlesitekit-typography--body googlesitekit-typography--small"
                 >
                   You can always add/edit this in the Site Kit Settings
                 </p>
@@ -149,7 +149,7 @@ exports[`EnhancedMeasurementActivationBanner should render the setup step when e
                 class="googlesitekit-banner__content"
               >
                 <p
-                  class="googlesitekit-banner__title"
+                  class="googlesitekit-typography googlesitekit-banner__title googlesitekit-typography--title googlesitekit-typography--medium"
                 >
                   Understand how visitors interact with your content
                 </p>
@@ -181,7 +181,7 @@ exports[`EnhancedMeasurementActivationBanner should render the setup step when e
                   </a>
                 </div>
                 <p
-                  class="googlesitekit-banner__help-text"
+                  class="googlesitekit-typography googlesitekit-banner__help-text googlesitekit-typography--body googlesitekit-typography--small"
                 >
                   You can always add/edit this in the Site Kit Settings
                 </p>

--- a/assets/js/modules/analytics-4/components/notifications/__snapshots__/GoogleTagIDMismatchNotification.test.js.snap
+++ b/assets/js/modules/analytics-4/components/notifications/__snapshots__/GoogleTagIDMismatchNotification.test.js.snap
@@ -24,7 +24,7 @@ exports[`GoogleTagIDMismatchNotification should render the "alternative GA4 Conf
                 class="googlesitekit-banner__content"
               >
                 <p
-                  class="googlesitekit-banner__title"
+                  class="googlesitekit-typography googlesitekit-banner__title googlesitekit-typography--headline googlesitekit-typography--medium"
                 >
                   Update Site Kit's Analytics configuration to continue seeing Analytics data on the dashboard
                 </p>
@@ -98,7 +98,7 @@ exports[`GoogleTagIDMismatchNotification should render the "alternative GA4 Conf
                 class="googlesitekit-banner__content"
               >
                 <p
-                  class="googlesitekit-banner__title"
+                  class="googlesitekit-typography googlesitekit-banner__title googlesitekit-typography--headline googlesitekit-typography--medium"
                 >
                   Your Google tag configuration has changed
                 </p>

--- a/assets/js/modules/analytics-4/components/settings/OptionalSettingsView.js
+++ b/assets/js/modules/analytics-4/components/settings/OptionalSettingsView.js
@@ -26,6 +26,8 @@ import { __, _x } from '@wordpress/i18n';
  */
 import { useSelect } from 'googlesitekit-data';
 import Typography from '@/js/components/Typography';
+import { SIZE_MEDIUM } from '@/js/components/Typography/constants';
+import P from '@/js/components/Typography/P';
 import { trackingExclusionLabels } from '@/js/modules/analytics-4/components/common/TrackingExclusionSwitches';
 import { MODULES_ANALYTICS_4 } from '@/js/modules/analytics-4/datastore/constants';
 
@@ -45,7 +47,10 @@ export default function OptionalSettingsView() {
 				>
 					{ __( 'Excluded from Analytics', 'google-site-kit' ) }
 				</Typography>
-				<p className="googlesitekit-settings-module__meta-item-data">
+				<P
+					className="googlesitekit-settings-module__meta-item-data"
+					size={ SIZE_MEDIUM }
+				>
 					{ !! trackingDisabled.length &&
 						trackingDisabled
 							.map(
@@ -60,7 +65,7 @@ export default function OptionalSettingsView() {
 							'Analytics is currently enabled for all visitors',
 							'google-site-kit'
 						) }
-				</p>
+				</P>
 			</div>
 		</div>
 	);

--- a/assets/js/modules/analytics-4/components/settings/SettingsView.js
+++ b/assets/js/modules/analytics-4/components/settings/SettingsView.js
@@ -31,6 +31,8 @@ import Link from '@/js/components/Link';
 import SettingsStatuses from '@/js/components/settings/SettingsStatuses';
 import StoreErrorNotices from '@/js/components/StoreErrorNotices';
 import Typography from '@/js/components/Typography';
+import { SIZE_MEDIUM, SIZE_SMALL } from '@/js/components/Typography/constants';
+import P from '@/js/components/Typography/P';
 import VisuallyHidden from '@/js/components/VisuallyHidden';
 import { CORE_SITE } from '@/js/googlesitekit/datastore/site/constants';
 import { useFeature } from '@/js/hooks/useFeature';
@@ -141,12 +143,18 @@ export default function SettingsView() {
 					>
 						{ __( 'Account', 'google-site-kit' ) }
 					</Typography>
-					<p className="googlesitekit-settings-module__meta-item-data">
+					<P
+						className="googlesitekit-settings-module__meta-item-data"
+						size={ SIZE_MEDIUM }
+					>
 						<DisplaySetting value={ accountID } />
-					</p>
+					</P>
 				</div>
 				<div className="googlesitekit-settings-module__meta-item googlesitekit-settings-module__meta-item--data-only">
-					<p className="googlesitekit-settings-module__meta-item-data googlesitekit-settings-module__meta-item-data--tiny">
+					<P
+						className="googlesitekit-settings-module__meta-item-data"
+						size={ SIZE_SMALL }
+					>
 						<Link href={ editAccountSettingsURL } external>
 							{ createInterpolateElement(
 								__(
@@ -158,7 +166,7 @@ export default function SettingsView() {
 								}
 							) }
 						</Link>
-					</p>
+					</P>
 				</div>
 			</div>
 
@@ -172,9 +180,12 @@ export default function SettingsView() {
 					>
 						{ __( 'Property', 'google-site-kit' ) }
 					</Typography>
-					<p className="googlesitekit-settings-module__meta-item-data">
+					<P
+						className="googlesitekit-settings-module__meta-item-data"
+						size={ SIZE_MEDIUM }
+					>
 						<DisplaySetting value={ propertyID } />
-					</p>
+					</P>
 				</div>
 				<div className="googlesitekit-settings-module__meta-item">
 					<Typography
@@ -193,9 +204,12 @@ export default function SettingsView() {
 							}
 						) }
 					</Typography>
-					<p className="googlesitekit-settings-module__meta-item-data">
+					<P
+						className="googlesitekit-settings-module__meta-item-data"
+						size={ SIZE_MEDIUM }
+					>
 						<DisplaySetting value={ measurementID } />
-					</p>
+					</P>
 				</div>
 				{ googleTagID && (
 					<div className="googlesitekit-settings-module__meta-item">
@@ -207,13 +221,19 @@ export default function SettingsView() {
 						>
 							{ __( 'Google Tag ID', 'google-site-kit' ) }
 						</Typography>
-						<p className="googlesitekit-settings-module__meta-item-data">
+						<P
+							className="googlesitekit-settings-module__meta-item-data"
+							size={ SIZE_MEDIUM }
+						>
 							<DisplaySetting value={ googleTagID } />
-						</p>
+						</P>
 					</div>
 				) }
 				<div className="googlesitekit-settings-module__meta-item googlesitekit-settings-module__meta-item--data-only">
-					<p className="googlesitekit-settings-module__meta-item-data googlesitekit-settings-module__meta-item-data--tiny">
+					<P
+						className="googlesitekit-settings-module__meta-item-data"
+						size={ SIZE_SMALL }
+					>
 						<Link href={ editDataStreamSettingsURL } external>
 							{ createInterpolateElement(
 								__(
@@ -225,7 +245,7 @@ export default function SettingsView() {
 								}
 							) }
 						</Link>
-					</p>
+					</P>
 				</div>
 			</div>
 
@@ -239,7 +259,10 @@ export default function SettingsView() {
 					>
 						{ __( 'Code Snippet', 'google-site-kit' ) }
 					</Typography>
-					<p className="googlesitekit-settings-module__meta-item-data">
+					<P
+						className="googlesitekit-settings-module__meta-item-data"
+						size={ SIZE_MEDIUM }
+					>
 						{ useSnippet && (
 							<span>
 								{ __(
@@ -257,7 +280,7 @@ export default function SettingsView() {
 							</span>
 						) }
 						{ useSnippet === undefined && BLANK_SPACE }
-					</p>
+					</P>
 				</div>
 			</div>
 

--- a/assets/js/modules/analytics-4/components/setup/SetupFormFields.js
+++ b/assets/js/modules/analytics-4/components/setup/SetupFormFields.js
@@ -26,6 +26,8 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { useDispatch, useSelect } from 'googlesitekit-data';
+import { SIZE_LARGE, SIZE_MEDIUM } from '@/js/components/Typography/constants';
+import P from '@/js/components/Typography/P';
 import { CORE_FORMS } from '@/js/googlesitekit/datastore/forms/constants';
 import { useFeature } from '@/js/hooks/useFeature';
 import {
@@ -88,12 +90,15 @@ export default function SetupFormFields() {
 	return (
 		<Fragment>
 			{ !! accounts.length && (
-				<p className="googlesitekit-setup-module__select_account">
+				<P
+					className="googlesitekit-setup-module__select_account"
+					size={ setupFlowRefreshEnabled ? SIZE_LARGE : SIZE_MEDIUM }
+				>
 					{ __(
 						'Please select the account information below. You can change this later in your settings.',
 						'google-site-kit'
 					) }
-				</p>
+				</P>
 			) }
 
 			<div className="googlesitekit-setup-module__inputs googlesitekit-setup-module__inputs--grid-layout">

--- a/assets/js/modules/analytics-4/components/setup/SetupLayout/__snapshots__/index.test.tsx.snap
+++ b/assets/js/modules/analytics-4/components/setup/SetupLayout/__snapshots__/index.test.tsx.snap
@@ -219,7 +219,7 @@ exports[`Analytics SetupLayout initial setup flow renders initial setup-specific
                   class="googlesitekit-analytics-setup__form"
                 >
                   <p
-                    class="googlesitekit-setup-module__select_account"
+                    class="googlesitekit-typography googlesitekit-setup-module__select_account googlesitekit-typography--body googlesitekit-typography--large"
                   >
                     Please select the account information below. You can change this later in your settings.
                   </p>
@@ -316,7 +316,9 @@ exports[`Analytics SetupLayout initial setup flow renders initial setup-specific
                       <div
                         class="googlesitekit-setup__step-hint"
                       >
-                        <p>
+                        <p
+                          class="googlesitekit-typography googlesitekit-typography--body googlesitekit-typography--small"
+                        >
                           What is an Analytics property?
                         </p>
                         <span
@@ -374,7 +376,9 @@ exports[`Analytics SetupLayout initial setup flow renders initial setup-specific
                       <div
                         class="googlesitekit-setup__step-hint"
                       >
-                        <p>
+                        <p
+                          class="googlesitekit-typography googlesitekit-typography--body googlesitekit-typography--small"
+                        >
                           What is a web data stream?
                         </p>
                         <span
@@ -660,7 +664,7 @@ exports[`Analytics SetupLayout renders the standard setup flow and tracks generi
                   class="mdc-layout-grid__cell mdc-layout-grid__cell--span-12"
                 >
                   <p
-                    class="googlesitekit-setup__intro-title"
+                    class="googlesitekit-typography googlesitekit-setup__intro-title googlesitekit-typography--title googlesitekit-typography--small"
                   >
                     Connect Service
                   </p>
@@ -688,7 +692,7 @@ exports[`Analytics SetupLayout renders the standard setup flow and tracks generi
                         class="googlesitekit-analytics-setup__form"
                       >
                         <p
-                          class="googlesitekit-setup-module__select_account"
+                          class="googlesitekit-typography googlesitekit-setup-module__select_account googlesitekit-typography--body googlesitekit-typography--medium"
                         >
                           Please select the account information below. You can change this later in your settings.
                         </p>

--- a/assets/js/modules/analytics-4/components/setup/__snapshots__/SetupForm.test.js.snap
+++ b/assets/js/modules/analytics-4/components/setup/__snapshots__/SetupForm.test.js.snap
@@ -6,7 +6,7 @@ exports[`SetupForm renders the form correctly 1`] = `
     class="googlesitekit-analytics-setup__form"
   >
     <p
-      class="googlesitekit-setup-module__select_account"
+      class="googlesitekit-typography googlesitekit-setup-module__select_account googlesitekit-typography--body googlesitekit-typography--medium"
     >
       Please select the account information below. You can change this later in your settings.
     </p>
@@ -232,7 +232,7 @@ exports[`SetupForm renders the form correctly with setupFlowRefresh enabled 1`] 
     class="googlesitekit-analytics-setup__form"
   >
     <p
-      class="googlesitekit-setup-module__select_account"
+      class="googlesitekit-typography googlesitekit-setup-module__select_account googlesitekit-typography--body googlesitekit-typography--large"
     >
       Please select the account information below. You can change this later in your settings.
     </p>
@@ -329,7 +329,9 @@ exports[`SetupForm renders the form correctly with setupFlowRefresh enabled 1`] 
         <div
           class="googlesitekit-setup__step-hint"
         >
-          <p>
+          <p
+            class="googlesitekit-typography googlesitekit-typography--body googlesitekit-typography--small"
+          >
             What is an Analytics property?
           </p>
           <span
@@ -387,7 +389,9 @@ exports[`SetupForm renders the form correctly with setupFlowRefresh enabled 1`] 
         <div
           class="googlesitekit-setup__step-hint"
         >
-          <p>
+          <p
+            class="googlesitekit-typography googlesitekit-typography--body googlesitekit-typography--small"
+          >
             What is a web data stream?
           </p>
           <span

--- a/assets/js/modules/analytics-4/components/site-goals/components/Tile.tsx
+++ b/assets/js/modules/analytics-4/components/site-goals/components/Tile.tsx
@@ -33,6 +33,8 @@ import { Select, useSelect } from 'googlesitekit-data';
 import ChangeBadge from '@/js/components/ChangeBadge';
 import PreviewBlock from '@/js/components/PreviewBlock';
 import ReportError from '@/js/components/ReportError';
+import { SIZE_SMALL } from '@/js/components/Typography/constants';
+import P from '@/js/components/Typography/P';
 import { CORE_USER } from '@/js/googlesitekit/datastore/user/constants';
 import { numFmt } from '@/js/util';
 import GoalTile from './GoalTile';
@@ -107,9 +109,12 @@ export const Tile: FC< TileProps > = ( {
 						<div className="googlesitekit-site-goals-tile__metric">
 							{ numFmt( currentValue, format ) }
 						</div>
-						<p className="googlesitekit-site-goals-tile__subtext">
+						<P
+							className="googlesitekit-site-goals-tile__subtext"
+							size={ SIZE_SMALL }
+						>
 							{ subtitle }
-						</p>
+						</P>
 					</div>
 					{ previousValue !== 0 && (
 						<div className="googlesitekit-site-goals-tile__change-container">
@@ -122,7 +127,10 @@ export const Tile: FC< TileProps > = ( {
 								) }
 							/>
 							{ comparisonDays && (
-								<p className="googlesitekit-site-goals-tile__comparison-label">
+								<P
+									className="googlesitekit-site-goals-tile__comparison-label"
+									size={ SIZE_SMALL }
+								>
 									{ sprintf(
 										/* translators: %d: number of days in the comparison period */
 										__(
@@ -131,7 +139,7 @@ export const Tile: FC< TileProps > = ( {
 										),
 										comparisonDays
 									) }
-								</p>
+								</P>
 							) }
 						</div>
 					) }

--- a/assets/js/modules/analytics-4/components/site-goals/components/TilesGroup.tsx
+++ b/assets/js/modules/analytics-4/components/site-goals/components/TilesGroup.tsx
@@ -23,6 +23,8 @@ import { FC, ReactNode } from 'react';
 /**
  * Internal dependencies
  */
+import { SIZE_MEDIUM, TYPE_TITLE } from '@/js/components/Typography/constants';
+import P from '@/js/components/Typography/P';
 import { BREAKPOINT_SMALL, useBreakpoint } from '@/js/hooks/useBreakpoint';
 
 export interface TilesGroupProps {
@@ -50,9 +52,13 @@ export const TilesGroup: FC< TilesGroupProps > = ( {
 			) }
 		>
 			<div className="googlesitekit-site-goals-tiles-group__header">
-				<p className="googlesitekit-site-goals-tiles-group__title">
+				<P
+					className="googlesitekit-site-goals-tiles-group__title"
+					size={ SIZE_MEDIUM }
+					type={ TYPE_TITLE }
+				>
 					{ title }
-				</p>
+				</P>
 				{ ! isMobileBreakpoint && headerCTA && (
 					<div className="googlesitekit-site-goals-tiles-group__cta">
 						{ headerCTA }

--- a/assets/js/modules/analytics-4/components/site-goals/goal-drivers/TopAuthorsZeroState.tsx
+++ b/assets/js/modules/analytics-4/components/site-goals/goal-drivers/TopAuthorsZeroState.tsx
@@ -26,6 +26,16 @@ import { FC } from 'react';
  */
 import { __ } from '@wordpress/i18n';
 
+/**
+ * Internal dependencies
+ */
+import {
+	SIZE_MEDIUM,
+	SIZE_SMALL,
+	TYPE_TITLE,
+} from '@/js/components/Typography/constants';
+import P from '@/js/components/Typography/P';
+
 interface TopAuthorsZeroStateProps {
 	hasMissingCustomDimensions: boolean;
 	isGatheringData: boolean | null | undefined;
@@ -42,16 +52,24 @@ const TopAuthorsZeroState: FC< TopAuthorsZeroStateProps > = ( {
 	if ( hasMissingCustomDimensions ) {
 		return (
 			<div className="googlesitekit-table-tile__custom-dimensions-missing">
-				<p className="googlesitekit-table-tile__custom-dimensions-missing-title">
+				<P
+					className="googlesitekit-table-tile__custom-dimensions-missing-title"
+					size={ SIZE_MEDIUM }
+					type={ TYPE_TITLE }
+				>
 					{ __( 'No data to show', 'google-site-kit' ) }
-				</p>
+				</P>
 
-				<p className="googlesitekit-table-tile__custom-dimensions-missing-description">
+				<P
+					className="googlesitekit-table-tile__custom-dimensions-missing-description"
+					size={ SIZE_SMALL }
+					type={ TYPE_TITLE }
+				>
 					{ __(
 						'Update Analytics to track metric',
 						'google-site-kit'
 					) }
-				</p>
+				</P>
 
 				<div className="googlesitekit-table-tile__custom-dimensions-missing-actions">
 					<button

--- a/assets/js/modules/analytics-4/components/widgets/__snapshots__/ConnectGA4CTATileWidget.test.js.snap
+++ b/assets/js/modules/analytics-4/components/widgets/__snapshots__/ConnectGA4CTATileWidget.test.js.snap
@@ -38,7 +38,7 @@ exports[`ConnectGA4CTATileWidget should render a title when only a single Connec
               class="googlesitekit-km-connect-module-cta-tile__content"
             >
               <p
-                class="googlesitekit-km-connect-module-cta-tile__text"
+                class="googlesitekit-typography googlesitekit-km-connect-module-cta-tile__text googlesitekit-typography--body googlesitekit-typography--medium"
               >
                 Analytics is disconnected, metric can’t be displayed
               </p>
@@ -81,7 +81,7 @@ exports[`ConnectGA4CTATileWidget should render the Connect GA4 CTA tile 1`] = `
               class="googlesitekit-km-connect-module-cta-tile__content"
             >
               <p
-                class="googlesitekit-km-connect-module-cta-tile__text"
+                class="googlesitekit-typography googlesitekit-km-connect-module-cta-tile__text googlesitekit-typography--body googlesitekit-typography--medium"
               >
                 Analytics is disconnected, some of your metrics can’t be displayed
               </p>

--- a/assets/js/modules/analytics-4/components/widgets/__snapshots__/EngagedTrafficSourceWidget.test.js.snap
+++ b/assets/js/modules/analytics-4/components/widgets/__snapshots__/EngagedTrafficSourceWidget.test.js.snap
@@ -40,7 +40,7 @@ exports[`EngagedTrafficSourceWidget should render correctly with the expected me
               Organic Search
             </div>
             <p
-              class="googlesitekit-km-widget-tile__subtext"
+              class="googlesitekit-typography googlesitekit-km-widget-tile__subtext googlesitekit-typography--label googlesitekit-typography--medium"
             >
               100% of 55 engaged sessions
             </p>

--- a/assets/js/modules/analytics-4/components/widgets/__snapshots__/NewVisitorsWidget.test.js.snap
+++ b/assets/js/modules/analytics-4/components/widgets/__snapshots__/NewVisitorsWidget.test.js.snap
@@ -40,7 +40,7 @@ exports[`NewVisitorsWidget should render correctly with the expected metrics 1`]
               55
             </div>
             <p
-              class="googlesitekit-km-widget-tile__subtext"
+              class="googlesitekit-typography googlesitekit-km-widget-tile__subtext googlesitekit-typography--label googlesitekit-typography--medium"
             >
               of 3 total visitors
             </p>

--- a/assets/js/modules/analytics-4/components/widgets/__snapshots__/PagesPerVisitWidget.test.js.snap
+++ b/assets/js/modules/analytics-4/components/widgets/__snapshots__/PagesPerVisitWidget.test.js.snap
@@ -40,7 +40,7 @@ exports[`PagesPerVisitWidget should render correctly with the expected metrics 1
               1.55
             </div>
             <p
-              class="googlesitekit-km-widget-tile__subtext"
+              class="googlesitekit-typography googlesitekit-km-widget-tile__subtext googlesitekit-typography--label googlesitekit-typography--medium"
             >
               14 page views
             </p>

--- a/assets/js/modules/analytics-4/components/widgets/__snapshots__/PopularAuthorsWidget.test.js.snap
+++ b/assets/js/modules/analytics-4/components/widgets/__snapshots__/PopularAuthorsWidget.test.js.snap
@@ -41,7 +41,7 @@ exports[`PopularAuthorsWidget should render correctly with the expected metrics 
                 class="googlesitekit-table__body-item"
               >
                 <p
-                  class="googlesitekit-km-widget-tile__table-plain-text"
+                  class="googlesitekit-typography googlesitekit-km-widget-tile__table-plain-text googlesitekit-typography--body googlesitekit-typography--small"
                 >
                   User 2
                 </p>
@@ -61,7 +61,7 @@ exports[`PopularAuthorsWidget should render correctly with the expected metrics 
                 class="googlesitekit-table__body-item"
               >
                 <p
-                  class="googlesitekit-km-widget-tile__table-plain-text"
+                  class="googlesitekit-typography googlesitekit-km-widget-tile__table-plain-text googlesitekit-typography--body googlesitekit-typography--small"
                 >
                   User 3
                 </p>
@@ -81,7 +81,7 @@ exports[`PopularAuthorsWidget should render correctly with the expected metrics 
                 class="googlesitekit-table__body-item"
               >
                 <p
-                  class="googlesitekit-km-widget-tile__table-plain-text"
+                  class="googlesitekit-typography googlesitekit-km-widget-tile__table-plain-text googlesitekit-typography--body googlesitekit-typography--small"
                 >
                   User 1
                 </p>

--- a/assets/js/modules/analytics-4/components/widgets/__snapshots__/ReturningVisitorsWidget.test.js.snap
+++ b/assets/js/modules/analytics-4/components/widgets/__snapshots__/ReturningVisitorsWidget.test.js.snap
@@ -40,7 +40,7 @@ exports[`ReturningVisitorsWidget should render correctly with the expected metri
               100%
             </div>
             <p
-              class="googlesitekit-km-widget-tile__subtext"
+              class="googlesitekit-typography googlesitekit-km-widget-tile__subtext googlesitekit-typography--label googlesitekit-typography--medium"
             >
               of 3 total visitors
             </p>

--- a/assets/js/modules/analytics-4/components/widgets/__snapshots__/TopCategoriesWidget.test.js.snap
+++ b/assets/js/modules/analytics-4/components/widgets/__snapshots__/TopCategoriesWidget.test.js.snap
@@ -41,7 +41,7 @@ exports[`TopCategoriesWidget should render correctly with the expected metrics 1
                 class="googlesitekit-table__body-item"
               >
                 <p
-                  class="googlesitekit-km-widget-tile__table-plain-text"
+                  class="googlesitekit-typography googlesitekit-km-widget-tile__table-plain-text googlesitekit-typography--body googlesitekit-typography--small"
                 >
                   Entertainment, Sports, Media
                 </p>
@@ -61,7 +61,7 @@ exports[`TopCategoriesWidget should render correctly with the expected metrics 1
                 class="googlesitekit-table__body-item"
               >
                 <p
-                  class="googlesitekit-km-widget-tile__table-plain-text"
+                  class="googlesitekit-typography googlesitekit-km-widget-tile__table-plain-text googlesitekit-typography--body googlesitekit-typography--small"
                 >
                   Wealth
                 </p>
@@ -81,7 +81,7 @@ exports[`TopCategoriesWidget should render correctly with the expected metrics 1
                 class="googlesitekit-table__body-item"
               >
                 <p
-                  class="googlesitekit-km-widget-tile__table-plain-text"
+                  class="googlesitekit-typography googlesitekit-km-widget-tile__table-plain-text googlesitekit-typography--body googlesitekit-typography--small"
                 >
                   Health & Wellness
                 </p>

--- a/assets/js/modules/analytics-4/components/widgets/__snapshots__/TopCitiesDrivingAddToCartWidget.test.js.snap
+++ b/assets/js/modules/analytics-4/components/widgets/__snapshots__/TopCitiesDrivingAddToCartWidget.test.js.snap
@@ -41,7 +41,7 @@ exports[`TopCitiesDrivingAddToCartWidget should render correctly with the expect
                 class="googlesitekit-table__body-item"
               >
                 <p
-                  class="googlesitekit-km-widget-tile__table-plain-text"
+                  class="googlesitekit-typography googlesitekit-km-widget-tile__table-plain-text googlesitekit-typography--body googlesitekit-typography--small"
                 >
                   Berlin
                 </p>
@@ -61,7 +61,7 @@ exports[`TopCitiesDrivingAddToCartWidget should render correctly with the expect
                 class="googlesitekit-table__body-item"
               >
                 <p
-                  class="googlesitekit-km-widget-tile__table-plain-text"
+                  class="googlesitekit-typography googlesitekit-km-widget-tile__table-plain-text googlesitekit-typography--body googlesitekit-typography--small"
                 >
                   Cork
                 </p>
@@ -81,7 +81,7 @@ exports[`TopCitiesDrivingAddToCartWidget should render correctly with the expect
                 class="googlesitekit-table__body-item"
               >
                 <p
-                  class="googlesitekit-km-widget-tile__table-plain-text"
+                  class="googlesitekit-typography googlesitekit-km-widget-tile__table-plain-text googlesitekit-typography--body googlesitekit-typography--small"
                 >
                   Dublin
                 </p>

--- a/assets/js/modules/analytics-4/components/widgets/__snapshots__/TopCitiesDrivingLeadsWidget.test.js.snap
+++ b/assets/js/modules/analytics-4/components/widgets/__snapshots__/TopCitiesDrivingLeadsWidget.test.js.snap
@@ -41,7 +41,7 @@ exports[`TopCitiesDrivingLeadsWidget should render correctly with the expected m
                 class="googlesitekit-table__body-item"
               >
                 <p
-                  class="googlesitekit-km-widget-tile__table-plain-text"
+                  class="googlesitekit-typography googlesitekit-km-widget-tile__table-plain-text googlesitekit-typography--body googlesitekit-typography--small"
                 >
                   Dublin
                 </p>
@@ -61,7 +61,7 @@ exports[`TopCitiesDrivingLeadsWidget should render correctly with the expected m
                 class="googlesitekit-table__body-item"
               >
                 <p
-                  class="googlesitekit-km-widget-tile__table-plain-text"
+                  class="googlesitekit-typography googlesitekit-km-widget-tile__table-plain-text googlesitekit-typography--body googlesitekit-typography--small"
                 >
                   Cork
                 </p>
@@ -81,7 +81,7 @@ exports[`TopCitiesDrivingLeadsWidget should render correctly with the expected m
                 class="googlesitekit-table__body-item"
               >
                 <p
-                  class="googlesitekit-km-widget-tile__table-plain-text"
+                  class="googlesitekit-typography googlesitekit-km-widget-tile__table-plain-text googlesitekit-typography--body googlesitekit-typography--small"
                 >
                   Berlin
                 </p>

--- a/assets/js/modules/analytics-4/components/widgets/__snapshots__/TopCitiesDrivingPurchasesWidget.test.js.snap
+++ b/assets/js/modules/analytics-4/components/widgets/__snapshots__/TopCitiesDrivingPurchasesWidget.test.js.snap
@@ -41,7 +41,7 @@ exports[`TopCitiesDrivingPurchasesWidget should render correctly with the expect
                 class="googlesitekit-table__body-item"
               >
                 <p
-                  class="googlesitekit-km-widget-tile__table-plain-text"
+                  class="googlesitekit-typography googlesitekit-km-widget-tile__table-plain-text googlesitekit-typography--body googlesitekit-typography--small"
                 >
                   Berlin
                 </p>
@@ -61,7 +61,7 @@ exports[`TopCitiesDrivingPurchasesWidget should render correctly with the expect
                 class="googlesitekit-table__body-item"
               >
                 <p
-                  class="googlesitekit-km-widget-tile__table-plain-text"
+                  class="googlesitekit-typography googlesitekit-km-widget-tile__table-plain-text googlesitekit-typography--body googlesitekit-typography--small"
                 >
                   Cork
                 </p>
@@ -81,7 +81,7 @@ exports[`TopCitiesDrivingPurchasesWidget should render correctly with the expect
                 class="googlesitekit-table__body-item"
               >
                 <p
-                  class="googlesitekit-km-widget-tile__table-plain-text"
+                  class="googlesitekit-typography googlesitekit-km-widget-tile__table-plain-text googlesitekit-typography--body googlesitekit-typography--small"
                 >
                   Dublin
                 </p>

--- a/assets/js/modules/analytics-4/components/widgets/__snapshots__/TopCitiesWidget.test.js.snap
+++ b/assets/js/modules/analytics-4/components/widgets/__snapshots__/TopCitiesWidget.test.js.snap
@@ -41,7 +41,7 @@ exports[`TopCitiesWidget should render correctly with the expected metrics 1`] =
                 class="googlesitekit-table__body-item"
               >
                 <p
-                  class="googlesitekit-km-widget-tile__table-plain-text"
+                  class="googlesitekit-typography googlesitekit-km-widget-tile__table-plain-text googlesitekit-typography--body googlesitekit-typography--small"
                 >
                   Dublin
                 </p>
@@ -61,7 +61,7 @@ exports[`TopCitiesWidget should render correctly with the expected metrics 1`] =
                 class="googlesitekit-table__body-item"
               >
                 <p
-                  class="googlesitekit-km-widget-tile__table-plain-text"
+                  class="googlesitekit-typography googlesitekit-km-widget-tile__table-plain-text googlesitekit-typography--body googlesitekit-typography--small"
                 >
                   Berlin
                 </p>
@@ -81,7 +81,7 @@ exports[`TopCitiesWidget should render correctly with the expected metrics 1`] =
                 class="googlesitekit-table__body-item"
               >
                 <p
-                  class="googlesitekit-km-widget-tile__table-plain-text"
+                  class="googlesitekit-typography googlesitekit-km-widget-tile__table-plain-text googlesitekit-typography--body googlesitekit-typography--small"
                 >
                   New York
                 </p>

--- a/assets/js/modules/analytics-4/components/widgets/__snapshots__/TopConvertingTrafficSourceWidget.test.js.snap
+++ b/assets/js/modules/analytics-4/components/widgets/__snapshots__/TopConvertingTrafficSourceWidget.test.js.snap
@@ -40,7 +40,7 @@ exports[`TopConvertingTrafficSourceWidget renders correctly with no data in the 
               Organic Search
             </div>
             <p
-              class="googlesitekit-km-widget-tile__subtext"
+              class="googlesitekit-typography googlesitekit-km-widget-tile__subtext googlesitekit-typography--label googlesitekit-typography--medium"
             >
               54.9% of visits led to key events
             </p>
@@ -101,7 +101,7 @@ exports[`TopConvertingTrafficSourceWidget should render correctly with the expec
               Organic Search
             </div>
             <p
-              class="googlesitekit-km-widget-tile__subtext"
+              class="googlesitekit-typography googlesitekit-km-widget-tile__subtext googlesitekit-typography--label googlesitekit-typography--medium"
             >
               54.9% of visits led to key events
             </p>

--- a/assets/js/modules/analytics-4/components/widgets/__snapshots__/TopCountriesWidget.test.js.snap
+++ b/assets/js/modules/analytics-4/components/widgets/__snapshots__/TopCountriesWidget.test.js.snap
@@ -41,7 +41,7 @@ exports[`TopCountriesWidget should render correctly with the expected metrics 1`
                 class="googlesitekit-table__body-item"
               >
                 <p
-                  class="googlesitekit-km-widget-tile__table-plain-text"
+                  class="googlesitekit-typography googlesitekit-km-widget-tile__table-plain-text googlesitekit-typography--body googlesitekit-typography--small"
                 >
                   United States
                 </p>
@@ -61,7 +61,7 @@ exports[`TopCountriesWidget should render correctly with the expected metrics 1`
                 class="googlesitekit-table__body-item"
               >
                 <p
-                  class="googlesitekit-km-widget-tile__table-plain-text"
+                  class="googlesitekit-typography googlesitekit-km-widget-tile__table-plain-text googlesitekit-typography--body googlesitekit-typography--small"
                 >
                   United Kingdom
                 </p>
@@ -81,7 +81,7 @@ exports[`TopCountriesWidget should render correctly with the expected metrics 1`
                 class="googlesitekit-table__body-item"
               >
                 <p
-                  class="googlesitekit-km-widget-tile__table-plain-text"
+                  class="googlesitekit-typography googlesitekit-km-widget-tile__table-plain-text googlesitekit-typography--body googlesitekit-typography--small"
                 >
                   Germany
                 </p>

--- a/assets/js/modules/analytics-4/components/widgets/__snapshots__/TopDeviceDrivingPurchasesWidget.test.js.snap
+++ b/assets/js/modules/analytics-4/components/widgets/__snapshots__/TopDeviceDrivingPurchasesWidget.test.js.snap
@@ -40,7 +40,7 @@ exports[`TopDeviceDrivingPurchasesWidget should render correctly with the expect
               Desktop
             </div>
             <p
-              class="googlesitekit-km-widget-tile__subtext"
+              class="googlesitekit-typography googlesitekit-km-widget-tile__subtext googlesitekit-typography--label googlesitekit-typography--medium"
             >
               100% of total purchases
             </p>

--- a/assets/js/modules/analytics-4/components/widgets/__snapshots__/TopTrafficSourceDrivingAddToCartWidget.test.js.snap
+++ b/assets/js/modules/analytics-4/components/widgets/__snapshots__/TopTrafficSourceDrivingAddToCartWidget.test.js.snap
@@ -40,7 +40,7 @@ exports[`TopTrafficSourceDrivingAddToCartWidget should render correctly with the
               Organic Search
             </div>
             <p
-              class="googlesitekit-km-widget-tile__subtext"
+              class="googlesitekit-typography googlesitekit-km-widget-tile__subtext googlesitekit-typography--label googlesitekit-typography--medium"
             >
               100% of total add to carts
             </p>

--- a/assets/js/modules/analytics-4/components/widgets/__snapshots__/TopTrafficSourceDrivingLeadsWidget.test.js.snap
+++ b/assets/js/modules/analytics-4/components/widgets/__snapshots__/TopTrafficSourceDrivingLeadsWidget.test.js.snap
@@ -40,7 +40,7 @@ exports[`TopTrafficSourceDrivingLeadsWidget should render correctly with the exp
               Organic Search
             </div>
             <p
-              class="googlesitekit-km-widget-tile__subtext"
+              class="googlesitekit-typography googlesitekit-km-widget-tile__subtext googlesitekit-typography--label googlesitekit-typography--medium"
             >
               100% of total leads
             </p>

--- a/assets/js/modules/analytics-4/components/widgets/__snapshots__/TopTrafficSourceDrivingPurchasesWidget.test.js.snap
+++ b/assets/js/modules/analytics-4/components/widgets/__snapshots__/TopTrafficSourceDrivingPurchasesWidget.test.js.snap
@@ -40,7 +40,7 @@ exports[`TopTrafficSourceDrivingPurchasesWidget should render correctly with the
               Organic Search
             </div>
             <p
-              class="googlesitekit-km-widget-tile__subtext"
+              class="googlesitekit-typography googlesitekit-km-widget-tile__subtext googlesitekit-typography--label googlesitekit-typography--medium"
             >
               100% of total purchases
             </p>

--- a/assets/js/modules/analytics-4/components/widgets/__snapshots__/TopTrafficSourceWidget.test.js.snap
+++ b/assets/js/modules/analytics-4/components/widgets/__snapshots__/TopTrafficSourceWidget.test.js.snap
@@ -40,7 +40,7 @@ exports[`TopTrafficSourceWidget renders correctly with no data in comparison dat
               Organic Search
             </div>
             <p
-              class="googlesitekit-km-widget-tile__subtext"
+              class="googlesitekit-typography googlesitekit-km-widget-tile__subtext googlesitekit-typography--label googlesitekit-typography--medium"
             >
               100% of total traffic
             </p>
@@ -101,7 +101,7 @@ exports[`TopTrafficSourceWidget should render correctly with the expected metric
               Organic Search
             </div>
             <p
-              class="googlesitekit-km-widget-tile__subtext"
+              class="googlesitekit-typography googlesitekit-km-widget-tile__subtext googlesitekit-typography--label googlesitekit-typography--medium"
             >
               100% of total traffic
             </p>
@@ -377,7 +377,7 @@ exports[`TopTrafficSourceWidget should retry both reports when an error is encou
               Organic Search
             </div>
             <p
-              class="googlesitekit-km-widget-tile__subtext"
+              class="googlesitekit-typography googlesitekit-km-widget-tile__subtext googlesitekit-typography--label googlesitekit-typography--medium"
             >
               100% of total traffic
             </p>

--- a/assets/js/modules/analytics-4/components/widgets/__snapshots__/VisitLengthWidget.test.js.snap
+++ b/assets/js/modules/analytics-4/components/widgets/__snapshots__/VisitLengthWidget.test.js.snap
@@ -40,7 +40,7 @@ exports[`VisitLengthWidget should render correctly with the expected metrics 1`]
               33s
             </div>
             <p
-              class="googlesitekit-km-widget-tile__subtext"
+              class="googlesitekit-typography googlesitekit-km-widget-tile__subtext googlesitekit-typography--label googlesitekit-typography--medium"
             >
               14 total visits
             </p>

--- a/assets/js/modules/analytics-4/components/widgets/__snapshots__/VisitsPerVisitorWidget.test.js.snap
+++ b/assets/js/modules/analytics-4/components/widgets/__snapshots__/VisitsPerVisitorWidget.test.js.snap
@@ -40,7 +40,7 @@ exports[`VisitsPerVisitorWidget should render correctly with the expected metric
               0.5
             </div>
             <p
-              class="googlesitekit-km-widget-tile__subtext"
+              class="googlesitekit-typography googlesitekit-km-widget-tile__subtext googlesitekit-typography--label googlesitekit-typography--medium"
             >
               14 total visits
             </p>

--- a/assets/js/modules/pagespeed-insights/components/settings/SettingsView.js
+++ b/assets/js/modules/pagespeed-insights/components/settings/SettingsView.js
@@ -25,6 +25,8 @@ import { __, sprintf } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { useSelect } from 'googlesitekit-data';
+import { SIZE_MEDIUM } from '@/js/components/Typography/constants';
+import P from '@/js/components/Typography/P';
 import { MODULES_PAGESPEED_INSIGHTS } from '@/js/modules/pagespeed-insights/datastore/constants';
 import { sanitizeHTML } from '@/js/util';
 
@@ -43,11 +45,12 @@ export default function SettingsView() {
 	);
 
 	return (
-		<p
+		<P
 			dangerouslySetInnerHTML={ sanitizeHTML( content, {
 				ALLOWED_TAGS: [ 'a' ],
 				ALLOWED_ATTR: [ 'href' ],
 			} ) }
+			size={ SIZE_MEDIUM }
 		/>
 	);
 }

--- a/assets/js/modules/reader-revenue-manager/components/common/PublicationCreate.js
+++ b/assets/js/modules/reader-revenue-manager/components/common/PublicationCreate.js
@@ -38,6 +38,8 @@ import { Button, SpinnerButton } from 'googlesitekit-components';
 import { useDispatch, useSelect } from 'googlesitekit-data';
 import SupportLink from '@/js/components/SupportLink';
 import Typography from '@/js/components/Typography';
+import { SIZE_MEDIUM } from '@/js/components/Typography/constants';
+import P from '@/js/components/Typography/P';
 import { CORE_FORMS } from '@/js/googlesitekit/datastore/forms/constants';
 import {
 	MODULES_READER_REVENUE_MANAGER,
@@ -94,7 +96,10 @@ export default function PublicationCreate( { onCompleteSetup } ) {
 							'google-site-kit'
 						) }
 					</Typography>
-					<p className="googlesitekit-setup-module__description">
+					<P
+						className="googlesitekit-setup-module__description"
+						size={ SIZE_MEDIUM }
+					>
 						{ createInterpolateElement(
 							__(
 								'Once you have created your publication, it is submitted for review. <a>Learn more</a>',
@@ -113,7 +118,7 @@ export default function PublicationCreate( { onCompleteSetup } ) {
 								),
 							}
 						) }
-					</p>
+					</P>
 					<div className="googlesitekit-setup-module__action">
 						<Button
 							href={ createPublicationURL }

--- a/assets/js/modules/reader-revenue-manager/components/settings/SettingsView.js
+++ b/assets/js/modules/reader-revenue-manager/components/settings/SettingsView.js
@@ -27,6 +27,8 @@ import { __ } from '@wordpress/i18n';
 import { useSelect } from 'googlesitekit-data';
 import DisplaySetting from '@/js/components/DisplaySetting';
 import Typography from '@/js/components/Typography';
+import { SIZE_MEDIUM } from '@/js/components/Typography/constants';
+import P from '@/js/components/Typography/P';
 import { CORE_SITE } from '@/js/googlesitekit/datastore/site/constants';
 import { CORE_MODULES } from '@/js/googlesitekit/modules/datastore/constants';
 import { useFeature } from '@/js/hooks/useFeature';
@@ -130,9 +132,12 @@ export default function SettingsView() {
 					>
 						{ __( 'Publication', 'google-site-kit' ) }
 					</Typography>
-					<p className="googlesitekit-settings-module__meta-item-data">
+					<P
+						className="googlesitekit-settings-module__meta-item-data"
+						size={ SIZE_MEDIUM }
+					>
 						<DisplaySetting value={ publicationID } />
-					</p>
+					</P>
 				</div>
 
 				<div className="googlesitekit-settings-module__meta-item">
@@ -144,9 +149,12 @@ export default function SettingsView() {
 					>
 						{ __( 'Default Product ID', 'google-site-kit' ) }
 					</Typography>
-					<p className="googlesitekit-settings-module__meta-item-data">
+					<P
+						className="googlesitekit-settings-module__meta-item-data"
+						size={ SIZE_MEDIUM }
+					>
 						<DisplaySetting value={ productID } />
-					</p>
+					</P>
 				</div>
 			</div>
 
@@ -163,13 +171,16 @@ export default function SettingsView() {
 					>
 						{ __( 'Display CTAs', 'google-site-kit' ) }
 					</Typography>
-					<p className="googlesitekit-settings-module__meta-item-data">
+					<P
+						className="googlesitekit-settings-module__meta-item-data"
+						size={ SIZE_MEDIUM }
+					>
 						<DisplaySetting
 							value={
 								SNIPPET_MODES[ snippetMode ] || snippetMode
 							}
 						/>
-					</p>
+					</P>
 				</div>
 
 				{ 'post_types' === snippetMode && (
@@ -185,9 +196,12 @@ export default function SettingsView() {
 								'google-site-kit'
 							) }
 						</Typography>
-						<p className="googlesitekit-settings-module__meta-item-data">
+						<P
+							className="googlesitekit-settings-module__meta-item-data"
+							size={ SIZE_MEDIUM }
+						>
 							<DisplaySetting value={ postTypes } />
-						</p>
+						</P>
 					</div>
 				) }
 			</div>

--- a/assets/js/modules/reader-revenue-manager/components/setup/SetupForm.js
+++ b/assets/js/modules/reader-revenue-manager/components/setup/SetupForm.js
@@ -34,6 +34,8 @@ import { SpinnerButton } from 'googlesitekit-components';
 import { useDispatch, useSelect } from 'googlesitekit-data';
 import Link from '@/js/components/Link';
 import StoreErrorNotices from '@/js/components/StoreErrorNotices';
+import { SIZE_MEDIUM } from '@/js/components/Typography/constants';
+import P from '@/js/components/Typography/P';
 import { CORE_FORMS } from '@/js/googlesitekit/datastore/forms/constants';
 import {
 	ProductIDSelect,
@@ -121,7 +123,10 @@ export default function SetupForm( { onCompleteSetup } ) {
 				moduleSlug={ MODULE_SLUG_READER_REVENUE_MANAGER }
 				storeName={ MODULES_READER_REVENUE_MANAGER }
 			/>
-			<p className="googlesitekit-margin-bottom-0">
+			<P
+				className="googlesitekit-setup-module__description"
+				size={ SIZE_MEDIUM }
+			>
 				{ publications?.length === 1
 					? __(
 							'Site Kit will connect your existing publication',
@@ -131,7 +136,7 @@ export default function SetupForm( { onCompleteSetup } ) {
 							'Select your preferred publication to connect with Site Kit',
 							'google-site-kit'
 					  ) }
-			</p>
+			</P>
 			<div className="googlesitekit-setup-module__inputs">
 				<PublicationSelect
 					onChange={ ( publication ) =>

--- a/assets/js/modules/reader-revenue-manager/components/setup/__snapshots__/SetupForm.test.js.snap
+++ b/assets/js/modules/reader-revenue-manager/components/setup/__snapshots__/SetupForm.test.js.snap
@@ -29,7 +29,7 @@ exports[`SetupForm should not silently fail when there is an error 1`] = `
       </div>
     </div>
     <p
-      class="googlesitekit-margin-bottom-0"
+      class="googlesitekit-typography googlesitekit-setup-module__description googlesitekit-typography--body googlesitekit-typography--medium"
     >
       Select your preferred publication to connect with Site Kit
     </p>
@@ -113,7 +113,7 @@ exports[`SetupForm should render the form correctly 1`] = `
 <div>
   <form>
     <p
-      class="googlesitekit-margin-bottom-0"
+      class="googlesitekit-typography googlesitekit-setup-module__description googlesitekit-typography--body googlesitekit-typography--medium"
     >
       Select your preferred publication to connect with Site Kit
     </p>

--- a/assets/js/modules/search-console/components/dashboard/SearchFunnelWidgetGA4/CreateKeyEventCTA.js
+++ b/assets/js/modules/search-console/components/dashboard/SearchFunnelWidgetGA4/CreateKeyEventCTA.js
@@ -33,6 +33,8 @@ import { __ } from '@wordpress/i18n';
 import { Button } from 'googlesitekit-components';
 import { useSelect } from 'googlesitekit-data';
 import PreviewGraph from '@/js/components/PreviewGraph';
+import { SIZE_MEDIUM, TYPE_BODY } from '@/js/components/Typography/constants';
+import P from '@/js/components/Typography/P';
 import { CORE_SITE } from '@/js/googlesitekit/datastore/site/constants';
 import useViewContext from '@/js/hooks/useViewContext';
 import { trackEvent } from '@/js/util';
@@ -65,12 +67,16 @@ export default function CreateKeyEventCTA() {
 				/>
 			</div>
 			<div className="googlesitekit-analytics-cta__details">
-				<p className="googlesitekit-analytics-cta--description">
+				<P
+					className="googlesitekit-analytics-cta--description"
+					size={ SIZE_MEDIUM }
+					type={ TYPE_BODY }
+				>
 					{ __(
 						'Set up key events to track how well your site fulfills your business objectives',
 						'google-site-kit'
 					) }
-				</p>
+				</P>
 				<Button
 					href={ createKeyEventsSupportURL }
 					target="_blank"

--- a/assets/js/modules/search-console/components/dashboard/SearchFunnelWidgetGA4/__snapshots__/Chart.test.js.snap
+++ b/assets/js/modules/search-console/components/dashboard/SearchFunnelWidgetGA4/__snapshots__/Chart.test.js.snap
@@ -79,7 +79,7 @@ exports[`SearchFunnelWidgetGA4 Chart Activate Analytics CTA with button "Complet
             class="googlesitekit-analytics-cta__details"
           >
             <p
-              class="googlesitekit-analytics-cta--description"
+              class="googlesitekit-typography googlesitekit-analytics-cta--description googlesitekit-typography--body googlesitekit-typography--medium"
             >
               See how many people visit your site from Search and track how you’re achieving your goals
             </p>
@@ -180,7 +180,7 @@ exports[`SearchFunnelWidgetGA4 Chart Activate Analytics CTA with button "Set up 
             class="googlesitekit-analytics-cta__details"
           >
             <p
-              class="googlesitekit-analytics-cta--description"
+              class="googlesitekit-typography googlesitekit-analytics-cta--description googlesitekit-typography--body googlesitekit-typography--medium"
             >
               See how many people visit your site from Search and track how you’re achieving your goals
             </p>

--- a/assets/js/modules/search-console/components/dashboard/SearchFunnelWidgetGA4/__snapshots__/Overview.test.js.snap
+++ b/assets/js/modules/search-console/components/dashboard/SearchFunnelWidgetGA4/__snapshots__/Overview.test.js.snap
@@ -279,7 +279,7 @@ exports[`Overview should render the Search Funnel Overview, including the Activa
             class="googlesitekit-analytics-cta__details"
           >
             <p
-              class="googlesitekit-analytics-cta--description"
+              class="googlesitekit-typography googlesitekit-analytics-cta--description googlesitekit-typography--body googlesitekit-typography--medium"
             >
               See how many people visit your site from Search and track how you’re achieving your goals
             </p>

--- a/assets/js/modules/search-console/components/dashboard/SearchFunnelWidgetGA4/__snapshots__/index.test.tsx.snap
+++ b/assets/js/modules/search-console/components/dashboard/SearchFunnelWidgetGA4/__snapshots__/index.test.tsx.snap
@@ -410,7 +410,7 @@ exports[`SearchFunnelWidgetGA4 should render the Search Funnel Widget, including
                 class="googlesitekit-analytics-cta__details"
               >
                 <p
-                  class="googlesitekit-analytics-cta--description"
+                  class="googlesitekit-typography googlesitekit-analytics-cta--description googlesitekit-typography--body googlesitekit-typography--medium"
                 >
                   See how many people visit your site from Search and track how you’re achieving your goals
                 </p>

--- a/assets/js/modules/search-console/components/settings/SettingsView.js
+++ b/assets/js/modules/search-console/components/settings/SettingsView.js
@@ -27,6 +27,8 @@ import { __ } from '@wordpress/i18n';
 import { useSelect } from 'googlesitekit-data';
 import DisplaySetting from '@/js/components/DisplaySetting';
 import Typography from '@/js/components/Typography';
+import { SIZE_MEDIUM } from '@/js/components/Typography/constants';
+import P from '@/js/components/Typography/P';
 import { MODULES_SEARCH_CONSOLE } from '@/js/modules/search-console/datastore/constants';
 
 export default function SettingsView() {
@@ -44,9 +46,12 @@ export default function SettingsView() {
 			>
 				{ __( 'Connected Property', 'google-site-kit' ) }
 			</Typography>
-			<p className="googlesitekit-settings-module__meta-item-data">
+			<P
+				className="googlesitekit-settings-module__meta-item-data"
+				size={ SIZE_MEDIUM }
+			>
 				<DisplaySetting value={ propertyID } />
-			</p>
+			</P>
 		</div>
 	);
 }

--- a/assets/js/modules/sign-in-with-google/components/common/Preview.js
+++ b/assets/js/modules/sign-in-with-google/components/common/Preview.js
@@ -26,6 +26,8 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { useSelect } from 'googlesitekit-data';
+import { SIZE_MEDIUM } from '@/js/components/Typography/constants';
+import P from '@/js/components/Typography/P';
 import { MODULES_SIGN_IN_WITH_GOOGLE } from '@/js/modules/sign-in-with-google/datastore/constants';
 import { getLocale } from '@/js/util';
 
@@ -79,9 +81,12 @@ export default function Preview() {
 
 	return (
 		<div className="googlesitekit-sign-in-with-google__preview">
-			<p className="googlesitekit-sign-in-with-google__preview--label">
+			<P
+				className="googlesitekit-sign-in-with-google__preview--label"
+				size={ SIZE_MEDIUM }
+			>
 				{ __( 'Preview', 'google-site-kit' ) }
-			</p>
+			</P>
 			<div ref={ containerRef } />
 			<div className="googlesitekit-sign-in-with-google__preview--protector" />
 		</div>

--- a/assets/js/modules/sign-in-with-google/components/settings/SettingsView.js
+++ b/assets/js/modules/sign-in-with-google/components/settings/SettingsView.js
@@ -28,6 +28,7 @@ import { useSelect } from 'googlesitekit-data';
 import DisplaySetting from '@/js/components/DisplaySetting';
 import StoreErrorNotices from '@/js/components/StoreErrorNotices';
 import Typography from '@/js/components/Typography';
+import { SIZE_MEDIUM } from '@/js/components/Typography/constants';
 import P from '@/js/components/Typography/P';
 import { CORE_SITE } from '@/js/googlesitekit/datastore/site/constants';
 import { SettingsNotice } from '@/js/modules/sign-in-with-google/components/common';
@@ -105,9 +106,12 @@ export default function SettingsView() {
 					>
 						{ __( 'Client ID', 'google-site-kit' ) }
 					</Typography>
-					<p className="googlesitekit-settings-module__meta-item-data">
+					<P
+						className="googlesitekit-settings-module__meta-item-data"
+						size={ SIZE_MEDIUM }
+					>
 						<DisplaySetting value={ clientID } />
-					</p>
+					</P>
 				</div>
 			</div>
 
@@ -121,9 +125,12 @@ export default function SettingsView() {
 					>
 						{ __( 'Button text', 'google-site-kit' ) }
 					</Typography>
-					<p className="googlesitekit-settings-module__meta-item-data">
+					<P
+						className="googlesitekit-settings-module__meta-item-data"
+						size={ SIZE_MEDIUM }
+					>
 						<DisplaySetting value={ buttonTextLabel } />
-					</p>
+					</P>
 				</div>
 
 				<div className="googlesitekit-settings-module__meta-item">
@@ -135,9 +142,12 @@ export default function SettingsView() {
 					>
 						{ __( 'Button theme', 'google-site-kit' ) }
 					</Typography>
-					<p className="googlesitekit-settings-module__meta-item-data">
+					<P
+						className="googlesitekit-settings-module__meta-item-data"
+						size={ SIZE_MEDIUM }
+					>
 						<DisplaySetting value={ buttonThemeLabel } />
-					</p>
+					</P>
 				</div>
 
 				<div className="googlesitekit-settings-module__meta-item">
@@ -149,9 +159,12 @@ export default function SettingsView() {
 					>
 						{ __( 'Button shape', 'google-site-kit' ) }
 					</Typography>
-					<p className="googlesitekit-settings-module__meta-item-data">
+					<P
+						className="googlesitekit-settings-module__meta-item-data"
+						size={ SIZE_MEDIUM }
+					>
 						<DisplaySetting value={ buttonShapeLabel } />
-					</p>
+					</P>
 				</div>
 			</div>
 
@@ -165,7 +178,10 @@ export default function SettingsView() {
 					>
 						{ __( 'One Tap sign in', 'google-site-kit' ) }
 					</Typography>
-					<p className="googlesitekit-settings-module__meta-item-data">
+					<P
+						className="googlesitekit-settings-module__meta-item-data"
+						size={ SIZE_MEDIUM }
+					>
 						<DisplaySetting
 							value={
 								!! oneTapEnabled
@@ -173,7 +189,7 @@ export default function SettingsView() {
 									: __( 'Disabled', 'google-site-kit' )
 							}
 						/>
-					</p>
+					</P>
 				</div>
 			</div>
 
@@ -212,7 +228,10 @@ export default function SettingsView() {
 						{ __( 'User registration', 'google-site-kit' ) }
 					</Typography>
 					{ isRegistrationOpen !== undefined && (
-						<p className="googlesitekit-settings-module__meta-item-data">
+						<P
+							className="googlesitekit-settings-module__meta-item-data"
+							size={ SIZE_MEDIUM }
+						>
 							<DisplaySetting
 								value={
 									isRegistrationOpen
@@ -220,7 +239,7 @@ export default function SettingsView() {
 										: __( 'Disabled', 'google-site-kit' )
 								}
 							/>
-						</p>
+						</P>
 					) }
 				</div>
 			</div>

--- a/assets/js/modules/sign-in-with-google/components/setup/SetupForm.js
+++ b/assets/js/modules/sign-in-with-google/components/setup/SetupForm.js
@@ -42,6 +42,8 @@ import Link from '@/js/components/Link';
 import MediaErrorHandler from '@/js/components/MediaErrorHandler';
 import PreviewBlock from '@/js/components/PreviewBlock';
 import StoreErrorNotices from '@/js/components/StoreErrorNotices';
+import { SIZE_MEDIUM } from '@/js/components/Typography/constants';
+import P from '@/js/components/Typography/P';
 import { CORE_SITE } from '@/js/googlesitekit/datastore/site/constants';
 import { ShowNextToCommentsToggle } from '@/js/modules/sign-in-with-google/components/common';
 import ClientIDTextField from '@/js/modules/sign-in-with-google/components/common/ClientIDTextField';
@@ -172,7 +174,10 @@ export default function SetupForm() {
 					moduleSlug={ MODULES_SIGN_IN_WITH_GOOGLE }
 					storeName={ MODULES_SIGN_IN_WITH_GOOGLE }
 				/>
-				<p className="googlesitekit-setup-module__step-description">
+				<P
+					className="googlesitekit-setup-module__step-description"
+					size={ SIZE_MEDIUM }
+				>
 					{ createInterpolateElement(
 						sprintf(
 							/* translators: %1$s: Sign in with Google service name */
@@ -190,13 +195,16 @@ export default function SetupForm() {
 							a: <Link href={ learnMoreURL } external />,
 						}
 					) }
-				</p>
-				<p className="googlesitekit-margin-bottom-0">
+				</P>
+				<P
+					className="googlesitekit-setup-module__step-description googlesitekit-margin-bottom-0"
+					size={ SIZE_MEDIUM }
+				>
 					{ __(
 						'Add your client ID here to complete setup:',
 						'google-site-kit'
 					) }
-				</p>
+				</P>
 				<div className="googlesitekit-setup-module__inputs">
 					<ClientIDTextField existingClientID={ existingClientID } />
 				</div>

--- a/assets/js/modules/sign-in-with-google/components/setup/__snapshots__/SetupForm.test.js.snap
+++ b/assets/js/modules/sign-in-with-google/components/setup/__snapshots__/SetupForm.test.js.snap
@@ -9,7 +9,7 @@ exports[`SetupForm should render existing client ID message when there is an exi
       class="googlesitekit-setup-module__panel-item"
     >
       <p
-        class="googlesitekit-setup-module__step-description"
+        class="googlesitekit-typography googlesitekit-setup-module__step-description googlesitekit-typography--body googlesitekit-typography--medium"
       >
         To set up Sign in with Google, Site Kit will help you create an “OAuth Client ID“ that will be used to enable Sign in with Google on your website. You will be directed to a page that will allow you to generate an “OAuth Client ID“. 
         <a
@@ -33,7 +33,7 @@ exports[`SetupForm should render existing client ID message when there is an exi
         </a>
       </p>
       <p
-        class="googlesitekit-margin-bottom-0"
+        class="googlesitekit-typography googlesitekit-setup-module__step-description googlesitekit-margin-bottom-0 googlesitekit-typography--body googlesitekit-typography--medium"
       >
         Add your client ID here to complete setup:
       </p>
@@ -117,7 +117,7 @@ exports[`SetupForm should render the form correctly 1`] = `
       class="googlesitekit-setup-module__panel-item"
     >
       <p
-        class="googlesitekit-setup-module__step-description"
+        class="googlesitekit-typography googlesitekit-setup-module__step-description googlesitekit-typography--body googlesitekit-typography--medium"
       >
         To set up Sign in with Google, Site Kit will help you create an “OAuth Client ID“ that will be used to enable Sign in with Google on your website. You will be directed to a page that will allow you to generate an “OAuth Client ID“. 
         <a
@@ -141,7 +141,7 @@ exports[`SetupForm should render the form correctly 1`] = `
         </a>
       </p>
       <p
-        class="googlesitekit-margin-bottom-0"
+        class="googlesitekit-typography googlesitekit-setup-module__step-description googlesitekit-margin-bottom-0 googlesitekit-typography--body googlesitekit-typography--medium"
       >
         Add your client ID here to complete setup:
       </p>
@@ -215,7 +215,7 @@ exports[`SetupForm should render the one tap and show next to comments toggles w
       class="googlesitekit-setup-module__panel-item"
     >
       <p
-        class="googlesitekit-setup-module__step-description"
+        class="googlesitekit-typography googlesitekit-setup-module__step-description googlesitekit-typography--body googlesitekit-typography--medium"
       >
         To set up Sign in with Google, Site Kit will help you create an “OAuth Client ID“ that will be used to enable Sign in with Google on your website. You will be directed to a page that will allow you to generate an “OAuth Client ID“. 
         <a
@@ -239,7 +239,7 @@ exports[`SetupForm should render the one tap and show next to comments toggles w
         </a>
       </p>
       <p
-        class="googlesitekit-margin-bottom-0"
+        class="googlesitekit-typography googlesitekit-setup-module__step-description googlesitekit-margin-bottom-0 googlesitekit-typography--body googlesitekit-typography--medium"
       >
         Add your client ID here to complete setup:
       </p>

--- a/assets/js/modules/tagmanager/components/settings/SettingsView.js
+++ b/assets/js/modules/tagmanager/components/settings/SettingsView.js
@@ -31,6 +31,7 @@ import Link from '@/js/components/Link';
 import SettingsStatuses from '@/js/components/settings/SettingsStatuses';
 import StoreErrorNotices from '@/js/components/StoreErrorNotices';
 import Typography from '@/js/components/Typography';
+import { SIZE_MEDIUM, SIZE_SMALL } from '@/js/components/Typography/constants';
 import P from '@/js/components/Typography/P';
 import VisuallyHidden from '@/js/components/VisuallyHidden';
 import { CORE_SITE } from '@/js/googlesitekit/datastore/site/constants';
@@ -117,9 +118,12 @@ export default function SettingsView() {
 					>
 						{ __( 'Account', 'google-site-kit' ) }
 					</Typography>
-					<p className="googlesitekit-settings-module__meta-item-data">
+					<P
+						className="googlesitekit-settings-module__meta-item-data"
+						size={ SIZE_MEDIUM }
+					>
 						<DisplaySetting value={ accountID } />
-					</p>
+					</P>
 				</div>
 
 				{ ( ! isAMP || isSecondaryAMP ) && (
@@ -148,13 +152,19 @@ export default function SettingsView() {
 									</span>
 								) }
 							</Typography>
-							<p className="googlesitekit-settings-module__meta-item-data">
+							<P
+								className="googlesitekit-settings-module__meta-item-data"
+								size={ SIZE_MEDIUM }
+							>
 								<DisplaySetting value={ containerID } />
-							</p>
+							</P>
 						</div>
 						{ editWebContainerURL && (
 							<div className="googlesitekit-settings-module__meta-item googlesitekit-settings-module__meta-item--data-only">
-								<p className="googlesitekit-settings-module__meta-item-data googlesitekit-settings-module__meta-item-data--tiny">
+								<P
+									className="googlesitekit-settings-module__meta-item-data"
+									size={ SIZE_SMALL }
+								>
 									<Link href={ editWebContainerURL } external>
 										{ createInterpolateElement(
 											sprintf(
@@ -180,7 +190,7 @@ export default function SettingsView() {
 											}
 										) }
 									</Link>
-								</p>
+								</P>
 							</div>
 						) }
 					</Fragment>
@@ -212,13 +222,19 @@ export default function SettingsView() {
 									</span>
 								) }
 							</Typography>
-							<p className="googlesitekit-settings-module__meta-item-data">
+							<P
+								className="googlesitekit-settings-module__meta-item-data"
+								size={ SIZE_MEDIUM }
+							>
 								<DisplaySetting value={ ampContainerID } />
-							</p>
+							</P>
 						</div>
 						{ editAMPContainerURL && (
 							<div className="googlesitekit-settings-module__meta-item googlesitekit-settings-module__meta-item--data-only">
-								<p className="googlesitekit-settings-module__meta-item-data googlesitekit-settings-module__meta-item-data--tiny">
+								<P
+									className="googlesitekit-settings-module__meta-item-data"
+									size={ SIZE_SMALL }
+								>
 									<Link href={ editAMPContainerURL } external>
 										{ createInterpolateElement(
 											sprintf(
@@ -244,7 +260,7 @@ export default function SettingsView() {
 											}
 										) }
 									</Link>
-								</p>
+								</P>
 							</div>
 						) }
 					</Fragment>
@@ -262,7 +278,10 @@ export default function SettingsView() {
 						{ __( 'Tag Manager Code Snippet', 'google-site-kit' ) }
 					</Typography>
 
-					<p className="googlesitekit-settings-module__meta-item-data">
+					<P
+						className="googlesitekit-settings-module__meta-item-data"
+						size={ SIZE_MEDIUM }
+					>
 						{ useSnippet && (
 							<span>
 								{ __(
@@ -279,10 +298,13 @@ export default function SettingsView() {
 								) }
 							</span>
 						) }
-					</p>
+					</P>
 
 					{ hasExistingTag && (
-						<P className="googlesitekit-margin-bottom-0">
+						<P
+							className="googlesitekit-margin-bottom-0"
+							size={ SIZE_SMALL }
+						>
 							{ __(
 								'Placing two tags at the same time is not recommended.',
 								'google-site-kit'

--- a/assets/sass/components/adminbar/_googlesitekit-adminbar.scss
+++ b/assets/sass/components/adminbar/_googlesitekit-adminbar.scss
@@ -76,8 +76,7 @@
 
 			.googlesitekit-adminbar__title--date-range {
 				color: $c-surfaces-on-surface-variant;
-				font-size: $fs-body-md;
-				letter-spacing: $ls-s;
+				font-weight: inherit;
 			}
 		}
 

--- a/assets/sass/components/ads/_googlesitekit-ads-settings.scss
+++ b/assets/sass/components/ads/_googlesitekit-ads-settings.scss
@@ -26,14 +26,13 @@
 
 		p.googlesitekit-settings-module__fields-group-helper-text {
 			color: $c-surfaces-on-surface-variant;
-			font-size: $fs-body-md;
-			font-weight: $fw-normal;
 			margin-bottom: 20px;
 			margin-top: 6px;
-		}
 
-		p.mdc-dialog__lead {
-			font-size: $fs-title-sm;
+			/* TODO: 11266 -- Remove this override and update VRT refrences. */
+			&.googlesitekit-typography {
+				line-height: $lh-body-lg;
+			}
 		}
 
 		.googlesitekit-setup-module__inputs {

--- a/assets/sass/components/ads/_googlesitekit-ads-setup-module.scss
+++ b/assets/sass/components/ads/_googlesitekit-ads-setup-module.scss
@@ -59,6 +59,11 @@
 
 			.instructions {
 				margin-top: 5px;
+
+				/* TODO: 11266 -- Remove this override and update VRT refrences. */
+				&.googlesitekit-typography {
+					line-height: $lh-body-lg;
+				}
 			}
 
 			.divider {

--- a/assets/sass/components/adsense/_googlesitekit-adsense-ad-blocking-recovery.scss
+++ b/assets/sass/components/adsense/_googlesitekit-adsense-ad-blocking-recovery.scss
@@ -111,8 +111,6 @@
 	.googlesitekit-ad-blocking-recovery__step-place-tags {
 
 		p.googlesitekit-ad-blocking-recovery__error-protection-tag-info {
-			font-size: $fs-body-md;
-			line-height: $lh-body-md;
 			margin: 52px 0 20px 34px; // Aligns the paragraph with the checkbox.
 		}
 	}

--- a/assets/sass/components/analytics-4/_googlesitekit-analytics-setup-module.scss
+++ b/assets/sass/components/analytics-4/_googlesitekit-analytics-setup-module.scss
@@ -19,6 +19,10 @@
 .googlesitekit-plugin {
 
 	.googlesitekit-setup-module--analytics {
+		/* TODO: 11266 -- Remove this override and update VRT refrences. */
+		.googlesitekit-setup-module__select_account.googlesitekit-typography {
+			line-height: $lh-body-lg;
+		}
 
 		&.googlesitekit-feature--setupFlowRefresh {
 
@@ -122,8 +126,6 @@
 			}
 
 			.googlesitekit-setup-module__select_account {
-				font-size: $fs-body-lg;
-				letter-spacing: $ls-m;
 				margin-bottom: 0;
 
 				@media (max-width: $bp-desktop) {
@@ -171,7 +173,7 @@
 				}
 
 				.googlesitekit-analytics-enable-enhanced-measurement {
-
+					/* TODO: 11266 -- Correct typography in components, remove this override and update VRT refrences. */
 					.googlesitekit-module-settings-group__helper-text {
 						color: $c-surfaces-on-surface-variant;
 						font-size: $fs-body-sm;
@@ -179,6 +181,7 @@
 						margin: 8px 0 0;
 					}
 
+					/* TODO: 11266 -- Correct typography in components, remove this override and update VRT refrences. */
 					.googlesitekit-analytics-enable-enhanced-measurement__already-enabled-label {
 						font-size: $fs-body-sm;
 						letter-spacing: $ls-xs;

--- a/assets/sass/components/analytics-4/_googlesitekit-site-goals.scss
+++ b/assets/sass/components/analytics-4/_googlesitekit-site-goals.scss
@@ -94,10 +94,6 @@ $site-goals-tile-connector-offset: 3.5px;
 
 		.googlesitekit-site-goals-tiles-group__title {
 			color: $c-surfaces-on-surface;
-			font-size: $fs-title-md;
-			font-weight: $fw-medium;
-			letter-spacing: $ls-xxs;
-			line-height: $lh-title-md;
 			margin: 0;
 		}
 
@@ -351,11 +347,12 @@ $site-goals-tile-connector-offset: 3.5px;
 
 		.googlesitekit-site-goals-tile__subtext {
 			color: $c-surfaces-on-background-variant;
-			font-size: $fs-label-sm;
-			font-weight: $fw-normal;
-			letter-spacing: $ls-xs;
-			line-height: 16px;
 			margin: 1px 0 0;
+
+			/* TODO: 11266 -- Remove this override and update VRT reference. */
+			&.googlesitekit-typography {
+				line-height: 16px;
+			}
 		}
 
 		.googlesitekit-site-goals-tile__change-container {
@@ -375,12 +372,13 @@ $site-goals-tile-connector-offset: 3.5px;
 
 		.googlesitekit-site-goals-tile__comparison-label {
 			color: $c-surfaces-on-background-variant;
-			font-size: $fs-label-sm;
-			font-weight: $fw-normal;
-			letter-spacing: $ls-xs;
-			line-height: 16px;
 			margin: 2px 0 0;
 			text-align: right;
+
+			/* TODO: 11266 -- Remove this override and update VRT reference. */
+			&.googlesitekit-typography {
+				line-height: 16px;
+			}
 		}
 
 		// These states hide the connector and the dot, so padding sets
@@ -600,17 +598,21 @@ $site-goals-tile-connector-offset: 3.5px;
 			line-height: $lh-body-sm;
 		}
 
+		.googlesitekit-table-tile__custom-dimensions-missing-title,
+		.googlesitekit-table-tile__custom-dimensions-missing-description {
+
+			&.googlesitekit-typography {
+				font-weight: $fw-normal;
+			}
+		}
+
 		.googlesitekit-table-tile__custom-dimensions-missing-title {
 			color: $c-surfaces-on-surface;
-			font-size: $fs-title-md;
-			line-height: $lh-title-md;
 			margin: 0 0 8px;
 		}
 
 		.googlesitekit-table-tile__custom-dimensions-missing-description {
 			color: $c-surfaces-on-surface;
-			font-size: $fs-title-sm;
-			line-height: $lh-title-sm;
 			margin: 0 0 16px;
 		}
 

--- a/assets/sass/components/analytics-4/audience-segmentation/_googlesitekit-audience-segmentation-tile-placeholder.scss
+++ b/assets/sass/components/analytics-4/audience-segmentation/_googlesitekit-audience-segmentation-tile-placeholder.scss
@@ -59,10 +59,12 @@
 
 	p.googlesitekit-audience-segmentation-tile-placeholder__description {
 		color: $c-surfaces-on-background-variant;
-		font-family: $f-primary;
-		font-size: $fs-body-sm;
-		line-height: $lh-body-sm;
 		margin: 0;
+
+		/* TODO: 11266 -- Remove this override and update VRT refrences. */
+		&.googlesitekit-typography.googlesitekit-typography {
+			letter-spacing: $ls-s;
+		}
 
 		.googlesitekit-cta-link {
 			font-weight: $fw-medium;

--- a/assets/sass/components/analytics-4/audience-segmentation/_googlesitekit-audience-segmentation-tile.scss
+++ b/assets/sass/components/analytics-4/audience-segmentation/_googlesitekit-audience-segmentation-tile.scss
@@ -250,11 +250,12 @@
 			}
 
 			.googlesitekit-audience-segmentation-tile__zero-data-description {
-				font-family: $f-primary;
-				font-size: $fs-title-sm;
-				font-weight: $fw-medium;
-				line-height: $lh-title-sm;
 				margin: 0;
+
+				/* TODO: 11266 -- Remove this override and update VRT refrences. */
+				&.googlesitekit-typography {
+					letter-spacing: $ls-s;
+				}
 			}
 
 			.googlesitekit-audience-segmentation-tile-hide-cta {

--- a/assets/sass/components/analytics-4/audience-segmentation/_googlesitekit-audience-selection-panel.scss
+++ b/assets/sass/components/analytics-4/audience-segmentation/_googlesitekit-audience-selection-panel.scss
@@ -155,11 +155,6 @@
 
 		p.googlesitekit-audience-selection-panel__audience-creation-notice-title {
 			color: $c-surfaces-on-surface-variant;
-			font-family: $f-primary;
-			font-size: $fs-label-sm;
-			font-weight: $fw-medium;
-			letter-spacing: $ls-xs;
-			line-height: $lh-label-sm;
 			margin: 0;
 		}
 
@@ -196,10 +191,6 @@
 		p.googlesitekit-audience-selection-panel__audience-creation-notice-audience-description {
 			color: $c-surfaces-on-surface;
 			font-family: $f-primary;
-			font-size: $fs-body-sm;
-			font-weight: $fw-normal;
-			letter-spacing: $ls-xs;
-			line-height: $lh-body-sm;
 			margin: 0;
 		}
 
@@ -237,9 +228,6 @@
 
 	p.googlesitekit-audience-selection-panel__success-notice-message {
 		color: inherit;
-		font-size: $fs-body-sm;
-		letter-spacing: $ls-xs;
-		line-height: $lh-body-sm;
 		margin: 0;
 	}
 

--- a/assets/sass/components/banner/_googlesitekit-banner.scss
+++ b/assets/sass/components/banner/_googlesitekit-banner.scss
@@ -59,25 +59,11 @@
 	}
 
 	p.googlesitekit-banner__title {
-		font-family: $f-primary;
-		font-size: $fs-title-md;
-		font-weight: $fw-medium;
-		letter-spacing: $ls-xxs;
-		line-height: $lh-title-md;
 		margin: 0 0 10px;
 
 		@media (min-width: $bp-nonMobile) {
-			font-family: $f-secondary;
-			font-size: $fs-headline-sm;
-			font-weight: $fw-normal;
 			letter-spacing: 0;
-			line-height: $lh-headline-sm;
 			margin: 0 0 8px;
-		}
-
-		@media (min-width: $bp-nonTablet) {
-			font-size: $fs-headline-md;
-			line-height: $lh-headline-md;
 		}
 	}
 
@@ -117,10 +103,6 @@
 
 	p.googlesitekit-banner__help-text {
 		color: $c-surfaces-on-surface-variant;
-		font-family: $f-primary;
-		font-size: $fs-body-sm;
-		letter-spacing: $ls-xs;
-		line-height: $lh-body-sm;
 		margin-bottom: 0;
 	}
 

--- a/assets/sass/components/dashboard/wizard/_googlesitekit-wizard-progress-step.scss
+++ b/assets/sass/components/dashboard/wizard/_googlesitekit-wizard-progress-step.scss
@@ -95,10 +95,14 @@
 
 		.googlesitekit-wizard-progress-step__text {
 			color: $c-tertiary;
-			font-size: $fs-body-md;
-			font-weight: $fw-medium;
-			letter-spacing: $ls-s;
 			margin: 0;
+
+			&.googlesitekit-typography {
+				font-weight: $fw-medium;
+
+				/* TODO: 11266 -- Remove this override and update VRT refrences. */
+				line-height: $lh-body-lg;
+			}
 
 			span {
 				color: $c-error;

--- a/assets/sass/components/global/_googlesitekit-analytics-cta.scss
+++ b/assets/sass/components/global/_googlesitekit-analytics-cta.scss
@@ -35,10 +35,12 @@
 		}
 
 		.googlesitekit-analytics-cta--description {
-			color: $c-surfaces-on-background;
-			font-size: $fs-body-md;
-			letter-spacing: $ls-s;
 			margin: 0;
+
+			/* TODO: 11266 -- Remove this override and update VRT refrences. */
+			&.googlesitekit-typography.googlesitekit-typography {
+				line-height: $lh-body-lg;
+			}
 		}
 
 		.mdc-button {
@@ -132,11 +134,6 @@
 		.googlesitekit-activate-analytics-cta__description {
 			color: $c-surfaces-on-surface;
 			flex: 1;
-			font-family: $f-primary;
-			font-size: $fs-body-md;
-			font-weight: $fw-normal;
-			letter-spacing: $ls-s;
-			line-height: $lh-body-md;
 			margin: 0;
 
 			a {

--- a/assets/sass/components/global/_googlesitekit-cta.scss
+++ b/assets/sass/components/global/_googlesitekit-cta.scss
@@ -79,6 +79,15 @@
 		p:first-child {
 			margin-top: 0;
 		}
+
+		/* TODO: 11266 -- Remove this override and update VRT refrences. */
+		&.googlesitekit-typography.googlesitekit-typography,
+		& p.googlesitekit-typography--body.googlesitekit-typography--medium {
+
+			&:not(.googlesitekit-googlechart-error-handler *) {
+				line-height: $lh-body-lg;
+			}
+		}
 	}
 
 	&.googlesitekit-cta--error {

--- a/assets/sass/components/global/_googlesitekit-dialog.scss
+++ b/assets/sass/components/global/_googlesitekit-dialog.scss
@@ -128,14 +128,7 @@
 
 		.googlesitekit-dialog__subtitle {
 			color: $c-surfaces-on-surface-variant;
-			font-size: $fs-body-sm;
-			letter-spacing: $ls-xs;
-			line-height: $lh-body-sm;
 			margin: 0;
-		}
-
-		.googlesitekit-dialog__subtitle--emphasis {
-			font-size: $fs-body-md;
 		}
 
 		.googlesitekit-dialog__footer {

--- a/assets/sass/components/global/_googlesitekit-selection-panel.scss
+++ b/assets/sass/components/global/_googlesitekit-selection-panel.scss
@@ -104,10 +104,12 @@
 
 		.googlesitekit-selection-panel-items__subheading {
 			color: $c-surfaces-on-surface-variant;
-			font-size: $fs-body-sm;
-			font-weight: $fw-medium;
-			line-height: $lh-body-sm;
 			margin: $grid-gap-phone 0 0 $grid-gap-phone;
+
+			/* TODO: 11266 -- Remove this override and update VRT refrences. */
+			&.googlesitekit-typography.googlesitekit-typography--label {
+				letter-spacing: $ls-s;
+			}
 
 			@media (min-width: $bp-tablet) {
 				margin: $grid-gap-desktop 0 0 $grid-gap-desktop;
@@ -188,22 +190,6 @@
 		margin-top: auto;
 		padding: $grid-gap-desktop / 2 $grid-gap-desktop $grid-gap-desktop;
 		width: 100%;
-
-		p {
-			font-size: $fs-body-sm;
-			letter-spacing: $ls-xs;
-			line-height: $lh-label-sm;
-
-			@media (min-width: $bp-tablet) {
-				font-size: $fs-title-sm;
-			}
-		}
-
-		.googlesitekit-error-text {
-			p {
-				font-size: $fs-label-md;
-			}
-		}
 	}
 
 	.googlesitekit-selection-panel-footer__content {
@@ -219,8 +205,11 @@
 	}
 
 	.googlesitekit-selection-panel-footer__item-count {
-		font-size: $fs-title-sm;
-		font-weight: $fw-medium;
+		/* TODO: 11266 -- Remove this override and update VRT refrences. */
+		&.googlesitekit-typography.googlesitekit-typography--label.googlesitekit-typography--medium {
+			letter-spacing: $ls-xs;
+			line-height: $lh-label-sm;
+		}
 
 		.googlesitekit-selection-panel-footer__item-count--max-count {
 			color: $c-surfaces-on-surface-variant;

--- a/assets/sass/components/global/_googlesitekit-sharing-settings.scss
+++ b/assets/sass/components/global/_googlesitekit-sharing-settings.scss
@@ -238,9 +238,6 @@
 
 	p.googlesitekit-dashboard-sharing-settings__note {
 		color: $c-boulder;
-		font-size: $fs-body-sm;
-		letter-spacing: $ls-xs;
-		line-height: $lh-body-sm;
 		margin: 0;
 	}
 
@@ -294,9 +291,6 @@
 			align-items: flex-end;
 			display: flex;
 			flex-wrap: wrap;
-			font-size: $fs-body-sm;
-			letter-spacing: $ls-xs;
-			line-height: $lh-body-sm;
 
 			span:not(.googlesitekit-dashboard-sharing-settings__tooltip-icon) {
 				width: 100%;
@@ -373,9 +367,6 @@
 		background-color: $c-surfaces-surface-2;
 		border-radius: $br-xs;
 		color: $c-surfaces-on-surface;
-		font-size: $fs-body-sm;
-		letter-spacing: $ls-xs;
-		line-height: $lh-body-sm;
 		margin: 0;
 		padding: 12px 24px;
 		width: 100%;

--- a/assets/sass/components/global/_googlesitekit-use-snippet-switch.scss
+++ b/assets/sass/components/global/_googlesitekit-use-snippet-switch.scss
@@ -20,7 +20,7 @@
 
 	.googlesitekit-analytics-usesnippet,
 	.googlesitekit-tagmanager-usesnippet {
-
+		/* TODO: 11266 -- Correct typography in components, remove this override and update VRT refrences. */
 		p {
 			font-size: $fs-body-sm;
 			letter-spacing: $ls-xs;

--- a/assets/sass/components/global/_googlesitekit-user-menu.scss
+++ b/assets/sass/components/global/_googlesitekit-user-menu.scss
@@ -125,13 +125,9 @@
 
 	.googlesitekit-user-menu__details-info__name {
 		color: $c-surfaces-on-surface;
-		font-weight: $fw-medium;
-		line-height: $lh-label-md;
 	}
 
 	.googlesitekit-user-menu__details-info__email {
 		color: $c-surfaces-on-surface-variant;
-		font-size: $fs-body-sm;
-		line-height: $lh-body-sm;
 	}
 }

--- a/assets/sass/components/key-metrics/_googlesitekit-km-add-metric-cta-tile.scss
+++ b/assets/sass/components/key-metrics/_googlesitekit-km-add-metric-cta-tile.scss
@@ -47,12 +47,12 @@
 
 		.googlesitekit-km-add-metric-cta-tile__text {
 			color: $c-surfaces-on-background-variant;
-			font-family: $f-secondary;
-			font-size: $fs-body-sm;
-			font-weight: $fw-medium;
-			letter-spacing: $ls-xs;
-			line-height: $lh-body-sm;
 			margin: 7px 0 0;
+
+			&.googlesitekit-typography {
+				font-family: $f-secondary;
+				font-weight: $fw-medium;
+			}
 		}
 	}
 }

--- a/assets/sass/components/key-metrics/_googlesitekit-km-connect-module-cta-tile.scss
+++ b/assets/sass/components/key-metrics/_googlesitekit-km-connect-module-cta-tile.scss
@@ -34,6 +34,11 @@
 
 		.googlesitekit-km-connect-module-cta-tile__content .googlesitekit-km-connect-module-cta-tile__text {
 			margin: 0 0 4px;
+
+			/* TODO: 11266 -- Remove this override and update VRT refrences. */
+			&.googlesitekit-typography {
+				line-height: $lh-body-lg;
+			}
 		}
 
 		&.googlesitekit-km-widget-tile {

--- a/assets/sass/components/key-metrics/_googlesitekit-km-widget-tile.scss
+++ b/assets/sass/components/key-metrics/_googlesitekit-km-widget-tile.scss
@@ -85,16 +85,20 @@
 		}
 
 		.googlesitekit-km-widget-tile__subtext {
-			font-size: $fs-label-sm;
-			font-weight: $fw-medium;
-			line-height: $lh-label-sm;
 			margin: -1px 0 1px;
 
+			/* TODO: 11266 -- Remove this override and update VRT refrences. */
+			&.googlesitekit-typography {
+				letter-spacing: $ls-s;
+			}
+
 			@media (min-width: $bp-nonMobile) {
-				font-size: $fs-label-md;
-				font-weight: $fw-normal;
-				line-height: $lh-label-md;
 				margin: -4px 0 1px;
+
+				/* TODO: 11266 -- Remove this override and update VRT refrences. */
+				&.googlesitekit-typography {
+					font-weight: $fw-normal;
+				}
 			}
 		}
 	}
@@ -113,16 +117,20 @@
 		}
 
 		.googlesitekit-km-widget-tile__subtext {
-			font-size: $fs-label-sm;
-			font-weight: $fw-medium;
-			line-height: $lh-label-sm;
 			margin: 2px 0 0;
 
+			/* TODO: 11266 -- Remove this override and update VRT refrences. */
+			&.googlesitekit-typography {
+				letter-spacing: $ls-s;
+			}
+
 			@media (min-width: $bp-nonMobile) {
-				font-size: $fs-label-md;
-				font-weight: $fw-normal;
-				line-height: $lh-label-md;
 				margin: 0;
+
+				/* TODO: 11266 -- Remove this override and update VRT refrences. */
+				&.googlesitekit-typography {
+					font-weight: $fw-normal;
+				}
 			}
 		}
 	}
@@ -167,9 +175,6 @@
 
 		.googlesitekit-km-widget-tile__table-plain-text {
 			color: $c-surfaces-on-surface;
-			font-size: $fs-body-sm;
-			letter-spacing: $ls-xs;
-			line-height: $lh-body-sm;
 			margin: 0;
 			overflow: hidden;
 			text-overflow: ellipsis;

--- a/assets/sass/components/notice/_googlesitekit-notice.scss
+++ b/assets/sass/components/notice/_googlesitekit-notice.scss
@@ -66,6 +66,7 @@
 	}
 
 	.googlesitekit-notice__content {
+		/* TODO: 11266 -- Correct typography in components, remove this override and update VRT refrences. */
 		font-family: $f-primary;
 		font-size: $fs-title-sm;
 		font-weight: $fw-normal;

--- a/assets/sass/components/overlay-card/_googlesitekit-overlay-card.scss
+++ b/assets/sass/components/overlay-card/_googlesitekit-overlay-card.scss
@@ -65,30 +65,19 @@
 		}
 
 		.googlesitekit-overlay-card__description {
-			font-size: $fs-body-sm;
-			font-weight: $fw-normal;
-			letter-spacing: $ls-xs;
-			line-height: $lh-body-sm;
 			margin: 0;
 		}
 
 		@media (min-width: $bp-tablet) {
 			padding: $grid-gap-desktop;
 
-			.googlesitekit-typography.googlesitekit-overlay-card__title {
-				font-family: $f-secondary;
-				font-size: $fs-headline-sm;
-				font-weight: $fw-normal;
-				letter-spacing: unset;
-				line-height: $lh-headline-sm;
+			.googlesitekit-overlay-card__title {
 				margin: 0 0 5px;
-			}
 
-			.googlesitekit-overlay-card__description {
-				font-size: $fs-body-md;
-				font-weight: $fw-normal;
-				letter-spacing: $ls-s;
-				line-height: $lh-body-md;
+				/* TODO: 11266 -- Remove this override and update VRT refrences. */
+				&.googlesitekit-typography {
+					letter-spacing: unset;
+				}
 			}
 		}
 	}

--- a/assets/sass/components/reader-revenue-manager/_googlesitekit-rrm-setup-module.scss
+++ b/assets/sass/components/reader-revenue-manager/_googlesitekit-rrm-setup-module.scss
@@ -31,18 +31,18 @@
 				margin-bottom: 40px;
 			}
 		}
+
+		.googlesitekit-setup-module__description {
+			margin-bottom: 0;
+
+			/* TODO: 11266 -- Remove this override and update VRT refrences. */
+			&.googlesitekit-typography {
+				line-height: $lh-body-lg;
+			}
+		}
 	}
 
 	.googlesitekit-setup-module__publication-create-screen {
-
-		.googlesitekit-setup-module__title,
-		.googlesitekit-setup-module__description {
-			font-family: $f-primary;
-			font-size: $fs-body-md;
-			font-weight: $fw-normal;
-			letter-spacing: $ls-s;
-			line-height: $lh-body-md;
-		}
 
 		.googlesitekit-setup-module__title {
 			margin-bottom: 0;
@@ -50,6 +50,11 @@
 
 		.googlesitekit-setup-module__description {
 			margin-top: 3px;
+
+			/* TODO: 11266 -- Remove this override and update VRT refrences. */
+			&.googlesitekit-typography {
+				line-height: $lh-body-md;
+			}
 		}
 
 		.googlesitekit-setup-module__action {

--- a/assets/sass/components/settings/_googlesitekit-settings-connect-module.scss
+++ b/assets/sass/components/settings/_googlesitekit-settings-connect-module.scss
@@ -58,10 +58,12 @@
 		}
 
 		.googlesitekit-settings-connect-module__text {
-			font-size: $fs-body-md;
-			letter-spacing: $ls-s;
-			line-height: $lh-body-md;
-			margin: 0;
+			margin-block-start: 0;
+		}
+
+		/* TODO: 11266 -- Remove this override and update VRT refrences. */
+		.googlesitekit-settings-connect-module__cta.googlesitekit-typography {
+			line-height: $lh-body-lg;
 		}
 
 		.googlesitekit-settings-connect-module__switch {
@@ -70,11 +72,6 @@
 			.spinner {
 				margin-top: -5px;
 			}
-		}
-
-		.googlesitekit-settings-connect-module__cta {
-			font-size: $fs-body-md;
-			letter-spacing: $ls-s;
 		}
 	}
 }

--- a/assets/sass/components/settings/_googlesitekit-settings-consent-mode.scss
+++ b/assets/sass/components/settings/_googlesitekit-settings-consent-mode.scss
@@ -21,13 +21,11 @@
 		.googlesitekit-settings-consent-mode-switch__enabled-notice,
 		.googlesitekit-settings-consent-mode-requirements__description {
 			color: $c-surfaces-on-background-variant;
-			font-size: $fs-body-sm;
-			letter-spacing: $ls-xs;
-			line-height: $lh-body-sm;
 		}
 
+		.googlesitekit-settings-consent-mode-switch-description,
 		.googlesitekit-settings-consent-mode-switch-description--loading {
-			margin: 14px 0;
+			margin: 1em 0;
 		}
 
 		.googlesitekit-settings-consent-mode-requirements__grid {
@@ -45,20 +43,19 @@
 			@media (min-width: $bp-nonMobile) {
 				padding: $grid-gap-desktop;
 			}
+		}
 
-			.googlesitekit-typography {
-				font-size: $fs-title-md;
-				font-weight: $fw-medium;
-				line-height: $lh-title-md;
-				margin: 0;
+		.googlesitekit-settings-consent-mode-requirement__title {
+			margin: 0;
+
+			/* TODO: 11266 -- Remove this override and update VRT refrences. */
+			&.googlesitekit-typography {
+				letter-spacing: 0;
 			}
 		}
 
 		.googlesitekit-settings-consent-mode-requirement__description {
 			flex: 1;
-			font-size: $fs-body-sm;
-			letter-spacing: $ls-xs;
-			line-height: $lh-body-sm;
 		}
 
 		.googlesitekit-notice {

--- a/assets/sass/components/settings/_googlesitekit-settings-group.scss
+++ b/assets/sass/components/settings/_googlesitekit-settings-group.scss
@@ -49,6 +49,7 @@
 			top: -2px;
 		}
 
+		/* TODO: 11266 -- Correct typography in components, remove this override and update VRT refrences. */
 		.googlesitekit-module-settings-group__helper-text {
 			color: $c-surfaces-on-surface-variant;
 			flex-basis: 100%;

--- a/assets/sass/components/settings/_googlesitekit-settings-module.scss
+++ b/assets/sass/components/settings/_googlesitekit-settings-module.scss
@@ -26,10 +26,6 @@
 			align-items: center;
 			color: $c-surfaces-on-surface;
 			display: flex;
-			font-size: $fs-body-md;
-			font-weight: $fw-medium;
-			letter-spacing: $ls-s;
-			line-height: $lh-body-md;
 			margin: 0;
 			text-align: right;
 		}
@@ -168,11 +164,6 @@
 				margin: 0 ($grid-gap-desktop * 2) $grid-gap-desktop 0;
 			}
 
-			p {
-				font-size: $fs-body-sm;
-				letter-spacing: $ls-xs;
-			}
-
 			.googlesitekit-settings-module__meta-item-type {
 				color: $c-primary;
 				margin: 0 0 8px;
@@ -180,9 +171,6 @@
 
 			.googlesitekit-settings-module__meta-item-data {
 				color: $c-surfaces-on-surface;
-				font-size: $fs-body-md;
-				letter-spacing: $ls-s;
-				line-height: $lh-body-md;
 				margin: 0;
 				overflow: hidden;
 				text-overflow: ellipsis;
@@ -194,13 +182,6 @@
 
 			.googlesitekit-settings-module__meta-item-data--wrap {
 				word-break: break-all;
-			}
-
-			.googlesitekit-settings-module__meta-item-data--tiny {
-				font-size: $fs-body-sm;
-				font-weight: $fw-normal;
-				letter-spacing: $ls-xs;
-				line-height: $lh-body-sm;
 			}
 
 			.googlesitekit-settings-module__meta-item-info {

--- a/assets/sass/components/settings/_googlesitekit-settings-user-input.scss
+++ b/assets/sass/components/settings/_googlesitekit-settings-user-input.scss
@@ -27,8 +27,6 @@
 
 		.googlesitekit-settings-user-input__heading {
 			color: $c-surfaces-on-background;
-			font-size: $fs-body-sm;
-			line-height: $lh-body-sm;
 			margin: 0;
 		}
 

--- a/assets/sass/components/setup/_googlesitekit-setup.scss
+++ b/assets/sass/components/setup/_googlesitekit-setup.scss
@@ -86,9 +86,6 @@
 
 			p {
 				color: $c-surfaces-on-background-variant;
-				font-size: $fs-body-sm;
-				letter-spacing: $ls-xs;
-				line-height: $lh-body-sm;
 				margin: 0;
 			}
 
@@ -121,11 +118,14 @@
 
 		.googlesitekit-setup__intro-title {
 			color: $c-primary;
-			font-family: $f-secondary;
-			font-size: $fs-title-sm;
-			font-weight: $fw-bold;
-			line-height: $lh-title-sm;
 			margin: 0 0 17px;
+
+			/* TODO: 11266 -- Correct typography in components, remove this override and update VRT refrences. */
+			&.googlesitekit-typography {
+				font-family: $f-secondary;
+				font-weight: $fw-bold;
+				letter-spacing: $ls-s;
+			}
 		}
 	}
 
@@ -194,6 +194,11 @@
 
 		.googlesitekit-setup__description {
 			margin: 0;
+
+			/* TODO: 11266 -- Remove this override and update VRT refrences. */
+			&.googlesitekit-typography {
+				line-height: $lh-body-lg;
+			}
 		}
 
 		.googlesitekit-opt-in {

--- a/assets/sass/components/setup/_googlesitekit-splash.scss
+++ b/assets/sass/components/setup/_googlesitekit-splash.scss
@@ -49,6 +49,11 @@
 
 		.googlesitekit-setup__description {
 			margin-top: 24px;
+
+			/* TODO: 11266 -- Remove this override and update VRT refrences. */
+			&.googlesitekit-typography {
+				line-height: $lh-body-lg;
+			}
 		}
 
 		.googlesitekit-setup__services-list {

--- a/assets/sass/components/sign-in-with-google/_googlesitekit-sign-in-with-google-settings-module.scss
+++ b/assets/sass/components/sign-in-with-google/_googlesitekit-sign-in-with-google-settings-module.scss
@@ -160,6 +160,11 @@
 		.googlesitekit-sign-in-with-google__preview--label {
 			margin: 0 0 1rem;
 			text-align: center;
+
+			/* TODO: 11266 -- Remove this override and update VRT refrences. */
+			&.googlesitekit-typography {
+				line-height: $lh-body-lg;
+			}
 		}
 
 		.googlesitekit-sign-in-with-google__preview--protector {

--- a/assets/sass/components/sign-in-with-google/_googlesitekit-sign-in-with-google-setup-module.scss
+++ b/assets/sass/components/sign-in-with-google/_googlesitekit-sign-in-with-google-setup-module.scss
@@ -88,6 +88,11 @@
 
 		.googlesitekit-setup-module__step-description {
 			margin: 0 0 1.7em;
+
+			/* TODO: 11266 -- Remove this override and update VRT refrences. */
+			&.googlesitekit-typography {
+				line-height: $lh-body-lg;
+			}
 		}
 
 		.googlesitekit-sign-in-with-google-client-id-cta {

--- a/assets/sass/components/user-input/googlesitekit-user-input-module.scss
+++ b/assets/sass/components/user-input/googlesitekit-user-input-module.scss
@@ -149,15 +149,11 @@
 
 	p.googlesitekit-user-input__select-instruction {
 		color: $c-surfaces-on-surface;
-		font-size: $fs-body-sm;
-		line-height: $lh-body-sm;
 		margin: 0;
 		padding-bottom: 15px;
 
 		@media (min-width: $bp-tablet) {
 			color: $c-surfaces-on-surface-variant;
-			font-size: $fs-title-lg;
-			font-weight: $fw-medium;
 		}
 	}
 
@@ -165,9 +161,6 @@
 
 		p {
 			color: $c-surfaces-on-surface-variant;
-			font-size: $fs-body-sm;
-			letter-spacing: $ls-s;
-			line-height: $lh-body-sm;
 			margin: 0 0 3px;
 		}
 

--- a/assets/sass/components/user-input/googlesitekit-user-input-questions.scss
+++ b/assets/sass/components/user-input/googlesitekit-user-input-questions.scss
@@ -44,9 +44,6 @@
 	// Used for the header questions X/Y number.
 	.googlesitekit-user-input__question-number {
 		color: $c-surfaces-on-surface-variant;
-		font-family: $f-primary;
-		font-size: $fs-title-sm;
-		line-height: $lh-title-sm;
 		margin-bottom: 10px;
 	}
 
@@ -75,15 +72,9 @@
 
 		.googlesitekit-user-input__question-instructions--description {
 			color: $c-surfaces-on-surface;
-			font-size: $fs-body-sm;
-			font-weight: $fw-normal;
-			letter-spacing: $ls-s;
-			line-height: $lh-display-sm;
 			margin: 0 0 1em;
 
 			@media (min-width: $bp-desktop) {
-				font-size: $fs-body-md;
-				line-height: $lh-body-md;
 				margin: 0 0 25px;
 			}
 		}
@@ -92,19 +83,12 @@
 	.googlesitekit-user-input__question-info {
 		p {
 			color: $c-surfaces-on-surface-variant;
-			font-size: $fs-body-sm;
-			letter-spacing: $ls-s;
-			line-height: $lh-body-sm;
 			margin: 0 0 3px;
 		}
 	}
 
 	p.googlesitekit-user-input__question-notice {
 		color: $c-surfaces-on-surface-variant;
-		font-size: $fs-body-sm;
-		font-weight: $fw-normal;
-		letter-spacing: $ls-s;
-		line-height: $lh-body-sm;
 		margin: 0 0 1em;
 
 		@media (min-width: $bp-desktop) {

--- a/assets/sass/vendor/_mdc-dialog.scss
+++ b/assets/sass/vendor/_mdc-dialog.scss
@@ -53,9 +53,6 @@
 	}
 
 	.mdc-dialog__lead {
-		font-size: $fs-label-md;
-		font-weight: $fw-medium;
-		line-height: $lh-label-md;
 		margin: 0;
 		max-width: 430px;
 	}
@@ -68,9 +65,6 @@
 	}
 
 	.mdc-dialog__note {
-		font-size: $fs-body-sm;
-		letter-spacing: $ls-xs;
-		line-height: $lh-body-sm;
 		margin: 1em 0;
 
 		strong {


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Related issue(s):

- Addresses #11266

## Relevant technical choices

This PR updates all `<p>` tags to use the `<P>` typography component. Redundant CSS for affected components has mostly been removed where possible.

Initially this change resulted in most VRTs failing and needing to be regenerated because of a high volume of cases where paragraph elements had typography styles incompletely applied. For example, a paragraph may have been styled as `body/small`, but the correct `letter-spacing` had not been added so the text was using the small body style with the medium body letter spacing. Many cases were also a result of generic paragraphs using `body/medium` styles but inheriting the WordPress global paragraph `line-height`.

For a very high number of cases where designs were available, I checked the designs and the GitHub history and almost every time I found that the incorrect styles were part of the original PR and there was no discussion in IB or CR about deviating from the design. Based on this I determined that the style changes caused by the use of the typography component made the styles more consistent and correct to the design and should be implemented.

The problem was that committing all the code and VRT changes at once would make for an unmanageable review, but cleanly splitting the changes into independent chunks wasn't feasible because of the large number of components that impacted shared VRT references. So what I've done is used [stacked PRs](https://github.github.com/gh-stack/) to make changes in sequence:

1. This first PR replaces all `<p>` tags with the `P` component, but keeps or tweaks CSS so that there's no visible changes and all existing VRTs pass.
2. The second PR #13383 makes changes and removes CSS overrides to correct the typography of notices only. 
3. The third PR #13384 makes changes and removes CSS overrides to correct the typography mostly in module-related components.
4. The final PR #13385 makes changes and removes CSS overrides to correct the typography in the remaining global related components.

PRs 2-4 still have lots of VRTs to review, but they make a much smaller number of code changes which should hopefully make it easier review the VRTs with confidence because it will be easier to know what to look for than if they also included the full suite of code changes.

<!-- Please describe your changes. -->

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.
- [ ] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>