### PR TITLE
Show the Site Goals cards at the top of the email report

### DIFF
--- a/includes/Core/Email_Reporting/Email_Assets.php
+++ b/includes/Core/Email_Reporting/Email_Assets.php
@@ -42,7 +42,6 @@ class Email_Assets {
 		'site-kit-logo'                 => '2025-12-01-site-kit-logo.png',
 		// email-report assets.
 		'shooting-stars-graphic'        => '2025-12-01-shooting-stars-graphic.png',
-		'icon-conversions'              => '2025-12-01-icon-conversions.png',
 		'icon-growth'                   => '2025-12-01-icon-growth.png',
 		'icon-link-arrow'               => '2025-12-01-icon-link-arrow.png',
 		'icon-search'                   => '2025-12-01-icon-search.png',
@@ -51,8 +50,6 @@ class Email_Assets {
 		'icon-star'                     => '2026-03-03-icon-star.png',
 		'icon-online-store'             => '2026-08-31-icon-online-store.png',
 		'icon-lead-generation'          => '2026-08-31-icon-lead-generation.png',
-		'conversions-timeline-green'    => '2025-12-01-conversions-timeline-green.png',
-		'conversions-timeline-red'      => '2025-12-01-conversions-timeline-red.png',
 		'notification-icon-star'        => '2025-12-01-notification-icon-star.png',
 		// invitation-email assets.
 		'invitation-envelope-graphic'   => '2026-02-05-invitation-envelope-graphic.png',

--- a/includes/Core/Email_Reporting/Email_Notices.php
+++ b/includes/Core/Email_Reporting/Email_Notices.php
@@ -42,13 +42,6 @@ class Email_Notices {
 	const PLACEMENT_HEADER = 'header';
 
 	/**
-	 * Section placement identifier.
-	 *
-	 * @since 1.175.0
-	 */
-	const PLACEMENT_SECTION = 'section';
-
-	/**
 	 * Maximum number of impressions before permanent dismissal.
 	 *
 	 * @since 1.175.0
@@ -140,49 +133,6 @@ class Email_Notices {
 	}
 
 	/**
-	 * Gets eligible section notices for a user and section key.
-	 *
-	 * @since 1.175.0
-	 *
-	 * @param WP_User $user        Recipient user.
-	 * @param string  $section_key Section key.
-	 * @return array Eligible section notices.
-	 */
-	public function get_section_notices( WP_User $user, $section_key ) {
-		return $this->get_notices_for_placement(
-			$user,
-			self::PLACEMENT_SECTION,
-			(string) $section_key
-		);
-	}
-
-	/**
-	 * Gets registered section notice keys.
-	 *
-	 * @since 1.175.0
-	 *
-	 * @return string[] Unique section keys.
-	 */
-	public function get_section_notice_keys() {
-		$section_keys = array();
-
-		foreach ( $this->notices as $notice ) {
-			if ( self::PLACEMENT_SECTION !== $notice->get_placement() ) {
-				continue;
-			}
-
-			$section_key = sanitize_key( $notice->get_section_key() );
-			if ( '' === $section_key ) {
-				continue;
-			}
-
-			$section_keys[] = $section_key;
-		}
-
-		return array_values( array_unique( $section_keys ) );
-	}
-
-	/**
 	 * Dismisses a notice for a user.
 	 *
 	 * @since 1.175.0
@@ -247,25 +197,20 @@ class Email_Notices {
 	}
 
 	/**
-	 * Gets eligible notices for a placement and optional section key.
+	 * Gets eligible notices for a placement.
 	 *
 	 * @since 1.175.0
+	 * @since n.e.x.t Removed the `$section_key` parameter.
 	 *
-	 * @param WP_User $user        Recipient user.
-	 * @param string  $placement   Placement slug.
-	 * @param string  $section_key Optional. Section key for section placement.
+	 * @param WP_User $user      Recipient user.
+	 * @param string  $placement Placement slug.
 	 * @return array Eligible notices.
 	 */
-	private function get_notices_for_placement( WP_User $user, $placement, $section_key = '' ) {
+	private function get_notices_for_placement( WP_User $user, $placement ) {
 		$eligible_notices = array();
-		$section_key      = sanitize_key( $section_key );
 
 		foreach ( $this->notices as $notice ) {
 			if ( $placement !== $notice->get_placement() ) {
-				continue;
-			}
-
-			if ( self::PLACEMENT_SECTION === $placement && $notice->get_section_key() !== $section_key ) {
 				continue;
 			}
 

--- a/includes/Core/Email_Reporting/Email_Reporting_Data_Requests.php
+++ b/includes/Core/Email_Reporting/Email_Reporting_Data_Requests.php
@@ -25,6 +25,7 @@ use Google\Site_Kit\Modules\Search_Console\Email_Reporting\Report_Options as Sea
 use Google\Site_Kit\Modules\Search_Console\Email_Reporting\Report_Request_Assembler as Search_Console_Report_Request_Assembler;
 use Google\Site_Kit\Modules\Analytics_4\Audience_Settings as Module_Audience_Settings;
 use Google\Site_Kit\Modules\Analytics_4\Custom_Dimensions_Data_Available;
+use Google\Site_Kit\Modules\Analytics_4\Site_Goals_Site_Settings;
 use WP_Error;
 use WP_User;
 
@@ -98,6 +99,14 @@ class Email_Reporting_Data_Requests {
 	private $audience_settings;
 
 	/**
+	 * Site Goals site settings instance.
+	 *
+	 * @since n.e.x.t
+	 * @var Site_Goals_Site_Settings
+	 */
+	private $site_goals_site_settings;
+
+	/**
 	 * Custom dimensions availability helper.
 	 *
 	 * @since 1.168.0
@@ -138,6 +147,7 @@ class Email_Reporting_Data_Requests {
 		$this->user_options = $user_options ?: new User_Options( $this->context );
 
 		$this->audience_settings                = new Module_Audience_Settings( new Options( $this->context ) );
+		$this->site_goals_site_settings         = new Site_Goals_Site_Settings( new Options( $this->context ) );
 		$this->custom_dimensions_data_available = new Custom_Dimensions_Data_Available( $transients );
 	}
 
@@ -348,6 +358,7 @@ class Email_Reporting_Data_Requests {
 	 *
 	 * @since 1.168.0
 	 * @since 1.187.0 Added the detected events and every custom dimension's availability to the report options.
+	 * @since n.e.x.t Added the active Site Goals widgets to the report options.
 	 *
 	 * @param object $module     Module instance.
 	 * @param array  $date_range Date range payload.
@@ -359,6 +370,7 @@ class Email_Reporting_Data_Requests {
 		$report_options->set_audience_segmentation_enabled( $this->is_audience_segmentation_enabled() );
 		$report_options->set_custom_dimension_availability( $this->custom_dimensions_data_available->get_data_availability() );
 		$report_options->set_detected_events( $module->get_settings()->get()['detectedEvents'] ?? array() );
+		$report_options->set_active_site_goals_widgets( $this->site_goals_site_settings->get()['activeWidgets'] ?? array() );
 
 		$request_assembler                = new Analytics_4_Report_Request_Assembler( $report_options );
 		list( $requests, $custom_titles ) = $request_assembler->build_requests();

--- a/includes/Core/Email_Reporting/Notices/Analytics_Setup_Email_Notice.php
+++ b/includes/Core/Email_Reporting/Notices/Analytics_Setup_Email_Notice.php
@@ -103,17 +103,6 @@ class Analytics_Setup_Email_Notice implements Email_Notice_Interface {
 	}
 
 	/**
-	 * Gets the target section key.
-	 *
-	 * @since 1.175.0
-	 *
-	 * @return string Empty for header notices.
-	 */
-	public function get_section_key() {
-		return '';
-	}
-
-	/**
 	 * Gets dismissal key for prompt storage.
 	 *
 	 * @since 1.175.0

--- a/includes/Core/Email_Reporting/Notices/Email_Notice_Interface.php
+++ b/includes/Core/Email_Reporting/Notices/Email_Notice_Interface.php
@@ -40,17 +40,6 @@ interface Email_Notice_Interface {
 	public function get_placement();
 
 	/**
-	 * Gets the target section key for section placement notices.
-	 *
-	 * Header notices should return an empty string.
-	 *
-	 * @since 1.175.0
-	 *
-	 * @return string Section key.
-	 */
-	public function get_section_key();
-
-	/**
 	 * Gets the dismissal slug used for prompt storage.
 	 *
 	 * @since 1.175.0

--- a/includes/Core/Email_Reporting/Sections_Map.php
+++ b/includes/Core/Email_Reporting/Sections_Map.php
@@ -12,6 +12,7 @@ namespace Google\Site_Kit\Core\Email_Reporting;
 
 use Google\Site_Kit\Context;
 use Google\Site_Kit\Core\Golinks\Golinks;
+use Google\Site_Kit\Modules\Analytics_4\Email_Reporting\Site_Goals_Section_Builder;
 
 /**
  * Class for mapping email report sections and their layout configuration.
@@ -112,16 +113,67 @@ class Sections_Map {
 	 * - section_parts: Array of template parts with their data.
 	 *
 	 * @since 1.168.0
+	 * @since n.e.x.t Added the online store and lead generation sections at the top.
 	 *
 	 * @return array Array of sections with their configuration.
 	 */
 	public function get_sections() {
 		return array_merge(
+			$this->get_site_goals_sections(),
 			$this->get_visitors_section(),
 			$this->get_traffic_sources_section(),
 			$this->get_attention_section(),
 			$this->get_growth_drivers_section()
 		);
+	}
+
+	/**
+	 * Gets the online store and lead generation sections, in the order the
+	 * dashboard shows their widgets.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @return array Section configuration array.
+	 */
+	protected function get_site_goals_sections() {
+		$cards = array(
+			'how_is_my_online_store_performing'      => array(
+				'payload_key' => Site_Goals_Section_Builder::ONLINE_STORE_SECTION_KEY,
+				'title'       => esc_html__( 'How is my online store performing?', 'google-site-kit' ),
+				'icon'        => 'online-store',
+			),
+			'are_people_reaching_out_to_my_business' => array(
+				'payload_key' => Site_Goals_Section_Builder::LEAD_GENERATION_SECTION_KEY,
+				'title'       => esc_html__( 'Are people reaching out to my business?', 'google-site-kit' ),
+				'icon'        => 'lead-generation',
+			),
+		);
+
+		$sections = array();
+
+		foreach ( $cards as $section_key => $card ) {
+			$section_parts = $this->filter_section_parts(
+				array(
+					$card['payload_key'] => array(
+						'data' => $this->payload[ $card['payload_key'] ] ?? array(),
+					),
+				)
+			);
+
+			if ( empty( $section_parts ) ) {
+				continue;
+			}
+
+			$sections[ $section_key ] = array(
+				'title'            => $card['title'],
+				'icon'             => $card['icon'],
+				'section_template' => 'section-site-goals',
+				'dashboard_url'    => $this->get_dashboard_url(),
+				'section_parts'    => $section_parts,
+			);
+		}
+
+		return $sections;
 	}
 
 	/**

--- a/includes/Modules/Analytics_4/Email_Reporting/Report_Options.php
+++ b/includes/Modules/Analytics_4/Email_Reporting/Report_Options.php
@@ -57,6 +57,14 @@ class Report_Options extends Base_Report_Options {
 	private $detected_events = array();
 
 	/**
+	 * Site Goals widget types in the site-wide `activeWidgets` setting.
+	 *
+	 * @since n.e.x.t
+	 * @var array
+	 */
+	private $active_site_goals_widgets = array();
+
+	/**
 	 * Whether audience segmentation is enabled.
 	 *
 	 * Null value means the 'audienceSegmentationSetupCompletedBy'
@@ -153,6 +161,29 @@ class Report_Options extends Base_Report_Options {
 	 */
 	private function get_detected_lead_events() {
 		return array_values( array_intersect( Conversion_Reporting_Events_Sync::LEAD_EVENT_NAMES, $this->detected_events ) );
+	}
+
+	/**
+	 * Sets the Site Goals widget types from the site-wide `activeWidgets` setting.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param array $active_widgets Widget types, such as `ecommerce` or `lead`.
+	 */
+	public function set_active_site_goals_widgets( array $active_widgets ) {
+		$this->active_site_goals_widgets = $active_widgets;
+	}
+
+	/**
+	 * Checks whether the site-wide `activeWidgets` setting lists a Site Goals widget type.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param string $widget_type Widget type, `ecommerce` or `lead`.
+	 * @return bool True when the setting lists the widget type, false otherwise.
+	 */
+	public function is_site_goals_widget_active( $widget_type ) {
+		return in_array( $widget_type, $this->active_site_goals_widgets, true );
 	}
 
 	/**

--- a/includes/Modules/Analytics_4/Email_Reporting/Report_Request_Assembler.php
+++ b/includes/Modules/Analytics_4/Email_Reporting/Report_Request_Assembler.php
@@ -10,6 +10,7 @@
 
 namespace Google\Site_Kit\Modules\Analytics_4\Email_Reporting;
 
+use Google\Site_Kit\Core\Conversion_Tracking\Conversion_Events_Provider;
 use Google\Site_Kit\Modules\Analytics_4;
 use Google\Site_Kit\Modules\Analytics_4\Email_Reporting\Report_Options as Analytics_Report_Options;
 
@@ -165,7 +166,9 @@ class Report_Request_Assembler {
 	}
 
 	/**
-	 * Builds the Site Goals requests for each widget whose events Analytics has detected.
+	 * Builds the Site Goals requests for each widget the dashboard shows.
+	 *
+	 * The dashboard decides which widgets to show in `isSiteGoalsWidgetRenderable()`.
 	 *
 	 * The online store widget and the lead generation widget each need their own key
 	 * action count, plus the engagement rate and the session count. Two widgets with no
@@ -177,13 +180,17 @@ class Report_Request_Assembler {
 	 *
 	 * @since 1.187.0
 	 * @since n.e.x.t Added the discovery report of each widget that splits its results.
+	 *                Skipped the reports of a widget the dashboard doesn't show.
 	 *
 	 * @return array Report requests keyed by payload key.
 	 */
 	private function build_site_goals_requests() {
 		$requests = array();
 
-		if ( $this->report_options->has_ecommerce_events() ) {
+		if (
+			$this->report_options->has_ecommerce_events()
+			&& $this->report_options->is_site_goals_widget_active( Conversion_Events_Provider::CATEGORY_ECOMMERCE )
+		) {
 			if ( $this->report_options->has_custom_dimension_data( Analytics_4::CUSTOM_DIMENSION_EVENT_PROVIDER ) ) {
 				$requests[ self::SITE_GOALS_ONLINE_STORE_PRIMARY_BY_PROVIDER_KEY ] = $this->report_options->get_online_store_primary_options( Analytics_4::CUSTOM_DIMENSION_EVENT_PROVIDER );
 				$requests[ self::SITE_GOALS_ONLINE_STORE_DISCOVERY_KEY ]           = $this->report_options->get_online_store_discovery_options( Analytics_4::CUSTOM_DIMENSION_EVENT_PROVIDER );
@@ -194,7 +201,10 @@ class Report_Request_Assembler {
 			}
 		}
 
-		if ( $this->report_options->has_lead_events() ) {
+		if (
+			$this->report_options->has_lead_events()
+			&& $this->report_options->is_site_goals_widget_active( Conversion_Events_Provider::CATEGORY_LEAD )
+		) {
 			if ( $this->report_options->has_custom_dimension_data( Analytics_4::CUSTOM_DIMENSION_FORM_ID ) ) {
 				$requests[ self::SITE_GOALS_LEAD_PRIMARY_BY_FORM_KEY ] = $this->report_options->get_lead_primary_options( Analytics_4::CUSTOM_DIMENSION_FORM_ID );
 				$requests[ self::SITE_GOALS_LEAD_DISCOVERY_KEY ]       = $this->report_options->get_lead_discovery_options( Analytics_4::CUSTOM_DIMENSION_FORM_ID );

--- a/tests/phpunit/integration/Core/Email_Reporting/Email_Reporting_Data_RequestsTest.php
+++ b/tests/phpunit/integration/Core/Email_Reporting/Email_Reporting_Data_RequestsTest.php
@@ -20,6 +20,7 @@ use Google\Site_Kit\Modules\Analytics_4;
 use Google\Site_Kit\Modules\Analytics_4\Audience_Settings as Module_Audience_Settings;
 use Google\Site_Kit\Modules\Analytics_4\Custom_Dimensions_Data_Available;
 use Google\Site_Kit\Modules\Analytics_4\Settings as Analytics_4_Settings;
+use Google\Site_Kit\Modules\Analytics_4\Site_Goals_Site_Settings;
 use Google\Site_Kit\Modules\Search_Console;
 use Google\Site_Kit\Modules\Search_Console\Settings as Search_Console_Settings;
 use Google\Site_Kit\Tests\FakeHttp;
@@ -621,6 +622,51 @@ class Email_Reporting_Data_RequestsTest extends TestCase {
 		$this->assertArrayHasKey( 'total_visitors', $payload, 'get_user_payload() should still return the total visitors report when Analytics detected no conversion event.' );
 	}
 
+	public function test_get_user_payload__adds_no_site_goals_report_when_no_site_goals_widget_is_active() {
+		$payload = $this->get_analytics_payload_for_detected_events( array( 'purchase', 'contact' ), array() );
+
+		$this->assertArrayNotHasKey( 'site_goals_online_store_primary', $payload, '`get_user_payload()` should return no online store report when `activeWidgets` is empty, even though `detectedEvents` has `purchase`.' );
+		$this->assertArrayNotHasKey( 'site_goals_lead_primary', $payload, '`get_user_payload()` should return no lead generation report when `activeWidgets` is empty, even though `detectedEvents` has `contact`.' );
+		$this->assertArrayHasKey( 'total_visitors', $payload, '`get_user_payload()` should still return the total visitors report when `activeWidgets` is empty.' );
+	}
+
+	public function test_get_user_payload__adds_the_site_goals_reports_only_for_a_role_that_analytics_is_shared_with() {
+		$admin_id  = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		$editor_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+		$author_id = self::factory()->user->create( array( 'role' => 'author' ) );
+
+		$this->authenticate_and_grant_required_scopes_for_user( $admin_id );
+
+		$this->activate_modules( Analytics_4::MODULE_SLUG );
+		$this->set_analytics_settings_connected(
+			array(
+				'ownerID'        => $admin_id,
+				'detectedEvents' => array( 'purchase', 'contact' ),
+			)
+		);
+		$this->options->set( Site_Goals_Site_Settings::OPTION, array( 'activeWidgets' => array( 'ecommerce', 'lead' ) ) );
+		$this->options->set(
+			Module_Sharing_Settings::OPTION,
+			array(
+				Analytics_4::MODULE_SLUG => array(
+					'sharedRoles' => array( 'editor' ),
+					'management'  => 'owner',
+				),
+			)
+		);
+
+		$analytics = $this->modules->get_module( Analytics_4::MODULE_SLUG );
+		$analytics->register();
+		$this->fake_analytics_report( $analytics );
+
+		$editor_payload = $this->create_data_requests()->get_user_payload( $editor_id, $this->date_range );
+		$author_payload = $this->create_data_requests()->get_user_payload( $author_id, $this->date_range );
+
+		$this->assertArrayHasKey( 'site_goals_online_store_primary', $editor_payload['analytics-4'], '`get_user_payload()` should return the online store count to an editor, because Analytics is shared with the editor role.' );
+		$this->assertArrayHasKey( 'site_goals_lead_primary', $editor_payload['analytics-4'], '`get_user_payload()` should return the lead generation count to an editor, because Analytics is shared with the editor role.' );
+		$this->assertSame( array(), $author_payload, "`get_user_payload()` should return an empty payload to an author, because Analytics isn't shared with the author role." );
+	}
+
 	public function test_get_user_payload__adds_the_author_and_category_reports_when_the_post_dimensions_have_data() {
 		$custom_dimension_data = new Custom_Dimensions_Data_Available( $this->transients );
 		$custom_dimension_data->set_data_available( Analytics_4::CUSTOM_DIMENSION_POST_AUTHOR );
@@ -633,12 +679,13 @@ class Email_Reporting_Data_RequestsTest extends TestCase {
 	}
 
 	/**
-	 * Gets the Analytics payload for an owner whose Analytics settings hold the given detected events.
+	 * Gets the Analytics payload for an owner, with the given `detectedEvents` and `activeWidgets` settings.
 	 *
 	 * @param array $detected_events Detected event names to store in the Analytics settings.
+	 * @param array $active_widgets  Optional. Site Goals widget types to store in `activeWidgets`. Default `ecommerce` and `lead`.
 	 * @return array Analytics payload keyed by request key.
 	 */
-	private function get_analytics_payload_for_detected_events( array $detected_events ) {
+	private function get_analytics_payload_for_detected_events( array $detected_events, array $active_widgets = array( 'ecommerce', 'lead' ) ) {
 		$admin_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
 		$this->authenticate_and_grant_required_scopes_for_user( $admin_id );
 
@@ -649,6 +696,7 @@ class Email_Reporting_Data_RequestsTest extends TestCase {
 				'detectedEvents' => $detected_events,
 			)
 		);
+		$this->options->set( Site_Goals_Site_Settings::OPTION, array( 'activeWidgets' => $active_widgets ) );
 
 		$analytics = $this->modules->get_module( Analytics_4::MODULE_SLUG );
 		$analytics->register();

--- a/tests/phpunit/integration/Core/Email_Reporting/Email_Template_RendererTest.php
+++ b/tests/phpunit/integration/Core/Email_Reporting/Email_Template_RendererTest.php
@@ -509,6 +509,63 @@ class Email_Template_RendererTest extends TestCase {
 		$this->assertStringNotContainsString( 'class="badge-negative"', $html_output, 'The card should show no negative badge when no metric has a change.' );
 	}
 
+	public function test_render__shows_the_online_store_and_lead_generation_cards_above_the_visitors_section() {
+		$context      = new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE );
+		$sections_map = new Sections_Map(
+			$context,
+			array(
+				'total_visitors'             => array(
+					'label'          => 'Total visitors',
+					'value'          => '120',
+					'change'         => 20,
+					'change_context' => 'Compared to previous 7 days',
+				),
+				'site_goals_online_store'    => array(
+					'values' => array( '116' ),
+					'groups' => array(
+						array(
+							'label'   => '',
+							'metrics' => array(
+								array(
+									'label' => 'Total sales',
+									'value' => '116',
+									'trend' => 7.2,
+								),
+							),
+						),
+					),
+				),
+				'site_goals_lead_generation' => array(
+					'values' => array( '85' ),
+					'groups' => array(
+						array(
+							'label'   => '',
+							'metrics' => array(
+								array(
+									'label' => 'Total form completions',
+									'value' => '85',
+									'trend' => 0.6,
+								),
+							),
+						),
+					),
+				),
+			),
+			new Golinks( $context )
+		);
+
+		$html_output = ( new Email_Template_Renderer( $sections_map ) )->render( 'email-report', $this->get_minimal_template_data() );
+
+		$online_store_position    = strpos( $html_output, 'How is my online store performing?' );
+		$lead_generation_position = strpos( $html_output, 'Are people reaching out to my business?' );
+		$visitors_position        = strpos( $html_output, 'How many people are finding and visiting my site?' );
+
+		$this->assertNotFalse( $online_store_position, 'The email should show the "How is my online store performing?" card.' );
+		$this->assertNotFalse( $lead_generation_position, 'The email should show the "Are people reaching out to my business?" card.' );
+		$this->assertLessThan( $lead_generation_position, $online_store_position, 'The email should show the online store card above the lead generation card.' );
+		$this->assertLessThan( $visitors_position, $lead_generation_position, 'The email should show the lead generation card above the visitors section.' );
+	}
+
 	/**
 	 * Builds one Site Goals section from the given part data.
 	 *

--- a/tests/phpunit/integration/Core/Email_Reporting/Sections_MapTest.php
+++ b/tests/phpunit/integration/Core/Email_Reporting/Sections_MapTest.php
@@ -1,0 +1,121 @@
+<?php
+/**
+ * Google\Site_Kit\Core\Email_Reporting\Sections_Map tests.
+ *
+ * @package   Google\Site_Kit\Tests\Core\Email_Reporting
+ * @copyright 2026 Google LLC
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License 2.0
+ * @link      https://sitekit.withgoogle.com
+ */
+
+namespace Google\Site_Kit\Tests\Core\Email_Reporting;
+
+use Google\Site_Kit\Context;
+use Google\Site_Kit\Core\Email_Reporting\Sections_Map;
+use Google\Site_Kit\Core\Golinks\Golinks;
+use Google\Site_Kit\Tests\TestCase;
+
+/**
+ * @group Email_Reporting
+ */
+class Sections_MapTest extends TestCase {
+
+	public function test_get_sections__lists_the_online_store_and_lead_generation_sections_above_the_visitors_section() {
+		$context      = new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE );
+		$sections_map = new Sections_Map(
+			$context,
+			array(
+				'total_visitors'             => array( 'value' => '1256' ),
+				'site_goals_lead_generation' => array( 'values' => array( '1.9%', '85' ) ),
+				'site_goals_online_store'    => array( 'values' => array( '3.8%', '116' ) ),
+			),
+			new Golinks( $context )
+		);
+
+		$this->assertSame(
+			array(
+				'how_is_my_online_store_performing',
+				'are_people_reaching_out_to_my_business',
+				'how_many_people_are_finding_and_visiting_my_site',
+			),
+			array_keys( $sections_map->get_sections() ),
+			'`get_sections()` should list the online store section, then the lead generation section, then the visitors section.'
+		);
+	}
+
+	public function test_get_sections__gives_each_site_goals_section_its_title_icon_and_dashboard_link() {
+		$context      = new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE );
+		$sections_map = new Sections_Map(
+			$context,
+			array(
+				'site_goals_online_store'    => array( 'values' => array( '3.8%', '116' ) ),
+				'site_goals_lead_generation' => array( 'values' => array( '1.9%', '85' ) ),
+			),
+			new Golinks( $context )
+		);
+
+		$this->assertSame(
+			array(
+				'how_is_my_online_store_performing'      => array(
+					'title'            => 'How is my online store performing?',
+					'icon'             => 'online-store',
+					'section_template' => 'section-site-goals',
+					'dashboard_url'    => 'http://example.org/wp-admin/index.php?action=googlesitekit_go&to=dashboard',
+					'section_parts'    => array(
+						'site_goals_online_store' => array(
+							'data' => array( 'values' => array( '3.8%', '116' ) ),
+						),
+					),
+				),
+				'are_people_reaching_out_to_my_business' => array(
+					'title'            => 'Are people reaching out to my business?',
+					'icon'             => 'lead-generation',
+					'section_template' => 'section-site-goals',
+					'dashboard_url'    => 'http://example.org/wp-admin/index.php?action=googlesitekit_go&to=dashboard',
+					'section_parts'    => array(
+						'site_goals_lead_generation' => array(
+							'data' => array( 'values' => array( '1.9%', '85' ) ),
+						),
+					),
+				),
+			),
+			$sections_map->get_sections(),
+			'`get_sections()` should give each Site Goals section its title, its icon, its payload, and the dashboard link.'
+		);
+	}
+
+	public function test_get_sections__lists_no_site_goals_section_when_the_payload_has_no_site_goals_data() {
+		$context      = new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE );
+		$sections_map = new Sections_Map(
+			$context,
+			array(
+				'total_visitors' => array( 'value' => '1256' ),
+			),
+			new Golinks( $context )
+		);
+
+		$this->assertSame(
+			array( 'how_many_people_are_finding_and_visiting_my_site' ),
+			array_keys( $sections_map->get_sections() ),
+			'`get_sections()` should list the visitors section alone when the payload has no Site Goals data.'
+		);
+	}
+
+	public function test_get_sections__lists_no_online_store_section_when_its_values_are_all_zero() {
+		$context      = new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE );
+		$sections_map = new Sections_Map(
+			$context,
+			array(
+				'total_visitors'          => array( 'value' => '1256' ),
+				'site_goals_online_store' => array( 'values' => array( '0%', '0' ) ),
+			),
+			new Golinks( $context )
+		);
+
+		$this->assertSame(
+			array( 'how_many_people_are_finding_and_visiting_my_site' ),
+			array_keys( $sections_map->get_sections() ),
+			'`get_sections()` should list no online store section when its sales rate and its total sales are both zero.'
+		);
+	}
+}

--- a/tests/phpunit/integration/Modules/Analytics_4/Email_Reporting/Report_OptionsTest.php
+++ b/tests/phpunit/integration/Modules/Analytics_4/Email_Reporting/Report_OptionsTest.php
@@ -590,6 +590,20 @@ class Analytics_4_Report_OptionsTest extends TestCase {
 		);
 	}
 
+	public function test_is_site_goals_widget_active__is_true_only_for_a_widget_type_in_the_active_widgets_setting() {
+		$builder = $this->create_builder();
+		$builder->set_active_site_goals_widgets( array( 'lead' ) );
+
+		$this->assertTrue(
+			$builder->is_site_goals_widget_active( 'lead' ),
+			'`is_site_goals_widget_active()` should be true for `lead` when `activeWidgets` has `lead`.'
+		);
+		$this->assertFalse(
+			$builder->is_site_goals_widget_active( 'ecommerce' ),
+			'`is_site_goals_widget_active()` should be false for `ecommerce` when `activeWidgets` has `lead` alone.'
+		);
+	}
+
 	/**
 	 * Asserts that a report covers the report period and the period before it.
 	 *

--- a/tests/phpunit/integration/Modules/Analytics_4/Email_Reporting/Report_Request_AssemblerTest.php
+++ b/tests/phpunit/integration/Modules/Analytics_4/Email_Reporting/Report_Request_AssemblerTest.php
@@ -155,6 +155,36 @@ class Analytics_4_Report_Request_AssemblerTest extends TestCase {
 		);
 	}
 
+	public function test_build_requests__registers_no_online_store_request_when_the_online_store_widget_is_not_active() {
+		$requests = $this->build_requests_for_events( array( 'purchase', 'contact' ), array(), array( 'lead' ) );
+
+		$this->assertSame(
+			array(),
+			$this->request_keys_starting_with( $requests, 'site_goals_online_store' ),
+			"`build_requests()` should register no online store request when `activeWidgets` doesn't have `ecommerce`, even though the site sends an ecommerce event."
+		);
+		$this->assertArrayHasKey(
+			'site_goals_lead_primary',
+			$requests,
+			'`build_requests()` should still register the lead generation count when `activeWidgets` has `lead`.'
+		);
+	}
+
+	public function test_build_requests__registers_no_lead_generation_request_when_the_lead_generation_widget_is_not_active() {
+		$requests = $this->build_requests_for_events( array( 'purchase', 'contact' ), array(), array( 'ecommerce' ) );
+
+		$this->assertSame(
+			array(),
+			$this->request_keys_starting_with( $requests, 'site_goals_lead' ),
+			"`build_requests()` should register no lead generation request when `activeWidgets` doesn't have `lead`, even though the site sends a lead event."
+		);
+		$this->assertArrayHasKey(
+			'site_goals_online_store_primary',
+			$requests,
+			'`build_requests()` should still register the online store count when `activeWidgets` has `ecommerce`.'
+		);
+	}
+
 	public function test_build_requests__registers_one_engagement_report_for_the_store_and_lead_widgets_when_neither_breakdown_dimension_has_data() {
 		$requests = $this->build_requests_for_events( array( 'purchase', 'contact' ) );
 
@@ -301,15 +331,17 @@ class Analytics_4_Report_Request_AssemblerTest extends TestCase {
 	}
 
 	/**
-	 * Builds the report requests for the given detected events and dimension availability.
+	 * Builds the report requests for the given events, dimension availability, and
+	 * Site Goals widget types.
 	 *
 	 * The `Report_Options` that built the requests stays in `$this->report_options`.
 	 *
 	 * @param array $detected_events Detected event names.
 	 * @param array $availability    Optional. Custom dimension availability keyed by dimension slug. Default empty.
+	 * @param array $active_widgets  Optional. Site Goals widget types in `activeWidgets`. Default `ecommerce` and `lead`.
 	 * @return array Report requests keyed by payload key.
 	 */
-	private function build_requests_for_events( array $detected_events, array $availability = array() ) {
+	private function build_requests_for_events( array $detected_events, array $availability = array(), array $active_widgets = array( 'ecommerce', 'lead' ) ) {
 		$this->report_options = new Analytics_4_Report_Options(
 			array(
 				'startDate'        => '2024-01-01',
@@ -321,11 +353,11 @@ class Analytics_4_Report_Request_AssemblerTest extends TestCase {
 			$this->context
 		);
 
-		// The test sets the same three options `Email_Reporting_Data_Requests` sets
-		// before it builds the requests.
+		// `Email_Reporting_Data_Requests` sets these values too, before it builds the requests.
 		$this->report_options->set_audience_segmentation_enabled( false );
 		$this->report_options->set_detected_events( $detected_events );
 		$this->report_options->set_custom_dimension_availability( $availability );
+		$this->report_options->set_active_site_goals_widgets( $active_widgets );
 
 		$assembler = new Analytics_4_Report_Request_Assembler( $this->report_options );
 


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses in the following list. -->
Related issue(s):

- Resolves #13014

## Relevant technical choices

- `includes/Core/Email_Reporting/Sections_Map.php`
  - Builds each Site Goals section whenever its payload has data, in place of checking the `siteGoals` flag.
- `includes/Modules/Analytics_4/Email_Reporting/Report_Request_Assembler.php`
  - Requests a widget's Site Goals reports when `activeWidgets` lists its type, in place of checking for an active provider plugin in `Sections_Map`.

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.
- [ ] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
