### PR TITLE
Fix the chart axis numbers cut off in the PDF report

### DIFF
--- a/assets/js/components/pdf-export/chart-axis.test.ts
+++ b/assets/js/components/pdf-export/chart-axis.test.ts
@@ -1,0 +1,139 @@
+/**
+ * PDF chart axis tests.
+ *
+ * Site Kit by Google, Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import {
+	formatShortValue,
+	getValueAxisGutter,
+	pickDateTicks,
+} from './chart-axis';
+
+/**
+ * The dates of a 28 day report.
+ */
+const DATES = Array.from(
+	{ length: 28 },
+	( _, index ) => new Date( 2026, 6, 1 + index )
+);
+
+describe( 'formatShortValue', () => {
+	it.each( [
+		[ 0, '0' ],
+		[ 58, '58' ],
+		[ 999, '999' ],
+		[ 1000, '1K' ],
+		[ 5500, '5.5K' ],
+		[ 58000, '58K' ],
+		[ 1200000, '1.2M' ],
+		[ 3200000000, '3.2B' ],
+		[ 4400000000000, '4.4T' ],
+	] )( 'shortens %p to "%s"', ( value, expected ) => {
+		expect( formatShortValue( value ) ).toBe( expected );
+	} );
+
+	it.each( [
+		[ 0.5, '0.5' ],
+		[ 0.25, '0.25' ],
+		[ 0.0642, '0.064' ],
+		[ 0.002, '0.002' ],
+	] )( 'keeps two significant digits of %p, as "%s"', ( value, expected ) => {
+		expect( formatShortValue( value ) ).toBe( expected );
+	} );
+
+	it( 'keeps the sign of a negative value', () => {
+		expect( formatShortValue( -58000 ) ).toBe( '-58K' );
+	} );
+} );
+
+describe( 'getValueAxisGutter', () => {
+	it.each( [
+		// `900` and `58K` are both three characters, so shortening keeps a
+		// large maximum in the same width as a small one.
+		[ 900, 59 ],
+		[ 58000, 59 ],
+		[ 1234567, 76 ],
+	] )(
+		'reserves the width the labels need for a maximum of %p',
+		( maxValue, expected ) => {
+			expect( getValueAxisGutter( maxValue, 28 ) ).toBe( expected );
+		}
+	);
+
+	it( 'measures the quarter values, not the maximum alone', () => {
+		// The maximum shortens to the two characters of `1M`, while its
+		// quarters need the four of `750K`.
+		expect( getValueAxisGutter( 1000000, 28 ) ).toBe( 76 );
+	} );
+
+	it( 'reserves room for the decimals a small ratio needs', () => {
+		// An AdSense page CTR peaking at `0.121` draws a `0.12` label for the
+		// maximum. Three quarters of it needs the five characters of `0.091`,
+		// so the gutter has to fit that instead.
+		expect( getValueAxisGutter( 0.121, 28 ) ).toBe( 93 );
+	} );
+
+	it( 'keeps less space free at a smaller font size', () => {
+		expect( getValueAxisGutter( 900, 14 ) ).toBe( 30 );
+	} );
+} );
+
+describe( 'pickDateTicks', () => {
+	it( 'starts and ends far enough in for a whole label to fit', () => {
+		const ticks = pickDateTicks( DATES, 4000, 28 );
+
+		expect( ticks ).toHaveLength( 26 );
+		expect( ticks[ 0 ] ).toEqual( DATES[ 1 ] );
+		expect( ticks[ 25 ] ).toEqual( DATES[ 26 ] );
+	} );
+
+	it( 'skips more dates at each end when the dates sit closer together', () => {
+		// A 90 day range packs its dates into the same width, so the second
+		// date is too near the left edge for a label centered on it.
+		const ninetyDays = Array.from(
+			{ length: 90 },
+			( _, index ) => new Date( 2026, 4, 26 + index )
+		);
+		const ticks = pickDateTicks( ninetyDays, 1949, 28 );
+
+		expect( ticks[ 0 ] ).toEqual( ninetyDays[ 3 ] );
+		expect( ticks[ ticks.length - 1 ] ).toEqual( ninetyDays[ 81 ] );
+	} );
+
+	it.each( [
+		[ 2000, 13 ],
+		[ 600, 5 ],
+		[ 300, 2 ],
+	] )(
+		'keeps fewer dates to fit a plot %p pixels wide',
+		( plotWidth, expected ) => {
+			expect( pickDateTicks( DATES, plotWidth, 28 ) ).toHaveLength(
+				expected
+			);
+		}
+	);
+
+	it( 'keeps two dates however narrow the plot is', () => {
+		expect( pickDateTicks( DATES, 10, 28 ) ).toHaveLength( 2 );
+	} );
+
+	it( 'returns nothing for a range too short to inset', () => {
+		expect( pickDateTicks( DATES.slice( 0, 2 ), 4000, 28 ) ).toEqual( [] );
+	} );
+} );

