### PR TITLE
Assert inline script order in GTagTest instead of fixed array positions

### DIFF
--- a/tests/phpunit/integration/Core/Tags/GTagTest.php
+++ b/tests/phpunit/integration/Core/Tags/GTagTest.php
@@ -83,12 +83,17 @@ class GTagTest extends TestCase {
 	public function test_gtag_script_contains_gtag_call() {
 		do_action( 'wp_enqueue_scripts' );
 
-		$scripts = wp_scripts();
-		$script  = $scripts->registered[ GTag::HANDLE ];
-
-		// Assert the array of inline script data contains the necessary gtag config line.
-		// Should be in index 5, the first registered gtag.
-		$this->assertEquals( 'gtag("config", "' . static::TEST_TAG_ID_1 . '");', $script->extra['after'][5], 'Inline script should include config call for first tag.' );
+		$this->assertSame(
+			array(
+				'window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments);}',
+				sprintf( 'gtag(%s);', '"' . static::TEST_COMMAND_2 . '",' . json_encode( static::TEST_COMMAND_2_PARAMS[0] ) ),
+				'gtag("js", new Date());',
+				'gtag("set", "developer_id.dZTNiMT", true);',
+				'gtag("config", "' . static::TEST_TAG_ID_1 . '");',
+			),
+			$this->get_inline_scripts( 'after' ),
+			'Inline scripts should end with the config call for the first tag, after the gtag bootstrap, commands and developer id.'
+		);
 	}
 
 	/**
@@ -166,14 +171,22 @@ class GTagTest extends TestCase {
 	public function test_gtag_script_commands() {
 		do_action( 'wp_enqueue_scripts' );
 
-		$scripts = wp_scripts();
-		$script  = $scripts->registered[ GTag::HANDLE ];
-
 		// Test commands in the before position.
-		$this->assertEquals( sprintf( 'gtag(%s");', '"' . static::TEST_COMMAND_1 . '","' . implode( '","', static::TEST_COMMAND_1_PARAMS ) ), $script->extra['before'][1], 'Before inline script should include first command call.' );
+		$this->assertContains(
+			sprintf( 'gtag(%s");', '"' . static::TEST_COMMAND_1 . '","' . implode( '","', static::TEST_COMMAND_1_PARAMS ) ),
+			$this->get_inline_scripts( 'before' ),
+			'Before inline script should include first command call.'
+		);
 
 		// Test commands in the after position.
-		$this->assertEquals( sprintf( 'gtag(%s);', '"' . static::TEST_COMMAND_2 . '",' . json_encode( static::TEST_COMMAND_2_PARAMS[0] ) ), $script->extra['after'][2], 'After inline script should include second command call.' );
+		$this->assertInlineScriptsInOrder(
+			array(
+				sprintf( 'gtag(%s);', '"' . static::TEST_COMMAND_2 . '",' . json_encode( static::TEST_COMMAND_2_PARAMS[0] ) ),
+				'gtag("js", new Date());',
+			),
+			'after',
+			'After inline script should include second command call, before the gtag js command.'
+		);
 	}
 
 	public function test_gtag_with_tag_config() {
@@ -181,12 +194,14 @@ class GTagTest extends TestCase {
 
 		do_action( 'wp_enqueue_scripts' );
 
-		$scripts = wp_scripts();
-		$script  = $scripts->registered[ GTag::HANDLE ];
-
-		// Assert the array of inline script data contains the necessary gtag entry for the second script.
-		// Should be in index 6, immediately after the first registered gtag.
-		$this->assertEquals( 'gtag("config", "' . static::TEST_TAG_ID_2 . '", ' . json_encode( self::TEST_TAG_ID_2_CONFIG ) . ');', $script->extra['after'][6], 'Inline script should include config call for second tag with config.' );
+		$this->assertInlineScriptsInOrder(
+			array(
+				'gtag("config", "' . static::TEST_TAG_ID_1 . '");',
+				'gtag("config", "' . static::TEST_TAG_ID_2 . '", ' . json_encode( self::TEST_TAG_ID_2_CONFIG ) . ');',
+			),
+			'after',
+			'Inline script should include config call for each tag, in the order the tags were added.'
+		);
 	}
 
 	public function test_get_gtag_src() {
@@ -217,15 +232,26 @@ class GTagTest extends TestCase {
 
 		do_action( 'wp_enqueue_scripts' );
 
-		$scripts = wp_scripts();
-		$script  = $scripts->registered[ GTag::HANDLE ];
-
-		$this->assertEquals( 'gtag("set", "developer_id.dZTNiMT", true);', $script->extra['after'][4], 'Inline script should include developer id always.' );
+		$this->assertInlineScriptsInOrder(
+			array(
+				'gtag("set", "developer_id.dZTNiMT", true);',
+				'gtag("config", "' . static::TEST_TAG_ID_1 . '");',
+			),
+			'after',
+			'Inline script should include developer id always, before the tag config call.'
+		);
 
 		if ( $data['settings']['isEnabled'] && $data['settings']['isGTGHealthy'] && $data['settings']['isScriptAccessEnabled'] ) {
-			$this->assertEquals( 'gtag("set", "developer_id.dZmZmYj", true);', $script->extra['after'][5], 'Inline script should include GTG developer id when conditions are met.' );
+			$this->assertInlineScriptsInOrder(
+				array(
+					'gtag("set", "developer_id.dZTNiMT", true);',
+					'gtag("set", "developer_id.dZmZmYj", true);',
+				),
+				'after',
+				'Inline script should include GTG developer id after the Site Kit developer id when conditions are met.'
+			);
 		} else {
-			$this->assertNotContains( 'gtag("set", "developer_id.dZmZmYj", true);', $script->extra['after'], 'Inline script should not include GTG developer id when conditions are not met.' );
+			$this->assertNotContains( 'gtag("set", "developer_id.dZmZmYj", true);', $this->get_inline_scripts( 'after' ), 'Inline script should not include GTG developer id when conditions are not met.' );
 		}
 	}
 
@@ -299,5 +325,33 @@ class GTagTest extends TestCase {
 			),
 			'All GTG handles should be enqueued.'
 		);
+	}
+
+	/**
+	 * Gets the inline scripts registered for the gtag handle.
+	 *
+	 * @param string $position Position the scripts were added at, either `before` or `after`.
+	 * @return array List of inline scripts, in the order they were added.
+	 */
+	private function get_inline_scripts( $position ) {
+		$script = wp_scripts()->registered[ GTag::HANDLE ];
+
+		// WordPress stored an unused falsy entry ahead of the first inline script before https://core.trac.wordpress.org/ticket/52320.
+		return array_values( array_filter( $script->extra[ $position ] ) );
+	}
+
+	/**
+	 * Asserts that the given inline scripts are all registered, in the given order relative to each other.
+	 *
+	 * Other inline scripts may appear before, between, or after them.
+	 *
+	 * @param array  $expected Inline scripts, in their expected relative order.
+	 * @param string $position Position the scripts were added at, either `before` or `after`.
+	 * @param string $message  Optional. Message to display when the assertion fails.
+	 */
+	private function assertInlineScriptsInOrder( array $expected, $position, $message = '' ) {
+		$scripts = $this->get_inline_scripts( $position );
+
+		$this->assertSame( $expected, array_values( array_intersect( $scripts, $expected ) ), $message );
 	}
 }


