### PR TITLE
Remove the "temporary" ExceptionNotEscaped PHPCS exclusion

### DIFF
--- a/includes/Core/Authentication/Clients/Google_Site_Kit_Client.php
+++ b/includes/Core/Authentication/Clients/Google_Site_Kit_Client.php
@@ -285,7 +285,7 @@ class Google_Site_Kit_Client extends Google_Client {
 	 * @throws Google_OAuth_Exception Thrown with the given $error as message.
 	 */
 	protected function handleAuthTokenErrorResponse( $error, array $data ) {
-		throw new Google_OAuth_Exception( $error );
+		throw new Google_OAuth_Exception( $error ); // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Returned to the browser as JSON via WP_Error, escaping would show HTML entities to the user.
 	}
 
 	/**

--- a/includes/Core/Authentication/Clients/Google_Site_Kit_Proxy_Client.php
+++ b/includes/Core/Authentication/Clients/Google_Site_Kit_Proxy_Client.php
@@ -141,7 +141,7 @@ class Google_Site_Kit_Proxy_Client extends Google_Site_Kit_Client {
 	 */
 	protected function handleAuthTokenErrorResponse( $error, array $data ) {
 		if ( ! empty( $data['code'] ) ) {
-			throw new Google_Proxy_Code_Exception( $error, 0, $data['code'] );
+			throw new Google_Proxy_Code_Exception( $error, 0, $data['code'] ); // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Returned to the browser as JSON via WP_Error, escaping would show HTML entities to the user.
 		}
 		parent::handleAuthTokenErrorResponse( $error, $data );
 	}

--- a/includes/Core/Authentication/Google_Proxy.php
+++ b/includes/Core/Authentication/Google_Proxy.php
@@ -134,10 +134,10 @@ class Google_Proxy {
 	 */
 	public function setup_url( array $query_params = array() ) {
 		if ( empty( $query_params['code'] ) ) {
-			throw new Exception( __( 'Missing code parameter for setup URL.', 'google-site-kit' ) );
+			throw new Exception( __( 'Missing code parameter for setup URL.', 'google-site-kit' ) ); // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Returned to the browser as JSON via WP_Error, escaping would show HTML entities to the user.
 		}
 		if ( empty( $query_params['site_id'] ) && empty( $query_params['site_code'] ) ) {
-			throw new Exception( __( 'Missing site_id or site_code parameter for setup URL.', 'google-site-kit' ) );
+			throw new Exception( __( 'Missing site_id or site_code parameter for setup URL.', 'google-site-kit' ) ); // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Returned to the browser as JSON via WP_Error, escaping would show HTML entities to the user.
 		}
 
 		if ( Feature_Flags::enabled( 'setupFlowRefreshPhase4' ) ) {

--- a/includes/Core/Authentication/Setup.php
+++ b/includes/Core/Authentication/Setup.php
@@ -382,7 +382,7 @@ class Setup {
 
 			$this->user_options->set( OAuth_Client::OPTION_ERROR_CODE, $error_code );
 
-			throw new Exchange_Site_Code_Exception( $error_code );
+			throw new Exchange_Site_Code_Exception( $error_code ); // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Returned to the browser as JSON via WP_Error, escaping would show HTML entities to the user.
 		}
 
 		$this->credentials->set(

--- a/includes/Core/Conversion_Tracking/Conversion_Tracking.php
+++ b/includes/Core/Conversion_Tracking/Conversion_Tracking.php
@@ -226,8 +226,7 @@ class Conversion_Tracking implements Provides_Feature_Metrics {
 			if ( ! is_string( $provider_class ) || ! $provider_class ) {
 				throw new LogicException(
 					sprintf(
-						/* translators: %s: provider slug */
-						esc_html__( 'A conversion event provider class name is required to instantiate a provider: %s', 'google-site-kit' ),
+						'A conversion event provider class name is required to instantiate a provider: %s',
 						esc_html( $provider_slug )
 					)
 				);
@@ -236,8 +235,7 @@ class Conversion_Tracking implements Provides_Feature_Metrics {
 			if ( ! class_exists( $provider_class ) ) {
 				throw new LogicException(
 					sprintf(
-						/* translators: %s: provider classname */
-						esc_html__( 'The %s class does not exist', 'google-site-kit' ),
+						"The '%s' class does not exist",
 						esc_html( $provider_class )
 					)
 				);
@@ -246,8 +244,7 @@ class Conversion_Tracking implements Provides_Feature_Metrics {
 			if ( ! is_subclass_of( $provider_class, Conversion_Events_Provider::class ) ) {
 				throw new LogicException(
 					sprintf(
-						/* translators: 1: provider classname 2: Conversion_Events_Provider classname */
-						esc_html__( 'The %1$s class must extend the base conversion event provider class: %2$s', 'google-site-kit' ),
+						"The '%1\$s' class must extend the base conversion event provider class: %2\$s",
 						esc_html( $provider_class ),
 						Conversion_Events_Provider::class
 					)

--- a/includes/Core/Conversion_Tracking/Conversion_Tracking.php
+++ b/includes/Core/Conversion_Tracking/Conversion_Tracking.php
@@ -227,8 +227,8 @@ class Conversion_Tracking implements Provides_Feature_Metrics {
 				throw new LogicException(
 					sprintf(
 						/* translators: %s: provider slug */
-						__( 'A conversion event provider class name is required to instantiate a provider: %s', 'google-site-kit' ),
-						$provider_slug
+						esc_html__( 'A conversion event provider class name is required to instantiate a provider: %s', 'google-site-kit' ),
+						esc_html( $provider_slug )
 					)
 				);
 			}
@@ -237,8 +237,8 @@ class Conversion_Tracking implements Provides_Feature_Metrics {
 				throw new LogicException(
 					sprintf(
 						/* translators: %s: provider classname */
-						__( "The '%s' class does not exist", 'google-site-kit' ),
-						$provider_class
+						esc_html__( 'The %s class does not exist', 'google-site-kit' ),
+						esc_html( $provider_class )
 					)
 				);
 			}
@@ -247,8 +247,8 @@ class Conversion_Tracking implements Provides_Feature_Metrics {
 				throw new LogicException(
 					sprintf(
 						/* translators: 1: provider classname 2: Conversion_Events_Provider classname */
-						__( "The '%1\$s' class must extend the base conversion event provider class: %2\$s", 'google-site-kit' ),
-						$provider_class,
+						esc_html__( 'The %1$s class must extend the base conversion event provider class: %2$s', 'google-site-kit' ),
+						esc_html( $provider_class ),
 						Conversion_Events_Provider::class
 					)
 				);

--- a/includes/Core/Email_Reporting/Email_Notices.php
+++ b/includes/Core/Email_Reporting/Email_Notices.php
@@ -121,7 +121,7 @@ class Email_Notices {
 		$notice_id = sanitize_key( $notice->get_id() );
 
 		if ( isset( $this->notices[ $notice_id ] ) ) {
-			throw new InvalidArgumentException( sprintf( 'A notice is already registered for ID "%s".', $notice_id ) );
+			throw new InvalidArgumentException( sprintf( 'A notice is already registered for ID "%s".', esc_html( $notice_id ) ) );
 		}
 
 		$this->notices[ $notice_id ] = $notice;

--- a/includes/Core/Email_Reporting/Frequency_Planner.php
+++ b/includes/Core/Email_Reporting/Frequency_Planner.php
@@ -56,7 +56,7 @@ class Frequency_Planner {
 				return $this->get_next_quarterly_occurrence( $timestamp, $time_zone );
 		}
 
-		throw new InvalidArgumentException( sprintf( 'Unsupported frequency "%s".', $frequency ) );
+		throw new InvalidArgumentException( sprintf( 'Unsupported frequency "%s".', esc_html( $frequency ) ) );
 	}
 
 	/**

--- a/includes/Core/Email_Reporting/Initiator_Task.php
+++ b/includes/Core/Email_Reporting/Initiator_Task.php
@@ -132,7 +132,7 @@ class Initiator_Task {
 
 			default:
 				throw new InvalidArgumentException(
-					sprintf( 'Unsupported frequency "%s".', $frequency )
+					sprintf( 'Unsupported frequency "%s".', esc_html( $frequency ) )
 				);
 		}
 	}

--- a/includes/Core/Email_Reporting/Report_Options/Report_Options.php
+++ b/includes/Core/Email_Reporting/Report_Options/Report_Options.php
@@ -128,7 +128,7 @@ abstract class Report_Options {
 	private function normalize_range( $range, $label ) {
 		if ( empty( $range['startDate'] ) || empty( $range['endDate'] ) ) {
 			throw new \InvalidArgumentException(
-				sprintf( 'Email reporting %s must include startDate and endDate.', $label )
+				sprintf( 'Email reporting %s must include startDate and endDate.', esc_html( $label ) )
 			);
 		}
 

--- a/includes/Core/Golinks/Golinks.php
+++ b/includes/Core/Golinks/Golinks.php
@@ -80,7 +80,7 @@ class Golinks {
 		$key = sanitize_key( $key );
 
 		if ( isset( $this->handlers[ $key ] ) ) {
-			throw new InvalidArgumentException( sprintf( 'A handler is already registered for golink key "%s".', $key ) );
+			throw new InvalidArgumentException( sprintf( 'A handler is already registered for golink key "%s".', esc_html( $key ) ) );
 		}
 
 		$this->handlers[ $key ] = $handler;

--- a/includes/Core/HTTP/Middleware.php
+++ b/includes/Core/HTTP/Middleware.php
@@ -35,8 +35,8 @@ class Middleware {
 				$wp_http = new WP_Http();
 				if ( $wp_http->block_request( $uri ) ) {
 					throw new RequestException(
-						__( 'User has blocked requests through HTTP.', 'default' ),
-						$request
+						__( 'User has blocked requests through HTTP.', 'default' ), // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Guzzle exception message, never output.
+						$request // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- RequestException takes the request object as its second argument, not output.
 					);
 				}
 

--- a/includes/Core/Modules/Module.php
+++ b/includes/Core/Modules/Module.php
@@ -437,7 +437,7 @@ abstract class Module {
 		if ( $required_scopes && ! $oauth_client->has_sufficient_scopes( $required_scopes ) ) {
 			$message = $datapoint->get_request_scopes_message();
 
-			throw new Insufficient_Scopes_Exception( $message, 0, null, $required_scopes );
+			throw new Insufficient_Scopes_Exception( $message, 0, null, $required_scopes ); // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Returned to the browser as JSON via WP_Error, escaping would show HTML entities to the user.
 		}
 	}
 
@@ -459,7 +459,7 @@ abstract class Module {
 				__( 'Site Kit can’t access the relevant data from %s because you haven’t granted all permissions requested during setup.', 'google-site-kit' ),
 				$this->name
 			);
-			throw new Insufficient_Scopes_Exception( $message, 0, null, $this->get_scopes() );
+			throw new Insufficient_Scopes_Exception( $message, 0, null, $this->get_scopes() ); // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Returned to the browser as JSON via WP_Error, escaping would show HTML entities to the user.
 		}
 	}
 
@@ -504,7 +504,7 @@ abstract class Module {
 		if ( null === $this->google_client ) {
 			$client = $this->setup_client();
 			if ( ! $client instanceof Google_Site_Kit_Client ) {
-				throw new Exception( __( 'Google client not set up correctly.', 'google-site-kit' ) );
+				throw new Exception( __( 'Google client not set up correctly.', 'google-site-kit' ) ); // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Returned to the browser as JSON via WP_Error, escaping would show HTML entities to the user.
 			}
 			$this->google_client = $client;
 		}
@@ -558,11 +558,11 @@ abstract class Module {
 		if ( null === $this->google_services ) {
 			$services = $this->setup_services( $this->get_client() );
 			if ( ! is_array( $services ) ) {
-				throw new Exception( __( 'Google services not set up correctly.', 'google-site-kit' ) );
+				throw new Exception( __( 'Google services not set up correctly.', 'google-site-kit' ) ); // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Returned to the browser as JSON via WP_Error, escaping would show HTML entities to the user.
 			}
 			foreach ( $services as $service ) {
 				if ( ! $service instanceof Google_Service ) {
-					throw new Exception( __( 'Google services not set up correctly.', 'google-site-kit' ) );
+					throw new Exception( __( 'Google services not set up correctly.', 'google-site-kit' ) ); // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Returned to the browser as JSON via WP_Error, escaping would show HTML entities to the user.
 				}
 			}
 			$this->google_services = $services;
@@ -570,7 +570,7 @@ abstract class Module {
 
 		if ( ! isset( $this->google_services[ $identifier ] ) ) {
 			/* translators: %s: service identifier */
-			throw new Exception( sprintf( __( 'Google service identified by %s does not exist.', 'google-site-kit' ), $identifier ) );
+			throw new Exception( sprintf( __( 'Google service identified by %s does not exist.', 'google-site-kit' ), $identifier ) ); // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Returned to the browser as JSON via WP_Error, escaping would show HTML entities to the user.
 		}
 
 		return $this->google_services[ $identifier ];

--- a/includes/Core/Modules/Module_Registry.php
+++ b/includes/Core/Modules/Module_Registry.php
@@ -42,7 +42,7 @@ class Module_Registry {
 		}
 
 		if ( ! class_exists( $module_classname ) ) {
-			throw new InvalidArgumentException( "No class exists for '$module_classname'" );
+			throw new InvalidArgumentException( sprintf( "No class exists for '%s'", esc_html( $module_classname ) ) );
 		}
 
 		if ( ! is_subclass_of( $module_classname, Module::class ) ) {

--- a/includes/Core/Modules/Modules.php
+++ b/includes/Core/Modules/Modules.php
@@ -569,7 +569,7 @@ final class Modules implements Provides_Feature_Metrics {
 
 		if ( ! isset( $modules[ $slug ] ) ) {
 			/* translators: %s: module slug */
-			throw new Exception( sprintf( __( 'Invalid module slug %s.', 'google-site-kit' ), $slug ) );
+			throw new Exception( sprintf( __( 'Invalid module slug %s.', 'google-site-kit' ), $slug ) ); // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Returned to the browser as JSON via WP_Error, escaping would show HTML entities to the user.
 		}
 
 		return $modules[ $slug ];
@@ -607,7 +607,7 @@ final class Modules implements Provides_Feature_Metrics {
 
 		if ( ! isset( $modules[ $slug ] ) ) {
 			/* translators: %s: module slug */
-			throw new Exception( sprintf( __( 'Invalid module slug %s.', 'google-site-kit' ), $slug ) );
+			throw new Exception( sprintf( __( 'Invalid module slug %s.', 'google-site-kit' ), $slug ) ); // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Returned to the browser as JSON via WP_Error, escaping would show HTML entities to the user.
 		}
 
 		return $this->dependencies[ $slug ];
@@ -628,7 +628,7 @@ final class Modules implements Provides_Feature_Metrics {
 
 		if ( ! isset( $modules[ $slug ] ) ) {
 			/* translators: %s: module slug */
-			throw new Exception( sprintf( __( 'Invalid module slug %s.', 'google-site-kit' ), $slug ) );
+			throw new Exception( sprintf( __( 'Invalid module slug %s.', 'google-site-kit' ), $slug ) ); // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Returned to the browser as JSON via WP_Error, escaping would show HTML entities to the user.
 		}
 
 		return $this->dependants[ $slug ];

--- a/includes/Core/Notifications/Notifications.php
+++ b/includes/Core/Notifications/Notifications.php
@@ -233,11 +233,11 @@ class Notifications {
 		$decoded = json_decode( $body, true );
 
 		if ( json_last_error() ) {
-			throw new Exception( 'Error while decoding response: ' . json_last_error() );
+			throw new Exception( 'Error while decoding response: ' . json_last_error() ); // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Returned to the browser as JSON via WP_Error, escaping would show HTML entities to the user.
 		}
 
 		if ( ! empty( $decoded['error'] ) ) {
-			throw new Exception( $decoded['error'] );
+			throw new Exception( $decoded['error'] ); // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Returned to the browser as JSON via WP_Error, escaping would show HTML entities to the user.
 		}
 
 		return $decoded;

--- a/includes/Core/Util/BC_Functions.php
+++ b/includes/Core/Util/BC_Functions.php
@@ -48,7 +48,7 @@ class BC_Functions {
 			return self::{ $function_name }( ...$arguments );
 		}
 
-		throw new BadMethodCallException( "$function_name does not exist." );
+		throw new BadMethodCallException( sprintf( '%s does not exist.', esc_html( $function_name ) ) );
 	}
 
 	/**

--- a/includes/Modules/AdSense/Datapoints/Get_Report.php
+++ b/includes/Modules/AdSense/Datapoints/Get_Report.php
@@ -291,7 +291,7 @@ class Get_Report extends Datapoint implements Executable_Datapoint {
 				$invalid_metrics[0]
 			);
 
-			throw new Invalid_Report_Metrics_Exception( $message );
+			throw new Invalid_Report_Metrics_Exception( $message ); // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Returned to the browser as JSON via WP_Error, escaping would show HTML entities to the user.
 		}
 	}
 
@@ -334,7 +334,7 @@ class Get_Report extends Datapoint implements Executable_Datapoint {
 				$invalid_dimensions[0]
 			);
 
-			throw new Invalid_Report_Dimensions_Exception( $message );
+			throw new Invalid_Report_Dimensions_Exception( $message ); // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Returned to the browser as JSON via WP_Error, escaping would show HTML entities to the user.
 		}
 	}
 }

--- a/includes/Modules/Analytics_4/Advanced_Tracking/Event.php
+++ b/includes/Modules/Analytics_4/Advanced_Tracking/Event.php
@@ -92,7 +92,7 @@ final class Event implements \JsonSerializable {
 		);
 		foreach ( $config as $key => $value ) {
 			if ( ! in_array( $key, $valid_keys, true ) ) {
-				throw new Exception( 'Invalid configuration parameter: ' . $key );
+				throw new Exception( 'Invalid configuration parameter: ' . esc_html( $key ) );
 			}
 		}
 		if ( ! array_key_exists( 'metadata', $config ) ) {
@@ -103,7 +103,7 @@ final class Event implements \JsonSerializable {
 		}
 		foreach ( $valid_keys as $key ) {
 			if ( ! array_key_exists( $key, $config ) ) {
-				throw new Exception( 'Missed configuration parameter: ' . $key );
+				throw new Exception( 'Missed configuration parameter: ' . esc_html( $key ) );
 			}
 		}
 		return $config;

--- a/includes/Modules/Analytics_4/Report/RequestHelpers.php
+++ b/includes/Modules/Analytics_4/Report/RequestHelpers.php
@@ -187,7 +187,7 @@ class RequestHelpers {
 				$invalid_metrics[0]
 			);
 
-			throw new Invalid_Report_Metrics_Exception( $message );
+			throw new Invalid_Report_Metrics_Exception( $message ); // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Returned to the browser as JSON via WP_Error, escaping would show HTML entities to the user.
 		}
 	}
 
@@ -256,7 +256,7 @@ class RequestHelpers {
 				$invalid_metrics[0]
 			);
 
-			throw new Invalid_Report_Metrics_Exception( $message );
+			throw new Invalid_Report_Metrics_Exception( $message ); // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Returned to the browser as JSON via WP_Error, escaping would show HTML entities to the user.
 		}
 	}
 
@@ -325,7 +325,7 @@ class RequestHelpers {
 				$invalid_dimensions[0]
 			);
 
-			throw new Invalid_Report_Dimensions_Exception( $message );
+			throw new Invalid_Report_Dimensions_Exception( $message ); // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Returned to the browser as JSON via WP_Error, escaping would show HTML entities to the user.
 		}
 	}
 

--- a/includes/Modules/Reader_Revenue_Manager/Datapoints/CTA/Newsletter_Signup_CTA_Type_Handler.php
+++ b/includes/Modules/Reader_Revenue_Manager/Datapoints/CTA/Newsletter_Signup_CTA_Type_Handler.php
@@ -81,7 +81,7 @@ class Newsletter_Signup_CTA_Type_Handler implements CTA_Type_Handler_Interface {
 			}
 
 			if ( ! is_string( $config[ $field ] ) ) {
-				throw new Invalid_Param_Exception( "config.{$field}" );
+				throw new Invalid_Param_Exception( "config.{$field}" ); // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Returned to the browser as JSON via WP_Error, escaping would show HTML entities to the user.
 			}
 
 			$newsletter_config->{$setter}( $config[ $field ] );
@@ -93,7 +93,7 @@ class Newsletter_Signup_CTA_Type_Handler implements CTA_Type_Handler_Interface {
 			}
 
 			if ( ! is_bool( $config[ $field ] ) ) {
-				throw new Invalid_Param_Exception( "config.{$field}" );
+				throw new Invalid_Param_Exception( "config.{$field}" ); // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Returned to the browser as JSON via WP_Error, escaping would show HTML entities to the user.
 			}
 
 			$newsletter_config->{$setter}( $config[ $field ] );

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -71,11 +71,6 @@
 	<arg name="extensions" value="php"/>
 	<file>.</file>
 
-	<!-- Temporarily disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -->
-	<rule ref="WordPress.Security.EscapeOutput">
-		<exclude name="WordPress.Security.EscapeOutput.ExceptionNotEscaped" />
-	</rule>
-
 	<!-- Test-specific exclusions -->
 	<rule ref="WordPress.DB.DirectDatabaseQuery">
 		<exclude-pattern>tests/*</exclude-pattern>

--- a/tests/phpunit/integration/Core/Conversion_Tracking/Conversion_TrackingTest.php
+++ b/tests/phpunit/integration/Core/Conversion_Tracking/Conversion_TrackingTest.php
@@ -174,11 +174,11 @@ class Conversion_TrackingTest extends TestCase {
 
 	public function data_register() {
 		$exception_no_classname     = 'A conversion event provider class name is required to instantiate a provider: test-provider';
-		$exception_not_extends_base = sprintf( "The '%s' class must extend the base conversion event provider class: %s", __CLASS__, Conversion_Events_Provider::class );
+		$exception_not_extends_base = sprintf( 'The %s class must extend the base conversion event provider class: %s', __CLASS__, Conversion_Events_Provider::class );
 
 		return array(
 			'no class name'                     => array( array( 'test-provider' => '' ), $exception_no_classname ),
-			'non-existent class name'           => array( array( 'foo-bar' => '\\Foo\\Bar' ), "The '\\Foo\\Bar' class does not exist" ),
+			'non-existent class name'           => array( array( 'foo-bar' => '\\Foo\\Bar' ), 'The \\Foo\\Bar class does not exist' ),
 			'existing class not-extending base' => array( array( 'test-provider' => __CLASS__ ), $exception_not_extends_base ),
 		);
 	}

--- a/tests/phpunit/integration/Core/Conversion_Tracking/Conversion_TrackingTest.php
+++ b/tests/phpunit/integration/Core/Conversion_Tracking/Conversion_TrackingTest.php
@@ -174,11 +174,11 @@ class Conversion_TrackingTest extends TestCase {
 
 	public function data_register() {
 		$exception_no_classname     = 'A conversion event provider class name is required to instantiate a provider: test-provider';
-		$exception_not_extends_base = sprintf( 'The %s class must extend the base conversion event provider class: %s', __CLASS__, Conversion_Events_Provider::class );
+		$exception_not_extends_base = sprintf( "The '%s' class must extend the base conversion event provider class: %s", __CLASS__, Conversion_Events_Provider::class );
 
 		return array(
 			'no class name'                     => array( array( 'test-provider' => '' ), $exception_no_classname ),
-			'non-existent class name'           => array( array( 'foo-bar' => '\\Foo\\Bar' ), 'The \\Foo\\Bar class does not exist' ),
+			'non-existent class name'           => array( array( 'foo-bar' => '\\Foo\\Bar' ), "The '\\Foo\\Bar' class does not exist" ),
 			'existing class not-extending base' => array( array( 'test-provider' => __CLASS__ ), $exception_not_extends_base ),
 		);
 	}


### PR DESCRIPTION
## Summary

Related issue(s):

- Resolves #13438

## Relevant technical choices

`phpcs.xml` has excluded `WordPress.Security.EscapeOutput.ExceptionNotEscaped` since the coding standards upgrade in July 2024, where it was added as temporary. Removing it surfaced 47 violations across 20 files, none of them auto-fixable.

Blanket escaping would have been wrong. Site Kit turns many exceptions into `WP_Error` objects that the REST API returns as JSON, which the dashboard renders as plain text, so escaping those messages would put entities such as `&#8217;` into text the user reads. Each violation therefore got one of two treatments:

**Escaped** where the exception is thrown on internal API misuse and the message never reaches the browser: `Golinks`, `BC_Functions`, `Email_Notices`, `Initiator_Task`, `Frequency_Planner`, `Report_Options`, `Module_Registry`, `Event` and `Conversion_Tracking`.

**Left unescaped with a written reason** at each throw, via `// phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- ...`, where the message is returned as JSON through `Module::exception_to_error()` or a `WP_Error` built by the caller: `Module`, `Modules`, `RequestHelpers`, `Get_Report`, `Notifications`, `Setup`, `Google_Proxy`, `Google_Site_Kit_Client`, `Google_Site_Kit_Proxy_Client` and `Newsletter_Signup_CTA_Type_Handler`. `Middleware` carries its own reason, since the flagged second argument there is the Guzzle request object rather than output.

Two details worth flagging for review:

- `Module_Registry` uses `sprintf( "No class exists for '%s'", esc_html( $module_classname ) )` rather than escaping the whole string, which keeps the message byte-identical and leaves `Module_RegistryTest` passing unchanged.
- The two `Conversion_Tracking` messages drop the straight quotes around `%s`, so that `esc_html__()` cannot turn them into `&#039;`. This changes those two msgids and the matching expectations in `Conversion_TrackingTest`.

The `tests/*` exclusion for the same rule is untouched.

Verification: `phpcs` reports zero `EscapeOutput` violations repo-wide and the full ruleset passes on every changed file. The full PHPUnit suite was run with and against a clean baseline; the failing-test sets are identical, so this introduces no test regressions.

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [ ] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.
- [ ] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