--- a/assets/js/components/pdf-export/chart-axis.ts
+++ b/assets/js/components/pdf-export/chart-axis.ts
@@ -1,0 +1,165 @@
+/**
+ * Chart axis label helpers for the PDF report.
+ *
+ * Site Kit by Google, Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * The width of one label character, as a share of the font size.
+ *
+ * The report draws its charts in a hidden container, where the browser can't
+ * measure the drawn text, so the helpers below count characters instead. In
+ * Google Sans Text a digit takes 0.556 of the font size and a magnitude letter
+ * takes a little more, so this share never gives a width that is too small.
+ */
+const LABEL_CHARACTER_WIDTH_RATIO = 0.6;
+
+/**
+ * Shortens a value the way the charts' `short` number format draws it.
+ *
+ * A value of a thousand or more takes the letter of its magnitude, so 58000
+ * becomes `58K`. A smaller value keeps its plain number, down to two
+ * significant digits, so 900 stays `900`. The chart draws the decimal places
+ * its gridline step needs, and two significant digits covers them.
+ *
+ * `getValueAxisGutter` measures the labels with this, so the width it reserves
+ * matches the text the chart draws.
+ *
+ * @since n.e.x.t
+ *
+ * @param {number} value The value to shorten.
+ * @return {string} The shortened value.
+ */
+export function formatShortValue( value: number ): string {
+	const magnitude = [
+		{ limit: 1e12, suffix: 'T' },
+		{ limit: 1e9, suffix: 'B' },
+		{ limit: 1e6, suffix: 'M' },
+		{ limit: 1e3, suffix: 'K' },
+	].find( ( { limit } ) => Math.abs( value ) >= limit );
+
+	if ( ! magnitude ) {
+		if ( value === 0 ) {
+			return '0';
+		}
+
+		// A value below one needs a decimal place for every leading zero after
+		// the point, and two more for its two significant digits.
+		const places = Math.max(
+			0,
+			1 - Math.floor( Math.log10( Math.abs( value ) ) )
+		);
+		const text = value.toFixed( places );
+
+		return places > 0 ? text.replace( /\.?0+$/, '' ) : text;
+	}
+
+	const scaled = value / magnitude.limit;
+	const rounded =
+		Math.abs( scaled ) < 10
+			? Math.round( scaled * 10 ) / 10
+			: Math.round( scaled );
+
+	return `${ rounded }${ magnitude.suffix }`;
+}
+
+/**
+ * Measures the width the value axis labels need, in chart pixels.
+ *
+ * The charts draw the value labels in the space `chartArea.right` keeps free to
+ * the right of the plot. When that space is too narrow the chart cuts a label
+ * off with an ellipsis, so this returns the width the widest label needs, plus
+ * half a character between the plot and the label.
+ *
+ * @since n.e.x.t
+ *
+ * @param {number} maxValue The highest value the axis reaches.
+ * @param {number} fontSize The label font size, in chart pixels.
+ * @return {number} The width to keep free, in chart pixels.
+ */
+export function getValueAxisGutter(
+	maxValue: number,
+	fontSize: number
+): number {
+	// The chart picks its own gridlines, so the labels it draws are unknown
+	// here. A quarter of the maximum needs a decimal place more often than a
+	// round gridline value does, so the widest of these four is never narrower
+	// than the widest label the chart draws.
+	const widestLabelCharacters = [ 1, 0.75, 0.5, 0.25 ].reduce(
+		( mostCharacters, share ) =>
+			Math.max(
+				mostCharacters,
+				formatShortValue( maxValue * share ).length
+			),
+		1
+	);
+
+	return Math.ceil(
+		( widestLabelCharacters + 0.5 ) * fontSize * LABEL_CHARACTER_WIDTH_RATIO
+	);
+}
+
+/**
+ * Picks the dates the horizontal axis draws as ticks.
+ *
+ * The chart centers each label on its own date, so a label near either end of
+ * the range runs past the plot. On the left the chart cuts it off. On the
+ * right it runs into the value labels and sits on top of the zero.
+ *
+ * The ticks start and end far enough in for a whole label to fit. Between
+ * those two, every Nth date stays, so the labels fit `plotWidth` on one line.
+ *
+ * The longer the range, the closer together the dates sit, so a 90 day range
+ * skips more dates at each end than a 28 day one.
+ *
+ * @since n.e.x.t
+ *
+ * @param {Date[]} dates     Every date in the range, in order.
+ * @param {number} plotWidth The width the labels have, in chart pixels.
+ * @param {number} fontSize  The label font size, in chart pixels.
+ * @return {Date[]} The dates to draw as ticks.
+ */
+export function pickDateTicks(
+	dates: Date[],
+	plotWidth: number,
+	fontSize: number
+): Date[] {
+	if ( dates.length < 3 ) {
+		return [];
+	}
+
+	// The charts draw a date in the `MMM d` format, so a label is at most six
+	// characters, such as `Sep 30`. One more character keeps two labels apart.
+	const labelWidth = 7 * fontSize * LABEL_CHARACTER_WIDTH_RATIO;
+	const pixelsPerDate = plotWidth / ( dates.length - 1 );
+
+	// A very narrow plot pushes the inset past the middle of the range, so
+	// hold it back far enough to leave two dates to draw.
+	const widestInset = Math.max( 1, Math.floor( ( dates.length - 2 ) / 2 ) );
+	const inset = Math.min(
+		widestInset,
+		Math.ceil( labelWidth / 2 / pixelsPerDate )
+	);
+	const innerDates = dates.slice( inset, dates.length - inset );
+
+	if ( innerDates.length < 2 ) {
+		return innerDates;
+	}
+
+	const labelsThatFit = Math.max( 2, Math.floor( plotWidth / labelWidth ) );
+	const step = Math.ceil( innerDates.length / labelsThatFit );
+
+	return innerDates.filter( ( _, index ) => index % step === 0 );
+}