### PR DESCRIPTION
## Summary

Related issue(s):

- Resolves #13545

## Relevant technical choices

`GTagTest` read `$script->extra['after']` and `$script->extra['before']` at hardcoded indexes. WordPress trunk r63579 ([core ticket #52320](https://core.trac.wordpress.org/ticket/52320)) removed the unused falsy entry that `WP_Scripts::add_inline_script()` stored ahead of the first inline script, so every entry shifted down by one and those indexes broke.

The inline scripts for the gtag handle are an ordered list. What matters is which scripts are registered and in what order, not which index each lands at. Two private helpers carry that:

* `get_inline_scripts( $position )` returns the list for `GTag::HANDLE` as a clean ordered array. `array_filter()` absorbs the leading falsy entry that WordPress before 7.2 stores, so the tests pass on both old and new core, and no individual test has to know the quirk exists.
* `assertInlineScriptsInOrder( $expected, $position, $message )` asserts the named scripts are all registered in that relative order, allowing others in between. `array_intersect( $actual, $expected )` keeps the order of the actual list, so one comparison checks presence and order together.

Each index-based assertion became either a presence check or a relative-order check, depending on what its index was standing in for. The one test whose purpose is placement asserts the complete ordered list rather than a partial chain, because partial chains leave gaps. A reordering of two adjacent scripts can satisfy every partial assertion and still be wrong.

No runtime code changed. `includes/Core/Tags/GTag.php` is untouched.

### Verification

* Passes on current core (WordPress 6.9.4), 20 tests and 32 assertions.
* Passes on the new core behaviour. I applied the two-line diff from r63579 to `vendor/roots/wordpress/wp-includes/class-wp-scripts.php` locally. Against that, the old assertions reproduce CI exactly with 3 errors and 5 failures, and the new ones pass.
* The order assertions are not vacuous. Reordering the `wp_add_inline_script()` calls in `GTag.php` fails the suite, including a swap of two adjacent scripts.
* The full local suite reports the same 60 pre-existing environment errors with and without this change. None involve `GTag`.

## PR Author Checklist

- [x] My code is tested and passes existing unit tests.
- [x] My code has an appropriate set of unit tests which all pass.
- [x] My code is backward-compatible with WordPress 5.2 and PHP 7.4.
- [x] My code follows the [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) coding standards.
- [x] My code has proper inline documentation.
- [x] I have added a QA Brief on the issue linked above.
- [x] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

---------------

_Do not alter or remove anything below. The following sections will be managed by moderators only._

## Code Reviewer Checklist

- [ ] Run the code.
- [ ] Ensure the acceptance criteria are satisfied.
- [ ] Reassess the implementation with the IB.
- [ ] Ensure no unrelated changes are included.
- [ ] Ensure CI checks pass.
- [ ] Check Storybook where applicable.
- [ ] Ensure there is a QA Brief.
- [ ] Ensure there are no unexpected significant changes to file sizes.

## Merge Reviewer Checklist

- [ ] Ensure the PR has the correct target branch.
- [ ] Double-check that the PR is okay to be merged.
- [ ] Ensure the corresponding issue has a ZenHub release assigned.
- [ ] Add a changelog message to the issue.
