### PR TITLE
Use Typography P for remaining settings copy

### DIFF
--- a/assets/js/modules/analytics-4/components/common/MeasurementSettingRow.tsx
+++ b/assets/js/modules/analytics-4/components/common/MeasurementSettingRow.tsx
@@ -26,6 +26,8 @@ import { FC, ReactNode } from 'react';
  * Internal dependencies
  */
 import { ProgressBar } from 'googlesitekit-components';
+import { SIZE_MEDIUM, TYPE_LABEL } from '@/js/components/Typography/constants';
+import P from '@/js/components/Typography/P';
 import CheckMark from '@/svg/icons/check-2.svg';
 import StarFill from '@/svg/icons/star-fill.svg';
 
@@ -68,12 +70,16 @@ const MeasurementSettingRow: FC< MeasurementSettingRowProps > = ( {
 
 			<div className="googlesitekit-settings-measurement-row__content">
 				<div className="googlesitekit-settings-measurement-row__details">
-					<p className="googlesitekit-settings-measurement-row__title">
+					<P
+						className="googlesitekit-settings-measurement-row__title"
+						type={ TYPE_LABEL }
+						size={ SIZE_MEDIUM }
+					>
 						{ title }
-					</p>
-					<p className="googlesitekit-module-settings-group__helper-text">
+					</P>
+					<P className="googlesitekit-module-settings-group__helper-text">
 						{ description }
-					</p>
+					</P>
 				</div>
 
 				{ ! isEnabled && action && (

--- a/assets/js/modules/reader-revenue-manager/components/setup/SetupMainExpress/SetupCTANewsletter/DisclaimerText.tsx
+++ b/assets/js/modules/reader-revenue-manager/components/setup/SetupMainExpress/SetupCTANewsletter/DisclaimerText.tsx
@@ -22,13 +22,18 @@
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
+/**
+ * Internal dependencies
+ */
+import P from '@/js/components/Typography/P';
+
 export default function DisclaimerText() {
 	const linkSpan = (
 		<span className="googlesitekit-rrm-newsletter-preview__link" />
 	);
 
 	return (
-		<p className="googlesitekit-rrm-newsletter-preview__disclaimer">
+		<P className="googlesitekit-rrm-newsletter-preview__disclaimer">
 			{ createInterpolateElement(
 				__(
 					'By continuing, you agree to provide your email and name (if applicable) to <em>YourSite</em> Test Publication through a Google service. Google delivers your information under its <tos>Terms of Service</tos> and <pp>Privacy Policy</pp>. <em>YourSite</em> Test Publication’s use of your data is subject to their own <terms>terms</terms> and <privacypolicy>privacy policy</privacypolicy>.',
@@ -42,6 +47,6 @@ export default function DisclaimerText() {
 					privacypolicy: linkSpan,
 				}
 			) }
-		</p>
+		</P>
 	);
 }


### PR DESCRIPTION
## Summary
- Replace leftover `<p>` tags in `MeasurementSettingRow` and the RRM newsletter disclaimer with the shared `Typography/P` component.
- Follow-up to the bulk conversion in #11266 for copy that landed later.

Fixes #13388

## Test plan
- [ ] Analytics settings measurement rows still render title + helper text
- [ ] RRM express newsletter disclaimer preview still looks correct