### PR TITLE
Wait for settings to resolve before selecting a publication.

### DIFF
--- a/assets/js/modules/reader-revenue-manager/components/setup/SetupMainExpress/common-steps/StepPublicationSetup/ConnectPublication.tsx
+++ b/assets/js/modules/reader-revenue-manager/components/setup/SetupMainExpress/common-steps/StepPublicationSetup/ConnectPublication.tsx
@@ -84,6 +84,14 @@ const ConnectPublication: FC< ConnectPublicationProps > = ( {
 		[]
 	);
 
+	const hasResolvedSettings = useSelect(
+		( select: Select ) =>
+			select( MODULES_READER_REVENUE_MANAGER ).hasFinishedResolution(
+				'getSettings'
+			),
+		[]
+	);
+
 	const isDoingSubmitChanges = useSelect(
 		( select: Select ) =>
 			select( MODULES_READER_REVENUE_MANAGER ).isDoingSubmitChanges(),
@@ -145,11 +153,19 @@ const ConnectPublication: FC< ConnectPublicationProps > = ( {
 			}
 		}
 
-		if ( publications && ! publicationID ) {
+		/**
+		 * Selecting a publication sets publication-related module settings.
+		 * This will cause settings to be defined, preventing the fetching of
+		 * default settings from the server, which can lead to
+		 * `canSubmitChanges` returning as `false` because settings are
+		 * incomplete if `publications` resolves before settings.
+		 */
+		if ( hasResolvedSettings && publications && ! publicationID ) {
 			autoSelectPublication();
 		}
 	}, [
 		findMatchedPublication,
+		hasResolvedSettings,
 		publicationID,
 		publications,
 		selectPublication,


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Related issue(s):

- Resolves #13021

## Relevant technical choices

Fixes a bug where the _Connect existing publication_ would be disabled and it wasn't possible to proceed to the next step.

The cause was a race condition where `selectPublication()` would partially populate settings with publication-related settings which would prevent the store from fetching default settings from the server because settings already appeared to be defined. Since `canSubmitChanges()` requires all settings to be present, it would not be possible to submit the form.

This change simply waits for `getSettings` to resolve before attempting to automatically select a publication.

Long term a better approach might be to avoid relying on `canSubmitChanges` and `submitChanges`, because those are designed to expect the full settings form, while we're only interested in connecting a publication for this step. A dedicated store with `connectPublication()` and `canConnectPublication()` that only validates what's needed for this form might be more appropriate. Other options would be letting us check whether `getPublicationID` has resolved, or resolving `getSettings` inside `selectPublication` before adding the publication settings.

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.
- [ ] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
