### PR TITLE
Fix WooCommerce purchase shipping and tax values losing decimals

### DIFF
--- a/assets/js/event-providers/woocommerce.test.js
+++ b/assets/js/event-providers/woocommerce.test.js
@@ -41,17 +41,19 @@ function createProduct( price ) {
  *
  * @since n.e.x.t
  *
- * @param {number} price The order total and the price of its one product, both in minor units.
+ * @param {number} price    The order total and the price of its one product, both in minor units.
+ * @param {number} shipping The shipping total in minor units.
+ * @param {number} tax      The tax total in minor units.
  * @return {Object} An order for `window._googlesitekit.wcdata`.
  */
-function createOrder( price ) {
+function createOrder( price, shipping = 0, tax = 0 ) {
 	return {
 		id: 99,
 		affiliation: 'Test Store',
 		totals: {
 			currency_code: 'USD',
-			tax_total: 0,
-			shipping_total: 0,
+			tax_total: tax,
+			shipping_total: shipping,
 			total_price: price,
 		},
 		items: [ createProduct( price ) ],
@@ -158,6 +160,41 @@ describe( 'WooCommerce event provider', () => {
 				],
 				googlesitekit_event_provider: 'woocommerce',
 			} );
+			expect( gtagEvent ).toHaveBeenCalledTimes( 1 );
+		}
+	);
+
+	// Each row is the store's decimal places, the shipping and tax in minor
+	// units, and the amounts the script should send.
+	const shippingAndTaxCases = [
+		[ 'shipping and tax', 2, 500, 250, 5, 2.5 ],
+		[ 'zero decimal places', 0, 5, 3, 5, 3 ],
+	];
+
+	it.each( shippingAndTaxCases )(
+		'should send the `purchase` shipping and tax for a store set to %s',
+		async (
+			_caseName,
+			currencyMinorUnit,
+			shippingMinor,
+			taxMinor,
+			expectedShipping,
+			expectedTax
+		) => {
+			const gtagEvent = await loadEventScript( {
+				currency: 'USD',
+				currencyMinorUnit,
+				eventsToTrack: [ 'add_to_cart', 'purchase' ],
+				purchase: createOrder( 5000, shippingMinor, taxMinor ),
+			} );
+
+			expect( gtagEvent ).toHaveBeenCalledWith(
+				'purchase',
+				expect.objectContaining( {
+					shipping: expectedShipping,
+					tax: expectedTax,
+				} )
+			);
 			expect( gtagEvent ).toHaveBeenCalledTimes( 1 );
 		}
 	);

--- a/assets/js/event-providers/woocommerce.ts
+++ b/assets/js/event-providers/woocommerce.ts
@@ -205,15 +205,17 @@
 		}
 
 		// Shipping can be 0, if only check if shipping is not empty value
-		// this will be omitted.
+		// this will be omitted. The PHP provider writes shipping and tax in
+		// the same minor units as the order total, so divide them back out
+		// the same way `value` and item prices are.
 		if ( typeof shipping === 'number' ) {
-			formattedData.shipping = shipping;
+			formattedData.shipping = formatPrice( String( shipping ) );
 		}
 
 		// Tax can be 0, if only check if shipping is not empty value
 		// this will be omitted.
 		if ( typeof tax === 'number' ) {
-			formattedData.tax = tax;
+			formattedData.tax = formatPrice( String( tax ) );
 		}
 
 		if ( Array.isArray( products ) ) {


### PR DESCRIPTION
## Summary

Related issue(s):

- Resolves #13362

WooCommerce conversion tracking sends a `purchase` event to GA4 with `value`, `items[].price`, `shipping` and `tax`. The PHP provider writes every amount in minor units (the order total multiplied by `10^currencyMinorUnit`), and the JS event provider divides `value` and `items[].price` back out with `formatPrice()`. `shipping` and `tax` were passed through as-is, so an order charging 5.00 for shipping arrived as `shipping: 500` in the dataLayer.

## Relevant technical choices

- `assets/js/event-providers/woocommerce.ts`
  - `formatEventData()` now formats `shipping` and `tax` with `formatPrice()` too, so they use the same `currencyMinorUnit` recovery as `value` and item prices.
- `assets/js/event-providers/woocommerce.test.js`
  - `createOrder()` now accepts `shipping` and `tax` (both default to `0`).
  - New `it.each` cases cover a 2-decimal store (500 → 5, 250 → 2.5) and a 0-decimal store (5 → 5, 3 → 3).

## Testing

1. `eslint assets/js/event-providers/woocommerce.ts assets/js/event-providers/woocommerce.test.js` — clean.
2. `jest assets/js/event-providers/woocommerce.test.js` — 10 tests pass.
3. Red-green: with the fix reverted, the new `shipping and tax` case fails with `shipping: 500`; with the fix applied it passes with `shipping: 5`.