### PR TITLE
Anchor the email reporting overlay to the features menu when the icon collapses

### DIFF
--- a/assets/js/components/email-reporting/SetUpEmailReportingOverlayNotification.test.tsx
+++ b/assets/js/components/email-reporting/SetUpEmailReportingOverlayNotification.test.tsx
@@ -24,6 +24,7 @@ import { waitFor } from '@testing-library/react';
 /**
  * Internal dependencies
  */
+import { FEATURES_MENU_BUTTON_CLASS } from '@/js/components/FeaturesMenu/constants';
 import Notifications from '@/js/components/notifications/Notifications';
 import {
 	VIEW_CONTEXT_MAIN_DASHBOARD,
@@ -269,11 +270,18 @@ describe( 'SetUpEmailReportingOverlayNotification', () => {
 	describe( 'rendering', () => {
 		let registry: ReturnType< typeof createTestRegistry >;
 		let anchor: HTMLButtonElement | null = null;
+		let featuresMenuButton: HTMLButtonElement | null = null;
 
 		function addHeaderIcon() {
 			anchor = document.createElement( 'button' );
 			anchor.className = MANAGE_EMAIL_REPORTS_BUTTON_CLASS;
 			document.body.appendChild( anchor );
+		}
+
+		function addFeaturesMenuButton() {
+			featuresMenuButton = document.createElement( 'button' );
+			featuresMenuButton.className = FEATURES_MENU_BUTTON_CLASS;
+			document.body.appendChild( featuresMenuButton );
 		}
 
 		function renderNotifications() {
@@ -312,6 +320,8 @@ describe( 'SetUpEmailReportingOverlayNotification', () => {
 		afterEach( () => {
 			anchor?.remove();
 			anchor = null;
+			featuresMenuButton?.remove();
+			featuresMenuButton = null;
 		} );
 
 		it( 'anchors the overlay to the header icon when it is present', async () => {
@@ -352,6 +362,29 @@ describe( 'SetUpEmailReportingOverlayNotification', () => {
 					'.googlesitekit-overlay-card--anchored'
 				)
 			).toBeNull();
+		} );
+
+		it( 'anchors the overlay to the features menu button when the header icon is absent', async () => {
+			mockSurveyEndpoints();
+			addFeaturesMenuButton();
+
+			const { waitForRegistry } = renderNotifications();
+
+			await waitForRegistry();
+
+			await waitFor( () =>
+				expect(
+					document.querySelector(
+						'.googlesitekit-overlay-card--anchored'
+					)
+				).toBeInTheDocument()
+			);
+
+			expect(
+				document.querySelector(
+					'.googlesitekit-popper--overlay-notification'
+				)
+			).toBeInTheDocument();
 		} );
 
 		it( 'labels the buttons "Try it" and "Got it"', async () => {

--- a/assets/js/components/email-reporting/SetUpEmailReportingOverlayNotification.tsx
+++ b/assets/js/components/email-reporting/SetUpEmailReportingOverlayNotification.tsx
@@ -31,6 +31,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { useDispatch } from 'googlesitekit-data';
+import { FEATURES_MENU_BUTTON_CLASS } from '@/js/components/FeaturesMenu/constants';
 import { CORE_UI } from '@/js/googlesitekit/datastore/ui/constants';
 import { CORE_USER } from '@/js/googlesitekit/datastore/user/constants';
 import OverlayNotification from '@/js/googlesitekit/notifications/components/layout/OverlayNotification';
@@ -76,7 +77,10 @@ const SetUpEmailReportingOverlayNotification: FC<
 			<OverlayNotification
 				notificationID={ id }
 				className="googlesitekit-email-reporting-introduction-overlay"
-				anchorID={ `.${ MANAGE_EMAIL_REPORTS_BUTTON_CLASS }` }
+				// On mobile and tablet the email reports button collapses into
+				// the features menu, so the overlay anchors to whichever
+				// trigger exists.
+				anchorID={ `.${ MANAGE_EMAIL_REPORTS_BUTTON_CLASS }, .${ FEATURES_MENU_BUTTON_CLASS }` }
 				title={ __(
 					'Get site insights in your inbox',
 					'google-site-kit'

--- a/tests/playwright/specs/email-reporting/email-reporting-view-only-with-data-access.spec.ts
+++ b/tests/playwright/specs/email-reporting/email-reporting-view-only-with-data-access.spec.ts
@@ -30,13 +30,17 @@ import { EmailReportingPage } from './email-reporting-page';
 // `proxy-auth.php`), so the dashboard is view-only. Search Console is connected
 // (owned by the admin, ID 1) and shared with the editor role, which is one of the
 // two modules email reports draw data from. The editor has the shared-dashboard
-// splash pre-dismissed so it lands on the view-only dashboard directly.
+// splash pre-dismissed so it lands on the view-only dashboard directly, and the
+// setup overlay pre-dismissed so it does not cover the features menu.
 test.describe(
 	'Email Reporting (view-only with data access)',
 	{
 		annotation: [
 			asUser( 'editor', {
-				dismissedItems: [ 'shared_dashboard_splash' ],
+				dismissedItems: [
+					'shared_dashboard_splash',
+					'email_reports_setup_overlay_notification',
+				],
 			} ),
 			withPlugins( 'proxy-credentials.php' ),
 			withConnectedModules( {

--- a/tests/playwright/specs/pdf-generation/pdf-generation.spec.ts
+++ b/tests/playwright/specs/pdf-generation/pdf-generation.spec.ts
@@ -424,13 +424,18 @@ test.describe(
 // credentials (no `proxy-auth.php`), so the dashboard is view-only. Search
 // Console is connected (owned by the admin, ID 1) and shared with the editor
 // role, while PageSpeed stays unshared. The editor has the shared-dashboard
-// splash pre-dismissed so it lands on the view-only dashboard directly.
+// splash pre-dismissed so it lands on the view-only dashboard directly, and the
+// introduction overlays pre-dismissed so they do not cover the features menu.
 test.describe(
 	'PDF Generation (view-only)',
 	{
 		annotation: [
 			asUser( 'editor', {
-				dismissedItems: [ 'shared_dashboard_splash' ],
+				dismissedItems: [
+					'shared_dashboard_splash',
+					'email_reports_setup_overlay_notification',
+					'pdf_introduction_overlay_notification',
+				],
 			} ),
 			featureFlags,
 			withPlugins( 'proxy-credentials.php' ),


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Related issue(s):

- Resolves #13369

## Relevant technical choices

Follow-up to #13437, which fixed this for the PDF export overlay only. QA found the email reports
overlay still drops to the bottom right at 900px and below, because it names just its own header
icon as an anchor.

Applies the same one line change: `anchorID` is given a selector list naming both the email
reports icon and the features menu button, so the overlay anchors to whichever trigger is
currently rendered. This matches the existing precedent for the email reports setup tooltip.

Targets `main` rather than `develop` because #13437 is already in the next release.

Mobile is unchanged and still renders the centered card, via the existing `BREAKPOINT_SMALL` guard.

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [ ] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.
- [ ] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
