### PR TITLE
Use mockIntersectionObserver in tests.

### DIFF
--- a/assets/js/components/KeyMetrics/KeyMetricsBackNotice.test.tsx
+++ b/assets/js/components/KeyMetrics/KeyMetricsBackNotice.test.tsx
@@ -17,11 +17,6 @@
  */
 
 /**
- * External dependencies
- */
-import { intersectionObserver } from '@shopify/jest-dom-mocks';
-
-/**
  * WordPress dependencies
  */
 import { WPDataRegistry } from '@wordpress/data/build-types/registry';
@@ -34,6 +29,7 @@ import { CORE_UI } from '@/js/googlesitekit/datastore/ui/constants';
 import { CORE_USER } from '@/js/googlesitekit/datastore/user/constants';
 import { getWidgetComponentProps } from '@/js/googlesitekit/widgets/util';
 import * as tracking from '@/js/util/tracking';
+import { mockIntersectionObserver } from '@tests/js/mock-browser-utils';
 import {
 	act,
 	createTestRegistry,
@@ -50,6 +46,8 @@ import KeyMetricsBackNotice from './KeyMetricsBackNotice';
 const mockTrackEvent = jest.spyOn( tracking, 'trackEvent' );
 mockTrackEvent.mockImplementation( () => Promise.resolve() );
 
+const { simulateAllIntersections } = mockIntersectionObserver();
+
 describe( 'KeyMetricsBackNotice', () => {
 	let registry: WPDataRegistry;
 
@@ -62,14 +60,11 @@ describe( 'KeyMetricsBackNotice', () => {
 	);
 
 	beforeEach( () => {
-		intersectionObserver.mock();
-
 		registry = createTestRegistry();
 		registry.dispatch( CORE_USER ).receiveGetDismissedItems( [] );
 	} );
 
 	afterEach( () => {
-		intersectionObserver.restore();
 		mockTrackEvent.mockClear();
 	} );
 
@@ -163,10 +158,7 @@ describe( 'KeyMetricsBackNotice', () => {
 
 		// Simulate the notice coming into view.
 		act( () => {
-			intersectionObserver.simulate( {
-				isIntersecting: true,
-				intersectionRatio: 1,
-			} );
+			simulateAllIntersections( true );
 		} );
 
 		await waitFor( () => {

--- a/assets/js/components/WelcomeModal.test.tsx
+++ b/assets/js/components/WelcomeModal.test.tsx
@@ -53,8 +53,12 @@ import { MODULE_SLUG_SEARCH_CONSOLE } from '@/js/modules/search-console/constant
 import { MODULES_SEARCH_CONSOLE } from '@/js/modules/search-console/datastore/constants';
 import * as tracking from '@/js/util/tracking';
 import { provideGatheringDataState } from '@tests/js/gathering-data-utils';
-import { mockBrowserScrolling } from '@tests/js/mock-browser-utils';
 import {
+	mockBrowserScrolling,
+	mockIntersectionObserver,
+} from '@tests/js/mock-browser-utils';
+import {
+	act,
 	createTestRegistry,
 	fireEvent,
 	render,
@@ -86,38 +90,6 @@ const mockWelcomeTour = getWelcomeTour( {
 
 jest.mock( '@/js/feature-tours/hooks/useWelcomeTour' );
 
-/**
- * The modal graphic is wrapped in `withIntersectionObserver`, which observes
- * its element with the native `IntersectionObserver`. jsdom has none, so use a
- * stub that reports the element as in view the moment it observes it. This
- * makes the modal send its `view_notice` event on render, as these tests
- * expect.
- */
-class InViewIntersectionObserver {
-	callback: IntersectionObserverCallback;
-
-	constructor( callback: IntersectionObserverCallback ) {
-		this.callback = callback;
-	}
-
-	observe( element: Element ) {
-		this.callback(
-			[
-				{
-					isIntersecting: true,
-					intersectionRatio: 1,
-					target: element,
-				} as IntersectionObserverEntry,
-			],
-			this as unknown as IntersectionObserver
-		);
-	}
-
-	unobserve() {}
-
-	disconnect() {}
-}
-
 describe( 'WelcomeModal', () => {
 	let registry: WPDataRegistry;
 
@@ -126,6 +98,7 @@ describe( 'WelcomeModal', () => {
 	);
 
 	mockBrowserScrolling();
+	const { simulateAllIntersections } = mockIntersectionObserver();
 
 	function provideDataAvailableVariantData() {
 		provideModules( registry, [
@@ -214,12 +187,7 @@ describe( 'WelcomeModal', () => {
 			] );
 	}
 
-	const originalIntersectionObserver = global.IntersectionObserver;
-
 	beforeEach( () => {
-		global.IntersectionObserver =
-			InViewIntersectionObserver as unknown as typeof IntersectionObserver;
-
 		registry = createTestRegistry();
 
 		fetchMock.post( dismissItemEndpoint, {
@@ -247,7 +215,6 @@ describe( 'WelcomeModal', () => {
 	} );
 
 	afterEach( () => {
-		global.IntersectionObserver = originalIntersectionObserver;
 		mockTrackEvent.mockClear();
 	} );
 
@@ -1182,6 +1149,12 @@ describe( 'WelcomeModal', () => {
 
 				await waitForRegistry();
 
+				act( () => {
+					simulateAllIntersections( true );
+				} );
+
+				await waitForRegistry();
+
 				// The `view_notice` event is also tracked on view.
 				expect( mockTrackEvent ).toHaveBeenCalledTimes( 3 );
 				expect( mockTrackEvent ).toHaveBeenCalledWith(
@@ -1199,6 +1172,12 @@ describe( 'WelcomeModal', () => {
 					registry,
 					viewContext: 'test-context',
 				} );
+
+				act( () => {
+					simulateAllIntersections( true );
+				} );
+
+				await waitForRegistry();
 
 				// Only the `view_notice` event should be tracked the second time the modal is shown.
 				expect( mockTrackEvent ).toHaveBeenCalledTimes( 1 );

--- a/assets/js/components/google-tag-gateway/GoogleTagGatewayToggle.test.js
+++ b/assets/js/components/google-tag-gateway/GoogleTagGatewayToggle.test.js
@@ -17,16 +17,12 @@
  */
 
 /**
- * External dependencies
- */
-import { intersectionObserver } from '@shopify/jest-dom-mocks';
-
-/**
  * Internal dependencies
  */
 import { VIEW_CONTEXT_MAIN_DASHBOARD } from '@/js/googlesitekit/constants';
 import { CORE_SITE } from '@/js/googlesitekit/datastore/site/constants';
 import * as tracking from '@/js/util/tracking';
+import { mockIntersectionObserver } from '@tests/js/mock-browser-utils';
 import {
 	act,
 	createTestRegistry,
@@ -40,6 +36,8 @@ import GoogleTagGatewayToggle from './GoogleTagGatewayToggle';
 const mockTrackEvent = jest.spyOn( tracking, 'trackEvent' );
 mockTrackEvent.mockImplementation( () => Promise.resolve() );
 
+const { simulateAllIntersections } = mockIntersectionObserver();
+
 describe( 'GoogleTagGatewayToggle', () => {
 	let registry;
 
@@ -48,8 +46,6 @@ describe( 'GoogleTagGatewayToggle', () => {
 	);
 
 	beforeEach( () => {
-		intersectionObserver.mock();
-
 		registry = createTestRegistry();
 
 		registry.dispatch( CORE_SITE ).receiveGetGoogleTagGatewaySettings( {
@@ -60,7 +56,6 @@ describe( 'GoogleTagGatewayToggle', () => {
 	} );
 
 	afterEach( () => {
-		intersectionObserver.restore();
 		jest.clearAllMocks();
 	} );
 
@@ -181,10 +176,7 @@ describe( 'GoogleTagGatewayToggle', () => {
 
 		// Simulate the warning notice becoming visible if it were present.
 		act( () => {
-			intersectionObserver.simulate( {
-				isIntersecting: true,
-				intersectionRatio: 1,
-			} );
+			simulateAllIntersections( true );
 		} );
 
 		expect( mockTrackEvent ).not.toHaveBeenCalled();
@@ -222,10 +214,7 @@ describe( 'GoogleTagGatewayToggle', () => {
 
 		// Simulate the warning notice becoming visible.
 		act( () => {
-			intersectionObserver.simulate( {
-				isIntersecting: true,
-				intersectionRatio: 1,
-			} );
+			simulateAllIntersections( true );
 		} );
 
 		expect( mockTrackEvent ).toHaveBeenCalledTimes( 1 );

--- a/assets/js/modules/analytics-4/components/audience-segmentation/dashboard/AudienceSegmentationBackNotice.test.tsx
+++ b/assets/js/modules/analytics-4/components/audience-segmentation/dashboard/AudienceSegmentationBackNotice.test.tsx
@@ -17,11 +17,6 @@
  */
 
 /**
- * External dependencies
- */
-import { intersectionObserver } from '@shopify/jest-dom-mocks';
-
-/**
  * WordPress dependencies
  */
 import { WPDataRegistry } from '@wordpress/data/build-types/registry';
@@ -34,6 +29,7 @@ import { CORE_UI } from '@/js/googlesitekit/datastore/ui/constants';
 import { CORE_USER } from '@/js/googlesitekit/datastore/user/constants';
 import { withWidgetComponentProps } from '@/js/googlesitekit/widgets/util';
 import * as tracking from '@/js/util/tracking';
+import { mockIntersectionObserver } from '@tests/js/mock-browser-utils';
 import {
 	act,
 	createTestRegistry,
@@ -49,6 +45,8 @@ import { AUDIENCE_SELECTION_PANEL_OPENED_KEY } from './AudienceSelectionPanel/co
 const mockTrackEvent = jest.spyOn( tracking, 'trackEvent' );
 mockTrackEvent.mockImplementation( () => Promise.resolve() );
 
+const { simulateAllIntersections } = mockIntersectionObserver();
+
 describe( 'AudienceSegmentationBackNotice', () => {
 	let registry: WPDataRegistry;
 
@@ -63,14 +61,11 @@ describe( 'AudienceSegmentationBackNotice', () => {
 	)( AudienceSegmentationBackNotice );
 
 	beforeEach( () => {
-		intersectionObserver.mock();
-
 		registry = createTestRegistry();
 		registry.dispatch( CORE_USER ).receiveGetDismissedItems( [] );
 	} );
 
 	afterEach( () => {
-		intersectionObserver.restore();
 		jest.clearAllMocks();
 	} );
 
@@ -172,10 +167,7 @@ describe( 'AudienceSegmentationBackNotice', () => {
 
 		// Simulate the notice coming into view.
 		act( () => {
-			intersectionObserver.simulate( {
-				isIntersecting: true,
-				intersectionRatio: 1,
-			} );
+			simulateAllIntersections( true );
 		} );
 
 		await waitFor( () => {

--- a/assets/js/modules/analytics-4/components/audience-segmentation/dashboard/AudienceSegmentationErrorWidget/index.test.js
+++ b/assets/js/modules/analytics-4/components/audience-segmentation/dashboard/AudienceSegmentationErrorWidget/index.test.js
@@ -17,11 +17,6 @@
  */
 
 /**
- * External dependencies
- */
-import { intersectionObserver } from '@shopify/jest-dom-mocks';
-
-/**
  * Internal dependencies
  */
 import { VIEW_CONTEXT_MAIN_DASHBOARD } from '@/js/googlesitekit/constants';
@@ -30,6 +25,7 @@ import { MODULE_SLUG_ANALYTICS_4 } from '@/js/modules/analytics-4/constants';
 import { MODULES_ANALYTICS_4 } from '@/js/modules/analytics-4/datastore/constants';
 import { ERROR_REASON_INSUFFICIENT_PERMISSIONS } from '@/js/util/errors';
 import * as tracking from '@/js/util/tracking';
+import { mockIntersectionObserver } from '@tests/js/mock-browser-utils';
 import {
 	act,
 	createTestRegistry,
@@ -46,13 +42,13 @@ import AudienceSegmentationErrorWidget from '.';
 const mockTrackEvent = jest.spyOn( tracking, 'trackEvent' );
 mockTrackEvent.mockImplementation( () => Promise.resolve() );
 
+const { simulateAllIntersections } = mockIntersectionObserver();
+
 describe( 'AudienceSegmentationErrorWidget', () => {
 	let registry;
 	let originalViewportWidth;
 
 	beforeEach( () => {
-		intersectionObserver.mock();
-
 		registry = createTestRegistry();
 		provideModules( registry, [
 			{
@@ -70,7 +66,6 @@ describe( 'AudienceSegmentationErrorWidget', () => {
 	} );
 
 	afterEach( () => {
-		intersectionObserver.restore();
 		mockTrackEvent.mockClear();
 		setViewportWidth( originalViewportWidth );
 	} );
@@ -149,10 +144,7 @@ describe( 'AudienceSegmentationErrorWidget', () => {
 
 			// Simulate the CTA becoming visible.
 			act( () => {
-				intersectionObserver.simulate( {
-					isIntersecting: true,
-					intersectionRatio: 1,
-				} );
+				simulateAllIntersections( true );
 			} );
 
 			expect( mockTrackEvent ).toHaveBeenCalledWith(
@@ -255,10 +247,7 @@ describe( 'AudienceSegmentationErrorWidget', () => {
 
 			// Simulate the CTA becoming visible.
 			act( () => {
-				intersectionObserver.simulate( {
-					isIntersecting: true,
-					intersectionRatio: 1,
-				} );
+				simulateAllIntersections( true );
 			} );
 
 			expect( mockTrackEvent ).toHaveBeenCalledWith(

--- a/assets/js/modules/analytics-4/components/audience-segmentation/dashboard/AudienceTilesWidget/AudienceTile/AudienceTileError/index.test.js
+++ b/assets/js/modules/analytics-4/components/audience-segmentation/dashboard/AudienceTilesWidget/AudienceTile/AudienceTileError/index.test.js
@@ -17,11 +17,6 @@
  */
 
 /**
- * External dependencies
- */
-import { intersectionObserver } from '@shopify/jest-dom-mocks';
-
-/**
  * Internal dependencies
  */
 import { VIEW_CONTEXT_MAIN_DASHBOARD } from '@/js/googlesitekit/constants';
@@ -29,6 +24,7 @@ import { MODULE_SLUG_ANALYTICS_4 } from '@/js/modules/analytics-4/constants';
 import { MODULES_ANALYTICS_4 } from '@/js/modules/analytics-4/datastore/constants';
 import { ERROR_REASON_INSUFFICIENT_PERMISSIONS } from '@/js/util/errors';
 import * as tracking from '@/js/util/tracking';
+import { mockIntersectionObserver } from '@tests/js/mock-browser-utils';
 import { act, fireEvent, render } from '@tests/js/test-utils';
 import {
 	createTestRegistry,
@@ -42,6 +38,8 @@ import AudienceTileError from '.';
 
 const mockTrackEvent = jest.spyOn( tracking, 'trackEvent' );
 mockTrackEvent.mockImplementation( () => Promise.resolve() );
+
+const { simulateAllIntersections } = mockIntersectionObserver();
 
 describe( 'AudienceTileError', () => {
 	let registry;
@@ -79,8 +77,6 @@ describe( 'AudienceTileError', () => {
 	};
 
 	beforeEach( () => {
-		intersectionObserver.mock();
-
 		registry = createTestRegistry();
 
 		provideModules( registry, [
@@ -103,7 +99,6 @@ describe( 'AudienceTileError', () => {
 	} );
 
 	afterEach( () => {
-		intersectionObserver.restore();
 		mockTrackEvent.mockClear();
 	} );
 
@@ -175,10 +170,7 @@ describe( 'AudienceTileError', () => {
 
 		// Simulate the CTA becoming visible.
 		act( () => {
-			intersectionObserver.simulate( {
-				isIntersecting: true,
-				intersectionRatio: 1,
-			} );
+			simulateAllIntersections( true );
 		} );
 
 		await waitForRegistry();
@@ -244,10 +236,7 @@ describe( 'AudienceTileError', () => {
 
 		// Simulate the CTA becoming visible.
 		act( () => {
-			intersectionObserver.simulate( {
-				isIntersecting: true,
-				intersectionRatio: 1,
-			} );
+			simulateAllIntersections( true );
 		} );
 
 		await waitForRegistry();

--- a/assets/js/modules/analytics-4/components/audience-segmentation/dashboard/AudienceTilesWidget/AudienceTile/index.test.js
+++ b/assets/js/modules/analytics-4/components/audience-segmentation/dashboard/AudienceTilesWidget/AudienceTile/index.test.js
@@ -19,7 +19,6 @@
 /**
  * External dependencies
  */
-import { intersectionObserver } from '@shopify/jest-dom-mocks';
 import { getByText as domGetByText } from '@testing-library/dom';
 
 /**
@@ -42,6 +41,7 @@ import { getAnalytics4MockResponse } from '@/js/modules/analytics-4/utils/data-m
 import { getPreviousDate } from '@/js/util';
 import { ERROR_REASON_INSUFFICIENT_PERMISSIONS } from '@/js/util/errors';
 import * as tracking from '@/js/util/tracking';
+import { mockIntersectionObserver } from '@tests/js/mock-browser-utils';
 import { act, fireEvent, render } from '@tests/js/test-utils';
 import {
 	createTestRegistry,
@@ -57,6 +57,8 @@ import AudienceTile from '.';
 
 const mockTrackEvent = jest.spyOn( tracking, 'trackEvent' );
 mockTrackEvent.mockImplementation( () => Promise.resolve() );
+
+const { simulateAllIntersections } = mockIntersectionObserver();
 
 describe( 'AudienceTile', () => {
 	let registry, originalViewportWidth;
@@ -155,8 +157,6 @@ describe( 'AudienceTile', () => {
 		// Ensure the viewport is wide enough to render the tooltips.
 		setViewportWidth( 1024 );
 
-		intersectionObserver.mock();
-
 		registry = createTestRegistry();
 		provideModules( registry, [
 			{
@@ -218,7 +218,6 @@ describe( 'AudienceTile', () => {
 	} );
 
 	afterEach( () => {
-		intersectionObserver.restore();
 		mockTrackEvent.mockClear();
 		setViewportWidth( originalViewportWidth );
 	} );
@@ -278,10 +277,7 @@ describe( 'AudienceTile', () => {
 
 			// Simulate the CTA becoming visible.
 			act( () => {
-				intersectionObserver.simulate( {
-					isIntersecting: true,
-					intersectionRatio: 1,
-				} );
+				simulateAllIntersections( true );
 			} );
 
 			expect( mockTrackEvent ).toHaveBeenCalledTimes( 1 );
@@ -500,10 +496,7 @@ describe( 'AudienceTile', () => {
 
 			// Simulate the tile coming into view.
 			act( () => {
-				intersectionObserver.simulate( {
-					isIntersecting: true,
-					intersectionRatio: 1,
-				} );
+				simulateAllIntersections( true );
 			} );
 
 			expect( mockTrackEvent ).toHaveBeenCalledTimes( 1 );

--- a/assets/js/modules/analytics-4/components/audience-segmentation/dashboard/InfoNoticeWidget/index.test.js
+++ b/assets/js/modules/analytics-4/components/audience-segmentation/dashboard/InfoNoticeWidget/index.test.js
@@ -17,11 +17,6 @@
  */
 
 /**
- * External dependencies
- */
-import { intersectionObserver } from '@shopify/jest-dom-mocks';
-
-/**
  * Internal dependencies.
  */
 import { VIEW_CONTEXT_MAIN_DASHBOARD } from '@/js/googlesitekit/constants';
@@ -32,6 +27,7 @@ import { availableAudiences } from '@/js/modules/analytics-4/datastore/__fixture
 import { MODULES_ANALYTICS_4 } from '@/js/modules/analytics-4/datastore/constants';
 import { WEEK_IN_SECONDS } from '@/js/util';
 import * as tracking from '@/js/util/tracking';
+import { mockIntersectionObserver } from '@tests/js/mock-browser-utils';
 import {
 	act,
 	createTestRegistry,
@@ -47,14 +43,14 @@ import InfoNoticeWidget from '.';
 const mockTrackEvent = jest.spyOn( tracking, 'trackEvent' );
 mockTrackEvent.mockImplementation( () => Promise.resolve() );
 
+const { simulateAllIntersections } = mockIntersectionObserver();
+
 describe( 'InfoNoticeWidget', () => {
 	let registry;
 
 	let dismissPromptSpy;
 
 	beforeEach( () => {
-		intersectionObserver.mock();
-
 		registry = createTestRegistry();
 		provideModules( registry, [
 			{
@@ -71,7 +67,6 @@ describe( 'InfoNoticeWidget', () => {
 	} );
 
 	afterEach( () => {
-		intersectionObserver.restore();
 		mockTrackEvent.mockClear();
 	} );
 
@@ -409,10 +404,7 @@ describe( 'InfoNoticeWidget', () => {
 
 				// Simulate the notice coming into view.
 				act( () => {
-					intersectionObserver.simulate( {
-						isIntersecting: true,
-						intersectionRatio: 1,
-					} );
+					simulateAllIntersections( true );
 				} );
 
 				expect( mockTrackEvent ).toHaveBeenCalledTimes( 1 );

--- a/assets/js/modules/analytics-4/components/audience-segmentation/dashboard/NoAudienceBannerWidget/index.test.js
+++ b/assets/js/modules/analytics-4/components/audience-segmentation/dashboard/NoAudienceBannerWidget/index.test.js
@@ -17,11 +17,6 @@
  */
 
 /**
- * External dependencies
- */
-import { intersectionObserver } from '@shopify/jest-dom-mocks';
-
-/**
  * Internal dependencies
  */
 import {
@@ -36,7 +31,10 @@ import { MODULE_SLUG_ANALYTICS_4 } from '@/js/modules/analytics-4/constants';
 import { availableAudiences } from '@/js/modules/analytics-4/datastore/__fixtures__';
 import { MODULES_ANALYTICS_4 } from '@/js/modules/analytics-4/datastore/constants';
 import * as tracking from '@/js/util/tracking';
-import { mockLocation } from '@tests/js/mock-browser-utils';
+import {
+	mockIntersectionObserver,
+	mockLocation,
+} from '@tests/js/mock-browser-utils';
 import { act, fireEvent, render } from '@tests/js/test-utils';
 import {
 	createTestRegistry,
@@ -54,6 +52,8 @@ mockTrackEvent.mockImplementation( () => Promise.resolve() );
 describe( 'NoAudienceBannerWidget', () => {
 	mockLocation();
 
+	const { simulateAllIntersections } = mockIntersectionObserver();
+
 	let registry;
 
 	const WidgetWithComponentProps = withWidgetComponentProps(
@@ -65,8 +65,6 @@ describe( 'NoAudienceBannerWidget', () => {
 	);
 
 	beforeEach( () => {
-		intersectionObserver.mock();
-
 		registry = createTestRegistry();
 		provideModules( registry, [
 			{
@@ -80,7 +78,6 @@ describe( 'NoAudienceBannerWidget', () => {
 	} );
 
 	afterEach( () => {
-		intersectionObserver.restore();
 		jest.clearAllMocks();
 	} );
 
@@ -241,10 +238,7 @@ describe( 'NoAudienceBannerWidget', () => {
 
 			// Simulate the CTA becoming visible.
 			act( () => {
-				intersectionObserver.simulate( {
-					isIntersecting: true,
-					intersectionRatio: 1,
-				} );
+				simulateAllIntersections( true );
 			} );
 
 			expect( mockTrackEvent ).toHaveBeenCalledTimes( 1 );
@@ -357,10 +351,7 @@ describe( 'NoAudienceBannerWidget', () => {
 
 			// Simulate the CTA becoming visible.
 			act( () => {
-				intersectionObserver.simulate( {
-					isIntersecting: true,
-					intersectionRatio: 1,
-				} );
+				simulateAllIntersections( true );
 			} );
 
 			expect( mockTrackEvent ).toHaveBeenCalledTimes( 1 );
@@ -456,10 +447,7 @@ describe( 'NoAudienceBannerWidget', () => {
 
 			// Simulate the CTA becoming visible.
 			act( () => {
-				intersectionObserver.simulate( {
-					isIntersecting: true,
-					intersectionRatio: 1,
-				} );
+				simulateAllIntersections( true );
 			} );
 
 			expect( mockTrackEvent ).toHaveBeenCalledTimes( 1 );
@@ -543,10 +531,7 @@ describe( 'NoAudienceBannerWidget', () => {
 
 			// Simulate the CTA becoming visible.
 			act( () => {
-				intersectionObserver.simulate( {
-					isIntersecting: true,
-					intersectionRatio: 1,
-				} );
+				simulateAllIntersections( true );
 			} );
 
 			expect( mockTrackEvent ).toHaveBeenCalledTimes( 1 );

--- a/assets/js/modules/analytics-4/components/audience-segmentation/settings/SettingsCardAudiences/SetupSuccess/index.test.js
+++ b/assets/js/modules/analytics-4/components/audience-segmentation/settings/SettingsCardAudiences/SetupSuccess/index.test.js
@@ -17,11 +17,6 @@
  */
 
 /**
- * External dependencies
- */
-import { intersectionObserver } from '@shopify/jest-dom-mocks';
-
-/**
  * WordPress dependencies
  */
 import { addQueryArgs } from '@wordpress/url';
@@ -35,7 +30,10 @@ import { CORE_UI } from '@/js/googlesitekit/datastore/ui/constants';
 import { CORE_USER } from '@/js/googlesitekit/datastore/user/constants';
 import { AREA_MAIN_DASHBOARD_TRAFFIC_AUDIENCE_SEGMENTATION } from '@/js/googlesitekit/widgets/default-areas';
 import * as tracking from '@/js/util/tracking';
-import { mockLocation } from '@tests/js/mock-browser-utils';
+import {
+	mockIntersectionObserver,
+	mockLocation,
+} from '@tests/js/mock-browser-utils';
 import {
 	act,
 	createTestRegistry,
@@ -58,9 +56,9 @@ describe( 'SettingsCardAudiences SetupSuccess', () => {
 
 	mockLocation();
 
-	beforeEach( () => {
-		intersectionObserver.mock();
+	const { simulateAllIntersections } = mockIntersectionObserver();
 
+	beforeEach( () => {
 		registry = createTestRegistry();
 
 		provideSiteInfo( registry );
@@ -81,7 +79,6 @@ describe( 'SettingsCardAudiences SetupSuccess', () => {
 	} );
 
 	afterEach( () => {
-		intersectionObserver.restore();
 		dismissItemSpy.mockReset();
 		mockTrackEvent.mockClear();
 	} );
@@ -116,10 +113,7 @@ describe( 'SettingsCardAudiences SetupSuccess', () => {
 
 		// Simulate the CTA becoming visible.
 		act( () => {
-			intersectionObserver.simulate( {
-				isIntersecting: true,
-				intersectionRatio: 1,
-			} );
+			simulateAllIntersections( true );
 		} );
 
 		expect( mockTrackEvent ).toHaveBeenCalledTimes( 1 );

--- a/assets/js/modules/analytics-4/components/site-goals/notifications/BreakdownNoticeArea.test.tsx
+++ b/assets/js/modules/analytics-4/components/site-goals/notifications/BreakdownNoticeArea.test.tsx
@@ -17,11 +17,6 @@
  */
 
 /**
- * External dependencies
- */
-import { intersectionObserver } from '@shopify/jest-dom-mocks';
-
-/**
  * WordPress dependencies
  */
 import { WPDataRegistry } from '@wordpress/data/build-types/registry';
@@ -54,6 +49,7 @@ import {
 import { ALL_CUSTOM_DIMENSIONS } from '@/js/modules/analytics-4/hooks/useBreakdownEnableHandler';
 import { provideCustomDimensionError } from '@/js/modules/analytics-4/utils/custom-dimensions';
 import * as tracking from '@/js/util/tracking';
+import { mockIntersectionObserver } from '@tests/js/mock-browser-utils';
 import { act, fireEvent, render, waitFor } from '@tests/js/test-utils';
 import {
 	createTestRegistry,
@@ -872,22 +868,19 @@ describe( 'BreakdownNoticeArea', () => {
 			typeof tracking.trackEventOnce
 		>;
 
+		const { simulateAllIntersections } = mockIntersectionObserver();
+
 		beforeEach( () => {
 			mockTrackEventOnce = jest.spyOn( tracking, 'trackEventOnce' );
-			intersectionObserver.mock();
 		} );
 
 		afterEach( () => {
 			mockTrackEventOnce.mockRestore();
-			intersectionObserver.restore();
 		} );
 
 		function simulateInView() {
 			act( () => {
-				intersectionObserver.simulate( {
-					isIntersecting: true,
-					intersectionRatio: 1,
-				} );
+				simulateAllIntersections( true );
 			} );
 		}
 

--- a/assets/js/modules/analytics-4/components/site-goals/notifications/IntroModalBanner/index.test.js
+++ b/assets/js/modules/analytics-4/components/site-goals/notifications/IntroModalBanner/index.test.js
@@ -50,6 +50,7 @@ import {
 } from '@/js/modules/analytics-4/datastore/constants';
 import { ANALYTICS_4_NOTIFICATIONS } from '@/js/modules/analytics-4/notifications';
 import * as scrollUtils from '@/js/util/scroll';
+import { mockIntersectionObserver } from '@tests/js/mock-browser-utils';
 import { dismissItemEndpoint } from '@tests/js/mock-dismiss-item-endpoints';
 import {
 	act,
@@ -72,33 +73,6 @@ jest.mock( '@/js/googlesitekit/notifications/hooks/useNotificationEvents' );
 const IntroModalComponent = withNotificationComponentProps(
 	SITE_GOALS_INTRO_MODAL_BANNER
 )( IntroModal );
-
-/**
- * The modal content renders inside a fixed-position Dialog, so the
- * `<Notification>` wrapper's own observer never sees it. `BannerModal` observes
- * its own graphic with `withIntersectionObserver`, which uses the native
- * `IntersectionObserver`. jsdom has none, so this stub reports the element as
- * in view the moment it is observed, which fires the modal's `onView` and makes
- * `<Notification>` send the `view_notification` event.
- *
- * @since 1.184.0
- */
-class InViewIntersectionObserver {
-	constructor( callback ) {
-		this.callback = callback;
-	}
-
-	observe( element ) {
-		this.callback(
-			[ { isIntersecting: true, intersectionRatio: 1, target: element } ],
-			this
-		);
-	}
-
-	unobserve() {}
-
-	disconnect() {}
-}
 
 const getNavigationalScrollTopSpy = jest.spyOn(
 	scrollUtils,
@@ -671,16 +645,12 @@ describe( 'IntroModal', () => {
 	} );
 
 	describe( 'view tracking', () => {
-		let originalIntersectionObserver;
-
-		beforeEach( () => {
-			originalIntersectionObserver = global.IntersectionObserver;
-			global.IntersectionObserver = InViewIntersectionObserver;
-		} );
-
-		afterEach( () => {
-			global.IntersectionObserver = originalIntersectionObserver;
-		} );
+		// The modal's content renders inside a fixed-position Dialog, so the
+		// `<Notification>` wrapper's own observer never sees it. `BannerModal`
+		// observes its own graphic with `withIntersectionObserver`, so
+		// simulating that observer's intersection fires the modal's `onView`
+		// and makes `<Notification>` send the `view_notification` event.
+		const { simulateAllIntersections } = mockIntersectionObserver();
 
 		it( 'sends the view_notification event once the modal comes into view', async () => {
 			registry
@@ -694,10 +664,11 @@ describe( 'IntroModal', () => {
 
 			await waitForIntroModalToShow( getByRole );
 
-			// The modal's content renders inside a fixed-position Dialog, so the
-			// `<Notification>` wrapper's own observer never marks it viewed.
-			// `BannerModal`'s `onView` fills that gap, which makes the wrapper
-			// send the view event labelled with the modal variant.
+			// Simulate the modal's graphic coming into view.
+			act( () => {
+				simulateAllIntersections( true );
+			} );
+
 			await waitFor( () => {
 				expect( trackEvents.view ).toHaveBeenCalledWith(
 					INTRO_MODAL_VARIANTS.ECOMMERCE,

--- a/assets/js/modules/analytics-4/components/site-goals/widgets/LeadGenerationPerformanceWidget.test.tsx
+++ b/assets/js/modules/analytics-4/components/site-goals/widgets/LeadGenerationPerformanceWidget.test.tsx
@@ -17,7 +17,6 @@
 /**
  * External dependencies
  */
-import { intersectionObserver } from '@shopify/jest-dom-mocks';
 import fetchMock from 'fetch-mock';
 
 /**
@@ -54,6 +53,7 @@ import {
 } from '@/js/modules/analytics-4/datastore/constants';
 import { provideAnalytics4MockReport } from '@/js/modules/analytics-4/utils/data-mock';
 import { getPreviousDate } from '@/js/util';
+import { mockIntersectionObserver } from '@tests/js/mock-browser-utils';
 import {
 	createTestRegistry,
 	fireEvent,
@@ -71,6 +71,8 @@ type WidgetComponentProps = ReturnType< typeof getWidgetComponentProps >;
 
 describe( 'LeadGenerationPerformanceWidget', () => {
 	let registry: WPDataRegistry;
+
+	const { getObservedElements } = mockIntersectionObserver();
 
 	const widgetProps: WidgetComponentProps = getWidgetComponentProps(
 		'analyticsLeadGenerationPerformance'
@@ -1924,8 +1926,6 @@ describe( 'LeadGenerationPerformanceWidget', () => {
 	} );
 
 	it( 'observes the widget element after it renders', async () => {
-		intersectionObserver.mock();
-
 		registry
 			.dispatch( MODULES_ANALYTICS_4 )
 			.setDetectedEvents( [ ENUM_CONVERSION_EVENTS.GENERATE_LEAD ] );
@@ -1937,15 +1937,10 @@ describe( 'LeadGenerationPerformanceWidget', () => {
 		);
 		await waitForRegistry();
 
-		const observedTargets = intersectionObserver.observers.map(
-			( observer ) => observer.target
-		);
-		expect( observedTargets ).toContain(
+		expect( getObservedElements() ).toContain(
 			container.querySelector(
 				'.googlesitekit-widget--analyticsLeadGenerationPerformance'
 			)
 		);
-
-		intersectionObserver.restore();
 	} );
 } );

--- a/assets/js/modules/analytics-4/components/site-goals/widgets/OnlineStorePerformanceWidget.test.tsx
+++ b/assets/js/modules/analytics-4/components/site-goals/widgets/OnlineStorePerformanceWidget.test.tsx
@@ -17,7 +17,6 @@
 /**
  * External dependencies
  */
-import { intersectionObserver } from '@shopify/jest-dom-mocks';
 import fetchMock from 'fetch-mock';
 
 /**
@@ -53,6 +52,7 @@ import {
 } from '@/js/modules/analytics-4/datastore/constants';
 import { provideAnalytics4MockReport } from '@/js/modules/analytics-4/utils/data-mock';
 import { getPreviousDate } from '@/js/util';
+import { mockIntersectionObserver } from '@tests/js/mock-browser-utils';
 import { fireEvent, render, waitFor } from '@tests/js/test-utils';
 import {
 	createTestRegistry,
@@ -68,6 +68,9 @@ type WidgetComponentProps = ReturnType< typeof getWidgetComponentProps >;
 
 describe( 'OnlineStorePerformanceWidget', () => {
 	let registry: WPDataRegistry;
+
+	const { getObservedElements } = mockIntersectionObserver();
+
 	const widgetProps: WidgetComponentProps = getWidgetComponentProps(
 		'analyticsOnlineStorePerformance'
 	);
@@ -1971,8 +1974,6 @@ describe( 'OnlineStorePerformanceWidget', () => {
 	} );
 
 	it( 'observes the widget element after it renders', async () => {
-		intersectionObserver.mock();
-
 		registry
 			.dispatch( MODULES_ANALYTICS_4 )
 			.setDetectedEvents( [ ENUM_CONVERSION_EVENTS.PURCHASE ] );
@@ -1984,15 +1985,10 @@ describe( 'OnlineStorePerformanceWidget', () => {
 		);
 		await waitForRegistry();
 
-		const observedTargets = intersectionObserver.observers.map(
-			( observer ) => observer.target
-		);
-		expect( observedTargets ).toContain(
+		expect( getObservedElements() ).toContain(
 			container.querySelector(
 				'.googlesitekit-widget--analyticsOnlineStorePerformance'
 			)
 		);
-
-		intersectionObserver.restore();
 	} );
 } );

--- a/tests/js/mock-browser-utils.js
+++ b/tests/js/mock-browser-utils.js
@@ -187,11 +187,27 @@ export function mockIntersectionObserver() {
 		global.IntersectionObserver = function MockIntersectionObserver(
 			callback
 		) {
+			// Identifies this observer instance's own entries below, since a
+			// single suite can have multiple observer instances (e.g. across
+			// remounts) whose stale entries must not linger and fire once
+			// disconnected/unobserved, as real `IntersectionObserver`s would.
+			const instance = this;
+
 			this.observe = function observe( target ) {
-				observers.push( { callback, target } );
+				observers.push( { callback, target, instance } );
 			};
-			this.disconnect = jest.fn();
-			this.unobserve = jest.fn();
+			this.unobserve = function unobserve( target ) {
+				observers = observers.filter(
+					( observer ) =>
+						observer.instance !== instance ||
+						observer.target !== target
+				);
+			};
+			this.disconnect = function disconnect() {
+				observers = observers.filter(
+					( observer ) => observer.instance !== instance
+				);
+			};
 			this.takeRecords = jest.fn().mockReturnValue( [] );
 		};
 	} );


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Related issue(s):

- Resolves #13187

## Relevant technical choices

#### Intentionally left unmigrated

- `useLatestIntersection.test.tsx`, `withIntersectionObserver.test.tsx` — these are unit tests of the intersection primitives themselves (thresholds/options, disconnect counts, multi-entry callbacks, exact entry shape), not "ad-hoc mocks emulating visibility for assertions.".

<!-- Please describe your changes. -->

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.
- [ ] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [x] Ensure the PR has the correct target branch.
- [x] Double-check that the PR is okay to be merged.
- [x] Ensure the corresponding issue has a ZenHub release assigned.
- [x] Add a changelog message to the issue.
