### PR TITLE
Decode HTML entities in plain text email reports

### DIFF
--- a/includes/Core/Email_Reporting/Plain_Text_Formatter.php
+++ b/includes/Core/Email_Reporting/Plain_Text_Formatter.php
@@ -85,7 +85,7 @@ class Plain_Text_Formatter {
 	 */
 	public static function format_simple_email( $data ) {
 		$site_domain     = $data['site']['domain'] ?? '';
-		$title           = wp_strip_all_tags( $data['title'] ?? '' );
+		$title           = self::sanitize_text( $data['title'] ?? '' );
 		$learn_more_url  = $data['learn_more_url'] ?? '';
 		$cta             = $data['primary_call_to_action'] ?? array();
 		$footer_copy     = $data['footer']['copy'] ?? '';
@@ -108,9 +108,8 @@ class Plain_Text_Formatter {
 
 		// Body paragraphs (convert links to text, then strip remaining HTML).
 		foreach ( (array) $body as $paragraph ) {
-			$paragraph = self::convert_links_to_text( $paragraph );
-			$lines[]   = wp_strip_all_tags( $paragraph );
-			$lines[]   = '';
+			$lines[] = self::sanitize_text( self::convert_links_to_text( $paragraph ) );
+			$lines[] = '';
 		}
 
 		// Learn more link (optional).
@@ -134,7 +133,7 @@ class Plain_Text_Formatter {
 
 		// Footer copy.
 		if ( ! empty( $footer_copy ) ) {
-			$lines[] = wp_strip_all_tags( self::convert_links_to_text( $footer_copy ) );
+			$lines[] = self::sanitize_text( self::convert_links_to_text( $footer_copy ) );
 		}
 
 		// Mirror the HTML `footer_type` branch: `inline` skips utility links.
@@ -244,6 +243,29 @@ class Plain_Text_Formatter {
 	}
 
 	/**
+	 * Prepares a string for plain text email output.
+	 *
+	 * Strips HTML tags and decodes HTML entities so plain text matches what the
+	 * HTML email displays in the browser.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param string $text Text that may contain HTML tags or entities.
+	 * @return string Sanitized plain text.
+	 */
+	protected static function sanitize_text( $text ) {
+		if ( '' === $text || null === $text ) {
+			return '';
+		}
+
+		return html_entity_decode(
+			wp_strip_all_tags( (string) $text ),
+			ENT_QUOTES | ENT_HTML5,
+			get_bloginfo( 'charset' )
+		);
+	}
+
+	/**
 	 * Converts HTML anchor tags to plain text format.
 	 *
 	 * Replaces `<a href="url">text</a>` with `text (url)` so that
@@ -295,7 +317,7 @@ class Plain_Text_Formatter {
 
 		// Footer copy.
 		if ( ! empty( $footer['copy'] ) ) {
-			$lines[] = wp_strip_all_tags( self::convert_links_to_text( $footer['copy'] ) );
+			$lines[] = self::sanitize_text( self::convert_links_to_text( $footer['copy'] ) );
 		}
 
 		$lines = self::append_footer_links( $lines, $footer['unsubscribe_url'] ?? '' );
@@ -374,7 +396,7 @@ class Plain_Text_Formatter {
 		);
 
 		if ( $has_any_change && ! empty( $first_part['data']['change_context'] ) ) {
-			$output .= $first_part['data']['change_context'] . "\n\n";
+			$output .= self::sanitize_text( $first_part['data']['change_context'] ) . "\n\n";
 		}
 
 		foreach ( $section_parts as $part_key => $part_config ) {
@@ -384,8 +406,8 @@ class Plain_Text_Formatter {
 
 			$data    = $part_config['data'];
 			$output .= self::format_metric(
-				$data['label'] ?? '',
-				$data['value'] ?? '',
+				self::sanitize_text( $data['label'] ?? '' ),
+				self::sanitize_text( $data['value'] ?? '' ),
 				$data['change'] ?? null
 			);
 			$output .= "\n";
@@ -412,7 +434,7 @@ class Plain_Text_Formatter {
 			}
 
 			$data       = $part_config['data'];
-			$part_label = Sections_Map::get_part_label( $part_key );
+			$part_label = self::sanitize_text( Sections_Map::get_part_label( $part_key ) );
 
 			// Part heading.
 			$output .= $part_label . "\n";
@@ -422,15 +444,15 @@ class Plain_Text_Formatter {
 			$has_any_change = ! empty( array_filter( $data['changes'] ?? array(), static fn( $change ) => null !== $change ) );
 
 			if ( $has_any_change && ! empty( $data['change_context'] ) ) {
-				$output .= $data['change_context'] . "\n";
+				$output .= self::sanitize_text( $data['change_context'] ) . "\n";
 			}
 
 			// Dimension values (list items).
 			if ( ! empty( $data['dimension_values'] ) && is_array( $data['dimension_values'] ) ) {
 				foreach ( $data['dimension_values'] as $index => $item ) {
-					$label  = is_array( $item ) ? ( $item['label'] ?? '' ) : $item;
+					$label  = self::sanitize_text( is_array( $item ) ? ( $item['label'] ?? '' ) : $item );
 					$url    = is_array( $item ) ? ( $item['url'] ?? '' ) : '';
-					$value  = $data['values'][ $index ] ?? '';
+					$value  = self::sanitize_text( $data['values'][ $index ] ?? '' );
 					$change = $data['changes'][ $index ] ?? null;
 
 					$output .= self::format_page_row( $label, $value, $change, $url ) . "\n";
@@ -475,18 +497,24 @@ class Plain_Text_Formatter {
 		);
 
 		if ( $has_any_change && ! empty( $first_part['data']['change_context'] ) ) {
-			$output .= $first_part['data']['change_context'] . "\n\n";
+			$output .= self::sanitize_text( $first_part['data']['change_context'] ) . "\n\n";
 		}
 
 		foreach ( $section_parts as $part_config ) {
 			foreach ( $part_config['data']['groups'] as $group ) {
-				if ( '' !== $group['label'] ) {
-					$output .= $group['label'] . "\n";
-					$output .= str_repeat( '-', mb_strlen( $group['label'] ) ) . "\n";
+				$group_label = self::sanitize_text( $group['label'] );
+
+				if ( '' !== $group_label ) {
+					$output .= $group_label . "\n";
+					$output .= str_repeat( '-', mb_strlen( $group_label ) ) . "\n";
 				}
 
 				foreach ( $group['metrics'] as $metric ) {
-					$output .= self::format_metric( $metric['label'], $metric['value'], $metric['trend'] ) . "\n";
+					$output .= self::format_metric(
+						self::sanitize_text( $metric['label'] ),
+						self::sanitize_text( $metric['value'] ),
+						$metric['trend']
+					) . "\n";
 				}
 
 				$output .= "\n";
@@ -496,9 +524,13 @@ class Plain_Text_Formatter {
 		$prompt = $first_part['data']['prompt'] ?? array();
 
 		if ( ! empty( $prompt ) ) {
-			$prompt_link = sprintf( '%s (%s)', $prompt['link_text'], $section['dashboard_url'] );
+			$prompt_link = sprintf(
+				'%s (%s)',
+				self::sanitize_text( $prompt['link_text'] ),
+				$section['dashboard_url']
+			);
 
-			$output .= sprintf( $prompt['text'], $prompt_link ) . "\n\n";
+			$output .= self::sanitize_text( sprintf( $prompt['text'], $prompt_link ) ) . "\n\n";
 		}
 
 		return $output;

--- a/tests/phpunit/integration/Core/Email_Reporting/Plain_Text_FormatterTest.php
+++ b/tests/phpunit/integration/Core/Email_Reporting/Plain_Text_FormatterTest.php
@@ -709,4 +709,71 @@ class Plain_Text_FormatterTest extends TestCase {
 		$this->assertStringContainsString( 'get help (https://example.com/help)', $result, 'Multiple body links should be converted.' );
 		$this->assertStringNotContainsString( '<a ', $result, 'No HTML anchor tags should remain in plain text.' );
 	}
+
+	public function test_format_section__decodes_html_entities_in_page_metric_labels() {
+		$section = array(
+			'title'            => 'What’s grabbing their attention?',
+			'section_template' => 'section-page-metrics',
+			'section_parts'    => array(
+				'top_categories' => array(
+					'data' => array(
+						'change_context'   => 'Compared to previous 7 days',
+						'dimension_values' => array(
+							array(
+								'label' => 'Tips &amp; Tricks',
+								'url'   => 'https://example.com/category/tips-tricks/',
+							),
+							array(
+								'label' => 'Dana&#8217;s Guide &#038; Tips',
+								'url'   => 'https://example.com/danas-guide-tips/',
+							),
+						),
+						'values'           => array( '500', '300' ),
+						'changes'          => array( 10.5, -2.3 ),
+					),
+				),
+			),
+		);
+
+		$result = Plain_Text_Formatter::format_section( $section );
+
+		$this->assertStringContainsString( '• Tips & Tricks: 500 (+10.5%)', $result, 'Category names with ampersand entities should decode for plain text.' );
+		$this->assertStringContainsString( '• Dana’s Guide & Tips: 300 (-2.3%)', $result, 'Page titles with numeric entities should decode for plain text.' );
+		$this->assertStringNotContainsString( '&amp;', $result, 'Plain text should not contain ampersand entities.' );
+		$this->assertStringNotContainsString( '&#8217;', $result, 'Plain text should not contain apostrophe entities.' );
+		$this->assertStringNotContainsString( '&#038;', $result, 'Plain text should not contain encoded ampersand entities.' );
+	}
+
+	public function test_format_section__decodes_html_entities_in_site_goals_metric_values() {
+		$section = array(
+			'title'            => 'Are people reaching out to my business?',
+			'section_template' => 'section-site-goals',
+			'dashboard_url'    => 'https://example.com/dashboard',
+			'section_parts'    => array(
+				'site_goals_lead_generation' => array(
+					'data' => array(
+						'change_context' => 'Compared to previous 7 days',
+						'groups'         => array(
+							array(
+								'label'   => '',
+								'metrics' => array(
+									array(
+										'label' => 'Total form completions',
+										'value' => '1&nbsp;234',
+										'trend' => 0.6,
+									),
+								),
+							),
+						),
+						'prompt'         => array(),
+					),
+				),
+			),
+		);
+
+		$result = Plain_Text_Formatter::format_section( $section );
+
+		$this->assertStringContainsString( 'Total form completions: 1 234 (+0.6%)', $result, 'Site Goals totals with non-breaking space entities should decode for plain text.' );
+		$this->assertStringNotContainsString( '&nbsp;', $result, 'Plain text should not contain non-breaking space entities.' );
+	}
 }


### PR DESCRIPTION
## Summary

Fixes google/site-kit-wp#13537.

The plain text email report showed raw HTML entity codes (e.g. `&#8217;`, `&#038;`, `&amp;`, `&nbsp;`) for page titles, category/author names, and Site Goals totals. The HTML version rendered correctly because email clients decode entities when rendering HTML, but the plain text path output the encoded strings verbatim.

## Cause

Report data often arrives with HTML entities already encoded (WordPress page titles from `get_the_title()`, taxonomy/author names stored as `&amp;`, and localized totals from `number_format_i18n()` using `&nbsp;`). The HTML templates pass these through `esc_html()`, which browsers decode on display. `Plain_Text_Formatter` previously copied the raw strings without decoding entities.

## Fix

Add a centralized `sanitize_text()` helper in `Plain_Text_Formatter` that strips HTML tags and decodes entities with `html_entity_decode()` (matching the pattern used in `Get_Form_Metadata.php`). Apply it across all plain text rendering paths: metrics, page metrics, Site Goals, simple email body/footer copy, and related labels/values.

## How to verify

1. On a connected site, rename a page to include an apostrophe and ampersand (e.g. `Dana's Guide & Tips`).
2. Ensure the page appears under **Pages with the most clicks from Search** in the email report data.
3. In **Site Kit > Tester Settings > Email Template Preview**, choose **Email Report** and click **Preview Plain Text**.
4. Confirm the page title, category/author names, and Site Goals totals show decoded characters (matching **Preview HTML**), not entity codes.

## Test plan

- [x] `composer run lint -- includes/Core/Email_Reporting/Plain_Text_Formatter.php`
- [x] `composer run test -- tests/phpunit/integration/Core/Email_Reporting/Plain_Text_FormatterTest.php`

---

**Note:** Please open this PR against `google/site-kit-wp` `develop` (cross-fork) if GitHub did not set the base repository automatically.