### PR TITLE
Restore the ability to analyze Webpack bundle sizes.

### DIFF
--- a/assets/package.json
+++ b/assets/package.json
@@ -87,6 +87,7 @@
 		"terser-webpack-plugin": "^5.3.14",
 		"url-loader": "^4.1.1",
 		"webpack": "^5.99.7",
+		"webpack-bundle-analyzer": "^5.3.2",
 		"webpack-cli": "^7.0.2",
 		"webpack-manifest-plugin": "^6.0.1",
 		"@types/react-router-dom": "^5.2.0"

--- a/assets/webpack.config.js
+++ b/assets/webpack.config.js
@@ -29,20 +29,25 @@ const testBundleConfig = require( './webpack/testBundle.config' );
 
 function* webpackConfig( env, argv ) {
 	const { mode } = argv;
+	const { ANALYZE } = env || {};
 
 	const rules = createRules( mode );
 
 	// Build the settings js..
-	yield modulesConfig( mode, rules );
+	yield modulesConfig( mode, rules, ANALYZE );
 
 	// Build basic modules that don't require advanced optimizations, splitting chunks, and so on...
-	yield basicModulesConfig( mode, rules );
+	yield basicModulesConfig( mode, rules, ANALYZE );
 
 	// Build modules that will be used on the frontend, that require wider browser support.
-	yield frontendModules( mode );
+	yield frontendModules( mode, ANALYZE );
 
 	// Build the Gutenberg blocks JS/CSS.
-	yield gutenbergBlocksConfig( mode );
+	yield gutenbergBlocksConfig( mode, ANALYZE );
+
+	if ( ANALYZE ) {
+		return;
+	}
 
 	// Build the main plugin admin css.
 	yield adminCssConfig( mode );

--- a/assets/webpack/basicModules.config.js
+++ b/assets/webpack/basicModules.config.js
@@ -19,6 +19,7 @@
 /**
  * External dependencies
  */
+const { BundleAnalyzerPlugin } = require( 'webpack-bundle-analyzer' );
 const { WebpackManifestPlugin } = require( 'webpack-manifest-plugin' );
 
 /**
@@ -31,7 +32,7 @@ const {
 	resolve,
 } = require( '../../webpack/common' );
 
-module.exports = ( mode, rules ) => ( {
+module.exports = ( mode, rules, ANALYZE ) => ( {
 	name: 'Basic Modules',
 	entry: {
 		'googlesitekit-i18n': './js/googlesitekit-i18n.ts',
@@ -56,6 +57,14 @@ module.exports = ( mode, rules ) => ( {
 				return ( file.name || '' ).match( /\.js$/ );
 			},
 		} ),
+		...( ANALYZE
+			? [
+					new BundleAnalyzerPlugin( {
+						analyzerPort: 'auto',
+						reportTitle: 'Basic Modules',
+					} ),
+			  ]
+			: [] ),
 	],
 	optimization: {
 		concatenateModules: true,

--- a/assets/webpack/basicModules.config.js
+++ b/assets/webpack/basicModules.config.js
@@ -60,7 +60,10 @@ module.exports = ( mode, rules, ANALYZE ) => ( {
 		...( ANALYZE
 			? [
 					new BundleAnalyzerPlugin( {
+						analyzerMode: 'static',
 						analyzerPort: 'auto',
+						openAnalyzer: false,
+						reportFilename: 'basic-modules-report.html',
 						reportTitle: 'Basic Modules',
 					} ),
 			  ]

--- a/assets/webpack/frontendModules.config.js
+++ b/assets/webpack/frontendModules.config.js
@@ -19,6 +19,7 @@
 /**
  * External dependencies
  */
+const { BundleAnalyzerPlugin } = require( 'webpack-bundle-analyzer' );
 const { WebpackManifestPlugin } = require( 'webpack-manifest-plugin' );
 
 /**
@@ -31,7 +32,7 @@ const {
 	resolve,
 } = require( '../../webpack/common' );
 
-module.exports = ( mode ) => ( {
+module.exports = ( mode, ANALYZE ) => ( {
 	name: 'Frontend Modules',
 	entry: {
 		// Consent mode
@@ -100,6 +101,14 @@ module.exports = ( mode ) => ( {
 				return ( file.name || '' ).match( /\.js$/ );
 			},
 		} ),
+		...( ANALYZE
+			? [
+					new BundleAnalyzerPlugin( {
+						analyzerPort: 'auto',
+						reportTitle: 'Frontend Modules',
+					} ),
+			  ]
+			: [] ),
 	],
 	optimization: {
 		concatenateModules: true,

--- a/assets/webpack/frontendModules.config.js
+++ b/assets/webpack/frontendModules.config.js
@@ -104,7 +104,10 @@ module.exports = ( mode, ANALYZE ) => ( {
 		...( ANALYZE
 			? [
 					new BundleAnalyzerPlugin( {
+						analyzerMode: 'static',
 						analyzerPort: 'auto',
+						openAnalyzer: false,
+						reportFilename: 'frontend-modules-report.html',
 						reportTitle: 'Frontend Modules',
 					} ),
 			  ]

--- a/assets/webpack/gutenbergBlocks.config.js
+++ b/assets/webpack/gutenbergBlocks.config.js
@@ -22,6 +22,7 @@
 const CopyWebpackPlugin = require( 'copy-webpack-plugin' );
 const ESLintPlugin = require( 'eslint-webpack-plugin' );
 const MiniCssExtractPlugin = require( 'mini-css-extract-plugin' );
+const { BundleAnalyzerPlugin } = require( 'webpack-bundle-analyzer' );
 const { WebpackManifestPlugin } = require( 'webpack-manifest-plugin' );
 
 /**
@@ -36,7 +37,7 @@ const {
 } = require( '../../webpack/common' );
 const { createMinimizerRules } = require( './common' );
 
-module.exports = ( mode ) => ( {
+module.exports = ( mode, ANALYZE ) => ( {
 	name: 'Gutenberg Blocks Entry Points',
 	entry: {
 		// Reader Revenue Manager
@@ -123,6 +124,14 @@ module.exports = ( mode ) => ( {
 			emitWarning: true,
 			failOnError: true,
 		} ),
+		...( ANALYZE
+			? [
+					new BundleAnalyzerPlugin( {
+						analyzerPort: 'auto',
+						reportTitle: 'Gutenberg Blocks Entry Points',
+					} ),
+			  ]
+			: [] ),
 	],
 	optimization: {
 		minimizer: createMinimizerRules(),

--- a/assets/webpack/gutenbergBlocks.config.js
+++ b/assets/webpack/gutenbergBlocks.config.js
@@ -127,7 +127,10 @@ module.exports = ( mode, ANALYZE ) => ( {
 		...( ANALYZE
 			? [
 					new BundleAnalyzerPlugin( {
+						analyzerMode: 'static',
 						analyzerPort: 'auto',
+						openAnalyzer: false,
+						reportFilename: 'gutenberg-blocks-report.html',
 						reportTitle: 'Gutenberg Blocks Entry Points',
 					} ),
 			  ]

--- a/assets/webpack/modules.config.js
+++ b/assets/webpack/modules.config.js
@@ -178,7 +178,10 @@ module.exports = function ( mode, rules, ANALYZE ) {
 			...( ANALYZE
 				? [
 						new BundleAnalyzerPlugin( {
+							analyzerMode: 'static',
 							analyzerPort: 'auto',
+							openAnalyzer: false,
+							reportFilename: 'modules-report.html',
 							reportTitle: 'Module Entry Points',
 						} ),
 				  ]

--- a/assets/webpack/modules.config.js
+++ b/assets/webpack/modules.config.js
@@ -23,6 +23,7 @@ const CreateFileWebpack = require( 'create-file-webpack' );
 const ESLintPlugin = require( 'eslint-webpack-plugin' );
 const path = require( 'path' );
 const { DefinePlugin, ProvidePlugin, ProgressPlugin } = require( 'webpack' );
+const { BundleAnalyzerPlugin } = require( 'webpack-bundle-analyzer' );
 const { WebpackManifestPlugin } = require( 'webpack-manifest-plugin' );
 
 /**
@@ -54,7 +55,7 @@ const LAZY_PDF_REPORT_VENDOR_MODULES = [
 	/[\\/]node_modules[\\/]restructure[\\/]/,
 ];
 
-module.exports = function ( mode, rules ) {
+module.exports = function ( mode, rules, ANALYZE ) {
 	const isProduction = mode === 'production';
 
 	return {
@@ -174,6 +175,14 @@ module.exports = function ( mode, rules ) {
 				chunkName: 'googlesitekit-vendor',
 				disallowed: LAZY_PDF_REPORT_VENDOR_MODULES,
 			} ),
+			...( ANALYZE
+				? [
+						new BundleAnalyzerPlugin( {
+							analyzerPort: 'auto',
+							reportTitle: 'Module Entry Points',
+						} ),
+				  ]
+				: [] ),
 		],
 		optimization: {
 			minimizer: createMinimizerRules(),

--- a/package-lock.json
+++ b/package-lock.json
@@ -163,6 +163,7 @@
 				"terser-webpack-plugin": "^5.3.14",
 				"url-loader": "^4.1.1",
 				"webpack": "^5.99.7",
+				"webpack-bundle-analyzer": "^5.3.2",
 				"webpack-cli": "^7.0.2",
 				"webpack-manifest-plugin": "^6.0.1"
 			}
@@ -8051,6 +8052,13 @@
 				"node": ">=18"
 			}
 		},
+		"node_modules/@polka/url": {
+			"version": "1.0.0-next.29",
+			"resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.29.tgz",
+			"integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/@popperjs/core": {
 			"version": "2.11.8",
 			"resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
@@ -12074,6 +12082,32 @@
 			"license": "MIT",
 			"peerDependencies": {
 				"acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+			}
+		},
+		"node_modules/acorn-walk": {
+			"version": "8.3.5",
+			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
+			"integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"acorn": "^8.11.0"
+			},
+			"engines": {
+				"node": ">=0.4.0"
+			}
+		},
+		"node_modules/acorn-walk/node_modules/acorn": {
+			"version": "8.18.0",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+			"integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"acorn": "bin/acorn"
+			},
+			"engines": {
+				"node": ">=0.4.0"
 			}
 		},
 		"node_modules/agent-base": {
@@ -21005,19 +21039,6 @@
 				"acorn-walk": "^8.0.2"
 			}
 		},
-		"node_modules/jest-environment-jsdom/node_modules/acorn-walk": {
-			"version": "8.3.5",
-			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
-			"integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"acorn": "^8.11.0"
-			},
-			"engines": {
-				"node": ">=0.4.0"
-			}
-		},
 		"node_modules/jest-environment-jsdom/node_modules/cssom": {
 			"version": "0.5.0",
 			"resolved": "https://registry.npmjs.org/cssom/-/cssom-0.5.0.tgz",
@@ -23853,6 +23874,16 @@
 			"integrity": "sha512-QNo4kEepaIBwiT8CDhP98umTetp+JNfQYBWvC1pc6/OAibuXtRcxZ58Qz8skvEHYvURne/7R8T5VoOI7rDsEUA==",
 			"license": "Apache-2.0 WITH LLVM-exception"
 		},
+		"node_modules/mrmime": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
+			"integrity": "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			}
+		},
 		"node_modules/ms": {
 			"version": "2.1.3",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -24582,6 +24613,16 @@
 			"license": "MIT",
 			"bin": {
 				"opencollective-postinstall": "index.js"
+			}
+		},
+		"node_modules/opener": {
+			"version": "1.5.2",
+			"resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
+			"integrity": "sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==",
+			"dev": true,
+			"license": "(WTFPL OR MIT)",
+			"bin": {
+				"opener": "bin/opener-bin.js"
 			}
 		},
 		"node_modules/optionator": {
@@ -29732,6 +29773,21 @@
 			"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
 			"license": "ISC"
 		},
+		"node_modules/sirv": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/sirv/-/sirv-3.0.2.tgz",
+			"integrity": "sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@polka/url": "^1.0.0-next.24",
+				"mrmime": "^2.0.0",
+				"totalist": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
 		"node_modules/sisteransi": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -31594,6 +31650,16 @@
 			"integrity": "sha512-BiZS+C1OS8g/q2RRbJmy59xpyghNBqrr6k5L/uKBGRsTfxmu3ffiRnd8mlGPUVayg8pvfi5urfnu8TU7DVOkLQ==",
 			"license": "MIT"
 		},
+		"node_modules/totalist": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
+			"integrity": "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
 		"node_modules/tough-cookie": {
 			"version": "4.1.4",
 			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
@@ -32556,6 +32622,74 @@
 					"optional": true
 				}
 			}
+		},
+		"node_modules/webpack-bundle-analyzer": {
+			"version": "5.3.2",
+			"resolved": "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-5.3.2.tgz",
+			"integrity": "sha512-IagCa/GrdxSz+ba9OMgK7UCfQp97HtXbgjXu7ObcqmRo9PTp0d+24rgY+mIFOx7JPQ9bo6FGsqZhA55rYRZrrQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@discoveryjs/json-ext": "^0.6.3",
+				"acorn": "^8.0.4",
+				"acorn-walk": "^8.0.0",
+				"commander": "^14.0.2",
+				"escape-string-regexp": "^5.0.0",
+				"html-escaper": "^3.0.3",
+				"opener": "^1.5.2",
+				"picocolors": "^1.0.0",
+				"sirv": "^3.0.2",
+				"ws": "^8.19.0"
+			},
+			"bin": {
+				"webpack-bundle-analyzer": "lib/bin/analyzer.js"
+			},
+			"engines": {
+				"node": ">= 20.9.0"
+			}
+		},
+		"node_modules/webpack-bundle-analyzer/node_modules/acorn": {
+			"version": "8.18.0",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+			"integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"acorn": "bin/acorn"
+			},
+			"engines": {
+				"node": ">=0.4.0"
+			}
+		},
+		"node_modules/webpack-bundle-analyzer/node_modules/commander": {
+			"version": "14.0.3",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+			"integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=20"
+			}
+		},
+		"node_modules/webpack-bundle-analyzer/node_modules/escape-string-regexp": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+			"integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/webpack-bundle-analyzer/node_modules/html-escaper": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-3.0.3.tgz",
+			"integrity": "sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/webpack-cli": {
 			"version": "7.0.2",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
 		"test": "npm run -w tests/js test:js:watch",
 		"test:visualtest": "npm run -w tests/backstop test:visualtest",
 		"test:visualapprove": "npm run -w tests/backstop test:visualapprove",
+		"test:analyze": "npm run -w assets build:production -- --env ANALYZE",
 		"test:js": "npm run -w tests/js test:js",
 		"test:js:watch": "npm run -w tests/js test:js:watch",
 		"test:storybook": "npm run -w storybook test",


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Related issue(s):

- Resolves #13282

## Relevant technical choices

<!-- Please describe your changes. -->

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.
- [ ] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [x] Ensure the PR has the correct target branch.
- [x] Double-check that the PR is okay to be merged.
- [x] Ensure the corresponding issue has a ZenHub release assigned.
- [x] Add a changelog message to the issue.
