### PR TITLE
Anchored overlay notifications are mispositioned when resizing across a breakpoint

### DIFF
--- a/assets/js/components/pdf-export/PDFDownloadButton.tsx
+++ b/assets/js/components/pdf-export/PDFDownloadButton.tsx
@@ -32,7 +32,10 @@ import { __ } from '@wordpress/i18n';
  */
 import { Button } from 'googlesitekit-components';
 import { Select, useDispatch, useSelect } from 'googlesitekit-data';
-import { PDF_DOWNLOAD_PANEL_OPENED_KEY } from '@/js/components/pdf-export/constants';
+import {
+	PDF_DOWNLOAD_BUTTON_CLASS,
+	PDF_DOWNLOAD_PANEL_OPENED_KEY,
+} from '@/js/components/pdf-export/constants';
 import { CORE_UI } from '@/js/googlesitekit/datastore/ui/constants';
 import useViewContext from '@/js/hooks/useViewContext';
 import { trackEvent } from '@/js/util';
@@ -62,7 +65,7 @@ const PDFDownloadButton: FC = () => {
 		<Button
 			aria-label={ __( 'Download PDF report', 'google-site-kit' ) }
 			// @ts-expect-error - The `Button` component is not typed yet.
-			className="googlesitekit-pdf-download__button googlesitekit-header__dropdown googlesitekit-border-radius-round googlesitekit-button-icon"
+			className={ `${ PDF_DOWNLOAD_BUTTON_CLASS } googlesitekit-header__dropdown googlesitekit-border-radius-round googlesitekit-button-icon` }
 			onClick={ togglePanel }
 			icon={ <DownloadIcon width={ 20 } height={ 20 } /> }
 			tooltipEnterDelayInMS={ 500 }

--- a/assets/js/components/pdf-export/PDFIntroductionOverlayNotification.test.tsx
+++ b/assets/js/components/pdf-export/PDFIntroductionOverlayNotification.test.tsx
@@ -24,6 +24,7 @@ import { waitFor } from '@testing-library/react';
 /**
  * Internal dependencies
  */
+import { FEATURES_MENU_BUTTON_CLASS } from '@/js/components/FeaturesMenu/constants';
 import Notifications from '@/js/components/notifications/Notifications';
 import {
 	PDF_DOWNLOAD_PANEL_OPENED_KEY,
@@ -174,5 +175,26 @@ describe( 'PDFIntroductionOverlayNotification', () => {
 		await waitForRegistry();
 
 		expect( queryByText( 'Export to PDF' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'anchors to the features menu button when the PDF download button is not rendered', async () => {
+		mockSurveyEndpoints();
+
+		const featuresMenuButton = document.createElement( 'button' );
+		featuresMenuButton.className = FEATURES_MENU_BUTTON_CLASS;
+		document.body.appendChild( featuresMenuButton );
+
+		const { container, waitForRegistry } = renderNotifications();
+
+		await waitForRegistry();
+
+		expect(
+			container.querySelector( '.googlesitekit-popper-root' )
+		).toBeInTheDocument();
+		expect(
+			container.querySelector( '.googlesitekit-overlay-card--anchored' )
+		).toBeInTheDocument();
+
+		featuresMenuButton.remove();
 	} );
 } );

--- a/assets/js/components/pdf-export/PDFIntroductionOverlayNotification.tsx
+++ b/assets/js/components/pdf-export/PDFIntroductionOverlayNotification.tsx
@@ -31,7 +31,11 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { useDispatch } from 'googlesitekit-data';
-import { PDF_DOWNLOAD_PANEL_OPENED_KEY } from '@/js/components/pdf-export/constants';
+import { FEATURES_MENU_BUTTON_CLASS } from '@/js/components/FeaturesMenu/constants';
+import {
+	PDF_DOWNLOAD_BUTTON_CLASS,
+	PDF_DOWNLOAD_PANEL_OPENED_KEY,
+} from '@/js/components/pdf-export/constants';
 import { CORE_UI } from '@/js/googlesitekit/datastore/ui/constants';
 import OverlayNotification from '@/js/googlesitekit/notifications/components/layout/OverlayNotification';
 import PDFExportOverlayGraphic from '@/svg/graphics/pdf-export-overlay.svg';
@@ -55,7 +59,10 @@ const PDFIntroductionOverlayNotification: FC<
 			<OverlayNotification
 				notificationID={ id }
 				className="googlesitekit-pdf-introduction-overlay"
-				anchorID=".googlesitekit-pdf-download__button"
+				// On mobile and tablet the PDF download button collapses into
+				// the features menu, so the overlay anchors to whichever
+				// trigger exists.
+				anchorID={ `.${ PDF_DOWNLOAD_BUTTON_CLASS }, .${ FEATURES_MENU_BUTTON_CLASS }` }
 				title={ __( 'Export to PDF', 'google-site-kit' ) }
 				description={ __(
 					'You can now create a custom report featuring current metrics from your dashboard',

--- a/assets/js/components/pdf-export/constants.ts
+++ b/assets/js/components/pdf-export/constants.ts
@@ -30,6 +30,16 @@ import {
 
 export const PDF_DOWNLOAD_PANEL_OPENED_KEY = 'pdfDownloadPanelOpened';
 
+/**
+ * Class name on the header button that opens the PDF download panel.
+ *
+ * The introduction overlay anchors to this button, so the class is shared
+ * rather than repeated as a selector string.
+ *
+ * @since n.e.x.t
+ */
+export const PDF_DOWNLOAD_BUTTON_CLASS = 'googlesitekit-pdf-download__button';
+
 export const PDF_INTRODUCTION_OVERLAY_NOTIFICATION =
 	'pdf_introduction_overlay_notification';
 

--- a/assets/js/googlesitekit/notifications/components/layout/OverlayNotification.test.tsx
+++ b/assets/js/googlesitekit/notifications/components/layout/OverlayNotification.test.tsx
@@ -23,6 +23,7 @@ import { VIEW_CONTEXT_MAIN_DASHBOARD } from '@/js/googlesitekit/constants';
 import {
 	BREAKPOINT_DESKTOP,
 	BREAKPOINT_SMALL,
+	BREAKPOINT_TABLET,
 	useBreakpoint,
 } from '@/js/hooks/useBreakpoint';
 import { createTestRegistry, render } from '@tests/js/test-utils';
@@ -124,5 +125,105 @@ describe( 'OverlayNotification', () => {
 		expect(
 			container.querySelector( '.googlesitekit-overlay-card--anchored' )
 		).not.toBeInTheDocument();
+	} );
+
+	it( 'renders the centered card once the breakpoint changes and the anchor element is removed', () => {
+		const { container, rerender } = renderOverlayNotification( {
+			anchorID: '.test-anchor',
+		} );
+
+		expect(
+			container.querySelector( '.googlesitekit-overlay-card--anchored' )
+		).toBeInTheDocument();
+
+		anchor.remove();
+		( useBreakpoint as jest.Mock ).mockReturnValue( BREAKPOINT_TABLET );
+
+		rerender(
+			<OverlayNotification
+				notificationID="test-notification"
+				title="Test title"
+				anchorID=".test-anchor"
+			/>
+		);
+
+		expect(
+			container.querySelector( '.googlesitekit-popper-root' )
+		).not.toBeInTheDocument();
+		expect(
+			container.querySelector( '.googlesitekit-overlay-card--anchored' )
+		).not.toBeInTheDocument();
+	} );
+
+	it( 're-anchors to the element when the breakpoint widens and the anchor is present again', () => {
+		anchor.remove();
+		( useBreakpoint as jest.Mock ).mockReturnValue( BREAKPOINT_TABLET );
+
+		const { container, rerender } = renderOverlayNotification( {
+			anchorID: '.test-anchor',
+		} );
+
+		expect(
+			container.querySelector( '.googlesitekit-overlay-card--anchored' )
+		).not.toBeInTheDocument();
+
+		document.body.appendChild( anchor );
+		( useBreakpoint as jest.Mock ).mockReturnValue( BREAKPOINT_DESKTOP );
+
+		rerender(
+			<OverlayNotification
+				notificationID="test-notification"
+				title="Test title"
+				anchorID=".test-anchor"
+			/>
+		);
+
+		expect(
+			container.querySelector( '.googlesitekit-popper-root' )
+		).toBeInTheDocument();
+		expect(
+			container.querySelector( '.googlesitekit-overlay-card--anchored' )
+		).toBeInTheDocument();
+	} );
+
+	it( 'renders the centered card across breakpoint changes when no anchorID is given', () => {
+		const { container, rerender } = renderOverlayNotification();
+
+		( useBreakpoint as jest.Mock ).mockReturnValue( BREAKPOINT_TABLET );
+
+		rerender(
+			<OverlayNotification
+				notificationID="test-notification"
+				title="Test title"
+			/>
+		);
+
+		expect(
+			container.querySelector( '.googlesitekit-popper-root' )
+		).not.toBeInTheDocument();
+		expect(
+			container.querySelector( '.googlesitekit-overlay-card--anchored' )
+		).not.toBeInTheDocument();
+	} );
+
+	it( 'anchors to the fallback selector when the first candidate is absent', () => {
+		anchor.remove();
+
+		const fallback = document.createElement( 'button' );
+		fallback.className = 'test-fallback-anchor';
+		document.body.appendChild( fallback );
+
+		const { container } = renderOverlayNotification( {
+			anchorID: '.test-anchor, .test-fallback-anchor',
+		} );
+
+		expect(
+			container.querySelector( '.googlesitekit-popper-root' )
+		).toBeInTheDocument();
+		expect(
+			container.querySelector( '.googlesitekit-overlay-card--anchored' )
+		).toBeInTheDocument();
+
+		fallback.remove();
 	} );
 } );

--- a/assets/js/googlesitekit/notifications/components/layout/OverlayNotification.tsx
+++ b/assets/js/googlesitekit/notifications/components/layout/OverlayNotification.tsx
@@ -69,6 +69,11 @@ interface OverlayNotificationProps {
 	GraphicMobile?: ComponentType;
 	newBadge?: boolean;
 	className?: string;
+	/**
+	 * Selector for the element to anchor to. Accepts a selector list, so an
+	 * overlay whose trigger collapses into another control at narrower
+	 * breakpoints can name each candidate and anchor to whichever exists.
+	 */
 	anchorID?: string;
 	gaTrackingEventArgs?: GATrackingEventArgs & {
 		confirmAction?: string;
@@ -107,7 +112,7 @@ const OverlayNotification: FC< OverlayNotificationProps > = ( {
 			// eslint-disable-next-line sitekit/acronym-case
 			anchorID ? document.querySelector< HTMLElement >( anchorID ) : null
 		);
-	}, [ anchorID ] );
+	}, [ anchorID, breakpoint ] );
 
 	const isAnchored =
 		Boolean( anchorElement ) && breakpoint !== BREAKPOINT_SMALL;


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Related issue(s):

- Resolves #13369

## Relevant technical choices

Deviates from the AC/IB on one point. The IB fixed the mispositioning by letting the overlay fall
back to a centered card once its anchor icon unmounts. Instead the overlay now follows its feature
into the three dots features menu, so the caret keeps pointing at the control it is introducing.
The affected AC bullet is struck through on the issue.

`anchorID` is passed a CSS selector list rather than gaining a new prop, matching the existing
precedent for the email reports setup tooltip, which anchors to
`.${ MANAGE_EMAIL_REPORTS_BUTTON_CLASS }, .${ FEATURES_MENU_BUTTON_CLASS }` for the same reason.
`document.querySelector` accepts a selector list, so no change to `OverlayNotification` was needed
beyond documenting the prop. Note this resolves in document order, which is safe here because the
feature icon and the features menu button are mutually exclusive.

The IB's one line change is still included and still required: without `breakpoint` in the effect
deps the anchor is never re-resolved on a live resize, so the overlay keeps the detached icon
rather than picking up the features menu.

`PDF_DOWNLOAD_BUTTON_CLASS` is now a shared constant, matching `MANAGE_EMAIL_REPORTS_BUTTON_CLASS`
and `FEATURES_MENU_BUTTON_CLASS`, rather than a literal repeated in the button and the overlay.

Only the PDF export overlay is covered. The email reports setup overlay gains its anchor in #13086,
which is not yet merged.

Mobile is unchanged and still renders the centered card, via the existing `BREAKPOINT_SMALL` guard.

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [ ] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.
- [ ] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.

