### PR TITLE
Fix : Site Kit menu icon alignment on mobile

### DIFF
--- a/includes/Core/Admin/Screens.php
+++ b/includes/Core/Admin/Screens.php
@@ -157,6 +157,7 @@ final class Screens {
 				<style type="text/css">
 					#adminmenu .toplevel_page_googlesitekit-dashboard img {
 						width: 16px;
+						vertical-align: middle;
 					}
 					#adminmenu .toplevel_page_googlesitekit-dashboard.current img,
 					#adminmenu .toplevel_page_googlesitekit-dashboard.wp-has-current-submenu img {


### PR DESCRIPTION
Resolves https://github.com/google/site-kit-wp/issues/13378

## Summary
Fix the Site Kit admin menu icon alignment on small screens by vertically centering the icon in the WordPress admin menu.

## Changes
- Added `vertical-align: middle;` to the Site Kit menu icon rule in `includes/Core/Admin/Screens.php`.

