### PR TITLE
Remove use of `uopz` extension in tests

### DIFF
--- a/.github/workflows/gemini.yml
+++ b/.github/workflows/gemini.yml
@@ -45,7 +45,7 @@ jobs:
         uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # ratchet:shivammathur/setup-php@v2
         with:
           php-version: "8.4"
-          extensions: mysqli, uopz
+          extensions: mysqli
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Get Composer Cache Directory

--- a/.github/workflows/php-lint-tests.yml
+++ b/.github/workflows/php-lint-tests.yml
@@ -191,7 +191,7 @@ jobs:
       - name: Setup PHP for Tests
         uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # ratchet:shivammathur/setup-php@v2
         with:
-          extensions: mysqli, uopz
+          extensions: mysqli
           php-version: ${{ matrix.php_version }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/php-lint-tests.yml
+++ b/.github/workflows/php-lint-tests.yml
@@ -1,5 +1,8 @@
 name: PHP Tests
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:

--- a/tests/phpunit/integration/Core/Tags/Guards/Tag_Environment_Type_GuardTest.php
+++ b/tests/phpunit/integration/Core/Tags/Guards/Tag_Environment_Type_GuardTest.php
@@ -10,10 +10,15 @@
 
 namespace Google\Site_Kit\Tests\Core\Tags\Guards;
 
-	use Google\Site_Kit\Core\Tags\Guards\Tag_Environment_Type_Guard;
-	use Google\Site_Kit\Tests\TestCase;
+use Google\Site_Kit\Core\Tags\Guards\Tag_Environment_Type_Guard;
+use Google\Site_Kit\Tests\TestCase;
 
 class Tag_Environment_Type_GuardTest extends TestCase {
+
+	public function tear_down() {
+		remove_all_filters( 'googlesitekit_allowed_tag_environment_types' );
+		parent::tear_down();
+	}
 
 	public function test_can_activate_on_post_5_5_version() {
 		if ( ! function_exists( 'wp_get_environment_type' ) ) {
@@ -33,44 +38,43 @@ class Tag_Environment_Type_GuardTest extends TestCase {
 		$this->assertTrue( $tagproduction->can_activate(), 'Tag should be able to activate on older versions.' );
 	}
 
-	public function test_can_not_activate_in_development() {
+	public function test_can_not_activate_when_current_environment_is_not_allowed() {
 		// Pre WP-5.5.0.
 		if ( ! function_exists( 'wp_get_environment_type' ) ) {
 			$this->markTestSkipped( 'Missing wp_get_environment_type() function.' );
 		}
-		if ( ! function_exists( 'uopz_set_static' ) ) {
-			$this->markTestSkipped( 'The uopz extension is not available.' );
-		}
-		$env_type      = wp_get_environment_type();
-		$tagproduction = new Tag_Environment_Type_Guard();
-		uopz_set_static( 'wp_get_environment_type', array( 'current_env' => 'development' ) );
-		$this->assertFalse( $tagproduction->can_activate(), 'Tag should not be able to activate in development environment.' );
-		uopz_set_static( 'wp_get_environment_type', array( 'current_env' => $env_type ) );
-	}
 
-	public function test_can_activate_in_development() {
-		// Pre WP-5.5.0.
-		if ( ! function_exists( 'wp_get_environment_type' ) ) {
-			$this->markTestSkipped( 'Missing wp_get_environment_type() function.' );
-		}
-		if ( ! function_exists( 'uopz_set_static' ) ) {
-			$this->markTestSkipped( 'The uopz extension is not available.' );
-		}
-		$env_type      = wp_get_environment_type();
-		$tagproduction = new Tag_Environment_Type_Guard();
-		uopz_set_static( 'wp_get_environment_type', array( 'current_env' => 'development' ) );
-		$this->assertFalse( $tagproduction->can_activate(), 'Tag should not be able to activate in development environment by default.' );
+		$current_env = wp_get_environment_type();
 
-		remove_all_filters( 'googlesitekit_allowed_tag_environment_types' );
 		add_filter(
 			'googlesitekit_allowed_tag_environment_types',
-			function ( $allowed_environments ) {
-				$allowed_environments[] = 'development';
-				return $allowed_environments;
+			function () use ( $current_env ) {
+				return array_values(
+					array_diff( array( 'local', 'development', 'staging', 'production' ), array( $current_env ) )
+				);
 			}
 		);
-		$this->assertTrue( $tagproduction->can_activate(), 'Tag should be able to activate in development environment when allowed.' );
 
-		uopz_set_static( 'wp_get_environment_type', array( 'current_env' => $env_type ) );
+		$tagproduction = new Tag_Environment_Type_Guard();
+		$this->assertFalse( $tagproduction->can_activate(), 'Tag should not be able to activate when the current environment is not allowed.' );
+	}
+
+	public function test_can_activate_when_current_environment_is_allowed() {
+		// Pre WP-5.5.0.
+		if ( ! function_exists( 'wp_get_environment_type' ) ) {
+			$this->markTestSkipped( 'Missing wp_get_environment_type() function.' );
+		}
+
+		$current_env = wp_get_environment_type();
+
+		add_filter(
+			'googlesitekit_allowed_tag_environment_types',
+			function () use ( $current_env ) {
+				return array( $current_env );
+			}
+		);
+
+		$tagproduction = new Tag_Environment_Type_Guard();
+		$this->assertTrue( $tagproduction->can_activate(), 'Tag should be able to activate when the current environment is allowed.' );
 	}
 }


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Addresses issue:

- #12332

## Relevant technical choices

- Added `permissions: contents: read` to `php-lint-tests.yml`, beyond the IB to fix the [zizmor CI failure](https://github.com/google/site-kit-wp/actions/runs/34207348179?pr=13521). The Actions scan only audits workflow files a PR touches, so editing this one surfaced four pre-existing `excessive-permissions` findings that blocked CI. Most other workflows still lack the block and will trip the same check when next edited.
- The refactored tests assert membership relative to the current environment rather than a literal `development` one, so both were renamed. Default production behaviour stays covered by `test_can_activate_on_post_5_5_version`.

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [ ] I have added a QA Brief on the issue linked above.
- [ ] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.
- [ ] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
