### PR TITLE
Use shared IntersectionObserver mock in component tests

### DIFF
--- a/assets/js/components/KeyMetrics/KeyMetricsBackNotice.test.tsx
+++ b/assets/js/components/KeyMetrics/KeyMetricsBackNotice.test.tsx
@@ -17,11 +17,6 @@
  */
 
 /**
- * External dependencies
- */
-import { intersectionObserver } from '@shopify/jest-dom-mocks';
-
-/**
  * WordPress dependencies
  */
 import { WPDataRegistry } from '@wordpress/data/build-types/registry';
@@ -34,6 +29,7 @@ import { CORE_UI } from '@/js/googlesitekit/datastore/ui/constants';
 import { CORE_USER } from '@/js/googlesitekit/datastore/user/constants';
 import { getWidgetComponentProps } from '@/js/googlesitekit/widgets/util';
 import * as tracking from '@/js/util/tracking';
+import { mockIntersectionObserver } from '@tests/js/mock-browser-utils';
 import {
 	act,
 	createTestRegistry,
@@ -51,6 +47,7 @@ const mockTrackEvent = jest.spyOn( tracking, 'trackEvent' );
 mockTrackEvent.mockImplementation( () => Promise.resolve() );
 
 describe( 'KeyMetricsBackNotice', () => {
+	const { simulateAllIntersections } = mockIntersectionObserver();
 	let registry: WPDataRegistry;
 
 	const viewContext = VIEW_CONTEXT_MAIN_DASHBOARD;
@@ -62,14 +59,11 @@ describe( 'KeyMetricsBackNotice', () => {
 	);
 
 	beforeEach( () => {
-		intersectionObserver.mock();
-
 		registry = createTestRegistry();
 		registry.dispatch( CORE_USER ).receiveGetDismissedItems( [] );
 	} );
 
 	afterEach( () => {
-		intersectionObserver.restore();
 		mockTrackEvent.mockClear();
 	} );
 
@@ -163,10 +157,7 @@ describe( 'KeyMetricsBackNotice', () => {
 
 		// Simulate the notice coming into view.
 		act( () => {
-			intersectionObserver.simulate( {
-				isIntersecting: true,
-				intersectionRatio: 1,
-			} );
+			simulateAllIntersections();
 		} );
 
 		await waitFor( () => {

--- a/assets/js/components/WelcomeModal.test.tsx
+++ b/assets/js/components/WelcomeModal.test.tsx
@@ -53,8 +53,12 @@ import { MODULE_SLUG_SEARCH_CONSOLE } from '@/js/modules/search-console/constant
 import { MODULES_SEARCH_CONSOLE } from '@/js/modules/search-console/datastore/constants';
 import * as tracking from '@/js/util/tracking';
 import { provideGatheringDataState } from '@tests/js/gathering-data-utils';
-import { mockBrowserScrolling } from '@tests/js/mock-browser-utils';
 import {
+	mockBrowserScrolling,
+	mockIntersectionObserver,
+} from '@tests/js/mock-browser-utils';
+import {
+	act,
 	createTestRegistry,
 	fireEvent,
 	render,
@@ -86,39 +90,9 @@ const mockWelcomeTour = getWelcomeTour( {
 
 jest.mock( '@/js/feature-tours/hooks/useWelcomeTour' );
 
-/**
- * The modal graphic is wrapped in `withIntersectionObserver`, which observes
- * its element with the native `IntersectionObserver`. jsdom has none, so use a
- * stub that reports the element as in view the moment it observes it. This
- * makes the modal send its `view_notice` event on render, as these tests
- * expect.
- */
-class InViewIntersectionObserver {
-	callback: IntersectionObserverCallback;
-
-	constructor( callback: IntersectionObserverCallback ) {
-		this.callback = callback;
-	}
-
-	observe( element: Element ) {
-		this.callback(
-			[
-				{
-					isIntersecting: true,
-					intersectionRatio: 1,
-					target: element,
-				} as IntersectionObserverEntry,
-			],
-			this as unknown as IntersectionObserver
-		);
-	}
-
-	unobserve() {}
-
-	disconnect() {}
-}
-
 describe( 'WelcomeModal', () => {
+	const { getObservedElements, simulateAllIntersections } =
+		mockIntersectionObserver();
 	let registry: WPDataRegistry;
 
 	const dismissItemEndpoint = new RegExp(
@@ -214,12 +188,7 @@ describe( 'WelcomeModal', () => {
 			] );
 	}
 
-	const originalIntersectionObserver = global.IntersectionObserver;
-
 	beforeEach( () => {
-		global.IntersectionObserver =
-			InViewIntersectionObserver as unknown as typeof IntersectionObserver;
-
 		registry = createTestRegistry();
 
 		fetchMock.post( dismissItemEndpoint, {
@@ -247,7 +216,6 @@ describe( 'WelcomeModal', () => {
 	} );
 
 	afterEach( () => {
-		global.IntersectionObserver = originalIntersectionObserver;
 		mockTrackEvent.mockClear();
 	} );
 
@@ -1181,9 +1149,15 @@ describe( 'WelcomeModal', () => {
 				} );
 
 				await waitForRegistry();
+				await waitFor( () => {
+					expect( getObservedElements() ).not.toHaveLength( 0 );
+				} );
+				act( () => simulateAllIntersections() );
 
 				// The `view_notice` event is also tracked on view.
-				expect( mockTrackEvent ).toHaveBeenCalledTimes( 3 );
+				await waitFor( () => {
+					expect( mockTrackEvent ).toHaveBeenCalledTimes( 3 );
+				} );
 				expect( mockTrackEvent ).toHaveBeenCalledWith(
 					'test-context_setup',
 					'setup_flow_v3_complete_site_setup'
@@ -1199,9 +1173,15 @@ describe( 'WelcomeModal', () => {
 					registry,
 					viewContext: 'test-context',
 				} );
+				await waitFor( () => {
+					expect( getObservedElements() ).not.toHaveLength( 0 );
+				} );
+				act( () => simulateAllIntersections() );
 
 				// Only the `view_notice` event should be tracked the second time the modal is shown.
-				expect( mockTrackEvent ).toHaveBeenCalledTimes( 1 );
+				await waitFor( () => {
+					expect( mockTrackEvent ).toHaveBeenCalledTimes( 1 );
+				} );
 				expect( mockTrackEvent ).toHaveBeenCalledWith(
 					'test-context_welcome-modal',
 					'view_notice',

--- a/assets/js/components/google-tag-gateway/GoogleTagGatewayToggle.test.js
+++ b/assets/js/components/google-tag-gateway/GoogleTagGatewayToggle.test.js
@@ -17,16 +17,12 @@
  */
 
 /**
- * External dependencies
- */
-import { intersectionObserver } from '@shopify/jest-dom-mocks';
-
-/**
  * Internal dependencies
  */
 import { VIEW_CONTEXT_MAIN_DASHBOARD } from '@/js/googlesitekit/constants';
 import { CORE_SITE } from '@/js/googlesitekit/datastore/site/constants';
 import * as tracking from '@/js/util/tracking';
+import { mockIntersectionObserver } from '@tests/js/mock-browser-utils';
 import {
 	act,
 	createTestRegistry,
@@ -41,6 +37,7 @@ const mockTrackEvent = jest.spyOn( tracking, 'trackEvent' );
 mockTrackEvent.mockImplementation( () => Promise.resolve() );
 
 describe( 'GoogleTagGatewayToggle', () => {
+	const { simulateAllIntersections } = mockIntersectionObserver();
 	let registry;
 
 	const serverRequirementStatusEndpoint = new RegExp(
@@ -48,8 +45,6 @@ describe( 'GoogleTagGatewayToggle', () => {
 	);
 
 	beforeEach( () => {
-		intersectionObserver.mock();
-
 		registry = createTestRegistry();
 
 		registry.dispatch( CORE_SITE ).receiveGetGoogleTagGatewaySettings( {
@@ -60,7 +55,6 @@ describe( 'GoogleTagGatewayToggle', () => {
 	} );
 
 	afterEach( () => {
-		intersectionObserver.restore();
 		jest.clearAllMocks();
 	} );
 
@@ -181,10 +175,7 @@ describe( 'GoogleTagGatewayToggle', () => {
 
 		// Simulate the warning notice becoming visible if it were present.
 		act( () => {
-			intersectionObserver.simulate( {
-				isIntersecting: true,
-				intersectionRatio: 1,
-			} );
+			simulateAllIntersections();
 		} );
 
 		expect( mockTrackEvent ).not.toHaveBeenCalled();
@@ -222,10 +213,7 @@ describe( 'GoogleTagGatewayToggle', () => {
 
 		// Simulate the warning notice becoming visible.
 		act( () => {
-			intersectionObserver.simulate( {
-				isIntersecting: true,
-				intersectionRatio: 1,
-			} );
+			simulateAllIntersections();
 		} );
 
 		expect( mockTrackEvent ).toHaveBeenCalledTimes( 1 );

--- a/assets/js/modules/analytics-4/components/audience-segmentation/dashboard/AudienceSegmentationBackNotice.test.tsx
+++ b/assets/js/modules/analytics-4/components/audience-segmentation/dashboard/AudienceSegmentationBackNotice.test.tsx
@@ -17,11 +17,6 @@
  */
 
 /**
- * External dependencies
- */
-import { intersectionObserver } from '@shopify/jest-dom-mocks';
-
-/**
  * WordPress dependencies
  */
 import { WPDataRegistry } from '@wordpress/data/build-types/registry';
@@ -34,6 +29,7 @@ import { CORE_UI } from '@/js/googlesitekit/datastore/ui/constants';
 import { CORE_USER } from '@/js/googlesitekit/datastore/user/constants';
 import { withWidgetComponentProps } from '@/js/googlesitekit/widgets/util';
 import * as tracking from '@/js/util/tracking';
+import { mockIntersectionObserver } from '@tests/js/mock-browser-utils';
 import {
 	act,
 	createTestRegistry,
@@ -50,6 +46,7 @@ const mockTrackEvent = jest.spyOn( tracking, 'trackEvent' );
 mockTrackEvent.mockImplementation( () => Promise.resolve() );
 
 describe( 'AudienceSegmentationBackNotice', () => {
+	const { simulateAllIntersections } = mockIntersectionObserver();
 	let registry: WPDataRegistry;
 
 	const dismissItemEndpoint = new RegExp(
@@ -63,14 +60,11 @@ describe( 'AudienceSegmentationBackNotice', () => {
 	)( AudienceSegmentationBackNotice );
 
 	beforeEach( () => {
-		intersectionObserver.mock();
-
 		registry = createTestRegistry();
 		registry.dispatch( CORE_USER ).receiveGetDismissedItems( [] );
 	} );
 
 	afterEach( () => {
-		intersectionObserver.restore();
 		jest.clearAllMocks();
 	} );
 
@@ -172,10 +166,7 @@ describe( 'AudienceSegmentationBackNotice', () => {
 
 		// Simulate the notice coming into view.
 		act( () => {
-			intersectionObserver.simulate( {
-				isIntersecting: true,
-				intersectionRatio: 1,
-			} );
+			simulateAllIntersections();
 		} );
 
 		await waitFor( () => {

--- a/assets/js/modules/analytics-4/components/audience-segmentation/dashboard/AudienceSegmentationErrorWidget/index.test.js
+++ b/assets/js/modules/analytics-4/components/audience-segmentation/dashboard/AudienceSegmentationErrorWidget/index.test.js
@@ -17,11 +17,6 @@
  */
 
 /**
- * External dependencies
- */
-import { intersectionObserver } from '@shopify/jest-dom-mocks';
-
-/**
  * Internal dependencies
  */
 import { VIEW_CONTEXT_MAIN_DASHBOARD } from '@/js/googlesitekit/constants';
@@ -30,6 +25,7 @@ import { MODULE_SLUG_ANALYTICS_4 } from '@/js/modules/analytics-4/constants';
 import { MODULES_ANALYTICS_4 } from '@/js/modules/analytics-4/datastore/constants';
 import { ERROR_REASON_INSUFFICIENT_PERMISSIONS } from '@/js/util/errors';
 import * as tracking from '@/js/util/tracking';
+import { mockIntersectionObserver } from '@tests/js/mock-browser-utils';
 import {
 	act,
 	createTestRegistry,
@@ -47,12 +43,11 @@ const mockTrackEvent = jest.spyOn( tracking, 'trackEvent' );
 mockTrackEvent.mockImplementation( () => Promise.resolve() );
 
 describe( 'AudienceSegmentationErrorWidget', () => {
+	const { simulateAllIntersections } = mockIntersectionObserver();
 	let registry;
 	let originalViewportWidth;
 
 	beforeEach( () => {
-		intersectionObserver.mock();
-
 		registry = createTestRegistry();
 		provideModules( registry, [
 			{
@@ -70,7 +65,6 @@ describe( 'AudienceSegmentationErrorWidget', () => {
 	} );
 
 	afterEach( () => {
-		intersectionObserver.restore();
 		mockTrackEvent.mockClear();
 		setViewportWidth( originalViewportWidth );
 	} );
@@ -149,10 +143,7 @@ describe( 'AudienceSegmentationErrorWidget', () => {
 
 			// Simulate the CTA becoming visible.
 			act( () => {
-				intersectionObserver.simulate( {
-					isIntersecting: true,
-					intersectionRatio: 1,
-				} );
+				simulateAllIntersections();
 			} );
 
 			expect( mockTrackEvent ).toHaveBeenCalledWith(
@@ -255,10 +246,7 @@ describe( 'AudienceSegmentationErrorWidget', () => {
 
 			// Simulate the CTA becoming visible.
 			act( () => {
-				intersectionObserver.simulate( {
-					isIntersecting: true,
-					intersectionRatio: 1,
-				} );
+				simulateAllIntersections();
 			} );
 
 			expect( mockTrackEvent ).toHaveBeenCalledWith(

--- a/assets/js/modules/analytics-4/components/audience-segmentation/dashboard/AudienceTilesWidget/AudienceTile/AudienceTileError/index.test.js
+++ b/assets/js/modules/analytics-4/components/audience-segmentation/dashboard/AudienceTilesWidget/AudienceTile/AudienceTileError/index.test.js
@@ -17,11 +17,6 @@
  */
 
 /**
- * External dependencies
- */
-import { intersectionObserver } from '@shopify/jest-dom-mocks';
-
-/**
  * Internal dependencies
  */
 import { VIEW_CONTEXT_MAIN_DASHBOARD } from '@/js/googlesitekit/constants';
@@ -29,6 +24,7 @@ import { MODULE_SLUG_ANALYTICS_4 } from '@/js/modules/analytics-4/constants';
 import { MODULES_ANALYTICS_4 } from '@/js/modules/analytics-4/datastore/constants';
 import { ERROR_REASON_INSUFFICIENT_PERMISSIONS } from '@/js/util/errors';
 import * as tracking from '@/js/util/tracking';
+import { mockIntersectionObserver } from '@tests/js/mock-browser-utils';
 import { act, fireEvent, render } from '@tests/js/test-utils';
 import {
 	createTestRegistry,
@@ -44,6 +40,7 @@ const mockTrackEvent = jest.spyOn( tracking, 'trackEvent' );
 mockTrackEvent.mockImplementation( () => Promise.resolve() );
 
 describe( 'AudienceTileError', () => {
+	const { simulateAllIntersections } = mockIntersectionObserver();
 	let registry;
 
 	const audienceSlug = 'new-visitors';
@@ -79,8 +76,6 @@ describe( 'AudienceTileError', () => {
 	};
 
 	beforeEach( () => {
-		intersectionObserver.mock();
-
 		registry = createTestRegistry();
 
 		provideModules( registry, [
@@ -103,7 +98,6 @@ describe( 'AudienceTileError', () => {
 	} );
 
 	afterEach( () => {
-		intersectionObserver.restore();
 		mockTrackEvent.mockClear();
 	} );
 
@@ -175,10 +169,7 @@ describe( 'AudienceTileError', () => {
 
 		// Simulate the CTA becoming visible.
 		act( () => {
-			intersectionObserver.simulate( {
-				isIntersecting: true,
-				intersectionRatio: 1,
-			} );
+			simulateAllIntersections();
 		} );
 
 		await waitForRegistry();
@@ -244,10 +235,7 @@ describe( 'AudienceTileError', () => {
 
 		// Simulate the CTA becoming visible.
 		act( () => {
-			intersectionObserver.simulate( {
-				isIntersecting: true,
-				intersectionRatio: 1,
-			} );
+			simulateAllIntersections();
 		} );
 
 		await waitForRegistry();

--- a/assets/js/modules/analytics-4/components/audience-segmentation/dashboard/AudienceTilesWidget/AudienceTile/index.test.js
+++ b/assets/js/modules/analytics-4/components/audience-segmentation/dashboard/AudienceTilesWidget/AudienceTile/index.test.js
@@ -19,7 +19,6 @@
 /**
  * External dependencies
  */
-import { intersectionObserver } from '@shopify/jest-dom-mocks';
 import { getByText as domGetByText } from '@testing-library/dom';
 
 /**
@@ -42,6 +41,7 @@ import { getAnalytics4MockResponse } from '@/js/modules/analytics-4/utils/data-m
 import { getPreviousDate } from '@/js/util';
 import { ERROR_REASON_INSUFFICIENT_PERMISSIONS } from '@/js/util/errors';
 import * as tracking from '@/js/util/tracking';
+import { mockIntersectionObserver } from '@tests/js/mock-browser-utils';
 import { act, fireEvent, render } from '@tests/js/test-utils';
 import {
 	createTestRegistry,
@@ -59,6 +59,7 @@ const mockTrackEvent = jest.spyOn( tracking, 'trackEvent' );
 mockTrackEvent.mockImplementation( () => Promise.resolve() );
 
 describe( 'AudienceTile', () => {
+	const { simulateAllIntersections } = mockIntersectionObserver();
 	let registry, originalViewportWidth;
 
 	const WidgetWithComponentProps =
@@ -155,8 +156,6 @@ describe( 'AudienceTile', () => {
 		// Ensure the viewport is wide enough to render the tooltips.
 		setViewportWidth( 1024 );
 
-		intersectionObserver.mock();
-
 		registry = createTestRegistry();
 		provideModules( registry, [
 			{
@@ -218,7 +217,6 @@ describe( 'AudienceTile', () => {
 	} );
 
 	afterEach( () => {
-		intersectionObserver.restore();
 		mockTrackEvent.mockClear();
 		setViewportWidth( originalViewportWidth );
 	} );
@@ -278,10 +276,7 @@ describe( 'AudienceTile', () => {
 
 			// Simulate the CTA becoming visible.
 			act( () => {
-				intersectionObserver.simulate( {
-					isIntersecting: true,
-					intersectionRatio: 1,
-				} );
+				simulateAllIntersections();
 			} );
 
 			expect( mockTrackEvent ).toHaveBeenCalledTimes( 1 );
@@ -500,10 +495,7 @@ describe( 'AudienceTile', () => {
 
 			// Simulate the tile coming into view.
 			act( () => {
-				intersectionObserver.simulate( {
-					isIntersecting: true,
-					intersectionRatio: 1,
-				} );
+				simulateAllIntersections();
 			} );
 
 			expect( mockTrackEvent ).toHaveBeenCalledTimes( 1 );

--- a/assets/js/modules/analytics-4/components/audience-segmentation/dashboard/InfoNoticeWidget/index.test.js
+++ b/assets/js/modules/analytics-4/components/audience-segmentation/dashboard/InfoNoticeWidget/index.test.js
@@ -17,12 +17,7 @@
  */
 
 /**
- * External dependencies
- */
-import { intersectionObserver } from '@shopify/jest-dom-mocks';
-
-/**
- * Internal dependencies.
+ * Internal dependencies
  */
 import { VIEW_CONTEXT_MAIN_DASHBOARD } from '@/js/googlesitekit/constants';
 import { CORE_USER } from '@/js/googlesitekit/datastore/user/constants';
@@ -32,6 +27,7 @@ import { availableAudiences } from '@/js/modules/analytics-4/datastore/__fixture
 import { MODULES_ANALYTICS_4 } from '@/js/modules/analytics-4/datastore/constants';
 import { WEEK_IN_SECONDS } from '@/js/util';
 import * as tracking from '@/js/util/tracking';
+import { mockIntersectionObserver } from '@tests/js/mock-browser-utils';
 import {
 	act,
 	createTestRegistry,
@@ -48,13 +44,12 @@ const mockTrackEvent = jest.spyOn( tracking, 'trackEvent' );
 mockTrackEvent.mockImplementation( () => Promise.resolve() );
 
 describe( 'InfoNoticeWidget', () => {
+	const { simulateAllIntersections } = mockIntersectionObserver();
 	let registry;
 
 	let dismissPromptSpy;
 
 	beforeEach( () => {
-		intersectionObserver.mock();
-
 		registry = createTestRegistry();
 		provideModules( registry, [
 			{
@@ -71,7 +66,6 @@ describe( 'InfoNoticeWidget', () => {
 	} );
 
 	afterEach( () => {
-		intersectionObserver.restore();
 		mockTrackEvent.mockClear();
 	} );
 
@@ -409,10 +403,7 @@ describe( 'InfoNoticeWidget', () => {
 
 				// Simulate the notice coming into view.
 				act( () => {
-					intersectionObserver.simulate( {
-						isIntersecting: true,
-						intersectionRatio: 1,
-					} );
+					simulateAllIntersections();
 				} );
 
 				expect( mockTrackEvent ).toHaveBeenCalledTimes( 1 );

--- a/assets/js/modules/analytics-4/components/audience-segmentation/dashboard/NoAudienceBannerWidget/index.test.js
+++ b/assets/js/modules/analytics-4/components/audience-segmentation/dashboard/NoAudienceBannerWidget/index.test.js
@@ -17,11 +17,6 @@
  */
 
 /**
- * External dependencies
- */
-import { intersectionObserver } from '@shopify/jest-dom-mocks';
-
-/**
  * Internal dependencies
  */
 import {
@@ -36,7 +31,10 @@ import { MODULE_SLUG_ANALYTICS_4 } from '@/js/modules/analytics-4/constants';
 import { availableAudiences } from '@/js/modules/analytics-4/datastore/__fixtures__';
 import { MODULES_ANALYTICS_4 } from '@/js/modules/analytics-4/datastore/constants';
 import * as tracking from '@/js/util/tracking';
-import { mockLocation } from '@tests/js/mock-browser-utils';
+import {
+	mockIntersectionObserver,
+	mockLocation,
+} from '@tests/js/mock-browser-utils';
 import { act, fireEvent, render } from '@tests/js/test-utils';
 import {
 	createTestRegistry,
@@ -52,6 +50,7 @@ const mockTrackEvent = jest.spyOn( tracking, 'trackEvent' );
 mockTrackEvent.mockImplementation( () => Promise.resolve() );
 
 describe( 'NoAudienceBannerWidget', () => {
+	const { simulateAllIntersections } = mockIntersectionObserver();
 	mockLocation();
 
 	let registry;
@@ -65,8 +64,6 @@ describe( 'NoAudienceBannerWidget', () => {
 	);
 
 	beforeEach( () => {
-		intersectionObserver.mock();
-
 		registry = createTestRegistry();
 		provideModules( registry, [
 			{
@@ -80,7 +77,6 @@ describe( 'NoAudienceBannerWidget', () => {
 	} );
 
 	afterEach( () => {
-		intersectionObserver.restore();
 		jest.clearAllMocks();
 	} );
 
@@ -241,10 +237,7 @@ describe( 'NoAudienceBannerWidget', () => {
 
 			// Simulate the CTA becoming visible.
 			act( () => {
-				intersectionObserver.simulate( {
-					isIntersecting: true,
-					intersectionRatio: 1,
-				} );
+				simulateAllIntersections();
 			} );
 
 			expect( mockTrackEvent ).toHaveBeenCalledTimes( 1 );
@@ -357,10 +350,7 @@ describe( 'NoAudienceBannerWidget', () => {
 
 			// Simulate the CTA becoming visible.
 			act( () => {
-				intersectionObserver.simulate( {
-					isIntersecting: true,
-					intersectionRatio: 1,
-				} );
+				simulateAllIntersections();
 			} );
 
 			expect( mockTrackEvent ).toHaveBeenCalledTimes( 1 );
@@ -456,10 +446,7 @@ describe( 'NoAudienceBannerWidget', () => {
 
 			// Simulate the CTA becoming visible.
 			act( () => {
-				intersectionObserver.simulate( {
-					isIntersecting: true,
-					intersectionRatio: 1,
-				} );
+				simulateAllIntersections();
 			} );
 
 			expect( mockTrackEvent ).toHaveBeenCalledTimes( 1 );
@@ -543,10 +530,7 @@ describe( 'NoAudienceBannerWidget', () => {
 
 			// Simulate the CTA becoming visible.
 			act( () => {
-				intersectionObserver.simulate( {
-					isIntersecting: true,
-					intersectionRatio: 1,
-				} );
+				simulateAllIntersections();
 			} );
 
 			expect( mockTrackEvent ).toHaveBeenCalledTimes( 1 );

--- a/assets/js/modules/analytics-4/components/audience-segmentation/settings/SettingsCardAudiences/SetupSuccess/index.test.js
+++ b/assets/js/modules/analytics-4/components/audience-segmentation/settings/SettingsCardAudiences/SetupSuccess/index.test.js
@@ -17,11 +17,6 @@
  */
 
 /**
- * External dependencies
- */
-import { intersectionObserver } from '@shopify/jest-dom-mocks';
-
-/**
  * WordPress dependencies
  */
 import { addQueryArgs } from '@wordpress/url';
@@ -35,7 +30,10 @@ import { CORE_UI } from '@/js/googlesitekit/datastore/ui/constants';
 import { CORE_USER } from '@/js/googlesitekit/datastore/user/constants';
 import { AREA_MAIN_DASHBOARD_TRAFFIC_AUDIENCE_SEGMENTATION } from '@/js/googlesitekit/widgets/default-areas';
 import * as tracking from '@/js/util/tracking';
-import { mockLocation } from '@tests/js/mock-browser-utils';
+import {
+	mockIntersectionObserver,
+	mockLocation,
+} from '@tests/js/mock-browser-utils';
 import {
 	act,
 	createTestRegistry,
@@ -53,14 +51,13 @@ const mockTrackEvent = jest.spyOn( tracking, 'trackEvent' );
 mockTrackEvent.mockImplementation( () => Promise.resolve() );
 
 describe( 'SettingsCardAudiences SetupSuccess', () => {
+	const { simulateAllIntersections } = mockIntersectionObserver();
 	let registry;
 	let dismissItemSpy;
 
 	mockLocation();
 
 	beforeEach( () => {
-		intersectionObserver.mock();
-
 		registry = createTestRegistry();
 
 		provideSiteInfo( registry );
@@ -81,7 +78,6 @@ describe( 'SettingsCardAudiences SetupSuccess', () => {
 	} );
 
 	afterEach( () => {
-		intersectionObserver.restore();
 		dismissItemSpy.mockReset();
 		mockTrackEvent.mockClear();
 	} );
@@ -116,10 +112,7 @@ describe( 'SettingsCardAudiences SetupSuccess', () => {
 
 		// Simulate the CTA becoming visible.
 		act( () => {
-			intersectionObserver.simulate( {
-				isIntersecting: true,
-				intersectionRatio: 1,
-			} );
+			simulateAllIntersections();
 		} );
 
 		expect( mockTrackEvent ).toHaveBeenCalledTimes( 1 );

--- a/assets/js/modules/analytics-4/components/site-goals/notifications/BreakdownNoticeArea.test.tsx
+++ b/assets/js/modules/analytics-4/components/site-goals/notifications/BreakdownNoticeArea.test.tsx
@@ -877,6 +877,7 @@ describe( 'BreakdownNoticeArea', () => {
 
 		function simulateInView() {
 			const observedElements = getObservedElements();
+			expect( observedElements.length ).toBeGreaterThan( 0 );
 
 			act( () => {
 				simulateIntersection(

--- a/assets/js/modules/analytics-4/components/site-goals/notifications/BreakdownNoticeArea.test.tsx
+++ b/assets/js/modules/analytics-4/components/site-goals/notifications/BreakdownNoticeArea.test.tsx
@@ -17,11 +17,6 @@
  */
 
 /**
- * External dependencies
- */
-import { intersectionObserver } from '@shopify/jest-dom-mocks';
-
-/**
  * WordPress dependencies
  */
 import { WPDataRegistry } from '@wordpress/data/build-types/registry';
@@ -54,6 +49,7 @@ import {
 import { ALL_CUSTOM_DIMENSIONS } from '@/js/modules/analytics-4/hooks/useBreakdownEnableHandler';
 import { provideCustomDimensionError } from '@/js/modules/analytics-4/utils/custom-dimensions';
 import * as tracking from '@/js/util/tracking';
+import { mockIntersectionObserver } from '@tests/js/mock-browser-utils';
 import { act, fireEvent, render, waitFor } from '@tests/js/test-utils';
 import {
 	createTestRegistry,
@@ -67,6 +63,8 @@ import BreakdownNoticeArea, {
 } from './BreakdownNoticeArea';
 
 describe( 'BreakdownNoticeArea', () => {
+	const { getObservedElements, simulateIntersection } =
+		mockIntersectionObserver();
 	let registry: WPDataRegistry;
 
 	function seedAvailableCustomDimensions(
@@ -871,20 +869,19 @@ describe( 'BreakdownNoticeArea', () => {
 
 		beforeEach( () => {
 			mockTrackEventOnce = jest.spyOn( tracking, 'trackEventOnce' );
-			intersectionObserver.mock();
 		} );
 
 		afterEach( () => {
 			mockTrackEventOnce.mockRestore();
-			intersectionObserver.restore();
 		} );
 
 		function simulateInView() {
+			const observedElements = getObservedElements();
+
 			act( () => {
-				intersectionObserver.simulate( {
-					isIntersecting: true,
-					intersectionRatio: 1,
-				} );
+				simulateIntersection(
+					observedElements[ observedElements.length - 1 ]
+				);
 			} );
 		}
 

--- a/assets/js/modules/analytics-4/components/site-goals/notifications/IntroModalBanner/index.test.js
+++ b/assets/js/modules/analytics-4/components/site-goals/notifications/IntroModalBanner/index.test.js
@@ -50,6 +50,7 @@ import {
 } from '@/js/modules/analytics-4/datastore/constants';
 import { ANALYTICS_4_NOTIFICATIONS } from '@/js/modules/analytics-4/notifications';
 import * as scrollUtils from '@/js/util/scroll';
+import { mockIntersectionObserver } from '@tests/js/mock-browser-utils';
 import { dismissItemEndpoint } from '@tests/js/mock-dismiss-item-endpoints';
 import {
 	act,
@@ -72,33 +73,6 @@ jest.mock( '@/js/googlesitekit/notifications/hooks/useNotificationEvents' );
 const IntroModalComponent = withNotificationComponentProps(
 	SITE_GOALS_INTRO_MODAL_BANNER
 )( IntroModal );
-
-/**
- * The modal content renders inside a fixed-position Dialog, so the
- * `<Notification>` wrapper's own observer never sees it. `BannerModal` observes
- * its own graphic with `withIntersectionObserver`, which uses the native
- * `IntersectionObserver`. jsdom has none, so this stub reports the element as
- * in view the moment it is observed, which fires the modal's `onView` and makes
- * `<Notification>` send the `view_notification` event.
- *
- * @since 1.184.0
- */
-class InViewIntersectionObserver {
-	constructor( callback ) {
-		this.callback = callback;
-	}
-
-	observe( element ) {
-		this.callback(
-			[ { isIntersecting: true, intersectionRatio: 1, target: element } ],
-			this
-		);
-	}
-
-	unobserve() {}
-
-	disconnect() {}
-}
 
 const getNavigationalScrollTopSpy = jest.spyOn(
 	scrollUtils,
@@ -134,6 +108,7 @@ async function waitForIntroModalToShow( getByRole ) {
 }
 
 describe( 'IntroModal', () => {
+	const { simulateAllIntersections } = mockIntersectionObserver();
 	let registry;
 	let trackEvents;
 
@@ -671,17 +646,6 @@ describe( 'IntroModal', () => {
 	} );
 
 	describe( 'view tracking', () => {
-		let originalIntersectionObserver;
-
-		beforeEach( () => {
-			originalIntersectionObserver = global.IntersectionObserver;
-			global.IntersectionObserver = InViewIntersectionObserver;
-		} );
-
-		afterEach( () => {
-			global.IntersectionObserver = originalIntersectionObserver;
-		} );
-
 		it( 'sends the view_notification event once the modal comes into view', async () => {
 			registry
 				.dispatch( MODULES_ANALYTICS_4 )
@@ -693,6 +657,7 @@ describe( 'IntroModal', () => {
 			} );
 
 			await waitForIntroModalToShow( getByRole );
+			act( () => simulateAllIntersections() );
 
 			// The modal's content renders inside a fixed-position Dialog, so the
 			// `<Notification>` wrapper's own observer never marks it viewed.

--- a/assets/js/modules/analytics-4/components/site-goals/widgets/LeadGenerationPerformanceWidget.test.tsx
+++ b/assets/js/modules/analytics-4/components/site-goals/widgets/LeadGenerationPerformanceWidget.test.tsx
@@ -17,7 +17,6 @@
 /**
  * External dependencies
  */
-import { intersectionObserver } from '@shopify/jest-dom-mocks';
 import fetchMock from 'fetch-mock';
 
 /**
@@ -54,6 +53,7 @@ import {
 } from '@/js/modules/analytics-4/datastore/constants';
 import { provideAnalytics4MockReport } from '@/js/modules/analytics-4/utils/data-mock';
 import { getPreviousDate } from '@/js/util';
+import { mockIntersectionObserver } from '@tests/js/mock-browser-utils';
 import {
 	createTestRegistry,
 	fireEvent,
@@ -70,6 +70,7 @@ import LeadGenerationPerformanceWidget from './LeadGenerationPerformanceWidget';
 type WidgetComponentProps = ReturnType< typeof getWidgetComponentProps >;
 
 describe( 'LeadGenerationPerformanceWidget', () => {
+	const { getObservedElements } = mockIntersectionObserver();
 	let registry: WPDataRegistry;
 
 	const widgetProps: WidgetComponentProps = getWidgetComponentProps(
@@ -1743,8 +1744,6 @@ describe( 'LeadGenerationPerformanceWidget', () => {
 	} );
 
 	it( 'observes the widget element after it renders', async () => {
-		intersectionObserver.mock();
-
 		registry
 			.dispatch( MODULES_ANALYTICS_4 )
 			.setDetectedEvents( [ ENUM_CONVERSION_EVENTS.GENERATE_LEAD ] );
@@ -1756,15 +1755,10 @@ describe( 'LeadGenerationPerformanceWidget', () => {
 		);
 		await waitForRegistry();
 
-		const observedTargets = intersectionObserver.observers.map(
-			( observer ) => observer.target
-		);
-		expect( observedTargets ).toContain(
+		expect( getObservedElements() ).toContain(
 			container.querySelector(
 				'.googlesitekit-widget--analyticsLeadGenerationPerformance'
 			)
 		);
-
-		intersectionObserver.restore();
 	} );
 } );

--- a/assets/js/modules/analytics-4/components/site-goals/widgets/OnlineStorePerformanceWidget.test.tsx
+++ b/assets/js/modules/analytics-4/components/site-goals/widgets/OnlineStorePerformanceWidget.test.tsx
@@ -17,7 +17,6 @@
 /**
  * External dependencies
  */
-import { intersectionObserver } from '@shopify/jest-dom-mocks';
 import fetchMock from 'fetch-mock';
 
 /**
@@ -53,6 +52,7 @@ import {
 } from '@/js/modules/analytics-4/datastore/constants';
 import { provideAnalytics4MockReport } from '@/js/modules/analytics-4/utils/data-mock';
 import { getPreviousDate } from '@/js/util';
+import { mockIntersectionObserver } from '@tests/js/mock-browser-utils';
 import { fireEvent, render, waitFor } from '@tests/js/test-utils';
 import {
 	createTestRegistry,
@@ -67,6 +67,7 @@ import OnlineStorePerformanceWidget from './OnlineStorePerformanceWidget';
 type WidgetComponentProps = ReturnType< typeof getWidgetComponentProps >;
 
 describe( 'OnlineStorePerformanceWidget', () => {
+	const { getObservedElements } = mockIntersectionObserver();
 	let registry: WPDataRegistry;
 	const widgetProps: WidgetComponentProps = getWidgetComponentProps(
 		'analyticsOnlineStorePerformance'
@@ -1838,8 +1839,6 @@ describe( 'OnlineStorePerformanceWidget', () => {
 	} );
 
 	it( 'observes the widget element after it renders', async () => {
-		intersectionObserver.mock();
-
 		registry
 			.dispatch( MODULES_ANALYTICS_4 )
 			.setDetectedEvents( [ ENUM_CONVERSION_EVENTS.PURCHASE ] );
@@ -1851,15 +1850,10 @@ describe( 'OnlineStorePerformanceWidget', () => {
 		);
 		await waitForRegistry();
 
-		const observedTargets = intersectionObserver.observers.map(
-			( observer ) => observer.target
-		);
-		expect( observedTargets ).toContain(
+		expect( getObservedElements() ).toContain(
 			container.querySelector(
 				'.googlesitekit-widget--analyticsOnlineStorePerformance'
 			)
 		);
-
-		intersectionObserver.restore();
 	} );
 } );


### PR DESCRIPTION
## Summary

Related issue(s):

- Resolves #13187

## Relevant technical choices

- Replace component-test uses of `@shopify/jest-dom-mocks` with the shared `mockIntersectionObserver` utility.
- Replace the two modal-specific `IntersectionObserver` classes with explicit shared-helper simulations.
- Keep the low-level hook and HOC tests on the Shopify mock because they verify observer constructor options and complete entry payloads rather than only emulating visibility.

## Testing

- `npm run -w tests/js test:js -- --runInBand <14 affected test files>` — 14 suites, 277 tests, and 25 snapshots passed.
- Touched-file ESLint and Prettier checks passed.
- Staged TypeScript check passed through the repository pre-commit hook.
- `npm run build:dev` passed; webpack reported existing Sass deprecation warnings.

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [ ] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.
- [ ] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