--- a/assets/js/modules/adsense/components/module/ModuleOverviewWidget/getPDFData.test.ts
+++ b/assets/js/modules/adsense/components/module/ModuleOverviewWidget/getPDFData.test.ts
@@ -260,10 +260,12 @@ describe( 'ModuleOverviewWidget getPDFData', () => {
 	 * Dispatches fixtures where every metric has data in both periods.
 	 *
 	 * @since 1.184.0
+	 * @since n.e.x.t Added the daily impressions argument.
 	 *
+	 * @param  [dailyImpressions=600] Impressions on each day of the current period.
 	 * @return {void}
 	 */
-	function provideReportsWithData() {
+	function provideReportsWithData( dailyImpressions = 600 ) {
 		provideReports( {
 			currentTotals: buildTotalsReport( {
 				startDate: DATES.startDate,
@@ -277,7 +279,7 @@ describe( 'ModuleOverviewWidget getPDFData', () => {
 			} ),
 			currentChart: buildChartReport( {
 				days: CURRENT_RANGE_DAYS,
-				dailyValues: [ 1.5, 2.5, 600, 0.05 ],
+				dailyValues: [ 1.5, 2.5, dailyImpressions, 0.05 ],
 				totals: [ 10.5, 2.5, 4200, 0.05 ],
 			} ),
 			previousChart: buildChartReport( {
@@ -378,7 +380,15 @@ describe( 'ModuleOverviewWidget getPDFData', () => {
 				hAxis: {
 					textStyle: { fontName: 'Google Sans Text' },
 				},
-				vAxis: { textStyle: { fontName: 'Google Sans Text' } },
+				// Both series render against axis 1, so that axis carries the
+				// styling and the shortened number format. Axis 0 draws nothing.
+				vAxes: {
+					0: { textPosition: 'none' },
+					1: {
+						format: 'short',
+						textStyle: { fontName: 'Google Sans Text' },
+					},
+				},
 				series: {
 					0: { color, lineWidth: 8 },
 					1: { color, lineWidth: 8, lineDashStyle: [ 4, 20 ] },
@@ -386,6 +396,29 @@ describe( 'ModuleOverviewWidget getPDFData', () => {
 			} );
 		} );
 	} );
+
+	it.each( [
+		[ 600, 59 ],
+		[ 5500, 76 ],
+	] )(
+		'should reserve the label width a peak of %p impressions needs',
+		async ( dailyImpressions, expectedGutter ) => {
+			provideReportsWithData( dailyImpressions );
+
+			await getPDFData( {
+				registry,
+				dates: DATES,
+				signal: new AbortController().signal,
+				viewOnly: false,
+			} );
+
+			// Impressions is the third metric. `5.5K` takes one character more
+			// than `600`, so its labels need a wider column beside the plot.
+			expect(
+				mockRenderGoogleChartToDataURI.mock.calls[ 2 ][ 0 ].options
+			).toMatchObject( { chartArea: { right: expectedGutter } } );
+		}
+	);
 
 	it( 'should drop a metric with no data in either period, like its dashboard card', async () => {
 		// Page CTR is zero across both periods. The other metrics keep their data.

--- a/assets/js/modules/adsense/components/module/ModuleOverviewWidget/getPDFData.ts
+++ b/assets/js/modules/adsense/components/module/ModuleOverviewWidget/getPDFData.ts
@@ -24,6 +24,10 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
+import {
+	getValueAxisGutter,
+	pickDateTicks,
+} from '@/js/components/pdf-export/chart-axis';
 import ensureGoogleChartsLoaded from '@/js/components/pdf-export/ensure-google-charts-loaded';
 import { PDF_COLORS } from '@/js/components/pdf-export/pdf-theme';
 import renderGoogleChartToDataURI, {
@@ -67,6 +71,14 @@ const LINE_CHART_SCALE_FACTOR = 4;
  * the chart's proportions at the larger render size.
  */
 const LINE_CHART_OPTION_SCALE = LINE_CHART_SCALE_FACTOR / 2;
+
+/**
+ * The value a chart with no data caps its axis at.
+ *
+ * A flat zero line needs a range of its own, and `getValueAxisGutter` measures
+ * the labels against the same cap.
+ */
+const EMPTY_AXIS_MAX_VALUE = 1;
 
 /**
  * One key per report metric, shared with the PDF component and its tests.
@@ -223,28 +235,37 @@ interface MetricCardResult {
  * line of the same color, matching the dashboard.
  *
  * @since 1.184.0
+ * @since n.e.x.t Fitted the value and date labels to the space they have.
  *
- * @param options         Options.
- * @param options.color   Series color for both lines.
- * @param options.ticks   Date ticks for the horizontal axis.
- * @param options.hasData Whether any data point is greater than zero.
+ * @param options          Options.
+ * @param options.color    Series color for both lines.
+ * @param options.dates    Every day in the range, in order.
+ * @param options.maxValue The highest value either line reaches.
  * @return Google Charts options object.
  */
 function getLineChartOptions( {
 	color,
-	ticks,
-	hasData,
+	dates,
+	maxValue,
 }: {
 	color: string;
-	ticks: Date[];
-	hasData: boolean;
+	dates: Date[];
+	maxValue: number;
 } ): object {
+	const fontSize = 14 * LINE_CHART_OPTION_SCALE;
+	const chartAreaLeft = 8 * LINE_CHART_OPTION_SCALE;
+	const hasData = maxValue > 0;
+	const valueAxisGutter = getValueAxisGutter(
+		hasData ? maxValue : EMPTY_AXIS_MAX_VALUE,
+		fontSize
+	);
+
 	return {
 		curveType: 'function',
 		colors: [ color ],
 		chartArea: {
-			left: 8 * LINE_CHART_OPTION_SCALE,
-			right: 40 * LINE_CHART_OPTION_SCALE,
+			left: chartAreaLeft,
+			right: valueAxisGutter,
 			top: 12 * LINE_CHART_OPTION_SCALE,
 			bottom: 22 * LINE_CHART_OPTION_SCALE,
 		},
@@ -259,27 +280,48 @@ function getLineChartOptions( {
 			textStyle: {
 				color: PDF_COLORS.SURFACES_ON_SURFACE_VARIANT,
 				fontName: 'Google Sans Text',
-				fontSize: 14 * LINE_CHART_OPTION_SCALE,
+				fontSize,
 			},
-			ticks,
+			ticks: pickDateTicks(
+				dates,
+				LINE_CHART_WIDTH * LINE_CHART_SCALE_FACTOR -
+					valueAxisGutter -
+					chartAreaLeft,
+				fontSize
+			),
 		},
-		vAxis: {
-			gridlines: {
-				color: PDF_COLORS.SURFACES_SURFACE_1,
+		vAxes: {
+			// The series render against axis 1, so axis 0 draws nothing.
+			0: {
+				gridlines: {
+					color: 'transparent',
+				},
+				minorGridlines: {
+					color: 'transparent',
+				},
+				textPosition: 'none',
 			},
-			minorGridlines: {
-				color: PDF_COLORS.SURFACES_SURFACE,
-			},
-			textStyle: {
-				color: PDF_COLORS.SURFACES_ON_SURFACE_VARIANT,
-				fontName: 'Google Sans Text',
-				fontSize: 14 * LINE_CHART_OPTION_SCALE,
-			},
-			viewWindow: {
-				min: 0,
-				// Limit the axis when there's no data, so a flat zero line
-				// still reads well.
-				...( hasData ? {} : { max: 1 } ),
+			1: {
+				// A large value shortens to a magnitude letter, so 58000 reads
+				// as `58K` and the label fits the width beside the plot.
+				format: 'short',
+				gridlines: {
+					color: PDF_COLORS.SURFACES_SURFACE_1,
+				},
+				minorGridlines: {
+					color: PDF_COLORS.SURFACES_SURFACE,
+				},
+				textStyle: {
+					color: PDF_COLORS.SURFACES_ON_SURFACE_VARIANT,
+					fontName: 'Google Sans Text',
+					fontSize,
+				},
+				viewWindow: {
+					min: 0,
+					// Limit the axis when there's no data, so a flat zero line
+					// still reads well.
+					...( hasData ? {} : { max: EMPTY_AXIS_MAX_VALUE } ),
+				},
 			},
 		},
 		series: {
@@ -366,17 +408,23 @@ function renderMetricChart( {
 	color: string;
 	signal: AbortSignal;
 } ): Promise< string > {
-	// One tick per day after the first day, matching the dashboard's
-	// overview chart. The first column is always the day `Date`.
-	const [ , ...ticks ] = dataRows.map( ( row ) => row[ 0 ] as Date );
-	const hasData = dataRows.some(
-		( row ) => Number( row[ 2 ] ) > 0 || Number( row[ 3 ] ) > 0
+	// The first column is always the day `Date`, and the current and previous
+	// values follow it.
+	const dates = dataRows.map( ( row ) => row[ 0 ] as Date );
+	const maxValue = dataRows.reduce(
+		( highest, row ) =>
+			Math.max(
+				highest,
+				Number( row[ 2 ] ) || 0,
+				Number( row[ 3 ] ) || 0
+			),
+		0
 	);
 
 	return renderGoogleChartToDataURI( {
 		chartType: 'LineChart',
 		dataTable: buildChartDataTable( dataRows, currentLabel ),
-		options: getLineChartOptions( { color, ticks, hasData } ),
+		options: getLineChartOptions( { color, dates, maxValue } ),
 		width: LINE_CHART_WIDTH,
 		height: LINE_CHART_HEIGHT,
 		scaleFactor: LINE_CHART_SCALE_FACTOR,

--- a/assets/js/modules/analytics-4/components/dashboard/DashboardAllTrafficWidgetGA4/getPDFData.test.ts
+++ b/assets/js/modules/analytics-4/components/dashboard/DashboardAllTrafficWidgetGA4/getPDFData.test.ts
@@ -134,6 +134,50 @@ describe( 'DashboardAllTrafficWidgetGA4 getPDFData', () => {
 	let registry: Registry;
 	let dataTable: { addColumn: jest.Mock; addRows: jest.Mock };
 
+	/**
+	 * Dispatches the reports the line chart reads, with empty breakdowns so the
+	 * line chart is the only chart that renders.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param  dailyUsers One user count per day, starting on 2025-01-08.
+	 * @return {void}
+	 */
+	function provideLineChartReports( dailyUsers: number[] ) {
+		registry
+			.dispatch( MODULES_ANALYTICS_4 )
+			.receiveGetReport(
+				{ totals: [ { metricValues: [ { value: '100' } ] } ] },
+				{ options: getTotalsReportArgs( DATES ) }
+			);
+		registry.dispatch( MODULES_ANALYTICS_4 ).receiveGetReport(
+			{
+				rows: dailyUsers.map( ( users, index ) => ( {
+					dimensionValues: [
+						{
+							value: `202501${ String( 8 + index ).padStart(
+								2,
+								'0'
+							) }`,
+						},
+					],
+					metricValues: [ { value: String( users ) } ],
+				} ) ),
+			},
+			{
+				options: getGraphReportArgs( {
+					startDate: DATES.startDate,
+					endDate: DATES.endDate,
+				} ),
+			}
+		);
+		[ channelsArgs, locationsArgs, devicesArgs ].forEach( ( options ) => {
+			registry
+				.dispatch( MODULES_ANALYTICS_4 )
+				.receiveGetReport( buildBreakdownReport( [] ), { options } );
+		} );
+	}
+
 	beforeEach( () => {
 		registry = createTestRegistry() as Registry;
 		provideSiteInfo( registry );
@@ -246,52 +290,7 @@ describe( 'DashboardAllTrafficWidgetGA4 getPDFData', () => {
 	} );
 
 	it( 'should load Google Charts and render the line chart with the expected DataTable and options', async () => {
-		const totalsReport = {
-			totals: [ { metricValues: [ { value: '100' } ] } ],
-		};
-		const graphReport = {
-			rows: [
-				{
-					dimensionValues: [ { value: '20250108' } ],
-					metricValues: [ { value: '10' } ],
-				},
-				{
-					dimensionValues: [ { value: '20250109' } ],
-					metricValues: [ { value: '20' } ],
-				},
-			],
-		};
-
-		registry
-			.dispatch( MODULES_ANALYTICS_4 )
-			.receiveGetReport( totalsReport, {
-				options: getTotalsReportArgs( DATES ),
-			} );
-		registry
-			.dispatch( MODULES_ANALYTICS_4 )
-			.receiveGetReport( graphReport, {
-				options: getGraphReportArgs( {
-					startDate: DATES.startDate,
-					endDate: DATES.endDate,
-				} ),
-			} );
-		// Empty breakdown reports leave the donuts unrendered, so the only
-		// rendered chart in this test is the line chart.
-		registry
-			.dispatch( MODULES_ANALYTICS_4 )
-			.receiveGetReport( buildBreakdownReport( [] ), {
-				options: channelsArgs,
-			} );
-		registry
-			.dispatch( MODULES_ANALYTICS_4 )
-			.receiveGetReport( buildBreakdownReport( [] ), {
-				options: locationsArgs,
-			} );
-		registry
-			.dispatch( MODULES_ANALYTICS_4 )
-			.receiveGetReport( buildBreakdownReport( [] ), {
-				options: devicesArgs,
-			} );
+		provideLineChartReports( [ 10, 20 ] );
 
 		const signal = new AbortController().signal;
 		const result = await getPDFData( { registry, dates: DATES, signal } );
@@ -330,12 +329,42 @@ describe( 'DashboardAllTrafficWidgetGA4 getPDFData', () => {
 				format: 'MMM d',
 				textStyle: { fontName: 'Google Sans Text' },
 			},
-			vAxis: { textStyle: { fontName: 'Google Sans Text' } },
+			// The series renders against axis 1, so that axis carries the
+			// styling and the shortened number format. Axis 0 draws nothing.
+			vAxes: {
+				0: { textPosition: 'none' },
+				1: {
+					format: 'short',
+					textStyle: { fontName: 'Google Sans Text' },
+				},
+			},
 			series: { 0: { color: '#3c7251', lineWidth: 4 } },
 		} );
 
 		expect( result.chartImages?.lineChart ).toBe( LINE_CHART_DATA_URI );
 	} );
+
+	it.each( [
+		[ 20, 21 ],
+		[ 5500, 38 ],
+	] )(
+		'should reserve the label width a peak of %p users needs',
+		async ( peakUsers, expectedGutter ) => {
+			provideLineChartReports( [ peakUsers / 2, peakUsers ] );
+
+			await getPDFData( {
+				registry,
+				dates: DATES,
+				signal: new AbortController().signal,
+			} );
+
+			// `5.5K` takes two characters more than `20`, so its labels need a
+			// wider column beside the plot.
+			expect(
+				mockRenderGoogleChartToDataURI.mock.calls[ 0 ][ 0 ].options
+			).toMatchObject( { chartArea: { right: expectedGutter } } );
+		}
+	);
 
 	it( 'should collapse a long breakdown to the top slices plus a single Others row', async () => {
 		const totalsReport = {

--- a/assets/js/modules/analytics-4/components/dashboard/DashboardAllTrafficWidgetGA4/getPDFData.ts
+++ b/assets/js/modules/analytics-4/components/dashboard/DashboardAllTrafficWidgetGA4/getPDFData.ts
@@ -24,6 +24,10 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
+import {
+	getValueAxisGutter,
+	pickDateTicks,
+} from '@/js/components/pdf-export/chart-axis';
 import ensureGoogleChartsLoaded from '@/js/components/pdf-export/ensure-google-charts-loaded';
 import {
 	PDF_COLORS,
@@ -56,6 +60,23 @@ import {
  */
 const LINE_CHART_WIDTH = 506;
 const LINE_CHART_HEIGHT = 133;
+
+/**
+ * The line chart renders at 2 times its display size, so the lines stay sharp
+ * when the PDF shrinks the image to fit.
+ *
+ * The renderer takes this factor, and the plot width below reads it too, so the
+ * chart and the label measurements count the same pixels.
+ */
+const LINE_CHART_SCALE_FACTOR = 2;
+
+/**
+ * The value a chart with no data caps its axis at.
+ *
+ * A flat zero line needs a range of its own, and `getValueAxisGutter` measures
+ * the labels against the same cap.
+ */
+const EMPTY_AXIS_MAX_VALUE = 100;
 
 /**
  * The size of the hole in the middle of each breakdown donut, from 0 to 1.
@@ -230,24 +251,32 @@ function buildLineChartDataTable( points: LineChartPoint[] ): object {
  * Builds Google Charts options matching the dashboard's All Visitors line chart.
  *
  * @since 1.182.0
+ * @since n.e.x.t Fitted the value and date labels to the space they have.
  *
  * @param points Parsed chart points.
  * @return Google Charts options object.
  */
 function getLineChartOptions( points: LineChartPoint[] ): object {
-	// A tick per day, dropping the first so a tick sits at the range start,
-	// matching the dashboard's `UserCountGraph`.
-	const [ , ...ticks ] = points.map( ( { date } ) => date );
-
-	const hasData = points.some( ( { value } ) => value > 0 );
+	const fontSize = 14;
+	const chartAreaLeft = 8;
+	const dates = points.map( ( { date } ) => date );
+	const maxValue = points.reduce(
+		( highest, { value } ) => Math.max( highest, value ),
+		0
+	);
+	const hasData = maxValue > 0;
+	const valueAxisGutter = getValueAxisGutter(
+		hasData ? maxValue : EMPTY_AXIS_MAX_VALUE,
+		fontSize
+	);
 
 	return {
 		curveType: 'function',
 		// Matches the dashboard's All Visitors line color.
 		colors: [ PDF_COLORS.SITE_KIT_SK_500 ],
 		chartArea: {
-			left: 8,
-			right: 40,
+			left: chartAreaLeft,
+			right: valueAxisGutter,
 			top: 16,
 			bottom: 28,
 		},
@@ -263,29 +292,50 @@ function getLineChartOptions( points: LineChartPoint[] ): object {
 			textStyle: {
 				color: PDF_COLORS.SURFACES_ON_SURFACE_VARIANT,
 				fontName: 'Google Sans Text',
-				fontSize: 14,
+				fontSize,
 			},
-			ticks,
+			ticks: pickDateTicks(
+				dates,
+				LINE_CHART_WIDTH * LINE_CHART_SCALE_FACTOR -
+					valueAxisGutter -
+					chartAreaLeft,
+				fontSize
+			),
 		},
-		vAxis: {
-			gridlines: {
-				color: PDF_COLORS.SURFACES_SURFACE_1,
+		vAxes: {
+			// The series renders against axis 1, so axis 0 draws nothing.
+			0: {
+				gridlines: {
+					color: 'transparent',
+				},
+				minorGridlines: {
+					color: 'transparent',
+				},
+				textPosition: 'none',
 			},
-			lineWidth: 3,
-			minorGridlines: {
-				color: PDF_COLORS.SURFACES_SURFACE,
-			},
-			minValue: 0,
-			textPosition: 'out',
-			textStyle: {
-				color: PDF_COLORS.SURFACES_ON_SURFACE_VARIANT,
-				fontName: 'Google Sans Text',
-				fontSize: 14,
-			},
-			viewWindow: {
-				min: 0,
-				// Cap the empty-data axis so a flat zero line still reads well.
-				...( hasData ? {} : { max: 100 } ),
+			1: {
+				// A large value shortens to a magnitude letter, so 58000 reads
+				// as `58K` and the label fits the width beside the plot.
+				format: 'short',
+				gridlines: {
+					color: PDF_COLORS.SURFACES_SURFACE_1,
+				},
+				lineWidth: 3,
+				minorGridlines: {
+					color: PDF_COLORS.SURFACES_SURFACE,
+				},
+				minValue: 0,
+				textPosition: 'out',
+				textStyle: {
+					color: PDF_COLORS.SURFACES_ON_SURFACE_VARIANT,
+					fontName: 'Google Sans Text',
+					fontSize,
+				},
+				viewWindow: {
+					min: 0,
+					// Cap the empty-data axis so a flat zero line still reads well.
+					...( hasData ? {} : { max: EMPTY_AXIS_MAX_VALUE } ),
+				},
 			},
 		},
 		series: {
@@ -529,6 +579,7 @@ export default async function getPDFData( {
 		options: getLineChartOptions( points ),
 		width: LINE_CHART_WIDTH,
 		height: LINE_CHART_HEIGHT,
+		scaleFactor: LINE_CHART_SCALE_FACTOR,
 		signal,
 	} );
 

--- a/assets/js/modules/search-console/components/dashboard/SearchFunnelWidgetGA4/getPDFData.test.ts
+++ b/assets/js/modules/search-console/components/dashboard/SearchFunnelWidgetGA4/getPDFData.test.ts
@@ -107,21 +107,23 @@ const visitorsArgs = getGA4VisitorsReportOptions( DATES );
  * Builds a 14-day Search Console report fixture.
  *
  * The 7 previous days (impressions 10, clicks 5) are followed by 7 current
- * days (impressions 20, clicks 10), so partitioning yields a clean +100%
- * change.
+ * days (impressions 20 by default, clicks 10). The default call gives a
+ * clean +100% change.
  *
  * @since 1.183.0
+ * @since n.e.x.t Added the current-period impressions argument.
  *
+ * @param [currentImpressions=20] Impressions on each of the 7 current days.
  * @return The report rows.
  */
-function buildSearchConsoleReport() {
+function buildSearchConsoleReport( currentImpressions = 20 ) {
 	return Array.from( { length: 14 }, ( _unused, index ) => {
 		const isCurrent = index >= 7;
 		const day = String( index + 1 ).padStart( 2, '0' );
 		return {
 			clicks: isCurrent ? 10 : 5,
 			ctr: 0.1,
-			impressions: isCurrent ? 20 : 10,
+			impressions: isCurrent ? currentImpressions : 10,
 			keys: [ `2025-01-${ day }` ],
 			position: 1,
 		};
@@ -162,14 +164,16 @@ function setGoogle( value: unknown ) {
  * resolves them without fetching.
  *
  * @since 1.183.0
+ * @since n.e.x.t Added the current-period impressions argument.
  *
- * @param  registry Test registry that receives the reports.
+ * @param  registry                Test registry that receives the reports.
+ * @param  [currentImpressions=20] Impressions on each of the 7 current days.
  * @return {void}
  */
-function provideReports( registry: Registry ) {
+function provideReports( registry: Registry, currentImpressions = 20 ) {
 	registry
 		.dispatch( MODULES_SEARCH_CONSOLE )
-		.receiveGetReport( buildSearchConsoleReport(), {
+		.receiveGetReport( buildSearchConsoleReport( currentImpressions ), {
 			options: searchConsoleArgs,
 		} );
 	registry
@@ -277,7 +281,15 @@ describe( 'SearchFunnelWidgetGA4 getPDFData', () => {
 				hAxis: {
 					textStyle: { fontName: 'Google Sans Text' },
 				},
-				vAxis: { textStyle: { fontName: 'Google Sans Text' } },
+				// Both series render against axis 1, so that axis carries the
+				// styling and the shortened number format. Axis 0 draws nothing.
+				vAxes: {
+					0: { textPosition: 'none' },
+					1: {
+						format: 'short',
+						textStyle: { fontName: 'Google Sans Text' },
+					},
+				},
 				series: {
 					0: { color, lineWidth: 8 },
 					1: { color, lineWidth: 8, lineDashStyle: [ 4, 20 ] },
@@ -285,6 +297,28 @@ describe( 'SearchFunnelWidgetGA4 getPDFData', () => {
 			} );
 		} );
 	} );
+
+	it.each( [
+		[ 20, 42 ],
+		[ 58000, 59 ],
+	] )(
+		'should reserve the label width a peak of %p impressions needs',
+		async ( currentImpressions, expectedGutter ) => {
+			provideReports( registry, currentImpressions );
+
+			await getPDFData( {
+				registry,
+				dates: DATES,
+				signal: new AbortController().signal,
+			} );
+
+			// Impressions render first. `58K` takes one character more than
+			// `20`, so its labels need a wider column beside the plot.
+			expect(
+				mockRenderGoogleChartToDataURI.mock.calls[ 0 ][ 0 ].options
+			).toMatchObject( { chartArea: { right: expectedGutter } } );
+		}
+	);
 
 	it( 'should isolate a single failing metric to its own card without aborting the others', async () => {
 		// Pre-populate every report except Unique Visitors, which fails to fetch.

--- a/assets/js/modules/search-console/components/dashboard/SearchFunnelWidgetGA4/getPDFData.ts
+++ b/assets/js/modules/search-console/components/dashboard/SearchFunnelWidgetGA4/getPDFData.ts
@@ -30,6 +30,10 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
+import {
+	getValueAxisGutter,
+	pickDateTicks,
+} from '@/js/components/pdf-export/chart-axis';
 import ensureGoogleChartsLoaded from '@/js/components/pdf-export/ensure-google-charts-loaded';
 import { PDF_COLORS } from '@/js/components/pdf-export/pdf-theme';
 import renderGoogleChartToDataURI, {
@@ -80,6 +84,14 @@ const LINE_CHART_SCALE_FACTOR = 4;
  * chart's proportions at the larger render size.
  */
 const LINE_CHART_OPTION_SCALE = LINE_CHART_SCALE_FACTOR / 2;
+
+/**
+ * The value a chart with no data caps its axis at.
+ *
+ * A flat zero line needs a range of its own, and `getValueAxisGutter` measures
+ * the labels against the same cap.
+ */
+const EMPTY_AXIS_MAX_VALUE = 1;
 
 type Registry = WPDataRegistry & {
 	// `resolveSelect` exists on the runtime registry but is absent from the
@@ -204,28 +216,37 @@ interface MetricCardResult {
  * dotted line of the same color, mirroring the dashboard.
  *
  * @since 1.183.0
+ * @since n.e.x.t Fitted the value and date labels to the space they have.
  *
- * @param options         Options.
- * @param options.color   Series color for both lines.
- * @param options.ticks   Date ticks for the horizontal axis.
- * @param options.hasData Whether any data point is greater than zero.
+ * @param options          Options.
+ * @param options.color    Series color for both lines.
+ * @param options.dates    Every day in the range, in order.
+ * @param options.maxValue The highest value either line reaches.
  * @return Google Charts options object.
  */
 function getLineChartOptions( {
 	color,
-	ticks,
-	hasData,
+	dates,
+	maxValue,
 }: {
 	color: string;
-	ticks: Date[];
-	hasData: boolean;
+	dates: Date[];
+	maxValue: number;
 } ): object {
+	const fontSize = 14 * LINE_CHART_OPTION_SCALE;
+	const chartAreaLeft = 8 * LINE_CHART_OPTION_SCALE;
+	const hasData = maxValue > 0;
+	const valueAxisGutter = getValueAxisGutter(
+		hasData ? maxValue : EMPTY_AXIS_MAX_VALUE,
+		fontSize
+	);
+
 	return {
 		curveType: 'function',
 		colors: [ color ],
 		chartArea: {
-			left: 8 * LINE_CHART_OPTION_SCALE,
-			right: 40 * LINE_CHART_OPTION_SCALE,
+			left: chartAreaLeft,
+			right: valueAxisGutter,
 			top: 12 * LINE_CHART_OPTION_SCALE,
 			bottom: 22 * LINE_CHART_OPTION_SCALE,
 		},
@@ -240,26 +261,47 @@ function getLineChartOptions( {
 			textStyle: {
 				color: PDF_COLORS.SURFACES_ON_SURFACE_VARIANT,
 				fontName: 'Google Sans Text',
-				fontSize: 14 * LINE_CHART_OPTION_SCALE,
+				fontSize,
 			},
-			ticks,
+			ticks: pickDateTicks(
+				dates,
+				LINE_CHART_WIDTH * LINE_CHART_SCALE_FACTOR -
+					valueAxisGutter -
+					chartAreaLeft,
+				fontSize
+			),
 		},
-		vAxis: {
-			gridlines: {
-				color: PDF_COLORS.SURFACES_SURFACE_1,
+		vAxes: {
+			// The series render against axis 1, so axis 0 draws nothing.
+			0: {
+				gridlines: {
+					color: 'transparent',
+				},
+				minorGridlines: {
+					color: 'transparent',
+				},
+				textPosition: 'none',
 			},
-			minorGridlines: {
-				color: PDF_COLORS.SURFACES_SURFACE,
-			},
-			textStyle: {
-				color: PDF_COLORS.SURFACES_ON_SURFACE_VARIANT,
-				fontName: 'Google Sans Text',
-				fontSize: 14 * LINE_CHART_OPTION_SCALE,
-			},
-			viewWindow: {
-				min: 0,
-				// Cap the empty-data axis so a flat zero line still reads well.
-				...( hasData ? {} : { max: 1 } ),
+			1: {
+				// A large value shortens to a magnitude letter, so 58000 reads
+				// as `58K` and the label fits the width beside the plot.
+				format: 'short',
+				gridlines: {
+					color: PDF_COLORS.SURFACES_SURFACE_1,
+				},
+				minorGridlines: {
+					color: PDF_COLORS.SURFACES_SURFACE,
+				},
+				textStyle: {
+					color: PDF_COLORS.SURFACES_ON_SURFACE_VARIANT,
+					fontName: 'Google Sans Text',
+					fontSize,
+				},
+				viewWindow: {
+					min: 0,
+					// Cap the empty-data axis so a flat zero line still reads well.
+					...( hasData ? {} : { max: EMPTY_AXIS_MAX_VALUE } ),
+				},
 			},
 		},
 		series: {
@@ -345,18 +387,23 @@ function renderMetricChart( {
 	color: string;
 	signal: AbortSignal;
 } ): Promise< string > {
-	// A tick per day, dropping the first so a tick sits at the range start,
-	// matching the dashboard's Search Funnel charts. The leading column is always
-	// the day `Date`.
-	const [ , ...ticks ] = dataRows.map( ( row ) => row[ 0 ] as Date );
-	const hasData = dataRows.some(
-		( row ) => Number( row[ 2 ] ) > 0 || Number( row[ 3 ] ) > 0
+	// The leading column is always the day `Date`, and the current and previous
+	// values follow it.
+	const dates = dataRows.map( ( row ) => row[ 0 ] as Date );
+	const maxValue = dataRows.reduce(
+		( highest, row ) =>
+			Math.max(
+				highest,
+				Number( row[ 2 ] ) || 0,
+				Number( row[ 3 ] ) || 0
+			),
+		0
 	);
 
 	return renderGoogleChartToDataURI( {
 		chartType: 'LineChart',
 		dataTable: buildChartDataTable( dataRows, currentLabel ),
-		options: getLineChartOptions( { color, ticks, hasData } ),
+		options: getLineChartOptions( { color, dates, maxValue } ),
 		width: LINE_CHART_WIDTH,
 		height: LINE_CHART_HEIGHT,
 		scaleFactor: LINE_CHART_SCALE_FACTOR,


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Related issue(s):

- Resolves #13218

## Relevant technical choices

<!-- Please describe your changes. -->

## PR Author Checklist

- [ ] My code is tested and passes existing unit tests.
- [ ] My code has an appropriate set of unit tests which all pass.
- [ ] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [ ] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [ ] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [ ] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.
- [ ] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
